### PR TITLE
Fix CDN missing en.json translation file

### DIFF
--- a/src/dev/build/tasks/create_cdn_assets_task.ts
+++ b/src/dev/build/tasks/create_cdn_assets_task.ts
@@ -47,7 +47,7 @@ export const CreateCdnAssets: Task = {
     const pluginPaths = plugins.map((plugin) => resolve(dirname(plugin)));
     const allTranslationPaths = await discoverAllTranslationPaths(pluginPaths);
     const discoveredLocales = Array.from(
-      new Set(allTranslationPaths.map((path) => basename(path, '.json')))
+      new Set(['en', ...allTranslationPaths.map((path) => basename(path, '.json'))])
     );
     for (const locale of discoveredLocales) {
       const translationFileContent = await generateTranslationFile(locale, pluginPaths);


### PR DESCRIPTION
Fixes the regression introduced by #260835.

## Summary

The CDN build task was changed to discover locales by scanning for translation files on disk (`discoverAllTranslationPaths`). English has no translation file — it's the source language and uses default messages — so `en` was never included in `discoveredLocales` and `en.json` was never written to the CDN.

This caused every serverless page load to 404 when fetching `translations/en.json`, which prevented `i18n.load()` from calling `init()`, leaving `isInitialized = false`. The fatal error screen then tried to render with `I18nProvider`, which threw `"kbn-i18n must be initialized before using"`.

The fix ensures `en` is always included in the CDN locale set.