### PR TITLE
[EDR Workflows] Re-enable Osquery add_integration Cypress suite

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
@@ -35,6 +35,7 @@ import {
   closeModalIfVisible,
   generateRandomStringName,
   integrationExistsWithinPolicyDetails,
+  installPackageWithVersion,
   interceptPackId,
   interceptAgentPolicyId,
   policyContainsIntegration,
@@ -83,6 +84,10 @@ describe('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => {
     let policyId: string;
 
     beforeEach(() => {
+      // PR #266513 disables Add integration when viewed package version differs from installed.
+      // FTR config auto-installs latest osquery_manager; force the old version so the button stays enabled.
+      installPackageWithVersion('osquery_manager', oldVersion);
+
       interceptAgentPolicyId((agentPolicyId) => {
         policyId = agentPolicyId;
       });
@@ -162,6 +167,10 @@ describe('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => {
     let packId: string;
 
     beforeEach(() => {
+      // PR #266513 disables Add integration when viewed package version differs from installed.
+      // FTR config auto-installs latest osquery_manager; force the old version so the button stays enabled.
+      installPackageWithVersion('osquery_manager', oldVersion);
+
       interceptAgentPolicyId((agentPolicyId) => {
         policyId = agentPolicyId;
       });


### PR DESCRIPTION
## Summary

Fleet PR https://github.com/elastic/kibana/pull/266513 disables the integrations detail **Add integration** button when the viewed package version differs from the installed package (VERSION_MISMATCH). Osquery FTR auto-installs latest `osquery_manager`, so specs that visit old version URLs (`0.7.4`, `1.2.0`) hit a disabled `addIntegrationPolicyButton`.

Before navigating to those URLs, each affected describe block now calls `installPackageWithVersion('osquery_manager', oldVersion)` with `force: true` (existing helper in `tasks/integrations.ts`), matching Fleet's own Cypress pattern so installed version matches the page.

Closes https://github.com/elastic/kibana/issues/266857

Related: skip PR https://github.com/elastic/kibana/pull/267293 