### PR TITLE
[9.2] Update kubernetes templates for elastic-agent

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/elastic_agent_manifest.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/elastic_agent_manifest.ts
@@ -42,7 +42,7 @@ spec:
       #      - -c
       #      - >-
       #        mkdir -p /etc/elastic-agent/inputs.d &&
-      #        curl -sL https://github.com/elastic/elastic-agent/archive/9.0.tar.gz | tar xz -C /etc/elastic-agent/inputs.d --strip=5 "elastic-agent-9.0/deploy/kubernetes/elastic-agent-standalone/templates.d"
+      #        curl -sL https://github.com/elastic/elastic-agent/archive/9.2.tar.gz | tar xz -C /etc/elastic-agent/inputs.d --strip=5 "elastic-agent-9.2/deploy/kubernetes/elastic-agent-standalone/templates.d"
       #    volumeMounts:
       #      - name: external-inputs
       #        mountPath: /etc/elastic-agent/inputs.d
@@ -72,12 +72,14 @@ spec:
             # For more info: https://www.elastic.co/guide/en/beats/metricbeat/current/add-host-metadata.html
             - name: ELASTIC_NETINFO
               value: "false"
+            # 'Defend for containers' integration (cloud-defend) uses the HOSTFS_PROC_PATH variable for accessing process information from the node.
+            - name: HOSTFS_PROC_PATH
+              value: "/hostfs/proc"
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:
@@ -113,6 +115,14 @@ spec:
               readOnly: true
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
+            - name: boot
+              mountPath: /boot
+              readOnly: true
+            - name: sys-fs-bpf
+              mountPath: /sys/fs/bpf
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
             # Uncomment if using hints feature
@@ -150,6 +160,17 @@ spec:
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug
+        # The following three mounts are needed for 'Defend for containers' integration (cloud-defend)
+        # If you are not using cloud-defend, then these volumes and the corresponding mounts can be removed.
+        - name: boot
+          hostPath:
+            path: /boot
+        - name: sys-fs-bpf
+          hostPath:
+            path: /sys/fs/bpf
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # Mount /var/lib/elastic-agent-managed/kube-system/state to store elastic-agent state
         # Update 'kube-system' with the namespace of your agent installation
         - name: elastic-agent-state
@@ -377,12 +398,14 @@ spec:
             # For more info: https://www.elastic.co/guide/en/beats/metricbeat/current/add-host-metadata.html
             - name: ELASTIC_NETINFO
               value: "false"
+            # 'Defend for containers' integration (cloud-defend) uses the HOSTFS_PROC_PATH variable for accessing process information from the node.
+            - name: HOSTFS_PROC_PATH
+              value: "/hostfs/proc"
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:
@@ -417,6 +440,14 @@ spec:
               readOnly: true
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
+            - name: boot
+              mountPath: /boot
+              readOnly: true
+            - name: sys-fs-bpf
+              mountPath: /sys/fs/bpf
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
       volumes:
@@ -453,6 +484,17 @@ spec:
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug
+        # The following three mounts are needed for 'Defend for containers' integration (cloud-defend)
+        # If you are not using cloud-defend, then these volumes and the corresponding mounts can be removed.
+        - name: boot
+          hostPath:
+            path: /boot
+        - name: sys-fs-bpf
+          hostPath:
+            path: /sys/fs/bpf
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
         # Mount /var/lib/elastic-agent-managed/kube-system/state to store elastic-agent state
         # Update 'kube-system' with the namespace of your agent installation
         - name: elastic-agent-state


### PR DESCRIPTION
Backport of #267341 to 9.2.

## Summary

- Adds `HOSTFS_PROC_PATH` env var for cloud-defend integration
- Adds `boot`, `sys-fs-bpf`, `sys-kernel-security` volume mounts and volumes for cloud-defend
- Removes `hostUsers: false` and `procMount: "Unmasked"` Universal Profiling commented lines
- Updates hints init-container curl URL to `9.2.tar.gz` (was `9.0`)

## Conflict resolution

The hints init-container version reference was updated from `9.0` (current on 9.2 branch) to `9.2` to match the target branch version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)