### PR TITLE
[Log threshold] Quote phrase values in alert details preview KQL

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts
@@ -53,18 +53,15 @@ describe('convertCriteriaToKQL', () => {
       }
     );
 
-    it.each(specialValues)(
-      'produces parseable KQL for "matches phrase" with value %p',
-      (value) => {
-        const kql = convertCriteriaToKQL({
-          field,
-          comparator: Comparator.MATCH_PHRASE,
-          value,
-        });
+    it.each(specialValues)('produces parseable KQL for "matches phrase" with value %p', (value) => {
+      const kql = convertCriteriaToKQL({
+        field,
+        comparator: Comparator.MATCH_PHRASE,
+        value,
+      });
 
-        expect(() => fromKueryExpression(kql)).not.toThrow();
-      }
-    );
+      expect(() => fromKueryExpression(kql)).not.toThrow();
+    });
 
     it('escapes embedded backslashes and double quotes', () => {
       const value = 'has "quote" and \\backslash';
@@ -81,15 +78,15 @@ describe('convertCriteriaToKQL', () => {
 
   describe('range comparators', () => {
     it('renders numeric values without quotes', () => {
-      expect(
-        convertCriteriaToKQL({ field: 'count', comparator: Comparator.GT, value: 5 })
-      ).toBe('count > 5');
+      expect(convertCriteriaToKQL({ field: 'count', comparator: Comparator.GT, value: 5 })).toBe(
+        'count > 5'
+      );
       expect(
         convertCriteriaToKQL({ field: 'count', comparator: Comparator.GT_OR_EQ, value: 5 })
       ).toBe('count >= 5');
-      expect(
-        convertCriteriaToKQL({ field: 'count', comparator: Comparator.LT, value: 5 })
-      ).toBe('count < 5');
+      expect(convertCriteriaToKQL({ field: 'count', comparator: Comparator.LT, value: 5 })).toBe(
+        'count < 5'
+      );
       expect(
         convertCriteriaToKQL({ field: 'count', comparator: Comparator.LT_OR_EQ, value: 5 })
       ).toBe('count <= 5');

--- a/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fromKueryExpression } from '@kbn/es-query';
+import { Comparator } from '../../../../../common/alerting/logs/log_threshold';
+import { convertCriteriaToKQL } from '.';
+
+describe('convertCriteriaToKQL', () => {
+  const field = 'message';
+
+  describe('quoting', () => {
+    const cases: Array<[Comparator, string, string]> = [
+      [Comparator.EQ, 'simple', `${field} : "simple"`],
+      [Comparator.MATCH, 'simple', `${field} : "simple"`],
+      [Comparator.MATCH_PHRASE, 'simple', `${field} : "simple"`],
+      [Comparator.NOT_EQ, 'simple', `NOT ${field} : "simple"`],
+      [Comparator.NOT_MATCH, 'simple', `NOT ${field} : "simple"`],
+      [Comparator.NOT_MATCH_PHRASE, 'simple', `NOT ${field} : "simple"`],
+    ];
+
+    it.each(cases)('quotes the value for %s', (comparator, value, expected) => {
+      expect(convertCriteriaToKQL({ field, comparator, value })).toBe(expected);
+    });
+  });
+
+  describe('values containing KQL special characters', () => {
+    // Regression test for https://github.com/elastic/kibana/issues/203071.
+    // Phrase values containing characters such as `:` were previously
+    // interpolated unquoted, producing unparseable KQL.
+    const specialValues = [
+      'foo: bar',
+      'something with (parens)',
+      'tag<value>',
+      'wild*card',
+      'has "inner" quotes',
+      'back\\slash',
+    ];
+
+    it.each(specialValues)(
+      'produces parseable KQL for "does not match phrase" with value %p',
+      (value) => {
+        const kql = convertCriteriaToKQL({
+          field,
+          comparator: Comparator.NOT_MATCH_PHRASE,
+          value,
+        });
+
+        expect(() => fromKueryExpression(kql)).not.toThrow();
+      }
+    );
+
+    it.each(specialValues)(
+      'produces parseable KQL for "matches phrase" with value %p',
+      (value) => {
+        const kql = convertCriteriaToKQL({
+          field,
+          comparator: Comparator.MATCH_PHRASE,
+          value,
+        });
+
+        expect(() => fromKueryExpression(kql)).not.toThrow();
+      }
+    );
+
+    it('escapes embedded backslashes and double quotes', () => {
+      const value = 'has "quote" and \\backslash';
+
+      expect(
+        convertCriteriaToKQL({
+          field,
+          comparator: Comparator.NOT_MATCH_PHRASE,
+          value,
+        })
+      ).toBe(`NOT ${field} : "has \\"quote\\" and \\\\backslash"`);
+    });
+  });
+
+  describe('range comparators', () => {
+    it('renders numeric values without quotes', () => {
+      expect(
+        convertCriteriaToKQL({ field: 'count', comparator: Comparator.GT, value: 5 })
+      ).toBe('count > 5');
+      expect(
+        convertCriteriaToKQL({ field: 'count', comparator: Comparator.GT_OR_EQ, value: 5 })
+      ).toBe('count >= 5');
+      expect(
+        convertCriteriaToKQL({ field: 'count', comparator: Comparator.LT, value: 5 })
+      ).toBe('count < 5');
+      expect(
+        convertCriteriaToKQL({ field: 'count', comparator: Comparator.LT_OR_EQ, value: 5 })
+      ).toBe('count <= 5');
+    });
+  });
+
+  describe('incomplete criteria', () => {
+    it('returns an empty string when the value is missing', () => {
+      expect(convertCriteriaToKQL({ field, comparator: Comparator.EQ })).toBe('');
+    });
+
+    it('returns an empty string when the comparator is missing', () => {
+      expect(convertCriteriaToKQL({ field, value: 'x' })).toBe('');
+    });
+
+    it('returns an empty string when the field is missing', () => {
+      expect(convertCriteriaToKQL({ comparator: Comparator.EQ, value: 'x' })).toBe('');
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx
@@ -19,6 +19,7 @@ import { i18n } from '@kbn/i18n';
 import { getPaddedAlertTimeRange } from '@kbn/observability-get-padded-alert-time-range-util';
 import { get, identity } from 'lodash';
 import { useElasticChartsTheme } from '@kbn/charts-theme';
+import { escapeQuotes } from '@kbn/es-query';
 import { useLogView } from '@kbn/logs-shared-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useKibanaContextForPlugin } from '../../../../hooks/use_kibana';
@@ -215,22 +216,26 @@ function convertComparatorToFill(comparator: Comparator) {
   }
 }
 
-function convertCriteriaToKQL(criteria: PartialCriterion) {
+// Exported for unit testing.
+export function convertCriteriaToKQL(criteria: PartialCriterion) {
   if (!criteria.value || !criteria.comparator || !criteria.field) {
     return '';
   }
 
+  // Phrase / equality / match values are interpolated into a quoted KQL string,
+  // so any embedded backslashes or double quotes need to be escaped to keep the
+  // resulting expression parseable. See https://github.com/elastic/kibana/issues/203071.
+  const quotedValue = `"${escapeQuotes(String(criteria.value))}"`;
+
   switch (criteria.comparator) {
     case Comparator.MATCH:
     case Comparator.EQ:
-      return `${criteria.field} : "${criteria.value}"`;
+    case Comparator.MATCH_PHRASE:
+      return `${criteria.field} : ${quotedValue}`;
     case Comparator.NOT_MATCH:
     case Comparator.NOT_EQ:
-      return `NOT ${criteria.field} : "${criteria.value}"`;
-    case Comparator.MATCH_PHRASE:
-      return `${criteria.field} : ${criteria.value}`;
     case Comparator.NOT_MATCH_PHRASE:
-      return `NOT ${criteria.field} : ${criteria.value}`;
+      return `NOT ${criteria.field} : ${quotedValue}`;
     case Comparator.GT:
       return `${criteria.field} > ${criteria.value}`;
     case Comparator.GT_OR_EQ:


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/203071.

The Lens preview chart on the Log threshold rule alert details page renders unparseable KQL when a criterion uses `matches phrase` / `does not match phrase` and the value contains a KQL special character (e.g. `:`, `(`, `)`, `<`, `>`, `*`, `"`, `\`). For example, a criterion configured as:

- field: `message`
- comparator: `does not match phrase`
- value: `foo: bar`

…produced this KQL:

```
NOT message : foo: bar
```

…which the parser rejects with:

```
Layer 1 error: Expected AND, OR, end of input but ":" found.
NOT message : foo: bar
-------------------^
```

### Root cause

`convertCriteriaToKQL` in `x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx` interpolated `criteria.value` straight into the KQL string for the `MATCH_PHRASE` / `NOT_MATCH_PHRASE` cases, without wrapping it in quotes and without escaping special characters. The other equality / match comparators wrapped the value in `"…"` but did not escape embedded quotes or backslashes either, so the same class of bug existed for any value containing a `"` or `\`.

### Fix

Quote the interpolated value for every comparator that takes a phrase / equality / match value, and run it through the existing `escapeQuotes` helper (`@kbn/es-query`) so embedded `"` and `\` are escaped. The same example now generates:

```
NOT message : "foo: bar"
```

…which the KQL parser accepts.

This is a UI-only change; alert rule execution is unaffected because the executor builds Elasticsearch DSL directly and does not go through this helper.

### Tests

A new unit test file co-located with the helper covers:

- All comparators wrap their value in double quotes (regression for the missing quoting on phrase comparators).
- For each `KQL` special character (`:`, `()`, `<>`, `*`, `"`, `\`), `convertCriteriaToKQL` produces an expression that `fromKueryExpression` from `@kbn/es-query` can parse. This is the same parser the Lens chart uses, so a passing test means the chart will accept the output.
- Embedded `"` and `\` are escaped using the standard `escapeQuotes` rules.
- Range comparators (`>`, `>=`, `<`, `<=`) still render numeric values without quotes.
- Incomplete criteria still return an empty string.

I also confirmed the test suite catches the regression: temporarily reverting just the `MATCH_PHRASE` / `NOT_MATCH_PHRASE` branches to the previous behaviour produces `KQLSyntaxError: Expected AND, OR, end of input but ":" found.` — the exact error from the linked issue — on the new tests. With the fix applied, all 23 cases pass.

```
PASS x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts
  convertCriteriaToKQL
    quoting
      ✓ quotes the value for equals
      ✓ quotes the value for matches
      ✓ quotes the value for matches phrase
      ✓ quotes the value for does not equal
      ✓ quotes the value for does not match
      ✓ quotes the value for does not match phrase
    values containing KQL special characters
      ✓ produces parseable KQL for "does not match phrase" with value "foo: bar"
      ✓ produces parseable KQL for "does not match phrase" with value "something with (parens)"
      ✓ produces parseable KQL for "does not match phrase" with value "tag<value>"
      ✓ produces parseable KQL for "does not match phrase" with value "wild*card"
      ✓ produces parseable KQL for "does not match phrase" with value "has \"inner\" quotes"
      ✓ produces parseable KQL for "does not match phrase" with value "back\\slash"
      ✓ produces parseable KQL for "matches phrase" with value "foo: bar"
      ✓ produces parseable KQL for "matches phrase" with value "something with (parens)"
      ✓ produces parseable KQL for "matches phrase" with value "tag<value>"
      ✓ produces parseable KQL for "matches phrase" with value "wild*card"
      ✓ produces parseable KQL for "matches phrase" with value "has \"inner\" quotes"
      ✓ produces parseable KQL for "matches phrase" with value "back\\slash"
      ✓ escapes embedded backslashes and double quotes
    range comparators
      ✓ renders numeric values without quotes
    incomplete criteria
      ✓ returns an empty string when the value is missing
      ✓ returns an empty string when the comparator is missing
      ✓ returns an empty string when the field is missing

Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total
```

`node scripts/type_check --project x-pack/solutions/observability/plugins/infra/tsconfig.json` also passes.

### Manual verification

I followed the exact reproduction steps from the issue against a local Kibana built from `main` plus this fix, with an Elasticsearch snapshot of matching version:

1. Created a log view (`test-logs`) backed by a `logs-test-*` data stream with a few error-level documents.
2. Created a Log threshold rule with these criteria:
   - `log.level` `equals` `error`
   - `message` `does not match phrase` `something: with a colon`
3. Indexed enough error logs to trigger the rule (count > 0 over 5m).
4. Opened the alert details page for the resulting alert.

**Before the fix** (rebuilt with the `MATCH_PHRASE` / `NOT_MATCH_PHRASE` branches reverted to their previous behaviour):

The Lens preview chart fails to render and shows the exact error from issue #203071:

> Layer 1 error: Expected AND, OR, end of input but ":" found.
> log.level : "error" AND NOT message : something: with a colon
> ----------------------------------------------------^

<img width="1600" height="1100" alt="image" src="https://github.com/user-attachments/assets/31444aef-2ba9-4734-a9bf-4058389252e5" />

**After the fix:**

The KQL syntax error is gone — the criterion is rendered as `NOT message : "something: with a colon"` and the chart layer is no longer in an error state from this code path.

<img width="1600" height="1100" alt="image" src="https://github.com/user-attachments/assets/4343221c-3c70-4c26-a049-27065b280c15" />

#### Note on a separate, pre-existing chart error

In the after screenshot, the Lens chart still shows a different error:

> [layeredXyVis] > [event_annotations_result] > [extendedAnnotationLayer] > [manual_point_event_annotation] > Value 'warning' is not among the allowed options for argument 'icon'

This is unrelated to issue #203071 — it comes from the threshold annotation expression building a `manual_point_event_annotation` with `icon: 'warning'`, which is not in the current allowed set on `main`. It happens regardless of whether a colon is present in any criterion value. It was also present before the fix, but masked by the KQL parse failure occurring earlier in the pipeline. Filing/finding a separate issue for that is out of scope for this PR; it does not affect the correctness of the change here.

### Programmatic verification

The new unit tests pipe `convertCriteriaToKQL` output through `fromKueryExpression` from `@kbn/es-query` — the same parser the Lens chart uses to validate KQL — for every problematic special character. Before the fix, those assertions throw `KQLSyntaxError: Expected AND, OR, end of input but ":" found.` (the exact error from the issue). After the fix, they pass.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Existing workarounds**: users who applied the documented workaround on the issue (wrapping the value in literal double quotes, e.g. `"foo: bar"`) will, after this fix, generate KQL like `NOT message : "\"foo: bar\""` from the alert details preview chart. The actual alert rule execution is unaffected (it does not pass through this helper). For preview-chart purposes the embedded quotes will be treated as part of the phrase text, which is more accurate to what the user typed than before but may cause the preview to show no matches if the underlying field tokenises punctuation. Users on the workaround can drop the extra quotes once they pick up this fix. No known data-loss or alert-firing impact.
- Severity: low. The change is contained to a single string helper that is used only for generating the KQL passed to the alert details Lens chart.

### Release Notes

Fixes a bug where the Log threshold rule's alert details preview chart would fail to render with a KQL syntax error when a criterion used `matches phrase` or `does not match phrase` with a value containing characters such as `:`.

---

Created with Cursor using Claude Opus 4.7
