### PR TITLE
[Workflows] Add editor settings popover to YAML editor

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/editor_settings_popover.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/editor_settings_popover.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  EuiButtonIcon,
+  EuiCheckbox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiToolTip,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { monaco } from '@kbn/monaco';
+
+interface EditorSettingsPopoverProps {
+  editorRef: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>;
+}
+
+export function EditorSettingsPopover({ editorRef }: EditorSettingsPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [showIndentGuides, setShowIndentGuides] = useState(true);
+  const [showWhitespace, setShowWhitespace] = useState(false);
+
+  const indentGuidesCheckboxId = useGeneratedHtmlId({ prefix: 'wf-editor-setting-indent-guides' });
+  const whitespaceCheckboxId = useGeneratedHtmlId({ prefix: 'wf-editor-setting-whitespace' });
+  const popoverTitleId = useGeneratedHtmlId({ prefix: 'wf-editor-settings-title' });
+
+  const handleIndentGuidesChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const enabled = e.target.checked;
+      setShowIndentGuides(enabled);
+      editorRef.current?.updateOptions({
+        guides: { indentation: enabled },
+      });
+    },
+    [editorRef]
+  );
+
+  const handleWhitespaceChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const enabled = e.target.checked;
+      setShowWhitespace(enabled);
+      editorRef.current?.updateOptions({
+        renderWhitespace: enabled ? 'all' : 'none',
+      });
+    },
+    [editorRef]
+  );
+
+  const label = i18n.translate('workflows.yamlEditor.editorSettings.label', {
+    defaultMessage: 'Editor settings',
+  });
+
+  return (
+    <EuiPopover
+      css={{ marginLeft: '8px' }}
+      data-test-subj="workflowYamlEditorSettingsPopover"
+      aria-labelledby={popoverTitleId}
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      anchorPosition="upRight"
+      panelPaddingSize="none"
+      button={
+        <EuiToolTip content={label} delay="long" disableScreenReaderOutput>
+          <EuiButtonIcon
+            size="xs"
+            iconType="controlsHorizontal"
+            data-test-subj="workflowYamlEditorSettingsButton"
+            onClick={() => setIsOpen(!isOpen)}
+            aria-label={label}
+            color="primary"
+          />
+        </EuiToolTip>
+      }
+    >
+      <EuiPopoverTitle id={popoverTitleId} paddingSize="s">
+        {label}
+      </EuiPopoverTitle>
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="s"
+        css={{ padding: '8px 12px 12px' }}
+        responsive={false}
+      >
+        <EuiFlexItem>
+          <EuiCheckbox
+            id={indentGuidesCheckboxId}
+            label={i18n.translate('workflows.yamlEditor.editorSettings.showIndentGuides', {
+              defaultMessage: 'Show indent guides',
+            })}
+            checked={showIndentGuides}
+            onChange={handleIndentGuidesChange}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCheckbox
+            id={whitespaceCheckboxId}
+            label={i18n.translate('workflows.yamlEditor.editorSettings.showWhitespace', {
+              defaultMessage: 'Show whitespace characters',
+            })}
+            checked={showWhitespace}
+            onChange={handleWhitespaceChange}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPopover>
+  );
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -30,6 +30,7 @@ import {
   useWorkflowIdDecorations,
 } from './decorations';
 import { DocumentationLink } from './documentation_link';
+import { EditorSettingsPopover } from './editor_settings_popover';
 import type { ExtraAction } from './extra_actions_bar';
 import { ExtraActionsBar } from './extra_actions_bar';
 import { useAgentBuilderIntegration } from './hooks/use_agent_builder_integration';
@@ -119,6 +120,7 @@ const editorOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
   fontSize: 14,
   lineHeight: 23, // default ~21px + 2px
   renderWhitespace: 'none',
+  guides: { indentation: true },
   wordWrap: 'on',
   wordWrapColumn: 80,
   wrappingIndent: 'indent',
@@ -649,8 +651,13 @@ export const WorkflowYAMLEditor = ({
         content: <KeyboardShortcutsPopover />,
         showInReadOnly: true,
       },
+      {
+        id: 'editor-settings',
+        content: <EditorSettingsPopover editorRef={editorRef} />,
+        showInReadOnly: true,
+      },
     ],
-    [openActionsPopover]
+    [openActionsPopover, editorRef]
   );
 
   // These were triggering rerendering of the actions containers on every scroll, because they were


### PR DESCRIPTION
## Summary

Adds an **Editor Settings** popover icon to the YAML editor bottom bar (to the right of the keyboard shortcuts icon), with two toggles:
- **Show indent guides** — vertical grey lines at each indent level (on by default)
- **Show whitespace characters** — dots for every space (off by default)

## Test plan

- [ ] Open the Workflow YAML editor — verify indent guide lines are visible by default
- [ ] Click the settings icon in the bottom bar — popover opens with two checkboxes
- [ ] Toggle "Show indent guides" off — vertical lines disappear from the editor
- [ ] Toggle "Show whitespace characters" on — dots appear for every space
- [ ] Settings icon and keyboard shortcuts icon coexist correctly in the bottom bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)