### PR TITLE
[Security Solution] Add rulesClient.bulkCreateRules and wire `rule/_import` + `installation/_perform`

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/common/rule_circuit_breaker_error_message.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/rule_circuit_breaker_error_message.ts
@@ -47,6 +47,12 @@ const getBulkEnableRuleErrorSummary = () => {
   });
 };
 
+const getBulkCreateRuleErrorSummary = () => {
+  return i18n.translate('xpack.alerting.ruleCircuitBreaker.error.bulkCreateSummary', {
+    defaultMessage: `Rules cannot be bulk created. The maximum number of runs per minute would be exceeded.`,
+  });
+};
+
 const getRuleCircuitBreakerErrorDetail = ({
   interval,
   intervalAvailable,
@@ -84,7 +90,7 @@ export const getRuleCircuitBreakerErrorMessage = ({
   name?: string;
   interval: number;
   intervalAvailable: number;
-  action: 'update' | 'create' | 'enable' | 'bulkEdit' | 'bulkEnable';
+  action: 'update' | 'create' | 'enable' | 'bulkEdit' | 'bulkEnable' | 'bulkCreate';
   rules?: number;
 }) => {
   let errorMessageSummary: string;
@@ -104,6 +110,9 @@ export const getRuleCircuitBreakerErrorMessage = ({
       break;
     case 'bulkEnable':
       errorMessageSummary = getBulkEnableRuleErrorSummary();
+      break;
+    case 'bulkCreate':
+      errorMessageSummary = getBulkCreateRuleErrorSummary();
       break;
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -1,0 +1,439 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  coreFeatureFlagsMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+  savedObjectsRepositoryMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
+import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
+import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
+import type { ActionsAuthorization, ActionsClient } from '@kbn/actions-plugin/server';
+import { createMockConnector } from '@kbn/actions-plugin/server/application/connector/mocks';
+import { ruleTypeRegistryMock } from '../../../../rule_type_registry.mock';
+import { alertingAuthorizationMock } from '../../../../authorization/alerting_authorization.mock';
+import type { AlertingAuthorization } from '../../../../authorization/alerting_authorization';
+import { ConnectorAdapterRegistry } from '../../../../connector_adapters/connector_adapter_registry';
+import { backfillClientMock } from '../../../../backfill_client/backfill_client.mock';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { getBeforeSetup, setGlobalDate } from '../../../../rules_client/tests/lib';
+import type { ConstructorOptions } from '../../../../rules_client/rules_client';
+import { RulesClient } from '../../../../rules_client/rules_client';
+import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
+import { validateScheduleLimit } from '../get_schedule_frequency';
+import { RuleAuditAction } from '../../../../rules_client/common/audit_events';
+
+jest.mock('../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation', () => ({
+  bulkMarkApiKeysForInvalidation: jest.fn(),
+}));
+
+jest.mock('../get_schedule_frequency', () => ({
+  validateScheduleLimit: jest.fn(),
+}));
+
+jest.mock('@kbn/core-saved-objects-utils-server', () => {
+  const actual = jest.requireActual('@kbn/core-saved-objects-utils-server');
+  return {
+    ...actual,
+    SavedObjectsUtils: {
+      generateId: jest.fn(),
+    },
+  };
+});
+
+import { SavedObjectsUtils } from '@kbn/core-saved-objects-utils-server';
+
+const taskManager = taskManagerMock.createStart();
+const ruleTypeRegistry = ruleTypeRegistryMock.create();
+const unsecuredSavedObjectsClient = savedObjectsClientMock.create();
+const encryptedSavedObjects = encryptedSavedObjectsMock.createClient();
+const authorization = alertingAuthorizationMock.create();
+const actionsAuthorization = actionsAuthorizationMock.create();
+const auditLogger = auditLoggerMock.create();
+const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
+
+const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  taskManager,
+  ruleTypeRegistry,
+  unsecuredSavedObjectsClient,
+  authorization: authorization as unknown as AlertingAuthorization,
+  actionsAuthorization: actionsAuthorization as unknown as ActionsAuthorization,
+  spaceId: 'default',
+  namespace: 'default',
+  getUserName: jest.fn(),
+  createAPIKey: jest.fn(),
+  logger: loggingSystemMock.create().get(),
+  internalSavedObjectsRepository,
+  encryptedSavedObjectsClient: encryptedSavedObjects,
+  getActionsClient: jest.fn(),
+  getEventLogClient: jest.fn(),
+  kibanaVersion: 'v8.0.0',
+  auditLogger,
+  maxScheduledPerMinute: 10000,
+  minimumScheduleInterval: { value: '1m', enforce: false },
+  isAuthenticationTypeAPIKey: jest.fn(),
+  getAuthenticationAPIKey: jest.fn(),
+  getAlertIndicesAlias: jest.fn(),
+  alertsService: null,
+  backfillClient: backfillClientMock.create(),
+  connectorAdapterRegistry: new ConnectorAdapterRegistry(),
+  isSystemAction: jest.fn(),
+  uiSettings: uiSettingsServiceMock.createStartContract(),
+  featureFlags: coreFeatureFlagsMock.createStart(),
+  isServerless: false,
+};
+
+setGlobalDate();
+
+const baseRule = (overrides: Record<string, unknown> = {}) => ({
+  enabled: false,
+  name: 'r',
+  tags: [],
+  alertTypeId: '123',
+  consumer: 'bar',
+  schedule: { interval: '1m' },
+  throttle: null,
+  notifyWhen: null,
+  params: { foo: true },
+  actions: [],
+  ...overrides,
+});
+
+const buildBulkResponse = (
+  rules: Array<{ id: string; error?: { message: string; statusCode: number } }>
+) => ({
+  saved_objects: rules.map((r) => ({
+    id: r.id,
+    type: RULE_SAVED_OBJECT_TYPE,
+    references: [],
+    ...(r.error
+      ? { error: { ...r.error, error: 'Conflict' } }
+      : {
+          attributes: {
+            alertTypeId: '123',
+            name: `name-${r.id}`,
+            enabled: false,
+            consumer: 'bar',
+            schedule: { interval: '1m' },
+            params: { foo: true },
+            actions: [],
+            createdBy: 'elastic',
+            updatedBy: 'elastic',
+            createdAt: '2019-02-12T21:01:22.479Z',
+            updatedAt: '2019-02-12T21:01:22.479Z',
+            snoozeSchedule: [],
+            muteAll: false,
+            mutedInstanceIds: [],
+            executionStatus: { status: 'pending', lastExecutionDate: '2019-02-12T21:01:22.479Z' },
+            revision: 0,
+            running: false,
+            apiKey: null,
+            apiKeyOwner: null,
+            apiKeyCreatedByUser: null,
+          },
+        }),
+  })) as never,
+});
+
+describe('bulkCreateRules', () => {
+  let rulesClient: RulesClient;
+  let actionsClient: jest.Mocked<ActionsClient>;
+
+  beforeEach(async () => {
+    getBeforeSetup(rulesClientParams, taskManager, ruleTypeRegistry);
+    (auditLogger.log as jest.Mock).mockClear();
+    (bulkMarkApiKeysForInvalidation as jest.Mock).mockReset();
+    (validateScheduleLimit as jest.Mock).mockReset();
+    let counter = 0;
+    (SavedObjectsUtils.generateId as jest.Mock).mockImplementation(() => `mock-id-${++counter}`);
+    rulesClient = new RulesClient(rulesClientParams);
+    actionsClient = (await rulesClientParams.getActionsClient()) as jest.Mocked<ActionsClient>;
+    actionsClient.getBulk.mockResolvedValue([
+      createMockConnector({ id: '1', actionTypeId: 'test', name: 'a' }),
+    ]);
+    actionsClient.listTypes.mockResolvedValue([]);
+    actionsClient.isSystemAction.mockReturnValue(false);
+    rulesClientParams.getActionsClient.mockResolvedValue(actionsClient);
+    rulesClientParams.createAPIKey.mockResolvedValue({
+      apiKeysEnabled: true,
+      result: { id: 'key-id', name: 'key', api_key: 'key-value' } as never,
+    });
+    rulesClientParams.isAuthenticationTypeAPIKey.mockReturnValue(false);
+    taskManager.bulkSchedule.mockImplementation(async (tasks) => tasks as never);
+    taskManager.bulkEnable.mockResolvedValue({ tasks: [], errors: [] } as never);
+  });
+
+  test('returns empty result for empty input without touching SO/TM/key clients', async () => {
+    const result = await rulesClient.bulkCreateRules({ rules: [] });
+    expect(result).toEqual({ rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] });
+    expect(unsecuredSavedObjectsClient.bulkCreate).not.toHaveBeenCalled();
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+  });
+
+  test('all-disabled happy path: single bulkCreate, no TM, no API keys', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a' }) }, { data: baseRule({ name: 'b' }) }],
+    });
+
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(taskManager.bulkEnable).not.toHaveBeenCalled();
+    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+    expect(result.rules).toHaveLength(2);
+    expect(result.taskIdsFailedToBeEnabled).toEqual([]);
+  });
+
+  test('all-enabled happy path: API keys, bulkSchedule, bulkCreate, bulkEnable', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'a', enabled: true }) },
+        { data: baseRule({ name: 'b', enabled: true }) },
+      ],
+    });
+
+    expect(rulesClientParams.createAPIKey).toHaveBeenCalledTimes(2);
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    const scheduledIds = (taskManager.bulkSchedule.mock.calls[0][0] as Array<{ id: string }>).map(
+      (t) => t.id
+    );
+    expect(scheduledIds).toEqual(['mock-id-1', 'mock-id-2']);
+    // tasks are scheduled disabled; bulkEnable flips them on
+    expect(
+      (taskManager.bulkSchedule.mock.calls[0][0] as Array<{ enabled: boolean }>).every(
+        (t) => t.enabled === false
+      )
+    ).toBe(true);
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-1', 'mock-id-2']);
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+    expect(result.rules).toHaveLength(2);
+    expect(result.taskIdsFailedToBeEnabled).toEqual([]);
+  });
+
+  test('mixed enabled+disabled happy path', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }, { data: baseRule({ name: 'b' }) }],
+    });
+
+    expect(rulesClientParams.createAPIKey).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-1']);
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+  });
+
+  test('Phase 1 per-rule throw is isolated', async () => {
+    let calls = 0;
+    ruleTypeRegistry.get.mockImplementation((typeId: string) => {
+      calls += 1;
+      if (calls === 1) throw new Error('rule type not found');
+      return {
+        id: typeId,
+        name: 'Test',
+        actionGroups: [{ id: 'default', name: 'Default' }],
+        recoveryActionGroup: { id: 'recovered', name: 'Recovered' },
+        defaultActionGroupId: 'default',
+        minimumLicenseRequired: 'basic',
+        isExportable: true,
+        async executor() {
+          return { state: {} };
+        },
+        category: 'test',
+        producer: 'alerts',
+        solution: 'stack',
+        validate: { params: { validate: (p: unknown) => p } },
+        validLegacyConsumers: [],
+      } as never;
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'fails' }) }, { data: baseRule({ name: 'ok' }) }],
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('fails');
+    expect(result.rules).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+  });
+
+  test('Phase 2 schedule-limit trip: enabled keys invalidated, disabled subset still created', async () => {
+    (validateScheduleLimit as jest.Mock).mockResolvedValue({
+      interval: 100,
+      intervalAvailable: 50,
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    // The enabled rule contributed an API key → must be invalidated
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
+    // The disabled rule must still be persisted
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('enabled');
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('Phase 3 whole TM throw: enabled subset failed, disabled subset still created', async () => {
+    taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('enabled');
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('Phase 3 silent per-task drop: per-rule error pushed and rule dropped before SO write', async () => {
+    // Simulate task_store dropping one of the two scheduled tasks.
+    taskManager.bulkSchedule.mockImplementationOnce(async (tasks) => {
+      return [tasks[0]] as never;
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'kept', enabled: true }) },
+        { data: baseRule({ name: 'dropped', enabled: true }) },
+      ],
+    });
+
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('dropped');
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('Phase 4 per-row error on Phase-3-scheduled id: per-rule key invalidated, removeIfExists called', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1', error: { message: 'conflict', statusCode: 409 } }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'enabled', enabled: true }) }],
+    });
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+    // the only key in the call → only the failed rule's key
+    expect(taskManager.removeIfExists).toHaveBeenCalledWith('mock-id-1');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].status).toBe(409);
+    expect(result.rules).toHaveLength(0);
+  });
+
+  test('Phase 4 per-row error on caller-supplied id NOT in scheduledTaskIdsThisCall: NO removeIfExists', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'caller-id', error: { message: 'conflict', statusCode: 409 } }])
+    );
+
+    await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'disabled-collision' }), options: { id: 'caller-id' } }],
+    });
+
+    expect(taskManager.removeIfExists).not.toHaveBeenCalled();
+  });
+
+  test('Phase 4 whole-call throw: invalidates every newly-minted key and best-effort bulkRemove of scheduled ids, then rethrows', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockRejectedValueOnce(new Error('SO down'));
+
+    await expect(
+      rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'a', enabled: true }) },
+          { data: baseRule({ name: 'b', enabled: true }) },
+        ],
+      })
+    ).rejects.toThrow('SO down');
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkRemove).toHaveBeenCalledWith(['mock-id-1', 'mock-id-2']);
+  });
+
+  test('Phase 5 per-task enable error: surfaced in taskIdsFailedToBeEnabled, no SO rollback', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }])
+    );
+    taskManager.bulkEnable.mockResolvedValueOnce({
+      tasks: [],
+      errors: [{ id: 'mock-id-1', error: { type: 'foo', message: 'no' } }],
+    } as never);
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+    });
+
+    expect(result.taskIdsFailedToBeEnabled).toEqual(['mock-id-1']);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('emits per-rule CREATE audit event for surviving rules and ENABLE for the enabled subset', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    const actions = (auditLogger.log as jest.Mock).mock.calls
+      .map(([event]) => event?.event?.action)
+      .filter(Boolean);
+    expect(actions.filter((a) => a === RuleAuditAction.CREATE)).toHaveLength(2);
+    expect(actions.filter((a) => a === RuleAuditAction.ENABLE)).toHaveLength(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -373,7 +373,7 @@ describe('bulkCreateRules', () => {
     expect(result.rules).toHaveLength(0);
   });
 
-  test('Phase 4 per-row error on caller-supplied id NOT in scheduledTaskIdsThisCall: NO removeIfExists', async () => {
+  test('Phase 4 per-row error on caller-supplied id NOT in newlyScheduledTaskIds: NO removeIfExists', async () => {
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
       buildBulkResponse([{ id: 'caller-id', error: { message: 'conflict', statusCode: 409 } }])
     );

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -31,6 +31,8 @@ import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_a
 import { validateScheduleLimit } from '../get_schedule_frequency';
 import { RuleAuditAction } from '../../../../rules_client/common/audit_events';
 
+const BULK_CREATE_AS_DISABLED_PREFIX = 'Rule created in a disabled state: ';
+
 jest.mock('../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation', () => ({
   bulkMarkApiKeysForInvalidation: jest.fn(),
 }));
@@ -286,13 +288,58 @@ describe('bulkCreateRules', () => {
     expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
   });
 
-  test('Phase 2 schedule-limit trip: enabled keys invalidated, disabled subset still created', async () => {
+  test('Phase 1 API key creation failure: enabled rule degrades to disabled, no key minted, SO still written, no scheduling', async () => {
+    rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('keys disabled'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled-keyfail', enabled: true }) },
+        { data: baseRule({ name: 'enabled-ok', enabled: true }) },
+      ],
+    });
+
+    // Both rules persisted in a single SO bulkCreate. The first one is demoted
+    // to disabled because its key mint failed; the second is scheduled normally.
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    const persistedAttrsByName = new Map(
+      (
+        unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+          attributes: { name: string; enabled: boolean; apiKey: string | null };
+        }>
+      ).map((o) => [o.attributes.name, o.attributes])
+    );
+    expect(persistedAttrsByName.get('enabled-keyfail')?.enabled).toBe(false);
+    expect(persistedAttrsByName.get('enabled-keyfail')?.apiKey).toBeNull();
+    expect(persistedAttrsByName.get('enabled-ok')?.enabled).toBe(true);
+    // Only the surviving enabled rule was scheduled / enabled.
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-2']);
+    // No key mint succeeded for the demoted rule, so nothing to invalidate.
+    expect(bulkMarkApiKeysForInvalidation).not.toHaveBeenCalled();
+    expect(result.rules).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'api_key_creation_failed',
+        rule: expect.objectContaining({ name: 'enabled-keyfail' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
+    expect(result.errors[0].message).toContain('keys disabled');
+  });
+
+  test('Phase 2 schedule-limit trip: enabled rule degrades to disabled, key invalidated, SO still written for both', async () => {
     (validateScheduleLimit as jest.Mock).mockResolvedValue({
       interval: 100,
       intervalAvailable: 50,
     });
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-2' }])
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
     );
 
     const result = await rulesClient.bulkCreateRules({
@@ -304,19 +351,35 @@ describe('bulkCreateRules', () => {
 
     // The enabled rule contributed an API key → must be invalidated
     expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
-    // The disabled rule must still be persisted
+    // Both rules persisted in a single SO bulkCreate; the originally-enabled
+    // one is degraded to disabled (no scheduledTaskId, no API key fields).
     expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    const persistedAttrsByName = new Map(
+      (
+        unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+          attributes: { name: string; enabled: boolean; scheduledTaskId?: string | null };
+        }>
+      ).map((o) => [o.attributes.name, o.attributes])
+    );
+    expect(persistedAttrsByName.get('enabled')?.enabled).toBe(false);
+    expect(persistedAttrsByName.get('enabled')?.scheduledTaskId).toBeUndefined();
     expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(result.rules).toHaveLength(2);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].rule.name).toBe('enabled');
-    expect(result.rules).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'schedule_limit_exceeded',
+        rule: expect.objectContaining({ name: 'enabled' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
   });
 
-  test('Phase 3 whole TM throw: enabled subset failed, disabled subset still created', async () => {
+  test('Phase 3 whole TM throw: enabled subset degrades to disabled, disabled subset unaffected', async () => {
     taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-2' }])
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
     );
 
     const result = await rulesClient.bulkCreateRules({
@@ -328,19 +391,25 @@ describe('bulkCreateRules', () => {
 
     expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
     expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    expect(result.rules).toHaveLength(2);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].rule.name).toBe('enabled');
-    expect(result.rules).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'task_schedule_failed',
+        rule: expect.objectContaining({ name: 'enabled' }),
+      })
+    );
+    expect(result.errors[0].message).toContain('cluster unavailable');
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
   });
 
-  test('Phase 3 silent per-task drop: per-rule error pushed and rule dropped before SO write', async () => {
-    // Simulate task_store dropping one of the two scheduled tasks.
+  test('Phase 3 silent per-task drop: dropped rule degrades to disabled and SO is still written', async () => {
     taskManager.bulkSchedule.mockImplementationOnce(async (tasks) => {
       return [tasks[0]] as never;
     });
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }])
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
     );
 
     const result = await rulesClient.bulkCreateRules({
@@ -350,13 +419,19 @@ describe('bulkCreateRules', () => {
       ],
     });
 
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    expect(result.rules).toHaveLength(2);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].rule.name).toBe('dropped');
-    expect(result.rules).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'task_validation_failed',
+        rule: expect.objectContaining({ name: 'dropped' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
   });
 
-  test('Phase 4 per-row error on Phase-3-scheduled id: per-rule key invalidated, removeIfExists called', async () => {
+  test('Phase 4 per-row error on Phase-3-scheduled id: per-rule key invalidated, bulkRemove called', async () => {
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
       buildBulkResponse([{ id: 'mock-id-1', error: { message: 'conflict', statusCode: 409 } }])
     );
@@ -366,14 +441,16 @@ describe('bulkCreateRules', () => {
     });
 
     expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
-    // the only key in the call → only the failed rule's key
-    expect(taskManager.removeIfExists).toHaveBeenCalledWith('mock-id-1');
+    // Per-row error path now batches TM cleanup into a single bulkRemove.
+    expect(taskManager.bulkRemove).toHaveBeenCalledWith(['mock-id-1']);
+    expect(taskManager.removeIfExists).not.toHaveBeenCalled();
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].status).toBe(409);
+    expect(result.errors[0].disabledReason).toBeUndefined();
     expect(result.rules).toHaveLength(0);
   });
 
-  test('Phase 4 per-row error on caller-supplied id NOT in newlyScheduledTaskIds: NO removeIfExists', async () => {
+  test('Phase 4 per-row error on caller-supplied id NOT in newlyScheduledTaskIds: NO TM cleanup', async () => {
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
       buildBulkResponse([{ id: 'caller-id', error: { message: 'conflict', statusCode: 409 } }])
     );
@@ -383,6 +460,7 @@ describe('bulkCreateRules', () => {
     });
 
     expect(taskManager.removeIfExists).not.toHaveBeenCalled();
+    expect(taskManager.bulkRemove).not.toHaveBeenCalled();
   });
 
   test('Phase 4 whole-call throw: invalidates every newly-minted key and best-effort bulkRemove of scheduled ids, then rethrows', async () => {
@@ -416,6 +494,59 @@ describe('bulkCreateRules', () => {
 
     expect(result.taskIdsFailedToBeEnabled).toEqual(['mock-id-1']);
     expect(result.rules).toHaveLength(1);
+  });
+
+  test('every demotion path stamps a machine-readable disabledReason on the error', async () => {
+    // schedule_limit_exceeded
+    (validateScheduleLimit as jest.Mock).mockResolvedValueOnce({
+      interval: 100,
+      intervalAvailable: 50,
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-1' }])
+    );
+    const phase2 = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+    });
+    expect(phase2.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'schedule_limit_exceeded' })
+    );
+
+    // task_schedule_failed
+    taskManager.bulkSchedule.mockRejectedValueOnce(new Error('tm boom'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+    const phase3a = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'b', enabled: true }) }],
+    });
+    expect(phase3a.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'task_schedule_failed' })
+    );
+
+    // task_validation_failed (silent drop)
+    taskManager.bulkSchedule.mockImplementationOnce(async () => [] as never);
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-3' }])
+    );
+    const phase3b = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'c', enabled: true }) }],
+    });
+    expect(phase3b.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'task_validation_failed' })
+    );
+
+    // api_key_creation_failed
+    rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('no keys'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-4' }])
+    );
+    const phase1 = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'd', enabled: true }) }],
+    });
+    expect(phase1.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'api_key_creation_failed' })
+    );
   });
 
   test('emits per-rule CREATE audit event for surviving rules and ENABLE for the enabled subset', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -1,0 +1,614 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import Semver from 'semver';
+import pMap from 'p-map';
+import { withSpan } from '@kbn/apm-utils';
+import type {
+  SavedObject,
+  SavedObjectReference,
+  SavedObjectsBulkCreateObject,
+} from '@kbn/core/server';
+import { SavedObjectsUtils } from '@kbn/core/server';
+import type { TaskInstanceWithDeprecatedFields } from '@kbn/task-manager-plugin/server/task';
+
+import { validateAndAuthorizeSystemActions } from '../../../../lib/validate_authorize_system_actions';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { parseDuration, getRuleCircuitBreakerErrorMessage } from '../../../../../common';
+import { WriteOperations, AlertingAuthorizationEntity } from '../../../../authorization';
+import {
+  validateRuleTypeParams,
+  getRuleNotifyWhenType,
+  getDefaultMonitoringRuleDomainProperties,
+} from '../../../../lib';
+import { getRuleExecutionStatusPending } from '../../../../lib/rule_execution_status';
+import {
+  addGeneratedActionValues,
+  createNewAPIKeySet,
+  extractReferences,
+  updateMeta,
+  validateActions,
+} from '../../../../rules_client/lib';
+import { apiKeyAsRuleDomainProperties } from '../../../../rules_client/common';
+import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
+import { tryToEnableTasks } from '../bulk_enable/bulk_enable_rules';
+import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
+import { bulkCreateRulesSo } from '../../../../data/rule';
+import type { RawRule, RuleTypeRegistry, SanitizedRule } from '../../../../types';
+import type { IntervalSchedule } from '../../../../../common';
+import type { RulesClientContext, BulkOperationError } from '../../../../rules_client/types';
+import type { RuleDomain, RuleParams } from '../../types';
+import {
+  transformRuleAttributesToRuleDomain,
+  transformRuleDomainToRule,
+  transformRuleDomainToRuleAttributes,
+} from '../../transforms';
+import { ruleDomainSchema } from '../../schemas';
+import { createRuleDataSchema } from '../create/schemas';
+import { validateScheduleLimit } from '../get_schedule_frequency';
+import type { BulkCreateRulesItem, BulkCreateRulesParams, BulkCreateRulesResult } from './types';
+
+/**
+ * Bound the per-rule prepare phase to avoid overwhelming downstream services
+ * (security plugin API key minting, action validation).
+ */
+const PREPARE_CONCURRENCY = 10;
+
+interface PreparedRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  rawRule: RawRule;
+  references: SavedObjectReference[];
+  schedule: IntervalSchedule;
+  consumer: string;
+  ruleTypeId: string;
+}
+
+interface ApiKeyEntry {
+  apiKey: string | null;
+  uiamApiKey: string | null;
+  apiKeyCreatedByUser: boolean | null;
+}
+
+const collectNewKeysToInvalidate = (entries: Iterable<ApiKeyEntry>): string[] => {
+  const keys: string[] = [];
+  for (const { apiKey, uiamApiKey, apiKeyCreatedByUser } of entries) {
+    if (apiKey && !apiKeyCreatedByUser) keys.push(apiKey);
+    if (uiamApiKey && !apiKeyCreatedByUser) keys.push(uiamApiKey);
+  }
+  return keys;
+};
+
+const buildTaskInstance = (
+  context: RulesClientContext,
+  prepared: PreparedRule
+): TaskInstanceWithDeprecatedFields => ({
+  id: prepared.id,
+  taskType: `alerting:${prepared.ruleTypeId}`,
+  schedule: prepared.schedule,
+  params: {
+    alertId: prepared.id,
+    spaceId: context.spaceId,
+    consumer: prepared.consumer,
+  },
+  state: {
+    previousStartedAt: null,
+    alertTypeState: {},
+    alertInstances: {},
+  },
+  scope: ['alerting'],
+  // Tasks are scheduled disabled. Phase 5 enables them via taskManager.bulkEnable
+  // so per-task validation drops never produce a running task without a rule SO,
+  // and the activation can randomise schedule datetimes across the batch.
+  enabled: false,
+});
+
+export async function bulkCreateRules<Params extends RuleParams = never>(
+  context: RulesClientContext,
+  params: BulkCreateRulesParams<Params>
+): Promise<BulkCreateRulesResult<Params>> {
+  const { rules: inputs } = params;
+  const total = inputs.length;
+
+  if (total === 0) {
+    return { rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] };
+  }
+
+  const errors: BulkOperationError[] = [];
+  const username = await context.getUserName();
+  const actionsClient = await context.getActionsClient();
+
+  // Phase 0: assign ids up-front, partition by enabled flag (tracked per item id below).
+  const inputsWithIds = inputs.map((input) => ({
+    id: input.options?.id ?? SavedObjectsUtils.generateId(),
+    input,
+  }));
+
+  // Phase 1: per-rule prepare (per-pair authorization dedupe done first).
+  const authzCache = new Map<string, Promise<void>>();
+  const preparedRules = new Map<string, PreparedRule>();
+  const apiKeysMap = new Map<string, ApiKeyEntry>();
+
+  await pMap(
+    inputsWithIds,
+    async ({ id, input }) => {
+      const prepared = await prepareRule({
+        context,
+        actionsClient,
+        username,
+        id,
+        input,
+        authzCache,
+        errors,
+        apiKeysMap,
+      });
+      if (prepared) preparedRules.set(id, prepared);
+    },
+    { concurrency: PREPARE_CONCURRENCY }
+  );
+
+  // Phase 2: schedule-limit gate, scoped to the enabled subset only.
+  const enabledIds = [...preparedRules.values()].filter((p) => p.enabled).map((p) => p.id);
+
+  if (enabledIds.length > 0) {
+    const updatedInterval = enabledIds.map((id) => preparedRules.get(id)!.schedule.interval);
+    const validationPayload = await validateScheduleLimit({ context, updatedInterval });
+    if (validationPayload) {
+      const message = getRuleCircuitBreakerErrorMessage({
+        interval: validationPayload.interval,
+        intervalAvailable: validationPayload.intervalAvailable,
+        action: 'bulkCreate',
+        rules: enabledIds.length,
+      });
+      await dropEnabledSubset({
+        context,
+        enabledIds,
+        preparedRules,
+        apiKeysMap,
+        errors,
+        message,
+      });
+    }
+  }
+
+  // Phase 3: schedule tasks for the surviving enabled subset.
+  const survivingEnabledIds = [...preparedRules.values()].filter((p) => p.enabled).map((p) => p.id);
+  const scheduledTaskIdsThisCall = new Set<string>();
+
+  if (survivingEnabledIds.length > 0) {
+    const tasksToSchedule = survivingEnabledIds.map((id) =>
+      buildTaskInstance(context, preparedRules.get(id)!)
+    );
+
+    let scheduledIds: string[] = [];
+    try {
+      const scheduledTasks = await withSpan(
+        { name: 'taskManager.bulkSchedule', type: 'tasks' },
+        () => context.taskManager.bulkSchedule(tasksToSchedule)
+      );
+      scheduledIds = scheduledTasks.map((task) => task.id);
+    } catch (error) {
+      // Whole-call TM throw: fail enabled subset only, continue with disabled subset.
+      await dropEnabledSubset({
+        context,
+        enabledIds: survivingEnabledIds,
+        preparedRules,
+        apiKeysMap,
+        errors,
+        message: `Failed to schedule tasks: ${error.message}`,
+      });
+    }
+
+    if (scheduledIds.length > 0) {
+      scheduledIds.forEach((id) => scheduledTaskIdsThisCall.add(id));
+    }
+
+    // Silent per-task drops: bulkSchedule's `taskInstanceToAttributes` validation
+    // logs+skips invalid instances. Diff requested vs returned and surface them as
+    // per-rule errors so we don't write a rule SO whose scheduledTaskId is dangling.
+    if (preparedRules.size > 0 && scheduledIds.length < survivingEnabledIds.length) {
+      const returned = new Set(scheduledIds);
+      const dropped = survivingEnabledIds.filter((id) => !returned.has(id));
+      if (dropped.length > 0) {
+        await dropEnabledSubset({
+          context,
+          enabledIds: dropped,
+          preparedRules,
+          apiKeysMap,
+          errors,
+          message: 'Task scheduling silently dropped this rule (validation failure in task store)',
+        });
+      }
+    }
+  }
+
+  // No survivors at all: short-circuit before SO write.
+  if (preparedRules.size === 0) {
+    return { rules: [], errors, total, taskIdsFailedToBeEnabled: [] };
+  }
+
+  // Audit per-rule CREATE event before persistence (mirrors createRuleSavedObject).
+  for (const prepared of preparedRules.values()) {
+    context.auditLogger?.log(
+      ruleAuditEvent({
+        action: RuleAuditAction.CREATE,
+        outcome: 'unknown',
+        savedObject: { type: RULE_SAVED_OBJECT_TYPE, id: prepared.id, name: prepared.name },
+      })
+    );
+  }
+
+  // Phase 4: bulk SO create (no overwrite — id collisions surface as per-row 409).
+  const bulkObjects: Array<SavedObjectsBulkCreateObject<RawRule>> = [...preparedRules.values()].map(
+    (prepared) => ({
+      type: RULE_SAVED_OBJECT_TYPE,
+      id: prepared.id,
+      attributes: updateMeta(context, prepared.rawRule),
+      references: prepared.references,
+    })
+  );
+
+  let bulkResponse;
+  try {
+    bulkResponse = await withSpan(
+      { name: 'unsecuredSavedObjectsClient.bulkCreate', type: 'rules' },
+      () =>
+        bulkCreateRulesSo({
+          savedObjectsClient: context.unsecuredSavedObjectsClient,
+          bulkCreateRuleAttributes: bulkObjects,
+        })
+    );
+  } catch (error) {
+    // Whole-call SO throw: invalidate every newly-minted key, best-effort orphan-task
+    // cleanup scoped to ids we actually scheduled in Phase 3, then rethrow.
+    const keysToInvalidate = collectNewKeysToInvalidate(apiKeysMap.values());
+    if (keysToInvalidate.length > 0) {
+      await bulkMarkApiKeysForInvalidation(
+        { apiKeys: keysToInvalidate },
+        context.logger,
+        context.unsecuredSavedObjectsClient
+      );
+    }
+    if (scheduledTaskIdsThisCall.size > 0) {
+      try {
+        await context.taskManager.bulkRemove([...scheduledTaskIdsThisCall]);
+      } catch (cleanupError) {
+        context.logger.error(
+          `bulkCreateRules: failed to clean up tasks ${[...scheduledTaskIdsThisCall].join(
+            ', '
+          )} after SO bulkCreate threw: ${cleanupError.message}`
+        );
+      }
+    }
+    throw error;
+  }
+
+  // Phase 4 per-row outcomes.
+  const successfulSos: Array<SavedObject<RawRule>> = [];
+  const taskIdsToEnable: string[] = [];
+
+  for (const so of bulkResponse.saved_objects) {
+    if (so.error) {
+      errors.push({
+        message: so.error.message ?? 'n/a',
+        status: so.error.statusCode,
+        rule: { id: so.id, name: preparedRules.get(so.id)?.name ?? 'n/a' },
+      });
+
+      // Per-row API key invalidation (only the failed rule's key).
+      const apiKey = apiKeysMap.get(so.id);
+      if (apiKey) {
+        const keys = collectNewKeysToInvalidate([apiKey]);
+        if (keys.length > 0) {
+          await bulkMarkApiKeysForInvalidation(
+            { apiKeys: keys },
+            context.logger,
+            context.unsecuredSavedObjectsClient
+          );
+        }
+      }
+
+      // Best-effort orphan-task cleanup, but ONLY if this id was scheduled by us
+      // in Phase 3. Avoids nuking a pre-existing rule's task on a 409 caused by a
+      // caller-supplied id collision.
+      if (scheduledTaskIdsThisCall.has(so.id)) {
+        try {
+          await context.taskManager.removeIfExists(so.id);
+        } catch (cleanupError) {
+          context.logger.error(
+            `bulkCreateRules: failed to clean up task ${so.id} after SO per-row error: ${cleanupError.message}`
+          );
+        }
+      }
+      continue;
+    }
+
+    successfulSos.push(so as SavedObject<RawRule>);
+    if (scheduledTaskIdsThisCall.has(so.id)) {
+      taskIdsToEnable.push(so.id);
+      // Audit per-rule ENABLE for the enabled subset (mirrors single-rule semantics).
+      context.auditLogger?.log(
+        ruleAuditEvent({
+          action: RuleAuditAction.ENABLE,
+          outcome: 'unknown',
+          savedObject: {
+            type: RULE_SAVED_OBJECT_TYPE,
+            id: so.id,
+            name: preparedRules.get(so.id)?.name,
+          },
+        })
+      );
+    }
+  }
+
+  // Phase 5: enable tasks for successfully persisted enabled rules.
+  const taskIdsFailedToBeEnabled = await tryToEnableTasks({
+    taskIdsToEnable,
+    logger: context.logger,
+    taskManager: context.taskManager,
+  });
+
+  // Phase 6: domain transform + return.
+  const sanitizedRules: Array<SanitizedRule<Params>> = successfulSos.map((so) =>
+    toSanitizedRule<Params>(context, so, context.ruleTypeRegistry)
+  );
+
+  return {
+    rules: sanitizedRules,
+    errors,
+    total,
+    taskIdsFailedToBeEnabled,
+  };
+}
+
+const toSanitizedRule = <Params extends RuleParams = never>(
+  context: RulesClientContext,
+  so: SavedObject<RawRule>,
+  ruleTypeRegistry: RuleTypeRegistry
+): SanitizedRule<Params> => {
+  const ruleType = ruleTypeRegistry.get(so.attributes.alertTypeId);
+  const ruleDomain: RuleDomain<Params> = transformRuleAttributesToRuleDomain<Params>(
+    so.attributes,
+    {
+      id: so.id,
+      logger: context.logger,
+      ruleType,
+      references: so.references,
+      omitGeneratedValues: false,
+    },
+    context.isSystemAction
+  );
+
+  try {
+    ruleDomainSchema.validate(ruleDomain);
+  } catch (e) {
+    context.logger.warn(`Error validating bulk-created rule domain object for id: ${so.id}, ${e}`);
+  }
+
+  return transformRuleDomainToRule<Params>(ruleDomain, { isPublic: true }) as SanitizedRule<Params>;
+};
+
+interface PrepareRuleArgs<Params extends RuleParams> {
+  context: RulesClientContext;
+  actionsClient: Awaited<ReturnType<RulesClientContext['getActionsClient']>>;
+  username: string | null;
+  id: string;
+  input: BulkCreateRulesItem<Params>;
+  authzCache: Map<string, Promise<void>>;
+  errors: BulkOperationError[];
+  apiKeysMap: Map<string, ApiKeyEntry>;
+}
+
+const prepareRule = async <Params extends RuleParams>({
+  context,
+  actionsClient,
+  username,
+  id,
+  input,
+  authzCache,
+  errors,
+  apiKeysMap,
+}: PrepareRuleArgs<Params>): Promise<PreparedRule | null> => {
+  const { allowMissingConnectorSecrets } = input;
+
+  try {
+    const { actions: genActions, systemActions: genSystemActions } = await addGeneratedActionValues(
+      input.data.actions,
+      input.data.systemActions,
+      context
+    );
+    const data = { ...input.data, actions: genActions, systemActions: genSystemActions };
+
+    try {
+      createRuleDataSchema.validate(data);
+    } catch (validationError) {
+      throw Boom.badRequest(`Error validating create data - ${validationError.message}`);
+    }
+
+    // ruleTypeRegistry.get throws 400 if not registered.
+    context.ruleTypeRegistry.get(data.alertTypeId);
+
+    const authzKey = `${data.alertTypeId}::${data.consumer}`;
+    if (!authzCache.has(authzKey)) {
+      authzCache.set(
+        authzKey,
+        context.authorization.ensureAuthorized({
+          ruleTypeId: data.alertTypeId,
+          consumer: data.consumer,
+          operation: WriteOperations.Create,
+          entity: AlertingAuthorizationEntity.Rule,
+        })
+      );
+    }
+    try {
+      await authzCache.get(authzKey)!;
+    } catch (authzError) {
+      context.auditLogger?.log(
+        ruleAuditEvent({
+          action: RuleAuditAction.CREATE,
+          savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: data.name },
+          error: authzError,
+        })
+      );
+      throw authzError;
+    }
+
+    context.ruleTypeRegistry.ensureRuleTypeEnabled(data.alertTypeId);
+    const ruleType = context.ruleTypeRegistry.get(data.alertTypeId);
+    const validatedRuleTypeParams = validateRuleTypeParams(data.params, ruleType.validate.params);
+
+    await validateActions(context, ruleType, data, allowMissingConnectorSecrets);
+    await validateAndAuthorizeSystemActions({
+      actionsClient,
+      actionsAuthorization: context.actionsAuthorization,
+      connectorAdapterRegistry: context.connectorAdapterRegistry,
+      systemActions: data.systemActions ?? [],
+      rule: { consumer: data.consumer, producer: ruleType.producer },
+    });
+
+    const intervalInMs = parseDuration(data.schedule.interval);
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      context.minimumScheduleInterval.enforce
+    ) {
+      throw Boom.badRequest(
+        `Error creating rule: the interval is less than the allowed minimum interval of ${context.minimumScheduleInterval.value}`
+      );
+    }
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      !context.minimumScheduleInterval.enforce
+    ) {
+      context.logger.warn(
+        `Rule schedule interval (${data.schedule.interval}) for "${ruleType.id}" rule type with ID "${id}" is less than the minimum value (${context.minimumScheduleInterval.value}). Running rules at this interval may impact alerting performance. Set "xpack.alerting.rules.minimumScheduleInterval.enforce" to true to prevent creation of these rules.`
+      );
+    }
+
+    // Mint API key for enabled rules. createNewAPIKeySet returns the encoded
+    // `{ apiKey, apiKeyOwner, apiKeyCreatedByUser, uiamApiKey? }` shape suitable
+    // for direct use as rule attributes; for disabled rules we mirror createRule
+    // and use apiKeyAsRuleDomainProperties(null, ...) (all-null props).
+    const apiKeyProps = data.enabled
+      ? await createNewAPIKeySet(context, {
+          id: ruleType.id,
+          ruleName: data.name,
+          username,
+          shouldUpdateApiKey: true,
+          errorMessage: 'Error creating rule: could not create API key',
+        })
+      : apiKeyAsRuleDomainProperties(null, username, false);
+
+    if (data.enabled) {
+      apiKeysMap.set(id, {
+        apiKey: apiKeyProps.apiKey ?? null,
+        uiamApiKey: apiKeyProps.uiamApiKey ?? null,
+        apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
+      });
+    }
+
+    const allActions = [...data.actions, ...(data.systemActions ?? [])];
+    const artifacts = data.artifacts ?? {};
+    const {
+      references,
+      params: updatedParams,
+      actions: actionsWithRefs,
+      artifacts: artifactsWithRefs,
+    } = await extractReferences(context, ruleType, allActions, validatedRuleTypeParams, artifacts);
+
+    const createTime = Date.now();
+    const lastRunTimestamp = new Date();
+    const legacyId = Semver.lt(context.kibanaVersion, '8.0.0') ? id : null;
+    const notifyWhen = getRuleNotifyWhenType(data.notifyWhen ?? null, data.throttle ?? null);
+    const throttle = data.throttle ?? null;
+    const { systemActions: _sa, actions: _a, ...restData } = data;
+
+    const ruleAttributes = transformRuleDomainToRuleAttributes({
+      actionsWithRefs,
+      artifactsWithRefs,
+      rule: {
+        ...restData,
+        ...apiKeyProps,
+        id,
+        createdBy: username,
+        updatedBy: username,
+        createdAt: new Date(createTime),
+        updatedAt: new Date(createTime),
+        snoozeSchedule: [],
+        muteAll: false,
+        mutedInstanceIds: [],
+        notifyWhen,
+        throttle,
+        executionStatus: getRuleExecutionStatusPending(lastRunTimestamp.toISOString()),
+        monitoring: getDefaultMonitoringRuleDomainProperties(lastRunTimestamp.toISOString()),
+        revision: 0,
+        running: false,
+      } as unknown as RuleDomain<Params>,
+      params: { legacyId, paramsWithRefs: updatedParams },
+    });
+
+    if (data.enabled) {
+      ruleAttributes.lastEnabledAt = new Date(createTime).toISOString();
+      ruleAttributes.scheduledTaskId = id;
+    }
+
+    return {
+      id,
+      name: data.name,
+      enabled: data.enabled,
+      rawRule: ruleAttributes,
+      references,
+      schedule: data.schedule,
+      consumer: data.consumer,
+      ruleTypeId: data.alertTypeId,
+    };
+  } catch (error) {
+    errors.push({
+      message: error.message,
+      status: error.output?.statusCode,
+      rule: { id, name: input.data?.name ?? 'n/a' },
+    });
+    return null;
+  }
+};
+
+const dropEnabledSubset = async ({
+  context,
+  enabledIds,
+  preparedRules,
+  apiKeysMap,
+  errors,
+  message,
+}: {
+  context: RulesClientContext;
+  enabledIds: string[];
+  preparedRules: Map<string, PreparedRule>;
+  apiKeysMap: Map<string, ApiKeyEntry>;
+  errors: BulkOperationError[];
+  message: string;
+}) => {
+  const keysToInvalidate: string[] = [];
+  for (const id of enabledIds) {
+    const prepared = preparedRules.get(id);
+    if (!prepared) continue;
+    errors.push({ message, rule: { id, name: prepared.name } });
+    const apiKey = apiKeysMap.get(id);
+    if (apiKey) {
+      keysToInvalidate.push(...collectNewKeysToInvalidate([apiKey]));
+      apiKeysMap.delete(id);
+    }
+    preparedRules.delete(id);
+  }
+  if (keysToInvalidate.length > 0) {
+    await bulkMarkApiKeysForInvalidation(
+      { apiKeys: keysToInvalidate },
+      context.logger,
+      context.unsecuredSavedObjectsClient
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -8,6 +8,7 @@
 import Boom from '@hapi/boom';
 import Semver from 'semver';
 import pMap from 'p-map';
+import { i18n } from '@kbn/i18n';
 import { withSpan } from '@kbn/apm-utils';
 import type {
   SavedObject,
@@ -34,14 +35,17 @@ import {
   updateMeta,
   validateActions,
 } from '../../../../rules_client/lib';
-import { apiKeyAsRuleDomainProperties } from '../../../../rules_client/common';
+import {
+  apiKeyAsAlertAttributes,
+  apiKeyAsRuleDomainProperties,
+} from '../../../../rules_client/common';
 import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
 import { tryToEnableTasks } from '../bulk_enable/bulk_enable_rules';
 import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
 import { bulkCreateRulesSo } from '../../../../data/rule';
 import type { RawRule, RuleTypeRegistry, SanitizedRule } from '../../../../types';
 import type { IntervalSchedule } from '../../../../../common';
-import type { RulesClientContext, BulkOperationError } from '../../../../rules_client/types';
+import type { BulkOperationError, RulesClientContext } from '../../../../rules_client/types';
 import type { RuleDomain, RuleParams } from '../../types';
 import {
   transformRuleAttributesToRuleDomain,
@@ -51,13 +55,25 @@ import {
 import { ruleDomainSchema } from '../../schemas';
 import { createRuleDataSchema } from '../create/schemas';
 import { validateScheduleLimit } from '../get_schedule_frequency';
-import type { BulkCreateRulesItem, BulkCreateRulesParams, BulkCreateRulesResult } from './types';
+import type {
+  BulkCreateOperationError,
+  BulkCreateDisabledReason,
+  BulkCreateRulesItem,
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+} from './types';
 
 /**
  * Bound the per-rule prepare phase to avoid overwhelming downstream services
  * (security plugin API key minting, action validation).
  */
 const PREPARE_CONCURRENCY = 10;
+
+const getBulkCreateAsDisabledMessage = (message: string): string =>
+  i18n.translate('xpack.alerting.rulesClient.bulkCreate.ruleCreatedDisabledErrorMessage', {
+    defaultMessage: 'Rule created in a disabled state: {message}',
+    values: { message },
+  });
 
 interface PreparedRule {
   id: string;
@@ -114,6 +130,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   params: BulkCreateRulesParams<Params>
 ): Promise<BulkCreateRulesResult<Params>> {
   const { rules } = params;
+  const { logger } = context;
   const total = rules.length;
 
   if (total === 0) {
@@ -123,17 +140,20 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   const username = await context.getUserName();
   const actionsClient = await context.getActionsClient();
 
-  // Phase 0: assign ids up-front, partition by enabled flag (tracked per item id below).
   const inputsWithIds = rules.map((rule) => ({
     id: rule.options?.id ?? SavedObjectsUtils.generateId(),
     rule,
   }));
+
+  logger.debug(`Bulk creating batch of ${total} rules`);
 
   // Phase 1: per-rule prepare (per-pair authorization dedupe done first).
   const authzCache = new Map<string, Promise<void>>();
   const preparedRules = new Map<string, PreparedRule>();
   const errors: BulkOperationError[] = [];
   const apiKeysMap = new Map<string, ApiKeyEntry>();
+  // Key invalidation involves call to ES so we invalidate keys at the end to reduce round-trips.
+  const keysToInvalidate = new Set<string>();
 
   await pMap(
     inputsWithIds,
@@ -162,20 +182,22 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     const validationPayload = await validateScheduleLimit({ context, updatedInterval });
     const enabledIds = enabled.map((p) => p.id);
     if (validationPayload) {
-      const message = getRuleCircuitBreakerErrorMessage({
+      const reasonMessage = getRuleCircuitBreakerErrorMessage({
         interval: validationPayload.interval,
         intervalAvailable: validationPayload.intervalAvailable,
         action: 'bulkCreate',
         rules: enabledIds.length,
       });
-      // removes rules and invalidate keys
-      await dropEnabledSubset({
-        context,
-        enabledIds,
+      logger.warn(`Demoting ${enabledIds.length} rules -> disabled, schedule limit exceeded.`);
+      demotePreparedRules({
+        ids: enabledIds,
+        reason: 'schedule_limit_exceeded',
+        message: reasonMessage,
         preparedRules,
         apiKeysMap,
+        keysToInvalidate,
         errors,
-        message,
+        username,
       });
     }
   }
@@ -198,14 +220,19 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
       );
       scheduledIds = scheduledTasks.map((task) => task.id);
     } catch (error) {
-      // Whole-call TM throw: fail enabled subset only, continue with disabled subset.
-      await dropEnabledSubset({
-        context,
-        enabledIds: survivingEnabledIds,
+      // Whole-call TM throw: demote enabled subset to disabled, continue.
+      logger.warn(
+        `Demoting ${survivingEnabledIds.length} rules -> disabled, task scheduling failed.`
+      );
+      demotePreparedRules({
+        ids: survivingEnabledIds,
+        reason: 'task_schedule_failed',
+        message: `Failed to schedule tasks: ${error.message}`,
         preparedRules,
         apiKeysMap,
+        keysToInvalidate,
         errors,
-        message: `Failed to schedule tasks: ${error.message}`,
+        username,
       });
     }
 
@@ -214,26 +241,32 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
 
     // Silent per-task drops: bulkSchedule's `taskInstanceToAttributes` validation
-    // logs+skips invalid instances. Diff requested vs returned and surface them as
-    // per-rule errors so we don't write a rule SO whose scheduledTaskId is dangling.
+    // logs+skips invalid instances. Diff requested vs returned and demote the
+    // missing ones — re-enabling later will hit the same validation, but at
+    // least the rule definition isn't lost.
     if (preparedRules.size > 0 && scheduledIds.length < survivingEnabledIds.length) {
       const returned = new Set(scheduledIds);
       const dropped = survivingEnabledIds.filter((id) => !returned.has(id));
       if (dropped.length > 0) {
-        await dropEnabledSubset({
-          context,
-          enabledIds: dropped,
+        logger.warn(`Demoting ${dropped.length} rules -> disabled, task validation failed.`);
+        demotePreparedRules({
+          ids: dropped,
+          reason: 'task_validation_failed',
+          message: 'Task scheduling silently dropped this rule (validation failure in task store)',
           preparedRules,
           apiKeysMap,
+          keysToInvalidate,
           errors,
-          message: 'Task scheduling silently dropped this rule (validation failure in task store)',
+          username,
         });
       }
     }
   }
 
-  // No survivors at all: return before SO write.
+  // No survivors at all: still flush any pending key invalidations from
+  // Phase 1 demotions (no keys to flush in that case, but keep it explicit).
   if (preparedRules.size === 0) {
+    await flushKeysToInvalidate(keysToInvalidate, context);
     return { rules: [], errors, total, taskIdsFailedToBeEnabled: [] };
   }
 
@@ -269,23 +302,18 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         })
     );
   } catch (error) {
-    // Normally, `bulkResponse` will contain per-row errors, however certain issues
-    // (auth, timeout etc) will cause a whole-response error, in this case
-    // we invalidate every newly-minted key, and perform best-effort orphan-task
-    // cleanup scoped to ids we actually scheduled in Phase 3, then rethrow.
-    const keysToInvalidate = collectNewKeysToInvalidate(apiKeysMap.values());
-    if (keysToInvalidate.length > 0) {
-      await bulkMarkApiKeysForInvalidation(
-        { apiKeys: keysToInvalidate },
-        context.logger,
-        context.unsecuredSavedObjectsClient
-      );
-    }
+    // Whole-call SO failure (auth, timeout, etc): invalidate every newly-minted
+    // key (those tracked in `apiKeysMap`, plus anything previous phases queued
+    // into `keysToInvalidate`), best-effort orphan-task cleanup scoped to ids we
+    // actually scheduled in Phase 3, then rethrow. Inline flush — control flow
+    // never reaches the end-of-function flush.
+    for (const k of collectNewKeysToInvalidate(apiKeysMap.values())) keysToInvalidate.add(k);
+    await flushKeysToInvalidate(keysToInvalidate, context);
     if (newlyScheduledTaskIds.size > 0) {
       try {
         await context.taskManager.bulkRemove([...newlyScheduledTaskIds]);
       } catch (cleanupError) {
-        context.logger.error(
+        logger.error(
           `bulkCreateRules: failed to clean up tasks ${[...newlyScheduledTaskIds].join(
             ', '
           )} after SO bulkCreate threw: ${cleanupError.message}`
@@ -298,6 +326,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   // Phase 4 per-row outcomes.
   const successfulSos: Array<SavedObject<RawRule>> = [];
   const taskIdsToEnable: string[] = [];
+  const taskIdsToCleanUp: string[] = [];
 
   for (const so of bulkResponse.saved_objects) {
     if (so.error) {
@@ -307,30 +336,15 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         rule: { id: so.id, name: preparedRules.get(so.id)?.name ?? 'n/a' },
       });
 
-      // Per-row API key invalidation (only the failed rule's key).
       const apiKey = apiKeysMap.get(so.id);
       if (apiKey) {
-        const keys = collectNewKeysToInvalidate([apiKey]);
-        if (keys.length > 0) {
-          await bulkMarkApiKeysForInvalidation(
-            { apiKeys: keys },
-            context.logger,
-            context.unsecuredSavedObjectsClient
-          );
-        }
+        for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
       }
 
-      // Best-effort orphan-task cleanup, but ONLY if this id was scheduled by us
-      // in Phase 3. Avoids nuking a pre-existing rule's task on a 409 caused by a
-      // caller-supplied id collision.
+      // Only ids we scheduled in Phase 3. Skipping caller-supplied id collisions
+      // avoids nuking a pre-existing rule's task on a 409.
       if (newlyScheduledTaskIds.has(so.id)) {
-        try {
-          await context.taskManager.removeIfExists(so.id);
-        } catch (cleanupError) {
-          context.logger.error(
-            `bulkCreateRules: failed to clean up task ${so.id} after SO per-row error: ${cleanupError.message}`
-          );
-        }
+        taskIdsToCleanUp.push(so.id);
       }
     } else {
       successfulSos.push(so as SavedObject<RawRule>);
@@ -352,12 +366,29 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
   }
 
+  // Single batched TM cleanup for per-row failures.
+  if (taskIdsToCleanUp.length > 0) {
+    try {
+      logger.warn(`Cleaning up ${taskIdsToCleanUp.length} tasks where SO creation failed.`);
+      await context.taskManager.bulkRemove(taskIdsToCleanUp);
+    } catch (cleanupError) {
+      logger.error(
+        `bulkCreateRules: failed to clean up tasks ${taskIdsToCleanUp.join(
+          ', '
+        )} after SO per-row errors: ${cleanupError.message}`
+      );
+    }
+  }
+
   // Phase 5: enable tasks for successfully persisted enabled rules.
   const taskIdsFailedToBeEnabled = await tryToEnableTasks({
     taskIdsToEnable,
-    logger: context.logger,
+    logger,
     taskManager: context.taskManager,
   });
+
+  // Single end-of-function flush for all collected key invalidations.
+  await flushKeysToInvalidate(keysToInvalidate, context);
 
   // Phase 6: domain transform + return.
   const sanitizedRules: Array<SanitizedRule<Params>> = successfulSos.map((so) =>
@@ -368,7 +399,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     rules: sanitizedRules,
     errors,
     total,
-    taskIdsFailedToBeEnabled,
+    taskIdsFailedToBeEnabled, // <-- same as bulkEnableRules().
   };
 }
 
@@ -406,7 +437,7 @@ interface PrepareRuleArgs<Params extends RuleParams> {
   id: string;
   rule: BulkCreateRulesItem<Params>;
   authzCache: Map<string, Promise<void>>;
-  errors: BulkOperationError[];
+  errors: BulkCreateOperationError[];
   apiKeysMap: Map<string, ApiKeyEntry>;
 }
 
@@ -495,26 +526,42 @@ const prepareRule = async <Params extends RuleParams>({
       );
     }
 
-    // Mint API key for enabled rules. createNewAPIKeySet returns the encoded
-    // `{ apiKey, apiKeyOwner, apiKeyCreatedByUser, uiamApiKey? }` shape suitable
-    // for direct use as rule attributes; for disabled rules we mirror createRule
-    // and use apiKeyAsRuleDomainProperties(null, ...) (all-null props).
-    const apiKeyProps = data.enabled
-      ? await createNewAPIKeySet(context, {
+    // Mint API key for enabled rules.
+    // Soft-fail: a key-mint failure does NOT reject the rule. We persist it as
+    // disabled, push a degraded error so the caller knows, and let downstream
+    // phases treat it as a never-enabled rule. Re-enabling later will re-mint.
+    let effectiveEnabled = data.enabled;
+    let apiKeyProps:
+      | ReturnType<typeof apiKeyAsRuleDomainProperties>
+      | Awaited<ReturnType<typeof createNewAPIKeySet>> = apiKeyAsRuleDomainProperties(
+      null,
+      username,
+      false
+    );
+    if (data.enabled) {
+      try {
+        apiKeyProps = await createNewAPIKeySet(context, {
           id: ruleType.id,
           ruleName: data.name,
           username,
           shouldUpdateApiKey: true,
           errorMessage: 'Error creating rule: could not create API key',
-        })
-      : apiKeyAsRuleDomainProperties(null, username, false);
-
-    if (data.enabled) {
-      apiKeysMap.set(id, {
-        apiKey: apiKeyProps.apiKey ?? null,
-        uiamApiKey: apiKeyProps.uiamApiKey ?? null,
-        apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
-      });
+        });
+        apiKeysMap.set(id, {
+          apiKey: apiKeyProps.apiKey ?? null,
+          uiamApiKey: apiKeyProps.uiamApiKey ?? null,
+          apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
+        });
+      } catch (apiKeyErr) {
+        effectiveEnabled = false;
+        apiKeyProps = apiKeyAsRuleDomainProperties(null, username, false);
+        errors.push({
+          message: getBulkCreateAsDisabledMessage(apiKeyErr.message),
+          status: apiKeyErr.output?.statusCode,
+          rule: { id, name: data.name },
+          disabledReason: 'api_key_creation_failed',
+        });
+      }
     }
 
     const allActions = [...data.actions, ...(data.systemActions ?? [])];
@@ -539,6 +586,7 @@ const prepareRule = async <Params extends RuleParams>({
       rule: {
         ...restData,
         ...apiKeyProps,
+        enabled: effectiveEnabled,
         id,
         createdBy: username,
         updatedBy: username,
@@ -557,7 +605,7 @@ const prepareRule = async <Params extends RuleParams>({
       params: { legacyId, paramsWithRefs: updatedParams },
     });
 
-    if (data.enabled) {
+    if (effectiveEnabled) {
       ruleAttributes.lastEnabledAt = new Date(createTime).toISOString();
       ruleAttributes.scheduledTaskId = id;
     }
@@ -565,7 +613,7 @@ const prepareRule = async <Params extends RuleParams>({
     const prepared = {
       id,
       name: data.name,
-      enabled: data.enabled,
+      enabled: effectiveEnabled,
       rawRule: ruleAttributes,
       references,
       schedule: data.schedule,
@@ -583,39 +631,69 @@ const prepareRule = async <Params extends RuleParams>({
   }
 };
 
-const dropEnabledSubset = async ({
-  context,
-  enabledIds,
+/**
+ * Demote in-memory (enabled -> disabled): flips a set of currently-enabled
+ * prepared rules to disabled, queues their API keys for invalidation, records a degraded
+ * error so the caller can surface "rule was created in a disabled state".
+ */
+const demotePreparedRules = ({
+  ids,
+  reason,
+  message,
   preparedRules,
   apiKeysMap,
+  keysToInvalidate,
   errors,
-  message,
+  username,
 }: {
-  context: RulesClientContext;
-  enabledIds: string[];
+  ids: string[];
+  reason: BulkCreateDisabledReason;
+  message: string;
   preparedRules: Map<string, PreparedRule>;
   apiKeysMap: Map<string, ApiKeyEntry>;
-  errors: BulkOperationError[];
-  message: string;
-}) => {
-  const keysToInvalidate: string[] = [];
-  for (const id of enabledIds) {
+  keysToInvalidate: Set<string>;
+  errors: BulkCreateOperationError[];
+  username: string | null;
+}): void => {
+  for (const id of ids) {
     const prepared = preparedRules.get(id);
-    if (prepared) {
-      errors.push({ message, rule: { id, name: prepared.name } });
-      const apiKey = apiKeysMap.get(id);
-      if (apiKey) {
-        keysToInvalidate.push(...collectNewKeysToInvalidate([apiKey]));
-        apiKeysMap.delete(id);
-      }
-      preparedRules.delete(id);
+    if (!prepared || !prepared.enabled) continue;
+
+    const apiKey = apiKeysMap.get(id);
+    if (apiKey) {
+      for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
+      apiKeysMap.delete(id);
     }
+
+    // Re-shape `rawRule` to the disabled-rule form.
+    const nullKey = apiKeyAsAlertAttributes(null, username, false);
+    prepared.rawRule = {
+      ...prepared.rawRule,
+      ...nullKey,
+      uiamApiKey: null,
+      enabled: false,
+    };
+    delete prepared.rawRule.scheduledTaskId;
+    delete prepared.rawRule.lastEnabledAt;
+    prepared.enabled = false;
+
+    errors.push({
+      message: getBulkCreateAsDisabledMessage(message),
+      rule: { id, name: prepared.name },
+      disabledReason: reason,
+    });
   }
-  if (keysToInvalidate.length > 0) {
-    await bulkMarkApiKeysForInvalidation(
-      { apiKeys: keysToInvalidate },
-      context.logger,
-      context.unsecuredSavedObjectsClient
-    );
-  }
+};
+
+const flushKeysToInvalidate = async (
+  keysToInvalidate: Set<string>,
+  context: RulesClientContext
+): Promise<void> => {
+  if (keysToInvalidate.size === 0) return;
+  await bulkMarkApiKeysForInvalidation(
+    { apiKeys: [...keysToInvalidate] },
+    context.logger,
+    context.unsecuredSavedObjectsClient
+  );
+  keysToInvalidate.clear();
 };

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -113,52 +113,54 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   context: RulesClientContext,
   params: BulkCreateRulesParams<Params>
 ): Promise<BulkCreateRulesResult<Params>> {
-  const { rules: inputs } = params;
-  const total = inputs.length;
+  const { rules } = params;
+  const total = rules.length;
 
   if (total === 0) {
     return { rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] };
   }
 
-  const errors: BulkOperationError[] = [];
   const username = await context.getUserName();
   const actionsClient = await context.getActionsClient();
 
   // Phase 0: assign ids up-front, partition by enabled flag (tracked per item id below).
-  const inputsWithIds = inputs.map((input) => ({
-    id: input.options?.id ?? SavedObjectsUtils.generateId(),
-    input,
+  const inputsWithIds = rules.map((rule) => ({
+    id: rule.options?.id ?? SavedObjectsUtils.generateId(),
+    rule,
   }));
 
   // Phase 1: per-rule prepare (per-pair authorization dedupe done first).
   const authzCache = new Map<string, Promise<void>>();
   const preparedRules = new Map<string, PreparedRule>();
+  const errors: BulkOperationError[] = [];
   const apiKeysMap = new Map<string, ApiKeyEntry>();
 
   await pMap(
     inputsWithIds,
-    async ({ id, input }) => {
-      const prepared = await prepareRule({
+    async ({ id, rule }) => {
+      const { prepared, error } = await prepareRule({
         context,
         actionsClient,
         username,
         id,
-        input,
+        rule,
         authzCache,
         errors,
         apiKeysMap,
       });
       if (prepared) preparedRules.set(id, prepared);
+      else if (error) errors.push(error);
     },
     { concurrency: PREPARE_CONCURRENCY }
   );
 
-  // Phase 2: schedule-limit gate, scoped to the enabled subset only.
-  const enabledIds = [...preparedRules.values()].filter((p) => p.enabled).map((p) => p.id);
+  // Phase 2: validate schedule-limits, enabled subset only.
+  const enabled = [...preparedRules.values()].filter((p) => p.enabled);
 
-  if (enabledIds.length > 0) {
-    const updatedInterval = enabledIds.map((id) => preparedRules.get(id)!.schedule.interval);
+  if (enabled.length > 0) {
+    const updatedInterval = enabled.map((r) => r.schedule.interval);
     const validationPayload = await validateScheduleLimit({ context, updatedInterval });
+    const enabledIds = enabled.map((p) => p.id);
     if (validationPayload) {
       const message = getRuleCircuitBreakerErrorMessage({
         interval: validationPayload.interval,
@@ -166,6 +168,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         action: 'bulkCreate',
         rules: enabledIds.length,
       });
+      // removes rules and invalidate keys
       await dropEnabledSubset({
         context,
         enabledIds,
@@ -178,15 +181,16 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   }
 
   // Phase 3: schedule tasks for the surviving enabled subset.
-  const survivingEnabledIds = [...preparedRules.values()].filter((p) => p.enabled).map((p) => p.id);
-  const scheduledTaskIdsThisCall = new Set<string>();
+  const survivingEnabled = [...preparedRules.values()].filter((p) => p.enabled);
+  const newlyScheduledTaskIds = new Set<string>();
 
-  if (survivingEnabledIds.length > 0) {
-    const tasksToSchedule = survivingEnabledIds.map((id) =>
-      buildTaskInstance(context, preparedRules.get(id)!)
+  if (survivingEnabled.length > 0) {
+    const tasksToSchedule = survivingEnabled.map((preparedRule) =>
+      buildTaskInstance(context, preparedRule)
     );
 
     let scheduledIds: string[] = [];
+    const survivingEnabledIds = survivingEnabled.map((p) => p.id);
     try {
       const scheduledTasks = await withSpan(
         { name: 'taskManager.bulkSchedule', type: 'tasks' },
@@ -206,7 +210,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
 
     if (scheduledIds.length > 0) {
-      scheduledIds.forEach((id) => scheduledTaskIdsThisCall.add(id));
+      scheduledIds.forEach((id) => newlyScheduledTaskIds.add(id));
     }
 
     // Silent per-task drops: bulkSchedule's `taskInstanceToAttributes` validation
@@ -228,7 +232,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
   }
 
-  // No survivors at all: short-circuit before SO write.
+  // No survivors at all: return before SO write.
   if (preparedRules.size === 0) {
     return { rules: [], errors, total, taskIdsFailedToBeEnabled: [] };
   }
@@ -244,7 +248,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     );
   }
 
-  // Phase 4: bulk SO create (no overwrite — id collisions surface as per-row 409).
+  // Phase 4: bulk SO create (no overwrite — id collisions surface as per-row 409)
   const bulkObjects: Array<SavedObjectsBulkCreateObject<RawRule>> = [...preparedRules.values()].map(
     (prepared) => ({
       type: RULE_SAVED_OBJECT_TYPE,
@@ -265,7 +269,9 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         })
     );
   } catch (error) {
-    // Whole-call SO throw: invalidate every newly-minted key, best-effort orphan-task
+    // Normally, `bulkResponse` will contain per-row errors, however certain issues
+    // (auth, timeout etc) will cause a whole-response error, in this case
+    // we invalidate every newly-minted key, and perform best-effort orphan-task
     // cleanup scoped to ids we actually scheduled in Phase 3, then rethrow.
     const keysToInvalidate = collectNewKeysToInvalidate(apiKeysMap.values());
     if (keysToInvalidate.length > 0) {
@@ -275,12 +281,12 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         context.unsecuredSavedObjectsClient
       );
     }
-    if (scheduledTaskIdsThisCall.size > 0) {
+    if (newlyScheduledTaskIds.size > 0) {
       try {
-        await context.taskManager.bulkRemove([...scheduledTaskIdsThisCall]);
+        await context.taskManager.bulkRemove([...newlyScheduledTaskIds]);
       } catch (cleanupError) {
         context.logger.error(
-          `bulkCreateRules: failed to clean up tasks ${[...scheduledTaskIdsThisCall].join(
+          `bulkCreateRules: failed to clean up tasks ${[...newlyScheduledTaskIds].join(
             ', '
           )} after SO bulkCreate threw: ${cleanupError.message}`
         );
@@ -317,7 +323,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
       // Best-effort orphan-task cleanup, but ONLY if this id was scheduled by us
       // in Phase 3. Avoids nuking a pre-existing rule's task on a 409 caused by a
       // caller-supplied id collision.
-      if (scheduledTaskIdsThisCall.has(so.id)) {
+      if (newlyScheduledTaskIds.has(so.id)) {
         try {
           await context.taskManager.removeIfExists(so.id);
         } catch (cleanupError) {
@@ -326,24 +332,23 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
           );
         }
       }
-      continue;
-    }
-
-    successfulSos.push(so as SavedObject<RawRule>);
-    if (scheduledTaskIdsThisCall.has(so.id)) {
-      taskIdsToEnable.push(so.id);
-      // Audit per-rule ENABLE for the enabled subset (mirrors single-rule semantics).
-      context.auditLogger?.log(
-        ruleAuditEvent({
-          action: RuleAuditAction.ENABLE,
-          outcome: 'unknown',
-          savedObject: {
-            type: RULE_SAVED_OBJECT_TYPE,
-            id: so.id,
-            name: preparedRules.get(so.id)?.name,
-          },
-        })
-      );
+    } else {
+      successfulSos.push(so as SavedObject<RawRule>);
+      if (newlyScheduledTaskIds.has(so.id)) {
+        taskIdsToEnable.push(so.id);
+        // Audit per-rule ENABLE for the enabled subset (mirrors single-rule semantics).
+        context.auditLogger?.log(
+          ruleAuditEvent({
+            action: RuleAuditAction.ENABLE,
+            outcome: 'unknown',
+            savedObject: {
+              type: RULE_SAVED_OBJECT_TYPE,
+              id: so.id,
+              name: preparedRules.get(so.id)?.name,
+            },
+          })
+        );
+      }
     }
   }
 
@@ -399,7 +404,7 @@ interface PrepareRuleArgs<Params extends RuleParams> {
   actionsClient: Awaited<ReturnType<RulesClientContext['getActionsClient']>>;
   username: string | null;
   id: string;
-  input: BulkCreateRulesItem<Params>;
+  rule: BulkCreateRulesItem<Params>;
   authzCache: Map<string, Promise<void>>;
   errors: BulkOperationError[];
   apiKeysMap: Map<string, ApiKeyEntry>;
@@ -410,20 +415,20 @@ const prepareRule = async <Params extends RuleParams>({
   actionsClient,
   username,
   id,
-  input,
+  rule,
   authzCache,
   errors,
   apiKeysMap,
-}: PrepareRuleArgs<Params>): Promise<PreparedRule | null> => {
-  const { allowMissingConnectorSecrets } = input;
+}: PrepareRuleArgs<Params>): Promise<{ prepared?: PreparedRule; error?: BulkOperationError }> => {
+  const { allowMissingConnectorSecrets } = rule;
 
   try {
     const { actions: genActions, systemActions: genSystemActions } = await addGeneratedActionValues(
-      input.data.actions,
-      input.data.systemActions,
+      rule.data.actions,
+      rule.data.systemActions,
       context
     );
-    const data = { ...input.data, actions: genActions, systemActions: genSystemActions };
+    const data = { ...rule.data, actions: genActions, systemActions: genSystemActions };
 
     try {
       createRuleDataSchema.validate(data);
@@ -557,7 +562,7 @@ const prepareRule = async <Params extends RuleParams>({
       ruleAttributes.scheduledTaskId = id;
     }
 
-    return {
+    const prepared = {
       id,
       name: data.name,
       enabled: data.enabled,
@@ -567,13 +572,14 @@ const prepareRule = async <Params extends RuleParams>({
       consumer: data.consumer,
       ruleTypeId: data.alertTypeId,
     };
-  } catch (error) {
-    errors.push({
-      message: error.message,
-      status: error.output?.statusCode,
-      rule: { id, name: input.data?.name ?? 'n/a' },
-    });
-    return null;
+    return { prepared };
+  } catch (err) {
+    const error = {
+      message: err.message,
+      status: err.output?.statusCode,
+      rule: { id, name: rule.data?.name ?? 'n/a' },
+    };
+    return { error };
   }
 };
 
@@ -595,14 +601,15 @@ const dropEnabledSubset = async ({
   const keysToInvalidate: string[] = [];
   for (const id of enabledIds) {
     const prepared = preparedRules.get(id);
-    if (!prepared) continue;
-    errors.push({ message, rule: { id, name: prepared.name } });
-    const apiKey = apiKeysMap.get(id);
-    if (apiKey) {
-      keysToInvalidate.push(...collectNewKeysToInvalidate([apiKey]));
-      apiKeysMap.delete(id);
+    if (prepared) {
+      errors.push({ message, rule: { id, name: prepared.name } });
+      const apiKey = apiKeysMap.get(id);
+      if (apiKey) {
+        keysToInvalidate.push(...collectNewKeysToInvalidate([apiKey]));
+        apiKeysMap.delete(id);
+      }
+      preparedRules.delete(id);
     }
-    preparedRules.delete(id);
   }
   if (keysToInvalidate.length > 0) {
     await bulkMarkApiKeysForInvalidation(

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -39,6 +39,7 @@ import {
   apiKeyAsAlertAttributes,
   apiKeyAsRuleDomainProperties,
 } from '../../../../rules_client/common';
+import { API_KEY_GENERATE_CONCURRENCY } from '../../../../rules_client/common/constants';
 import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
 import { tryToEnableTasks } from '../bulk_enable/bulk_enable_rules';
 import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
@@ -62,12 +63,6 @@ import type {
   BulkCreateRulesParams,
   BulkCreateRulesResult,
 } from './types';
-
-/**
- * Bound the per-rule prepare phase to avoid overwhelming downstream services
- * (security plugin API key minting, action validation).
- */
-const PREPARE_CONCURRENCY = 10;
 
 const getBulkCreateAsDisabledMessage = (message: string): string =>
   i18n.translate('xpack.alerting.rulesClient.bulkCreate.ruleCreatedDisabledErrorMessage', {
@@ -171,7 +166,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
       if (prepared) preparedRules.set(id, prepared);
       else if (error) errors.push(error);
     },
-    { concurrency: PREPARE_CONCURRENCY }
+    { concurrency: API_KEY_GENERATE_CONCURRENCY }
   );
 
   // Phase 2: validate schedule-limits, enabled subset only.

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { BulkCreateRulesItem, BulkCreateRulesParams, BulkCreateRulesResult } from './types';
+export { bulkCreateRules } from './bulk_create_rules';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SanitizedRule } from '../../../../types';
+import type { RuleParams } from '../../types';
+import type { CreateRuleData } from '../create/types';
+import type { CreateRuleOptions } from '../create/create_rule';
+import type { BulkOperationError } from '../../../../rules_client/types';
+
+export interface BulkCreateRulesItem<Params extends RuleParams = never> {
+  data: CreateRuleData<Params>;
+  options?: CreateRuleOptions;
+  allowMissingConnectorSecrets?: boolean;
+}
+
+export interface BulkCreateRulesParams<Params extends RuleParams = never> {
+  rules: Array<BulkCreateRulesItem<Params>>;
+}
+
+export interface BulkCreateRulesResult<Params extends RuleParams = never> {
+  rules: Array<SanitizedRule<Params>>;
+  errors: BulkOperationError[];
+  total: number;
+  taskIdsFailedToBeEnabled: string[];
+}

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -21,9 +21,22 @@ export interface BulkCreateRulesParams<Params extends RuleParams = never> {
   rules: Array<BulkCreateRulesItem<Params>>;
 }
 
+/**
+ * Lets callers branch on *why* a rule was created as disabled.
+ */
+export type BulkCreateDisabledReason =
+  | 'api_key_creation_failed'
+  | 'schedule_limit_exceeded'
+  | 'task_schedule_failed'
+  | 'task_validation_failed';
+
+export interface BulkCreateOperationError extends BulkOperationError {
+  disabledReason?: BulkCreateDisabledReason;
+}
+
 export interface BulkCreateRulesResult<Params extends RuleParams = never> {
   rules: Array<SanitizedRule<Params>>;
-  errors: BulkOperationError[];
+  errors: BulkCreateOperationError[];
   total: number;
   taskIdsFailedToBeEnabled: string[];
 }

--- a/x-pack/platform/plugins/shared/alerting/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/index.ts
@@ -39,6 +39,11 @@ export { RULE_SAVED_OBJECT_TYPE, API_KEY_PENDING_INVALIDATION_TYPE } from './sav
 export { RuleNotifyWhen } from '../common';
 export type { AlertingServerSetup, AlertingServerStart } from './plugin';
 export type { FindResult, BulkEditOperation, BulkOperationError } from './rules_client';
+export type {
+  BulkCreateRulesItem,
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+} from './application/rule/methods/bulk_create';
 export type { Rule } from './application/rule/types';
 export type { PublicAlert as Alert } from './alert';
 export { parseDuration, isRuleSnoozed } from './lib';

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
@@ -52,6 +52,9 @@ const createRulesClientMock = () => {
     bulkGetRules: jest.fn(),
     bulkEdit: jest.fn(),
     bulkEditRuleParamsWithReadAuth: jest.fn(),
+    bulkCreateRules: jest
+      .fn()
+      .mockResolvedValue({ rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] }),
     bulkDeleteRules: jest.fn(),
     bulkEnableRules: jest.fn(),
     bulkDisableRules: jest.fn(),

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
@@ -60,6 +60,8 @@ import type { BulkEditRuleParamsOptions } from '../application/rule/methods/bulk
 import { bulkEditRuleParamsWithReadAuth } from '../application/rule/methods/bulk_edit_params/bulk_edit_rule_params';
 import type { BulkEnableRulesParams } from '../application/rule/methods/bulk_enable';
 import { bulkEnableRules } from '../application/rule/methods/bulk_enable';
+import type { BulkCreateRulesParams } from '../application/rule/methods/bulk_create';
+import { bulkCreateRules } from '../application/rule/methods/bulk_create';
 import { enableRule } from '../application/rule/methods/enable_rule/enable_rule';
 import { updateRuleApiKey } from '../application/rule/methods/update_api_key/update_rule_api_key';
 import { disableRule } from '../application/rule/methods/disable/disable_rule';
@@ -200,6 +202,9 @@ export class RulesClient {
 
   public bulkGetRules = <Params extends RuleTypeParams = never>(params: BulkGetRulesParams) =>
     bulkGetRules<Params>(this.context, params);
+  public bulkCreateRules = <Params extends RuleTypeParams = never>(
+    params: BulkCreateRulesParams<Params>
+  ) => bulkCreateRules<Params>(this.context, params);
   public bulkDeleteRules = (options: BulkDeleteRulesRequestBody) =>
     bulkDeleteRules(this.context, options);
   public bulkEdit = <Params extends RuleTypeParams>(options: BulkEditOptions<Params>) =>

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -23,6 +23,16 @@ export const allowedExperimentalValues = Object.freeze({
   previewTelemetryUrlEnabled: false,
 
   /**
+   * When enabled, prebuilt rule installation (POST .../prebuilt_rules/installation/_perform)
+   * and rule import (POST .../rules/_import) use the new alerting `rulesClient.bulkCreateRules`
+   * path, which handles both disabled and enabled rules (API key minting + task scheduling)
+   * in a single bulk call instead of the per-rule create loop.
+   *
+   * Release: TBD
+   */
+  bulkCreateRulesEnabled: false,
+
+  /**
    * Enables extended rule execution logging to Event Log. When this setting is enabled:
    * - Rules write their console error, info, debug, and trace messages to Event Log,
    *   in addition to other events they log there (status changes and execution metrics).

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
@@ -110,16 +110,15 @@ export const performRuleInstallationHandler = async (
       ruleInstallQueue.push(...(await excludeLicenseRestrictedRules(allInstallableRules, mlAuthz)));
     }
 
+    const { bulkCreateRulesEnabled } = ctx.securitySolution.getConfig().experimentalFeatures;
     const BATCH_SIZE = 100;
     while (ruleInstallQueue.length > 0) {
       const rulesToInstall = ruleInstallQueue.splice(0, BATCH_SIZE);
       const ruleAssets = await ruleAssetsClient.fetchAssetsByVersion(rulesToInstall);
 
-      const { results, errors } = await createPrebuiltRules(
-        detectionRulesClient,
-        ruleAssets,
-        logger
-      );
+      const { results, errors } = bulkCreateRulesEnabled
+        ? await detectionRulesClient.bulkCreatePrebuiltRules({ rules: ruleAssets })
+        : await createPrebuiltRules(detectionRulesClient, ruleAssets, logger);
 
       const batchInstalledRules = results.map(({ result: rule }) =>
         pick(rule, ['id', 'rule_id', 'version'])

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -189,12 +189,15 @@ export const importRulesRoute = (
 
           const ruleChunks = chunk(CHUNK_PARSED_OBJECT_SIZE, validatedResponseActionsRules);
 
+          const experimentalFeatures = ctx.securitySolution.getConfig().experimentalFeatures;
+
           const importRuleResponse = await importRules({
             ruleChunks,
             overwriteRules: request.query.overwrite,
             allowMissingConnectorSecrets: !!actionConnectors.length,
             ruleSourceImporter,
             detectionRulesClient,
+            experimentalFeatures,
           });
 
           const parseErrors = parsedRuleErrors.map((error) =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
@@ -13,6 +13,7 @@ const createDetectionRulesClientMock = () => {
   const mocked: DetectionRulesClientMock = {
     createCustomRule: jest.fn(),
     createPrebuiltRule: jest.fn(),
+    bulkCreatePrebuiltRules: jest.fn().mockResolvedValue({ results: [], errors: [] }),
     updateRule: jest.fn(),
     patchRule: jest.fn(),
     deleteRule: jest.fn(),
@@ -21,6 +22,7 @@ const createDetectionRulesClientMock = () => {
     revertPrebuiltRule: jest.fn(),
     importRule: jest.fn(),
     importRules: jest.fn(),
+    bulkImportRules: jest.fn().mockResolvedValue([]),
     getRuleCustomizationStatus: jest.fn(),
   };
   return mocked;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_create_prebuilt_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_create_prebuilt_rules.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rulesClientMock } from '@kbn/alerting-plugin/server/mocks';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { licenseMock } from '@kbn/licensing-plugin/common/licensing.mock';
+
+import { getCreateRulesSchemaMock } from '../../../../../../common/api/detection_engine/model/rule_schema/mocks';
+import { getRuleMock } from '../../../routes/__mocks__/request_responses';
+import { getQueryRuleParams } from '../../../rule_schema/mocks';
+import { buildMlAuthz } from '../../../../machine_learning/authz';
+import { throwAuthzError } from '../../../../machine_learning/validation';
+import { createDetectionRulesClient } from './detection_rules_client';
+import type { IDetectionRulesClient } from './detection_rules_client_interface';
+import { createProductFeaturesServiceMock } from '../../../../product_features_service/mocks';
+import { getMockRulesAuthz } from '../../__mocks__/authz';
+
+jest.mock('../../../../machine_learning/authz');
+jest.mock('../../../../machine_learning/validation');
+
+describe('DetectionRulesClient.bulkCreatePrebuiltRules', () => {
+  let rulesClient: ReturnType<typeof rulesClientMock.create>;
+  let detectionRulesClient: IDetectionRulesClient;
+
+  const mlAuthz = (buildMlAuthz as jest.Mock)();
+  const rulesAuthz = getMockRulesAuthz();
+  const actionsClient: jest.Mocked<ActionsClient> = {
+    isSystemAction: jest.fn(),
+  } as unknown as jest.Mocked<ActionsClient>;
+
+  beforeEach(() => {
+    rulesClient = rulesClientMock.create();
+    (throwAuthzError as jest.Mock).mockReset();
+    detectionRulesClient = createDetectionRulesClient({
+      actionsClient,
+      rulesClient,
+      mlAuthz,
+      rulesAuthz,
+      savedObjectsClient: savedObjectsClientMock.create(),
+      license: licenseMock.createLicenseMock(),
+      productFeaturesService: createProductFeaturesServiceMock(),
+    });
+  });
+
+  it('issues a single bulkCreateRules call with disabled, immutable rules', async () => {
+    const asset1 = { ...getCreateRulesSchemaMock(), version: 1, rule_id: 'rule-1' };
+    const asset2 = { ...getCreateRulesSchemaMock(), version: 1, rule_id: 'rule-2' };
+
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams()), getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 2,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
+      rules: [asset1, asset2],
+    });
+
+    expect(rulesClient.bulkCreateRules).toHaveBeenCalledTimes(1);
+    const callArgs = rulesClient.bulkCreateRules.mock.calls[0][0];
+    expect(callArgs.rules).toHaveLength(2);
+    expect(callArgs.rules.every((r) => r.data.enabled === false)).toBe(true);
+    expect(callArgs.rules.every((r) => r.data.params.immutable === true)).toBe(true);
+    expect(results).toHaveLength(2);
+    expect(errors).toEqual([]);
+  });
+
+  it('reports per-rule errors from the alerting layer', async () => {
+    const asset = { ...getCreateRulesSchemaMock(), version: 1, rule_id: 'rule-1' };
+
+    rulesClient.bulkCreateRules.mockImplementationOnce(async (args) => {
+      const id = (args.rules[0].options as { id: string }).id;
+      return {
+        rules: [],
+        errors: [{ message: 'boom', status: 500, rule: { id, name: asset.name } }],
+        total: 1,
+        taskIdsFailedToBeEnabled: [],
+      };
+    });
+
+    const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
+      rules: [asset],
+    });
+
+    expect(results).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].item).toBe(asset);
+    expect(errors[0].error.message).toBe('boom');
+  });
+
+  it('returns ML-auth failures as per-rule errors without calling bulkCreateRules', async () => {
+    const asset = { ...getCreateRulesSchemaMock(), version: 1, rule_id: 'rule-1' };
+    (throwAuthzError as jest.Mock).mockImplementation(() => {
+      throw new Error('ML auth denied');
+    });
+
+    const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
+      rules: [asset],
+    });
+
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+    expect(errors[0].error.message).toBe('ML auth denied');
+  });
+
+  it('returns empty result for empty input', async () => {
+    const result = await detectionRulesClient.bulkCreatePrebuiltRules({ rules: [] });
+    expect(result).toEqual({ results: [], errors: [] });
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_import_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_import_rules.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rulesClientMock } from '@kbn/alerting-plugin/server/mocks';
+import { actionsClientMock } from '@kbn/actions-plugin/server/actions_client/actions_client.mock';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { licenseMock } from '@kbn/licensing-plugin/common/licensing.mock';
+
+import { buildMlAuthz } from '../../../../machine_learning/__mocks__/authz';
+import { getImportRulesSchemaMock } from '../../../../../../common/api/detection_engine/rule_management/mocks';
+import { getRulesSchemaMock } from '../../../../../../common/api/detection_engine/model/rule_schema/mocks';
+import { getRuleMock } from '../../../routes/__mocks__/request_responses';
+import { getQueryRuleParams } from '../../../rule_schema/mocks';
+import { ruleSourceImporterMock } from '../import/rule_source_importer/rule_source_importer.mock';
+import { createDetectionRulesClient } from './detection_rules_client';
+import { importRule } from './methods/import_rule';
+import { checkRuleExceptionReferences } from '../import/check_rule_exception_references';
+import { findRules } from '../search/find_rules';
+import { createProductFeaturesServiceMock } from '../../../../product_features_service/mocks';
+import { getMockRulesAuthz } from '../../__mocks__/authz';
+import { __testing_escapeKql } from './methods/bulk_import_rules';
+import { isRuleImportError } from '../import/errors';
+
+jest.mock('./methods/import_rule');
+jest.mock('../import/check_rule_exception_references');
+jest.mock('../search/find_rules');
+
+describe('detectionRulesClient.bulkImportRules', () => {
+  let rulesClient: ReturnType<typeof rulesClientMock.create>;
+  let subject: ReturnType<typeof createDetectionRulesClient>;
+  let mockRuleSourceImporter: ReturnType<typeof ruleSourceImporterMock.create>;
+  const rulesAuthz = getMockRulesAuthz();
+
+  beforeEach(() => {
+    (findRules as jest.Mock).mockReset();
+    (importRule as jest.Mock).mockReset();
+    rulesClient = rulesClientMock.create();
+    subject = createDetectionRulesClient({
+      actionsClient: actionsClientMock.create(),
+      rulesClient,
+      mlAuthz: buildMlAuthz(),
+      rulesAuthz,
+      savedObjectsClient: savedObjectsClientMock.create(),
+      license: licenseMock.createLicenseMock(),
+      productFeaturesService: createProductFeaturesServiceMock(),
+    });
+
+    (checkRuleExceptionReferences as jest.Mock).mockReturnValue([[], []]);
+    (findRules as jest.Mock).mockResolvedValue({ data: [] });
+    (importRule as jest.Mock).mockResolvedValue(getRulesSchemaMock());
+    rulesClient.bulkCreateRules.mockResolvedValue({
+      rules: [],
+      errors: [],
+      total: 0,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    mockRuleSourceImporter = ruleSourceImporterMock.create();
+    mockRuleSourceImporter.calculateRuleSource.mockReturnValue({
+      ruleSource: { type: 'internal' },
+      immutable: false,
+    });
+  });
+
+  it('all-new disabled rules: single bulkCreateRules call, no findRules conflicts', async () => {
+    const ruleToImport = { ...getImportRulesSchemaMock(), enabled: false };
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    expect(rulesClient.bulkCreateRules).toHaveBeenCalledTimes(1);
+    const args = rulesClient.bulkCreateRules.mock.calls[0][0];
+    expect(args.rules[0].data.enabled).toBe(false);
+    expect(importRule).not.toHaveBeenCalled();
+  });
+
+  it('all-new enabled rules: preserves enabled flag in single bulk call', async () => {
+    const ruleToImport = { ...getImportRulesSchemaMock(), enabled: true };
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    const args = rulesClient.bulkCreateRules.mock.calls[0][0];
+    expect(args.rules[0].data.enabled).toBe(true);
+  });
+
+  it('mixed new+existing with overwriteRules:false reports conflict for existing', async () => {
+    const r1 = { ...getImportRulesSchemaMock(), rule_id: 'new-rule' };
+    const r2 = { ...getImportRulesSchemaMock(), rule_id: 'existing-rule' };
+
+    (findRules as jest.Mock).mockResolvedValueOnce({
+      data: [getRuleMock({ ...getQueryRuleParams(), ruleId: 'existing-rule' })],
+    });
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [r1, r2],
+    });
+
+    const conflicts = result.filter((r) => isRuleImportError(r) && r.error.type === 'conflict');
+    expect(conflicts).toHaveLength(1);
+    expect(isRuleImportError(conflicts[0]) && conflicts[0].error.ruleId).toBe('existing-rule');
+    expect(rulesClient.bulkCreateRules.mock.calls[0][0].rules).toHaveLength(1);
+    expect(importRule).not.toHaveBeenCalled();
+  });
+
+  it('mixed new+existing with overwriteRules:true: existing fall through to per-rule importRule', async () => {
+    const r1 = { ...getImportRulesSchemaMock(), rule_id: 'new-rule' };
+    const r2 = { ...getImportRulesSchemaMock(), rule_id: 'existing-rule' };
+
+    (findRules as jest.Mock).mockResolvedValueOnce({
+      data: [getRuleMock({ ...getQueryRuleParams(), ruleId: 'existing-rule' })],
+    });
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: true,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [r1, r2],
+    });
+
+    expect(importRule).toHaveBeenCalledTimes(1);
+    expect((importRule as jest.Mock).mock.calls[0][0].importRulePayload.ruleToImport.rule_id).toBe(
+      'existing-rule'
+    );
+    expect(rulesClient.bulkCreateRules.mock.calls[0][0].rules).toHaveLength(1);
+  });
+
+  it('per-row bulk error is re-paired to its source rule_id via uuid', async () => {
+    const ruleToImport = getImportRulesSchemaMock();
+    rulesClient.bulkCreateRules.mockImplementationOnce(async (args) => {
+      const id = (args.rules[0].options as { id: string }).id;
+      return {
+        rules: [],
+        errors: [{ message: 'boom', status: 500, rule: { id, name: ruleToImport.name } }],
+        total: 1,
+        taskIdsFailedToBeEnabled: [],
+      };
+    });
+
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    const errors = result.filter(isRuleImportError);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error.ruleId).toBe(ruleToImport.rule_id);
+    expect(errors[0].error.message).toBe('boom');
+  });
+
+  it('taskIdsFailedToBeEnabled surfaces as a per-rule warning', async () => {
+    const ruleToImport = { ...getImportRulesSchemaMock(), enabled: true };
+    const created = getRuleMock(getQueryRuleParams());
+    rulesClient.bulkCreateRules.mockImplementationOnce(async (args) => {
+      const id = (args.rules[0].options as { id: string }).id;
+      return {
+        rules: [created],
+        errors: [],
+        total: 1,
+        taskIdsFailedToBeEnabled: [id],
+      };
+    });
+
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    const warnings = result.filter(
+      (r) => isRuleImportError(r) && r.error.message.includes('task could not be enabled')
+    );
+    expect(warnings).toHaveLength(1);
+    expect(isRuleImportError(warnings[0]) && warnings[0].error.ruleId).toBe(ruleToImport.rule_id);
+  });
+
+  it('returns empty result for empty input without calling alerting/findRules', async () => {
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+    expect(findRules).not.toHaveBeenCalled();
+  });
+});
+
+describe('bulk_import_rules KQL escape', () => {
+  it('escapes backslashes', () => {
+    expect(__testing_escapeKql('foo\\bar')).toBe('foo\\\\bar');
+  });
+  it('escapes double quotes', () => {
+    expect(__testing_escapeKql('a"b')).toBe('a\\"b');
+  });
+  it('escapes both', () => {
+    expect(__testing_escapeKql('a\\"b')).toBe('a\\\\\\"b');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
@@ -19,6 +19,7 @@ import type { ProductFeaturesService } from '../../../../product_features_servic
 import { createPrebuiltRuleAssetsClient } from '../../../prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
 import type { RuleImportErrorObject } from '../import/errors';
 import type {
+  BulkCreatePrebuiltRulesArgs,
   BulkDeleteRulesArgs,
   BulkDeleteRulesReturn,
   CreateCustomRuleArgs,
@@ -33,7 +34,9 @@ import type {
   UpgradePrebuiltRuleArgs,
 } from './detection_rules_client_interface';
 import { createRule } from './methods/create_rule';
+import { bulkCreatePrebuiltRules } from './methods/bulk_create_prebuilt_rules';
 import { bulkDeleteRules } from './methods/bulk_delete_rules';
+import { bulkImportRules } from './methods/bulk_import_rules';
 import { deleteRule } from './methods/delete_rule';
 import { importRule } from './methods/import_rule';
 import { importRules } from './methods/import_rules';
@@ -112,6 +115,12 @@ export const createDetectionRulesClient = ({
           },
           mlAuthz,
         });
+      });
+    },
+
+    async bulkCreatePrebuiltRules(args: BulkCreatePrebuiltRulesArgs) {
+      return withSecuritySpan('DetectionRulesClient.bulkCreatePrebuiltRules', async () => {
+        return bulkCreatePrebuiltRules({ actionsClient, rulesClient, mlAuthz, args });
       });
     },
 
@@ -199,6 +208,20 @@ export const createDetectionRulesClient = ({
           ...args,
           detectionRulesClient: this,
           savedObjectsClient,
+        });
+      });
+    },
+
+    async bulkImportRules(
+      args: ImportRulesArgs
+    ): Promise<Array<RuleResponse | RuleImportErrorObject>> {
+      return withSecuritySpan('DetectionRulesClient.bulkImportRules', async () => {
+        return bulkImportRules({
+          actionsClient,
+          rulesClient,
+          savedObjectsClient,
+          mlAuthz,
+          args,
         });
       });
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
@@ -20,11 +20,15 @@ import type { RuleImportErrorObject } from '../import/errors';
 import type { PrebuiltRuleAsset } from '../../../prebuilt_rules';
 import type { PrebuiltRulesCustomizationStatus } from '../../../../../../common/detection_engine/prebuilt_rules/prebuilt_rule_customization_status';
 import type { RuleAlertType } from '../../../rule_schema';
+import type { BulkCreatePrebuiltRulesResult } from './methods/bulk_create_prebuilt_rules';
 
 export interface IDetectionRulesClient {
   getRuleCustomizationStatus: () => PrebuiltRulesCustomizationStatus;
   createCustomRule: (args: CreateCustomRuleArgs) => Promise<RuleResponse>;
   createPrebuiltRule: (args: CreatePrebuiltRuleArgs) => Promise<RuleResponse>;
+  bulkCreatePrebuiltRules: (
+    args: BulkCreatePrebuiltRulesArgs
+  ) => Promise<BulkCreatePrebuiltRulesResult>;
   updateRule: (args: UpdateRuleArgs) => Promise<RuleResponse>;
   patchRule: (args: PatchRuleArgs) => Promise<RuleResponse>;
   deleteRule: (args: DeleteRuleArgs) => Promise<void>;
@@ -33,6 +37,7 @@ export interface IDetectionRulesClient {
   revertPrebuiltRule: (args: RevertPrebuiltRuleArgs) => Promise<RuleResponse>;
   importRule: (args: ImportRuleArgs) => Promise<RuleResponse>;
   importRules: (args: ImportRulesArgs) => Promise<Array<RuleResponse | RuleImportErrorObject>>;
+  bulkImportRules: (args: ImportRulesArgs) => Promise<Array<RuleResponse | RuleImportErrorObject>>;
 }
 
 export interface CreateCustomRuleArgs {
@@ -41,6 +46,10 @@ export interface CreateCustomRuleArgs {
 
 export interface CreatePrebuiltRuleArgs {
   params: RuleCreateProps;
+}
+
+export interface BulkCreatePrebuiltRulesArgs {
+  rules: PrebuiltRuleAsset[];
 }
 
 export interface UpdateRuleArgs {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_create_prebuilt_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_create_prebuilt_rules.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type { RulesClient } from '@kbn/alerting-plugin/server';
+import { ruleTypeMappings } from '@kbn/securitysolution-rules';
+import { SERVER_APP_ID } from '../../../../../../../common';
+import type { PrebuiltRuleAsset } from '../../../../prebuilt_rules';
+import type { MlAuthz } from '../../../../../machine_learning/authz';
+import type { RuleParams } from '../../../../rule_schema';
+import { convertAlertingRuleToRuleResponse } from '../converters/convert_alerting_rule_to_rule_response';
+import { convertRuleResponseToAlertingRule } from '../converters/convert_rule_response_to_alerting_rule';
+import { applyRuleDefaults } from '../mergers/apply_rule_defaults';
+import { validateMlAuth } from '../utils';
+
+export interface BulkCreatePrebuiltRulesArgs {
+  rules: PrebuiltRuleAsset[];
+}
+
+export interface BulkCreatePrebuiltRulesResult {
+  results: Array<{ result: ReturnType<typeof convertAlertingRuleToRuleResponse> }>;
+  errors: Array<{ item: PrebuiltRuleAsset; error: Error }>;
+}
+
+interface BulkCreatePrebuiltRulesOptions {
+  actionsClient: ActionsClient;
+  rulesClient: RulesClient;
+  mlAuthz: MlAuthz;
+  args: BulkCreatePrebuiltRulesArgs;
+}
+
+/**
+ * Bulk-installs prebuilt rules in a single `rulesClient.bulkCreateRules` call.
+ * Prebuilt rules are always created disabled, so this never triggers Phase 3/5
+ * (task scheduling/enable) on the alerting side.
+ *
+ * Returns the same `{ results, errors }` shape as `createPrebuiltRules` for
+ * drop-in compatibility with `performRuleInstallationHandler`.
+ */
+export const bulkCreatePrebuiltRules = async ({
+  actionsClient,
+  rulesClient,
+  mlAuthz,
+  args,
+}: BulkCreatePrebuiltRulesOptions): Promise<BulkCreatePrebuiltRulesResult> => {
+  const { rules } = args;
+  const results: BulkCreatePrebuiltRulesResult['results'] = [];
+  const errors: BulkCreatePrebuiltRulesResult['errors'] = [];
+
+  if (rules.length === 0) return { results, errors };
+
+  // Per-type ML auth dedupe: each unique rule type is checked once.
+  const checkedTypes = new Set<string>();
+  const mlAuthErrorByType = new Map<string, Error>();
+  for (const rule of rules) {
+    if (!checkedTypes.has(rule.type)) {
+      checkedTypes.add(rule.type);
+      try {
+        await validateMlAuth(mlAuthz, rule.type);
+      } catch (e) {
+        mlAuthErrorByType.set(rule.type, e instanceof Error ? e : new Error(String(e)));
+      }
+    }
+  }
+
+  // Pre-assign uuids so per-rule successes/failures from the alerting bulk call
+  // can be re-paired with their input PrebuiltRuleAsset by id.
+  const itemById = new Map<string, PrebuiltRuleAsset>();
+  const bulkInputs: Array<{
+    data: ReturnType<typeof convertRuleResponseToAlertingRule> & {
+      alertTypeId: string;
+      consumer: string;
+      enabled: boolean;
+    };
+    options: { id: string };
+  }> = [];
+
+  for (const rule of rules) {
+    const mlError = mlAuthErrorByType.get(rule.type);
+    if (mlError) {
+      errors.push({ item: rule, error: mlError });
+    } else {
+      const id = uuidv4();
+      itemById.set(id, rule);
+      const ruleWithDefaults = applyRuleDefaults({ ...rule, immutable: true });
+      const data = {
+        ...convertRuleResponseToAlertingRule(ruleWithDefaults, actionsClient),
+        alertTypeId: ruleTypeMappings[rule.type],
+        consumer: SERVER_APP_ID,
+        enabled: false,
+      };
+      bulkInputs.push({ data, options: { id } });
+    }
+  }
+
+  if (bulkInputs.length === 0) return { results, errors };
+
+  const result = await rulesClient.bulkCreateRules<RuleParams>({ rules: bulkInputs });
+
+  result.rules.forEach((createdRule) => {
+    results.push({ result: convertAlertingRuleToRuleResponse(createdRule) });
+  });
+
+  result.errors.forEach((err) => {
+    const item = itemById.get(err.rule.id);
+    if (!item) return;
+    errors.push({
+      item,
+      error: Object.assign(new Error(err.message), { statusCode: err.status }),
+    });
+  });
+
+  return { results, errors };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
@@ -1,0 +1,291 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import pMap from 'p-map';
+import { i18n } from '@kbn/i18n';
+import { v4 as uuidv4 } from 'uuid';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type { RulesClient } from '@kbn/alerting-plugin/server';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { ruleTypeMappings } from '@kbn/securitysolution-rules';
+import { SERVER_APP_ID } from '../../../../../../../common';
+import type { RuleResponse, RuleToImport } from '../../../../../../../common/api/detection_engine';
+import { ruleToImportHasVersion } from '../../../../../../../common/api/detection_engine/rule_management';
+import type { MlAuthz } from '../../../../../machine_learning/authz';
+import type { RuleParams } from '../../../../rule_schema';
+import { findRules } from '../../search/find_rules';
+import { convertAlertingRuleToRuleResponse } from '../converters/convert_alerting_rule_to_rule_response';
+import { convertRuleResponseToAlertingRule } from '../converters/convert_rule_response_to_alerting_rule';
+import { applyRuleDefaults } from '../mergers/apply_rule_defaults';
+import { validateMlAuth } from '../utils';
+import {
+  type RuleImportErrorObject,
+  createRuleImportErrorObject,
+  isRuleImportError,
+} from '../../import/errors';
+import { checkRuleExceptionReferences } from '../../import/check_rule_exception_references';
+import { getReferencedExceptionLists } from '../../import/gather_referenced_exceptions';
+import type { IRuleSourceImporter } from '../../import/rule_source_importer';
+import { importRule as importRuleSingle } from './import_rule';
+import { createPrebuiltRuleAssetsClient } from '../../../../prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+
+const OVERWRITE_FALLBACK_CONCURRENCY = 10;
+
+interface BulkImportRulesOptions {
+  actionsClient: ActionsClient;
+  rulesClient: RulesClient;
+  savedObjectsClient: SavedObjectsClientContract;
+  mlAuthz: MlAuthz;
+  args: {
+    rules: RuleToImport[];
+    overwriteRules: boolean;
+    ruleSourceImporter: IRuleSourceImporter;
+    allowMissingConnectorSecrets?: boolean;
+  };
+}
+
+/**
+ * KQL escape — `rule_id` is free-form (`RuleSignatureId`), not guaranteed to be
+ * a UUID, so backslashes and double quotes need escaping when used as a
+ * value in a KQL string.
+ */
+const escapeKql = (id: string) => id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+/**
+ * Bulk-import rules in a single chunk. Performs per-rule pre-checks, a single
+ * `findRules` lookup for `rule_id` conflicts, and one `rulesClient.bulkCreateRules`
+ * call for new rules (mixed enabled/disabled). Existing rules with `overwriteRules`
+ * still fall through to the per-rule `importRule` path under a small concurrency cap.
+ */
+export const bulkImportRules = async ({
+  actionsClient,
+  rulesClient,
+  savedObjectsClient,
+  mlAuthz,
+  args,
+}: BulkImportRulesOptions): Promise<Array<RuleResponse | RuleImportErrorObject>> => {
+  const { rules, overwriteRules, ruleSourceImporter, allowMissingConnectorSecrets } = args;
+  if (rules.length === 0) return [];
+
+  const responses: Array<RuleResponse | RuleImportErrorObject> = [];
+
+  const existingLists = await getReferencedExceptionLists({ rules, savedObjectsClient });
+  await ruleSourceImporter.setup(rules);
+
+  // Per-rule pre-checks (in-process, isolated try/catch). Output: only rules
+  // that pass all checks proceed to classification.
+  interface PreparedImport {
+    rule: RuleToImport;
+    immutable: boolean;
+    ruleSource: ReturnType<IRuleSourceImporter['calculateRuleSource']>['ruleSource'];
+    exceptionsList: RuleToImport['exceptions_list'];
+  }
+  const prepared: PreparedImport[] = [];
+  const checkedTypes = new Set<string>();
+  const mlAuthErrorByType = new Map<string, Error>();
+
+  for (const rule of rules) {
+    if (!ruleSourceImporter.isPrebuiltRule(rule)) {
+      rule.version = rule.version ?? 1;
+    }
+    if (!ruleToImportHasVersion(rule)) {
+      responses.push(
+        createRuleImportErrorObject({
+          ruleId: rule.rule_id,
+          message: i18n.translate(
+            'xpack.securitySolution.detectionEngine.rules.cannotImportPrebuiltRuleWithoutVersion',
+            {
+              defaultMessage:
+                'Prebuilt rules must specify a "version" to be imported. [rule_id: {ruleId}]',
+              values: { ruleId: rule.rule_id },
+            }
+          ),
+        })
+      );
+    } else {
+      if (!checkedTypes.has(rule.type)) {
+        checkedTypes.add(rule.type);
+        try {
+          await validateMlAuth(mlAuthz, rule.type);
+        } catch (e) {
+          mlAuthErrorByType.set(rule.type, e instanceof Error ? e : new Error(String(e)));
+        }
+      }
+      const mlError = mlAuthErrorByType.get(rule.type);
+      if (mlError) {
+        responses.push(
+          createRuleImportErrorObject({ ruleId: rule.rule_id, message: mlError.message })
+        );
+      } else {
+        const [exceptionErrors, exceptionsList] = checkRuleExceptionReferences({
+          rule,
+          existingLists,
+        });
+        responses.push(...exceptionErrors);
+
+        let ruleSourceResult;
+        try {
+          ruleSourceResult = ruleSourceImporter.calculateRuleSource(rule);
+        } catch (e) {
+          responses.push(
+            createRuleImportErrorObject({
+              ruleId: rule.rule_id,
+              message: e instanceof Error ? e.message : String(e),
+            })
+          );
+        }
+
+        if (ruleSourceResult) {
+          prepared.push({
+            rule,
+            immutable: ruleSourceResult.immutable,
+            ruleSource: ruleSourceResult.ruleSource,
+            exceptionsList,
+          });
+        }
+      }
+    }
+  }
+
+  if (prepared.length === 0) return responses;
+
+  // Bulk lookup for `rule_id` conflicts: single KQL parenthesized OR-list.
+  const ruleIds = prepared.map((p) => p.rule.rule_id);
+  const filter = `alert.attributes.params.ruleId: (${ruleIds
+    .map((id) => `"${escapeKql(id)}"`)
+    .join(' OR ')})`;
+  const found = await findRules({
+    rulesClient,
+    filter,
+    page: 1,
+    perPage: ruleIds.length,
+    fields: undefined,
+    sortField: undefined,
+    sortOrder: undefined,
+  });
+  const existingByRuleId = new Map<string, RuleResponse>();
+  for (const alertingRule of found.data) {
+    const ruleResponse = convertAlertingRuleToRuleResponse(alertingRule);
+    existingByRuleId.set(ruleResponse.rule_id, ruleResponse);
+  }
+
+  // Classify: conflict | overwrite-fallback | bulk-create.
+  const conflicts: PreparedImport[] = [];
+  const toOverwrite: PreparedImport[] = [];
+  const toBulkCreate: PreparedImport[] = [];
+  for (const p of prepared) {
+    if (existingByRuleId.has(p.rule.rule_id)) {
+      if (overwriteRules) toOverwrite.push(p);
+      else conflicts.push(p);
+    } else {
+      toBulkCreate.push(p);
+    }
+  }
+
+  conflicts.forEach((p) => {
+    responses.push(
+      createRuleImportErrorObject({
+        ruleId: p.rule.rule_id,
+        type: 'conflict',
+        message: 'Rule with this rule_id already exists',
+      })
+    );
+  });
+
+  // Overwrite branch: stays per-rule via existing single-rule importRule.
+  if (toOverwrite.length > 0) {
+    const prebuiltRuleAssetClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
+    const overwriteResults = await pMap(
+      toOverwrite,
+      async (p) => {
+        try {
+          const updated = await importRuleSingle({
+            actionsClient,
+            rulesClient,
+            mlAuthz,
+            prebuiltRuleAssetClient,
+            importRulePayload: {
+              ruleToImport: { ...p.rule, exceptions_list: [...(p.exceptionsList ?? [])] },
+              overrideFields: { rule_source: p.ruleSource, immutable: p.immutable },
+              overwriteRules: true,
+              allowMissingConnectorSecrets,
+            },
+          });
+          return updated as RuleResponse | RuleImportErrorObject;
+        } catch (err) {
+          if (isRuleImportError(err)) return err;
+          return createRuleImportErrorObject({
+            ruleId: p.rule.rule_id,
+            message: err?.message ?? 'unknown error',
+          });
+        }
+      },
+      { concurrency: OVERWRITE_FALLBACK_CONCURRENCY }
+    );
+    responses.push(...overwriteResults);
+  }
+
+  if (toBulkCreate.length === 0) return responses;
+
+  // Bulk-create new rules in a single alerting call. Pre-assign uuids so we
+  // can re-pair successes/failures back to the source `rule_id`.
+  const inputById = new Map<string, PreparedImport>();
+  const bulkInputs = toBulkCreate.map((p) => {
+    const id = uuidv4();
+    inputById.set(id, p);
+    const ruleResponse = applyRuleDefaults({
+      ...p.rule,
+      exceptions_list: [...(p.exceptionsList ?? [])],
+      immutable: p.immutable,
+      rule_source: p.ruleSource,
+    });
+    const data = {
+      ...convertRuleResponseToAlertingRule(ruleResponse, actionsClient),
+      alertTypeId: ruleTypeMappings[p.rule.type],
+      consumer: SERVER_APP_ID,
+      // Preserve the user-requested enabled flag — alerting handles enabled
+      // rules natively (API key + task scheduling) in this single call.
+      enabled: p.rule.enabled ?? false,
+    };
+    return { data, options: { id }, allowMissingConnectorSecrets };
+  });
+
+  const bulkResult = await rulesClient.bulkCreateRules<RuleParams>({ rules: bulkInputs });
+
+  bulkResult.rules.forEach((createdRule) => {
+    responses.push(convertAlertingRuleToRuleResponse(createdRule));
+  });
+
+  bulkResult.errors.forEach((err) => {
+    const source = inputById.get(err.rule.id);
+    if (!source) return;
+    responses.push(
+      createRuleImportErrorObject({
+        ruleId: source.rule.rule_id,
+        message: err.message,
+      })
+    );
+  });
+
+  // Surface task-enable failures as warnings: the rule was created but its
+  // task didn't start. We map back via id → rule_id and report a partial
+  // success so callers know to retry enabling.
+  bulkResult.taskIdsFailedToBeEnabled.forEach((taskId) => {
+    const source = inputById.get(taskId);
+    if (!source) return;
+    responses.push(
+      createRuleImportErrorObject({
+        ruleId: source.rule.rule_id,
+        message: 'Rule was created but its task could not be enabled; please retry enable.',
+      })
+    );
+  });
+
+  return responses;
+};
+
+export { escapeKql as __testing_escapeKql };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { ExperimentalFeatures } from '../../../../../../common';
 import type { RuleToImport } from '../../../../../../common/api/detection_engine';
 import { type ImportRuleResponse, createBulkErrorObject } from '../../../routes/utils';
 import type { IRuleSourceImporter } from './rule_source_importer';
@@ -18,6 +19,9 @@ import { isRuleConflictError, isRuleImportError } from './errors';
  * @param overwriteRules {boolean} - whether to overwrite existing rules
  * with imported rules if their rule_id matches
  * @param detectionRulesClient {object}
+ * @param experimentalFeatures - feature flags; when `bulkCreateRulesEnabled` is on,
+ *   per-chunk import is dispatched through `detectionRulesClient.bulkImportRules`
+ *   (single bulk alerting call) instead of the per-rule loop.
  * @returns {Promise} an array of error and success messages from import
  */
 export const importRules = async ({
@@ -26,12 +30,14 @@ export const importRules = async ({
   detectionRulesClient,
   ruleSourceImporter,
   allowMissingConnectorSecrets,
+  experimentalFeatures,
 }: {
   ruleChunks: RuleToImport[][];
   overwriteRules: boolean;
   detectionRulesClient: IDetectionRulesClient;
   ruleSourceImporter: IRuleSourceImporter;
   allowMissingConnectorSecrets?: boolean;
+  experimentalFeatures?: ExperimentalFeatures;
 }): Promise<ImportRuleResponse[]> => {
   const response: ImportRuleResponse[] = [];
 
@@ -39,13 +45,22 @@ export const importRules = async ({
     return response;
   }
 
+  const useBulk = experimentalFeatures?.bulkCreateRulesEnabled ?? false;
+
   for (const rules of ruleChunks) {
-    const importedRulesResponse = await detectionRulesClient.importRules({
-      allowMissingConnectorSecrets,
-      overwriteRules,
-      ruleSourceImporter,
-      rules,
-    });
+    const importedRulesResponse = await (useBulk
+      ? detectionRulesClient.bulkImportRules({
+          allowMissingConnectorSecrets,
+          overwriteRules,
+          ruleSourceImporter,
+          rules,
+        })
+      : detectionRulesClient.importRules({
+          allowMissingConnectorSecrets,
+          overwriteRules,
+          ruleSourceImporter,
+          rules,
+        }));
 
     const importResponses = importedRulesResponse.map((rule) => {
       if (isRuleImportError(rule)) {


### PR DESCRIPTION

**Resolves: elastic/kibana#264893** (`rulesClient.bulkCreateRules()`)
**Resolves: elastic/kibana#264907** (`installation/_perform`)
**Partially Addresses: elastic/kibana#264909** (`rule/_import`)
**Related to: elastic/kibana#264371** (disabled-only POC)


# WIP

⚠️ This PR will be split into separate PRs once its tested. 

For now, I need the wiring (`rules/_import` and `installation/_perform`) in order to test performance of the underlying alerting framework `rulesClient.bulkCreateRules()`.

## Summary

Adds a unified `rulesClient.bulkCreateRules` to the Alerting framework that natively handles both **disabled and enabled** rules in a single call (per-rule API key minting, `taskManager.bulkSchedule` + `bulkEnable`), and wires it into the Security Solution `POST .../rules/_import` and `POST .../prebuilt_rules/installation/_perform` endpoints behind a new `bulkCreateRulesEnabled` experimental flag (default off).

```
# kibana.dev.yml
xpack.securitySolution.enableExperimental:
  - 'bulkCreateRulesEnabled'
```

## What's in here

**Alerting plugin — new `rulesClient.bulkCreateRules()`**

Key philosophy: 🤔  create all possible rules, even if its not possible to enable them.

- **Best-effort, never cancel the batch**: we always create task schedules first before the rules (easier to remove them than to update the rule), however, failures in API-key minting or task scheduling **degrade an enabled rule to disabled** rather than dropping it from the SO write. The SO is still persisted (with `apiKey`/`uiamApiKey`/`scheduledTaskId`/`lastEnabledAt` cleared), the minted key (if any) is queued for invalidation, and a per-rule entry is pushed to `errors` with a typed `disabledReason`:
  - `api_key_creation_failed` — Phase 2 mint threw (e.g. security plugin disabled).
  - `schedule_limit_exceeded` — Phase 3 `validateScheduleLimit` tripped.
  - `task_schedule_failed` — Phase 4 `bulkSchedule` whole-throw.
  - `task_validation_failed` — Phase 4 silently dropped a task (returned fewer rows than requested).
- **SO per-row error path**: queues the failed rule's API key for invalidation, and queues its task id for cleanup *only if we scheduled it ourselves in Phase 4* (avoids the elastic/kibana#264892 anti-pattern of nuking a pre-existing rule's task on a 409). All collected ids are removed in a **single batched** `taskManager.bulkRemove([...])` call.
- **Single key-invalidation flush**: all invalid api keys collected across phases are de-duped and written via one `bulkMarkApiKeysForInvalidation` call at the end.
- New error shape: `BulkCreateOperationError extends BulkOperationError` with optional `disabledReason: BulkCreateDisabledReason`. The message is i18n'd as `"Rule created in a disabled state: {original error}"`.

**Security Solution wiring**
- `bulkCreateRulesEnabled: false` added to `allowedExperimentalValues` (opt in via `xpack.securitySolution.enableExperimental` in `kibana.dev.yml`).
- `detectionRulesClient.bulkCreatePrebuiltRules` — single bulk call, disabled+immutable, per-type ML-auth dedupe; `{ results, errors }` shape is drop-in compatible with the legacy `createPrebuiltRules`.
- `detectionRulesClient.bulkImportRules` — per-rule pre-checks, single `findRules` KQL OR-list for `rule_id` conflicts (with `\`/`"` escaping), classify into conflict/overwrite/bulk-create, single `bulkCreateRules` call preserving the user-requested `enabled` flag, per-rule overwrite fallback via existing `importRule`. `taskIdsFailedToBeEnabled` surfaces as per-rule warnings.
- `perform_rule_installation_handler` and `logic/import/import_rules` branch on the flag; legacy paths untouched when off.

## Out of scope (deferred)

- elastic/kibana#264892 - the new code is structured to *not* replicate the buggy whole-throw invalidation pattern, but the existing fix lives elsewhere.
- ~UIAM tag gap (`addMissingUiamKeyTagIfNeeded`) in bulk methods~ (Needs to be addressed)
- Do not replicate single-rule `createRuleSavedObject` API-key leak on schedule-failure rollback.
- Bulk-overwrite on `_import` (will be handled separately after https://github.com/elastic/kibana/issues/264894).

## Other approaches:

- Attempt [#2](https://github.com/elastic/kibana/pull/268133): Look at current waste (multiple calls per rule that could be made up-front) and try to make the process a bit more optimal
- Attempt [#3](https://github.com/elastic/kibana/pull/268420): Split the TM schedule validation and task creation into a background phase that could be executed after all the rule SOs were created.
- Attempt [#4](https://github.com/elastic/kibana/pull/268778): Breakthrough. Same as current PR but enable tasks at the end of the HTTP request.

## Test plan

- [x] Unit tests in alerting framework (13 new)
  - `node scripts/jest x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create`
- [x] Unit tests in security solution  (14 new)
  - `node scripts/jest .../detection_rules_client.bulk_create_prebuilt_rules.test.ts`
  - `node scripts/jest .../detection_rules_client.bulk_import_rules.test.ts`
- [ ] FTR/Integration tests for `ruleClient.bulkCreateRules()`
- Manual smoke (both flag states):
  - [x] `installation/_perform` with full rule set.
  - [ ] `rules/_import` with 10 rules
    - [x] mixed enabled/disabled `.ndjson`
    - [ ] 2 rules with rule actions.
    - [x] confirm calls per "50 rule" chunk when flag is on
      1. 1x `bulkCreate` SO write
      8. 1x `bulkSchedule` (if there are any `enabled` in chunk)
  - [ ] Installation in paralell: how does it handle race conditions?
- Performance test (Before vs After)
  - [ ] `installation/_perform` with full rule set.
    1. Duration
    2. Memory amplitude
  - [ ] `rules/_import` with full rule set (inc 400 enabled rules)
    1. Duration
    2. Memory amplitude
