### PR TITLE
[EDR Workflows] Skip Osquery add_integration Cypress suite

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
@@ -42,7 +42,7 @@ import {
 } from '../../tasks/integrations';
 import { ServerlessRoleName } from '../../support/roles';
 
-describe('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => {
+describe.skip('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => {
   let savedQueryId: string;
 
   before(() => {


### PR DESCRIPTION
Skips the `add_integration.cy.ts` Cypress suite by using `describe.skip` on the top-level block.

This removes the add integration flow from the Cypress run until the suite is stabilized or re-enabled.

Tracking - https://github.com/elastic/kibana/issues/266857