### PR TITLE
[Background search] Migrate custom SplitButton to EuiSplitButton

### DIFF
--- a/src/platform/plugins/shared/unified_search/moon.yml
+++ b/src/platform/plugins/shared/unified_search/moon.yml
@@ -53,7 +53,6 @@ dependsOn:
   - '@kbn/field-utils'
   - '@kbn/esql-types'
   - '@kbn/background-search'
-  - '@kbn/split-button'
   - '@kbn/cps'
   - '@kbn/css-utils'
   - '@kbn/kql'

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -43,6 +43,7 @@ import {
   EuiButton,
   EuiButtonIcon,
   EuiIconTip,
+  EuiSplitButton,
   useEuiTheme,
   type EuiTimeZoneDisplayProps,
 } from '@elastic/eui';
@@ -53,7 +54,6 @@ import { UI_SETTINGS } from '@kbn/data-plugin/common';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { ESQLControlVariable, ESQLQueryStats } from '@kbn/esql-types';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { SplitButton } from '@kbn/split-button';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { QueryStringInput, FilterButtonGroup } from '@kbn/kql/public';
 import type { SuggestionsAbstraction, SuggestionsListSize } from '@kbn/kql/public';
@@ -74,8 +74,6 @@ import { FilterBarContextProvider } from '../filter_bar/filter_bar_context';
 
 /** Feature flag key for the new DateRangePicker. Falls back to `true` (new picker). */
 const DATE_RANGE_PICKER_FEATURE_FLAG = 'unifiedSearch.newDateRangePickerEnabled';
-
-const BUTTON_MIN_WIDTH = 108;
 
 const SuperDatePicker = React.memo(
   EuiSuperDatePicker as any
@@ -863,25 +861,27 @@ export const QueryBarTopRow = React.memo(
 
       if (props.useBackgroundSearchButton) {
         return (
-          <SplitButton
-            aria-label={buttonLabelCancel}
-            color="text"
-            data-test-subj="queryCancelButton"
-            iconType="cross"
-            isMainButtonLoading={isCancelling}
-            isDisabled={isCancelling}
-            isSecondaryButtonDisabled={!canSendToBackground}
-            isSecondaryButtonLoading={isSendingToBackground}
-            onClick={onClickCancelButton}
-            onSecondaryButtonClick={onClickSendToBackground}
-            secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
-            secondaryButtonIcon="backgroundTask"
-            secondaryButtonTitle={strings.getSendToBackgroundLabel()}
-            size="s"
-            minWidth={BUTTON_MIN_WIDTH}
-          >
-            {buttonLabelCancel}
-          </SplitButton>
+          <EuiSplitButton color="text" size="s">
+            <EuiSplitButton.ActionPrimary
+              aria-label={buttonLabelCancel}
+              iconType="cross"
+              isLoading={isCancelling}
+              isDisabled={isCancelling}
+              onClick={onClickCancelButton}
+              data-test-subj="queryCancelButton"
+            >
+              {buttonLabelCancel}
+            </EuiSplitButton.ActionPrimary>
+            <EuiSplitButton.ActionSecondary
+              isLoading={isSendingToBackground}
+              isDisabled={!canSendToBackground}
+              onClick={onClickSendToBackground}
+              title={strings.getSendToBackgroundLabel()}
+              aria-label={strings.getSendToBackgroundLabel()}
+              iconType="backgroundTask"
+              data-test-subj="queryCancelButton-secondary-button"
+            />
+          </EuiSplitButton>
         );
       }
 
@@ -955,25 +955,27 @@ export const QueryBarTopRow = React.memo(
       } = getSubmitButtonProps();
 
       const updateButton = props.useBackgroundSearchButton ? (
-        <SplitButton
-          aria-label={buttonAriaLabel}
-          color={buttonColor}
-          data-test-subj="querySubmitButton"
-          iconType={buttonIcon}
-          isDisabled={isDateRangeInvalid || props.isDisabled}
-          isLoading={props.isLoading}
-          isSecondaryButtonDisabled={!canSendToBackground}
-          isSecondaryButtonLoading={isSendingToBackground}
-          onClick={onClickSubmitButton}
-          onSecondaryButtonClick={onClickSendToBackground}
-          secondaryButtonAriaLabel={strings.getSendToBackgroundLabel()}
-          secondaryButtonIcon="backgroundTask"
-          secondaryButtonTitle={strings.getSendToBackgroundLabel()}
-          size="s"
-          minWidth={BUTTON_MIN_WIDTH}
-        >
-          {buttonText}
-        </SplitButton>
+        <EuiSplitButton color={buttonColor} size="s">
+          <EuiSplitButton.ActionPrimary
+            iconType={buttonIcon}
+            isLoading={props.isLoading}
+            isDisabled={isDateRangeInvalid || props.isDisabled}
+            onClick={onClickSubmitButton}
+            aria-label={buttonAriaLabel}
+            data-test-subj="querySubmitButton"
+          >
+            {buttonText}
+          </EuiSplitButton.ActionPrimary>
+          <EuiSplitButton.ActionSecondary
+            iconType="backgroundTask"
+            isLoading={isSendingToBackground}
+            isDisabled={!canSendToBackground}
+            onClick={onClickSendToBackground}
+            title={strings.getSendToBackgroundLabel()}
+            aria-label={strings.getSendToBackgroundLabel()}
+            data-test-subj="querySubmitButton-secondary-button"
+          />
+        </EuiSplitButton>
       ) : (
         <EuiSuperUpdateButton
           iconType={buttonIcon}

--- a/src/platform/plugins/shared/unified_search/tsconfig.json
+++ b/src/platform/plugins/shared/unified_search/tsconfig.json
@@ -41,7 +41,6 @@
     "@kbn/field-utils",
     "@kbn/esql-types",
     "@kbn/background-search",
-    "@kbn/split-button",
     "@kbn/cps",
     "@kbn/css-utils",
     "@kbn/kql",


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/267444

When background search was first implemented we didn't have a split button in EUI so we had to build our own. Now there's already one in EUI so we can just use it instead.

| Before | After |
|--------|------|
| <img width="150" height="41" alt="image" src="https://github.com/user-attachments/assets/1e88ab49-eb25-463a-9e05-9d5ec5f9d44d" /> | <img width="141" height="45" alt="image" src="https://github.com/user-attachments/assets/8977e0bf-3cfc-44e3-938f-07cdb5bc14ee" /> |
| <img width="149" height="41" alt="image" src="https://github.com/user-attachments/assets/c9b79067-0707-43a2-a39a-5aa9033ef3c3" /> | <img width="141" height="41" alt="image" src="https://github.com/user-attachments/assets/7a44f711-f75c-4f24-a010-96ca6c3bf51f" /> |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

