### PR TITLE
Revert "Fix FTR spot instance zone targeting to reduce preemption retries !!"

### DIFF
--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -85,7 +85,7 @@ const expandAgentQueue = (queueName: string = 'n2-4-spot', diskSizeGb?: number) 
   const zonesToUse = 'southamerica-east1-c,asia-south2-a,us-central1-f';
   const additionalProps =
     {
-      spot: { preemptible: true, spotZones: zonesToUse },
+      spot: { preemptible: true, zones: zonesToUse },
       virt: { enableNestedVirtualization: true, spotZones: zonesToUse },
     }[addition] || {};
 


### PR DESCRIPTION
Reverts elastic/kibana#266579

i think spot zones are too small, they are generating even more preemptions 