### PR TITLE
[9.2] feat(eslint,security): forbid new axios imports in favor of native fetch (#266556)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -389,6 +389,91 @@ const RESTRICTED_IMPORTS = [
     name: `fp-ts/lib`,
     message: `Please, use fp-ts to avoid duplicating the package import`,
   },
+  {
+    name: 'axios',
+    message:
+      'Do not introduce new axios usage. Use the native `fetch` API instead (available in Node.js 22 and modern browsers). Existing consumers are being migrated incrementally; the allowlist in AXIOS_LEGACY_CONSUMERS will shrink over time.',
+  },
+];
+
+/**
+ * Files that already import axios. New axios imports must not be added here;
+ * this list is expected to shrink as consumers migrate to the native `fetch` API.
+ * Globs are scoped to existing feature boundaries to keep the leak surface small.
+ */
+const AXIOS_LEGACY_CONSUMERS = [
+  '.buildkite/**/*.{js,mjs,ts,tsx,jsx}',
+  'packages/kbn-ci-stats-performance-metrics/**/*.{js,mjs,ts,tsx}',
+  'packages/kbn-failed-test-reporter-cli/**/*.{js,mjs,ts,tsx}',
+  'packages/kbn-generate/**/*.{js,mjs,ts,tsx}',
+  'src/dev/build/lib/**/*.{js,mjs,ts,tsx}',
+  'src/dev/build/tasks/**/*.{js,mjs,ts,tsx}',
+  'src/dev/prs/**/*.{js,mjs,ts,tsx}',
+  'src/platform/packages/private/kbn-ci-stats-reporter/**/*.{js,mjs,ts,tsx}',
+  'src/platform/packages/private/kbn-journeys/**/*.{js,mjs,ts,tsx}',
+  'src/platform/packages/shared/kbn-cypress-test-helper/**/*.{js,mjs,ts,tsx}',
+  'src/platform/packages/shared/kbn-dev-utils/src/axios/**/*.{js,mjs,ts,tsx}',
+  'src/platform/packages/shared/kbn-kbn-client/**/*.{js,mjs,ts,tsx}',
+  'src/platform/packages/shared/kbn-test-saml-auth/**/*.{js,mjs,ts,tsx}',
+  'src/platform/plugins/shared/workflows_execution_engine/server/step/http_step/**/*.{js,mjs,ts,tsx}',
+  'src/platform/plugins/shared/workflows_management/server/connectors/workflows/**/*.{js,mjs,ts,tsx}',
+  'src/platform/test/api_integration/apis/telemetry/**/*.{js,mjs,ts,tsx}',
+  'x-pack/examples/alerting_example/server/rule_types/**/*.{js,mjs,ts,tsx}',
+  'x-pack/packages/kbn-synthetics-private-location/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/packages/shared/kbn-data-forge/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/packages/shared/kbn-evals/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/private/canvas/common/lib/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/private/data_usage/server/services/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/private/indices_metadata/server/lib/services/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/actions/server/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/dataset_quality/server/test_helpers/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/fleet/server/services/agents/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/fleet/server/telemetry/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/inference/scripts/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/observability_ai_assistant/server/service/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/osquery/cypress/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/screenshotting/server/browsers/chromium/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/screenshotting/server/browsers/download/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/stack_connectors/common/auth/oauth2_delete_token_axios_interceptor.ts',
+  'x-pack/platform/plugins/shared/stack_connectors/server/connector_types/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/plugins/shared/stack_connectors/server/routes/valid_slack_api_channels.ts',
+  'x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/sub_action_connector.ts',
+  'x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/mustache_templates.ts',
+  'x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/mustache_templates.ts',
+  'x-pack/platform/test/api_integration/services/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/test/fleet_api_integration/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/test/fleet_cypress/agent.ts',
+  'x-pack/platform/test/fleet_cypress/artifact_manager.ts',
+  'x-pack/platform/test/fleet_cypress/fleet_server.ts',
+  'x-pack/platform/test/fleet_multi_cluster/**/*.{js,mjs,ts,tsx}',
+  'x-pack/platform/test/ui_capabilities/common/services/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/packages/alerting-test-data/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/plugins/apm/scripts/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/plugins/apm/server/test_helpers/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/plugins/observability_onboarding/server/test_helpers/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/plugins/synthetics/scripts/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/plugins/synthetics/server/telemetry/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/test/api_integration/profiling/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/observability/test/profiling_cypress/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/packages/kbn-securitysolution-utils/src/axios/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/plugins/elastic_assistant/scripts/**/*.{js,mjs,ts,tsx,jsx}',
+  'x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/plugins/security_solution/common/endpoint/format_axios_error.ts',
+  'x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/plugins/security_solution/scripts/endpoint/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts',
+  'x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/project_handler/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/plugins/security_solution/scripts/telemetry/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/plugins/security_solution/server/integration_tests/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/scripts/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/test/security_solution_api_integration/config/services/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/test/security_solution_cypress/cypress/support/**/*.{js,mjs,ts,tsx}',
+  'x-pack/solutions/security/test/security_solution_playwright/api_utils/api_key.ts',
 ];
 
 /**
@@ -2565,6 +2650,23 @@ module.exports = {
             disallowedMessage:
               'Use `@kbn/fs` for file write operations instead of direct `fs` in production code',
           },
+        ],
+      },
+    },
+    {
+      // Allow axios in files that already use it. New axios imports are blocked
+      // globally by RESTRICTED_IMPORTS; this allowlist should only ever shrink
+      // as consumers migrate to the native `fetch` API. Placed last so it wins
+      // over any earlier override that re-applies RESTRICTED_IMPORTS (e.g. the
+      // security_solution and workflows_management blocks). The trade-off: the
+      // 35 allowlisted files that overlap with those blocks lose their
+      // `*legacy*` pattern check; verified that none of them currently import
+      // any path matching `*legacy*`.
+      files: AXIOS_LEGACY_CONSUMERS,
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          ...RESTRICTED_IMPORTS.filter(({ name }) => name !== 'axios'),
         ],
       },
     },

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone/mocks.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/sentinelone/mocks.ts
@@ -7,7 +7,7 @@
 
 import type { DeepPartial } from '@kbn/utility-types';
 import { merge } from 'lodash';
-import type { AxiosResponse } from 'axios/index';
+import type { AxiosResponse } from 'axios';
 import type {
   ServiceParams,
   SubActionRequestParams,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [feat(eslint,security): forbid new axios imports in favor of native fetch (#266556)](https://github.com/elastic/kibana/pull/266556)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-04-30T15:42:08Z","message":"feat(eslint,security): forbid new axios imports in favor of native fetch (#266556)\n\n## Summary\n\nFirst step toward removing `axios` from Kibana in favor of the native\n`fetch` API (built-in on Node.js 22 and supported by all browsers we\ntarget). The migration of existing consumers will happen incrementally;\nthis PR puts up the fence so no new axios usage slips in while that's in\nflight.\n\n- Adds `axios` to the global `no-restricted-imports` list with a message\npointing readers at `fetch`.\n- Adds an `AXIOS_LEGACY_CONSUMERS` allowlist with **72 globs** covering\nall **251 existing consumers** exactly. Globs are scoped at feature\nboundaries and tightened to specific subdirectories or file paths\nwherever a broad glob could be replaced with ≤3 narrower ones (e.g.\n`fleet/server/{services/agents,telemetry}/**` instead of\n`fleet/server/**`, file-level entries for `fleet_cypress/`,\n`alerting_api_integration/**`, etc.). The list should only ever shrink\nas consumers migrate.\n- The override is placed last in the `overrides` array so it wins\nagainst the security_solution and workflows_management blocks that\nre-apply `RESTRICTED_IMPORTS`.\n- Renames a stray `'axios/index'` import to `'axios'` in\n`sentinelone/mocks.ts` so the rule only has to handle one specifier.\n\n### Acknowledged trade-off\n\n35 allowlisted files that overlap with the security_solution and\nworkflows_management overrides lose their `*legacy*` import-pattern\ncheck (the original overrides ban imports of paths containing `legacy`).\nVerified that none of those files currently import any path matching\n`*legacy*`, and the overlap list shrinks naturally as axios consumers\nmigrate. Documented in a comment next to the override. An earlier\nattempt to preserve `*legacy*` for those files via a `patterns:` entry\nin the override was abandoned because it leaked the restriction to\nthousands of unrelated files inside the broader globs.\n\n### Not covered\n\nThis catches ESM `import` only. The two existing `require('axios')`\ncallsites both happen to live in allowlisted directories, so the freeze\nstill holds in practice. A follow-up can extend `no-restricted-modules`\nif we also want to block `require` in new code.\n\n### Why mid/file-level globs over the two extremes\n\n- **File-level allowlist (~251 entries):** too verbose; the diff churn\non every migration would obscure the actual list shrinkage.\n- **Top-level dir globs (~30 entries):** too leaky; would let axios\nspread into unrelated subtrees (e.g. `public/`, `common/`) of plugins\nthat currently only use it server-side.\n\nMid-level globs draw the line where existing usage actually clusters;\nbroad globs were tightened to narrower subdirectories or file paths\nwhenever ≤3 replacements would suffice. Areas that genuinely span many\nsubdirectories (e.g. `actions/server/**`,\n`stack_connectors/server/connector_types/**`) are kept broad.","sha":"0dd88e2baea45a8c1e0c1f0f26bf4ff7c3326916","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","dependencies","backport:all-open","v9.5.0"],"title":"feat(eslint,security): forbid new axios imports in favor of native fetch","number":266556,"url":"https://github.com/elastic/kibana/pull/266556","mergeCommit":{"message":"feat(eslint,security): forbid new axios imports in favor of native fetch (#266556)\n\n## Summary\n\nFirst step toward removing `axios` from Kibana in favor of the native\n`fetch` API (built-in on Node.js 22 and supported by all browsers we\ntarget). The migration of existing consumers will happen incrementally;\nthis PR puts up the fence so no new axios usage slips in while that's in\nflight.\n\n- Adds `axios` to the global `no-restricted-imports` list with a message\npointing readers at `fetch`.\n- Adds an `AXIOS_LEGACY_CONSUMERS` allowlist with **72 globs** covering\nall **251 existing consumers** exactly. Globs are scoped at feature\nboundaries and tightened to specific subdirectories or file paths\nwherever a broad glob could be replaced with ≤3 narrower ones (e.g.\n`fleet/server/{services/agents,telemetry}/**` instead of\n`fleet/server/**`, file-level entries for `fleet_cypress/`,\n`alerting_api_integration/**`, etc.). The list should only ever shrink\nas consumers migrate.\n- The override is placed last in the `overrides` array so it wins\nagainst the security_solution and workflows_management blocks that\nre-apply `RESTRICTED_IMPORTS`.\n- Renames a stray `'axios/index'` import to `'axios'` in\n`sentinelone/mocks.ts` so the rule only has to handle one specifier.\n\n### Acknowledged trade-off\n\n35 allowlisted files that overlap with the security_solution and\nworkflows_management overrides lose their `*legacy*` import-pattern\ncheck (the original overrides ban imports of paths containing `legacy`).\nVerified that none of those files currently import any path matching\n`*legacy*`, and the overlap list shrinks naturally as axios consumers\nmigrate. Documented in a comment next to the override. An earlier\nattempt to preserve `*legacy*` for those files via a `patterns:` entry\nin the override was abandoned because it leaked the restriction to\nthousands of unrelated files inside the broader globs.\n\n### Not covered\n\nThis catches ESM `import` only. The two existing `require('axios')`\ncallsites both happen to live in allowlisted directories, so the freeze\nstill holds in practice. A follow-up can extend `no-restricted-modules`\nif we also want to block `require` in new code.\n\n### Why mid/file-level globs over the two extremes\n\n- **File-level allowlist (~251 entries):** too verbose; the diff churn\non every migration would obscure the actual list shrinkage.\n- **Top-level dir globs (~30 entries):** too leaky; would let axios\nspread into unrelated subtrees (e.g. `public/`, `common/`) of plugins\nthat currently only use it server-side.\n\nMid-level globs draw the line where existing usage actually clusters;\nbroad globs were tightened to narrower subdirectories or file paths\nwhenever ≤3 replacements would suffice. Areas that genuinely span many\nsubdirectories (e.g. `actions/server/**`,\n`stack_connectors/server/connector_types/**`) are kept broad.","sha":"0dd88e2baea45a8c1e0c1f0f26bf4ff7c3326916"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266556","number":266556,"mergeCommit":{"message":"feat(eslint,security): forbid new axios imports in favor of native fetch (#266556)\n\n## Summary\n\nFirst step toward removing `axios` from Kibana in favor of the native\n`fetch` API (built-in on Node.js 22 and supported by all browsers we\ntarget). The migration of existing consumers will happen incrementally;\nthis PR puts up the fence so no new axios usage slips in while that's in\nflight.\n\n- Adds `axios` to the global `no-restricted-imports` list with a message\npointing readers at `fetch`.\n- Adds an `AXIOS_LEGACY_CONSUMERS` allowlist with **72 globs** covering\nall **251 existing consumers** exactly. Globs are scoped at feature\nboundaries and tightened to specific subdirectories or file paths\nwherever a broad glob could be replaced with ≤3 narrower ones (e.g.\n`fleet/server/{services/agents,telemetry}/**` instead of\n`fleet/server/**`, file-level entries for `fleet_cypress/`,\n`alerting_api_integration/**`, etc.). The list should only ever shrink\nas consumers migrate.\n- The override is placed last in the `overrides` array so it wins\nagainst the security_solution and workflows_management blocks that\nre-apply `RESTRICTED_IMPORTS`.\n- Renames a stray `'axios/index'` import to `'axios'` in\n`sentinelone/mocks.ts` so the rule only has to handle one specifier.\n\n### Acknowledged trade-off\n\n35 allowlisted files that overlap with the security_solution and\nworkflows_management overrides lose their `*legacy*` import-pattern\ncheck (the original overrides ban imports of paths containing `legacy`).\nVerified that none of those files currently import any path matching\n`*legacy*`, and the overlap list shrinks naturally as axios consumers\nmigrate. Documented in a comment next to the override. An earlier\nattempt to preserve `*legacy*` for those files via a `patterns:` entry\nin the override was abandoned because it leaked the restriction to\nthousands of unrelated files inside the broader globs.\n\n### Not covered\n\nThis catches ESM `import` only. The two existing `require('axios')`\ncallsites both happen to live in allowlisted directories, so the freeze\nstill holds in practice. A follow-up can extend `no-restricted-modules`\nif we also want to block `require` in new code.\n\n### Why mid/file-level globs over the two extremes\n\n- **File-level allowlist (~251 entries):** too verbose; the diff churn\non every migration would obscure the actual list shrinkage.\n- **Top-level dir globs (~30 entries):** too leaky; would let axios\nspread into unrelated subtrees (e.g. `public/`, `common/`) of plugins\nthat currently only use it server-side.\n\nMid-level globs draw the line where existing usage actually clusters;\nbroad globs were tightened to narrower subdirectories or file paths\nwhenever ≤3 replacements would suffice. Areas that genuinely span many\nsubdirectories (e.g. `actions/server/**`,\n`stack_connectors/server/connector_types/**`) are kept broad.","sha":"0dd88e2baea45a8c1e0c1f0f26bf4ff7c3326916"}}]}] BACKPORT-->