### PR TITLE
[Discover][Logs] Fix multi-value field array delimiters rendering as raw HTML in resource badges

### DIFF
--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.test.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.test.ts
@@ -32,6 +32,25 @@ describe('truncateAndPreserveHighlightTags', () => {
     });
   });
 
+  describe('when there are <span class="ffArray__highlight"> tags', () => {
+    const SPAN = '<span class="ffArray__highlight">';
+    const CLOSE = '</span>';
+    const ARRAY_SHORT = `${SPAN}[${CLOSE}ab${SPAN}]${CLOSE}`;
+    const ARRAY_LONG = `${SPAN}[${CLOSE}elastic-agent-service${SPAN},${CLOSE} filebeat${SPAN}]${CLOSE}`;
+
+    describe('and text is shorter than maxLength', () => {
+      it('should return the original string with the tags', () => {
+        expect(truncateAndPreserveHighlightTags(ARRAY_SHORT, MAX_LENGTH)).toBe(ARRAY_SHORT);
+      });
+    });
+
+    describe('and text is longer than or equal to maxLength', () => {
+      it('should truncate and strip the array spans', () => {
+        expect(truncateAndPreserveHighlightTags(ARRAY_LONG, MAX_LENGTH)).toBe('[elast...beat]');
+      });
+    });
+  });
+
   describe('when there are <mark> tags', () => {
     describe('and text is shorter than maxLength', () => {
       const result = truncateAndPreserveHighlightTags(`<mark>${SHORT_TEXT}</mark>`, MAX_LENGTH);

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.test.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.test.ts
@@ -46,7 +46,7 @@ describe('truncateAndPreserveHighlightTags', () => {
 
     describe('and text is longer than or equal to maxLength', () => {
       it('should truncate and strip the array spans', () => {
-        expect(truncateAndPreserveHighlightTags(ARRAY_LONG, MAX_LENGTH)).toBe('[elast...beat]');
+        expect(truncateAndPreserveHighlightTags(ARRAY_LONG, MAX_LENGTH)).toBe('[elas...beat]');
       });
     });
   });

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.ts
@@ -9,10 +9,12 @@
 
 export function extractTextAndMarkTags(html: string) {
   const markTags: string[] = [];
-  const cleanText = html.replace(/<\/?mark[^>]*>/g, (match) => {
-    markTags.push(match);
-    return '';
-  });
+  const cleanText = html
+    .replace(/<\/?mark[^>]*>/g, (match) => {
+      markTags.push(match);
+      return '';
+    })
+    .replace(/<span class="ffArray__highlight">|<\/span>/g, '');
 
   return { cleanText, markTags };
 }

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.test.ts
@@ -47,6 +47,17 @@ describe('escapeAndPreserveHighlightTags', () => {
       `${ES_PRE}test${ES_POST}`
     );
   });
+
+  it('preserves ffArray__highlight spans for array-valued fields', () => {
+    const SPAN = '<span class="ffArray__highlight">';
+    const CLOSE = '</span>';
+    const input = `${SPAN}[${CLOSE}elastic-agent-service${SPAN},${CLOSE} filebeat${SPAN}]${CLOSE}`;
+    expect(escapeAndPreserveHighlightTags(input)).toBe(input);
+  });
+
+  it('escapes orphaned </span> that has no matching ffArray__highlight opening tag', () => {
+    expect(escapeAndPreserveHighlightTags('foo</span>bar')).toBe('foo&lt;/span&gt;bar');
+  });
 });
 
 describe('getHighlightedFieldValue', () => {

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.ts
@@ -20,29 +20,62 @@ const HTML_HIGHLIGHT_POST_TAG = '</mark>';
 const ES_HIGHLIGHT_PRE_TAG = '@kibana-highlighted-field@';
 const ES_HIGHLIGHT_POST_TAG = '@/kibana-highlighted-field@';
 
+const ARRAY_HIGHLIGHT_PRE_TAG = '<span class="ffArray__highlight">';
+const ARRAY_HIGHLIGHT_POST_TAG = '</span>';
+
+// Matches all candidate tags in one pass; state tracking below decides which to preserve.
+const TAGS_REGEX = new RegExp(
+  [
+    HTML_HIGHLIGHT_PRE_TAG,
+    HTML_HIGHLIGHT_POST_TAG,
+    ARRAY_HIGHLIGHT_PRE_TAG,
+    ARRAY_HIGHLIGHT_POST_TAG,
+  ]
+    .map((tag) => tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|'),
+  'g'
+);
+
 /**
- * Escapes HTML in a string while preserving field-format highlight <mark> tags.
+ * Escapes HTML in a string while preserving field-format highlight <mark> tags
+ * and array-formatting <span class="ffArray__highlight"> tags.
  * Used for values already processed by formatFieldValue / getHighlightHtml (e.g. resource badges).
+ *
+ * Closing tags are only preserved when a matching opening tag was already seen, so orphaned
+ * </mark> or </span> in arbitrary input are still escaped.
  */
 export function escapeAndPreserveHighlightTags(value: string): string {
-  if (!value.includes(HTML_HIGHLIGHT_PRE_TAG)) {
-    return escape(value);
+  const parts: string[] = [];
+  let lastIndex = 0;
+  let inSearchHighlight = false;
+  let inArrayHighlight = false;
+
+  for (const match of value.matchAll(TAGS_REGEX)) {
+    const tag = match[0];
+    const before = value.slice(lastIndex, match.index);
+
+    if (tag === HTML_HIGHLIGHT_PRE_TAG) {
+      parts.push(escape(before), tag);
+      inSearchHighlight = true;
+    } else if (tag === HTML_HIGHLIGHT_POST_TAG && inSearchHighlight) {
+      parts.push(escape(before), tag);
+      inSearchHighlight = false;
+    } else if (tag === ARRAY_HIGHLIGHT_PRE_TAG) {
+      parts.push(escape(before), tag);
+      inArrayHighlight = true;
+    } else if (tag === ARRAY_HIGHLIGHT_POST_TAG && inArrayHighlight) {
+      parts.push(escape(before), tag);
+      inArrayHighlight = false;
+    } else {
+      // Orphaned closing tag — escape it along with the preceding text
+      parts.push(escape(before + tag));
+    }
+
+    lastIndex = match.index! + tag.length;
   }
 
-  return value
-    .split(HTML_HIGHLIGHT_PRE_TAG)
-    .map((segment, index) => {
-      if (index === 0) return escape(segment);
-
-      const postTagIndex = segment.indexOf(HTML_HIGHLIGHT_POST_TAG);
-      if (postTagIndex === -1) return escape(segment);
-
-      const highlighted = segment.substring(0, postTagIndex);
-      const rest = segment.substring(postTagIndex + HTML_HIGHLIGHT_POST_TAG.length);
-
-      return HTML_HIGHLIGHT_PRE_TAG + escape(highlighted) + HTML_HIGHLIGHT_POST_TAG + escape(rest);
-    })
-    .join('');
+  parts.push(escape(value.slice(lastIndex)));
+  return parts.join('');
 }
 
 /**

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.ts
@@ -21,18 +21,14 @@ const ES_HIGHLIGHT_PRE_TAG = '@kibana-highlighted-field@';
 const ES_HIGHLIGHT_POST_TAG = '@/kibana-highlighted-field@';
 
 const ARRAY_HIGHLIGHT_PRE_TAG = '<span class="ffArray__highlight">';
-const ARRAY_HIGHLIGHT_POST_TAG = '</span>';
 
-// Matches all candidate tags in one pass; state tracking below decides which to preserve.
-const TAGS_REGEX = new RegExp(
-  [
-    HTML_HIGHLIGHT_PRE_TAG,
-    HTML_HIGHLIGHT_POST_TAG,
-    ARRAY_HIGHLIGHT_PRE_TAG,
-    ARRAY_HIGHLIGHT_POST_TAG,
-  ]
-    .map((tag) => tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-    .join('|'),
+const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Matches complete known tag pairs. Groups 1-3 capture mark open/content/close;
+// group 0 is used as-is for array spans (content is only [ ] , — no HTML-special chars).
+const PRESERVED_TAGS_PATTERN = new RegExp(
+  `(${esc(HTML_HIGHLIGHT_PRE_TAG)})([\\s\\S]*?)(${esc(HTML_HIGHLIGHT_POST_TAG)})` +
+    `|${esc(ARRAY_HIGHLIGHT_PRE_TAG)}[^<]*${esc('</span>')}`,
   'g'
 );
 
@@ -40,38 +36,21 @@ const TAGS_REGEX = new RegExp(
  * Escapes HTML in a string while preserving field-format highlight <mark> tags
  * and array-formatting <span class="ffArray__highlight"> tags.
  * Used for values already processed by formatFieldValue / getHighlightHtml (e.g. resource badges).
- *
- * Closing tags are only preserved when a matching opening tag was already seen, so orphaned
- * </mark> or </span> in arbitrary input are still escaped.
  */
 export function escapeAndPreserveHighlightTags(value: string): string {
   const parts: string[] = [];
   let lastIndex = 0;
-  let inSearchHighlight = false;
-  let inArrayHighlight = false;
 
-  for (const match of value.matchAll(TAGS_REGEX)) {
-    const tag = match[0];
-    const before = value.slice(lastIndex, match.index);
-
-    if (tag === HTML_HIGHLIGHT_PRE_TAG) {
-      parts.push(escape(before), tag);
-      inSearchHighlight = true;
-    } else if (tag === HTML_HIGHLIGHT_POST_TAG && inSearchHighlight) {
-      parts.push(escape(before), tag);
-      inSearchHighlight = false;
-    } else if (tag === ARRAY_HIGHLIGHT_PRE_TAG) {
-      parts.push(escape(before), tag);
-      inArrayHighlight = true;
-    } else if (tag === ARRAY_HIGHLIGHT_POST_TAG && inArrayHighlight) {
-      parts.push(escape(before), tag);
-      inArrayHighlight = false;
+  for (const match of value.matchAll(PRESERVED_TAGS_PATTERN)) {
+    parts.push(escape(value.slice(lastIndex, match.index!)));
+    if (match[1]) {
+      // mark tag: preserve open/close, escape inner content
+      parts.push(match[1], escape(match[2]), match[3]);
     } else {
-      // Orphaned closing tag — escape it along with the preceding text
-      parts.push(escape(before + tag));
+      // array span: preserve as-is
+      parts.push(match[0]);
     }
-
-    lastIndex = match.index! + tag.length;
+    lastIndex = match.index! + match[0].length;
   }
 
   parts.push(escape(value.slice(lastIndex)));


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/267474 (flagged in v9.3.3)

When a field like `service.name` holds a multi-value array, the HTML field formatter wraps the delimiters (`[`, `]`, `,`) with `<span class="ffArray__highlight">` spans. These were passed through `escapeAndPreserveHighlightTags`, which only knew to preserve search-highlight`<mark>` tags,  everything else was escaped, so the span tags appeared as literal text in the resource badge.

Two files are changed:

- `escapeAndPreserveHighlightTags` is updated to also preserve `<span class="ffArray__highlight">` pairs.
- `extractTextAndMarkTags` is updated to strip array spans before measuring length, so `truncateAndPreserveHighlightTags` slices at the correct character position rather than cutting through HTML tag strings.

> [!NOTE]
> This is a 9.4.x-9.3.x workaround. 
> In `main` the issue no longer exists, the badge was refactored to use `formatFieldValueReact` (ReactNode) instead of an HTML string, so this code path is never reached.




|Before|After|
|-|-|
|<img width="1918" height="970" alt="array_before" src="https://github.com/user-attachments/assets/bec4d0a2-283b-4abf-99e6-6a57592753f8" />|<img width="1920" height="968" alt="array_after" src="https://github.com/user-attachments/assets/8a42fe18-6288-4757-a492-971cb98ba2d9" />|




