### PR TITLE
agent-centric connectors

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/definition.ts
@@ -118,6 +118,13 @@ export interface AgentConfiguration {
   plugin_ids?: string[];
 
   /**
+   * Optional list of connector IDs associated with this agent.
+   * When set, SML search filters connector results to only those in this list.
+   * When undefined, all connectors remain visible (backward compatibility).
+   */
+  connector_ids?: string[];
+
+  /**
    * Custom configuration for the research step of the agent.
    */
   research?: AgentResearchStepConfiguration;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/handler.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/handler.ts
@@ -13,6 +13,7 @@ import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-ser
 import type { ToolResult } from '@kbn/agent-builder-common/tools/tool_result';
 import type { PromptRequest } from '@kbn/agent-builder-common/agents/prompts';
 import type { AgentExecutionMode } from '@kbn/agent-builder-common';
+import type { AgentConfiguration } from '@kbn/agent-builder-common';
 import type {
   ToolEventEmitter,
   ModelProvider,
@@ -167,4 +168,9 @@ export interface ToolHandlerContext {
    * When 'standalone', the execution is non-interactive (HITL disabled).
    */
   executionMode?: AgentExecutionMode;
+  /**
+   * The effective agent configuration for the current run, with any
+   * runtime configuration overrides already applied.
+   */
+  agentConfiguration?: AgentConfiguration;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.test.tsx
@@ -48,6 +48,14 @@ jest.mock('../../../../../../../hooks/sml/use_sml_search', () => ({
   useSmlSearch: () => mockUseSmlSearchReturn,
 }));
 
+jest.mock('../../../../../../../hooks/use_conversation', () => ({
+  useAgentId: () => 'test-agent-id',
+}));
+
+jest.mock('../../../../../../../hooks/agents/use_agent_by_id', () => ({
+  useAgentBuilderAgentById: () => ({ agent: null, isLoading: false, error: null }),
+}));
+
 beforeEach(() => {
   mockUseSmlSearchReturn = {
     results: defaultMockResults,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/sml.tsx
@@ -9,16 +9,22 @@ import React, { forwardRef, useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import { EuiHighlight, useEuiTheme } from '@elastic/eui';
 import { useSmlSearch } from '../../../../../../../hooks/sml/use_sml_search';
+import { useAgentId } from '../../../../../../../hooks/use_conversation';
+import { useAgentBuilderAgentById } from '../../../../../../../hooks/agents/use_agent_by_id';
 import type { CommandMenuComponentProps, CommandMenuHandle } from '../../types';
 import { CommandId } from '../../types';
 import { getSmlMenuHighlightSearchStrings } from '../../utils/sml_command_menu_highlight';
+import { buildSmlFiltersFromAgent } from '../../utils/sml_filters';
 import { CommandMenuList } from '../components/command_menu_list';
 import type { CommandMenuListOption } from '../components/command_menu_list';
 
 export const Sml = forwardRef<CommandMenuHandle, CommandMenuComponentProps>(
   ({ query, onSelect }, ref) => {
+    const agentId = useAgentId();
+    const { agent } = useAgentBuilderAgentById(agentId);
+    const filters = useMemo(() => buildSmlFiltersFromAgent(agent), [agent]);
     const { euiTheme } = useEuiTheme();
-    const { results, isLoading } = useSmlSearch(query, { skipContent: true });
+    const { results, isLoading } = useSmlSearch(query, { skipContent: true, filters });
     const { type, title } = useMemo(() => getSmlMenuHighlightSearchStrings(query), [query]);
 
     const smlMenuLabelStyles = useMemo(

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/use_prefetch_sml.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/menus/sml/use_prefetch_sml.ts
@@ -7,12 +7,13 @@
 
 import { useCallback } from 'react';
 import { useQueryClient } from '@kbn/react-query';
+import type { SmlSearchFilters } from '@kbn/agent-context-layer-plugin/public';
 import { SML_SEARCH_DEFAULT_SIZE } from '../../../../../../../../services/sml/constants';
 import { queryKeys } from '../../../../../../../query_keys';
 import { useAgentBuilderServices } from '../../../../../../../hooks/use_agent_builder_service';
 import { useExperimentalFeatures } from '../../../../../../../hooks/use_experimental_features';
 
-export const usePrefetchSml = () => {
+export const usePrefetchSml = (filters?: SmlSearchFilters) => {
   const queryClient = useQueryClient();
   const { smlService } = useAgentBuilderServices();
   const experimentalFeaturesEnabled = useExperimentalFeatures();
@@ -22,13 +23,14 @@ export const usePrefetchSml = () => {
       return;
     }
     queryClient.prefetchQuery({
-      queryKey: queryKeys.sml.search('*', true),
+      queryKey: queryKeys.sml.search('*', true, filters),
       queryFn: () =>
         smlService.search({
           query: '*',
           size: SML_SEARCH_DEFAULT_SIZE,
           skipContent: true,
+          filters,
         }),
     });
-  }, [experimentalFeaturesEnabled, queryClient, smlService]);
+  }, [experimentalFeaturesEnabled, queryClient, smlService, filters]);
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/use_command_menu_prefetch.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/use_command_menu_prefetch.ts
@@ -5,25 +5,40 @@
  * 2.0.
  */
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { usePrefetchSkills } from './menus/skills/use_prefetch_skills';
 import { usePrefetchSml } from './menus/sml/use_prefetch_sml';
+import { useAgentId } from '../../../../../hooks/use_conversation';
+import { useAgentBuilderAgentById } from '../../../../../hooks/agents/use_agent_by_id';
+import { buildSmlFiltersFromAgent } from './utils/sml_filters';
 
 /**
  * Prefetches data for all command menus on first invocation.
+ * Re-prefetches SML when the agent's filters change (e.g. after the async
+ * agent fetch resolves with connector_ids).
  * Returns a callback that should be called when the editor receives focus.
  */
+const NOT_YET_PREFETCHED = Symbol('not-yet-prefetched');
+
 export const useCommandMenuPrefetch = () => {
-  const hasPrefetched = useRef(false);
+  const hasPrefetchedSkills = useRef(false);
+  const lastSmlFiltersJson = useRef<string | symbol>(NOT_YET_PREFETCHED);
+  const agentId = useAgentId();
+  const { agent } = useAgentBuilderAgentById(agentId);
+  const filters = useMemo(() => buildSmlFiltersFromAgent(agent), [agent]);
   const prefetchSkills = usePrefetchSkills();
-  const prefetchSml = usePrefetchSml();
+  const prefetchSml = usePrefetchSml(filters);
 
   return useCallback(() => {
-    if (hasPrefetched.current) {
-      return;
+    if (!hasPrefetchedSkills.current) {
+      hasPrefetchedSkills.current = true;
+      prefetchSkills();
     }
-    hasPrefetched.current = true;
-    prefetchSkills();
-    prefetchSml();
-  }, [prefetchSkills, prefetchSml]);
+
+    const filtersJson = filters ? JSON.stringify(filters) : '';
+    if (filtersJson !== lastSmlFiltersJson.current) {
+      lastSmlFiltersJson.current = filtersJson;
+      prefetchSml();
+    }
+  }, [prefetchSkills, prefetchSml, filters]);
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/utils/sml_filters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_menu/utils/sml_filters.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentDefinition } from '@kbn/agent-builder-common/agents/definition';
+import type { SmlSearchFilters } from '@kbn/agent-context-layer-plugin/public';
+import { SmlSearchFilterType } from '@kbn/agent-context-layer-plugin/public';
+
+// Three states: undefined → no filtering (all connectors visible),
+// [] → no connectors allowed, ['id1', ...] → only those connectors.
+export const buildSmlFiltersFromAgent = (
+  agent: AgentDefinition | null
+): SmlSearchFilters | undefined => {
+  const connectorIds = agent?.configuration?.connector_ids;
+  if (connectorIds === undefined) {
+    return undefined;
+  }
+  return { [SmlSearchFilterType.connector]: { ids: connectorIds } };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/sml/use_sml_search.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/sml/use_sml_search.ts
@@ -10,6 +10,7 @@ import { useDebouncedValue } from '@kbn/react-hooks';
 import { useQuery } from '@kbn/react-query';
 import { formatAgentBuilderErrorMessage } from '@kbn/agent-builder-browser';
 import { i18n } from '@kbn/i18n';
+import type { SmlSearchFilters } from '@kbn/agent-context-layer-plugin/public';
 import { SML_SEARCH_DEFAULT_SIZE } from '../../../services/sml/constants';
 import { queryKeys } from '../../query_keys';
 import { useAgentBuilderServices } from '../use_agent_builder_service';
@@ -28,6 +29,8 @@ const smlSearchErrorToastTitle = i18n.translate(
 export interface UseSmlSearchOptions {
   /** When true, the server omits indexed `content` on each hit (smaller payload; e.g. command-menu autocomplete). */
   readonly skipContent?: boolean;
+  /** Per-type filters for SML search. */
+  readonly filters?: SmlSearchFilters;
 }
 
 export const useSmlSearch = (query: string, options?: UseSmlSearchOptions) => {
@@ -35,16 +38,18 @@ export const useSmlSearch = (query: string, options?: UseSmlSearchOptions) => {
   const { smlService } = useAgentBuilderServices();
   const debouncedQuery = useDebouncedValue(query, SML_SEARCH_DEBOUNCE_MS);
   const skipContent = options?.skipContent ?? false;
+  const filters = options?.filters;
 
   const searchQuery = useMemo(() => normalizeSmlSearchQuery(debouncedQuery), [debouncedQuery]);
 
   const { isError, isLoading, error, data } = useQuery({
-    queryKey: queryKeys.sml.search(searchQuery, skipContent),
+    queryKey: queryKeys.sml.search(searchQuery, skipContent, filters),
     queryFn: () =>
       smlService.search({
         query: searchQuery,
         size: SML_SEARCH_DEFAULT_SIZE,
         skipContent,
+        filters,
       }),
     staleTime: SML_SEARCH_STALE_TIME_MS,
     cacheTime: SML_SEARCH_CACHE_TIME_MS,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { SmlSearchFilters } from '@kbn/agent-context-layer-plugin/public';
+
 /**
  * Query keys for react-query
  */
@@ -51,8 +53,8 @@ export const queryKeys = {
     byAgent: (agentId?: string) => ['skills', 'byAgent', agentId],
   },
   sml: {
-    search: (query: string, skipContent: boolean) =>
-      ['sml', 'search', { query, skipContent }] as const,
+    search: (query: string, skipContent: boolean, filters?: SmlSearchFilters) =>
+      ['sml', 'search', { query, skipContent, filters }] as const,
   },
   plugins: {
     all: ['plugins', 'list'] as const,

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/sml/sml_service.ts
@@ -6,7 +6,10 @@
  */
 
 import type { HttpSetup } from '@kbn/core-http-browser';
-import type { SmlSearchHttpResponse } from '@kbn/agent-context-layer-plugin/public';
+import type {
+  SmlSearchFilters,
+  SmlSearchHttpResponse,
+} from '@kbn/agent-context-layer-plugin/public';
 import { smlSearchPath } from '@kbn/agent-context-layer-plugin/public';
 
 /** Browser client for SML search (`/internal/agent_context_layer/sml/_search`). */
@@ -21,12 +24,14 @@ export class SmlService {
     query: string;
     size: number;
     skipContent?: boolean;
+    filters?: SmlSearchFilters;
   }): Promise<SmlSearchHttpResponse> {
     return await this.http.post<SmlSearchHttpResponse>(smlSearchPath, {
       body: JSON.stringify({
         query: params.query,
         size: params.size,
         ...(params.skipContent === true ? { skip_content: true } : {}),
+        ...(params.filters ? { filters: params.filters } : {}),
       }),
     });
   }

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/agents.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/agents.ts
@@ -59,6 +59,16 @@ const PLUGINS_SCHEMA = schema.arrayOf(
   }
 );
 
+const CONNECTORS_SCHEMA = schema.arrayOf(
+  schema.string({
+    meta: { description: 'Connector ID to associate with the agent.' },
+  }),
+  {
+    maxSize: 100,
+    meta: { description: 'Array of connector IDs to associate with the agent.' },
+  }
+);
+
 export function registerAgentRoutes({
   router,
   getInternalServices,
@@ -239,6 +249,7 @@ export function registerAgentRoutes({
                     )
                   ),
                   plugin_ids: schema.maybe(PLUGINS_SCHEMA),
+                  connector_ids: schema.maybe(CONNECTORS_SCHEMA),
                 },
                 {
                   meta: { description: 'Configuration settings for the agent.' },
@@ -382,6 +393,7 @@ export function registerAgentRoutes({
                       )
                     ),
                     plugin_ids: schema.maybe(PLUGINS_SCHEMA),
+                    connector_ids: schema.maybe(CONNECTORS_SCHEMA),
                   },
                   {
                     meta: { description: 'Updated configuration settings for the agent.' },

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
@@ -52,6 +52,7 @@ export const fromEs = (document: Document): PersistedAgentDefinition => {
         (resolvedId === agentBuilderDefaultAgentId ? true : undefined),
       workflow_ids: configuration.workflow_ids,
       plugin_ids: configuration.plugin_ids,
+      connector_ids: configuration.connector_ids,
     },
   };
 };
@@ -86,6 +87,7 @@ export const createRequestToEs = ({
       enable_elastic_capabilities: profile.configuration.enable_elastic_capabilities,
       workflow_ids: profile.configuration.workflow_ids,
       plugin_ids: profile.configuration.plugin_ids,
+      connector_ids: profile.configuration.connector_ids,
     },
     created_at: creationDate.toISOString(),
     updated_at: creationDate.toISOString(),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/storage.ts
@@ -33,6 +33,7 @@ const storageSettings = {
           workflow_ids: types.keyword({}),
           plugin_ids: types.keyword({}),
           skill_ids: types.keyword({}),
+          connector_ids: types.keyword({}),
         },
         dynamic: false,
       }),
@@ -68,6 +69,7 @@ export interface AgentConfigurationProperties {
   enable_elastic_capabilities?: boolean;
   workflow_ids?: string[];
   plugin_ids?: string[];
+  connector_ids?: string[];
 }
 
 export type AgentProfileStorageSettings = typeof storageSettings;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/create_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/create_handler.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { AgentConfiguration } from '@kbn/agent-builder-common';
 import type { AgentHandlerFn } from '@kbn/agent-builder-server';
 import type { InternalAgentDefinition } from '../../agents/agent_registry';
 import { runAgent } from './run_agent';
@@ -14,8 +15,10 @@ import { runAgent } from './run_agent';
  */
 export const createAgentHandler = ({
   agent,
+  effectiveConfiguration,
 }: {
   agent: InternalAgentDefinition;
+  effectiveConfiguration: AgentConfiguration;
 }): AgentHandlerFn => {
   return async (
     {
@@ -35,11 +38,6 @@ export const createAgentHandler = ({
     },
     context
   ) => {
-    const effectiveConfiguration = {
-      ...agent.configuration,
-      ...(configurationOverrides || {}),
-    };
-
     const { round } = await runAgent(
       {
         nextInput,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/run_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/run_agent.ts
@@ -135,8 +135,16 @@ export const runAgent = async ({
   const agentRegistry = await agentsService.getRegistry({ request });
   const agent = await agentRegistry.get(agentId);
 
+  // Single merge point for runtime overrides — consumed by both the agent handler
+  // (prompt construction, tool selection) and tool handlers (via ToolHandlerContext).
+  const effectiveConfiguration = {
+    ...agent.configuration,
+    ...(agentParams.configurationOverrides || {}),
+  };
+  manager.deps.agentConfiguration = effectiveConfiguration;
+
   const agentResult = await withAgentSpan({ agent }, async () => {
-    const agentHandler = createAgentHandler({ agent });
+    const agentHandler = createAgentHandler({ agent, effectiveConfiguration });
     const agentHandlerContext = await createAgentHandlerContext({ agentExecutionParams, manager });
     return await agentHandler(
       {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/run_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/run_tool.ts
@@ -324,6 +324,7 @@ export const createToolHandlerContext = async <TParams = Record<string, unknown>
     events: createToolEventEmitter({ eventHandler: onEvent, context: manager.context }),
     runContext: manager.context,
     executionMode: manager.deps.executionMode,
+    agentConfiguration: manager.deps.agentConfiguration,
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/runner.ts
@@ -13,7 +13,7 @@ import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
-import type { Conversation, ConverseInput } from '@kbn/agent-builder-common';
+import type { AgentConfiguration, Conversation, ConverseInput } from '@kbn/agent-builder-common';
 import {
   AgentExecutionMode,
   createInternalError,
@@ -102,6 +102,8 @@ export interface CreateScopedRunnerDeps {
   executionMode: AgentExecutionMode;
   /** Sub-agent executor for spawning child executions. */
   subAgentExecutor: SubAgentExecutor;
+  /** The effective agent configuration for the current run (with overrides applied). */
+  agentConfiguration?: AgentConfiguration;
 }
 
 export type CreateRunnerDeps = Omit<

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_search.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_search.test.ts
@@ -61,6 +61,7 @@ describe('createSmlSearchTool', () => {
       spaceId: 'default',
       esClient: mockContext.esClient,
       request: mockContext.request,
+      filters: undefined,
     });
   });
 
@@ -136,6 +137,76 @@ describe('createSmlSearchTool', () => {
       expect.objectContaining({
         query: 'test',
         size: undefined,
+      })
+    );
+  });
+
+  it('passes connector_ids as filters from agentConfiguration', async () => {
+    mockSearch.mockResolvedValue({ results: [], total: 0 });
+    const contextWithConnectors = {
+      ...mockContext,
+      agentConfiguration: { connector_ids: ['conn-1', 'conn-2'], tools: [] },
+    };
+
+    const tool = createSmlSearchTool({ getAgentContextLayer });
+    await tool.handler({ query: 'test' }, contextWithConnectors as unknown as ToolHandlerContext);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: { connector: { ids: ['conn-1', 'conn-2'] } },
+      })
+    );
+  });
+
+  it('does not pass filters when agentConfiguration has no connector_ids', async () => {
+    mockSearch.mockResolvedValue({ results: [], total: 0 });
+    const contextWithoutConnectors = {
+      ...mockContext,
+      agentConfiguration: { tools: [] },
+    };
+
+    const tool = createSmlSearchTool({ getAgentContextLayer });
+    await tool.handler(
+      { query: 'test' },
+      contextWithoutConnectors as unknown as ToolHandlerContext
+    );
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: undefined,
+      })
+    );
+  });
+
+  it('passes empty connector ids filter when connector_ids is []', async () => {
+    mockSearch.mockResolvedValue({ results: [], total: 0 });
+    const contextWithEmptyConnectors = {
+      ...mockContext,
+      agentConfiguration: { connector_ids: [], tools: [] },
+    };
+
+    const tool = createSmlSearchTool({ getAgentContextLayer });
+    await tool.handler(
+      { query: 'test' },
+      contextWithEmptyConnectors as unknown as ToolHandlerContext
+    );
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: { connector: { ids: [] } },
+      })
+    );
+  });
+
+  it('does not pass filters when agentConfiguration is undefined', async () => {
+    mockSearch.mockResolvedValue({ results: [], total: 0 });
+
+    const tool = createSmlSearchTool({ getAgentContextLayer });
+    await tool.handler({ query: 'test' }, mockContext as unknown as ToolHandlerContext);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: undefined,
       })
     );
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_search.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_search.ts
@@ -11,6 +11,7 @@ import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import { getToolResultId, createErrorResult } from '@kbn/agent-builder-server';
 import { AGENT_CONTEXT_LAYER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
+import { SmlSearchFilterType } from '@kbn/agent-context-layer-plugin/server';
 import type { SmlToolsOptions } from './types';
 
 const smlSearchSchema = z.object({
@@ -63,7 +64,13 @@ export const createSmlSearchTool = ({
   },
   handler: async ({ query, size }, context) => {
     const agentContextLayer = getAgentContextLayer();
-    const { spaceId, esClient, request } = context;
+    const { spaceId, esClient, request, agentConfiguration } = context;
+
+    const connectorIds = agentConfiguration?.connector_ids;
+    const filters =
+      connectorIds !== undefined
+        ? { [SmlSearchFilterType.connector]: { ids: connectorIds } }
+        : undefined;
 
     let searchResult;
     try {
@@ -73,6 +80,7 @@ export const createSmlSearchTool = ({
         spaceId,
         esClient,
         request,
+        filters,
       });
     } catch (error) {
       return {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/types.ts
@@ -9,8 +9,7 @@ import type { AgentContextLayerPluginStart } from '@kbn/agent-context-layer-plug
 
 /**
  * Options for creating SML tools.
- * Uses a getter for lazy resolution — the agent context layer start contract
- * is not available until after plugin start.
+ * Uses a getter for lazy resolution — the start contract is not available until after plugin start.
  */
 export interface SmlToolsOptions {
   getAgentContextLayer: () => AgentContextLayerPluginStart;

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
@@ -6,6 +6,20 @@
  */
 
 /**
+ * Allowed type keys for the `filters` parameter in SML search.
+ * Extend this enum when adding new filterable SML types.
+ */
+export enum SmlSearchFilterType {
+  connector = 'connector',
+}
+
+/**
+ * Per-type filter criteria for SML search.
+ * Keys must be values of {@link SmlSearchFilterType}.
+ */
+export type SmlSearchFilters = Partial<Record<SmlSearchFilterType, { ids?: string[] }>>;
+
+/**
  * Max length of `query` for POST `/internal/agent_context_layer/sml/_search`.
  */
 export const SML_HTTP_SEARCH_QUERY_MAX_LENGTH = 512;

--- a/x-pack/platform/plugins/shared/agent_context_layer/public/index.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/public/index.ts
@@ -8,8 +8,12 @@
 import type { PluginInitializer } from '@kbn/core-plugins-browser';
 
 export { smlSearchPath, internalApiPath } from '../common/constants';
-export { SML_HTTP_SEARCH_QUERY_MAX_LENGTH } from '../common/http_api/sml';
-export type { SmlSearchHttpResponse, SmlSearchHttpResultItem } from '../common/http_api/sml';
+export { SML_HTTP_SEARCH_QUERY_MAX_LENGTH, SmlSearchFilterType } from '../common/http_api/sml';
+export type {
+  SmlSearchFilters,
+  SmlSearchHttpResponse,
+  SmlSearchHttpResultItem,
+} from '../common/http_api/sml';
 
 export const plugin: PluginInitializer<{}, {}> = () => ({
   setup: () => ({}),

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/index.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/index.ts
@@ -27,12 +27,14 @@ export type {
   SmlToAttachmentContext,
   SmlListItem,
   SmlSearchResult,
+  SmlSearchFilters,
   SmlDocument,
   SmlIndexAction,
 } from './services/sml/types';
 
 export type { SmlResolvedItemResult } from './services/sml/execute_sml_attach_items';
 export { smlElasticsearchIndexMappings, smlIndexName } from './services/sml/sml_storage';
+export { SmlSearchFilterType } from '../common/http_api/sml';
 
 export const plugin: PluginInitializer<
   AgentContextLayerPluginSetup,

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.ts
@@ -11,7 +11,7 @@ import type { RouteSecurity } from '@kbn/core-http-server';
 import { AGENT_CONTEXT_LAYER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
 import { apiPrivileges } from '../../common/features';
 import type { SmlSearchHttpResponse } from '../../common/http_api/sml';
-import { SML_HTTP_SEARCH_QUERY_MAX_LENGTH } from '../../common/http_api/sml';
+import { SML_HTTP_SEARCH_QUERY_MAX_LENGTH, SmlSearchFilterType } from '../../common/http_api/sml';
 import { smlSearchPath } from '../../common/constants';
 import type { SmlService } from '../services/sml/types';
 import type { AgentContextLayerStartDependencies, AgentContextLayerPluginStart } from '../types';
@@ -41,6 +41,14 @@ export const registerSearchRoute = ({
           query: schema.string({ minLength: 1, maxLength: SML_HTTP_SEARCH_QUERY_MAX_LENGTH }),
           size: schema.maybe(schema.number({ min: 1, max: SML_SEARCH_SIZE_MAX })),
           skip_content: schema.maybe(schema.boolean()),
+          filters: schema.maybe(
+            schema.recordOf(
+              schema.literal(SmlSearchFilterType.connector),
+              schema.object({
+                ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+              })
+            )
+          ),
         }),
       },
       options: { access: 'internal' },
@@ -59,7 +67,7 @@ export const registerSearchRoute = ({
         }
 
         const sml = getSmlService();
-        const { query, size, skip_content: skipContent } = request.body;
+        const { query, size, skip_content: skipContent, filters } = request.body;
         const esClient = coreContext.elasticsearch.client;
 
         const [, startDeps] = await coreSetup.getStartServices();
@@ -72,6 +80,7 @@ export const registerSearchRoute = ({
           esClient,
           request,
           skipContent,
+          filters,
         });
 
         const body: SmlSearchHttpResponse = {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_connector_filter.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_connector_filter.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SmlSearchFilterType } from '../../../common/http_api/sml';
+import { buildTypeFilters } from './sml_service';
+
+// buildTypeFilters is designed to combine clauses from multiple SmlSearchFilterType
+// values. When the enum grows beyond 'connector', add multi-type tests here.
+
+describe('buildTypeFilters', () => {
+  it('returns undefined when filters is undefined', () => {
+    expect(buildTypeFilters(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when filters is empty', () => {
+    expect(buildTypeFilters({})).toBeUndefined();
+  });
+
+  it('returns undefined when type criteria has no ids', () => {
+    expect(buildTypeFilters({ [SmlSearchFilterType.connector]: {} })).toBeUndefined();
+  });
+
+  it('excludes the type entirely when ids is empty', () => {
+    const filter = buildTypeFilters({ [SmlSearchFilterType.connector]: { ids: [] } });
+    expect(filter).toEqual({
+      bool: { must_not: [{ term: { type: 'connector' } }] },
+    });
+  });
+
+  it('returns a filter for a single type with ids', () => {
+    const filter = buildTypeFilters({
+      [SmlSearchFilterType.connector]: { ids: ['conn-1', 'conn-2'] },
+    });
+    expect(filter).toEqual({
+      bool: {
+        should: [
+          {
+            bool: {
+              must: [
+                { term: { type: 'connector' } },
+                { terms: { origin_id: ['conn-1', 'conn-2'] } },
+              ],
+            },
+          },
+          {
+            bool: {
+              must_not: [{ term: { type: 'connector' } }],
+            },
+          },
+        ],
+        minimum_should_match: 1,
+      },
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -10,7 +10,13 @@ import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { AuthorizationServiceSetup } from '@kbn/security-plugin-types-server';
-import type { SmlService, SmlSearchResult, SmlDocument, SmlTypeDefinition } from './types';
+import type {
+  SmlService,
+  SmlSearchResult,
+  SmlDocument,
+  SmlTypeDefinition,
+  SmlSearchFilters,
+} from './types';
 import { createSmlTypeRegistry, type SmlTypeRegistry } from './sml_type_registry';
 import { createSmlIndexer, type SmlIndexer } from './sml_indexer';
 import { SmlCrawlerImpl } from './sml_crawler';
@@ -75,7 +81,7 @@ class SmlServiceImpl implements SmlServiceInstance {
 
     return {
       getCrawler: () => crawler,
-      search: async ({ query, size = 10, spaceId, esClient, request, skipContent }) => {
+      search: async ({ query, size = 10, spaceId, esClient, request, skipContent, filters }) => {
         const rawResults = await searchSml({
           query,
           size,
@@ -83,6 +89,7 @@ class SmlServiceImpl implements SmlServiceInstance {
           esClient,
           logger,
           skipContent,
+          filters,
         });
         return filterResultsByPermissions({
           searchResult: rawResults,
@@ -346,6 +353,63 @@ const buildSmlSearchQuery = (query: string): Record<string, unknown> => {
 };
 
 /**
+ * Build an ES filter clause from per-type SML search filters.
+ *
+ * For each type with an `ids` constraint, the filter returns documents that
+ * either (a) match the type AND have an origin_id in the list, or (b) are
+ * NOT of the constrained type. Types without filters are unaffected.
+ */
+export const buildTypeFilters = (
+  filters: SmlSearchFilters | undefined
+): Record<string, unknown> | undefined => {
+  if (!filters) {
+    return undefined;
+  }
+
+  const clauses: Array<Record<string, unknown>> = [];
+
+  for (const [typeId, criteria] of Object.entries(filters)) {
+    if (!criteria?.ids) {
+      continue;
+    }
+
+    if (criteria.ids.length === 0) {
+      // Explicitly empty → exclude all documents of this type
+      clauses.push({ bool: { must_not: [{ term: { type: typeId } }] } });
+    } else {
+      // Non-empty → allow matching documents of this type, pass through other types
+      clauses.push({
+        bool: {
+          should: [
+            {
+              bool: {
+                must: [{ term: { type: typeId } }, { terms: { origin_id: criteria.ids } }],
+              },
+            },
+            {
+              bool: {
+                must_not: [{ term: { type: typeId } }],
+              },
+            },
+          ],
+          minimum_should_match: 1,
+        },
+      });
+    }
+  }
+
+  if (clauses.length === 0) {
+    return undefined;
+  }
+
+  if (clauses.length === 1) {
+    return clauses[0];
+  }
+
+  return { bool: { must: clauses } };
+};
+
+/**
  * Search the SML index. When the index hasn't been created yet,
  * the function returns empty results silently.
  */
@@ -356,6 +420,7 @@ const searchSml = async ({
   esClient,
   logger,
   skipContent,
+  filters,
 }: {
   query: string;
   size: number;
@@ -363,6 +428,7 @@ const searchSml = async ({
   esClient: IScopedClusterClient;
   logger: Logger;
   skipContent?: boolean;
+  filters?: SmlSearchFilters;
 }): Promise<{ results: SmlSearchResult[]; total: number }> => {
   logger.debug(
     `SML search: query=${JSON.stringify(
@@ -373,6 +439,19 @@ const searchSml = async ({
   try {
     const smlQuery = buildSmlSearchQuery(query);
 
+    const typeFilter = buildTypeFilters(filters);
+    const filterClauses: Array<Record<string, unknown>> = [
+      {
+        bool: {
+          should: [{ term: { spaces: spaceId } }, { term: { spaces: '*' } }],
+          minimum_should_match: 1,
+        },
+      },
+    ];
+    if (typeFilter) {
+      filterClauses.push(typeFilter);
+    }
+
     const response = await esClient.asInternalUser.search<SmlDocument>({
       index: smlIndexName,
       size,
@@ -381,14 +460,7 @@ const searchSml = async ({
       query: {
         bool: {
           must: [smlQuery],
-          filter: [
-            {
-              bool: {
-                should: [{ term: { spaces: spaceId } }, { term: { spaces: '*' } }],
-                minimum_should_match: 1,
-              },
-            },
-          ],
+          filter: filterClauses,
         },
       },
       _source: skipContent ? { excludes: ['content', 'description'] } : true,

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
@@ -13,6 +13,7 @@ import type {
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import type { SmlSearchFilters } from '../../../common/http_api/sml';
 
 /**
  * A single SML chunk to be indexed.
@@ -187,6 +188,12 @@ export interface SmlCrawler {
 }
 
 /**
+ * Per-type filter parameters for SML search.
+ * Re-exported from the shared HTTP API types so server and client use a single definition.
+ */
+export type { SmlSearchFilters } from '../../../common/http_api/sml';
+
+/**
  * SML service interface — exposed on the plugin start contract.
  */
 export interface SmlService {
@@ -201,6 +208,8 @@ export interface SmlService {
     request: KibanaRequest;
     /** When true, Elasticsearch omits `content` from `_source` (smaller payloads for autocomplete). */
     skipContent?: boolean;
+    /** Per-type filters. See {@link SmlSearchFilters}. */
+    filters?: SmlSearchFilters;
   }) => Promise<{ results: SmlSearchResult[]; total: number }>;
 
   /**

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/types.ts
@@ -19,6 +19,7 @@ import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
 import type {
   SmlTypeDefinition,
   SmlSearchResult,
+  SmlSearchFilters,
   SmlDocument,
   SmlIndexAction,
 } from './services/sml/types';
@@ -47,6 +48,7 @@ export interface AgentContextLayerPluginStart {
     esClient: IScopedClusterClient;
     request: KibanaRequest;
     skipContent?: boolean;
+    filters?: SmlSearchFilters;
   }) => Promise<{ results: SmlSearchResult[]; total: number }>;
 
   checkItemsAccess: (params: {


### PR DESCRIPTION
## Summary

Enables scoping agents to a subset of configured connectors, and adjusts SML search to only the connectors that are enabled for the current Agent.

To test:
1. enable the experimental feature flag
2.  create some connectors
3. go to the Agent UI, and type `@` (all your connectors auto-complete)
4. update the agent to just a subset of connector IDs
```
PUT kbn://api/agent_builder/agents/elastic-ai-agent                                                                                                   
{
  "configuration": {
    "connector_ids": [
      "<connector-id-1>",
      "<connector-id-2>"
    ]
  }
}
```

5. then go to the Agent UI and type `@` (only your configured connectors auto-complete)


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Release Notes

Introduces an optional configuration for Agent Builder Agents: `connector_ids`. If unset, a given agent has access to all configured kibana connectors. When set, the Agent will have access only to the listed connectors.



