### PR TITLE
[Cases]Fix All Cases view phrase search

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
@@ -3549,5 +3549,62 @@ describe('CasesService', () => {
         expect((persistedAttributes as CaseAttributes).incremental_id).toBeUndefined();
       });
     });
+
+    describe('getCaseIdsByAttachmentSearch', () => {
+      const namespaces = ['default'];
+      const search = 'awesome case';
+
+      const mockEmptySearchResponse = () => {
+        // The SO mock doesn't include `search` by default, so wire it up here.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (unsecuredSavedObjectsClient as any).search = jest
+          .fn()
+          .mockResolvedValue({ hits: { hits: [] } });
+      };
+
+      it('uses match_phrase for cases-comments.comment so multi-word searches require an exact phrase', async () => {
+        mockEmptySearchResponse();
+
+        await service.getCaseIdsByAttachmentSearch(namespaces, search, ['cases-comments.comment']);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const searchCall = (unsecuredSavedObjectsClient as any).search.mock.calls[0][0];
+        expect(searchCall.query.bool.should).toEqual([
+          { match_phrase: { 'cases-comments.comment': search } },
+        ]);
+      });
+
+      it('uses match (not match_phrase) for keyword identifier fields like alertId and eventId', async () => {
+        mockEmptySearchResponse();
+
+        await service.getCaseIdsByAttachmentSearch(namespaces, search, [
+          'cases-comments.alertId',
+          'cases-comments.eventId',
+        ]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const searchCall = (unsecuredSavedObjectsClient as any).search.mock.calls[0][0];
+        expect(searchCall.query.bool.should).toEqual([
+          { match: { 'cases-comments.alertId': search } },
+          { match: { 'cases-comments.eventId': search } },
+        ]);
+      });
+
+      it('mixes match_phrase for comment and match for keyword fields when both are searched', async () => {
+        mockEmptySearchResponse();
+
+        await service.getCaseIdsByAttachmentSearch(namespaces, search, [
+          'cases-comments.alertId',
+          'cases-comments.comment',
+        ]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const searchCall = (unsecuredSavedObjectsClient as any).search.mock.calls[0][0];
+        expect(searchCall.query.bool.should).toEqual([
+          { match: { 'cases-comments.alertId': search } },
+          { match_phrase: { 'cases-comments.comment': search } },
+        ]);
+      });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
@@ -103,6 +103,25 @@ import {
 
 const PartialCaseTransformedAttributesRt = getPartialCaseTransformedAttributesRt();
 
+/**
+ * `cases-comments.comment` is a text-analyzed field: we use `match_phrase` so the user's
+ * input has to appear as a contiguous sequence
+ *
+ * `cases-comments.alertId` and `cases-comments.eventId` are keyword fields used
+ * to look up an exact ID, so a regular `match` is the correct semantic
+ */
+const buildAttachmentSearchClause = (
+  field: string,
+  search: string
+): estypes.QueryDslQueryContainer => {
+  // TODO: add support for CASE_ATTACHMENT_SAVED_OBJECT
+  // https://github.com/elastic/security-team/issues/15066
+  if (field === `${CASE_COMMENT_SAVED_OBJECT}.comment`) {
+    return { match_phrase: { [field]: search } };
+  }
+  return { match: { [field]: search } };
+};
+
 export class CasesService {
   private readonly log: Logger;
   private readonly unsecuredSavedObjectsClient: SavedObjectsClientContract;
@@ -206,14 +225,7 @@ export class CasesService {
       namespaces,
       query: {
         bool: {
-          should: [
-            ...attachmentSearchFields.map((field) => ({
-              // use match instead of term to support non-keyword search for fields like comments
-              match: {
-                [field]: search,
-              },
-            })),
-          ],
+          should: attachmentSearchFields.map((field) => buildAttachmentSearchClause(field, search)),
         },
       },
     });

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/utils.test.ts
@@ -621,10 +621,13 @@ describe('constructSearchQuery with fieldLabelFilters', () => {
     );
     expect(existsClause).toBeDefined();
 
-    const multiMatchClause = shouldClauses!.find(
-      (c: estypes.QueryDslQueryContainer) => c?.multi_match != null
+    const freeTextSearchClause = shouldClauses!.find(
+      (c: estypes.QueryDslQueryContainer) => c?.simple_query_string != null
     );
-    expect(multiMatchClause).toBeDefined();
+    expect(freeTextSearchClause?.simple_query_string).toEqual({
+      query: 'test',
+      fields: [`${CASE_SAVED_OBJECT}.title`],
+    });
   });
 
   it('combines fieldLabelFilters (should) with extendedFieldFilters (filter) correctly', () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/utils.test.ts
@@ -219,7 +219,7 @@ const searchFieldQuery: estypes.QueryDslQueryContainer[] = [
     },
   },
   {
-    multi_match: {
+    simple_query_string: {
       query: search,
       fields: DEFAULT_CASE_SEARCH_FIELDS,
     },
@@ -272,7 +272,7 @@ describe('constructSearchQuery', () => {
 
     expect(result).toEqual({
       bool: {
-        should: searchFieldQuery.slice(0, 2), // id and multi_match
+        should: searchFieldQuery.slice(0, 2), // id and simple_query_string
         minimum_should_match: 1,
       },
     });

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/utils.ts
@@ -120,7 +120,7 @@ export const constructSearchQuery = ({
 
     if (caseSearchFields?.length) {
       shouldClauses.push({
-        multi_match: {
+        simple_query_string: {
           query: search,
           fields: caseSearchFields,
         },


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/266825

This PR restores phrase-search behavior in the All Cases search bar that regressed after #245321 switched the cases search path from `simple_query_string` (via SO `find`) to `multi_match`.

**After**

`test case` (without quotes) matches cases with word `test` or `case`
<img width="1033" height="253" alt="image" src="https://github.com/user-attachments/assets/d3c9cb2f-69b7-4406-83c3-4f806399a56e" />


`"test case"` matches cases with phrase `test case`
<img width="1020" height="192" alt="image" src="https://github.com/user-attachments/assets/308ef4d9-b1b8-4091-9325-7cfc59224a73" />


## How to test
1. Create a few cases with titles like `my awesome case`, `another case`, `awesome work`.
2. In the All Cases page, search for `"awesome case"` (with quotes) and confirm only `my awesome case` matches.
3. Add a comment containing `connection refused` to one case, then search `"connection refused"` and confirm only that case matches.
4. Confirm unquoted multi-token search (`awesome case`) still returns OR-style results, matching pre-#245321 behavior.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->