### PR TITLE
[Discover] fix bug where enhanced security flyout was not rendering header, content and footer when Discover is embedded in a Dashboard

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
@@ -320,6 +320,7 @@ describe('Discover documents layout', () => {
       expect(flyoutProps.hit).toEqual(expandedDoc);
       expect(flyoutProps.hits).toEqual([expandedDoc, nextExpandedDoc]);
       expect(flyoutProps.columns).toEqual(['bytes']);
+      expect(flyoutProps.docViewerExtensionActions?.refreshData).toEqual(expect.any(Function));
 
       act(() => {
         flyoutProps.setExpandedDoc(nextExpandedDoc);

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -367,8 +367,9 @@ function DiscoverDocumentsComponent({
     () => ({
       openInNewTab: (params) => dispatch(internalStateActions.openInNewTabExtPointAction(params)),
       updateESQLQuery: onUpdateESQLQuery,
+      refreshData: () => dataStateContainer.refetch$.next(undefined),
     }),
-    [dispatch, onUpdateESQLQuery]
+    [dispatch, onUpdateESQLQuery, dataStateContainer]
   );
 
   const docViewerUiState = useCurrentTabSelector((state) => state.uiState.docViewer);

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.test.tsx
@@ -15,16 +15,6 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { EnhancedAlertEventOverview } from './enhanced_alert_event_overview';
 import type { ProfileProviderServices } from '../../profile_provider_services';
 
-const mockRefetchNext = jest.fn();
-
-jest.mock('../../../../application/main/state_management/redux', () => ({
-  useCurrentTabDataStateContainer: () => ({
-    refetch$: {
-      next: mockRefetchNext,
-    },
-  }),
-}));
-
 const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
   ({
     id: '1',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_event_overview.tsx
@@ -8,9 +8,9 @@
  */
 
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import { useCallback } from 'react';
 import type { ProfileProviderServices } from '../../profile_provider_services';
-import { useCurrentTabDataStateContainer } from '../../../../application/main/state_management/redux';
+
+const noop = () => {};
 
 /**
  * This component is a placeholder for the new alert/event Overview tab content.
@@ -20,22 +20,20 @@ import { useCurrentTabDataStateContainer } from '../../../../application/main/st
  */
 export interface EnhancedAlertEventOverviewProps extends DocViewRenderProps {
   providerServices: ProfileProviderServices;
+  refreshData?: () => void;
 }
 
 export const EnhancedAlertEventOverview = ({
   hit,
   providerServices,
+  refreshData,
   ...docViewProps
 }: EnhancedAlertEventOverviewProps) => {
-  const dataStateContainer = useCurrentTabDataStateContainer();
   const alertFlyoutOverviewTabFeature = providerServices.discoverShared.features.registry.getById(
     'security-solution-alert-flyout-overview-tab'
   );
-
-  const onAlertUpdated = useCallback(() => {
-    dataStateContainer.refetch$.next(undefined);
-  }, [dataStateContainer]);
+  const handleAlertUpdated = refreshData ?? noop;
 
   const render = alertFlyoutOverviewTabFeature?.render;
-  return render ? render({ hit, ...docViewProps, onAlertUpdated }) : null;
+  return render ? render({ hit, ...docViewProps, onAlertUpdated: handleAlertUpdated }) : null;
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_footer.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_footer.test.tsx
@@ -15,16 +15,6 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { EnhancedAlertFlyoutFooter } from './enhanced_alert_flyout_footer';
 import type { ProfileProviderServices } from '../../profile_provider_services';
 
-const mockRefetchNext = jest.fn();
-
-jest.mock('../../../../application/main/state_management/redux', () => ({
-  useCurrentTabDataStateContainer: () => ({
-    refetch$: {
-      next: mockRefetchNext,
-    },
-  }),
-}));
-
 const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
   ({
     id: '1',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_footer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_footer.tsx
@@ -8,33 +8,32 @@
  */
 
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import { useCallback } from 'react';
 import type { ReactElement } from 'react';
 import type { ProfileProviderServices } from '../../profile_provider_services';
-import { useCurrentTabDataStateContainer } from '../../../../application/main/state_management/redux';
+
+const noop = () => {};
 
 export interface EnhancedAlertFlyoutFooterProps extends DocViewRenderProps {
   providerServices: ProfileProviderServices;
+  refreshData?: () => void;
   fallbackRenderFooter?: (props: DocViewRenderProps) => ReactElement | undefined;
 }
 
 export const EnhancedAlertFlyoutFooter = ({
   hit,
   providerServices,
+  refreshData,
   fallbackRenderFooter,
   ...docViewProps
 }: EnhancedAlertFlyoutFooterProps) => {
-  const dataStateContainer = useCurrentTabDataStateContainer();
   const alertFlyoutFooterFeature = providerServices.discoverShared.features.registry.getById(
     'security-solution-alert-flyout-footer'
   );
+  const handleAlertUpdated = refreshData ?? noop;
 
   const renderFooter = alertFlyoutFooterFeature?.renderFooter;
-  const onAlertUpdated = useCallback(() => {
-    dataStateContainer.refetch$.next(undefined);
-  }, [dataStateContainer]);
 
   return renderFooter
-    ? renderFooter({ hit, ...docViewProps, onAlertUpdated })
+    ? renderFooter({ hit, ...docViewProps, onAlertUpdated: handleAlertUpdated })
     : fallbackRenderFooter?.({ hit, ...docViewProps }) ?? null;
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_header.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_header.test.tsx
@@ -15,16 +15,6 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { EnhancedAlertFlyoutHeader } from './enhanced_alert_flyout_header';
 import type { ProfileProviderServices } from '../../profile_provider_services';
 
-const mockRefetchNext = jest.fn();
-
-jest.mock('../../../../application/main/state_management/redux', () => ({
-  useCurrentTabDataStateContainer: () => ({
-    refetch$: {
-      next: mockRefetchNext,
-    },
-  }),
-}));
-
 const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
   ({
     id: '1',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_header.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_header.tsx
@@ -8,33 +8,32 @@
  */
 
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import { useCallback } from 'react';
 import type { ReactElement } from 'react';
 import type { ProfileProviderServices } from '../../profile_provider_services';
-import { useCurrentTabDataStateContainer } from '../../../../application/main/state_management/redux';
+
+const noop = () => {};
 
 export interface EnhancedAlertFlyoutHeaderProps extends DocViewRenderProps {
   providerServices: ProfileProviderServices;
+  refreshData?: () => void;
   fallbackRenderHeader?: (props: DocViewRenderProps) => ReactElement | undefined;
 }
 
 export const EnhancedAlertFlyoutHeader = ({
   hit,
   providerServices,
+  refreshData,
   fallbackRenderHeader,
   ...docViewProps
 }: EnhancedAlertFlyoutHeaderProps) => {
-  const dataStateContainer = useCurrentTabDataStateContainer();
   const alertFlyoutHeaderFeature = providerServices.discoverShared.features.registry.getById(
     'security-solution-alert-flyout-header-title'
   );
+  const handleAlertUpdated = refreshData ?? noop;
 
   const renderHeader = alertFlyoutHeaderFeature?.renderHeader;
-  const onAlertUpdated = useCallback(() => {
-    dataStateContainer.refetch$.next(undefined);
-  }, [dataStateContainer]);
 
   return renderHeader
-    ? renderHeader({ hit, ...docViewProps, onAlertUpdated })
+    ? renderHeader({ hit, ...docViewProps, onAlertUpdated: handleAlertUpdated })
     : fallbackRenderHeader?.({ hit, ...docViewProps }) ?? null;
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import type { DataTableRecord } from '@kbn/discover-utils';
+import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import { ALERT_RULE_TYPE_ID, ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID } from '@kbn/rule-data-utils';
 import type { ProfileProviderServices } from '../profile_provider_services';
 import { DocumentType } from '../../profiles';
@@ -21,7 +22,12 @@ const createRecord = (flattened: DataTableRecord['flattened']): DataTableRecord 
     isAnchor: false,
   } as DataTableRecord);
 
-const getDocViewerResult = (record: DataTableRecord) => {
+const getDocViewerResult = (
+  record: DataTableRecord,
+  actions: {
+    refreshData?: () => void;
+  } = {}
+) => {
   const providerServices = {} as ProfileProviderServices;
   const [enhancedProvider] = createSecurityDocumentProfileProviders(providerServices);
   const prevRenderHeader = jest.fn();
@@ -35,7 +41,7 @@ const getDocViewerResult = (record: DataTableRecord) => {
   const getDocViewer = enhancedProvider.profile.getDocViewer!(prev, {
     context: { type: DocumentType.Default },
   });
-  const result = getDocViewer({ actions: {}, record } as Parameters<typeof getDocViewer>[0]);
+  const result = getDocViewer({ actions, record } as Parameters<typeof getDocViewer>[0]);
   return { result, prevRenderHeader, prevRenderFooter };
 };
 
@@ -227,6 +233,46 @@ describe('createSecurityDocumentProfileProviders', () => {
 
       expect(registry.add).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'doc_view_alerts_overview' })
+      );
+    });
+
+    it('forwards refreshData action to enhanced flyout header', () => {
+      const refreshData = jest.fn();
+      const hit = createRecord({ 'event.kind': 'signal' });
+      const { result } = getDocViewerResult(hit, { refreshData });
+
+      const renderedHeader = result.renderHeader?.({ hit, dataView: dataViewMock });
+      expect(renderedHeader).toBeDefined();
+      expect((renderedHeader as { props: { refreshData: () => void } }).props.refreshData).toBe(
+        refreshData
+      );
+    });
+
+    it('forwards refreshData action to enhanced flyout footer', () => {
+      const refreshData = jest.fn();
+      const hit = createRecord({ 'event.kind': 'signal' });
+      const { result } = getDocViewerResult(hit, { refreshData });
+
+      const renderedFooter = result.renderFooter?.({ hit, dataView: dataViewMock });
+      expect(renderedFooter).toBeDefined();
+      expect((renderedFooter as { props: { refreshData: () => void } }).props.refreshData).toBe(
+        refreshData
+      );
+    });
+
+    it('forwards refreshData action to enhanced overview tab', () => {
+      const refreshData = jest.fn();
+      const hit = createRecord({ 'event.kind': 'signal' });
+      const { result } = getDocViewerResult(hit, { refreshData });
+      const registry = { add: jest.fn() };
+
+      result.docViewsRegistry(registry as never);
+      const addedOverviewTab = registry.add.mock.calls[0][0];
+
+      const renderedOverview = addedOverviewTab.render({ hit, dataView: dataViewMock });
+      expect(renderedOverview).toBeDefined();
+      expect((renderedOverview as { props: { refreshData: () => void } }).props.refreshData).toBe(
+        refreshData
       );
     });
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
@@ -49,8 +49,9 @@ export const createSecurityDocumentProfileProviders = (
           renderFooter = (props) => (
             <EnhancedAlertFlyoutFooterLazy
               {...props}
-              providerServices={providerServices}
               fallbackRenderFooter={prevDocViewer.renderFooter}
+              providerServices={providerServices}
+              refreshData={params.actions.refreshData}
             />
           );
         }
@@ -68,8 +69,9 @@ export const createSecurityDocumentProfileProviders = (
           renderHeader = (props) => (
             <EnhancedAlertFlyoutHeaderLazy
               {...props}
-              providerServices={providerServices}
               fallbackRenderHeader={prevDocViewer.renderHeader}
+              providerServices={providerServices}
+              refreshData={params.actions.refreshData}
             />
           );
         }
@@ -93,7 +95,11 @@ export const createSecurityDocumentProfileProviders = (
                 title: i18n.overviewTabTitle(isAlert),
                 order: 0,
                 render: (props) => (
-                  <EnhancedAlertEventOverviewLazy {...props} providerServices={providerServices} />
+                  <EnhancedAlertEventOverviewLazy
+                    {...props}
+                    providerServices={providerServices}
+                    refreshData={params.actions.refreshData}
+                  />
                 ),
               });
             }

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -231,6 +231,10 @@ export interface DocViewerExtensionParams {
      * Updates the current ES|QL query
      */
     updateESQLQuery?: UpdateESQLQueryFn;
+    /**
+     * Refreshes the current Discover table data.
+     */
+    refreshData?: () => void;
   };
   /**
    * The record being displayed in the doc viewer

--- a/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
@@ -43,13 +43,15 @@ interface DiscoverGridEmbeddableProps extends Omit<UnifiedDataTableProps, 'sampl
   interceptedWarnings?: SearchResponseWarning[];
   onAddColumn: (column: string) => void;
   onRemoveColumn: (column: string) => void;
+  onRefreshData?: () => void;
   savedSearchId?: string;
   enableDocumentViewer: boolean;
   inlineEditing: InlineEditing;
 }
 
 export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
-  const { enableDocumentViewer, inlineEditing, interceptedWarnings, ...gridProps } = props;
+  const { enableDocumentViewer, inlineEditing, interceptedWarnings, onRefreshData, ...gridProps } =
+    props;
 
   const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>(undefined);
   const [initialTabId, setInitialTabId] = useState<string | undefined>(undefined);
@@ -66,6 +68,10 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
       }
     },
     []
+  );
+  const docViewerExtensionActions = useMemo(
+    () => ({ refreshData: onRefreshData }),
+    [onRefreshData]
   );
 
   const renderDocumentView = useCallback(
@@ -89,6 +95,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         onClose={() => setExpandedDoc(undefined)}
         setExpandedDoc={setExpandedDocWithInitialTab}
         initialTabId={initialTabId}
+        docViewerExtensionActions={docViewerExtensionActions}
         query={props.query}
         filters={props.filters}
         docViewerRef={docViewerRef}
@@ -105,6 +112,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
       props.filters,
       setExpandedDocWithInitialTab,
       initialTabId,
+      docViewerExtensionActions,
     ]
   );
 

--- a/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_grid_component.test.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_grid_component.test.tsx
@@ -93,7 +93,13 @@ describe('SearchEmbeddableGridComponent', () => {
     jest.clearAllMocks();
   });
 
-  const renderComponent = ({ isEsql }: { isEsql: boolean }) => {
+  const renderComponent = ({
+    isEsql,
+    onRefreshData,
+  }: {
+    isEsql: boolean;
+    onRefreshData?: () => void;
+  }) => {
     const savedSearch = createSavedSearch(isEsql);
     const api = createApi(savedSearch);
     const stateManager = createStateManager();
@@ -106,6 +112,7 @@ describe('SearchEmbeddableGridComponent', () => {
           api={api}
           dataView={dataViewMock}
           stateManager={stateManager}
+          onRefreshData={onRefreshData}
           enableDocumentViewer={true}
           inlineEditing={{
             isActive: false,
@@ -140,6 +147,20 @@ describe('SearchEmbeddableGridComponent', () => {
       const lastCallProps = mockDiscoverGridEmbeddableProps.mock.calls.at(-1)?.[0];
       expect(lastCallProps?.onUpdateSampleSize).toBeDefined();
       expect(typeof lastCallProps?.onUpdateSampleSize).toBe('function');
+    });
+  });
+
+  describe('refresh action wiring', () => {
+    it('passes onRefreshData to DiscoverGridEmbeddable', async () => {
+      const onRefreshData = jest.fn();
+      renderComponent({ isEsql: false, onRefreshData });
+
+      await waitFor(() => {
+        expect(mockDiscoverGridEmbeddableProps).toHaveBeenCalled();
+      });
+
+      const lastCallProps = mockDiscoverGridEmbeddableProps.mock.calls.at(-1)?.[0];
+      expect(lastCallProps?.onRefreshData).toBe(onRefreshData);
     });
   });
 });

--- a/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_grid_component.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/search_embeddable_grid_component.tsx
@@ -48,6 +48,7 @@ interface SavedSearchEmbeddableComponentProps {
   };
   dataView: DataView;
   onAddFilter?: DocViewFilterFn;
+  onRefreshData?: () => void;
   enableDocumentViewer: boolean;
   inlineEditing: InlineEditing;
   stateManager: SearchEmbeddableStateManager;
@@ -59,6 +60,7 @@ export function SearchEmbeddableGridComponent({
   api,
   dataView,
   onAddFilter,
+  onRefreshData,
   enableDocumentViewer,
   inlineEditing,
   stateManager,
@@ -234,6 +236,7 @@ export function SearchEmbeddableGridComponent({
       dataView={dataView}
       interceptedWarnings={interceptedWarnings}
       onFilter={onAddFilter}
+      onRefreshData={onRefreshData}
       rows={rows}
       rowsPerPageState={savedSearch.rowsPerPage ?? defaults.rowsPerPage}
       sampleSizeState={fetchedSampleSize}

--- a/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { BehaviorSubject, firstValueFrom, merge, skip, map } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, map, merge, skip } from 'rxjs';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import { generateFilters } from '@kbn/data-plugin/public';
 import { SEARCH_EMBEDDABLE_TYPE } from '@kbn/discover-utils';
@@ -20,10 +20,10 @@ import type { FetchContext } from '@kbn/presentation-publishing';
 import {
   initializeTimeRangeManager,
   initializeTitleManager,
+  initializeUnsavedChanges,
   timeRangeComparators,
   titleComparators,
   useBatchedPublishingSubjects,
-  initializeUnsavedChanges,
 } from '@kbn/presentation-publishing';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import type { SearchResponseIncompleteWarning } from '@kbn/search-response-warnings/src/types';
@@ -118,6 +118,7 @@ export const getSearchEmbeddableFactory = ({
       const dataLoading$ = new BehaviorSubject<boolean | undefined>(true);
       const fetchContext$ = new BehaviorSubject<FetchContext | undefined>(undefined);
       const fetchWarnings$ = new BehaviorSubject<SearchResponseIncompleteWarning[]>([]);
+      const refreshTrigger$ = new BehaviorSubject<void>(undefined);
 
       /** Build API */
       const titleManager = initializeTitleManager(runtimeState);
@@ -299,6 +300,7 @@ export const getSearchEmbeddableFactory = ({
         discoverServices,
         stateManager: searchEmbeddable.stateManager,
         scopedProfilesManager,
+        refreshTrigger$,
         setDataLoading: (dataLoading: boolean | undefined) => dataLoading$.next(dataLoading),
         setBlockingError: (error: Error | undefined) => blockingError$.next(error),
       });
@@ -361,6 +363,10 @@ export const getSearchEmbeddableFactory = ({
             },
             [dataView]
           );
+
+          const onRefreshData = useCallback(() => {
+            refreshTrigger$.next(undefined);
+          }, []);
 
           const renderAsFieldStatsTable = useMemo(
             () => isFieldStatsMode(savedSearch, dataView, discoverServices.uiSettings),
@@ -429,6 +435,7 @@ export const getSearchEmbeddableFactory = ({
                       <SearchEmbeddableGridComponent
                         api={{ ...api, fetchWarnings$, fetchContext$ }}
                         dataView={dataView!}
+                        onRefreshData={onRefreshData}
                         onAddFilter={
                           runtimeState.nonPersistedDisplayOptions?.enableFilters === false
                             ? undefined

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.test.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 
 import { createSearchSourceMock } from '@kbn/data-plugin/public/mocks';
 import { buildDataTableRecord } from '@kbn/discover-utils';
@@ -34,6 +34,7 @@ describe('initialize fetch', () => {
     stateManager,
     setters,
   } = getMockedSearchApi({ searchSource, savedSearch });
+  const refreshTrigger$ = new BehaviorSubject<void>(undefined);
 
   const waitOneTick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -45,6 +46,7 @@ describe('initialize fetch', () => {
       scopedProfilesManager: discoverServiceMock.profilesManager.createScopedProfilesManager({
         scopedEbtManager: discoverServiceMock.ebtManager.createScopedEBTManager(),
       }),
+      refreshTrigger$,
       ...setters,
     });
     await waitOneTick();
@@ -116,5 +118,28 @@ describe('initialize fetch', () => {
     await waitOneTick();
     expect(abortSignals[1].aborted).toBe(true); // second request should have been aborted
     expect(abortSignals[2].aborted).toBe(false); // third request was not aborted
+  });
+
+  it('should fetch again when refresh trigger emits', async () => {
+    const fetchMock = jest.fn().mockImplementation(() =>
+      of({
+        rawResponse: {
+          hits: {
+            hits: [{ _id: '1', _index: dataViewMock.id }],
+            total: 1,
+          },
+        },
+      })
+    );
+    searchSource.fetch$ = fetchMock;
+
+    mockedApi.savedSearch$.next(savedSearch);
+    await waitOneTick();
+    const callsBeforeRefresh = fetchMock.mock.calls.length;
+
+    refreshTrigger$.next(undefined);
+    await waitOneTick();
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsBeforeRefresh);
   });
 });

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.ts
@@ -133,6 +133,7 @@ export function initializeFetch({
   stateManager,
   discoverServices,
   scopedProfilesManager,
+  refreshTrigger$,
   setDataLoading,
   setBlockingError,
 }: {
@@ -140,13 +141,14 @@ export function initializeFetch({
   stateManager: SearchEmbeddableStateManager;
   discoverServices: DiscoverServices;
   scopedProfilesManager: ScopedProfilesManager;
+  refreshTrigger$: BehaviorSubject<void>;
   setDataLoading: (dataLoading: boolean | undefined) => void;
   setBlockingError: (error: Error | undefined) => void;
 }) {
   const inspectorAdapters = { requests: new RequestAdapter() };
   let abortController: AbortController | undefined;
 
-  const observables = [fetch$(api), api.savedSearch$, api.dataViews$] as const;
+  const observables = [fetch$(api), api.savedSearch$, api.dataViews$, refreshTrigger$] as const;
 
   const fetchSubscription = combineLatest(observables)
     .pipe(

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.test.tsx
@@ -55,6 +55,11 @@ jest.mock('../../common/hooks/use_experimental_features', () => ({
     mockUseIsExperimentalFeatureEnabled(feature),
 }));
 
+const mockUseIsInSecurityApp = jest.fn();
+jest.mock('../../common/hooks/is_in_security_app', () => ({
+  useIsInSecurityApp: () => mockUseIsInSecurityApp(),
+}));
+
 describe('AlertFlyoutOverviewTab', () => {
   const onAlertUpdated = jest.fn();
   const servicesMock = {
@@ -74,6 +79,7 @@ describe('AlertFlyoutOverviewTab', () => {
     mockOverviewTab.mockClear();
     mockUseInitDataViewManager.mockReset();
     mockUseIsExperimentalFeatureEnabled.mockReset();
+    mockUseIsInSecurityApp.mockReturnValue(false);
   });
 
   it('wraps the overview tab in KibanaContextProvider and ReactQueryClientProvider', async () => {
@@ -343,5 +349,59 @@ describe('AlertFlyoutOverviewTab', () => {
     const lastProps = lastCall?.[0] as { renderCellActions?: unknown } | undefined;
     const renderCellActions = lastProps?.renderCellActions;
     expect(renderCellActions).not.toBe(noopCellActionRenderer);
+  });
+
+  it('renders DataViewManagerBootstrap when not in the Security app', async () => {
+    const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
+    mockUseIsInSecurityApp.mockReturnValue(false);
+    mockUseIsExperimentalFeatureEnabled.mockImplementation(
+      (feature: string) => feature === 'newDataViewPickerEnabled'
+    );
+
+    const initSpy = jest.fn();
+    mockUseInitDataViewManager.mockReturnValue(initSpy);
+
+    const store = createStore(() => ({ dataViewManager: { shared: { status: 'pristine' } } }));
+
+    await act(async () => {
+      TestRenderer.create(
+        <AlertFlyoutOverviewTab
+          hit={hit}
+          servicesPromise={Promise.resolve(servicesMock)}
+          storePromise={Promise.resolve(store as never)}
+          onAlertUpdated={onAlertUpdated}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render DataViewManagerBootstrap when in the Security app', async () => {
+    const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
+    mockUseIsInSecurityApp.mockReturnValue(true);
+    mockUseIsExperimentalFeatureEnabled.mockImplementation(
+      (feature: string) => feature === 'newDataViewPickerEnabled'
+    );
+
+    const initSpy = jest.fn();
+    mockUseInitDataViewManager.mockReturnValue(initSpy);
+
+    const store = createStore(() => ({ dataViewManager: { shared: { status: 'pristine' } } }));
+
+    await act(async () => {
+      TestRenderer.create(
+        <AlertFlyoutOverviewTab
+          hit={hit}
+          servicesPromise={Promise.resolve(servicesMock)}
+          storePromise={Promise.resolve(store as never)}
+          onAlertUpdated={onAlertUpdated}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    expect(initSpy).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
@@ -16,6 +16,7 @@ import type { StartServices } from '../../types';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
 import { DataViewManagerBootstrap } from './data_view_manager_bootstrap';
 import { DiscoverCellActions } from '../cell_actions';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 
 export interface AlertFlyoutOverviewTabProps {
   /**
@@ -64,6 +65,7 @@ export const AlertFlyoutOverviewTab = ({
 }: AlertFlyoutOverviewTabProps) => {
   const [services, setServices] = useState<StartServices | null>(null);
   const [store, setStore] = useState<SecurityAppStore | null>(null);
+
   const renderCellActions = useCallback<CellActionRenderer>(
     (props) => (
       <DiscoverCellActions
@@ -109,15 +111,49 @@ export const AlertFlyoutOverviewTab = ({
     services,
     store,
     children: (
-      <>
-        <DataViewManagerBootstrap />
-        <EuiSpacer size="m" />
-        <OverviewTab
-          hit={hit}
-          renderCellActions={renderCellActions}
-          onAlertUpdated={onAlertUpdated}
-        />
-      </>
+      <AlertFlyoutOverviewTabContent
+        hit={hit}
+        renderCellActions={renderCellActions}
+        onAlertUpdated={onAlertUpdated}
+      />
     ),
   });
+};
+
+interface AlertFlyoutOverviewTabContentProps {
+  /**
+   * The document record that will be used to render the content of the overview tab in the alert details flyout.
+   */
+  hit: DataTableRecord;
+  /**
+   * Callback passed to the flyout content to render cell actions
+   */
+  renderCellActions: CellActionRenderer;
+  /**
+   * Callback invoked after alert mutations to refresh the Discover table.
+   */
+  onAlertUpdated: () => void;
+}
+
+/**
+ * The content of the overview tab in the alert details flyout. This is rendered inside the flyout providers to have access to the services and store.
+ */
+const AlertFlyoutOverviewTabContent = ({
+  hit,
+  renderCellActions,
+  onAlertUpdated,
+}: AlertFlyoutOverviewTabContentProps) => {
+  const isInSecurityApp = useIsInSecurityApp();
+
+  return (
+    <>
+      {!isInSecurityApp && <DataViewManagerBootstrap />}
+      <EuiSpacer size="m" />
+      <OverviewTab
+        hit={hit}
+        renderCellActions={renderCellActions}
+        onAlertUpdated={onAlertUpdated}
+      />
+    </>
+  );
 };


### PR DESCRIPTION
## Summary

This PR fixes an issue where the newly added `enhanced-document-profile` flyout isn't rendering when Discover is embedded in a dashboard.

### Code changes

The enhanced flyout has its header, content and footer retrieve the `refetch$` observable via the `useCurrentTabDataStateContainer` hook. This allows it to refresh the table when for example the user changes the status on an alert from within the flyout.

This hook needed a context to be used, hence we were getting the following error
```typescript
Uncaught Error: useCurrentTabContext must be used within a CurrentTabProvider
    at useCurrentTabContext (hooks.tsx:73:1)
    at useCurrentTabDataStateContainer (runtime_state.tsx:118:1)
```

<img width="1401" height="931" alt="Screenshot 2026-05-01 at 9 29 08 AM" src="https://github.com/user-attachments/assets/82d4a837-f356-4294-9c7a-1709c578bfd3" />

The PR fixes that by removing the dependency on that hook and instead pass the necessary value via a new `refreshData` prop, all the way down to the flyout's content.

<img width="1401" height="931" alt="Screenshot 2026-05-01 at 10 06 51 AM" src="https://github.com/user-attachments/assets/486a59c8-bbfa-4e83-8aaa-e1337a139096" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->