### PR TITLE
[Security solution] Fix serverless nav using Classic when chat default is Agent

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.test.ts
@@ -99,4 +99,27 @@ describe('Security Side Nav', () => {
 
     expect(mockedCreateNavigationTree).toHaveBeenCalledWith(services, AIChatExperience.Agent);
   });
+
+  it('passes workflows UI enabled true when settings return true', async () => {
+    services.settings.client.get$ = jest.fn().mockImplementation((key: string) => {
+      if (key === WORKFLOWS_UI_SETTING_ID) {
+        return of(true);
+      }
+
+      return of(AIChatExperience.Classic);
+    });
+
+    await registerSolutionNavigation(services, [
+      {
+        product_line: 'ai_soc' as ProductLine,
+        product_tier: 'search_ai_lake' as ProductTier,
+      },
+    ]);
+
+    expect(mockedCreateAiNavigationTree).toHaveBeenCalledWith(
+      AIChatExperience.Classic,
+      true,
+      false
+    );
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
@@ -8,7 +8,7 @@
 import * as Rx from 'rxjs';
 import { firstValueFrom } from 'rxjs';
 import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
-import { AIChatExperience } from '@kbn/ai-assistant-common';
+import type { AIChatExperience } from '@kbn/ai-assistant-common';
 import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows/common/constants';
 import { ProductLine } from '../../common/product';
 import type { SecurityProductTypes } from '../../common/config';
@@ -24,10 +24,9 @@ export const registerSolutionNavigation = async (
     (productType) => productType.product_line === ProductLine.aiSoc
   );
 
-  const chatExperience$ = services.settings.client.get$<AIChatExperience>(
-    AI_CHAT_EXPERIENCE_TYPE,
-    AIChatExperience.Classic
-  );
+  // Do not pass a defaultOverride: when userValue is unset, get() must use the registered
+  // default (e.g. Agent for security spaces from aiAssistantManagementSelection), not Classic.
+  const chatExperience$ = services.settings.client.get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE);
 
   // Get initial chat experience for setting initial navigation tree
   const initialChatExperience = await firstValueFrom(chatExperience$);

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
@@ -31,10 +31,9 @@ export const registerSolutionNavigation = async (
   // Get initial chat experience for setting initial navigation tree
   const initialChatExperience = await firstValueFrom(chatExperience$);
 
-  const workflowsUiEnabled$ = services.settings.client.get$<boolean>(
-    WORKFLOWS_UI_SETTING_ID,
-    false
-  );
+  // Same as chat experience: no defaultOverride so unset values use the registered default
+  // (workflows:ui:enabled defaults to true in workflows_management).
+  const workflowsUiEnabled$ = services.settings.client.get$<boolean>(WORKFLOWS_UI_SETTING_ID);
   const workflowsUiEnabled = await firstValueFrom(workflowsUiEnabled$);
 
   const showAlertingV2 = Boolean(services.application.capabilities.alertingVTwo);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/navigation/navigation.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/navigation/navigation.cy.ts
@@ -409,19 +409,15 @@ describe('Serverless side navigation links', { tags: '@serverless' }, () => {
   });
 
   it('navigates to the Timelines page', () => {
-    // Investigations panel opener may live under chrome "More" when the strip is full (e.g. Agent entry).
-    ServerlessHeaders.showMoreItems();
     navigateFromHeaderTo(ServerlessHeaders.TIMELINES, true);
     cy.url().should('include', TIMELINES_URL);
   });
   it('navigates to the Osquery page', () => {
-    ServerlessHeaders.showMoreItems();
     navigateFromHeaderTo(ServerlessHeaders.OSQUERY, true);
     cy.url().should('include', OSQUERY_URL);
   });
 
   it('navigates to the Indicators page', () => {
-    ServerlessHeaders.showMoreItems();
     navigateFromHeaderTo(ServerlessHeaders.THREAT_INTELLIGENCE, true);
     cy.url().should('include', INDICATORS_URL);
   });
@@ -442,7 +438,6 @@ describe('Serverless side navigation links', { tags: '@serverless' }, () => {
   });
 
   it('navigates to the Endpoints page', () => {
-    ServerlessHeaders.showMoreItems();
     navigateFromHeaderTo(ServerlessHeaders.ENDPOINTS, true);
     cy.url().should('include', ENDPOINTS_URL);
   });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/navigation/navigation.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/navigation/navigation.cy.ts
@@ -409,10 +409,13 @@ describe('Serverless side navigation links', { tags: '@serverless' }, () => {
   });
 
   it('navigates to the Timelines page', () => {
+    // Investigations panel opener may live under chrome "More" when the strip is full (e.g. Agent entry).
+    ServerlessHeaders.showMoreItems();
     navigateFromHeaderTo(ServerlessHeaders.TIMELINES, true);
     cy.url().should('include', TIMELINES_URL);
   });
   it('navigates to the Osquery page', () => {
+    ServerlessHeaders.showMoreItems();
     navigateFromHeaderTo(ServerlessHeaders.OSQUERY, true);
     cy.url().should('include', OSQUERY_URL);
   });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/serverless_security_header.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/serverless_security_header.ts
@@ -105,9 +105,30 @@ export const openNavigationPanelFor = (pageName: string) => {
   }
 };
 
-// opens the navigation panel of a main link
-export const openNavigationPanel = (pageName: string) => {
-  cy.get(pageName).click();
+/**
+ * Serverless chrome can move top-level nav items into the "More" overflow when the strip is full.
+ * Unconditionally opening "More" when the control is already visible is a common flake (extra overlay, layout races).
+ */
+const clickWhenVisibleElseOpenMore = (selector: string) => {
+  cy.get('body').then(($body) => {
+    const hasVisible = $body.find(selector).filter(':visible').length > 0;
+    if (hasVisible) {
+      cy.get(selector).filter(':visible').first().should('be.visible').click();
+    } else {
+      showMoreItems();
+      cy.get(selector).filter(':visible').first().should('be.visible').click();
+    }
+  });
+};
+
+// opens the navigation panel of a main link (panel opener may be under "More")
+export const openNavigationPanel = (panelSelector: string) => {
+  clickWhenVisibleElseOpenMore(panelSelector);
+};
+
+/** Clicks a nav control that may be on the primary strip or under "More" (e.g. deep links with no panel). */
+export const clickServerlessChromeNavControl = (selector: string) => {
+  clickWhenVisibleElseOpenMore(selector);
 };
 
 export const showMoreItems = () => {
@@ -115,8 +136,8 @@ export const showMoreItems = () => {
   // so we really try to get a stable reference here before proceeding
   // https://github.com/elastic/kibana/issues/239331
   cy.get('[data-test-subj~="nav-item"]').should('exist');
-  cy.get('[data-test-subj="globalLoadingIndicator-hidden"').should('exist');
-  cy.get('[data-test-subj="globalLoadingIndicator"').should('not.exist');
+  cy.get('[data-test-subj="globalLoadingIndicator-hidden"]').should('exist');
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 
   // TODO: https://github.com/elastic/kibana/issues/239331
   // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/security_header.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/security_header.ts
@@ -7,7 +7,10 @@
 
 import { TOASTER } from '../screens/alerts_detection_rules';
 import { KQL_INPUT, openNavigationPanelFor, REFRESH_BUTTON } from '../screens/security_header';
-import { openNavigationPanelFor as openServerlessNavigationPanelFor } from '../screens/serverless_security_header';
+import {
+  clickServerlessChromeNavControl,
+  openNavigationPanelFor as openServerlessNavigationPanelFor,
+} from '../screens/serverless_security_header';
 
 export const clearSearchBar = () => {
   cy.get(KQL_INPUT()).clear();
@@ -21,10 +24,11 @@ export const kqlSearch = (search: string, dataTestSubj?: string) => {
 export const navigateFromHeaderTo = (page: string, isServerless: boolean = false) => {
   if (isServerless) {
     openServerlessNavigationPanelFor(page);
+    clickServerlessChromeNavControl(page);
   } else {
     openNavigationPanelFor(page);
+    cy.get(page).click();
   }
-  cy.get(page).click();
 };
 
 export const verifyNavigatesFromDashboardLandingTo = (dashboardId: string, URL: string) => {


### PR DESCRIPTION
## Summary

**Preferred chat experience (`aiAssistant:preferredChatExperience`):** Serverless Security subscribed with a client `defaultOverride` of `classic`. When no value is saved in the space, `IUiSettingsClient` uses that override instead of the registered default—so navigation stayed on Classic after the product default moved to **Agent**, while Gen AI Settings correctly showed Agent.

**Workflows UI (`workflows:ui:enabled`):** The same pattern applied: a `false` defaultOverride forced workflows off whenever no user value existed, even though `workflows_management` registers the setting with default **true**.

**What we changed:** Call `get$` with no second argument for both settings, matching ESS chat-experience behavior and letting unset values use server-registered defaults.

## Manual verification testing

1. Run es + kibana in serverless security complete
2. Confirm that the Chat experience is AI Agent
3. Check the side nav for Agents (it should be there, it was not before)

## Release note

Fixes Security serverless navigation ignoring UI defaults when preferred chat experience or Elastic Workflows UI has no saved space value (wrong classic/disabled state vs Gen AI Settings and registered defaults).

_PR developed with Cursor + claude-sonnet-4-5_

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->