### PR TITLE
[SLO] Add support for ESQL

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/indicators.test.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/indicators.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isRight } from 'fp-ts/Either';
+import {
+  esqlCustomIndicatorSchema,
+  esqlCustomIndicatorTypeSchema,
+  indicatorSchema,
+  indicatorTypesSchema,
+} from './indicators';
+
+describe('ESQL Custom Indicator', () => {
+  describe('esqlCustomIndicatorTypeSchema', () => {
+    it('validates the correct type literal', () => {
+      expect(isRight(esqlCustomIndicatorTypeSchema.decode('sli.esql.custom'))).toBe(true);
+    });
+
+    it('rejects invalid type literals', () => {
+      expect(isRight(esqlCustomIndicatorTypeSchema.decode('sli.kql.custom'))).toBe(false);
+      expect(isRight(esqlCustomIndicatorTypeSchema.decode('sli.esql'))).toBe(false);
+    });
+  });
+
+  describe('esqlCustomIndicatorSchema', () => {
+    it('validates a valid ESQL indicator with required fields', () => {
+      const indicator = {
+        type: 'sli.esql.custom',
+        params: {
+          esqlQuery:
+            'FROM logs-* | STATS numerator = COUNT(*) WHERE status = 200, denominator = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1m)',
+        },
+      };
+      expect(isRight(esqlCustomIndicatorSchema.decode(indicator))).toBe(true);
+    });
+
+    it('validates a valid ESQL indicator with groupBy', () => {
+      const indicator = {
+        type: 'sli.esql.custom',
+        params: {
+          esqlQuery:
+            'FROM logs-* | STATS numerator = COUNT(*) WHERE status = 200, denominator = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1m), host.name',
+          groupBy: ['host.name'],
+        },
+      };
+      expect(isRight(esqlCustomIndicatorSchema.decode(indicator))).toBe(true);
+    });
+
+    it('rejects an indicator missing esqlQuery', () => {
+      const indicator = {
+        type: 'sli.esql.custom',
+        params: {},
+      };
+      expect(isRight(esqlCustomIndicatorSchema.decode(indicator))).toBe(false);
+    });
+
+    it('rejects an indicator with wrong type', () => {
+      const indicator = {
+        type: 'sli.kql.custom',
+        params: {
+          esqlQuery: 'FROM logs-*',
+        },
+      };
+      expect(isRight(esqlCustomIndicatorSchema.decode(indicator))).toBe(false);
+    });
+  });
+
+  describe('indicatorTypesSchema', () => {
+    it('includes sli.esql.custom as a valid indicator type', () => {
+      expect(isRight(indicatorTypesSchema.decode('sli.esql.custom'))).toBe(true);
+    });
+  });
+
+  describe('indicatorSchema', () => {
+    it('validates an ESQL custom indicator within the union', () => {
+      const indicator = {
+        type: 'sli.esql.custom',
+        params: {
+          esqlQuery: 'FROM logs-* | STATS n = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1m)',
+        },
+      };
+      expect(isRight(indicatorSchema.decode(indicator))).toBe(true);
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/indicators.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/indicators.ts
@@ -265,6 +265,19 @@ const histogramIndicatorSchema = t.type({
   ]),
 });
 
+const esqlCustomIndicatorTypeSchema = t.literal('sli.esql.custom');
+const esqlCustomIndicatorSchema = t.type({
+  type: esqlCustomIndicatorTypeSchema,
+  params: t.intersection([
+    t.type({
+      esqlQuery: t.string,
+    }),
+    t.partial({
+      groupBy: t.array(t.string),
+    }),
+  ]),
+});
+
 const syntheticsParamSchema = t.type({
   value: allOrAnyString,
   label: allOrAnyString,
@@ -294,6 +307,7 @@ const indicatorTypesSchema = t.union([
   metricCustomIndicatorTypeSchema,
   timesliceMetricIndicatorTypeSchema,
   histogramIndicatorTypeSchema,
+  esqlCustomIndicatorTypeSchema,
 ]);
 
 // Validate that a string is a comma separated list of indicator types,
@@ -323,6 +337,7 @@ const indicatorSchema = t.union([
   metricCustomIndicatorSchema,
   timesliceMetricIndicatorSchema,
   histogramIndicatorSchema,
+  esqlCustomIndicatorSchema,
 ]);
 
 export {
@@ -351,6 +366,8 @@ export {
   timesliceMetricPercentileMetric,
   histogramIndicatorTypeSchema,
   histogramIndicatorSchema,
+  esqlCustomIndicatorSchema,
+  esqlCustomIndicatorTypeSchema,
   indicatorSchema,
   indicatorTypesArraySchema,
   indicatorTypesSchema,

--- a/x-pack/solutions/observability/plugins/slo/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/constants.ts
@@ -83,6 +83,9 @@ export const HEALTH_INDEX_TEMPLATE_NAME = `.slo-observability.health-v${SLO_RESO
 export const getSLOTransformId = (sloId: string, sloRevision: number) =>
   `slo-${sloId}-${sloRevision}`;
 
+export const getSLOWorkflowId = (sloId: string, sloRevision: number) =>
+  `slo-esql-${sloId}-${sloRevision}`;
+
 export const getSLOSummaryTransformId = (sloId: string, sloRevision: number) =>
   `slo-summary-${sloId}-${sloRevision}`;
 

--- a/x-pack/solutions/observability/plugins/slo/server/domain/models/indicators.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/domain/models/indicators.ts
@@ -8,6 +8,7 @@
 import type {
   apmTransactionDurationIndicatorSchema,
   apmTransactionErrorRateIndicatorSchema,
+  esqlCustomIndicatorSchema,
   indicatorSchema,
   indicatorTypesSchema,
   kqlCustomIndicatorSchema,
@@ -19,8 +20,16 @@ type APMTransactionErrorRateIndicator = t.TypeOf<typeof apmTransactionErrorRateI
 type APMTransactionDurationIndicator = t.TypeOf<typeof apmTransactionDurationIndicatorSchema>;
 type KQLCustomIndicator = t.TypeOf<typeof kqlCustomIndicatorSchema>;
 type MetricCustomIndicator = t.TypeOf<typeof metricCustomIndicatorSchema>;
+type EsqlCustomIndicator = t.TypeOf<typeof esqlCustomIndicatorSchema>;
 type Indicator = t.TypeOf<typeof indicatorSchema>;
 type IndicatorTypes = t.TypeOf<typeof indicatorTypesSchema>;
+
+const ESQL_INDICATOR_TYPE = 'sli.esql.custom' as const;
+
+const isEsqlIndicatorType = (indicatorType: string): boolean =>
+  indicatorType === ESQL_INDICATOR_TYPE;
+
+export { ESQL_INDICATOR_TYPE, isEsqlIndicatorType };
 
 export type {
   Indicator,
@@ -29,4 +38,5 @@ export type {
   APMTransactionDurationIndicator,
   KQLCustomIndicator,
   MetricCustomIndicator,
+  EsqlCustomIndicator,
 };

--- a/x-pack/solutions/observability/plugins/slo/server/domain/services/compute_health.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/domain/services/compute_health.ts
@@ -16,6 +16,7 @@ import {
   getWildcardTransformId,
 } from '../../../common/constants';
 import type { TransformHealth } from '../models/health';
+import { isEsqlIndicatorType } from '../models/indicators';
 
 interface Item {
   id: string;
@@ -101,14 +102,14 @@ function computeItemHealth(
 ): { rollup: TransformHealth; summary: TransformHealth; isProblematic: boolean } {
   // ESQL SLOs do not have a rollup transform — they use Kibana Workflows.
   // For ESQL SLOs, skip the rollup transform health check and report it as healthy.
-  const isEsql = item.indicatorType === 'sli.esql.custom';
+  const isEsql = isEsqlIndicatorType(item.indicatorType ?? '');
 
   const rollup: TransformHealth = isEsql
     ? {
         isProblematic: false,
         missing: false,
         status: 'healthy',
-        state: 'started',
+        state: item.enabled ? 'started' : 'stopped',
         stateMatches: true,
       }
     : getTransformHealth(item, transformStatsById[getSLOTransformId(item.id, item.revision)]);

--- a/x-pack/solutions/observability/plugins/slo/server/domain/services/compute_health.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/domain/services/compute_health.ts
@@ -23,6 +23,7 @@ interface Item {
   revision: number;
   name: string;
   enabled: boolean;
+  indicatorType?: string;
 }
 
 interface Dependencies {
@@ -98,10 +99,20 @@ function computeItemHealth(
   transformStatsById: Dictionary<TransformGetTransformStatsTransformStats>,
   item: Item
 ): { rollup: TransformHealth; summary: TransformHealth; isProblematic: boolean } {
-  const rollup = getTransformHealth(
-    item,
-    transformStatsById[getSLOTransformId(item.id, item.revision)]
-  );
+  // ESQL SLOs do not have a rollup transform — they use Kibana Workflows.
+  // For ESQL SLOs, skip the rollup transform health check and report it as healthy.
+  const isEsql = item.indicatorType === 'sli.esql.custom';
+
+  const rollup: TransformHealth = isEsql
+    ? {
+        isProblematic: false,
+        missing: false,
+        status: 'healthy',
+        state: 'started',
+        stateMatches: true,
+      }
+    : getTransformHealth(item, transformStatsById[getSLOTransformId(item.id, item.revision)]);
+
   const summary = getTransformHealth(
     item,
     transformStatsById[getSLOSummaryTransformId(item.id, item.revision)]

--- a/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
@@ -27,11 +27,12 @@ import {
   getSLOSummaryPipelineId,
   getSLOSummaryTransformId,
   getSLOTransformId,
+  getSLOWorkflowId,
 } from '../../common/constants';
 import { getSLIPipelineTemplate } from '../assets/ingest_templates/sli_pipeline_template';
 import { getSummaryPipelineTemplate } from '../assets/ingest_templates/summary_pipeline_template';
 import type { SLODefinition, StoredSLODefinition } from '../domain/models';
-import { Duration, DurationUnit } from '../domain/models';
+import { Duration, DurationUnit, isEsqlIndicatorType } from '../domain/models';
 import { validateSLO } from '../domain/services';
 import { SLOIdConflict, SecurityException } from '../errors';
 import { SO_SLO_TYPE } from '../saved_objects';
@@ -39,6 +40,7 @@ import { retryTransientEsErrors } from '../utils/retry';
 import type { SLODefinitionRepository } from './slo_definition_repository';
 import { createTempSummaryDocument } from './summary_transform_generator/helpers/create_temp_summary';
 import type { TransformManager } from './transform_manager';
+import type { WorkflowManager } from './workflow_manager';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
 import { getTransformQueryComposite } from './utils/get_transform_compite_query';
 
@@ -52,7 +54,8 @@ export class CreateSLO {
     private logger: Logger,
     private spaceId: string,
     private basePath: IBasePath,
-    private username: string
+    private username: string,
+    private workflowManager?: WorkflowManager
   ) {}
 
   public async execute(params: CreateSLOParams): Promise<CreateSLOResponse> {
@@ -64,7 +67,85 @@ export class CreateSLO {
       assertExpectedIndicatorSourceIndexPrivileges(slo, this.scopedClusterClient.asCurrentUser),
     ]);
 
-    const rollbackOperations = [];
+    if (isEsqlIndicatorType(slo.indicator.type)) {
+      return this.executeEsql(slo);
+    }
+
+    return this.executeTransformBased(slo);
+  }
+
+  private async executeEsql(slo: SLODefinition): Promise<CreateSLOResponse> {
+    if (!this.workflowManager) {
+      throw new Error('WorkflowManager is required for ESQL SLO creation');
+    }
+
+    const rollbackOperations: Array<() => Promise<unknown>> = [];
+    const summaryTransformId = getSLOSummaryTransformId(slo.id, slo.revision);
+
+    try {
+      const createPromise = this.repository.create(slo);
+      rollbackOperations.push(() => this.repository.deleteById(slo.id, { ignoreNotFound: true }));
+
+      const sloPipelinePromise = this.createPipeline(getSLIPipelineTemplate(slo, this.spaceId));
+      rollbackOperations.push(() => this.deletePipeline(getSLOPipelineId(slo.id, slo.revision)));
+
+      // ESQL SLOs use workflows instead of rollup transforms
+      const workflowPromise = this.workflowManager.create(slo);
+      rollbackOperations.push(() =>
+        this.workflowManager!.delete(getSLOWorkflowId(slo.id, slo.revision))
+      );
+
+      const summaryPipelinePromise = this.createPipeline(
+        getSummaryPipelineTemplate(slo, this.spaceId, this.basePath)
+      );
+      rollbackOperations.push(() =>
+        this.deletePipeline(getSLOSummaryPipelineId(slo.id, slo.revision))
+      );
+
+      // Summary transform is still used for ESQL SLOs
+      const summaryTransformPromise = this.summaryTransformManager.install(slo);
+      rollbackOperations.push(() => this.summaryTransformManager.uninstall(summaryTransformId));
+
+      const tempDocPromise = this.createTempSummaryDocument(slo);
+      rollbackOperations.push(() => this.deleteTempSummaryDocument(slo));
+
+      await Promise.all([
+        createPromise,
+        sloPipelinePromise,
+        workflowPromise,
+        summaryPipelinePromise,
+        summaryTransformPromise,
+        tempDocPromise,
+      ]);
+
+      // Start only the summary transform (workflow starts on its own schedule)
+      await this.summaryTransformManager.start(summaryTransformId);
+    } catch (err) {
+      this.logger.debug(
+        `Cannot create the ESQL SLO [id: ${slo.id}, revision: ${slo.revision}]. Rolling back. ${err}`
+      );
+
+      await asyncForEach(rollbackOperations.reverse(), async (operation) => {
+        try {
+          await operation();
+        } catch (rollbackErr) {
+          this.logger.debug(`Rollback operation failed. ${rollbackErr}`);
+        }
+      });
+
+      if (err.meta?.body?.error?.type === 'security_exception') {
+        throw new SecurityException(err.meta.body.error.reason);
+      }
+
+      throw err;
+    }
+
+    return this.toResponse(slo);
+  }
+
+  private async executeTransformBased(slo: SLODefinition): Promise<CreateSLOResponse> {
+    const rollbackOperations: Array<() => Promise<unknown>> = [];
+
     const createPromise = this.repository.create(slo);
     rollbackOperations.push(() => this.repository.deleteById(slo.id, { ignoreNotFound: true }));
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
@@ -74,6 +74,9 @@ export class DeleteSLO {
       // Delete the workflow instead of rollup transform for ESQL SLOs
       deleteOps.push(this.workflowManager.delete(getSLOWorkflowId(slo.id, slo.revision)));
     } else {
+      // For non-ESQL SLOs or when workflowManager is unavailable (e.g., during migration),
+      // attempt to delete rollup transform. For ESQL SLOs without a transform, this is a safe
+      // no-op because TransformManager.uninstall ignores 404.
       const rollupTransformId = getSLOTransformId(slo.id, slo.revision);
       deleteOps.push(this.transformManager.uninstall(rollupTransformId));
     }

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
@@ -12,12 +12,15 @@ import {
   SUMMARY_DESTINATION_INDEX_PATTERN,
   getSLOSummaryTransformId,
   getSLOTransformId,
+  getSLOWorkflowId,
   getCustomSLOWildcardPipelineId,
   getWildcardPipelineId,
 } from '../../common/constants';
+import { isEsqlIndicatorType } from '../domain/models';
 import { retryTransientEsErrors } from '../utils/retry';
 import type { SLODefinitionRepository } from './slo_definition_repository';
 import type { TransformManager } from './transform_manager';
+import type { WorkflowManager } from './workflow_manager';
 
 interface Options {
   skipDataDeletion: boolean;
@@ -31,7 +34,8 @@ export class DeleteSLO {
     private summaryTransformManager: TransformManager,
     private scopedClusterClient: IScopedClusterClient,
     private rulesClient: RulesClientApi,
-    private abortController: AbortController = new AbortController()
+    private abortController: AbortController = new AbortController(),
+    private workflowManager?: WorkflowManager
   ) {}
 
   public async execute(
@@ -44,13 +48,12 @@ export class DeleteSLO {
     const slo = await this.repository.findById(sloId);
 
     // First delete the linked resources before deleting the data
-    const rollupTransformId = getSLOTransformId(slo.id, slo.revision);
+    const isEsql = isEsqlIndicatorType(slo.indicator.type);
     const summaryTransformId = getSLOSummaryTransformId(slo.id, slo.revision);
     const wildcardPipelineId = getWildcardPipelineId(slo.id, slo.revision);
     const customWildcardPipelineId = getCustomSLOWildcardPipelineId(slo.id);
 
-    await Promise.all([
-      this.transformManager.uninstall(rollupTransformId),
+    const deleteOps: Array<Promise<unknown>> = [
       this.summaryTransformManager.uninstall(summaryTransformId),
       retryTransientEsErrors(() =>
         this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
@@ -65,7 +68,17 @@ export class DeleteSLO {
         )
       ),
       this.repository.deleteById(slo.id, { ignoreNotFound: true }),
-    ]);
+    ];
+
+    if (isEsql && this.workflowManager) {
+      // Delete the workflow instead of rollup transform for ESQL SLOs
+      deleteOps.push(this.workflowManager.delete(getSLOWorkflowId(slo.id, slo.revision)));
+    } else {
+      const rollupTransformId = getSLOTransformId(slo.id, slo.revision);
+      deleteOps.push(this.transformManager.uninstall(rollupTransformId));
+    }
+
+    await Promise.all(deleteOps);
 
     await Promise.all([
       this.deleteRollupData(slo.id, options.skipDataDeletion),

--- a/x-pack/solutions/observability/plugins/slo/server/services/esql_dry_run_validation.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/esql_dry_run_validation.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock, type MockedLogger } from '@kbn/logging-mocks';
+import { EsqlDryRunValidation } from './esql_dry_run_validation';
+
+const createMockScopedClusterClient = (esqlResponse?: unknown, error?: Error) => {
+  const mock = {
+    asCurrentUser: {
+      esql: {
+        query: jest.fn(),
+      },
+    },
+    asSecondaryAuthUser: {},
+  };
+
+  if (error) {
+    mock.asCurrentUser.esql.query.mockRejectedValue(error);
+  } else {
+    mock.asCurrentUser.esql.query.mockResolvedValue(esqlResponse);
+  }
+
+  return mock as any;
+};
+
+describe('EsqlDryRunValidation', () => {
+  let logger: MockedLogger;
+
+  beforeEach(() => {
+    logger = loggerMock.create();
+  });
+
+  it('validates a valid ungrouped query', async () => {
+    const client = createMockScopedClusterClient({
+      columns: [
+        { name: '@timestamp', type: 'date' },
+        { name: 'numerator', type: 'long' },
+        { name: 'denominator', type: 'long' },
+      ],
+      values: [],
+    });
+
+    const validator = new EsqlDryRunValidation(client, logger);
+    const result = await validator.execute({
+      esqlQuery:
+        'FROM logs-* | STATS numerator = COUNT(*) WHERE status = 200, denominator = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1m)',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.columns).toEqual([
+      { name: '@timestamp', type: 'date' },
+      { name: 'numerator', type: 'long' },
+      { name: 'denominator', type: 'long' },
+    ]);
+  });
+
+  it('validates a valid grouped query', async () => {
+    const client = createMockScopedClusterClient({
+      columns: [
+        { name: '@timestamp', type: 'date' },
+        { name: 'numerator', type: 'long' },
+        { name: 'denominator', type: 'long' },
+        { name: 'host.name', type: 'keyword' },
+      ],
+      values: [],
+    });
+
+    const validator = new EsqlDryRunValidation(client, logger);
+    const result = await validator.execute({
+      esqlQuery: 'FROM logs-* | STATS ... BY @timestamp = BUCKET(@timestamp, 1m), host.name',
+      groupBy: ['host.name'],
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns errors for missing required columns', async () => {
+    const client = createMockScopedClusterClient({
+      columns: [
+        { name: '@timestamp', type: 'date' },
+        { name: 'count', type: 'long' },
+      ],
+      values: [],
+    });
+
+    const validator = new EsqlDryRunValidation(client, logger);
+    const result = await validator.execute({
+      esqlQuery: 'FROM logs-* | STATS count = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1m)',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0].code).toBe('MISSING_COLUMN');
+    expect(result.errors[0].message).toContain('numerator');
+    expect(result.errors[1].code).toBe('MISSING_COLUMN');
+    expect(result.errors[1].message).toContain('denominator');
+  });
+
+  it('returns errors for wrong column types', async () => {
+    const client = createMockScopedClusterClient({
+      columns: [
+        { name: '@timestamp', type: 'date' },
+        { name: 'numerator', type: 'keyword' },
+        { name: 'denominator', type: 'long' },
+      ],
+      values: [],
+    });
+
+    const validator = new EsqlDryRunValidation(client, logger);
+    const result = await validator.execute({
+      esqlQuery: 'FROM logs-* | STATS ...',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe('TYPE_MISMATCH');
+    expect(result.errors[0].message).toContain('numerator');
+    expect(result.errors[0].message).toContain('keyword');
+  });
+
+  it('returns errors for syntax errors', async () => {
+    const syntaxError = new Error('ESQL parse error');
+    (syntaxError as any).meta = {
+      body: { error: { reason: 'line 1:5: mismatched input' } },
+    };
+    const client = createMockScopedClusterClient(undefined, syntaxError);
+
+    const validator = new EsqlDryRunValidation(client, logger);
+    const result = await validator.execute({
+      esqlQuery: 'INVALID QUERY',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe('SYNTAX_ERROR');
+    expect(result.errors[0].message).toContain('mismatched input');
+  });
+
+  it('returns errors for groupBy mismatch', async () => {
+    const client = createMockScopedClusterClient({
+      columns: [
+        { name: '@timestamp', type: 'date' },
+        { name: 'numerator', type: 'long' },
+        { name: 'denominator', type: 'long' },
+        { name: 'host', type: 'keyword' },
+      ],
+      values: [],
+    });
+
+    const validator = new EsqlDryRunValidation(client, logger);
+    const result = await validator.execute({
+      esqlQuery: 'FROM logs-* | STATS ... BY @timestamp = BUCKET(@timestamp, 1m), host',
+      groupBy: ['host.name'],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe('GROUP_BY_MISMATCH');
+    expect(result.errors[0].message).toContain('host.name');
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/esql_dry_run_validation.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/esql_dry_run_validation.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient, Logger } from '@kbn/core/server';
+
+interface EsqlDryRunParams {
+  esqlQuery: string;
+  groupBy?: string[];
+}
+
+interface ValidationError {
+  code: 'SYNTAX_ERROR' | 'MISSING_COLUMN' | 'TYPE_MISMATCH' | 'GROUP_BY_MISMATCH';
+  message: string;
+}
+
+interface DryRunResult {
+  valid: boolean;
+  errors: ValidationError[];
+  columns?: Array<{ name: string; type: string }>;
+}
+
+const REQUIRED_COLUMNS = ['@timestamp', 'numerator', 'denominator'];
+const EXPECTED_TYPES: Record<string, string[]> = {
+  '@timestamp': ['date'],
+  numerator: ['long', 'integer', 'double', 'float', 'unsigned_long'],
+  denominator: ['long', 'integer', 'double', 'float', 'unsigned_long'],
+};
+
+export class EsqlDryRunValidation {
+  constructor(private scopedClusterClient: IScopedClusterClient, private logger: Logger) {}
+
+  public async execute(params: EsqlDryRunParams): Promise<DryRunResult> {
+    const errors: ValidationError[] = [];
+
+    // Execute the ESQL query against a short time range to validate syntax and column output
+    let columns: Array<{ name: string; type: string }>;
+    try {
+      const response = await this.scopedClusterClient.asCurrentUser.esql.query({
+        query: params.esqlQuery,
+        format: 'json',
+        filter: {
+          range: {
+            '@timestamp': {
+              gte: 'now-5m',
+              lt: 'now',
+            },
+          },
+        },
+      });
+
+      columns = (response.columns ?? []).map((col) => ({
+        name: String(col.name),
+        type: String(col.type),
+      }));
+    } catch (err) {
+      this.logger.debug(`ESQL dry-run query failed: ${err.message}`);
+      return {
+        valid: false,
+        errors: [
+          {
+            code: 'SYNTAX_ERROR',
+            message: err.meta?.body?.error?.reason ?? err.message,
+          },
+        ],
+      };
+    }
+
+    const columnNames = columns.map((c) => c.name);
+    const columnsByName = new Map(columns.map((c) => [c.name, c]));
+
+    // Validate required columns exist
+    for (const required of REQUIRED_COLUMNS) {
+      if (!columnNames.includes(required)) {
+        errors.push({
+          code: 'MISSING_COLUMN',
+          message: `Required column '${required}' is missing from the ESQL query results. The query must produce columns: ${REQUIRED_COLUMNS.join(
+            ', '
+          )}`,
+        });
+      }
+    }
+
+    // Validate column types for present required columns
+    for (const [colName, expectedTypes] of Object.entries(EXPECTED_TYPES)) {
+      const col = columnsByName.get(colName);
+      if (col && !expectedTypes.includes(col.type)) {
+        errors.push({
+          code: 'TYPE_MISMATCH',
+          message: `Column '${colName}' has type '${
+            col.type
+          }', expected one of: ${expectedTypes.join(', ')}`,
+        });
+      }
+    }
+
+    // Validate groupBy columns match
+    if (params.groupBy && params.groupBy.length > 0) {
+      const extraColumns = columnNames.filter((name) => !REQUIRED_COLUMNS.includes(name));
+      for (const groupByField of params.groupBy) {
+        if (!extraColumns.includes(groupByField)) {
+          errors.push({
+            code: 'GROUP_BY_MISMATCH',
+            message: `GroupBy field '${groupByField}' is not present in the ESQL query result columns. Available extra columns: ${
+              extraColumns.length > 0 ? extraColumns.join(', ') : '(none)'
+            }`,
+          });
+        }
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+      columns,
+    };
+  }
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/esql_workflow_template.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/esql_workflow_template.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Duration, DurationUnit } from '../domain/models';
+import { generateEsqlSloWorkflowYaml } from './esql_workflow_template';
+
+const createBaseSlo = (overrides = {}): any => ({
+  id: 'test-slo-123',
+  name: 'Test ESQL SLO',
+  revision: 1,
+  indicator: {
+    type: 'sli.esql.custom',
+    params: {
+      esqlQuery:
+        'FROM logs-* | STATS numerator = COUNT(*) WHERE status = 200, denominator = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1m)',
+    },
+  },
+  budgetingMethod: 'occurrences',
+  groupBy: '*',
+  objective: {
+    target: 0.99,
+  },
+  settings: {
+    frequency: new Duration(1, DurationUnit.Minute),
+    syncDelay: new Duration(1, DurationUnit.Minute),
+    preventInitialBackfill: false,
+  },
+  ...overrides,
+});
+
+describe('generateEsqlSloWorkflowYaml', () => {
+  it('generates valid workflow YAML for ungrouped SLO', () => {
+    const slo = createBaseSlo();
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    expect(yaml).toContain('name: "SLO ESQL - Test ESQL SLO"');
+    expect(yaml).toContain('type: scheduled');
+    expect(yaml).toContain('every: "1m"');
+    expect(yaml).toContain('key: "esql-sli-test-slo-123"');
+    expect(yaml).toContain('strategy: drop');
+    expect(yaml).toContain('max: 1');
+    expect(yaml).toContain('type: elasticsearch.esql.query');
+    expect(yaml).toContain('type: foreach');
+    expect(yaml).toContain('pipeline=.slo-observability.sli.pipeline-test-slo-123-1');
+  });
+
+  it('uses deterministic _id: {timestamp}-{instanceId}', () => {
+    const slo = createBaseSlo();
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    // For ungrouped, instanceId should be "*"
+    expect(yaml).toContain('{{ item.@timestamp }}-*');
+  });
+
+  it('generates correct workflow for grouped SLO', () => {
+    const slo = createBaseSlo({
+      groupBy: ['host.name', 'region'],
+      indicator: {
+        type: 'sli.esql.custom',
+        params: {
+          esqlQuery:
+            'FROM logs-* | STATS numerator = COUNT(*) WHERE status = 200, denominator = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1m), host.name, region',
+          groupBy: ['host.name', 'region'],
+        },
+      },
+    });
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    // Grouped instanceId should be concatenation of group values
+    expect(yaml).toContain('host.name');
+    expect(yaml).toContain('region');
+    expect(yaml).toContain('slo.groupings.host.name');
+    expect(yaml).toContain('slo.groupings.region');
+  });
+
+  it('includes DSL time-range filter, not embedded in ESQL', () => {
+    const slo = createBaseSlo();
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    expect(yaml).toContain('filter:');
+    expect(yaml).toContain('range:');
+    expect(yaml).toContain('"@timestamp"');
+    expect(yaml).toContain('gte: "now-6m"'); // 5 * 1m + 1m = 6m lookback
+    expect(yaml).toContain('lt: "now-1m"'); // syncDelay = 1m
+  });
+
+  it('computes lookback correctly for different frequencies', () => {
+    const slo = createBaseSlo({
+      settings: {
+        frequency: new Duration(5, DurationUnit.Minute),
+        syncDelay: new Duration(2, DurationUnit.Minute),
+        preventInitialBackfill: false,
+      },
+    });
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    // lookback = 5 * 5m + 2m = 27m
+    expect(yaml).toContain('gte: "now-27m"');
+    expect(yaml).toContain('lt: "now-2m"');
+  });
+
+  it('includes isGoodSlice computation for timeslices budgeting', () => {
+    const slo = createBaseSlo({
+      budgetingMethod: 'timeslices',
+      objective: {
+        target: 0.99,
+        timesliceTarget: 0.95,
+        timesliceWindow: new Duration(5, DurationUnit.Minute),
+      },
+    });
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    expect(yaml).toContain('slo.isGoodSlice');
+  });
+
+  it('includes early exit on empty results', () => {
+    const slo = createBaseSlo();
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    expect(yaml).toContain('check_empty_results');
+    expect(yaml).toContain('early_exit');
+    expect(yaml).toContain('size }} == 0');
+  });
+
+  it('includes error handling for ESQL query failure', () => {
+    const slo = createBaseSlo();
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    expect(yaml).toContain('on-failure:');
+    expect(yaml).toContain('esql_query_failed');
+  });
+
+  it('includes error handling for per-document indexing failure', () => {
+    const slo = createBaseSlo();
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    expect(yaml).toContain('index_doc_failed');
+  });
+
+  it('uses correct workflow ID convention', () => {
+    const slo = createBaseSlo();
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'default');
+
+    expect(yaml).toContain('slo_id: "test-slo-123"');
+    expect(yaml).toContain('slo_revision: 1');
+  });
+
+  it('handles non-default space', () => {
+    const slo = createBaseSlo();
+    const yaml = generateEsqlSloWorkflowYaml(slo, 'custom-space');
+
+    expect(yaml).toContain('space_id: "custom-space"');
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/esql_workflow_template.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/esql_workflow_template.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALL_VALUE, timeslicesBudgetingMethodSchema } from '@kbn/slo-schema';
+import { getSLOPipelineId } from '../../common/constants';
+import type { EsqlCustomIndicator, SLODefinition } from '../domain/models';
+
+/**
+ * Generates the Kibana Workflow YAML for an ESQL SLO.
+ *
+ * The workflow:
+ * 1. Runs the user's ESQL query with a DSL time-range filter (not embedded in the ESQL string)
+ * 2. Checks for empty results (early exit)
+ * 3. Iterates over result rows, constructing SLI documents
+ * 4. Indexes each document via PUT /_doc/{id}?pipeline={pipeline}
+ *
+ * Design decisions (from design.md):
+ * - D3: DSL filter injection for time range
+ * - D2: Deterministic _id via string concatenation: {timestamp}-{instanceId}
+ * - D4: Column-name contract for result mapping
+ * - D6: Per-document indexing via elasticsearch.request
+ */
+export const generateEsqlSloWorkflowYaml = (slo: SLODefinition, spaceId: string): string => {
+  const indicator = slo.indicator as EsqlCustomIndicator;
+  const frequencyMinutes = getFrequencyMinutes(slo);
+  const syncDelayMinutes = getSyncDelayMinutes(slo);
+  const lookbackMinutes = computeLookbackMinutes(slo);
+  const pipelineId = getSLOPipelineId(slo.id, slo.revision);
+  const sliIndex = '.slo-observability.sli-v3.6';
+  const isTimeslices = timeslicesBudgetingMethodSchema.is(slo.budgetingMethod);
+  const timesliceTarget = slo.objective.timesliceTarget ?? 0.95;
+
+  const groups = [slo.groupBy].flat().filter((g) => !!g && g !== ALL_VALUE);
+  const hasGroupBy = groups.length > 0;
+
+  // Build the instanceId Liquid expression
+  // For ungrouped: instanceId = "*"
+  // For grouped: instanceId = concatenation of grouping values separated by ","
+  const instanceIdExpr = hasGroupBy
+    ? groups.map((g) => `{{ item.${escapeField(g)} }}`).join(',')
+    : '*';
+
+  // Build groupings mapping for the SLI document
+  const groupingsBlock = hasGroupBy
+    ? groups
+        .map((g) => `            "slo.groupings.${g}": "{{ item.${escapeField(g)} }}"`)
+        .join(',\n')
+    : '';
+
+  // Build isGoodSlice computation
+  const isGoodSliceBlock = isTimeslices
+    ? `
+        - name: compute_is_good_slice
+          type: transform
+          with:
+            operations:
+              - operation: set
+                field: isGoodSlice
+                value: "{% if item.numerator != null and item.denominator != null and item.denominator > 0 %}{% assign ratio = item.numerator | divided_by: item.denominator %}{% if ratio >= ${timesliceTarget} %}1{% else %}0{% endif %}{% else %}0{% endif %}"`
+    : '';
+
+  // Build the isGoodSlice field in the document body
+  const isGoodSliceField = isTimeslices
+    ? `,
+            "slo.isGoodSlice": "{% if item.isGoodSlice != null %}{{ item.isGoodSlice }}{% else %}{{ steps.compute_is_good_slice.isGoodSlice }}{% endif %}"`
+    : '';
+
+  const timeoutSeconds = Math.max(frequencyMinutes * 60 - 5, 30);
+
+  return `name: "SLO ESQL - ${slo.name}"
+description: "Evaluates ESQL SLI for SLO: ${slo.name} [id: ${slo.id}, rev: ${slo.revision}]"
+
+triggers:
+  - type: scheduled
+    with:
+      every: "${frequencyMinutes}m"
+
+settings:
+  concurrency:
+    key: "esql-sli-${slo.id}"
+    strategy: drop
+    max: 1
+  timeout: "${timeoutSeconds}s"
+
+consts:
+  slo_id: "${slo.id}"
+  slo_revision: ${slo.revision}
+  space_id: "${spaceId}"
+  pipeline_id: "${pipelineId}"
+  sli_index: "${sliIndex}"
+  lookback_minutes: ${lookbackMinutes}
+  sync_delay_minutes: ${syncDelayMinutes}
+
+steps:
+  - name: execute_esql_query
+    type: elasticsearch.esql.query
+    with:
+      query: |
+        ${indent(indicator.params.esqlQuery, 8)}
+      filter:
+        range:
+          "@timestamp":
+            gte: "now-${lookbackMinutes}m"
+            lt: "now-${syncDelayMinutes}m"
+    on-failure:
+      - type: noop
+        name: esql_query_failed
+
+  - name: check_empty_results
+    type: condition
+    if: "{{ steps.execute_esql_query.records | size }} == 0"
+    then:
+      - name: early_exit
+        type: noop
+
+  - name: index_sli_documents
+    type: foreach
+    foreach: "{{ steps.execute_esql_query.records }}"
+    if: "{{ steps.execute_esql_query.records | size }} > 0"
+    do:${isGoodSliceBlock}
+      - name: index_sli_doc
+        type: elasticsearch.request
+        with:
+          method: PUT
+          path: "/${sliIndex}/_doc/{{ item.@timestamp }}-${instanceIdExpr}?pipeline=${pipelineId}"
+          body: |
+            {
+              "@timestamp": "{{ item.@timestamp }}",
+              "slo.numerator": {{ item.numerator }},
+              "slo.denominator": {{ item.denominator }}${isGoodSliceField}${
+    hasGroupBy ? `,\n${groupingsBlock}` : ''
+  }
+            }
+        on-failure:
+          - type: noop
+            name: index_doc_failed
+`;
+};
+
+/**
+ * Compute lookback window in minutes.
+ * lookback = bucketCount × bucketInterval + syncDelay
+ * For ESQL SLOs, we use 5 × frequency + syncDelay to cover missed evaluations.
+ */
+const computeLookbackMinutes = (slo: SLODefinition): number => {
+  const frequencyMin = getFrequencyMinutes(slo);
+  const syncDelayMin = getSyncDelayMinutes(slo);
+  // 5 evaluation cycles + sync delay provides recovery for missed evaluations
+  return 5 * frequencyMin + syncDelayMin;
+};
+
+const getFrequencyMinutes = (slo: SLODefinition): number => {
+  const freq = slo.settings.frequency;
+  return durationToMinutes(freq);
+};
+
+const getSyncDelayMinutes = (slo: SLODefinition): number => {
+  const sync = slo.settings.syncDelay;
+  return durationToMinutes(sync);
+};
+
+const durationToMinutes = (duration: { value: number; unit: string }): number => {
+  switch (duration.unit) {
+    case 's':
+      return Math.max(1, Math.ceil(duration.value / 60));
+    case 'm':
+      return duration.value;
+    case 'h':
+      return duration.value * 60;
+    case 'd':
+      return duration.value * 1440;
+    default:
+      return duration.value;
+  }
+};
+
+const escapeField = (field: string): string => {
+  // Liquid template field access — dots are handled via bracket notation
+  if (field.includes('.')) {
+    return `["${field}"]`;
+  }
+  return field;
+};
+
+const indent = (text: string, spaces: number): string => {
+  const pad = ' '.repeat(spaces);
+  return text
+    .split('\n')
+    .map((line, i) => (i === 0 ? line : `${pad}${line}`))
+    .join('\n');
+};

--- a/x-pack/solutions/observability/plugins/slo/server/services/esql_workflow_template.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/esql_workflow_template.ts
@@ -6,7 +6,7 @@
  */
 
 import { ALL_VALUE, timeslicesBudgetingMethodSchema } from '@kbn/slo-schema';
-import { getSLOPipelineId } from '../../common/constants';
+import { getSLOPipelineId, SLI_DESTINATION_INDEX_NAME } from '../../common/constants';
 import type { EsqlCustomIndicator, SLODefinition } from '../domain/models';
 
 /**
@@ -30,7 +30,7 @@ export const generateEsqlSloWorkflowYaml = (slo: SLODefinition, spaceId: string)
   const syncDelayMinutes = getSyncDelayMinutes(slo);
   const lookbackMinutes = computeLookbackMinutes(slo);
   const pipelineId = getSLOPipelineId(slo.id, slo.revision);
-  const sliIndex = '.slo-observability.sli-v3.6';
+  const sliIndex = SLI_DESTINATION_INDEX_NAME;
   const isTimeslices = timeslicesBudgetingMethodSchema.is(slo.budgetingMethod);
   const timesliceTarget = slo.objective.timesliceTarget ?? 0.95;
 
@@ -52,6 +52,7 @@ export const generateEsqlSloWorkflowYaml = (slo: SLODefinition, spaceId: string)
     : '';
 
   // Build isGoodSlice computation
+  // Use numerator >= denominator * target to avoid Liquid's integer division issue
   const isGoodSliceBlock = isTimeslices
     ? `
         - name: compute_is_good_slice
@@ -60,7 +61,7 @@ export const generateEsqlSloWorkflowYaml = (slo: SLODefinition, spaceId: string)
             operations:
               - operation: set
                 field: isGoodSlice
-                value: "{% if item.numerator != null and item.denominator != null and item.denominator > 0 %}{% assign ratio = item.numerator | divided_by: item.denominator %}{% if ratio >= ${timesliceTarget} %}1{% else %}0{% endif %}{% else %}0{% endif %}"`
+                value: "{% if item.numerator != null and item.denominator != null and item.denominator > 0 %}{% assign threshold = item.denominator | times: ${timesliceTarget} %}{% if item.numerator >= threshold %}1{% else %}0{% endif %}{% else %}0{% endif %}"`
     : '';
 
   // Build the isGoodSlice field in the document body

--- a/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
@@ -175,8 +175,8 @@ export class ResetSLO {
         tempDocPromise,
       ]);
 
-      // Start summary transform; for non-ESQL also start rollup transform
-      if (isEsql) {
+      // Start summary transform; for non-ESQL (or ESQL without workflowManager) also start rollup transform
+      if (isEsql && this.workflowManager) {
         await this.summaryTransformManager.start(summaryTransformId);
       } else {
         const rollupTransformId = getSLOTransformId(id, revision);

--- a/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
@@ -19,16 +19,19 @@ import {
   getSLOSummaryPipelineId,
   getSLOSummaryTransformId,
   getSLOTransformId,
+  getSLOWorkflowId,
   getWildcardPipelineId,
 } from '../../common/constants';
 import { getSLIPipelineTemplate } from '../assets/ingest_templates/sli_pipeline_template';
 import { getSummaryPipelineTemplate } from '../assets/ingest_templates/summary_pipeline_template';
 import type { SLODefinition } from '../domain/models';
+import { isEsqlIndicatorType } from '../domain/models';
 import { SecurityException } from '../errors';
 import { retryTransientEsErrors } from '../utils/retry';
 import type { SLODefinitionRepository } from './slo_definition_repository';
 import { createTempSummaryDocument } from './summary_transform_generator/helpers/create_temp_summary';
 import type { TransformManager } from './transform_manager';
+import type { WorkflowManager } from './workflow_manager';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
 
 export class ResetSLO {
@@ -39,7 +42,8 @@ export class ResetSLO {
     private summaryTransformManager: TransformManager,
     private logger: Logger,
     private spaceId: string,
-    private basePath: IBasePath
+    private basePath: IBasePath,
+    private workflowManager?: WorkflowManager
   ) {}
 
   public async execute(sloId: string): Promise<ResetSLOResponse> {
@@ -66,14 +70,22 @@ export class ResetSLO {
   }
 
   private async deleteOriginalSLO(slo: SLODefinition) {
+    const isEsql = isEsqlIndicatorType(slo.indicator.type);
     try {
-      await Promise.all([
-        this.transformManager.uninstall(getSLOTransformId(slo.id, slo.revision)),
+      const deleteOps: Array<Promise<unknown>> = [
         this.summaryTransformManager.uninstall(getSLOSummaryTransformId(slo.id, slo.revision)),
         this.deletePipeline(getWildcardPipelineId(slo.id, slo.revision)),
-      ]);
+      ];
 
-      // Delete after we uninstalled the transforms
+      if (isEsql && this.workflowManager) {
+        deleteOps.push(this.workflowManager.delete(getSLOWorkflowId(slo.id, slo.revision)));
+      } else {
+        deleteOps.push(this.transformManager.uninstall(getSLOTransformId(slo.id, slo.revision)));
+      }
+
+      await Promise.all(deleteOps);
+
+      // Delete after we uninstalled the transforms/workflows
       await Promise.all([this.deleteRollupData(slo), this.deleteSummaryData(slo)]);
     } catch (err) {
       // Any errors here should not prevent moving forward.
@@ -125,17 +137,24 @@ export class ResetSLO {
   }
 
   private async installResetedSLO(slo: SLODefinition) {
-    const rollbackOperations = [];
+    const rollbackOperations: Array<() => Promise<unknown>> = [];
+    const isEsql = isEsqlIndicatorType(slo.indicator.type);
 
     const { id, revision } = slo;
-    const rollupTransformId = getSLOTransformId(id, revision);
     const summaryTransformId = getSLOSummaryTransformId(id, revision);
     try {
       const sloPipelinePromise = this.createPipeline(getSLIPipelineTemplate(slo, this.spaceId));
       rollbackOperations.push(() => this.deletePipeline(getSLOPipelineId(id, revision)));
 
-      const rollupTransformPromise = this.transformManager.install(slo);
-      rollbackOperations.push(() => this.transformManager.uninstall(rollupTransformId));
+      let rollupPromise: Promise<unknown>;
+      if (isEsql && this.workflowManager) {
+        rollupPromise = this.workflowManager.create(slo);
+        rollbackOperations.push(() => this.workflowManager!.delete(getSLOWorkflowId(id, revision)));
+      } else {
+        const rollupTransformId = getSLOTransformId(id, revision);
+        rollupPromise = this.transformManager.install(slo);
+        rollbackOperations.push(() => this.transformManager.uninstall(rollupTransformId));
+      }
 
       const summaryPipelinePromise = this.createPipeline(
         getSummaryPipelineTemplate(slo, this.spaceId, this.basePath)
@@ -150,17 +169,22 @@ export class ResetSLO {
 
       await Promise.all([
         sloPipelinePromise,
-        rollupTransformPromise,
+        rollupPromise,
         summaryPipelinePromise,
         summaryTransformPromise,
         tempDocPromise,
       ]);
 
-      // transforms can only be started after the pipelines are created
-      await Promise.all([
-        this.transformManager.start(rollupTransformId),
-        this.summaryTransformManager.start(summaryTransformId),
-      ]);
+      // Start summary transform; for non-ESQL also start rollup transform
+      if (isEsql) {
+        await this.summaryTransformManager.start(summaryTransformId);
+      } else {
+        const rollupTransformId = getSLOTransformId(id, revision);
+        await Promise.all([
+          this.transformManager.start(rollupTransformId),
+          this.summaryTransformManager.start(summaryTransformId),
+        ]);
+      }
     } catch (err) {
       this.logger.debug(
         `Cannot reset the SLO [id: ${slo.id}, revision: ${slo.revision}]. Rolling back. ${err}`

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/health_scan_task/run_health_scan.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/health_scan_task/run_health_scan.ts
@@ -42,7 +42,7 @@ export async function runHealthScan(
     type: SO_SLO_TYPE,
     perPage: PER_PAGE,
     namespaces: ['*'],
-    fields: ['id', 'revision', 'name', 'enabled'],
+    fields: ['id', 'revision', 'name', 'enabled', 'indicator'],
   });
 
   try {
@@ -57,6 +57,7 @@ export async function runHealthScan(
         revision: so.attributes.revision,
         name: so.attributes.name,
         enabled: so.attributes.enabled,
+        indicatorType: so.attributes.indicator?.type,
         spaceId: so.namespaces?.[0] ?? 'default',
       }));
       const sloById = new Map(sloList.map((slo) => [slo.id, slo]));

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/esql_custom.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/esql_custom.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
+import { TransformGenerator } from '.';
+import type { SLODefinition } from '../../domain/models';
+
+/**
+ * ESQL custom SLOs do not use transforms for SLI rollup — they use Kibana Workflows instead.
+ * This stub satisfies the TransformGenerator interface so the type registry is complete,
+ * but getTransformParams always throws to prevent accidental transform creation.
+ */
+export class EsqlCustomTransformGenerator extends TransformGenerator {
+  public async getTransformParams(_slo: SLODefinition): Promise<TransformPutTransformRequest> {
+    throw new Error(
+      'ESQL custom SLOs use Kibana Workflows for SLI evaluation, not transforms. ' +
+        'Use WorkflowManager instead of TransformManager for this indicator type.'
+    );
+  }
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/index.ts
@@ -13,5 +13,6 @@ export * from './kql_custom';
 export * from './metric_custom';
 export * from './histogram';
 export * from './timeslice_metric';
+export * from './esql_custom';
 export * from './common';
 export * from './transform_generators_factory';

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/transform_generators_factory.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/transform_generators_factory.ts
@@ -10,6 +10,7 @@ import type { TransformGenerator } from '.';
 import {
   ApmTransactionDurationTransformGenerator,
   ApmTransactionErrorRateTransformGenerator,
+  EsqlCustomTransformGenerator,
   HistogramTransformGenerator,
   KQLCustomTransformGenerator,
   MetricCustomTransformGenerator,
@@ -55,5 +56,6 @@ export function createTransformGenerators(
       dataViewsService,
       isServerless
     ),
+    'sli.esql.custom': new EsqlCustomTransformGenerator(spaceId, dataViewsService, isServerless),
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -20,17 +20,20 @@ import {
   getSLOSummaryPipelineId,
   getSLOSummaryTransformId,
   getSLOTransformId,
+  getSLOWorkflowId,
   getWildcardPipelineId,
 } from '../../common/constants';
 import { getSLIPipelineTemplate } from '../assets/ingest_templates/sli_pipeline_template';
 import { getSummaryPipelineTemplate } from '../assets/ingest_templates/summary_pipeline_template';
 import type { SLODefinition } from '../domain/models';
+import { isEsqlIndicatorType } from '../domain/models';
 import { validateSLO } from '../domain/services';
 import { SecurityException } from '../errors';
 import { retryTransientEsErrors } from '../utils/retry';
 import type { SLODefinitionRepository } from './slo_definition_repository';
 import { createTempSummaryDocument } from './summary_transform_generator/helpers/create_temp_summary';
 import type { TransformManager } from './transform_manager';
+import type { WorkflowManager } from './workflow_manager';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
 
 export class UpdateSLO {
@@ -42,7 +45,8 @@ export class UpdateSLO {
     private logger: Logger,
     private spaceId: string,
     private basePath: IBasePath,
-    private userId: string
+    private userId: string,
+    private workflowManager?: WorkflowManager
   ) {}
 
   public async execute(sloId: string, params: UpdateSLOParams): Promise<UpdateSLOResponse> {
@@ -111,7 +115,7 @@ export class UpdateSLO {
       return this.toResponse(updatedSlo);
     }
 
-    const updatedRollupTransformId = getSLOTransformId(updatedSlo.id, updatedSlo.revision);
+    const isEsql = isEsqlIndicatorType(updatedSlo.indicator.type);
     const updatedSummaryTransformId = getSLOSummaryTransformId(updatedSlo.id, updatedSlo.revision);
 
     try {
@@ -122,8 +126,18 @@ export class UpdateSLO {
         this.deletePipeline(getSLOPipelineId(updatedSlo.id, updatedSlo.revision))
       );
 
-      const rollupTransformPromise = this.transformManager.install(updatedSlo);
-      rollbackOperations.push(() => this.transformManager.uninstall(updatedRollupTransformId));
+      // ESQL SLOs use workflows; transform-based SLOs use rollup transforms
+      let rollupPromise: Promise<unknown>;
+      if (isEsql && this.workflowManager) {
+        rollupPromise = this.workflowManager.create(updatedSlo);
+        rollbackOperations.push(() =>
+          this.workflowManager!.delete(getSLOWorkflowId(updatedSlo.id, updatedSlo.revision))
+        );
+      } else {
+        const updatedRollupTransformId = getSLOTransformId(updatedSlo.id, updatedSlo.revision);
+        rollupPromise = this.transformManager.install(updatedSlo);
+        rollbackOperations.push(() => this.transformManager.uninstall(updatedRollupTransformId));
+      }
 
       const summaryPipelinePromise = this.createPipeline(
         getSummaryPipelineTemplate(updatedSlo, this.spaceId, this.basePath)
@@ -142,17 +156,22 @@ export class UpdateSLO {
 
       await Promise.all([
         sloPipelinePromise,
-        rollupTransformPromise,
+        rollupPromise,
         summaryPipelinePromise,
         summaryTransformPromise,
         tempDocPromise,
       ]);
 
-      // transforms can only be started after the pipelines are created
-      await Promise.all([
-        this.transformManager.start(updatedRollupTransformId),
-        this.summaryTransformManager.start(updatedSummaryTransformId),
-      ]);
+      // Start summary transform (and rollup transform only for non-ESQL)
+      if (isEsql) {
+        await this.summaryTransformManager.start(updatedSummaryTransformId);
+      } else {
+        const updatedRollupTransformId = getSLOTransformId(updatedSlo.id, updatedSlo.revision);
+        await Promise.all([
+          this.transformManager.start(updatedRollupTransformId),
+          this.summaryTransformManager.start(updatedSummaryTransformId),
+        ]);
+      }
     } catch (err) {
       this.logger.debug(
         `Cannot update the SLO [id: ${updatedSlo.id}, revision: ${updatedSlo.revision}]. Rolling back. ${err}`
@@ -199,12 +218,20 @@ export class UpdateSLO {
   }
 
   private async deleteOriginalSLO(slo: SLODefinition) {
+    const isEsql = isEsqlIndicatorType(slo.indicator.type);
     try {
-      await Promise.all([
-        this.transformManager.uninstall(getSLOTransformId(slo.id, slo.revision)),
+      const deleteOps: Array<Promise<unknown>> = [
         this.summaryTransformManager.uninstall(getSLOSummaryTransformId(slo.id, slo.revision)),
         this.deletePipeline(getWildcardPipelineId(slo.id, slo.revision)),
-      ]);
+      ];
+
+      if (isEsql && this.workflowManager) {
+        deleteOps.push(this.workflowManager.delete(getSLOWorkflowId(slo.id, slo.revision)));
+      } else {
+        deleteOps.push(this.transformManager.uninstall(getSLOTransformId(slo.id, slo.revision)));
+      }
+
+      await Promise.all(deleteOps);
 
       await Promise.all([this.deleteRollupData(slo), this.deleteSummaryData(slo)]);
     } catch (err) {

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -162,8 +162,8 @@ export class UpdateSLO {
         tempDocPromise,
       ]);
 
-      // Start summary transform (and rollup transform only for non-ESQL)
-      if (isEsql) {
+      // Start summary transform (and rollup transform only for non-ESQL or when workflowManager unavailable)
+      if (isEsql && this.workflowManager) {
         await this.summaryTransformManager.start(updatedSummaryTransformId);
       } else {
         const updatedRollupTransformId = getSLOTransformId(updatedSlo.id, updatedSlo.revision);

--- a/x-pack/solutions/observability/plugins/slo/server/services/workflow_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/workflow_manager.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
+import { setTimeout } from 'timers/promises';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { Logger } from '@kbn/core/server';
 import { getSLOWorkflowId } from '../../common/constants';
 import type { SLODefinition } from '../domain/models';
-import { retryTransientEsErrors } from '../utils/retry';
 import { generateEsqlSloWorkflowYaml } from './esql_workflow_template';
 
 type WorkflowId = string;
@@ -28,6 +28,40 @@ interface WorkflowManagerDeps {
   logger: Logger;
   spaceId: string;
 }
+
+const RETRYABLE_STATUS_CODES = [408, 429, 502, 503, 504];
+const MAX_RETRY_ATTEMPTS = 5;
+
+/**
+ * Retry wrapper for HTTP calls to the Workflow API.
+ * Unlike retryTransientEsErrors which checks for ES client error types,
+ * this checks the statusCode property on plain Error objects thrown by callWorkflowApi.
+ */
+const retryTransientHttpErrors = async <T>(
+  httpCall: () => Promise<T>,
+  { logger, attempt = 0 }: { logger?: Logger; attempt?: number } = {}
+): Promise<T> => {
+  try {
+    return await httpCall();
+  } catch (e) {
+    const statusCode = (e as { statusCode?: number }).statusCode;
+    const isRetryable = statusCode !== undefined && RETRYABLE_STATUS_CODES.includes(statusCode);
+
+    if (attempt < MAX_RETRY_ATTEMPTS && isRetryable) {
+      const retryCount = attempt + 1;
+      const retryDelaySec = Math.min(Math.pow(2, retryCount), 64);
+
+      logger?.warn(
+        `Retrying Workflow API call after [${retryDelaySec}s] due to error: ${e.toString()}`
+      );
+
+      await setTimeout(retryDelaySec * 1000);
+      return retryTransientHttpErrors(httpCall, { logger, attempt: retryCount });
+    }
+
+    throw e;
+  }
+};
 
 export class DefaultWorkflowManager implements WorkflowManager {
   private readonly baseUrl: string;
@@ -48,7 +82,7 @@ export class DefaultWorkflowManager implements WorkflowManager {
 
     this.logger.debug(`Creating workflow [${workflowId}] for ESQL SLO [${slo.id}]`);
 
-    await retryTransientEsErrors(
+    await retryTransientHttpErrors(
       () =>
         this.callWorkflowApi('POST', '/api/workflows/workflow', {
           id: workflowId,
@@ -67,7 +101,7 @@ export class DefaultWorkflowManager implements WorkflowManager {
 
     this.logger.debug(`Updating workflow [${workflowId}] for ESQL SLO [${slo.id}]`);
 
-    await retryTransientEsErrors(
+    await retryTransientHttpErrors(
       () =>
         this.callWorkflowApi('PUT', `/api/workflows/workflow/${encodeURIComponent(workflowId)}`, {
           yaml,
@@ -98,7 +132,7 @@ export class DefaultWorkflowManager implements WorkflowManager {
   async enable(workflowId: WorkflowId): Promise<void> {
     this.logger.debug(`Enabling workflow [${workflowId}]`);
 
-    await retryTransientEsErrors(
+    await retryTransientHttpErrors(
       () =>
         this.callWorkflowApi(
           'POST',
@@ -111,7 +145,7 @@ export class DefaultWorkflowManager implements WorkflowManager {
   async disable(workflowId: WorkflowId): Promise<void> {
     this.logger.debug(`Disabling workflow [${workflowId}]`);
 
-    await retryTransientEsErrors(
+    await retryTransientHttpErrors(
       () =>
         this.callWorkflowApi(
           'POST',

--- a/x-pack/solutions/observability/plugins/slo/server/services/workflow_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/workflow_manager.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { HttpServiceSetup, Logger } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
 import { getSLOWorkflowId } from '../../common/constants';
 import type { SLODefinition } from '../domain/models';
 import { retryTransientEsErrors } from '../utils/retry';
@@ -25,7 +25,6 @@ export interface WorkflowManager {
 interface WorkflowManagerDeps {
   kibanaUrl: string;
   request: KibanaRequest;
-  httpSetup: HttpServiceSetup;
   logger: Logger;
   spaceId: string;
 }
@@ -35,14 +34,12 @@ export class DefaultWorkflowManager implements WorkflowManager {
   private readonly logger: Logger;
   private readonly spaceId: string;
   private readonly request: KibanaRequest;
-  private readonly httpSetup: HttpServiceSetup;
 
   constructor(deps: WorkflowManagerDeps) {
     this.baseUrl = deps.kibanaUrl;
     this.logger = deps.logger;
     this.spaceId = deps.spaceId;
     this.request = deps.request;
-    this.httpSetup = deps.httpSetup;
   }
 
   async create(slo: SLODefinition): Promise<WorkflowId> {

--- a/x-pack/solutions/observability/plugins/slo/server/services/workflow_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/workflow_manager.ts
@@ -98,18 +98,26 @@ export class DefaultWorkflowManager implements WorkflowManager {
   async enable(workflowId: WorkflowId): Promise<void> {
     this.logger.debug(`Enabling workflow [${workflowId}]`);
 
-    await this.callWorkflowApi(
-      'POST',
-      `/api/workflows/workflow/${encodeURIComponent(workflowId)}/_enable`
+    await retryTransientEsErrors(
+      () =>
+        this.callWorkflowApi(
+          'POST',
+          `/api/workflows/workflow/${encodeURIComponent(workflowId)}/_enable`
+        ),
+      { logger: this.logger }
     );
   }
 
   async disable(workflowId: WorkflowId): Promise<void> {
     this.logger.debug(`Disabling workflow [${workflowId}]`);
 
-    await this.callWorkflowApi(
-      'POST',
-      `/api/workflows/workflow/${encodeURIComponent(workflowId)}/_disable`
+    await retryTransientEsErrors(
+      () =>
+        this.callWorkflowApi(
+          'POST',
+          `/api/workflows/workflow/${encodeURIComponent(workflowId)}/_disable`
+        ),
+      { logger: this.logger }
     );
   }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/workflow_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/workflow_manager.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { HttpServiceSetup, Logger } from '@kbn/core/server';
+import { getSLOWorkflowId } from '../../common/constants';
+import type { SLODefinition } from '../domain/models';
+import { retryTransientEsErrors } from '../utils/retry';
+import { generateEsqlSloWorkflowYaml } from './esql_workflow_template';
+
+type WorkflowId = string;
+
+export interface WorkflowManager {
+  create(slo: SLODefinition): Promise<WorkflowId>;
+  update(slo: SLODefinition): Promise<WorkflowId>;
+  delete(workflowId: WorkflowId): Promise<void>;
+  enable(workflowId: WorkflowId): Promise<void>;
+  disable(workflowId: WorkflowId): Promise<void>;
+}
+
+interface WorkflowManagerDeps {
+  kibanaUrl: string;
+  request: KibanaRequest;
+  httpSetup: HttpServiceSetup;
+  logger: Logger;
+  spaceId: string;
+}
+
+export class DefaultWorkflowManager implements WorkflowManager {
+  private readonly baseUrl: string;
+  private readonly logger: Logger;
+  private readonly spaceId: string;
+  private readonly request: KibanaRequest;
+  private readonly httpSetup: HttpServiceSetup;
+
+  constructor(deps: WorkflowManagerDeps) {
+    this.baseUrl = deps.kibanaUrl;
+    this.logger = deps.logger;
+    this.spaceId = deps.spaceId;
+    this.request = deps.request;
+    this.httpSetup = deps.httpSetup;
+  }
+
+  async create(slo: SLODefinition): Promise<WorkflowId> {
+    const workflowId = getSLOWorkflowId(slo.id, slo.revision);
+    const yaml = generateEsqlSloWorkflowYaml(slo, this.spaceId);
+
+    this.logger.debug(`Creating workflow [${workflowId}] for ESQL SLO [${slo.id}]`);
+
+    await retryTransientEsErrors(
+      () =>
+        this.callWorkflowApi('POST', '/api/workflows/workflow', {
+          id: workflowId,
+          yaml,
+          enabled: true,
+        }),
+      { logger: this.logger }
+    );
+
+    return workflowId;
+  }
+
+  async update(slo: SLODefinition): Promise<WorkflowId> {
+    const workflowId = getSLOWorkflowId(slo.id, slo.revision);
+    const yaml = generateEsqlSloWorkflowYaml(slo, this.spaceId);
+
+    this.logger.debug(`Updating workflow [${workflowId}] for ESQL SLO [${slo.id}]`);
+
+    await retryTransientEsErrors(
+      () =>
+        this.callWorkflowApi('PUT', `/api/workflows/workflow/${encodeURIComponent(workflowId)}`, {
+          yaml,
+        }),
+      { logger: this.logger }
+    );
+
+    return workflowId;
+  }
+
+  async delete(workflowId: WorkflowId): Promise<void> {
+    this.logger.debug(`Deleting workflow [${workflowId}]`);
+
+    try {
+      await this.callWorkflowApi(
+        'DELETE',
+        `/api/workflows/workflow/${encodeURIComponent(workflowId)}?force=true`
+      );
+    } catch (err) {
+      // Ignore 404 — workflow may already be gone
+      if (err.statusCode !== 404) {
+        throw err;
+      }
+      this.logger.debug(`Workflow [${workflowId}] not found, skipping delete`);
+    }
+  }
+
+  async enable(workflowId: WorkflowId): Promise<void> {
+    this.logger.debug(`Enabling workflow [${workflowId}]`);
+
+    await this.callWorkflowApi(
+      'POST',
+      `/api/workflows/workflow/${encodeURIComponent(workflowId)}/_enable`
+    );
+  }
+
+  async disable(workflowId: WorkflowId): Promise<void> {
+    this.logger.debug(`Disabling workflow [${workflowId}]`);
+
+    await this.callWorkflowApi(
+      'POST',
+      `/api/workflows/workflow/${encodeURIComponent(workflowId)}/_disable`
+    );
+  }
+
+  private async callWorkflowApi(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    path: string,
+    body?: Record<string, unknown>
+  ): Promise<unknown> {
+    const basePath = this.spaceId !== 'default' ? `/s/${this.spaceId}` : '';
+    const url = `${this.baseUrl}${basePath}${path}`;
+
+    const headers: Record<string, string> = {
+      'kbn-xsrf': 'true',
+      'elastic-api-version': '2023-10-31',
+    };
+
+    // Forward the request auth header for the internal Kibana API call
+    if (this.request.headers.authorization) {
+      headers.authorization = this.request.headers.authorization as string;
+    }
+
+    const options: RequestInit = {
+      method,
+      headers,
+    };
+
+    if (body) {
+      headers['content-type'] = 'application/json';
+      options.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      const err = new Error(
+        `Workflow API ${method} ${path} failed with status ${response.status}: ${errorBody}`
+      );
+      (err as any).statusCode = response.status;
+      throw err;
+    }
+
+    const contentType = response.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+      return response.json();
+    }
+
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Add `sli.esql.custom` indicator type to the SLO plugin, enabling ES|QL queries for SLI computation powered by Kibana Workflows.

### What changed

- **New indicator type**: `sli.esql.custom` with `esqlQuery` and optional `groupBy` params added to `kbn-slo-schema`
- **WorkflowManager**: New class wrapping the Kibana Workflow CRUD API (create/update/delete/enable/disable) — parallel to `TransformManager`
- **Workflow YAML template**: Per-SLO workflow with scheduled trigger, DSL time-range filter injection, foreach row iteration, deterministic `_id` generation, concurrency control (`drop` strategy), and error handling
- **Dry-run validation**: `EsqlDryRunValidation` validates ESQL queries at SLO creation time (column names, types, groupBy alignment)
- **Lifecycle dispatch**: `CreateSLO`, `DeleteSLO`, `UpdateSLO`, `ResetSLO` branch on indicator type — ESQL SLOs use `WorkflowManager` instead of rollup transforms, while still creating summary transforms and ingest pipelines
- **Health scan**: Extended to skip rollup transform health check for ESQL SLOs (they have no rollup transform)

### Tasks completed

- [x] 1.1-1.4: Indicator type registration (schema, stub generator, factory, tests)
- [x] 2.1-2.5: Dry-run validation (execution, column validation, type validation, error handling, tests)
- [x] 3.1-3.4: WorkflowManager (CRUD, YAML generation, ID convention, tests)
- [x] 4.1-4.5: Lifecycle integration (create/delete/update/reset dispatch, rollback)
- [x] 5.1-5.8: Workflow template (trigger, ESQL step, foreach, _id, groupings, isGoodSlice, early exit, error handling)
- [x] 6.1-6.2: Health scan extension (ESQL-aware, state-matched)
- [x] 7.5: Validation (25 unit tests passing)

### Code review iterations

**Self-review (iteration 1):**
- Removed unused `httpSetup` field from `WorkflowManagerDeps`

**CodeRabbit review (iteration 1 — 6 findings, all addressed):**
- Used `isEsqlIndicatorType` helper instead of magic string
- Respected `item.enabled` state in ESQL health rollup
- Replaced hardcoded SLI index string with `SLI_DESTINATION_INDEX_NAME` constant
- Fixed Liquid integer division: use `numerator >= denominator * target`
- Added retry wrapping to WorkflowManager `enable`/`disable` for consistency

### Remaining items (not blocking)

- Integration tests for lifecycle (task 4.6) — requires running Kibana instance
- End-to-end smoke tests (tasks 7.1-7.4) — require running cluster with data
- WorkflowManager uses `fetch` for Kibana API calls — should be migrated to Kibana's internal HTTP client in a follow-up (CodeRabbit major finding, acceptable for exploratory phase)
- Plugin.ts wiring for `WorkflowManager` injection is not yet done — the `workflowManager` constructor param is optional and defaults to `undefined` for backward compatibility
