### PR TITLE
[Fleet] Fix fleet packages daily CI pipeline (kibana-build-xpack missing)

### DIFF
--- a/.buildkite/pipelines/fleet/packages_daily.yml
+++ b/.buildkite/pipelines/fleet/packages_daily.yml
@@ -21,6 +21,8 @@ steps:
     env:
       # ensure that the FTR logs all output for these tests
       DISABLE_CI_LOG_OUTPUT_CAPTURE: 'true'
+      # this pipeline has no build step, so skip downloading a pre-built artifact
+      KIBANA_BUILD_ID: 'false'
     timeout_in_minutes: 90
 
   - wait: ~

--- a/.buildkite/pipelines/fleet/packages_daily.yml
+++ b/.buildkite/pipelines/fleet/packages_daily.yml
@@ -21,8 +21,6 @@ steps:
     env:
       # ensure that the FTR logs all output for these tests
       DISABLE_CI_LOG_OUTPUT_CAPTURE: 'true'
-      # disable downloading a kibana build, this step does not use it
-      KIBANA_BUILD_ID: 'false'
     timeout_in_minutes: 90
 
   - wait: ~

--- a/.buildkite/scripts/steps/fleet/install_all_packages.sh
+++ b/.buildkite/scripts/steps/fleet/install_all_packages.sh
@@ -9,5 +9,4 @@ echo '--- Installing all packages'
 node scripts/functional_tests \
   --debug \
   --bail \
-  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
   --config x-pack/platform/test/fleet_packages/config.ts


### PR DESCRIPTION
## Summary

Fixes the `kibana-fleet-packages` daily CI pipeline, which has been failing since build 1622 with:

```
ERROR Error: cwd ".../kibana-build-xpack" does not exist
```

## Root cause

The regression was introduced by #262983 ([CI] Skip redundant webpack pre-build in CI steps).

That PR added `--kibana-install-dir "\$KIBANA_BUILD_LOCATION"` to `install_all_packages.sh` as part of a sweep to make all FTR steps run from the pre-built distributable. However, the `kibana-fleet-packages` pipeline is a **standalone daily pipeline with no build step** — it never produces a `kibana-default.tar.zst` artifact. This step was always intended to run from source, which is why `KIBANA_BUILD_ID: 'false'` was set in `packages_daily.yml` to skip the artifact download.

After #262983:
- `--kibana-install-dir "$KIBANA_BUILD_LOCATION"` was added → Kibana must start from `kibana-build-xpack`
- `KIBANA_BUILD_ID: 'false'` was still set → artifact download is skipped → `kibana-build-xpack` never created
- Result: `cwd "kibana-build-xpack" does not exist`

Removing `KIBANA_BUILD_ID: 'false'` (attempted in build 1623) only shifts the failure: the download is attempted but fails with `No artifacts found` since no build step ever uploads one.

The fleet packages pipeline runs on a separate daily schedule and is not exercised in PR builds, so the regression in #262983 was not caught before merge.

## Fix

Revert the `--kibana-install-dir` addition to `install_all_packages.sh` and restore `KIBANA_BUILD_ID: 'false'` in `packages_daily.yml` (with a clearer comment). The step runs from source as originally designed.

## Test plan

- [x] Trigger the `kibana-fleet-packages` daily pipeline manually and verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)