### PR TITLE
[ILM] Add rollover min_* fields

### DIFF
--- a/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/policies.ts
+++ b/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/policies.ts
@@ -89,10 +89,6 @@ export interface RolloverAction {
    */
   max_size?: string;
 
-  /**
-   * Currently we do not yet support configuring min_* values in the UI
-   * but they are accepted by the API.
-   */
   min_age?: string;
   min_docs?: number;
   min_size?: string;

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/lib/rollover.test.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/lib/rollover.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SerializedPolicy } from '../../../common/types';
+import { defaultRolloverAction } from '../constants';
+import { isUsingDefaultRollover } from './rollover';
+
+const createPolicyWithRollover = (
+  rollover: NonNullable<SerializedPolicy['phases']['hot']>['actions']['rollover']
+): SerializedPolicy => ({
+  name: 'test-policy',
+  phases: {
+    hot: {
+      actions: {
+        rollover,
+      },
+    },
+  },
+});
+
+describe('isUsingDefaultRollover', () => {
+  it('returns false when rollover is not configured', () => {
+    const policy: SerializedPolicy = {
+      name: 'test-policy',
+      phases: {
+        hot: {
+          actions: {},
+        },
+      },
+    };
+
+    expect(isUsingDefaultRollover(policy)).toBe(false);
+  });
+
+  it('returns true when rollover matches defaults 1:1', () => {
+    expect(isUsingDefaultRollover(createPolicyWithRollover({ ...defaultRolloverAction }))).toBe(
+      true
+    );
+  });
+
+  it('returns false when a default key is missing', () => {
+    const policy = createPolicyWithRollover({
+      max_age: defaultRolloverAction.max_age,
+    });
+
+    expect(isUsingDefaultRollover(policy)).toBe(false);
+  });
+
+  it('returns false when a default value differs', () => {
+    const policy = createPolicyWithRollover({
+      ...defaultRolloverAction,
+      max_age: '29d',
+    });
+
+    expect(isUsingDefaultRollover(policy)).toBe(false);
+  });
+
+  it('returns false when extra max_* threshold keys exist', () => {
+    const policy = createPolicyWithRollover({
+      ...defaultRolloverAction,
+      max_docs: 1000,
+    });
+
+    expect(isUsingDefaultRollover(policy)).toBe(false);
+  });
+
+  it('returns false when extra min_* threshold keys exist', () => {
+    const policy = createPolicyWithRollover({
+      ...defaultRolloverAction,
+      min_age: '1d',
+    });
+
+    expect(isUsingDefaultRollover(policy)).toBe(false);
+  });
+
+  it('returns false when an unknown key exists', () => {
+    const policy = createPolicyWithRollover({
+      ...defaultRolloverAction,
+      // @ts-expect-error testing extra unknown keys
+      unknown_setting: 123,
+    });
+
+    expect(isUsingDefaultRollover(policy)).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/lib/rollover.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/lib/rollover.ts
@@ -8,13 +8,30 @@
 import type { SerializedPolicy } from '../../../common/types';
 import { defaultRolloverAction } from '../constants';
 
+const isKeyOf = <T extends object>(obj: T, key: PropertyKey): key is keyof T => key in obj;
+
 export const isUsingDefaultRollover = (policy: SerializedPolicy): boolean => {
   const rollover = policy?.phases?.hot?.actions?.rollover;
-  return Boolean(
-    rollover &&
-      rollover.max_age === defaultRolloverAction.max_age &&
-      rollover.max_docs === defaultRolloverAction.max_docs &&
-      rollover.max_primary_shard_size === defaultRolloverAction.max_primary_shard_size &&
-      rollover.max_primary_shard_docs === defaultRolloverAction.max_primary_shard_docs
-  );
+  if (!rollover) {
+    return false;
+  }
+
+  // "Use recommended defaults" should only be enabled when the rollover action
+  // matches the default rollover settings exactly, with no additional thresholds.
+  const rolloverKeys = Object.keys(rollover);
+  const hasOnlyDefaultKeys = rolloverKeys.every((key) => isKeyOf(defaultRolloverAction, key));
+  if (!hasOnlyDefaultKeys) {
+    return false;
+  }
+
+  const defaultKeys = Object.keys(defaultRolloverAction);
+  const hasAllDefaultKeysWithSameValues = defaultKeys.every((key) => {
+    if (!isKeyOf(defaultRolloverAction, key)) {
+      return false;
+    }
+
+    return rollover[key] === defaultRolloverAction[key];
+  });
+
+  return rolloverKeys.length === defaultKeys.length && hasAllDefaultKeysWithSameValues;
 };

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/index.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/index.ts
@@ -14,3 +14,13 @@ export { MaxAgeField } from './max_age_field';
 export { MaxDocumentCountField } from './max_document_count_field';
 
 export { MaxIndexSizeField } from './max_index_size_field';
+
+export { MinPrimaryShardSizeField } from './min_primary_shard_size_field';
+
+export { MinPrimaryShardDocsField } from './min_primary_shard_docs_field';
+
+export { MinAgeField } from './min_age_field';
+
+export { MinDocumentCountField } from './min_document_count_field';
+
+export { MinIndexSizeField } from './min_index_size_field';

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_age_field.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_age_field.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FunctionComponent } from 'react';
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+import { NumericField } from '../../../../../../../shared_imports';
+import { UseField } from '../../../../form';
+import { ROLLOVER_FORM_PATHS, timeUnits } from '../../../../constants';
+import { UnitField } from '../../shared_fields/unit_field';
+
+export const MinAgeField: FunctionComponent = () => {
+  return (
+    <EuiFlexGroup alignItems="flexStart" gutterSize="s">
+      <EuiFlexItem style={{ maxWidth: 400 }}>
+        <UseField
+          path={ROLLOVER_FORM_PATHS.minAge}
+          component={NumericField}
+          componentProps={{
+            euiFieldProps: {
+              'data-test-subj': `hot-selectedMinAge`,
+              min: 1,
+              append: (
+                <UnitField
+                  path="_meta.hot.customRollover.minAgeUnit"
+                  options={timeUnits}
+                  euiFieldProps={{
+                    'data-test-subj': 'hot-selectedMinAgeUnits',
+                    'aria-label': i18n.translate(
+                      'xpack.indexLifecycleMgmt.hotPhase.minimumAgeUnitsAriaLabel',
+                      {
+                        defaultMessage: 'Minimum age units',
+                      }
+                    ),
+                  }}
+                />
+              ),
+            },
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_document_count_field.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_document_count_field.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FunctionComponent } from 'react';
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+import { NumericField } from '../../../../../../../shared_imports';
+import { UseField } from '../../../../form';
+import { ROLLOVER_FORM_PATHS } from '../../../../constants';
+
+export const MinDocumentCountField: FunctionComponent = () => {
+  return (
+    <EuiFlexGroup alignItems="flexStart" gutterSize="s">
+      <EuiFlexItem style={{ maxWidth: 400 }}>
+        <UseField
+          path={ROLLOVER_FORM_PATHS.minDocs}
+          component={NumericField}
+          componentProps={{
+            euiFieldProps: {
+              'data-test-subj': `hot-selectedMinDocuments`,
+              min: 1,
+            },
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_index_size_field.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_index_size_field.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FunctionComponent } from 'react';
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+import { NumericField } from '../../../../../../../shared_imports';
+import { UseField } from '../../../../form';
+import { byteSizeUnits, ROLLOVER_FORM_PATHS } from '../../../../constants';
+import { UnitField } from '../../shared_fields/unit_field';
+
+export const MinIndexSizeField: FunctionComponent = () => {
+  return (
+    <EuiFlexGroup alignItems="flexStart" gutterSize="s">
+      <EuiFlexItem style={{ maxWidth: 400 }}>
+        <UseField
+          path={ROLLOVER_FORM_PATHS.minSize}
+          component={NumericField}
+          componentProps={{
+            euiFieldProps: {
+              'data-test-subj': 'hot-selectedMinSizeStored',
+              min: 1,
+              append: (
+                <UnitField
+                  path="_meta.hot.customRollover.minStorageSizeUnit"
+                  options={byteSizeUnits}
+                  euiFieldProps={{
+                    'data-test-subj': 'hot-selectedMinSizeStoredUnits',
+                    'aria-label': i18n.translate(
+                      'xpack.indexLifecycleMgmt.hotPhase.minimumIndexSizeUnitsAriaLabel',
+                      {
+                        defaultMessage: 'Minimum index size units',
+                      }
+                    ),
+                  }}
+                />
+              ),
+            },
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_primary_shard_docs_field.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_primary_shard_docs_field.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FunctionComponent } from 'react';
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+import { NumericField } from '../../../../../../../shared_imports';
+import { UseField } from '../../../../form';
+import { ROLLOVER_FORM_PATHS } from '../../../../constants';
+
+export const MinPrimaryShardDocsField: FunctionComponent = () => {
+  return (
+    <EuiFlexGroup alignItems="flexStart" gutterSize="s">
+      <EuiFlexItem style={{ maxWidth: 400 }}>
+        <UseField
+          path={ROLLOVER_FORM_PATHS.minPrimaryShardDocs}
+          component={NumericField}
+          componentProps={{
+            euiFieldProps: {
+              'data-test-subj': 'hot-selectedMinPrimaryShardDocs',
+              min: 1,
+            },
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_primary_shard_size_field.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/components/min_primary_shard_size_field.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FunctionComponent } from 'react';
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+import { NumericField } from '../../../../../../../shared_imports';
+import { UseField } from '../../../../form';
+import { byteSizeUnits, ROLLOVER_FORM_PATHS } from '../../../../constants';
+import { UnitField } from '../../shared_fields/unit_field';
+
+export const MinPrimaryShardSizeField: FunctionComponent = () => {
+  return (
+    <EuiFlexGroup alignItems="flexStart" gutterSize="s">
+      <EuiFlexItem style={{ maxWidth: 400 }}>
+        <UseField
+          path={ROLLOVER_FORM_PATHS.minPrimaryShardSize}
+          component={NumericField}
+          componentProps={{
+            euiFieldProps: {
+              'data-test-subj': 'hot-selectedMinPrimaryShardSize',
+              min: 1,
+              append: (
+                <UnitField
+                  path="_meta.hot.customRollover.minPrimaryShardSizeUnit"
+                  options={byteSizeUnits}
+                  euiFieldProps={{
+                    'data-test-subj': 'hot-selectedMinPrimaryShardSizeUnits',
+                    'aria-label': i18n.translate(
+                      'xpack.indexLifecycleMgmt.editPolicy.minimumPrimaryShardSizeAriaLabel',
+                      {
+                        defaultMessage: 'Minimum shard size units',
+                      }
+                    ),
+                  }}
+                />
+              ),
+            },
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/hot_phase.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/hot_phase.tsx
@@ -41,6 +41,11 @@ import {
   MaxAgeField,
   MaxDocumentCountField,
   MaxIndexSizeField,
+  MinPrimaryShardSizeField,
+  MinPrimaryShardDocsField,
+  MinAgeField,
+  MinDocumentCountField,
+  MinIndexSizeField,
 } from './components';
 
 const rolloverFieldPaths = Object.values(ROLLOVER_FORM_PATHS);
@@ -160,6 +165,21 @@ export const HotPhase: FunctionComponent = () => {
 
                 {/* This field is currently deprecated and will be removed in v8+ of the stack */}
                 <MaxIndexSizeField />
+                <EuiSpacer />
+
+                <MinPrimaryShardSizeField />
+                <EuiSpacer />
+
+                <MinPrimaryShardDocsField />
+                <EuiSpacer />
+
+                <MinAgeField />
+                <EuiSpacer />
+
+                <MinDocumentCountField />
+                <EuiSpacer />
+
+                <MinIndexSizeField />
               </>
             )}
           </div>

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/use_rollover_value_required_validation.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/hot_phase/use_rollover_value_required_validation.ts
@@ -12,7 +12,13 @@ import { useFormData, useFormContext } from '../../../../../../shared_imports';
 import { ROLLOVER_FORM_PATHS } from '../../../constants';
 import { ROLLOVER_VALUE_REQUIRED_VALIDATION_CODE } from '../../../form';
 
-const rolloverFieldPaths = Object.values(ROLLOVER_FORM_PATHS);
+const rolloverFieldPaths = [
+  ROLLOVER_FORM_PATHS.maxDocs,
+  ROLLOVER_FORM_PATHS.maxAge,
+  ROLLOVER_FORM_PATHS.maxSize,
+  ROLLOVER_FORM_PATHS.maxPrimaryShardSize,
+  ROLLOVER_FORM_PATHS.maxPrimaryShardDocs,
+];
 
 export const useRolloverValueRequiredValidation = (): boolean => {
   const [isValid, setIsValid] = useState(false);

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/constants.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/constants.ts
@@ -25,6 +25,11 @@ export const ROLLOVER_FORM_PATHS = {
   maxSize: 'phases.hot.actions.rollover.max_size',
   maxPrimaryShardSize: 'phases.hot.actions.rollover.max_primary_shard_size',
   maxPrimaryShardDocs: 'phases.hot.actions.rollover.max_primary_shard_docs',
+  minDocs: 'phases.hot.actions.rollover.min_docs',
+  minAge: 'phases.hot.actions.rollover.min_age',
+  minSize: 'phases.hot.actions.rollover.min_size',
+  minPrimaryShardSize: 'phases.hot.actions.rollover.min_primary_shard_size',
+  minPrimaryShardDocs: 'phases.hot.actions.rollover.min_primary_shard_docs',
 };
 
 /**

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer.ts
@@ -106,6 +106,26 @@ export const createDeserializer =
         result.phases.hot.actions.rollover.max_age = maxAge.size;
         result._meta.hot.customRollover.maxAgeUnit = maxAge.units;
       }
+
+      if (result.phases.hot.actions.rollover.min_size) {
+        const minSize = splitSizeAndUnits(result.phases.hot.actions.rollover.min_size);
+        result.phases.hot.actions.rollover.min_size = minSize.size;
+        result._meta.hot.customRollover.minStorageSizeUnit = minSize.units;
+      }
+
+      if (result.phases.hot.actions.rollover.min_primary_shard_size) {
+        const minPrimaryShardSize = splitSizeAndUnits(
+          result.phases.hot.actions.rollover.min_primary_shard_size
+        );
+        result.phases.hot.actions.rollover.min_primary_shard_size = minPrimaryShardSize.size;
+        result._meta.hot.customRollover.minPrimaryShardSizeUnit = minPrimaryShardSize.units;
+      }
+
+      if (result.phases.hot.actions.rollover.min_age) {
+        const minAge = splitSizeAndUnits(result.phases.hot.actions.rollover.min_age);
+        result.phases.hot.actions.rollover.min_age = minAge.size;
+        result._meta.hot.customRollover.minAgeUnit = minAge.units;
+      }
     }
     if (result.phases.hot?.actions.shrink?.max_primary_shard_size) {
       const primaryShardSize = splitSizeAndUnits(

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer_and_serializer.test.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer_and_serializer.test.ts
@@ -289,7 +289,6 @@ describe('deserializer and serializer', () => {
 
   it('preserves rollover fields the UI does not manage when using default rollover', () => {
     formInternal._meta.hot.isUsingDefaultRollover = true;
-    formInternal.phases.hot!.actions.rollover!.min_primary_shard_size = '5gb';
     // @ts-expect-error - this is an unknown field that should be preserved by the serializer even when using default rollover
     formInternal.phases.hot!.actions.rollover!.unknown_setting = 123;
 
@@ -299,7 +298,6 @@ describe('deserializer and serializer', () => {
     expect(rollover).toEqual(
       expect.objectContaining({
         ...defaultRolloverAction,
-        min_primary_shard_size: '5gb',
         unknown_setting: 123,
       })
     );
@@ -308,7 +306,7 @@ describe('deserializer and serializer', () => {
     expect(rollover!.max_size).toBeUndefined();
   });
 
-  it('does not drop rollover min_* fields on save when using default rollover', () => {
+  it('does not enable default rollover mode when min_* fields are present', () => {
     const policyWithRolloverMinFields: SerializedPolicy = {
       name: 'policyWithRolloverMinFields',
       phases: {
@@ -331,6 +329,7 @@ describe('deserializer and serializer', () => {
 
     const nextSerializer = createSerializer(cloneDeep(policyWithRolloverMinFields));
     const nextFormInternal = deserializer(cloneDeep(policyWithRolloverMinFields));
+    expect(nextFormInternal._meta.hot.isUsingDefaultRollover).toBe(false);
     const result = nextSerializer(nextFormInternal);
 
     const rollover = result.phases.hot!.actions.rollover!;

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/schema.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/schema.ts
@@ -23,7 +23,21 @@ import {
   downsampleIntervalMultipleOfPreviousOne,
 } from './validations';
 
-const rolloverFormPaths = Object.values(ROLLOVER_FORM_PATHS);
+const rolloverMaxFormPaths = [
+  ROLLOVER_FORM_PATHS.maxDocs,
+  ROLLOVER_FORM_PATHS.maxAge,
+  ROLLOVER_FORM_PATHS.maxSize,
+  ROLLOVER_FORM_PATHS.maxPrimaryShardSize,
+  ROLLOVER_FORM_PATHS.maxPrimaryShardDocs,
+];
+
+const rolloverMinFormPaths = [
+  ROLLOVER_FORM_PATHS.minDocs,
+  ROLLOVER_FORM_PATHS.minAge,
+  ROLLOVER_FORM_PATHS.minSize,
+  ROLLOVER_FORM_PATHS.minPrimaryShardSize,
+  ROLLOVER_FORM_PATHS.minPrimaryShardDocs,
+];
 
 const { emptyField, isInteger, numberGreaterThanField } = fieldValidators;
 
@@ -272,6 +286,15 @@ export const getSchema = (isCloudEnabled: boolean): FormSchema => ({
         maxAgeUnit: {
           defaultValue: 'd',
         },
+        minStorageSizeUnit: {
+          defaultValue: 'gb',
+        },
+        minPrimaryShardSizeUnit: {
+          defaultValue: 'gb',
+        },
+        minAgeUnit: {
+          defaultValue: 'd',
+        },
       },
       bestCompression: {
         label: i18nTexts.editPolicy.bestCompressionFieldLabel,
@@ -431,7 +454,7 @@ export const getSchema = (isCloudEnabled: boolean): FormSchema => ({
                 validator: isInteger({ message: i18nTexts.editPolicy.errors.integerRequired }),
               },
             ],
-            fieldsToValidateOnChange: rolloverFormPaths,
+            fieldsToValidateOnChange: rolloverMaxFormPaths,
           },
           max_docs: {
             label: i18nTexts.editPolicy.maxDocsLabel,
@@ -447,7 +470,7 @@ export const getSchema = (isCloudEnabled: boolean): FormSchema => ({
               },
             ],
             serializer: serializers.stringToNumber,
-            fieldsToValidateOnChange: rolloverFormPaths,
+            fieldsToValidateOnChange: rolloverMaxFormPaths,
           },
           max_primary_shard_size: {
             label: i18nTexts.editPolicy.maxPrimaryShardSizeLabel,
@@ -459,7 +482,7 @@ export const getSchema = (isCloudEnabled: boolean): FormSchema => ({
                 validator: ifExistsNumberGreaterThanZero,
               },
             ],
-            fieldsToValidateOnChange: rolloverFormPaths,
+            fieldsToValidateOnChange: rolloverMaxFormPaths,
           },
           max_primary_shard_docs: {
             label: i18nTexts.editPolicy.maxPrimaryShardDocsLabel,
@@ -475,7 +498,7 @@ export const getSchema = (isCloudEnabled: boolean): FormSchema => ({
               },
             ],
             serializer: serializers.stringToNumber,
-            fieldsToValidateOnChange: rolloverFormPaths,
+            fieldsToValidateOnChange: rolloverMaxFormPaths,
           },
           max_size: {
             label: i18nTexts.editPolicy.maxSizeLabel,
@@ -487,7 +510,63 @@ export const getSchema = (isCloudEnabled: boolean): FormSchema => ({
                 validator: ifExistsNumberGreaterThanZero,
               },
             ],
-            fieldsToValidateOnChange: rolloverFormPaths,
+            fieldsToValidateOnChange: rolloverMaxFormPaths,
+          },
+          min_age: {
+            label: i18nTexts.editPolicy.minRolloverAgeLabel,
+            validations: [
+              {
+                validator: ifExistsNumberGreaterThanZero,
+              },
+              {
+                validator: isInteger({ message: i18nTexts.editPolicy.errors.integerRequired }),
+              },
+            ],
+            fieldsToValidateOnChange: rolloverMinFormPaths,
+          },
+          min_docs: {
+            label: i18nTexts.editPolicy.minRolloverDocsLabel,
+            validations: [
+              {
+                validator: ifExistsNumberGreaterThanZero,
+              },
+              {
+                validator: isInteger({ message: i18nTexts.editPolicy.errors.integerRequired }),
+              },
+            ],
+            serializer: serializers.stringToNumber,
+            fieldsToValidateOnChange: rolloverMinFormPaths,
+          },
+          min_primary_shard_size: {
+            label: i18nTexts.editPolicy.minPrimaryShardSizeLabel,
+            validations: [
+              {
+                validator: ifExistsNumberGreaterThanZero,
+              },
+            ],
+            fieldsToValidateOnChange: rolloverMinFormPaths,
+          },
+          min_primary_shard_docs: {
+            label: i18nTexts.editPolicy.minPrimaryShardDocsLabel,
+            validations: [
+              {
+                validator: ifExistsNumberGreaterThanZero,
+              },
+              {
+                validator: isInteger({ message: i18nTexts.editPolicy.errors.integerRequired }),
+              },
+            ],
+            serializer: serializers.stringToNumber,
+            fieldsToValidateOnChange: rolloverMinFormPaths,
+          },
+          min_size: {
+            label: i18nTexts.editPolicy.minRolloverSizeLabel,
+            validations: [
+              {
+                validator: ifExistsNumberGreaterThanZero,
+              },
+            ],
+            fieldsToValidateOnChange: rolloverMinFormPaths,
           },
         },
         forcemerge: {

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/serializer.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/serializer.ts
@@ -85,19 +85,21 @@ export const createSerializer =
             }
 
             // We are using user-defined, custom rollover settings.
-            if (updatedPolicy.phases.hot?.actions.rollover?.max_age) {
+            const updatedRollover = updatedPolicy.phases.hot?.actions.rollover;
+            const rolloverMeta = hotMeta?.customRollover;
+            if (updatedRollover?.max_age) {
               hotPhaseActions.rollover.max_age = `${hotPhaseActions.rollover.max_age}${
-                hotMeta?.customRollover?.maxAgeUnit ?? ''
+                rolloverMeta?.maxAgeUnit ?? ''
               }`;
             } else {
               delete hotPhaseActions.rollover.max_age;
             }
 
-            if (typeof updatedPolicy.phases.hot?.actions.rollover?.max_docs !== 'number') {
+            if (typeof updatedRollover?.max_docs !== 'number') {
               delete hotPhaseActions.rollover.max_docs;
             }
 
-            if (updatedPolicy.phases.hot?.actions.rollover?.max_primary_shard_size) {
+            if (updatedRollover?.max_primary_shard_size) {
               hotPhaseActions.rollover.max_primary_shard_size = `${
                 hotPhaseActions.rollover.max_primary_shard_size
               }${hotMeta?.customRollover?.maxPrimaryShardSizeUnit ?? ''}`;
@@ -105,18 +107,53 @@ export const createSerializer =
               delete hotPhaseActions.rollover.max_primary_shard_size;
             }
 
-            if (
-              typeof updatedPolicy.phases.hot?.actions.rollover?.max_primary_shard_docs !== 'number'
-            ) {
+            if (typeof updatedRollover?.max_primary_shard_docs !== 'number') {
               delete hotPhaseActions.rollover.max_primary_shard_docs;
             }
 
-            if (updatedPolicy.phases.hot?.actions.rollover?.max_size) {
+            if (updatedRollover?.max_size) {
               hotPhaseActions.rollover.max_size = `${hotPhaseActions.rollover.max_size}${
-                hotMeta?.customRollover?.maxStorageSizeUnit ?? ''
+                rolloverMeta?.maxStorageSizeUnit ?? ''
               }`;
             } else {
               delete hotPhaseActions.rollover.max_size;
+            }
+
+            if (updatedRollover?.min_age) {
+              hotPhaseActions.rollover.min_age = `${updatedRollover.min_age}${
+                rolloverMeta?.minAgeUnit ?? ''
+              }`;
+            } else {
+              delete hotPhaseActions.rollover.min_age;
+            }
+
+            if (typeof updatedRollover?.min_docs === 'number') {
+              hotPhaseActions.rollover.min_docs = updatedRollover.min_docs;
+            } else {
+              delete hotPhaseActions.rollover.min_docs;
+            }
+
+            if (updatedRollover?.min_size) {
+              hotPhaseActions.rollover.min_size = `${updatedRollover.min_size}${
+                rolloverMeta?.minStorageSizeUnit ?? ''
+              }`;
+            } else {
+              delete hotPhaseActions.rollover.min_size;
+            }
+
+            if (updatedRollover?.min_primary_shard_size) {
+              hotPhaseActions.rollover.min_primary_shard_size = `${
+                updatedRollover.min_primary_shard_size
+              }${rolloverMeta?.minPrimaryShardSizeUnit ?? ''}`;
+            } else {
+              delete hotPhaseActions.rollover.min_primary_shard_size;
+            }
+
+            if (typeof updatedRollover?.min_primary_shard_docs === 'number') {
+              hotPhaseActions.rollover.min_primary_shard_docs =
+                updatedRollover.min_primary_shard_docs;
+            } else {
+              delete hotPhaseActions.rollover.min_primary_shard_docs;
             }
           }
 

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/utils.test.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/utils.test.ts
@@ -20,7 +20,7 @@ describe('excludeControlledRolloverThresholds', () => {
     expect(result).toEqual({});
   });
 
-  it('preserves min_* fields', () => {
+  it('removes UI-controlled min_* fields', () => {
     const result = excludeControlledRolloverThresholds({
       max_age: '30d',
       min_age: '1d',
@@ -30,13 +30,7 @@ describe('excludeControlledRolloverThresholds', () => {
       min_primary_shard_docs: 50,
     });
 
-    expect(result).toEqual({
-      min_age: '1d',
-      min_docs: 100,
-      min_size: '10gb',
-      min_primary_shard_size: '5gb',
-      min_primary_shard_docs: 50,
-    });
+    expect(result).toEqual({});
   });
 
   it('preserves unknown fields not managed by the UI', () => {

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/utils.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/utils.ts
@@ -13,12 +13,17 @@ const CONTROLLED_ROLLOVER_THRESHOLDS: ReadonlyArray<string> = [
   'max_primary_shard_size',
   'max_primary_shard_docs',
   'max_size',
+  'min_age',
+  'min_docs',
+  'min_size',
+  'min_primary_shard_size',
+  'min_primary_shard_docs',
 ] satisfies Array<keyof RolloverAction>;
 
 /**
  * When switching to recommended defaults, we intentionally reset the rollover
  * thresholds controlled by the UI, but preserve any additional keys that the
- * UI does not manage (e.g. min_* settings).
+ * UI does not manage.
  */
 export const excludeControlledRolloverThresholds = (rolloverAction: RolloverAction) =>
   Object.entries(rolloverAction).reduce<Record<string, unknown>>((acc, [key, value]) => {

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/validations.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/validations.ts
@@ -60,7 +60,13 @@ export const ROLLOVER_VALUE_REQUIRED_VALIDATION_CODE = 'ROLLOVER_VALUE_REQUIRED_
 
 export const DATA_PHASE_REQUIRED_VALIDATION_CODE = 'DATA_PHASE_REQUIRED_VALIDATION_CODE';
 
-const rolloverFieldPaths = Object.values(ROLLOVER_FORM_PATHS);
+const rolloverMaxFieldPaths = [
+  ROLLOVER_FORM_PATHS.maxDocs,
+  ROLLOVER_FORM_PATHS.maxAge,
+  ROLLOVER_FORM_PATHS.maxSize,
+  ROLLOVER_FORM_PATHS.maxPrimaryShardSize,
+  ROLLOVER_FORM_PATHS.maxPrimaryShardDocs,
+];
 
 /**
  * An ILM policy requires that for rollover a value must be set for one of the threshold values.
@@ -71,7 +77,7 @@ const rolloverFieldPaths = Object.values(ROLLOVER_FORM_PATHS);
 export const rolloverThresholdsValidator: ValidationFunc = ({ form, path }) => {
   const fields = form.getFields();
   // At least one rollover field needs a value specified for this action.
-  const someRolloverFieldHasAValue = rolloverFieldPaths.some((rolloverFieldPath) =>
+  const someRolloverFieldHasAValue = rolloverMaxFieldPaths.some((rolloverFieldPath) =>
     Boolean(fields[rolloverFieldPath]?.value)
   );
   if (!someRolloverFieldHasAValue) {
@@ -97,7 +103,7 @@ export const rolloverThresholdsValidator: ValidationFunc = ({ form, path }) => {
     }
     return errorToReturn;
   } else {
-    rolloverFieldPaths.forEach((rolloverFieldPath) => {
+    rolloverMaxFieldPaths.forEach((rolloverFieldPath) => {
       fields[rolloverFieldPath]?.clearErrors(ROLLOVER_VALUE_REQUIRED_VALIDATION_CODE);
     });
   }

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/i18n_texts.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/i18n_texts.ts
@@ -143,6 +143,18 @@ export const i18nTexts = {
         defaultMessage: 'Maximum docs in the primary shard',
       }
     ),
+    minPrimaryShardSizeLabel: i18n.translate(
+      'xpack.indexLifecycleMgmt.hotPhase.minimumPrimaryShardSizeLabel',
+      {
+        defaultMessage: 'Minimum primary shard size',
+      }
+    ),
+    minPrimaryShardDocsLabel: i18n.translate(
+      'xpack.indexLifecycleMgmt.hotPhase.minimumPrimaryShardDocsLabel',
+      {
+        defaultMessage: 'Minimum docs in the primary shard',
+      }
+    ),
     maxPrimaryShardSizeUnitsLabel: i18n.translate(
       'xpack.indexLifecycleMgmt.editPolicy.maximumPrimaryShardSizeAriaLabel',
       {
@@ -152,12 +164,27 @@ export const i18nTexts = {
     maxAgeLabel: i18n.translate('xpack.indexLifecycleMgmt.hotPhase.maximumAgeLabel', {
       defaultMessage: 'Maximum age',
     }),
+    minRolloverAgeLabel: i18n.translate('xpack.indexLifecycleMgmt.hotPhase.minimumAgeLabel', {
+      defaultMessage: 'Minimum age',
+    }),
     maxDocsLabel: i18n.translate('xpack.indexLifecycleMgmt.hotPhase.maximumDocumentsLabel', {
       defaultMessage: 'Maximum documents',
     }),
+    minRolloverDocsLabel: i18n.translate(
+      'xpack.indexLifecycleMgmt.hotPhase.minimumDocumentsLabel',
+      {
+        defaultMessage: 'Minimum documents',
+      }
+    ),
     maxSizeLabel: i18n.translate('xpack.indexLifecycleMgmt.hotPhase.maximumIndexSizeLabel', {
       defaultMessage: 'Maximum index size',
     }),
+    minRolloverSizeLabel: i18n.translate(
+      'xpack.indexLifecycleMgmt.hotPhase.minimumIndexSizeLabel',
+      {
+        defaultMessage: 'Minimum index size',
+      }
+    ),
     downsampleLabel: i18n.translate('xpack.indexLifecycleMgmt.editPolicy.downsampleTitle', {
       defaultMessage: 'Downsample',
     }),

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/types.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/types.ts
@@ -59,6 +59,9 @@ interface HotPhaseMetaFields extends ForcemergeFields, ShrinkFields, DownsampleF
     enabled: boolean;
     maxPrimaryShardSizeUnit?: string;
     maxAgeUnit?: string;
+    minPrimaryShardSizeUnit?: string;
+    minAgeUnit?: string;
+    minStorageSizeUnit?: string;
 
     /**
      * @deprecated This is the byte size unit for the max_size field which will by removed in version 8+ of the stack.

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/policy_list/policy_flyout/components/rollover.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/policy_list/policy_flyout/components/rollover.tsx
@@ -67,6 +67,51 @@ export const Rollover = ({ phase, phases }: ActionComponentProps) => {
     );
   }
 
+  if (rollover?.min_primary_shard_size) {
+    descriptionItems.push(
+      <>
+        {`${i18nTexts.editPolicy.minPrimaryShardSizeLabel}: `}
+        <strong>{rollover.min_primary_shard_size}</strong>
+      </>
+    );
+  }
+
+  if (rollover?.min_primary_shard_docs) {
+    descriptionItems.push(
+      <>
+        {`${i18nTexts.editPolicy.minPrimaryShardDocsLabel}: `}
+        <strong>{rollover.min_primary_shard_docs}</strong>
+      </>
+    );
+  }
+
+  if (rollover?.min_age) {
+    descriptionItems.push(
+      <>
+        {`${i18nTexts.editPolicy.minRolloverAgeLabel}: `}
+        <strong>{rollover.min_age}</strong>
+      </>
+    );
+  }
+
+  if (rollover?.min_docs) {
+    descriptionItems.push(
+      <>
+        {`${i18nTexts.editPolicy.minRolloverDocsLabel}: `}
+        <strong>{rollover.min_docs}</strong>
+      </>
+    );
+  }
+
+  if (rollover?.min_size) {
+    descriptionItems.push(
+      <>
+        {`${i18nTexts.editPolicy.minRolloverSizeLabel}: `}
+        <strong>{rollover.min_size}</strong>
+      </>
+    );
+  }
+
   return rollover ? (
     <ActionDescription
       title={i18nTexts.editPolicy.rolloverLabel}


### PR DESCRIPTION
Closes #137464
Closes #217860

## Summary

This PR:
  - Added support in the ILM policy editor to configure rollover `min_*` thresholds (age, docs, size, primary shard size/docs) with unit handling,
  - Updated ILM policy schema + serialization/deserialization to round-trip rollover `min_*` settings and their units,
  - Improved “Use recommended defaults” detection to only enable when rollover matches the default settings 1:1 (no extra keys), and added unit tests for this behavior,
  - Updated rollover validation/watch logic to continue requiring at least one `max_*` rollover condition (min-only does not satisfy the requirement),
  - Updated the policy flyout rollover display to include configured `min_*` rollover settings.

### How to test

1. Navigate to Stack Management -> Index Lifecycle Management
2. Press `Create policy` button
3. Configure rollover settings and save
4. Open policy details flyout

### Screenshots

<img width="1728" height="963" alt="Screenshot 2026-05-04 at 12 11 13" src="https://github.com/user-attachments/assets/822e5f89-50dd-4855-9a0b-3a95dc826a68" />

<img width="1727" height="961" alt="Screenshot 2026-05-04 at 12 11 29" src="https://github.com/user-attachments/assets/d3003a24-eea8-4748-af67-b8cdd62f2a2b" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.