### PR TITLE
[9.3] [Fleet] Validate SSL certificate paths for whitespace

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -107,3 +107,5 @@ export {
 export { removeSOAttributes, getSortConfig, checkTargetVersionsValidity } from './agent_utils';
 
 export { isAwsCloudConnectorVars, isAzureCloudConnectorVars } from './cloud_connector_helpers';
+
+export { validateSslCertPath } from './ssl_validators';

--- a/x-pack/platform/plugins/shared/fleet/common/services/ssl_validators.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/ssl_validators.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateSslCertPath } from './ssl_validators';
+
+describe('validateSslCertPath', () => {
+  describe('valid inputs (returns undefined)', () => {
+    it('empty string', () => {
+      expect(validateSslCertPath('')).toBeUndefined();
+    });
+
+    it('Linux path without spaces', () => {
+      expect(validateSslCertPath('/etc/certs/ca.pem')).toBeUndefined();
+    });
+
+    it('relative path without spaces', () => {
+      expect(validateSslCertPath('./certs/ca.pem')).toBeUndefined();
+    });
+
+    it('Windows absolute path without spaces', () => {
+      expect(validateSslCertPath('C:\\certs\\server.pem')).toBeUndefined();
+    });
+
+    it('Windows forward-slash path without spaces', () => {
+      expect(validateSslCertPath('C:/certs/server.pem')).toBeUndefined();
+    });
+
+    it('UNC path without spaces', () => {
+      expect(validateSslCertPath('\\\\server\\share\\cert.pem')).toBeUndefined();
+    });
+
+    it('PEM certificate content', () => {
+      expect(
+        validateSslCertPath(
+          '-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAJC1\n-----END CERTIFICATE-----'
+        )
+      ).toBeUndefined();
+    });
+
+    it('PEM RSA private key', () => {
+      expect(
+        validateSslCertPath(
+          '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----'
+        )
+      ).toBeUndefined();
+    });
+
+    it('PEM EC private key', () => {
+      expect(
+        validateSslCertPath(
+          '-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIO\n-----END EC PRIVATE KEY-----'
+        )
+      ).toBeUndefined();
+    });
+
+    it('PEM content with leading whitespace', () => {
+      expect(
+        validateSslCertPath('  -----BEGIN CERTIFICATE-----\nMIID\n-----END CERTIFICATE-----')
+      ).toBeUndefined();
+    });
+  });
+
+  describe('invalid inputs (returns error string)', () => {
+    it('Linux path with spaces', () => {
+      expect(validateSslCertPath('/path/to my cert.pem')).toBeDefined();
+    });
+
+    it('relative path with spaces', () => {
+      expect(validateSslCertPath('./my certs/ca.pem')).toBeDefined();
+    });
+
+    it('Windows path with spaces', () => {
+      expect(validateSslCertPath('C:\\Program Files\\certs\\server.pem')).toBeDefined();
+    });
+
+    it('Windows forward-slash path with spaces', () => {
+      expect(validateSslCertPath('C:/Program Files/certs/server.pem')).toBeDefined();
+    });
+
+    it('UNC path with spaces in share name', () => {
+      expect(validateSslCertPath('\\\\server\\my share\\cert.pem')).toBeDefined();
+    });
+
+    it('path with tab character', () => {
+      expect(validateSslCertPath('/path/to\tcert.pem')).toBeDefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/common/services/ssl_validators.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/ssl_validators.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+// PEM content (-----BEGIN ...) is exempt — it naturally contains whitespace
+export function validateSslCertPath(value: string): string | undefined {
+  if (!value || value.trimStart().startsWith('-----BEGIN')) return undefined;
+  if (/\s/.test(value)) {
+    return i18n.translate('xpack.fleet.sslValidation.pathSpacesError', {
+      defaultMessage: 'SSL certificate path cannot contain whitespace',
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/output.ts
@@ -100,7 +100,7 @@ export interface KafkaOutput extends NewBaseOutput {
   version?: string;
   key?: string;
   compression?: ValueOf<KafkaCompressionType>;
-  compression_level?: number;
+  compression_level?: number | null;
   auth_type?: ValueOf<KafkaAuthType>;
   connection_type?: ValueOf<KafkaConnectionTypeType>;
   username?: string | null;

--- a/x-pack/platform/plugins/shared/fleet/cypress/e2e/fleet_settings.cy.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/e2e/fleet_settings.cy.ts
@@ -136,8 +136,12 @@ describe('Edit settings', () => {
     cy.getBySel(SETTINGS_OUTPUTS.TYPE_INPUT).select('logstash');
     cy.get('[placeholder="Specify host"').clear().type('logstash:5044');
     cy.getBySel(SETTINGS_OUTPUTS.SSL_BUTTON).click();
-    cy.get('[placeholder="Specify SSL certificate"]').clear().type('SSL CERTIFICATE');
-    cy.get('[placeholder="Specify certificate key"]').clear().type('SSL KEY');
+    cy.get('[placeholder="Specify SSL certificate"]')
+      .clear()
+      .type('-----BEGIN CERTIFICATE-----', { parseSpecialCharSequences: false });
+    cy.get('[placeholder="Specify certificate key"]')
+      .clear()
+      .type('-----BEGIN PRIVATE KEY-----', { parseSpecialCharSequences: false });
 
     cy.intercept('/api/fleet/outputs', {
       items: [
@@ -157,8 +161,8 @@ describe('Edit settings', () => {
       is_default: false,
       is_default_monitoring: false,
       ssl: {
-        certificate: "SSL CERTIFICATE');",
-        key: 'SSL KEY',
+        certificate: '-----BEGIN CERTIFICATE-----',
+        key: '-----BEGIN PRIVATE KEY-----',
       },
     }).as('postLogstashOutput');
 

--- a/x-pack/platform/plugins/shared/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
@@ -178,12 +178,11 @@ queue:
   describe('Remote ES', () => {
     it('displays proper error messages', () => {
       selectRemoteESOutput();
+      cy.getBySel(SETTINGS_OUTPUTS.NAME_INPUT).type('name');
+      cy.get('[placeholder="Specify host URL"').clear().type('https://localhost:5000');
       cy.getBySel(SETTINGS_SAVE_BTN).click();
 
-      cy.contains('Name is required');
-      cy.contains('URL is required');
       cy.contains('Service token is required');
-      shouldDisplayError(SETTINGS_OUTPUTS.NAME_INPUT);
       shouldDisplayError('serviceTokenSecretInput');
     });
 
@@ -388,18 +387,17 @@ queue:
 
       it('displays proper error messages', () => {
         selectKafkaOutput();
+        cy.getBySel(SETTINGS_OUTPUTS.NAME_INPUT).type('name');
+        cy.get('[placeholder="Specify host"').type('localhost:5000');
         cy.getBySel(SETTINGS_OUTPUTS_KAFKA.HEADERS_CLIENT_ID_INPUT).clear();
         cy.getBySel(SETTINGS_SAVE_BTN).click();
 
-        cy.contains('Name is required');
-        cy.contains('Host is required');
         cy.contains('Username is required');
         cy.contains('Password is required');
         cy.contains('Default topic is required');
         cy.contains(
           'Client ID is invalid. Only letters, numbers, dots, underscores, and dashes are allowed.'
         );
-        shouldDisplayError(SETTINGS_OUTPUTS.NAME_INPUT);
         shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_USERNAME_INPUT);
         shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_PASSWORD_INPUT);
         shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.TOPICS_DEFAULT_TOPIC_INPUT);
@@ -560,8 +558,12 @@ queue:
         cy.get('[placeholder="Specify host"').clear().type('localhost:5000');
 
         cy.getBySel(SETTINGS_OUTPUTS.SSL_BUTTON).click();
-        cy.get('[placeholder="Specify SSL certificate"]').clear().type('SSL CERTIFICATE');
-        cy.get('[placeholder="Specify certificate key"]').clear().type('SSL KEY');
+        cy.get('[placeholder="Specify SSL certificate"]')
+          .clear()
+          .type('-----BEGIN CERTIFICATE-----', { parseSpecialCharSequences: false });
+        cy.get('[placeholder="Specify certificate key"]')
+          .clear()
+          .type('-----BEGIN PRIVATE KEY-----', { parseSpecialCharSequences: false });
 
         cy.intercept('PUT', '**/api/fleet/outputs/**').as('saveOutput');
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.test.tsx
@@ -5,7 +5,115 @@
  * 2.0.
  */
 
-import { validateHost } from './use_download_source_flyout_form';
+import { act } from '@testing-library/react';
+
+import { createFleetTestRendererMock } from '../../../../../../mock';
+
+import {
+  validateHost,
+  validateDownloadSourceHeaders,
+  useDowloadSourceFlyoutForm,
+  type AuthType,
+} from './use_download_source_flyout_form';
+
+jest.mock('../../../../../../hooks/use_authz', () => ({
+  useAuthz: () => ({
+    fleet: {
+      allSettings: true,
+    },
+  }),
+}));
+
+describe('useDowloadSourceFlyoutForm SSL certificate path validation', () => {
+  it('should block submission when certificate path contains spaces', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    const onSuccess = jest.fn();
+    const { result } = testRenderer.renderHook(() =>
+      useDowloadSourceFlyoutForm(onSuccess, undefined)
+    );
+
+    act(() => {
+      result.current.inputs.nameInput.setValue('My Source');
+      result.current.inputs.hostInput.setValue('https://artifacts.example.com');
+      result.current.inputs.sslCertificateInput.setValue('/path with spaces/cert.pem');
+    });
+
+    await act(() => result.current.submit());
+
+    await testRenderer.waitFor(() => {
+      expect(result.current.inputs.sslCertificateInput.errors).toBeDefined();
+      expect(onSuccess).not.toBeCalled();
+      expect(result.current.isDisabled).toBeTruthy();
+    });
+  });
+
+  it('should block submission when certificate key path contains spaces', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    const onSuccess = jest.fn();
+    const { result } = testRenderer.renderHook(() =>
+      useDowloadSourceFlyoutForm(onSuccess, undefined)
+    );
+
+    act(() => {
+      result.current.inputs.nameInput.setValue('My Source');
+      result.current.inputs.hostInput.setValue('https://artifacts.example.com');
+      result.current.inputs.sslKeyInput.setValue('/path with spaces/key.pem');
+    });
+
+    await act(() => result.current.submit());
+
+    await testRenderer.waitFor(() => {
+      expect(result.current.inputs.sslKeyInput.errors).toBeDefined();
+      expect(onSuccess).not.toBeCalled();
+      expect(result.current.isDisabled).toBeTruthy();
+    });
+  });
+
+  it('should block submission when certificate authorities path contains spaces', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    const onSuccess = jest.fn();
+    const { result } = testRenderer.renderHook(() =>
+      useDowloadSourceFlyoutForm(onSuccess, undefined)
+    );
+
+    act(() => {
+      result.current.inputs.nameInput.setValue('My Source');
+      result.current.inputs.hostInput.setValue('https://artifacts.example.com');
+      result.current.inputs.sslCertificateAuthoritiesInput.props.onChange([
+        '/path with spaces/ca.pem',
+      ]);
+    });
+
+    await act(() => result.current.submit());
+
+    await testRenderer.waitFor(() => {
+      expect(result.current.inputs.sslCertificateAuthoritiesInput.props.errors).toBeDefined();
+      expect(onSuccess).not.toBeCalled();
+      expect(result.current.isDisabled).toBeTruthy();
+    });
+  });
+
+  it('should allow submission when all SSL paths are valid', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    const onSuccess = jest.fn();
+    testRenderer.startServices.http.post.mockResolvedValue({ item: {} });
+    const { result } = testRenderer.renderHook(() =>
+      useDowloadSourceFlyoutForm(onSuccess, undefined)
+    );
+
+    act(() => {
+      result.current.inputs.nameInput.setValue('My Source');
+      result.current.inputs.hostInput.setValue('https://artifacts.example.com');
+      result.current.inputs.sslCertificateInput.setValue('/valid/path/cert.pem');
+      result.current.inputs.sslKeyInput.setValue('/valid/path/key.pem');
+      result.current.inputs.sslCertificateAuthoritiesInput.props.onChange(['/valid/ca.pem']);
+    });
+
+    await act(() => result.current.submit());
+
+    await testRenderer.waitFor(() => expect(onSuccess).toBeCalled());
+  });
+});
 
 describe('Download source form validation', () => {
   describe('validateHost', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx
@@ -23,6 +23,12 @@ import { useConfirmModal } from '../../hooks/use_confirm_modal';
 
 import type { DownloadSourceBase } from '../../../../../../../common/types';
 
+import {
+  validateSslPathInput,
+  validateSslPathInputSecret,
+  validateSslPathsCombo,
+} from '../ssl_form_validators';
+
 import { confirmUpdate } from './confirm_update';
 
 export interface DownloadSourceFormInputsType {
@@ -58,19 +64,19 @@ export function useDowloadSourceFlyoutForm(onSuccess: () => void, downloadSource
   const sslCertificateAuthoritiesInput = useComboInput(
     'sslCertificateAuthoritiesComboxBox',
     downloadSource?.ssl?.certificate_authorities ?? [],
-    undefined,
+    validateSslPathsCombo,
     undefined
   );
   const sslCertificateInput = useInput(
     downloadSource?.ssl?.certificate ?? '',
-    undefined,
+    validateSslPathInput,
     undefined
   );
-  const sslKeyInput = useInput(downloadSource?.ssl?.key ?? '', undefined, undefined);
+  const sslKeyInput = useInput(downloadSource?.ssl?.key ?? '', validateSslPathInput, undefined);
 
   const sslKeySecretInput = useSecretInput(
     (downloadSource as DownloadSourceBase)?.secrets?.ssl?.key,
-    undefined,
+    validateSslPathInputSecret,
     undefined
   );
 
@@ -91,12 +97,88 @@ export function useDowloadSourceFlyoutForm(onSuccess: () => void, downloadSource
     const nameInputValid = nameInput.validate();
     const hostValid = hostInput.validate();
 
+    const sslCertificateAuthoritiesValid = sslCertificateAuthoritiesInput.validate();
     const sslCertificateValid = sslCertificateInput.validate();
     const sslKeyValid = sslKeyInput.validate();
     const sslKeySecretValid = sslKeySecretInput.validate();
 
-    return nameInputValid && hostValid && sslCertificateValid && sslKeyValid && sslKeySecretValid;
-  }, [nameInput, hostInput, sslCertificateInput, sslKeyInput, sslKeySecretInput]);
+    const usernameValid = usernameInput.validate();
+    const passwordValid = passwordInput.validate();
+    const passwordSecretValid = passwordSecretInput.validate();
+    const apiKeyValid = apiKeyInput.validate();
+    const apiKeySecretValid = apiKeySecretInput.validate();
+    const headersValid = headersInput.validate();
+
+    // Validate auth credentials based on selected auth type
+    const authType = authTypeInput.value as AuthType;
+    let authValid = true;
+    if (authType === 'username_password') {
+      // Username & password tab: require both username and password
+      const hasUsername = !!usernameInput.value;
+      const hasPassword = !!passwordInput.value || !!passwordSecretInput.value;
+      if (!hasUsername) {
+        usernameInput.setErrors([
+          i18n.translate('xpack.fleet.settings.dowloadSourceFlyoutForm.usernameRequired', {
+            defaultMessage: 'Username is required',
+          }),
+        ]);
+        authValid = false;
+      }
+      if (!hasPassword) {
+        const passwordRequiredError = [
+          i18n.translate('xpack.fleet.settings.dowloadSourceFlyoutForm.passwordRequired', {
+            defaultMessage: 'Password is required',
+          }),
+        ];
+        passwordInput.setErrors(passwordRequiredError);
+        passwordSecretInput.setErrors(passwordRequiredError);
+        authValid = false;
+      }
+    } else if (authType === 'api_key') {
+      // API key tab: require api_key
+      const hasApiKey = !!apiKeyInput.value || !!apiKeySecretInput.value;
+      if (!hasApiKey) {
+        const apiKeyRequiredError = [
+          i18n.translate('xpack.fleet.settings.dowloadSourceFlyoutForm.apiKeyRequired', {
+            defaultMessage: 'API key is required',
+          }),
+        ];
+        apiKeyInput.setErrors(apiKeyRequiredError);
+        apiKeySecretInput.setErrors(apiKeyRequiredError);
+        authValid = false;
+      }
+    }
+
+    return (
+      nameInputValid &&
+      hostValid &&
+      sslCertificateAuthoritiesValid &&
+      sslCertificateValid &&
+      sslKeyValid &&
+      sslKeySecretValid &&
+      usernameValid &&
+      passwordValid &&
+      passwordSecretValid &&
+      apiKeyValid &&
+      apiKeySecretValid &&
+      headersValid &&
+      authValid
+    );
+  }, [
+    nameInput,
+    hostInput,
+    sslCertificateAuthoritiesInput,
+    sslCertificateInput,
+    sslKeyInput,
+    sslKeySecretInput,
+    usernameInput,
+    passwordInput,
+    passwordSecretInput,
+    apiKeyInput,
+    apiKeySecretInput,
+    headersInput,
+    authTypeInput.value,
+  ]);
 
   const submit = useCallback(async () => {
     try {
@@ -170,11 +252,26 @@ export function useDowloadSourceFlyoutForm(onSuccess: () => void, downloadSource
     validate,
   ]);
 
+  const authType = authTypeInput.value as AuthType;
+  const isAuthMissing =
+    (authType === 'username_password' &&
+      (!usernameInput.value || (!passwordInput.value && !passwordSecretInput.value))) ||
+    (authType === 'api_key' && !apiKeyInput.value && !apiKeySecretInput.value);
+
   return {
     inputs,
     submit,
     isLoading,
-    isDisabled: isLoading || (downloadSource && !hasChanged) || isEditDisabled,
+    isDisabled:
+      isLoading ||
+      (downloadSource && !hasChanged) ||
+      isEditDisabled ||
+      !nameInput.value ||
+      !hostInput.value ||
+      isAuthMissing ||
+      sslCertificateAuthoritiesInput.props.isInvalid ||
+      sslCertificateInput.props.isInvalid ||
+      (sslKeyInput.value ? sslKeyInput.props.isInvalid : sslKeySecretInput.props.isInvalid),
   };
 }
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_fleet_proxy_flyout/use_fleet_proxy_form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_fleet_proxy_flyout/use_fleet_proxy_form.test.tsx
@@ -11,6 +11,11 @@ import { createFleetTestRendererMock } from '../../../../../../mock';
 
 import { useFleetProxyForm } from './use_fleet_proxy_form';
 
+jest.mock('../../hooks/use_confirm_modal', () => ({
+  ...jest.requireActual('../../hooks/use_confirm_modal'),
+  useConfirmModal: () => ({ confirm: () => true }),
+}));
+
 jest.mock('../../../../../../hooks/use_authz', () => ({
   useAuthz: () => ({
     fleet: {
@@ -51,6 +56,70 @@ describe('useFleetProxyForm', () => {
       act(() => expect(result.current.inputs.urlInput.validate()).toBeFalsy());
 
       expect(result.current.inputs.urlInput.errors).toEqual(['Invalid URL']);
+    });
+  });
+
+  describe('SSL certificate path validation', () => {
+    it('should block submission when certificate path contains spaces', async () => {
+      const testRenderer = createFleetTestRendererMock();
+      const onSuccess = jest.fn();
+      const { result } = testRenderer.renderHook(() => useFleetProxyForm(undefined, onSuccess));
+
+      act(() => {
+        result.current.inputs.nameInput.setValue('My Proxy');
+        result.current.inputs.urlInput.setValue('http://proxy.example.com:3128');
+        result.current.inputs.certificateInput.setValue('/path with spaces/cert.pem');
+      });
+
+      await act(() => result.current.submit());
+
+      await testRenderer.waitFor(() => {
+        expect(result.current.inputs.certificateInput.errors).toBeDefined();
+        expect(onSuccess).not.toBeCalled();
+        expect(result.current.isDisabled).toBeTruthy();
+      });
+    });
+
+    it('should block submission when certificate key path contains spaces', async () => {
+      const testRenderer = createFleetTestRendererMock();
+      const onSuccess = jest.fn();
+      const { result } = testRenderer.renderHook(() => useFleetProxyForm(undefined, onSuccess));
+
+      act(() => {
+        result.current.inputs.nameInput.setValue('My Proxy');
+        result.current.inputs.urlInput.setValue('http://proxy.example.com:3128');
+        result.current.inputs.certificateKeyInput.setValue('/path with spaces/key.pem');
+      });
+
+      await act(() => result.current.submit());
+
+      await testRenderer.waitFor(() => {
+        expect(result.current.inputs.certificateKeyInput.errors).toBeDefined();
+        expect(onSuccess).not.toBeCalled();
+        expect(result.current.isDisabled).toBeTruthy();
+      });
+    });
+
+    it('should allow submission with valid certificate path', () => {
+      const testRenderer = createFleetTestRendererMock();
+      const { result } = testRenderer.renderHook(() => useFleetProxyForm(undefined, () => {}));
+
+      act(() => result.current.inputs.certificateInput.setValue('/valid/path/cert.pem'));
+      act(() => expect(result.current.inputs.certificateInput.validate()).toBeTruthy());
+      expect(result.current.inputs.certificateInput.errors).toBeUndefined();
+    });
+
+    it('should allow PEM certificate content regardless of spaces', () => {
+      const testRenderer = createFleetTestRendererMock();
+      const { result } = testRenderer.renderHook(() => useFleetProxyForm(undefined, () => {}));
+
+      act(() =>
+        result.current.inputs.certificateInput.setValue(
+          '-----BEGIN CERTIFICATE-----\nMIID\n-----END CERTIFICATE-----'
+        )
+      );
+      act(() => expect(result.current.inputs.certificateInput.validate()).toBeTruthy());
+      expect(result.current.inputs.certificateInput.errors).toBeUndefined();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_fleet_proxy_flyout/use_fleet_proxy_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_fleet_proxy_flyout/use_fleet_proxy_form.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../../hooks';
 
 import { useConfirmModal } from '../../hooks/use_confirm_modal';
+import { validateSslPathInput } from '../ssl_form_validators';
 import type { FleetProxy } from '../../../../types';
 import { PROXY_URL_REGEX } from '../../../../../../../common/constants';
 
@@ -100,13 +101,17 @@ export function useFleetProxyForm(fleetProxy: FleetProxy | undefined, onSuccess:
   );
   const certificateAuthoritiesInput = useInput(
     fleetProxy?.certificate_authorities ?? '',
-    () => undefined,
+    validateSslPathInput,
     isEditDisabled
   );
-  const certificateInput = useInput(fleetProxy?.certificate ?? '', () => undefined, isEditDisabled);
+  const certificateInput = useInput(
+    fleetProxy?.certificate ?? '',
+    validateSslPathInput,
+    isEditDisabled
+  );
   const certificateKeyInput = useInput(
     fleetProxy?.certificate_key ?? '',
-    () => undefined,
+    validateSslPathInput,
     isEditDisabled
   );
 
@@ -191,7 +196,15 @@ export function useFleetProxyForm(fleetProxy: FleetProxy | undefined, onSuccess:
   const hasChanged = Object.values(inputs).some((input) => input.hasChanged);
 
   const isDisabled =
-    isLoading || !hasChanged || nameInput.props.isInvalid || urlInput.props.isInvalid;
+    isLoading ||
+    !hasChanged ||
+    !nameInput.value ||
+    !urlInput.value ||
+    nameInput.props.isInvalid ||
+    urlInput.props.isInvalid ||
+    certificateAuthoritiesInput.props.isInvalid ||
+    certificateInput.props.isInvalid ||
+    certificateKeyInput.props.isInvalid;
 
   return {
     isLoading,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
@@ -9,6 +9,9 @@ import { i18n } from '@kbn/i18n';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import { load } from 'js-yaml';
 
+import { validateSslPathInput, validateSslPathsCombo } from '../ssl_form_validators';
+export { validateSslPathInput, validateSslPathsCombo };
+
 const toSecretValidator =
   (validator: (value: string) => string[] | undefined) =>
   (value: string | { id: string } | undefined) => {
@@ -335,6 +338,7 @@ export function validateSSLCertificate(value: string) {
       }),
     ];
   }
+  return validateSslPathInput(value);
 }
 
 export function validateSSLKey(value: string) {
@@ -345,6 +349,7 @@ export function validateSSLKey(value: string) {
       }),
     ];
   }
+  return validateSslPathInput(value);
 }
 
 export const validateSSLKeySecret = toSecretValidator(validateSSLKey);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -76,6 +76,8 @@ import {
   validateDynamicKafkaTopics,
   validateKibanaURL,
   validateKibanaAPIKey,
+  validateSslPathInput,
+  validateSslPathsCombo,
 } from './output_form_validators';
 import { confirmUpdate } from './confirm_update';
 
@@ -381,25 +383,29 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
   const sslCertificateAuthoritiesInput = useComboInput(
     'sslCertificateAuthoritiesComboxBox',
     output?.ssl?.certificate_authorities ?? [],
-    undefined,
+    validateSslPathsCombo,
     isSSLEditable
   );
   const sslCertificateInput = useInput(
     output?.ssl?.certificate ?? '',
-    output?.type === 'logstash' && logstashEnableSSLInput.value
+    typeInput.value === 'logstash' && logstashEnableSSLInput.value
       ? validateSSLCertificate
-      : undefined,
+      : validateSslPathInput,
     isSSLEditable
   );
   const sslKeyInput = useInput(
     output?.ssl?.key ?? '',
-    output?.type === 'logstash' && logstashEnableSSLInput.value ? validateSSLKey : undefined,
+    typeInput.value === 'logstash' && logstashEnableSSLInput.value
+      ? validateSSLKey
+      : validateSslPathInput,
     isSSLEditable
   );
 
   const sslKeySecretInput = useSecretInput(
     (output as NewLogstashOutput)?.secrets?.ssl?.key,
-    output?.type === 'logstash' && logstashEnableSSLInput.value ? validateSSLKeySecret : undefined,
+    typeInput.value === 'logstash' && logstashEnableSSLInput.value
+      ? validateSSLKeySecret
+      : undefined,
     isSSLEditable
   );
 
@@ -454,7 +460,7 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
   const kafkaSslCertificateAuthoritiesInput = useComboInput(
     'kafkaSslCertificateAuthoritiesComboBox',
     kafkaOutput?.ssl?.certificate_authorities ?? [],
-    undefined,
+    validateSslPathsCombo,
     isSSLEditable
   );
   const kafkaSslCertificateInput = useInput(
@@ -664,6 +670,7 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
     const kafkaPasswordPlainValid = kafkaAuthPasswordInput.validate();
     const kafkaPasswordSecretValid = kafkaAuthPasswordSecretInput.validate();
     const kafkaClientIDValid = kafkaClientIdInput.validate();
+    const kafkaSslCertificateAuthoritiesValid = kafkaSslCertificateAuthoritiesInput.validate();
     const kafkaSslCertificateValid = kafkaSslCertificateInput.validate();
     const kafkaSslKeyPlainValid = kafkaSslKeyInput.validate();
     const kafkaSslKeySecretValid = kafkaSslKeySecretInput.validate();
@@ -675,6 +682,7 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
     const serviceTokenSecretValid = serviceTokenSecretInput.validate();
     const kibanaAPIKeyValid = kibanaAPIKeyInput.validate();
     const kibanaURLInputValid = kibanaURLInput.validate();
+    const sslCertificateAuthoritiesValid = sslCertificateAuthoritiesInput.validate();
     const sslCertificateValid = sslCertificateInput.validate();
     const sslKeyValid = sslKeyInput.validate();
     const sslKeySecretValid = sslKeySecretInput.validate();
@@ -698,6 +706,7 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
         logstashHostsValid &&
         additionalYamlConfigValid &&
         nameInputValid &&
+        sslCertificateAuthoritiesValid &&
         sslCertificateValid &&
         (sslKeyValid || sslKeySecretValid)
       );
@@ -707,6 +716,7 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
       return (
         nameInputValid &&
         kafkaHostsValid &&
+        kafkaSslCertificateAuthoritiesValid &&
         kafkaSslCertificateValid &&
         kafkaSslKeyValid &&
         kafkaUsernameValid &&
@@ -725,6 +735,9 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
         elasticsearchUrlsValid &&
         additionalYamlConfigValid &&
         nameInputValid &&
+        sslCertificateAuthoritiesValid &&
+        sslCertificateValid &&
+        sslKeyValid &&
         ((serviceTokenInput.value && serviceTokenValid) ||
           (serviceTokenSecretInput.value && serviceTokenSecretValid)) &&
         ((!syncIntegrationsInput.value && kibanaURLInputValid) ||
@@ -740,7 +753,10 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
         additionalYamlConfigValid &&
         nameInputValid &&
         caTrustedFingerprintValid &&
-        diskQueuePathValid
+        diskQueuePathValid &&
+        sslCertificateAuthoritiesValid &&
+        sslCertificateValid &&
+        sslKeyValid
       );
     }
   }, [
@@ -751,6 +767,7 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
     kafkaAuthPasswordInput,
     kafkaAuthPasswordSecretInput,
     kafkaClientIdInput,
+    kafkaSslCertificateAuthoritiesInput,
     kafkaSslCertificateInput,
     kafkaSslKeyInput,
     kafkaSslKeySecretInput,
@@ -763,6 +780,7 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
     kibanaAPIKeyInput,
     syncIntegrationsInput,
     kibanaURLInput,
+    sslCertificateAuthoritiesInput,
     sslCertificateInput,
     sslKeyInput,
     sslKeySecretInput,
@@ -1156,6 +1174,14 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
     notifications.toasts,
   ]);
 
+  const isHostsMissing = isKafka
+    ? !kafkaHostsInput.value.some((v) => v.trim())
+    : isLogstash
+    ? !logstashHostsInput.value.some((v) => v.trim())
+    : isRemoteElasticsearch
+    ? !remoteElasticsearchUrlInput.value.some((v) => v.trim())
+    : !elasticsearchUrlInput.value.some((v) => v.trim());
+
   return {
     inputs,
     submit,
@@ -1163,6 +1189,22 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
     hasEncryptedSavedObjectConfigured,
     isShipperEnabled: !isShipperDisabled,
     isDisabled:
-      isLoading || (output && !hasChanged) || (isLogstash && !hasEncryptedSavedObjectConfigured),
+      isLoading ||
+      (output && !hasChanged) ||
+      !nameInput.value ||
+      isHostsMissing ||
+      (isLogstash && !hasEncryptedSavedObjectConfigured) ||
+      (!isKafka &&
+        (sslCertificateAuthoritiesInput.props.isInvalid ||
+          sslCertificateInput.props.isInvalid ||
+          (sslKeySecretInput.value
+            ? sslKeySecretInput.props.isInvalid
+            : sslKeyInput.props.isInvalid))) ||
+      (isKafka &&
+        (kafkaSslCertificateAuthoritiesInput.props.isInvalid ||
+          kafkaSslCertificateInput.props.isInvalid ||
+          (kafkaSslKeySecretInput.value
+            ? kafkaSslKeySecretInput.props.isInvalid
+            : kafkaSslKeyInput.props.isInvalid))),
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.test.tsx
@@ -73,7 +73,7 @@ describe('useFleetServerHostsForm', () => {
   it('should submit a valid form with SSL options', async () => {
     const testRenderer = createFleetTestRendererMock();
     const onSuccess = jest.fn();
-    testRenderer.startServices.http.post.mockResolvedValue({});
+    testRenderer.startServices.http.put.mockResolvedValue({});
     const { result } = testRenderer.renderHook(() =>
       useFleetServerHostsForm(
         {
@@ -83,13 +83,13 @@ describe('useFleetServerHostsForm', () => {
           is_default: false,
           is_preconfigured: false,
           ssl: {
-            certificate_authorities: ['cert authorities'],
-            es_certificate_authorities: ['ES cert authorities'],
-            certificate: 'path/to/cert',
-            es_certificate: 'path/to/EScert',
-            agent_certificate_authorities: ['agent cert authorities'],
-            agent_certificate: 'path/to/agent_cert',
-            agent_key: 'path/to/agent_key',
+            certificate_authorities: ['/etc/certs/ca.pem'],
+            es_certificate_authorities: ['/etc/certs/es-ca.pem'],
+            certificate: '/etc/certs/cert.pem',
+            es_certificate: '/etc/certs/es-cert.pem',
+            agent_certificate_authorities: ['/etc/certs/agent-ca.pem'],
+            agent_certificate: '/etc/certs/agent-cert.pem',
+            agent_key: '/etc/certs/agent-key.pem',
           },
         },
         onSuccess
@@ -101,6 +101,94 @@ describe('useFleetServerHostsForm', () => {
     await act(() => result.current.submit());
 
     await testRenderer.waitFor(() => expect(onSuccess).toBeCalled());
+  });
+
+  describe('SSL certificate path validation', () => {
+    it('should block submission when a certificate path contains spaces', async () => {
+      const testRenderer = createFleetTestRendererMock();
+      const onSuccess = jest.fn();
+      const { result } = testRenderer.renderHook(() =>
+        useFleetServerHostsForm(
+          {
+            id: 'id1',
+            name: 'fleet server 1',
+            host_urls: ['https://test.fr'],
+            is_default: false,
+            is_preconfigured: false,
+          },
+          onSuccess
+        )
+      );
+
+      act(() => result.current.inputs.sslCertificateInput.setValue('/path with spaces/cert.pem'));
+
+      await act(() => result.current.submit());
+
+      await testRenderer.waitFor(() => {
+        expect(result.current.inputs.sslCertificateInput.errors).toBeDefined();
+        expect(onSuccess).not.toBeCalled();
+        expect(result.current.isDisabled).toBeTruthy();
+      });
+    });
+
+    it('should block submission when an ES certificate authorities path contains spaces', async () => {
+      const testRenderer = createFleetTestRendererMock();
+      const onSuccess = jest.fn();
+      const { result } = testRenderer.renderHook(() =>
+        useFleetServerHostsForm(
+          {
+            id: 'id1',
+            name: 'fleet server 1',
+            host_urls: ['https://test.fr'],
+            is_default: false,
+            is_preconfigured: false,
+          },
+          onSuccess
+        )
+      );
+
+      act(() =>
+        result.current.inputs.sslEsCertificateAuthoritiesInput.props.onChange([
+          '/path with spaces/ca.pem',
+        ])
+      );
+
+      await act(() => result.current.submit());
+
+      await testRenderer.waitFor(() => {
+        expect(result.current.inputs.sslEsCertificateAuthoritiesInput.props.errors).toBeDefined();
+        expect(onSuccess).not.toBeCalled();
+        expect(result.current.isDisabled).toBeTruthy();
+      });
+    });
+
+    it('should allow submission when all SSL paths are valid', async () => {
+      const testRenderer = createFleetTestRendererMock();
+      const onSuccess = jest.fn();
+      testRenderer.startServices.http.put.mockResolvedValue({});
+      const { result } = testRenderer.renderHook(() =>
+        useFleetServerHostsForm(
+          {
+            id: 'id1',
+            name: 'fleet server 1',
+            host_urls: ['https://test.fr'],
+            is_default: false,
+            is_preconfigured: false,
+          },
+          onSuccess
+        )
+      );
+
+      act(() => {
+        result.current.inputs.sslCertificateInput.setValue('/valid/path/cert.pem');
+        result.current.inputs.sslKeyInput.setValue('/valid/path/key.pem');
+        result.current.inputs.sslCertificateAuthoritiesInput.props.onChange(['/valid/ca.pem']);
+      });
+
+      await act(() => result.current.submit());
+
+      await testRenderer.waitFor(() => expect(onSuccess).toBeCalled());
+    });
   });
 
   it('should allow the user to correct and submit an invalid form', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_flyout/use_fleet_server_host_form.tsx
@@ -22,6 +22,7 @@ import {
   useSecretInput,
 } from '../../../../hooks';
 import { isDiffPathProtocol } from '../../../../../../../common/services';
+import { validateSslPathInput, validateSslPathsCombo } from '../ssl_form_validators';
 import { useConfirmModal } from '../../hooks/use_confirm_modal';
 import type { FleetServerHost } from '../../../../types';
 import type { ClientAuth, NewFleetServerHost, ValueOf } from '../../../../../../../common/types';
@@ -172,28 +173,36 @@ export function useFleetServerHostsForm(
   const sslCertificateAuthoritiesInput = useComboInput(
     'sslCertificateAuthoritiesComboxBox',
     fleetServerHost?.ssl?.certificate_authorities ?? [],
-    undefined,
+    validateSslPathsCombo,
     isEditDisabled
   );
   const sslCertificateInput = useInput(
     fleetServerHost?.ssl?.certificate ?? '',
-    () => undefined,
+    validateSslPathInput,
     isEditDisabled
   );
 
   const sslEsCertificateAuthoritiesInput = useComboInput(
     'sslEsCertificateAuthoritiesComboxBox',
     fleetServerHost?.ssl?.es_certificate_authorities ?? [],
-    undefined,
+    validateSslPathsCombo,
     isEditDisabled
   );
   const sslEsCertificateInput = useInput(
     fleetServerHost?.ssl?.es_certificate ?? '',
-    () => undefined,
+    validateSslPathInput,
     isEditDisabled
   );
-  const sslKeyInput = useInput(fleetServerHost?.ssl?.key ?? '', undefined, isEditDisabled);
-  const sslESKeyInput = useInput(fleetServerHost?.ssl?.es_key ?? '', undefined, isEditDisabled);
+  const sslKeyInput = useInput(
+    fleetServerHost?.ssl?.key ?? '',
+    validateSslPathInput,
+    isEditDisabled
+  );
+  const sslESKeyInput = useInput(
+    fleetServerHost?.ssl?.es_key ?? '',
+    validateSslPathInput,
+    isEditDisabled
+  );
 
   const sslKeySecretInput = useSecretInput(
     (fleetServerHost as FleetServerHost)?.secrets?.ssl?.key,
@@ -215,12 +224,12 @@ export function useFleetServerHostsForm(
   const sslAgentCertificateAuthoritiesInput = useComboInput(
     'sslAgentCertificateAuthoritiesComboxBox',
     fleetServerHost?.ssl?.agent_certificate_authorities ?? [],
-    undefined,
+    validateSslPathsCombo,
     isEditDisabled
   );
   const sslAgentCertificateInput = useInput(
     fleetServerHost?.ssl?.agent_certificate ?? '',
-    () => undefined,
+    validateSslPathInput,
     isEditDisabled
   );
   const sslAgentKeySecretInput = useSecretInput(
@@ -230,7 +239,7 @@ export function useFleetServerHostsForm(
   );
   const sslAgentKeyInput = useInput(
     fleetServerHost?.ssl?.agent_key ?? '',
-    undefined,
+    validateSslPathInput,
     isEditDisabled
   );
 
@@ -378,8 +387,19 @@ export function useFleetServerHostsForm(
     isEditDisabled ||
     isLoading ||
     !hasChanged ||
+    !nameInput.value ||
+    !hostUrlsInput.value.some((v) => v.trim()) ||
     hostUrlsInput.props.isInvalid ||
-    nameInput.props.isInvalid;
+    nameInput.props.isInvalid ||
+    sslCertificateAuthoritiesInput.props.isInvalid ||
+    sslCertificateInput.props.isInvalid ||
+    sslKeyInput.props.isInvalid ||
+    sslEsCertificateAuthoritiesInput.props.isInvalid ||
+    sslEsCertificateInput.props.isInvalid ||
+    sslESKeyInput.props.isInvalid ||
+    sslAgentCertificateAuthoritiesInput.props.isInvalid ||
+    sslAgentCertificateInput.props.isInvalid ||
+    sslAgentKeyInput.props.isInvalid;
 
   return {
     isLoading,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/ssl_form_validators.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/ssl_form_validators.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateSslCertPath } from '../../../../../../common/services';
+
+export function validateSslPathInput(value: string): string[] | undefined {
+  const err = validateSslCertPath(value);
+  return err ? [err] : undefined;
+}
+
+// For useSecretInput: skips existing secret references ({ id }), validates plain strings
+export function validateSslPathInputSecret(
+  value: string | { id: string } | undefined
+): string[] | undefined {
+  if (!value || typeof value === 'object') return undefined;
+  return validateSslPathInput(value);
+}
+
+export function validateSslPathsCombo(
+  values: string[]
+): Array<{ message: string; index: number }> | undefined {
+  const errors = values
+    .map((v, index) => ({ err: validateSslCertPath(v), index }))
+    .filter((x): x is { err: string; index: number } => x.err !== undefined)
+    .map(({ err, index }) => ({ message: err, index }));
+  return errors.length ? errors : undefined;
+}

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_input.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_input.ts
@@ -34,8 +34,11 @@ export function useInput(
     (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
       const newValue = e.target.value;
       setValue(newValue);
-      if (errors && validate && validate(newValue) === undefined) {
-        setErrors(undefined);
+      if (errors && validate) {
+        const newErrors = validate(newValue);
+        if (newErrors?.join() !== errors.join()) {
+          setErrors(newErrors);
+        }
       }
     },
     [errors, validate]
@@ -97,8 +100,11 @@ export function useSecretInput(
     (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
       const newValue = e.target.value;
       setValue(newValue);
-      if (errors && validate && validate(newValue) === undefined) {
-        setErrors(undefined);
+      if (errors && validate) {
+        const newErrors = validate(newValue);
+        if (newErrors?.join() !== errors.join()) {
+          setErrors(newErrors);
+        }
       }
     },
     [errors, validate]

--- a/x-pack/platform/plugins/shared/fleet/server/routes/download_source/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/download_source/handler.ts
@@ -25,8 +25,32 @@ import type {
 } from '../../../common/types';
 import { downloadSourceService } from '../../services/download_source';
 import { agentPolicyService } from '../../services';
+import { throwIfSslPathInvalid } from '../utils/ssl_utils';
 
-function ensureNoDuplicateSecrets(downloadSource: Partial<DownloadSource>) {
+// Support clearing auth via PUT requests
+export type DownloadSourceWithNullableAuth = Partial<DownloadSource> & {
+  auth?: DownloadSource['auth'] | null;
+};
+
+/**
+ * Validates download source auth configuration.
+ *
+ * Allowed auth configurations:
+ * - auth headers only (no credentials)
+ * - username + password (together), optionally with headers (no api_key)
+ * - api_key, optionally with headers (no username/password)
+ * - auth: null (to clear all auth data)
+ * - auth: undefined (no changes to auth)
+ */
+export function validateDownloadSource(downloadSource: DownloadSourceWithNullableAuth) {
+  throwIfSslPathInvalid([
+    ...(downloadSource.ssl?.certificate_authorities ?? []),
+    downloadSource.ssl?.certificate,
+    downloadSource.ssl?.key,
+    downloadSource.secrets?.ssl?.key,
+  ]);
+
+  // For settings that can be stored as secrets, only allow either plain text or secret reference.
   if (downloadSource.ssl?.key && downloadSource.secrets?.ssl?.key) {
     throw Boom.badRequest('Cannot specify both ssl.key and secrets.ssl.key');
   }

--- a/x-pack/platform/plugins/shared/fleet/server/routes/fleet_proxies/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/fleet_proxies/handler.ts
@@ -32,6 +32,7 @@ import type {
 } from '../../types';
 import { agentPolicyService } from '../../services';
 import { MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_20 } from '../../constants';
+import { throwIfSslPathInvalid } from '../utils/ssl_utils';
 
 async function bumpRelatedPolicies(
   soClient: SavedObjectsClientContract,
@@ -81,6 +82,7 @@ export const postFleetProxyHandler: RequestHandler<
   const coreContext = await context.core;
   const soClient = coreContext.savedObjects.client;
   const { id, ...data } = request.body;
+  throwIfSslPathInvalid([data.certificate_authorities, data.certificate, data.certificate_key]);
   const proxy = await createFleetProxy(soClient, { ...data, is_preconfigured: false }, { id });
 
   const body = {
@@ -101,6 +103,11 @@ export const putFleetProxyHandler: RequestHandler<
     const soClient = coreContext.savedObjects.client;
     const esClient = coreContext.elasticsearch.client.asInternalUser;
 
+    throwIfSslPathInvalid([
+      request.body.certificate_authorities,
+      request.body.certificate,
+      request.body.certificate_key,
+    ]);
     const item = await updateFleetProxy(soClient, proxyId, request.body);
     const body = {
       item,

--- a/x-pack/platform/plugins/shared/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -9,9 +9,9 @@ import type { TypeOf } from '@kbn/config-schema';
 import type { RequestHandler, SavedObjectsClientContract } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { isEqual } from 'lodash';
-
 import Boom from '@hapi/boom';
 
+import { throwIfSslPathInvalid } from '../utils/ssl_utils';
 import { SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID } from '../../constants';
 
 import { FleetServerHostUnauthorizedError } from '../../errors';
@@ -23,6 +23,23 @@ import type {
   PostFleetServerHostRequestSchema,
   PutFleetServerHostRequestSchema,
 } from '../../types';
+
+function validateFleetServerHostSsl(fleetServerHost: Partial<FleetServerHost>) {
+  throwIfSslPathInvalid([
+    ...(fleetServerHost.ssl?.certificate_authorities ?? []),
+    fleetServerHost.ssl?.certificate,
+    fleetServerHost.ssl?.key,
+    ...(fleetServerHost.ssl?.es_certificate_authorities ?? []),
+    fleetServerHost.ssl?.es_certificate,
+    fleetServerHost.ssl?.es_key,
+    ...(fleetServerHost.ssl?.agent_certificate_authorities ?? []),
+    fleetServerHost.ssl?.agent_certificate,
+    fleetServerHost.ssl?.agent_key,
+    fleetServerHost.secrets?.ssl?.key,
+    fleetServerHost.secrets?.ssl?.es_key,
+    fleetServerHost.secrets?.ssl?.agent_key,
+  ]);
+}
 
 function ensureNoDuplicateSecrets(fleetServerHost: Partial<FleetServerHost>) {
   if (fleetServerHost.ssl?.key && fleetServerHost.secrets?.ssl?.key) {
@@ -69,6 +86,7 @@ export const postFleetServerHost: RequestHandler<
   await checkFleetServerHostsWriteAPIsAllowed(soClient, request.body.host_urls);
 
   const { id, ...data } = request.body;
+  validateFleetServerHostSsl(data);
   ensureNoDuplicateSecrets(data);
 
   const FleetServerHost = await fleetServerHostService.create(
@@ -147,6 +165,7 @@ export const putFleetServerHostHandler: RequestHandler<
     if (request.body.host_urls) {
       await checkFleetServerHostsWriteAPIsAllowed(soClient, request.body.host_urls);
     }
+    validateFleetServerHostSsl(request.body);
     ensureNoDuplicateSecrets(request.body);
 
     const item = await fleetServerHostService.update(

--- a/x-pack/platform/plugins/shared/fleet/server/routes/output/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/output/handler.ts
@@ -32,6 +32,16 @@ import { outputService } from '../../services/output';
 import { FleetUnauthorizedError } from '../../errors';
 import { agentPolicyService, appContextService } from '../../services';
 import { generateLogstashApiKey, canCreateLogstashApiKey } from '../../services/api_keys';
+import { throwIfSslPathInvalid } from '../utils/ssl_utils';
+
+function validateOutputSslPaths(output: Partial<Output>) {
+  throwIfSslPathInvalid([
+    ...(output.ssl?.certificate_authorities ?? []),
+    output.ssl?.certificate,
+    output.ssl?.key,
+    output.secrets?.ssl?.key,
+  ]);
+}
 
 function ensureNoDuplicateSecrets(output: Partial<Output>) {
   if (output.type === outputType.Kafka && output?.password && output?.secrets?.password) {
@@ -93,6 +103,7 @@ export const putOutputHandler: RequestHandler<
   const outputUpdate = request.body;
   try {
     await validateOutputServerless(outputUpdate, soClient, request.params.outputId);
+    validateOutputSslPaths(outputUpdate);
     ensureNoDuplicateSecrets(outputUpdate);
     await outputService.update(soClient, esClient, request.params.outputId, outputUpdate);
     const output = await outputService.get(request.params.outputId);
@@ -128,6 +139,7 @@ export const postOutputHandler: RequestHandler<
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const { id, ...newOutput } = request.body;
   await validateOutputServerless(newOutput, soClient);
+  validateOutputSslPaths(newOutput);
   ensureNoDuplicateSecrets(newOutput);
   const output = await outputService.create(soClient, esClient, newOutput, { id });
   if (output.is_default || output.is_default_monitoring) {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/utils/ssl_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/utils/ssl_utils.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+
+import { validateSslCertPath } from '../../../common/services';
+
+export function throwIfSslPathInvalid(
+  paths: Array<string | Record<string, unknown> | undefined | null>
+) {
+  for (const p of paths) {
+    // SOSecret values can be a plain string or a { id } secret reference — skip references
+    if (!p || typeof p === 'object') continue;
+    const err = validateSslCertPath(p);
+    if (err) throw Boom.badRequest(err);
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/output.ts
@@ -230,12 +230,7 @@ export const KafkaSchema = {
       schema.literal(kafkaCompressionType.None),
     ])
   ),
-  compression_level: schema.conditional(
-    schema.siblingRef('compression'),
-    schema.string({ validate: (val) => (val === kafkaCompressionType.Gzip ? undefined : 'never') }),
-    schema.number(),
-    schema.never()
-  ),
+  compression_level: schema.maybe(schema.oneOf([schema.literal(null), schema.number()])),
   client_id: schema.maybe(schema.string()),
   auth_type: schema.oneOf([
     schema.literal(kafkaAuthType.None),

--- a/x-pack/platform/test/fleet_api_integration/apis/download_sources/crud.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/download_sources/crud.ts
@@ -97,6 +97,16 @@ export default function (providerContext: FtrProviderContext) {
     }
   };
 
+  const authHeaderConflictCases: Array<[string, { auth?: {}; secrets?: {} }]> = [
+    ['username/password', { auth: { username: 'testuser', password: 'testpassword' } }],
+    [
+      'username/password as secret',
+      { auth: { username: 'testuser' }, secrets: { auth: { password: 'testpassword' } } },
+    ],
+    ['api_key', { auth: { api_key: 'my-api-key' } }],
+    ['api_key as secret', { secrets: { auth: { api_key: 'my-api-key' } } }],
+  ];
+
   describe('fleet_download_sources_crud', function () {
     let defaultDownloadSourceId: string;
     let fleetServerPolicyId: string;
@@ -204,7 +214,7 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     describe('POST /agent_download_sources', () => {
-      it('should not store secrets if fleet server does not meet minimum version', async function () {
+      it('should not store SSL secrets if fleet server does not meet minimum version', async function () {
         await clearAgents();
         await createFleetServerAgent(fleetServerPolicyId, 'server_1', '7.0.0');
 
@@ -329,8 +339,8 @@ export default function (providerContext: FtrProviderContext) {
             host: 'http://test.fr:443',
             is_default: false,
             ssl: {
-              certificate_authorities: ['cert authorities'],
-              certificate: 'path/to/cert',
+              certificate_authorities: ['/path/to/cert-authority'],
+              certificate: '/path/to/cert',
               key: 'KEY',
             },
             secrets: { ssl: { key: 'KEY' } },
@@ -340,7 +350,7 @@ export default function (providerContext: FtrProviderContext) {
         expect(res.body.message).to.equal('Cannot specify both ssl.key and secrets.ssl.key');
       });
 
-      it('should store secrets if fleet server meets minimum version', async function () {
+      it('should store SSL secrets if fleet server meets minimum version', async function () {
         await clearAgents();
         await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.3.0');
         const res = await supertest
@@ -351,7 +361,7 @@ export default function (providerContext: FtrProviderContext) {
             host: 'http://test.fr:443',
             is_default: false,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
             },
             secrets: { ssl: { key: 'KEY1' } },
@@ -363,6 +373,273 @@ export default function (providerContext: FtrProviderContext) {
         const secret1 = await getSecretById(secretId1);
         // @ts-ignore _source unknown type
         expect(secret1._source.value).to.equal('KEY1');
+      });
+
+      it('should allow creating a download source with username/password auth', async function () {
+        const { body: postResponse } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with auth ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              password: 'testpassword',
+            },
+          })
+          .expect(200);
+
+        expect(postResponse.item.auth.username).to.eql('testuser');
+        expect(postResponse.item.auth.password).to.eql('testpassword');
+      });
+
+      it('should allow creating a download source with api_key auth', async function () {
+        const { body: postResponse } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with api key ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              api_key: 'my-api-key',
+            },
+          })
+          .expect(200);
+
+        expect(postResponse.item.auth.api_key).to.eql('my-api-key');
+      });
+
+      it('should not allow both username/password and api_key', async function () {
+        const res = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with conflicting auth ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              password: 'testpassword',
+              api_key: 'my-api-key',
+            },
+          })
+          .expect(400);
+
+        expect(res.body.message).to.contain(
+          'Cannot specify both username/password and api_key authentication'
+        );
+      });
+
+      it('should require password when username is provided', async function () {
+        const res = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with username only ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+            },
+          })
+          .expect(400);
+
+        expect(res.body.message).to.contain('Username and password must be provided together');
+      });
+
+      it('should require username when password is provided', async function () {
+        const res = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with password only ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              password: 'testpassword',
+            },
+          })
+          .expect(400);
+
+        expect(res.body.message).to.contain('Username and password must be provided together');
+      });
+
+      it('should not allow auth.password and secrets.auth.password at the same time', async function () {
+        const res = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with duplicate password ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              password: 'plainpassword',
+            },
+            secrets: {
+              auth: {
+                password: 'secretpassword',
+              },
+            },
+          })
+          .expect(400);
+
+        expect(res.body.message).to.contain(
+          'Cannot specify both auth.password and secrets.auth.password'
+        );
+      });
+
+      it('should not allow auth.api_key and secrets.auth.api_key at the same time', async function () {
+        const res = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with duplicate api_key ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              api_key: 'plain-api-key',
+            },
+            secrets: {
+              auth: {
+                api_key: 'secret-api-key',
+              },
+            },
+          })
+          .expect(400);
+
+        expect(res.body.message).to.contain(
+          'Cannot specify both auth.api_key and secrets.auth.api_key'
+        );
+      });
+
+      authHeaderConflictCases.forEach(([description, { auth, secrets }]) => {
+        it(`should return 400 when Authorization header is combined with ${description} credentials on create`, async function () {
+          const baseAuth = {
+            headers: [{ key: 'Authorization', value: 'Bearer token' }],
+          };
+
+          const res = await supertest
+            .post(`/api/fleet/agent_download_sources`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `Download source auth conflict ${Date.now()}`,
+              host: 'http://test.fr:443',
+              is_default: false,
+              auth: { ...baseAuth, ...auth },
+              ...(secrets ? { secrets } : {}),
+            })
+            .expect(400);
+
+          expect(res.body.message).to.contain('Cannot use "Authorization" custom header');
+        });
+      });
+
+      it('should store auth secrets when fleet server meets minimum version', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.4.0');
+        const res = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with auth secret ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+            },
+            secrets: {
+              auth: {
+                password: 'secretpassword',
+              },
+            },
+          })
+          .expect(200);
+
+        expect(res.body.item.auth.username).to.eql('testuser');
+        expect(res.body.item.secrets.auth.password).to.have.property('id');
+        const secretId = res.body.item.secrets.auth.password.id;
+        const secret = await getSecretById(secretId);
+        // @ts-ignore _source unknown type
+        expect(secret._source.value).to.eql('secretpassword');
+      });
+
+      it('should allow creating a download source with auth headers', async function () {
+        const { body: postResponse } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with headers ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              password: 'testpassword',
+              headers: [
+                { key: 'X-Custom-Header', value: 'custom-value' },
+                { key: 'X-Another-Header', value: 'another-value' },
+              ],
+            },
+          })
+          .expect(200);
+
+        expect(postResponse.item.auth.username).to.eql('testuser');
+        expect(postResponse.item.auth.headers).to.eql([
+          { key: 'X-Custom-Header', value: 'custom-value' },
+          { key: 'X-Another-Header', value: 'another-value' },
+        ]);
+      });
+
+      it('should allow creating a download source with api_key and headers', async function () {
+        const { body: postResponse } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with api_key and headers ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              api_key: 'my-api-key',
+              headers: [{ key: 'X-Custom-Header', value: 'custom-value' }],
+            },
+          })
+          .expect(200);
+
+        const apiKey =
+          postResponse.item.auth?.api_key ?? postResponse.item.secrets?.auth?.api_key?.id;
+        expect(apiKey).to.be.ok();
+        expect(postResponse.item.auth.headers).to.eql([
+          { key: 'X-Custom-Header', value: 'custom-value' },
+        ]);
+      });
+
+      it('should allow creating a download source with auth headers only', async function () {
+        const { body: postResponse } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Download source with headers only ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              headers: [
+                { key: 'X-Custom-Header', value: 'custom-value' },
+                { key: 'X-Another-Header', value: 'another-value' },
+              ],
+            },
+          })
+          .expect(200);
+
+        expect(postResponse.item.auth.headers).to.eql([
+          { key: 'X-Custom-Header', value: 'custom-value' },
+          { key: 'X-Another-Header', value: 'another-value' },
+        ]);
+
+        expect(postResponse.item.auth.username).to.be(undefined);
+        expect(postResponse.item.auth.password).to.be(undefined);
+        expect(postResponse.item.auth.api_key).to.be(undefined);
       });
     });
 
@@ -412,7 +689,7 @@ export default function (providerContext: FtrProviderContext) {
             host: 'https://test.co',
             is_default: true,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
             },
             secrets: { ssl: { key: 'KEY1' } },
@@ -438,7 +715,7 @@ export default function (providerContext: FtrProviderContext) {
             host: 'http://test.fr:443',
             is_default: false,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
             },
             secrets: { ssl: { key: 'KEY1' } },
@@ -458,7 +735,7 @@ export default function (providerContext: FtrProviderContext) {
             host: 'http://test.fr:443',
             is_default: false,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
             },
             secrets: { ssl: { key: 'NEW_KEY' } },
@@ -493,7 +770,7 @@ export default function (providerContext: FtrProviderContext) {
             host: 'http://test.fr:443',
             is_default: false,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               key: 'KEY1',
             },
@@ -509,7 +786,7 @@ export default function (providerContext: FtrProviderContext) {
             host: 'http://test.fr:443',
             is_default: false,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
             },
             secrets: { ssl: { key: 'NEW_KEY' } },
@@ -545,6 +822,489 @@ export default function (providerContext: FtrProviderContext) {
             is_default: true,
           })
           .expect(400);
+      });
+
+      authHeaderConflictCases.forEach(([description, { auth, secrets }]) => {
+        it(`should return 400 when Authorization header is combined with ${description} credentials on update`, async function () {
+          const { body: createRes } = await supertest
+            .post(`/api/fleet/agent_download_sources`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `Bad auth combination test ${Date.now()}`,
+              host: 'http://test.fr:443',
+              is_default: false,
+            })
+            .expect(200);
+
+          const baseAuth = {
+            headers: [{ key: 'Authorization', value: 'Bearer token' }],
+          };
+
+          const res = await supertest
+            .put(`/api/fleet/agent_download_sources/${createRes.item.id}`)
+            .set('kbn-xsrf', 'xxxx')
+            .send({
+              name: `Download source auth conflict ${Date.now()}`,
+              host: 'http://test.fr:443',
+              is_default: false,
+              auth: { ...baseAuth, ...auth },
+              ...(secrets ? { secrets } : {}),
+            })
+            .expect(400);
+
+          expect(res.body.message).to.contain('Cannot use "Authorization" custom header');
+        });
+      });
+
+      it('should delete password secret when switching from username/password to api_key', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.4.0');
+
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Switch auth test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+            },
+            secrets: {
+              auth: {
+                password: 'secretpassword',
+              },
+            },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+        const passwordSecretId = createRes.item.secrets.auth.password.id;
+
+        await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Switch auth test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            secrets: {
+              auth: {
+                api_key: 'new-api-key',
+              },
+            },
+          })
+          .expect(200);
+
+        try {
+          await getSecretById(passwordSecretId);
+          expect().fail('Password secret should have been deleted');
+        } catch (e) {
+          // not found - expected
+        }
+
+        const { body: getRes } = await supertest
+          .get(`/api/fleet/agent_download_sources/${dsId}`)
+          .expect(200);
+
+        expect(getRes.item.auth).to.be(undefined);
+        expect(getRes.item.secrets.auth.api_key).to.have.property('id');
+      });
+
+      it('should delete api_key secret when switching from api_key to username/password', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.4.0');
+
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Switch auth test 2 ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            secrets: {
+              auth: {
+                api_key: 'secret-api-key',
+              },
+            },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+        const apiKeySecretId = createRes.item.secrets.auth.api_key.id;
+
+        await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Switch auth test 2 ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'newuser',
+            },
+            secrets: {
+              auth: {
+                password: 'newpassword',
+              },
+            },
+          })
+          .expect(200);
+
+        try {
+          await getSecretById(apiKeySecretId);
+          expect().fail('API key secret should have been deleted');
+        } catch (e) {
+          // not found - expected
+        }
+
+        const { body: getRes } = await supertest
+          .get(`/api/fleet/agent_download_sources/${dsId}`)
+          .expect(200);
+
+        expect(getRes.item.auth.username).to.eql('newuser');
+        expect(getRes.item.secrets.auth.password).to.have.property('id');
+      });
+
+      it('should convert plain text auth to secret when secret storage is enabled', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.4.0');
+
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Plain text to secret test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              password: 'plaintextpassword',
+            },
+          })
+          .expect(200);
+
+        expect(createRes.item.auth.username).to.eql('testuser');
+        expect(createRes.item.auth.password).to.be(undefined);
+        expect(createRes.item.secrets.auth.password).to.have.property('id');
+
+        const secretId = createRes.item.secrets.auth.password.id;
+        const secret = await getSecretById(secretId);
+        // @ts-ignore _source unknown type
+        expect(secret._source.value).to.eql('plaintextpassword');
+      });
+
+      it('should allow updating headers on existing download source', async function () {
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Update headers test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              password: 'testpassword',
+              headers: [{ key: 'X-Original-Header', value: 'original-value' }],
+            },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+        expect(createRes.item.auth.headers).to.eql([
+          { key: 'X-Original-Header', value: 'original-value' },
+        ]);
+
+        const { body: updateRes } = await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Update headers test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              password: 'testpassword',
+              headers: [
+                { key: 'X-Updated-Header', value: 'updated-value' },
+                { key: 'X-New-Header', value: 'new-value' },
+              ],
+            },
+          })
+          .expect(200);
+
+        expect(updateRes.item.auth.headers).to.eql([
+          { key: 'X-Updated-Header', value: 'updated-value' },
+          { key: 'X-New-Header', value: 'new-value' },
+        ]);
+      });
+
+      it('should replace auth entirely when updating with headers only', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.4.0');
+
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Replace auth test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              headers: [{ key: 'X-Original-Header', value: 'original-value' }],
+            },
+            secrets: { auth: { password: 'SECRET_PASSWORD' } },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+
+        const { body: updateRes } = await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Replace auth test updated ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              headers: [
+                { key: 'X-Updated-Header', value: 'updated-value' },
+                { key: 'X-New-Header', value: 'new-value' },
+              ],
+            },
+          })
+          .expect(200);
+
+        expect(updateRes.item.auth.headers).to.eql([
+          { key: 'X-Updated-Header', value: 'updated-value' },
+          { key: 'X-New-Header', value: 'new-value' },
+        ]);
+        expect(updateRes.item.auth.username).to.be(undefined);
+        expect(updateRes.item.secrets?.auth?.password).to.be(undefined);
+      });
+
+      it('should replace api_key auth with headers only (complete replacement)', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.4.0');
+
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Replace api_key test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              headers: [{ key: 'X-Original-Header', value: 'original-value' }],
+            },
+            secrets: { auth: { api_key: 'SECRET_API_KEY' } },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+
+        const { body: updateRes } = await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Replace api_key test updated ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              headers: [{ key: 'X-Updated-Header', value: 'updated-value' }],
+            },
+          })
+          .expect(200);
+
+        expect(updateRes.item.auth.headers).to.eql([
+          { key: 'X-Updated-Header', value: 'updated-value' },
+        ]);
+        expect(updateRes.item.secrets?.auth?.api_key).to.be(undefined);
+      });
+
+      it('should preserve SSL secrets when updating only name/host', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '8.12.0');
+
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Preserve SSL secrets test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            ssl: {
+              certificate_authorities: ['/path/to/cert-authority'],
+              certificate: 'path/to/cert',
+            },
+            secrets: { ssl: { key: 'SSL_KEY_VALUE' } },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+        const secretId = createRes.item.secrets.ssl.key.id;
+
+        const secret = await getSecretById(secretId);
+        // @ts-ignore _source unknown type
+        expect(secret._source.value).to.equal('SSL_KEY_VALUE');
+
+        const { body: updateRes } = await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Preserve SSL secrets test updated ${Date.now()}`,
+            host: 'http://updated.test.fr:443',
+            is_default: false,
+          })
+          .expect(200);
+
+        expect(updateRes.item.secrets.ssl.key.id).to.equal(secretId);
+        expect(updateRes.item.ssl.certificate).to.equal('path/to/cert');
+        expect(updateRes.item.ssl.certificate_authorities).to.eql(['/path/to/cert-authority']);
+
+        const secretAfterUpdate = await getSecretById(secretId);
+        // @ts-ignore _source unknown type
+        expect(secretAfterUpdate._source.value).to.equal('SSL_KEY_VALUE');
+      });
+
+      it('should preserve auth secrets when updating only name/host', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.4.0');
+
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Preserve auth secrets test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              headers: [{ key: 'X-Custom-Header', value: 'custom-value' }],
+            },
+            secrets: { auth: { password: 'SECRET_PASSWORD' } },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+        const secretId = createRes.item.secrets.auth.password.id;
+
+        const secret = await getSecretById(secretId);
+        // @ts-ignore _source unknown type
+        expect(secret._source.value).to.equal('SECRET_PASSWORD');
+
+        const { body: updateRes } = await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Preserve auth secrets test updated ${Date.now()}`,
+            host: 'http://updated.test.fr:443',
+            is_default: false,
+          })
+          .expect(200);
+
+        expect(updateRes.item.secrets.auth.password.id).to.equal(secretId);
+        expect(updateRes.item.auth.username).to.equal('testuser');
+        expect(updateRes.item.auth.headers).to.eql([
+          { key: 'X-Custom-Header', value: 'custom-value' },
+        ]);
+
+        const secretAfterUpdate = await getSecretById(secretId);
+        // @ts-ignore _source unknown type
+        expect(secretAfterUpdate._source.value).to.equal('SECRET_PASSWORD');
+      });
+
+      it('should preserve both SSL and auth secrets when updating only name/host', async function () {
+        await clearAgents();
+        await createFleetServerAgent(fleetServerPolicyId, 'server_1', '9.4.0');
+
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Preserve all secrets test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            ssl: {
+              certificate_authorities: ['/path/to/cert-authority'],
+              certificate: 'path/to/cert',
+            },
+            secrets: {
+              ssl: { key: 'SSL_KEY_VALUE' },
+              auth: { password: 'SECRET_PASSWORD' },
+            },
+            auth: {
+              username: 'testuser',
+              headers: [{ key: 'X-Custom-Header', value: 'custom-value' }],
+            },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+        const sslSecretId = createRes.item.secrets.ssl.key.id;
+        const authSecretId = createRes.item.secrets.auth.password.id;
+
+        const { body: updateRes } = await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Preserve all secrets test updated ${Date.now()}`,
+            host: 'http://updated.test.fr:443',
+            is_default: false,
+          })
+          .expect(200);
+
+        expect(updateRes.item.secrets.ssl.key.id).to.equal(sslSecretId);
+        expect(updateRes.item.secrets.auth.password.id).to.equal(authSecretId);
+        expect(updateRes.item.ssl.certificate).to.equal('path/to/cert');
+        expect(updateRes.item.auth.username).to.equal('testuser');
+
+        const sslSecretAfterUpdate = await getSecretById(sslSecretId);
+        // @ts-ignore _source unknown type
+        expect(sslSecretAfterUpdate._source.value).to.equal('SSL_KEY_VALUE');
+
+        const authSecretAfterUpdate = await getSecretById(authSecretId);
+        // @ts-ignore _source unknown type
+        expect(authSecretAfterUpdate._source.value).to.equal('SECRET_PASSWORD');
+      });
+
+      it('should clear auth and headers when setting auth to null', async function () {
+        const { body: createRes } = await supertest
+          .post(`/api/fleet/agent_download_sources`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Clear auth test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: {
+              username: 'testuser',
+              password: 'testpassword',
+              headers: [{ key: 'X-Custom-Header', value: 'custom-value' }],
+            },
+          })
+          .expect(200);
+
+        const dsId = createRes.item.id;
+        expect(createRes.item.auth.username).to.eql('testuser');
+        expect(createRes.item.auth.headers).to.have.length(1);
+
+        await supertest
+          .put(`/api/fleet/agent_download_sources/${dsId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `Clear auth test ${Date.now()}`,
+            host: 'http://test.fr:443',
+            is_default: false,
+            auth: null,
+          })
+          .expect(200);
+
+        const { body: getRes } = await supertest
+          .get(`/api/fleet/agent_download_sources/${dsId}`)
+          .expect(200);
+
+        expect(getRes.item.auth).to.be(undefined);
       });
     });
 
@@ -800,7 +1560,7 @@ export default function (providerContext: FtrProviderContext) {
             host: 'http://test.fr:443',
             is_default: false,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
             },
             secrets: { ssl: { key: 'KEY1' } },

--- a/x-pack/platform/test/fleet_api_integration/apis/fleet_server_hosts/crud.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/fleet_server_hosts/crud.ts
@@ -193,10 +193,10 @@ export default function (providerContext: FtrProviderContext) {
             host_urls: ['https://test.fr:8080', 'https://test.fr:8081'],
             is_default: true,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
             },
             secrets: { ssl: { key: 'KEY1', es_key: 'KEY2' } },
           })
@@ -238,10 +238,10 @@ export default function (providerContext: FtrProviderContext) {
             host_urls: ['https://test.fr:8080', 'https://test.fr:8081'],
             is_default: true,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
             },
           })
           .expect(200);
@@ -297,10 +297,10 @@ export default function (providerContext: FtrProviderContext) {
             is_default: true,
             id,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
               key: 'KEY',
             },
             secrets: { ssl: { key: 'KEY' } },
@@ -322,10 +322,10 @@ export default function (providerContext: FtrProviderContext) {
             is_default: true,
             id,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
               es_key: 'KEY',
             },
             secrets: { ssl: { es_key: 'KEY' } },
@@ -346,10 +346,10 @@ export default function (providerContext: FtrProviderContext) {
             host_urls: ['https://test.fr:8080', 'https://test.fr:8081'],
             is_default: true,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
             },
             secrets: { ssl: { key: 'KEY1', es_key: 'KEY2' } },
           })
@@ -394,10 +394,10 @@ export default function (providerContext: FtrProviderContext) {
           .send({
             name: 'Default',
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
             },
           })
           .expect(200);
@@ -409,9 +409,11 @@ export default function (providerContext: FtrProviderContext) {
           .expect(200);
 
         expect(fleetServerHost.ssl.certificate).to.eql('path/to/cert');
-        expect(fleetServerHost.ssl.certificate_authorities).to.eql(['cert authorities']);
+        expect(fleetServerHost.ssl.certificate_authorities).to.eql(['/path/to/cert-authority']);
         expect(fleetServerHost.ssl.es_certificate).to.eql('path/to/EScert');
-        expect(fleetServerHost.ssl.es_certificate_authorities).to.eql(['ES cert authorities']);
+        expect(fleetServerHost.ssl.es_certificate_authorities).to.eql([
+          '/path/to/es-cert-authority',
+        ]);
       });
 
       it('should return a 404 when updating a non existing fleet server host', async function () {
@@ -435,10 +437,10 @@ export default function (providerContext: FtrProviderContext) {
             host_urls: ['https://test.fr:8080', 'https://test.fr:8081'],
             is_default: true,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
             },
             secrets: { ssl: { key: 'KEY1', es_key: 'KEY2' } },
           })
@@ -457,10 +459,10 @@ export default function (providerContext: FtrProviderContext) {
             host_urls: ['https://test.fr:8080', 'https://test.fr:8081'],
             is_default: true,
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
             },
             secrets: { ssl: { key: 'NEW_KEY' } },
           })
@@ -517,10 +519,10 @@ export default function (providerContext: FtrProviderContext) {
             name: `Default ${Date.now()}`,
             host_urls: ['https://test.fr:8080', 'https://test.fr:8081'],
             ssl: {
-              certificate_authorities: ['cert authorities'],
+              certificate_authorities: ['/path/to/cert-authority'],
               certificate: 'path/to/cert',
               es_certificate: 'path/to/EScert',
-              es_certificate_authorities: ['ES cert authorities'],
+              es_certificate_authorities: ['/path/to/es-cert-authority'],
             },
             secrets: { ssl: { es_key: 'KEY2' } },
           })


### PR DESCRIPTION
# Backport

This is a backport of PR #266365 to `9.3`.

## Original PR description

Validates SSL certificate path fields for whitespace characters to prevent
silent failures when saving Fleet settings flyouts.

## Conflict resolution

- `oas_docs/output/kibana.serverless.yaml` and `kibana.yaml`: accepted 9.3 version (generated files)
- `x-pack/platform/plugins/shared/fleet/common/services/index.ts`: added only the `validateSslCertPath` export; excluded exports for modules that don't exist on 9.3 (`yaml_utils`, `var_group_helpers`, `cloud_connectors`, `otelcol_helpers`)
- `x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx`: took incoming auth validation logic
- `x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.test.tsx`: took incoming imports
- `x-pack/platform/plugins/shared/fleet/server/routes/download_source/handler.ts`: took incoming `validateDownloadSource` function
- `x-pack/platform/plugins/shared/fleet/server/types/models/output.ts`: took incoming `compression_level` schema fix
- `x-pack/platform/test/fleet_api_integration/apis/download_sources/crud.ts`: took incoming new test cases