### PR TITLE
[Scout] Fail manifest generation when Playwright `--list` errors

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/cli/manifests.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/manifests.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { generateScoutConfigManifest } from './manifests';
+import { playwrightCLI } from '../playwright/cli_wrapper';
+
+jest.mock('../playwright/cli_wrapper', () => ({
+  playwrightCLI: { test: jest.fn() },
+}));
+
+describe('generateScoutConfigManifest', () => {
+  const playwrightTestMock = playwrightCLI.test as jest.Mock;
+  const configPath = 'x-pack/some/test/scout/api/playwright.config.ts';
+
+  beforeEach(() => {
+    playwrightTestMock.mockReset();
+  });
+
+  it(`returns the Playwright result when '--list' exits with code 0`, async () => {
+    playwrightTestMock.mockResolvedValueOnce({ exitCode: 0 });
+
+    await expect(generateScoutConfigManifest(configPath)).resolves.toEqual({ exitCode: 0 });
+
+    expect(playwrightTestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: configPath,
+        list: true,
+        passWithNoTests: true,
+        project: 'local',
+      }),
+      {},
+      undefined
+    );
+  });
+
+  it(`throws when '--list' exits non-zero (real discovery failure)`, async () => {
+    playwrightTestMock.mockResolvedValueOnce({ exitCode: 1 });
+
+    await expect(generateScoutConfigManifest(configPath)).rejects.toThrow(
+      /Failed to discover tests for Scout config at '.*playwright\.config\.ts': playwright --list exited with code 1/
+    );
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/cli/manifests.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/manifests.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { isFailError } from '@kbn/dev-cli-errors';
 import { generateScoutConfigManifest } from './manifests';
 import { playwrightCLI } from '../playwright/cli_wrapper';
 
@@ -39,10 +40,13 @@ describe('generateScoutConfigManifest', () => {
     );
   });
 
-  it(`throws when '--list' exits non-zero (real discovery failure)`, async () => {
+  it(`throws a FailError when '--list' exits non-zero (real discovery failure)`, async () => {
     playwrightTestMock.mockResolvedValueOnce({ exitCode: 1 });
 
-    await expect(generateScoutConfigManifest(configPath)).rejects.toThrow(
+    const error = await generateScoutConfigManifest(configPath).catch((e) => e);
+
+    expect(isFailError(error)).toBe(true);
+    expect(error.message).toMatch(
       /Failed to discover tests for Scout config at '.*playwright\.config\.ts': playwright --list exited with code 1/
     );
   });

--- a/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { createFailError } from '@kbn/dev-cli-errors';
 import type { Command } from '@kbn/dev-cli-runner';
 import type { ToolingLog } from '@kbn/tooling-log';
 import CliTable3 from 'cli-table3';
@@ -45,7 +46,7 @@ export async function generateScoutConfigManifest(configPath: string, log?: Tool
   );
 
   if (result.exitCode !== 0) {
-    throw new Error(
+    throw createFailError(
       `Failed to discover tests for Scout config at '${configPath}': ` +
         `playwright --list exited with code ${result.exitCode}. ` +
         `This usually means the config has a real error (e.g. a syntax/transpilation error) ` +

--- a/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
@@ -28,7 +28,7 @@ const manifestUpdateReporter = path.join(
   '/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/manifest_updater'
 );
 
-async function generateScoutConfigManifest(configPath: string, log?: ToolingLog) {
+export async function generateScoutConfigManifest(configPath: string, log?: ToolingLog) {
   // passWithNoTests lets configs with zero tests exit cleanly (code 0) so we can
   // unambiguously treat any non-zero exit as a real discovery failure (e.g. a syntax
   // error during Playwright transpilation).

--- a/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
@@ -29,7 +29,7 @@ const manifestUpdateReporter = path.join(
 );
 
 async function generateScoutConfigManifest(configPath: string, log?: ToolingLog) {
-  // `passWithNoTests` lets configs with zero tests exit cleanly (code 0) so we can
+  // passWithNoTests lets configs with zero tests exit cleanly (code 0) so we can
   // unambiguously treat any non-zero exit as a real discovery failure (e.g. a syntax
   // error during Playwright transpilation).
   const result = await playwrightCLI.test(

--- a/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
@@ -31,7 +31,7 @@ const manifestUpdateReporter = path.join(
 async function generateScoutConfigManifest(configPath: string, log?: ToolingLog) {
   // `passWithNoTests` lets configs with zero tests exit cleanly (code 0) so we can
   // unambiguously treat any non-zero exit as a real discovery failure (e.g. a syntax
-  // error during Playwright transpilation). See https://github.com/elastic/kibana/issues/262787.
+  // error during Playwright transpilation).
   const result = await playwrightCLI.test(
     {
       config: configPath,
@@ -49,8 +49,7 @@ async function generateScoutConfigManifest(configPath: string, log?: ToolingLog)
       `Failed to discover tests for Scout config at '${configPath}': ` +
         `playwright --list exited with code ${result.exitCode}. ` +
         `This usually means the config has a real error (e.g. a syntax/transpilation error) ` +
-        `rather than legitimately zero tests. ` +
-        `See https://github.com/elastic/kibana/issues/262787 for context.`
+        `rather than legitimately zero tests.`
     );
   }
 

--- a/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/manifests.ts
@@ -29,11 +29,32 @@ const manifestUpdateReporter = path.join(
 );
 
 async function generateScoutConfigManifest(configPath: string, log?: ToolingLog) {
-  return await playwrightCLI.test(
-    { config: configPath, reporters: [manifestUpdateReporter], list: true, project: 'local' },
+  // `passWithNoTests` lets configs with zero tests exit cleanly (code 0) so we can
+  // unambiguously treat any non-zero exit as a real discovery failure (e.g. a syntax
+  // error during Playwright transpilation). See https://github.com/elastic/kibana/issues/262787.
+  const result = await playwrightCLI.test(
+    {
+      config: configPath,
+      reporters: [manifestUpdateReporter],
+      list: true,
+      project: 'local',
+      passWithNoTests: true,
+    },
     {},
     log
   );
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to discover tests for Scout config at '${configPath}': ` +
+        `playwright --list exited with code ${result.exitCode}. ` +
+        `This usually means the config has a real error (e.g. a syntax/transpilation error) ` +
+        `rather than legitimately zero tests. ` +
+        `See https://github.com/elastic/kibana/issues/262787 for context.`
+    );
+  }
+
+  return result;
 }
 
 async function updateScoutConfigManifests(

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.test.ts
@@ -78,7 +78,7 @@ describe('hasTestsInPlaywrightConfig', () => {
     );
 
     expect(execPromiseMock).toHaveBeenCalledWith(
-      'playwright test pwArgs --list',
+      'playwright test pwArgs --list --pass-with-no-tests',
       expect.objectContaining({
         env: expect.objectContaining({
           SCOUT_REPORTER_ENABLED: 'false',
@@ -92,8 +92,13 @@ describe('hasTestsInPlaywrightConfig', () => {
     expect(exitCode).toEqual(0);
   });
 
-  it(`should log an error and return '2' when no tests are found`, async () => {
-    execPromiseMock.mockRejectedValueOnce(new Error('No tests found'));
+  it(`should return '0' when a config legitimately has zero tests (--pass-with-no-tests)`, async () => {
+    execPromiseMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        stdout: 'Listing tests:\nTotal: 0 tests in 0 files\n',
+        stderr: '',
+      })
+    );
 
     const exitCode = await hasTestsInPlaywrightConfig(
       mockLog,
@@ -102,11 +107,12 @@ describe('hasTestsInPlaywrightConfig', () => {
       'configPath/playwright.config.ts'
     );
 
-    expect(mockLog.info).toHaveBeenCalledWith('scout: Validate Playwright config has tests');
-    expect(mockLog.error).toHaveBeenCalledWith(
-      'scout: No tests found in [configPath/playwright.config.ts]'
+    expect(execPromiseMock).toHaveBeenCalledWith(
+      'playwright test pwArgs --list --pass-with-no-tests',
+      expect.any(Object)
     );
-    expect(exitCode).toEqual(2);
+    expect(mockLog.error).not.toHaveBeenCalled();
+    expect(exitCode).toEqual(0);
   });
 
   it(`should log an error and return '1' when test command throws error`, async () => {
@@ -126,8 +132,10 @@ describe('hasTestsInPlaywrightConfig', () => {
     expect(exitCode).toEqual(1);
   });
 
-  it(`should log an error and return '1' when unknown error occurs`, async () => {
-    execPromiseMock.mockRejectedValueOnce(new Error(`unknown error`));
+  it(`should log an error and return '1' when discovery fails (e.g. syntax error)`, async () => {
+    execPromiseMock.mockRejectedValueOnce(
+      new Error(`SyntaxError: Unexpected token 'export'`)
+    );
 
     const exitCode = await hasTestsInPlaywrightConfig(
       mockLog,
@@ -138,7 +146,9 @@ describe('hasTestsInPlaywrightConfig', () => {
 
     expect(mockLog.info).toHaveBeenCalledWith('scout: Validate Playwright config has tests');
     expect(mockLog.error).toHaveBeenCalledWith(
-      expect.stringMatching(/^scout: Unknown error occurred\./)
+      expect.stringMatching(
+        /^scout: Failed to discover tests in \[configPath\/playwright\.config\.ts\]\..*SyntaxError/s
+      )
     );
     expect(exitCode).toEqual(1);
   });

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.test.ts
@@ -78,7 +78,7 @@ describe('hasTestsInPlaywrightConfig', () => {
     );
 
     expect(execPromiseMock).toHaveBeenCalledWith(
-      'playwright test pwArgs --list --pass-with-no-tests',
+      'playwright test pwArgs --list',
       expect.objectContaining({
         env: expect.objectContaining({
           SCOUT_REPORTER_ENABLED: 'false',
@@ -92,13 +92,8 @@ describe('hasTestsInPlaywrightConfig', () => {
     expect(exitCode).toEqual(0);
   });
 
-  it(`should return '0' when a config legitimately has zero tests (--pass-with-no-tests)`, async () => {
-    execPromiseMock.mockImplementationOnce(() =>
-      Promise.resolve({
-        stdout: 'Listing tests:\nTotal: 0 tests in 0 files\n',
-        stderr: '',
-      })
-    );
+  it(`should log an error and return '1' when no tests are found`, async () => {
+    execPromiseMock.mockRejectedValueOnce(new Error('No tests found'));
 
     const exitCode = await hasTestsInPlaywrightConfig(
       mockLog,
@@ -107,12 +102,11 @@ describe('hasTestsInPlaywrightConfig', () => {
       'configPath/playwright.config.ts'
     );
 
-    expect(execPromiseMock).toHaveBeenCalledWith(
-      'playwright test pwArgs --list --pass-with-no-tests',
-      expect.any(Object)
+    expect(mockLog.info).toHaveBeenCalledWith('scout: Validate Playwright config has tests');
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.stringMatching(/^scout: No tests found in \[configPath\/playwright\.config\.ts\]\./)
     );
-    expect(mockLog.error).not.toHaveBeenCalled();
-    expect(exitCode).toEqual(0);
+    expect(exitCode).toEqual(1);
   });
 
   it(`should log an error and return '1' when test command throws error`, async () => {
@@ -132,10 +126,8 @@ describe('hasTestsInPlaywrightConfig', () => {
     expect(exitCode).toEqual(1);
   });
 
-  it(`should log an error and return '1' when discovery fails (e.g. syntax error)`, async () => {
-    execPromiseMock.mockRejectedValueOnce(
-      new Error(`SyntaxError: Unexpected token 'export'`)
-    );
+  it(`should log an error and return '1' when unknown error occurs`, async () => {
+    execPromiseMock.mockRejectedValueOnce(new Error(`unknown error`));
 
     const exitCode = await hasTestsInPlaywrightConfig(
       mockLog,
@@ -146,9 +138,7 @@ describe('hasTestsInPlaywrightConfig', () => {
 
     expect(mockLog.info).toHaveBeenCalledWith('scout: Validate Playwright config has tests');
     expect(mockLog.error).toHaveBeenCalledWith(
-      expect.stringMatching(
-        /^scout: Failed to discover tests in \[configPath\/playwright\.config\.ts\]\..*SyntaxError/s
-      )
+      expect.stringMatching(/^scout: Unknown error occurred\./)
     );
     expect(exitCode).toEqual(1);
   });

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.test.ts
@@ -92,7 +92,7 @@ describe('hasTestsInPlaywrightConfig', () => {
     expect(exitCode).toEqual(0);
   });
 
-  it(`should log an error and return '1' when no tests are found`, async () => {
+  it(`should log an error and return '2' when no tests are found`, async () => {
     execPromiseMock.mockRejectedValueOnce(new Error('No tests found'));
 
     const exitCode = await hasTestsInPlaywrightConfig(
@@ -106,7 +106,7 @@ describe('hasTestsInPlaywrightConfig', () => {
     expect(mockLog.error).toHaveBeenCalledWith(
       expect.stringMatching(/^scout: No tests found in \[configPath\/playwright\.config\.ts\]\./)
     );
-    expect(exitCode).toEqual(1);
+    expect(exitCode).toEqual(2);
   });
 
   it(`should log an error and return '1' when test command throws error`, async () => {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -102,7 +102,7 @@ export async function hasTestsInPlaywrightConfig(
         `scout: No tests found in [${configPath}]. ` +
           `Run 'npx playwright test --list --config ${configPath}' to see Playwright errors.`
       );
-      return 1;
+      return 2; // "no tests" code, no hard failure on CI
     }
 
     if (errorMessage.includes(`unknown command 'test'`)) {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -82,7 +82,10 @@ export async function hasTestsInPlaywrightConfig(
 ): Promise<number> {
   log.info(`scout: Validate Playwright config has tests`);
   try {
-    const validationCmd = [cmd, ...cmdArgs, '--list'].join(' ');
+    // `--pass-with-no-tests` lets a config with zero tests exit cleanly (code 0) so any
+    // rejection here unambiguously signals a real discovery failure (e.g. a syntax error
+    // during Playwright transpilation). See https://github.com/elastic/kibana/issues/262787.
+    const validationCmd = [cmd, ...cmdArgs, '--list', '--pass-with-no-tests'].join(' ');
 
     const result = await execPromise(validationCmd, {
       env: withKibanaBabelRegister({
@@ -93,21 +96,21 @@ export async function hasTestsInPlaywrightConfig(
     const lastLine = result.stdout.trim().split('\n').pop() || '';
 
     log.info(`scout: ${lastLine}`);
-    return 0; // success
+    return 0; // success (covers both "tests found" and "legitimately zero tests")
   } catch (err) {
     const errorMessage = (err as Error).message || String(err);
-
-    if (errorMessage.includes('No tests found')) {
-      log.error(`scout: No tests found in [${configPath}]`);
-      return 2; // "no tests" code, no hard failure on CI
-    }
 
     if (errorMessage.includes(`unknown command 'test'`)) {
       log.error(`scout: Playwright CLI is probably broken.\n${errorMessage}`);
       return 1;
     }
 
-    log.error(`scout: Unknown error occurred.\n${errorMessage}`);
+    log.error(
+      `scout: Failed to discover tests in [${configPath}]. ` +
+        `This usually means the config has a real error (e.g. a syntax/transpilation error) ` +
+        `rather than legitimately zero tests. ` +
+        `See https://github.com/elastic/kibana/issues/262787 for context.\n${errorMessage}`
+    );
     return 1;
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -82,10 +82,7 @@ export async function hasTestsInPlaywrightConfig(
 ): Promise<number> {
   log.info(`scout: Validate Playwright config has tests`);
   try {
-    // `--pass-with-no-tests` lets a config with zero tests exit cleanly (code 0) so any
-    // rejection here unambiguously signals a real discovery failure (e.g. a syntax error
-    // during Playwright transpilation). See https://github.com/elastic/kibana/issues/262787.
-    const validationCmd = [cmd, ...cmdArgs, '--list', '--pass-with-no-tests'].join(' ');
+    const validationCmd = [cmd, ...cmdArgs, '--list'].join(' ');
 
     const result = await execPromise(validationCmd, {
       env: withKibanaBabelRegister({
@@ -96,21 +93,24 @@ export async function hasTestsInPlaywrightConfig(
     const lastLine = result.stdout.trim().split('\n').pop() || '';
 
     log.info(`scout: ${lastLine}`);
-    return 0; // success (covers both "tests found" and "legitimately zero tests")
+    return 0; // success
   } catch (err) {
     const errorMessage = (err as Error).message || String(err);
+
+    if (errorMessage.includes('No tests found')) {
+      log.error(
+        `scout: No tests found in [${configPath}]. ` +
+          `Run 'npx playwright test --list --config ${configPath}' to see Playwright errors.`
+      );
+      return 1;
+    }
 
     if (errorMessage.includes(`unknown command 'test'`)) {
       log.error(`scout: Playwright CLI is probably broken.\n${errorMessage}`);
       return 1;
     }
 
-    log.error(
-      `scout: Failed to discover tests in [${configPath}]. ` +
-        `This usually means the config has a real error (e.g. a syntax/transpilation error) ` +
-        `rather than legitimately zero tests. ` +
-        `See https://github.com/elastic/kibana/issues/262787 for context.\n${errorMessage}`
-    );
+    log.error(`scout: Unknown error occurred.\n${errorMessage}`);
     return 1;
   }
 }


### PR DESCRIPTION
### Context

Two scenarios cause `npx playwright test --list --config <config-file>` to return a **non-zero exit code**:

- The config genuinely has zero tests --> this is acceptable and should not block CI.
- Playwright can't transpile the config or its imports (e.g. a `SyntaxError` from a barrel re-export pattern) --> we want to surface this error.

As of today these two are indistinguishable and the second item causes the Kibana CI to not run configs (see #262787) as Playwright syntax errors cause Scout to output `tests: []` for those configs. 

### Fix

This PR updates the internal test config manifests generation logic to accept tests without tests by passing `passWithNoTests: true`. We then throw an error if the exit code isn't zero, as it will have surfaced a real issue.

### Reproduce locally

I have tested these changes locally by following the steps below:

1. Add a `return;` line at the end of any spec, e.g. `src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/overview_tab.spec.ts` to cause a syntax error.

2. Confirm the Playwright layer exits non-zero:
    ```
    SCOUT_REPORTER_ENABLED=false ./node_modules/.bin/playwright test \
      --config src/platform/plugins/shared/discover/test/scout/ui/parallel.playwright.config.ts \
      --list --pass-with-no-tests --project=local
    echo "exit code: $?"
    ```
    You should see a `SyntaxError: 'return' outside of function` and `exit code: 1`.

3. Regenerate manifests through the Scout CLI (the actual code path this PR patches):
    ```
    node scripts/scout.js update-test-config-manifests --concurrencyLimit 3 --includingUpToDate
    ```
    Expected output:
    ```
     info Generating manifest for test config at 'src/platform/plugins/shared/discover/test/scout/ui/parallel.playwright.config.ts'
    ERROR Failed to discover tests for Scout config at 'src/platform/plugins/shared/discover/test/scout/ui/parallel.playwright.config.ts': playwright --list exited with code 1. This usually means the config has a real error (e.g. a syntax/transpilation error) rather than legitimately zero tests.
    ```

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->