### PR TITLE
Remove trailing slash workaround from UIAM OAuth audience parameter

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -410,7 +410,7 @@ describe('UiamService', () => {
         token: 'essu_ephemeral_token_value',
         credentials: {
           oauth: {
-            audience: 'https://my-project.kb.us-east-1.cloud.es.io:9243/',
+            audience: 'https://my-project.kb.us-east-1.cloud.es.io:9243',
           },
         },
       };
@@ -426,7 +426,7 @@ describe('UiamService', () => {
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://uiam.service/uiam/api/v1/authentication/_authenticate?include_token=true&audience=https%3A%2F%2Fmy-project.kb.us-east-1.cloud.es.io%3A9243%2F',
+        'https://uiam.service/uiam/api/v1/authentication/_authenticate?include_token=true&audience=https%3A%2F%2Fmy-project.kb.us-east-1.cloud.es.io%3A9243',
         {
           method: 'POST',
           headers: {

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -401,10 +401,7 @@ export class UiamService implements UiamServicePublic {
   async exchangeOAuthToken(accessToken: string): Promise<string> {
     this.#logger.debug('Attempting to exchange OAuth access token for ephemeral token.');
 
-    // Temporary workaround for https://github.com/elastic/cp-iam-team/issues/2697
-    const expectedAudience = this.#kibanaServerURL.endsWith('/')
-      ? this.#kibanaServerURL
-      : `${this.#kibanaServerURL}/`;
+    const expectedAudience = this.#kibanaServerURL;
     const url = new URL(`${this.#config.url}/uiam/api/v1/authentication/_authenticate`);
     url.searchParams.set('include_token', 'true');
     url.searchParams.set('audience', expectedAudience);

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_local/api/parallel_tests/uiam_oauth_token_exchange.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_local/api/parallel_tests/uiam_oauth_token_exchange.spec.ts
@@ -20,7 +20,7 @@ apiTest.describe(
     let oauthAccessToken: string;
 
     apiTest.beforeAll(async ({ kbnUrl, config: { organizationId, projectType } }) => {
-      const audience = `${new URL(kbnUrl.get()).origin}/`;
+      const audience = new URL(kbnUrl.get()).origin;
 
       oauthAccessToken = await createUiamOAuthAccessToken({
         username: '1234567890',

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_mcp_flow.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_mcp_flow.spec.ts
@@ -44,7 +44,7 @@ apiTest.describe(
         projectType: projectType!,
         roles: ['admin'],
         email: 'elastic_admin@elastic.co',
-        audience: `${kibanaBaseUrl}/`,
+        audience: kibanaBaseUrl,
       });
     });
 


### PR DESCRIPTION
## Summary

Removes the temporary trailing slash workaround from UiamService.exchangeOAuthToken.

Previously, Kibana always appended a `/ ` to kibanaServerURL before sending it as the audience parameter to UIAM's _authenticate endpoint. 

This caused an audience mismatch when OAuth clients were registered with a resource that didn't include a trailing slash (e.g., `http://localhost:5601` vs `http://localhost:5601/`), since UIAM performs a strict string comparison between the registered resource and the requested audience.

Now the audience parameter is sent exactly as kibanaServerURL is constructed in plugin.ts (protocol://hostname:port, no trailing slash), ensuring consistency between client registration and token exchange.


