### PR TITLE
[One Workflow] Fix registered step summary/description swap

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.ts
@@ -113,11 +113,13 @@ function getRegisteredStepDefinitions(): BaseConnectorContract[] {
       };
 
       if (stepSchemas.isPublicStepDefinition(stepDefinition)) {
-        // Only public step definitions have documentation and examples
+        // Only public step definitions have documentation and examples.
+        // Match the convention used by every other connector source: summary
+        // is the short label, description is the longer behavioral explanation.
         return {
           ...definition,
-          description: stepDefinition.label, // Short title-like text
-          summary: stepDefinition.description ?? null, // Explanation of the step behavior
+          summary: stepDefinition.label,
+          description: stepDefinition.description ?? null,
           documentation: stepDefinition.documentation?.url,
           examples: stepDefinition.documentation?.examples
             ? { snippet: stepDefinition.documentation?.examples.join('\n') }

--- a/src/platform/plugins/shared/workflows_management/common/schema_additional.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema_additional.test.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { StepCategory } from '@kbn/workflows';
+import { z } from '@kbn/zod/v4';
 import {
   createMockConnectorInstance,
   createMockConnectorTypeInfo,
@@ -20,6 +22,7 @@ import {
   getCachedDynamicConnectorTypes,
   getDeprecatedStepMetadataMap,
 } from './schema';
+import { stepSchemas } from './step_schemas';
 
 describe('schema - additional coverage', () => {
   describe('getAllConnectorsInternal', () => {
@@ -306,6 +309,51 @@ describe('schema - additional coverage', () => {
       const connector = map?.get('lookup-test');
       expect(connector).toBeDefined();
       expect(connector?.summary).toBe('Lookup Test');
+    });
+  });
+
+  describe('registered step definitions (public)', () => {
+    const longDescription =
+      'Transform an array of items by applying a step to each one. Useful for shaping data.';
+    const publicStepDefinition = {
+      id: 'data.test_map',
+      label: 'Map Collection',
+      description: longDescription,
+      category: StepCategory.Data,
+      inputSchema: z.object({}),
+      outputSchema: z.any(),
+    };
+
+    let originalGetAll: typeof stepSchemas.getAllRegisteredStepDefinitions;
+    let originalGetByType: typeof stepSchemas.getStepDefinition;
+
+    beforeAll(() => {
+      originalGetAll = stepSchemas.getAllRegisteredStepDefinitions.bind(stepSchemas);
+      originalGetByType = stepSchemas.getStepDefinition.bind(stepSchemas);
+
+      stepSchemas.getAllRegisteredStepDefinitions = () => [publicStepDefinition] as never;
+      stepSchemas.getStepDefinition = (stepTypeId: string) =>
+        stepTypeId === publicStepDefinition.id ? (publicStepDefinition as never) : undefined;
+
+      // Force the all-connectors cache to be rebuilt with the registered step.
+      stepSchemas.setAllConnectorsCache(null);
+      stepSchemas.setAllConnectorsMapCache(null);
+    });
+
+    afterAll(() => {
+      stepSchemas.getAllRegisteredStepDefinitions = originalGetAll;
+      stepSchemas.getStepDefinition = originalGetByType;
+      stepSchemas.setAllConnectorsCache(null);
+      stepSchemas.setAllConnectorsMapCache(null);
+    });
+
+    it('exposes the short label as `summary` and the long description as `description`', () => {
+      const connectors = getAllConnectorsInternal();
+      const registered = connectors.find((c) => c.type === publicStepDefinition.id);
+
+      expect(registered).toBeDefined();
+      expect(registered?.summary).toBe('Map Collection');
+      expect(registered?.description).toBe(longDescription);
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_type/get_connector_type_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_type/get_connector_type_suggestions.test.ts
@@ -395,5 +395,21 @@ describe('getConnectorTypeSuggestions', () => {
         documentation: 'Workflow connector - .custom',
       });
     });
+
+    it('should prefer summary over description for the display label of registered steps', () => {
+      (getCachedAllConnectors as jest.Mock).mockReturnValue([
+        {
+          type: 'data.map',
+          summary: 'Map Collection',
+          description: 'Transform an array of items by applying a step to each one.',
+        },
+      ]);
+      const result = getConnectorTypeSuggestions('data.', mockRange);
+      const mapSuggestion = result.find((s) => s.detail === 'data.map');
+      expect(mapSuggestion).toMatchObject({
+        label: 'Map Collection',
+        documentation: 'Transform an array of items by applying a step to each one.',
+      });
+    });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_type/get_connector_type_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_type/get_connector_type_suggestions.ts
@@ -81,9 +81,10 @@ export function getConnectorTypeSuggestions(
     // Only use display names for dynamic connectors (not elasticsearch.* or kibana.*)
     const isDynamicConnector =
       !connectorType.startsWith('elasticsearch.') && !connectorType.startsWith('kibana.');
+    const shortName = connector?.summary || connector?.description;
     const displayName =
-      isDynamicConnector && connector?.description
-        ? connector.description.replace(' connector', '').replace(' (no instances configured)', '')
+      isDynamicConnector && shortName
+        ? shortName.replace(' connector', '').replace(' (no instances configured)', '')
         : connectorType;
 
     return {
@@ -97,7 +98,7 @@ export function getConnectorTypeSuggestions(
         ? `Elasticsearch API - ${connectorType.replace('elasticsearch.', '')}`
         : connectorType.startsWith('kibana.')
         ? `Kibana API - ${connectorType.replace('kibana.', '')}`
-        : connector?.description || `Workflow connector - ${connectorType}`,
+        : connector?.description || connector?.summary || `Workflow connector - ${connectorType}`,
       filterText: connectorType,
       sortText: `!${connectorType}`, // Priority prefix to sort before default suggestions
       preselect: false,


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/17130

## Summary

`getRegisteredStepDefinitions` was producing connector contracts where `summary` held the long step description and `description` held the short label — inverted from every other connector source (static, ES-generated, Kibana, dynamic). The bad contract was then cached and read by every consumer, so `data.*` registered steps showed up wrong in:

- Agent tools (`get_step_definitions`, `validate_workflow`) — `formatConnectorStep` used `summary` as label, so the agent saw a paragraph as the step label and the short title (truncated) as the description.
- YAML schema `type:` literal docs — `generateStepSchemaForConnector` and `buildConnectorStepSchema` call `.describe(connector.description)`, which put the short label where the longer doc should live.

Fix:

- `common/schema.ts:115-128` — public registered step contracts now follow the convention `summary = label`, `description = description`.
- `public/.../autocomplete/.../get_connector_type_suggestions.ts:84-100` — autocomplete display name now prefers `connector.summary`, doc tooltip prefers `connector.description`. Without this, the corrected swap would have regressed the autocomplete to show a paragraph as the label for `data.*` steps.

Tests added:

- `schema_additional.test.ts` — stubs `stepSchemas` with a public step definition and asserts the produced contract has the short label as `summary` and the long explanation as `description`.
- `get_connector_type_suggestions.test.ts` — verifies that when a connector exposes both `summary` and `description`, the autocomplete uses `summary` as the label and `description` as the documentation.

## Test plan

- [ ] `node scripts/jest src/platform/plugins/shared/workflows_management` passes
- [ ] `node scripts/jest src/platform/packages/shared/kbn-workflows` passes
- [ ] In the YAML editor, type `type: data.` and confirm `data.map` / `data.filter` / etc. still display their short labels in autocomplete and show the longer description in the hover doc
- [ ] In Agent Builder, call `get_step_definitions` for `data.map` and confirm `label` is `"Map Collection"` (not the long description) and `description` is the longer behavioral text