### PR TITLE
[Streams] Ingest flow POC — single-screen graph view

### DIFF
--- a/x-pack/platform/plugins/shared/streams/common/flow/index.ts
+++ b/x-pack/platform/plugins/shared/streams/common/flow/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './types';

--- a/x-pack/platform/plugins/shared/streams/common/flow/types.ts
+++ b/x-pack/platform/plugins/shared/streams/common/flow/types.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+
+// ── Shared atoms ─────────────────────────────────────────────────────────────
+
+export const flowHealthSchema = z.object({
+  status: z.enum(['healthy', 'degraded', 'down', 'unknown']),
+  message: z.string().optional(),
+});
+
+export type FlowHealth = z.infer<typeof flowHealthSchema>;
+
+export const flowThroughputSchema = z.object({
+  docsPerSec: z.number().nonnegative(),
+  bytesPerSec: z.number().nonnegative().optional(),
+});
+
+export type FlowThroughput = z.infer<typeof flowThroughputSchema>;
+
+export const flowFailureRateSchema = z.object({
+  docsPerSec: z.number().nonnegative(),
+  lastSeenAt: z.number().int().optional(), // epoch ms
+});
+
+export type FlowFailureRate = z.infer<typeof flowFailureRateSchema>;
+
+// ── Node discriminated union ─────────────────────────────────────────────────
+
+const flowNodeBase = z.object({
+  id: z.string(),
+  label: z.string(),
+  column: z.enum(['shippers', 'endpoints', 'streams']),
+  lane: z.enum(['agents', 'agentless', 'prometheus', 'pipelines', 'bulk', 'streams']),
+  parentId: z.string().optional(),
+  health: flowHealthSchema.optional(),
+  throughput: flowThroughputSchema.optional(),
+});
+
+export const flowNodeSchema = z.discriminatedUnion('kind', [
+  flowNodeBase.extend({
+    kind: z.literal('agent'),
+    agentId: z.string(),
+    policyId: z.string(),
+    hostname: z.string(),
+    version: z.string(),
+    agentStatus: z.string(),
+  }),
+  flowNodeBase.extend({
+    kind: z.literal('agentPolicy'),
+    policyId: z.string(),
+    agentCount: z.number().int(),
+  }),
+  flowNodeBase.extend({
+    kind: z.literal('agentlessIntegration'),
+    packagePolicyId: z.string(),
+    packageName: z.string(),
+    packageTitle: z.string(),
+    autoPolicyId: z.string(),
+  }),
+  flowNodeBase.extend({
+    kind: z.literal('prometheusScraper'),
+    scraperId: z.string(),
+    targetHost: z.string(),
+    scrapeIntervalSec: z.number().int(),
+  }),
+  flowNodeBase.extend({
+    kind: z.literal('cloudPipeline'),
+    pipelineId: z.string(),
+    targetStreamName: z.string().optional(),
+  }),
+  flowNodeBase.extend({
+    kind: z.literal('bulkEndpoint'),
+    url: z.string().optional(),
+  }),
+  flowNodeBase.extend({
+    kind: z.literal('wiredStream'),
+    streamName: z.string(),
+    processingStepCount: z.number().int(),
+    routingRuleCount: z.number().int(),
+    failureRate: flowFailureRateSchema.optional(),
+  }),
+  flowNodeBase.extend({
+    kind: z.literal('classicStream'),
+    streamName: z.string(),
+    dataStream: z.string(),
+    failureRate: flowFailureRateSchema.optional(),
+  }),
+]);
+
+export type FlowNode = z.infer<typeof flowNodeSchema>;
+
+// ── Edge schema ──────────────────────────────────────────────────────────────
+
+export const flowEdgeSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  target: z.string(),
+  kind: z.enum([
+    'agent->endpoint',
+    'agent->pipeline',
+    'agentless->endpoint',
+    'prometheus->pipeline',
+    'prometheus->endpoint',
+    'pipeline->stream',
+    'bulk->stream',
+    'stream->stream',
+  ]),
+  routingRuleId: z.string().optional(),
+  isMock: z.boolean().optional(),
+  health: flowHealthSchema.optional(),
+  throughput: flowThroughputSchema.optional(),
+});
+
+export type FlowEdge = z.infer<typeof flowEdgeSchema>;
+
+// ── Top-level payload ────────────────────────────────────────────────────────
+
+export const flowGraphPayloadSchema = z.object({
+  nodes: z.array(flowNodeSchema),
+  edges: z.array(flowEdgeSchema),
+  meta: z.object({
+    generatedAt: z.number().int(),
+    fleetAvailable: z.boolean(),
+    cloudPipelinesMock: z.literal(true),
+    prometheusMock: z.literal(true),
+    timeWindow: z.object({ start: z.number().int(), end: z.number().int() }),
+  }),
+});
+
+export type FlowGraphPayload = z.infer<typeof flowGraphPayloadSchema>;
+
+export const flowThroughputPayloadSchema = z.object({
+  perNode: z.record(z.string(), flowThroughputSchema),
+  perNodeFailureRate: z.record(z.string(), flowFailureRateSchema),
+  perNodeHealth: z.record(z.string(), flowHealthSchema),
+  perEdge: z.record(z.string(), flowThroughputSchema),
+  generatedAt: z.number().int(),
+});
+
+export type FlowThroughputPayload = z.infer<typeof flowThroughputPayloadSchema>;

--- a/x-pack/platform/plugins/shared/streams/common/index.ts
+++ b/x-pack/platform/plugins/shared/streams/common/index.ts
@@ -48,3 +48,21 @@ export {
 } from './get_streams_location/get_streams_location';
 
 export type { StreamSummary } from './stream_summary';
+export {
+  flowHealthSchema,
+  flowThroughputSchema,
+  flowFailureRateSchema,
+  flowNodeSchema,
+  flowEdgeSchema,
+  flowGraphPayloadSchema,
+  flowThroughputPayloadSchema,
+} from './flow';
+export type {
+  FlowHealth,
+  FlowThroughput,
+  FlowFailureRate,
+  FlowNode,
+  FlowEdge,
+  FlowGraphPayload,
+  FlowThroughputPayload,
+} from './flow';

--- a/x-pack/platform/plugins/shared/streams/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/streams/kibana.jsonc
@@ -32,6 +32,7 @@
       "agentBuilder",
       "cloud",
       "esql",
+      "fleet",
       "serverless",
       "globalSearch",
       "searchInferenceEndpoints",

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/client.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { generatePipelineMetrics } from './metrics';
+import type { CloudPipelinesStore } from './storage';
+import type { ICloudPipelinesClient, OtlpEndpointConfig, PipelineMetricsResult } from './types';
+
+export class CloudPipelinesMockClient implements ICloudPipelinesClient {
+  constructor(private readonly store: CloudPipelinesStore) {}
+
+  async list(): Promise<OtlpEndpointConfig[]> {
+    return this.store.list();
+  }
+
+  async get(id: string): Promise<OtlpEndpointConfig | undefined> {
+    return this.store.get(id);
+  }
+
+  async create(
+    input: Omit<OtlpEndpointConfig, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<OtlpEndpointConfig> {
+    return this.store.create(input);
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Omit<OtlpEndpointConfig, 'id' | 'createdAt'>>
+  ): Promise<OtlpEndpointConfig> {
+    return this.store.update(id, patch);
+  }
+
+  async delete(id: string): Promise<void> {
+    return this.store.delete(id);
+  }
+
+  async duplicate(id: string): Promise<OtlpEndpointConfig> {
+    return this.store.duplicate(id);
+  }
+
+  async getMetrics(now: number, availableStreamNames: string[]): Promise<PipelineMetricsResult> {
+    const pipelines = this.store.list();
+    return generatePipelineMetrics(pipelines, now, availableStreamNames);
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/metrics.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/metrics.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { hashString, noisyRate, seededHealth, seededRandom } from '../shared/seeded_noise';
+import type {
+  OtlpEdgeThroughput,
+  OtlpEndpointConfig,
+  OtlpEndpointHealth,
+  OtlpEndpointThroughput,
+  PipelineMetricsResult,
+} from './types';
+
+export const generatePipelineMetrics = (
+  pipelines: OtlpEndpointConfig[],
+  now: number,
+  availableStreamNames: string[]
+): PipelineMetricsResult => {
+  const bucketTime = Math.floor(now / 5000);
+
+  const perPipeline: Record<string, OtlpEndpointThroughput> = {};
+  const perEdge: Record<string, OtlpEdgeThroughput> = {};
+  const health: Record<string, OtlpEndpointHealth> = {};
+
+  for (const pipeline of pipelines) {
+    const { id } = pipeline;
+
+    // Base rate: 200–2200 docs/sec range
+    const baseRate = seededRandom(hashString(id)) * 2000 + 200;
+    const docsPerSec = noisyRate(baseRate, id, bucketTime);
+    const bytesPerSec = docsPerSec * (500 + seededRandom(hashString(`${id}:bytes`)) * 300);
+
+    const status = seededHealth(id, bucketTime);
+
+    perPipeline[id] = { id, docsPerSec, bytesPerSec };
+    health[id] = { id, status };
+
+    // Edge distribution
+    if (pipeline.targetStreamName) {
+      const edgeKey = `${id}->${pipeline.targetStreamName}`;
+      perEdge[edgeKey] = {
+        endpointId: id,
+        streamName: pipeline.targetStreamName,
+        docsPerSec,
+      };
+    } else if (availableStreamNames.length > 0) {
+      // Distribute evenly across first 2 available streams
+      const targets = availableStreamNames.slice(0, 2);
+      const docsPerStream = docsPerSec / targets.length;
+      for (const streamName of targets) {
+        const edgeKey = `${id}->${streamName}`;
+        perEdge[edgeKey] = {
+          endpointId: id,
+          streamName,
+          docsPerSec: docsPerStream,
+        };
+      }
+    }
+  }
+
+  return { perPipeline, perEdge, health };
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/seed.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/seed.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CloudPipelinesStore } from './storage';
+
+export const seedCloudPipelines = (store: CloudPipelinesStore): void => {
+  if (!store.isEmpty()) {
+    return;
+  }
+
+  store.create({ name: 'EU West 1 OTLP', targetStreamName: 'logs' });
+  store.create({ name: 'US East 1 OTLP', targetStreamName: 'logs.app' });
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/seed.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/seed.ts
@@ -12,6 +12,8 @@ export const seedCloudPipelines = (store: CloudPipelinesStore): void => {
     return;
   }
 
-  store.create({ name: 'EU West 1 OTLP', targetStreamName: 'logs' });
-  store.create({ name: 'US East 1 OTLP', targetStreamName: 'logs.app' });
+  // No targetStreamName — the graph assembler will assign real root streams
+  // at render time via round-robin fallback, so numbers always match real data.
+  store.create({ name: 'EU West 1 OTLP' });
+  store.create({ name: 'US East 1 OTLP' });
 };

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/storage.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/storage.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { randomUUID } from 'crypto';
+import type { OtlpEndpointConfig } from './types';
+
+export class CloudPipelinesStore {
+  private readonly store = new Map<string, OtlpEndpointConfig>();
+
+  list(): OtlpEndpointConfig[] {
+    return Array.from(this.store.values());
+  }
+
+  get(id: string): OtlpEndpointConfig | undefined {
+    return this.store.get(id);
+  }
+
+  create(input: Omit<OtlpEndpointConfig, 'id' | 'createdAt' | 'updatedAt'>): OtlpEndpointConfig {
+    const now = Date.now();
+    const config: OtlpEndpointConfig = {
+      ...input,
+      id: randomUUID(),
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.store.set(config.id, config);
+    return config;
+  }
+
+  update(
+    id: string,
+    patch: Partial<Omit<OtlpEndpointConfig, 'id' | 'createdAt'>>
+  ): OtlpEndpointConfig {
+    const existing = this.store.get(id);
+    if (!existing) {
+      throw new Error(`Cloud pipeline with id "${id}" not found`);
+    }
+    const updated: OtlpEndpointConfig = {
+      ...existing,
+      ...patch,
+      id: existing.id,
+      createdAt: existing.createdAt,
+      updatedAt: Date.now(),
+    };
+    this.store.set(id, updated);
+    return updated;
+  }
+
+  delete(id: string): void {
+    if (!this.store.has(id)) {
+      throw new Error(`Cloud pipeline with id "${id}" not found`);
+    }
+    this.store.delete(id);
+  }
+
+  duplicate(id: string): OtlpEndpointConfig {
+    const existing = this.store.get(id);
+    if (!existing) {
+      throw new Error(`Cloud pipeline with id "${id}" not found`);
+    }
+    return this.create({
+      name: `${existing.name} (copy)`,
+      targetStreamName: existing.targetStreamName,
+    });
+  }
+
+  isEmpty(): boolean {
+    return this.store.size === 0;
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/cloud_pipelines/types.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface OtlpEndpointConfig {
+  id: string;
+  name: string;
+  targetStreamName?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface OtlpEndpointHealth {
+  id: string;
+  status: 'healthy' | 'degraded' | 'down';
+  message?: string;
+}
+
+export interface OtlpEndpointThroughput {
+  id: string;
+  docsPerSec: number;
+  bytesPerSec?: number;
+}
+
+export interface OtlpEdgeThroughput {
+  endpointId: string;
+  streamName: string;
+  docsPerSec: number;
+}
+
+export interface PipelineMetricsResult {
+  perPipeline: Record<string, OtlpEndpointThroughput>;
+  perEdge: Record<string, OtlpEdgeThroughput>; // key: `${endpointId}->${streamName}`
+  health: Record<string, OtlpEndpointHealth>;
+}
+
+export interface ICloudPipelinesClient {
+  list(): Promise<OtlpEndpointConfig[]>;
+  get(id: string): Promise<OtlpEndpointConfig | undefined>;
+  create(
+    input: Omit<OtlpEndpointConfig, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<OtlpEndpointConfig>;
+  update(
+    id: string,
+    patch: Partial<Omit<OtlpEndpointConfig, 'id' | 'createdAt'>>
+  ): Promise<OtlpEndpointConfig>;
+  delete(id: string): Promise<void>;
+  duplicate(id: string): Promise<OtlpEndpointConfig>;
+  getMetrics(now: number, availableStreamNames: string[]): Promise<PipelineMetricsResult>;
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type {
+  ICloudPipelinesClient,
+  OtlpEdgeThroughput,
+  OtlpEndpointConfig,
+  OtlpEndpointHealth,
+  OtlpEndpointThroughput,
+  PipelineMetricsResult,
+} from './cloud_pipelines/types';
+export { CloudPipelinesMockClient } from './cloud_pipelines/client';
+export { CloudPipelinesStore } from './cloud_pipelines/storage';
+export { seedCloudPipelines } from './cloud_pipelines/seed';
+
+export type {
+  IPrometheusMockClient,
+  PrometheusScraper,
+  PrometheusScraperHealth,
+  ScraperMetricsResult,
+} from './prometheus/types';
+export { PrometheusMockClient } from './prometheus/client';
+export { PrometheusStore } from './prometheus/storage';
+export { seedPrometheusScrapers } from './prometheus/seed';

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/client.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { generateScraperMetrics } from './metrics';
+import type { PrometheusStore } from './storage';
+import type { IPrometheusMockClient, PrometheusScraper, ScraperMetricsResult } from './types';
+
+export class PrometheusMockClient implements IPrometheusMockClient {
+  constructor(private readonly store: PrometheusStore) {}
+
+  async list(): Promise<PrometheusScraper[]> {
+    return this.store.list();
+  }
+
+  async get(id: string): Promise<PrometheusScraper | undefined> {
+    return this.store.get(id);
+  }
+
+  async create(
+    input: Omit<PrometheusScraper, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<PrometheusScraper> {
+    return this.store.create(input);
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Omit<PrometheusScraper, 'id' | 'createdAt'>>
+  ): Promise<PrometheusScraper> {
+    return this.store.update(id, patch);
+  }
+
+  async delete(id: string): Promise<void> {
+    return this.store.delete(id);
+  }
+
+  async getMetrics(now: number): Promise<ScraperMetricsResult> {
+    const scrapers = this.store.list();
+    return generateScraperMetrics(scrapers, now);
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/metrics.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/metrics.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { hashString, noisyRate, seededHealth, seededRandom } from '../shared/seeded_noise';
+import type { PrometheusScraperHealth, ScraperMetricsResult } from './types';
+import type { PrometheusScraper } from './types';
+
+export const generateScraperMetrics = (
+  scrapers: PrometheusScraper[],
+  now: number
+): ScraperMetricsResult => {
+  const bucketTime = Math.floor(now / 5000);
+
+  const perScraper: Record<string, { docsPerSec: number; bytesPerSec: number }> = {};
+  const health: Record<string, PrometheusScraperHealth> = {};
+
+  for (const scraper of scrapers) {
+    const { id, scrapeIntervalSec } = scraper;
+
+    // Base docs/sec derived from scrape interval — higher frequency = more docs
+    const intervalFactor = 60 / scrapeIntervalSec; // 15s→4, 30s→2, 60s→1
+    const baseRate = seededRandom(hashString(id)) * 400 * intervalFactor + 50;
+    const docsPerSec = noisyRate(baseRate, id, bucketTime);
+    const bytesPerSec = docsPerSec * (200 + seededRandom(hashString(`${id}:bytes`)) * 150);
+
+    const status = seededHealth(id, bucketTime);
+
+    perScraper[id] = { docsPerSec, bytesPerSec };
+    health[id] = { id, status };
+  }
+
+  return { perScraper, health };
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/seed.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/seed.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CloudPipelinesStore } from '../cloud_pipelines/storage';
+import type { PrometheusStore } from './storage';
+
+export const seedPrometheusScrapers = (
+  store: PrometheusStore,
+  cloudPipelinesStore: CloudPipelinesStore
+): void => {
+  if (!store.isEmpty()) {
+    return;
+  }
+
+  // Wire k8s cluster to the first seeded cloud pipeline if available
+  const pipelines = cloudPipelinesStore.list();
+  const firstPipelineId = pipelines[0]?.id ?? '';
+
+  store.create({
+    name: 'k8s-cluster-prod',
+    targetHost: 'prometheus.svc.cluster.local:9090',
+    scrapeIntervalSec: 15,
+    destination: { kind: 'cloudPipeline', pipelineId: firstPipelineId },
+  });
+
+  store.create({
+    name: 'vm-fleet-staging',
+    targetHost: '10.0.0.45:9090',
+    scrapeIntervalSec: 30,
+    destination: { kind: 'bulkEndpoint' },
+  });
+
+  store.create({
+    name: 'legacy-app-metrics',
+    targetHost: 'legacy.internal:9090',
+    scrapeIntervalSec: 60,
+    destination: { kind: 'bulkEndpoint' },
+  });
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/storage.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/storage.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { randomUUID } from 'crypto';
+import type { PrometheusScraper } from './types';
+
+export class PrometheusStore {
+  private readonly store = new Map<string, PrometheusScraper>();
+
+  list(): PrometheusScraper[] {
+    return Array.from(this.store.values());
+  }
+
+  get(id: string): PrometheusScraper | undefined {
+    return this.store.get(id);
+  }
+
+  create(input: Omit<PrometheusScraper, 'id' | 'createdAt' | 'updatedAt'>): PrometheusScraper {
+    const now = Date.now();
+    const scraper: PrometheusScraper = {
+      ...input,
+      id: randomUUID(),
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.store.set(scraper.id, scraper);
+    return scraper;
+  }
+
+  update(
+    id: string,
+    patch: Partial<Omit<PrometheusScraper, 'id' | 'createdAt'>>
+  ): PrometheusScraper {
+    const existing = this.store.get(id);
+    if (!existing) {
+      throw new Error(`Prometheus scraper with id "${id}" not found`);
+    }
+    const updated: PrometheusScraper = {
+      ...existing,
+      ...patch,
+      id: existing.id,
+      createdAt: existing.createdAt,
+      updatedAt: Date.now(),
+    };
+    this.store.set(id, updated);
+    return updated;
+  }
+
+  delete(id: string): void {
+    if (!this.store.has(id)) {
+      throw new Error(`Prometheus scraper with id "${id}" not found`);
+    }
+    this.store.delete(id);
+  }
+
+  isEmpty(): boolean {
+    return this.store.size === 0;
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/prometheus/types.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface PrometheusScraper {
+  id: string;
+  name: string;
+  targetHost: string;
+  scrapeIntervalSec: 15 | 30 | 60;
+  destination: { kind: 'cloudPipeline'; pipelineId: string } | { kind: 'bulkEndpoint' };
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PrometheusScraperHealth {
+  id: string;
+  status: 'healthy' | 'degraded' | 'down';
+  message?: string;
+}
+
+export interface ScraperMetricsResult {
+  perScraper: Record<string, { docsPerSec: number; bytesPerSec: number }>;
+  health: Record<string, PrometheusScraperHealth>;
+}
+
+export interface IPrometheusMockClient {
+  list(): Promise<PrometheusScraper[]>;
+  get(id: string): Promise<PrometheusScraper | undefined>;
+  create(
+    input: Omit<PrometheusScraper, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<PrometheusScraper>;
+  update(
+    id: string,
+    patch: Partial<Omit<PrometheusScraper, 'id' | 'createdAt'>>
+  ): Promise<PrometheusScraper>;
+  delete(id: string): Promise<void>;
+  getMetrics(now: number): Promise<ScraperMetricsResult>;
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/shared/seeded_noise.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/shared/seeded_noise.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Returns a deterministic pseudo-random float in [0, 1) given an integer seed.
+ * Uses a Park-Miller LCG to avoid bitwise operators.
+ */
+export const seededRandom = (seed: number): number => {
+  // Park-Miller LCG: x_{n+1} = (a * x_n) mod m
+  // a = 16807, m = 2147483647 (Mersenne prime)
+  const a = 16807;
+  const m = 2147483647;
+  const s = (((Math.abs(seed) % (m - 1)) + 1) * a) % m;
+  return (s - 1) / (m - 1);
+};
+
+/**
+ * Hash a string to an integer using djb2-style polynomial rolling hash (no bitwise ops).
+ */
+export const hashString = (str: string): number => {
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = h * 33 + str.charCodeAt(i);
+    // Keep in safe integer range using modulo
+    h = h % 2147483647;
+  }
+  return Math.abs(h);
+};
+
+/**
+ * Returns a noisy rate: baseRate * (0.8 + 0.4 * sin(bucketTime * phase))
+ * bucketTime = Math.floor(Date.now() / 5000) — changes every 5 seconds.
+ * Deterministic: same id + same bucketTime → same result.
+ */
+export const noisyRate = (baseRate: number, id: string, bucketTime: number): number => {
+  const phase = seededRandom(hashString(id)) * Math.PI * 2;
+  const sinVal = Math.sin(bucketTime * 0.3 + phase);
+  return baseRate * (0.8 + 0.4 * ((sinVal + 1) / 2)); // maps sin [-1,1] → multiplier [0.8, 1.2]
+};
+
+/**
+ * Returns a health status, seeded so it's stable within a 5s bucket.
+ * ~88% healthy, ~10% degraded, ~2% down.
+ */
+export const seededHealth = (id: string, bucketTime: number): 'healthy' | 'degraded' | 'down' => {
+  const combined = hashString(`${id}:${bucketTime}`);
+  const r = seededRandom(combined);
+  if (r < 0.02) return 'down';
+  if (r < 0.12) return 'degraded';
+  return 'healthy';
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/flow/assemble_flow_graph.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/flow/assemble_flow_graph.ts
@@ -1,0 +1,538 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { WiredStream, ClassicStream } from '@kbn/streams-schema';
+import type { Streams } from '@kbn/streams-schema';
+import type { StreamDocsStat } from '../../../../common';
+import type {
+  FlowEdge,
+  FlowGraphPayload,
+  FlowNode,
+  FlowThroughputPayload,
+} from '../../../../common/flow/types';
+import type {
+  OtlpEndpointConfig,
+  PipelineMetricsResult,
+} from '../../mock_ingest_sources/cloud_pipelines/types';
+import type {
+  PrometheusScraper,
+  ScraperMetricsResult,
+} from '../../mock_ingest_sources/prometheus/types';
+
+// ── Fleet types (minimal shape, avoids tight coupling to fleet internals) ─────
+
+interface FleetAgent {
+  id: string;
+  policy_id?: string | null;
+  status?: string;
+  local_metadata: Record<string, unknown>;
+  agent?: { id?: string; version?: string };
+}
+
+interface FleetAgentPolicyPackagePolicy {
+  id: string;
+  name: string;
+  package?: { name?: string; title?: string };
+  policy_id?: string | null;
+  policy_ids?: string[];
+}
+
+interface FleetAgentPolicy {
+  id: string;
+  name: string;
+  supports_agentless?: boolean | null;
+  agents?: number;
+  package_policies?: FleetAgentPolicyPackagePolicy[];
+}
+
+// ── Input shape ───────────────────────────────────────────────────────────────
+
+export interface AssembleFlowGraphInputs {
+  streams: Array<{ stream: Streams.all.Definition; exists: boolean }>;
+  streamDocCounts: StreamDocsStat[];
+  streamFailedCounts: StreamDocsStat[];
+  windowSeconds: number;
+  agents: FleetAgent[];
+  agentPolicies: FleetAgentPolicy[];
+  cloudPipelines: OtlpEndpointConfig[];
+  cloudPipelineMetrics: PipelineMetricsResult;
+  prometheusScrapers: PrometheusScraper[];
+  prometheusMetrics: ScraperMetricsResult;
+  fleetAvailable: boolean;
+  now: number;
+}
+
+// ── Helper: build a map from stream name → doc count ─────────────────────────
+
+const buildCountMap = (stats: StreamDocsStat[]): Map<string, number> => {
+  const map = new Map<string, number>();
+  for (const { stream, count } of stats) {
+    map.set(stream, count);
+  }
+  return map;
+};
+
+// ── Main assembler ────────────────────────────────────────────────────────────
+
+export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowGraphPayload => {
+  const {
+    streams,
+    streamDocCounts,
+    streamFailedCounts,
+    windowSeconds,
+    agents,
+    agentPolicies,
+    cloudPipelines,
+    cloudPipelineMetrics,
+    prometheusScrapers,
+    prometheusMetrics,
+    fleetAvailable,
+    now,
+  } = inputs;
+
+  const nodes: FlowNode[] = [];
+  const edges: FlowEdge[] = [];
+
+  const docCountMap = buildCountMap(streamDocCounts);
+  const failedCountMap = buildCountMap(streamFailedCounts);
+
+  const BULK_ENDPOINT_ID = 'bulk-endpoint';
+
+  // ── Separate agentless policies from regular ones ─────────────────────────
+  const agentlessPolicies = agentPolicies.filter((p) => p.supports_agentless === true);
+  const regularPolicies = agentPolicies.filter((p) => !p.supports_agentless);
+
+  // ── Build policy group nodes + agent nodes ────────────────────────────────
+  for (const policy of regularPolicies) {
+    const policyNodeId = `agent-policy-${policy.id}`;
+    const policyAgents = agents.filter((a) => a.policy_id === policy.id);
+
+    nodes.push({
+      kind: 'agentPolicy',
+      id: policyNodeId,
+      label: policy.name,
+      column: 'shippers',
+      lane: 'agents',
+      policyId: policy.id,
+      agentCount: policy.agents ?? policyAgents.length,
+    });
+
+    for (const agent of policyAgents) {
+      const localMeta = agent.local_metadata;
+      const hostMeta = localMeta.host as Record<string, unknown> | undefined;
+      const elasticMeta = localMeta.elastic as Record<string, unknown> | undefined;
+      const agentMeta = elasticMeta?.agent as Record<string, unknown> | undefined;
+
+      const hostname =
+        (hostMeta?.hostname as string | undefined) ??
+        (agent.agent?.id as string | undefined) ??
+        agent.id;
+      const version =
+        (agentMeta?.version as string | undefined) ??
+        (agent.agent?.version as string | undefined) ??
+        'unknown';
+      const agentStatus = agent.status ?? 'unknown';
+
+      nodes.push({
+        kind: 'agent',
+        id: `agent-${agent.id}`,
+        label: hostname,
+        column: 'shippers',
+        lane: 'agents',
+        parentId: policyNodeId,
+        agentId: agent.id,
+        policyId: policy.id,
+        hostname,
+        version,
+        agentStatus,
+        health: { status: mapAgentStatusToHealth(agentStatus) },
+      });
+    }
+  }
+
+  // ── Agentless integration nodes ───────────────────────────────────────────
+  for (const policy of agentlessPolicies) {
+    const pkgPolicies = policy.package_policies ?? [];
+    for (const pkgPolicy of pkgPolicies) {
+      const nodeId = `agentless-${pkgPolicy.id}`;
+      nodes.push({
+        kind: 'agentlessIntegration',
+        id: nodeId,
+        label: pkgPolicy.package?.title ?? pkgPolicy.name,
+        column: 'shippers',
+        lane: 'agentless',
+        packagePolicyId: pkgPolicy.id,
+        packageName: pkgPolicy.package?.name ?? '',
+        packageTitle: pkgPolicy.package?.title ?? pkgPolicy.name,
+        autoPolicyId: policy.id,
+      });
+    }
+  }
+
+  // ── Cloud pipeline nodes ──────────────────────────────────────────────────
+  for (const pipeline of cloudPipelines) {
+    const pipelineNodeId = `cloud-pipeline-${pipeline.id}`;
+    const pipelineThroughput = cloudPipelineMetrics.perPipeline[pipeline.id];
+    const pipelineHealth = cloudPipelineMetrics.health[pipeline.id];
+
+    nodes.push({
+      kind: 'cloudPipeline',
+      id: pipelineNodeId,
+      label: pipeline.name,
+      column: 'endpoints',
+      lane: 'pipelines',
+      pipelineId: pipeline.id,
+      targetStreamName: pipeline.targetStreamName,
+      throughput: pipelineThroughput
+        ? { docsPerSec: pipelineThroughput.docsPerSec, bytesPerSec: pipelineThroughput.bytesPerSec }
+        : undefined,
+      health: pipelineHealth
+        ? { status: pipelineHealth.status, message: pipelineHealth.message }
+        : undefined,
+    });
+  }
+
+  // ── Bulk endpoint node ────────────────────────────────────────────────────
+  nodes.push({
+    kind: 'bulkEndpoint',
+    id: BULK_ENDPOINT_ID,
+    label: 'ES Bulk',
+    column: 'endpoints',
+    lane: 'bulk',
+  });
+
+  // ── Prometheus scraper nodes ──────────────────────────────────────────────
+  for (const scraper of prometheusScrapers) {
+    const scraperNodeId = `prom-scraper-${scraper.id}`;
+    const scraperThroughput = prometheusMetrics.perScraper[scraper.id];
+    const scraperHealth = prometheusMetrics.health[scraper.id];
+
+    nodes.push({
+      kind: 'prometheusScraper',
+      id: scraperNodeId,
+      label: scraper.name,
+      column: 'shippers',
+      lane: 'prometheus',
+      scraperId: scraper.id,
+      targetHost: scraper.targetHost,
+      scrapeIntervalSec: scraper.scrapeIntervalSec,
+      throughput: scraperThroughput
+        ? { docsPerSec: scraperThroughput.docsPerSec, bytesPerSec: scraperThroughput.bytesPerSec }
+        : undefined,
+      health: scraperHealth
+        ? { status: scraperHealth.status, message: scraperHealth.message }
+        : undefined,
+    });
+  }
+
+  // ── Stream nodes ──────────────────────────────────────────────────────────
+  const streamNodeIdByName = new Map<string, string>();
+
+  for (const { stream } of streams) {
+    const streamNodeId = `stream-${stream.name}`;
+    streamNodeIdByName.set(stream.name, streamNodeId);
+
+    const rawDocCount = docCountMap.get(stream.name) ?? 0;
+    const rawFailedCount = failedCountMap.get(stream.name) ?? 0;
+    const docsPerSec = windowSeconds > 0 ? rawDocCount / windowSeconds : 0;
+    const failedDocsPerSec = windowSeconds > 0 ? rawFailedCount / windowSeconds : 0;
+
+    if (WiredStream.Definition.is(stream)) {
+      const parentName = getParentStreamName(stream.name);
+      const parentId = parentName ? `stream-${parentName}` : undefined;
+
+      nodes.push({
+        kind: 'wiredStream',
+        id: streamNodeId,
+        label: stream.name,
+        column: 'streams',
+        lane: 'streams',
+        parentId,
+        streamName: stream.name,
+        processingStepCount: stream.ingest.processing.steps?.length ?? 0,
+        routingRuleCount: stream.ingest.wired.routing.length,
+        throughput: { docsPerSec },
+        failureRate:
+          rawFailedCount > 0 ? { docsPerSec: failedDocsPerSec, lastSeenAt: now } : undefined,
+      });
+    } else if (ClassicStream.Definition.is(stream)) {
+      nodes.push({
+        kind: 'classicStream',
+        id: streamNodeId,
+        label: stream.name,
+        column: 'streams',
+        lane: 'streams',
+        streamName: stream.name,
+        dataStream: stream.name,
+        throughput: { docsPerSec },
+        failureRate:
+          rawFailedCount > 0 ? { docsPerSec: failedDocsPerSec, lastSeenAt: now } : undefined,
+      });
+    }
+  }
+
+  // ── Wired stream → stream edges (routing rules) ───────────────────────────
+  for (const { stream } of streams) {
+    if (!WiredStream.Definition.is(stream)) continue;
+
+    const sourceNodeId = streamNodeIdByName.get(stream.name);
+    if (!sourceNodeId) continue;
+
+    for (const rule of stream.ingest.wired.routing) {
+      const targetNodeId = streamNodeIdByName.get(rule.destination);
+      if (!targetNodeId) continue;
+
+      edges.push({
+        id: `stream-edge-${stream.name}->${rule.destination}`,
+        source: sourceNodeId,
+        target: targetNodeId,
+        kind: 'stream->stream',
+        routingRuleId: rule.destination,
+      });
+    }
+  }
+
+  // ── Cloud pipeline → stream edges ────────────────────────────────────────
+  for (const pipeline of cloudPipelines) {
+    const pipelineNodeId = `cloud-pipeline-${pipeline.id}`;
+    if (pipeline.targetStreamName) {
+      const targetStreamNodeId = streamNodeIdByName.get(pipeline.targetStreamName);
+      if (targetStreamNodeId) {
+        const edgeKey = `${pipeline.id}->${pipeline.targetStreamName}`;
+        const edgeThroughput = cloudPipelineMetrics.perEdge[edgeKey];
+
+        edges.push({
+          id: `pipeline-stream-edge-${pipeline.id}->${pipeline.targetStreamName}`,
+          source: pipelineNodeId,
+          target: targetStreamNodeId,
+          kind: 'pipeline->stream',
+          isMock: true,
+          throughput: edgeThroughput ? { docsPerSec: edgeThroughput.docsPerSec } : undefined,
+        });
+      }
+    }
+  }
+
+  // ── Bulk endpoint → stream edges (classic streams go via bulk) ────────────
+  for (const { stream } of streams) {
+    if (!ClassicStream.Definition.is(stream)) continue;
+    const streamNodeId = streamNodeIdByName.get(stream.name);
+    if (!streamNodeId) continue;
+
+    edges.push({
+      id: `bulk-stream-edge-${stream.name}`,
+      source: BULK_ENDPOINT_ID,
+      target: streamNodeId,
+      kind: 'bulk->stream',
+    });
+  }
+
+  // ── Agent policy → bulk endpoint + cloud pipeline edges ──────────────────
+  // Approximation: all fleet agents → bulk endpoint + all cloud pipelines (spec §9)
+  for (const policy of regularPolicies) {
+    const policyNodeId = `agent-policy-${policy.id}`;
+
+    edges.push({
+      id: `agent-policy-edge-${policy.id}->bulk`,
+      source: policyNodeId,
+      target: BULK_ENDPOINT_ID,
+      kind: 'agent->endpoint',
+    });
+
+    for (const pipeline of cloudPipelines) {
+      const pipelineNodeId = `cloud-pipeline-${pipeline.id}`;
+      edges.push({
+        id: `agent-policy-edge-${policy.id}->${pipeline.id}`,
+        source: policyNodeId,
+        target: pipelineNodeId,
+        kind: 'agent->pipeline',
+        isMock: true,
+      });
+    }
+  }
+
+  // ── Agentless → bulk endpoint edges ──────────────────────────────────────
+  for (const policy of agentlessPolicies) {
+    const pkgPolicies = policy.package_policies ?? [];
+    for (const pkgPolicy of pkgPolicies) {
+      const nodeId = `agentless-${pkgPolicy.id}`;
+      edges.push({
+        id: `agentless-edge-${pkgPolicy.id}->bulk`,
+        source: nodeId,
+        target: BULK_ENDPOINT_ID,
+        kind: 'agentless->endpoint',
+      });
+    }
+  }
+
+  // ── Prometheus scraper edges ──────────────────────────────────────────────
+  for (const scraper of prometheusScrapers) {
+    const scraperNodeId = `prom-scraper-${scraper.id}`;
+
+    if (scraper.destination.kind === 'cloudPipeline') {
+      const pipelineNodeId = `cloud-pipeline-${scraper.destination.pipelineId}`;
+      edges.push({
+        id: `prom-edge-${scraper.id}->${scraper.destination.pipelineId}`,
+        source: scraperNodeId,
+        target: pipelineNodeId,
+        kind: 'prometheus->pipeline',
+        isMock: true,
+      });
+    } else {
+      edges.push({
+        id: `prom-edge-${scraper.id}->bulk`,
+        source: scraperNodeId,
+        target: BULK_ENDPOINT_ID,
+        kind: 'prometheus->endpoint',
+        isMock: true,
+      });
+    }
+  }
+
+  return {
+    nodes,
+    edges,
+    meta: {
+      generatedAt: now,
+      fleetAvailable,
+      cloudPipelinesMock: true,
+      prometheusMock: true,
+      timeWindow: {
+        start: now - windowSeconds * 1000,
+        end: now,
+      },
+    },
+  };
+};
+
+// ── Throughput payload assembler ──────────────────────────────────────────────
+
+export const assembleFlowThroughputPayload = (
+  inputs: Pick<
+    AssembleFlowGraphInputs,
+    | 'streams'
+    | 'streamDocCounts'
+    | 'streamFailedCounts'
+    | 'windowSeconds'
+    | 'cloudPipelines'
+    | 'cloudPipelineMetrics'
+    | 'prometheusScrapers'
+    | 'prometheusMetrics'
+    | 'now'
+  >
+): FlowThroughputPayload => {
+  const {
+    streams,
+    streamDocCounts,
+    streamFailedCounts,
+    windowSeconds,
+    cloudPipelines,
+    cloudPipelineMetrics,
+    prometheusScrapers,
+    prometheusMetrics,
+    now,
+  } = inputs;
+
+  const docCountMap = buildCountMap(streamDocCounts);
+  const failedCountMap = buildCountMap(streamFailedCounts);
+
+  const perNode: FlowThroughputPayload['perNode'] = {};
+  const perNodeFailureRate: FlowThroughputPayload['perNodeFailureRate'] = {};
+  const perNodeHealth: FlowThroughputPayload['perNodeHealth'] = {};
+  const perEdge: FlowThroughputPayload['perEdge'] = {};
+
+  // Stream nodes
+  for (const { stream } of streams) {
+    const nodeId = `stream-${stream.name}`;
+    const rawDocCount = docCountMap.get(stream.name) ?? 0;
+    const rawFailedCount = failedCountMap.get(stream.name) ?? 0;
+    const docsPerSec = windowSeconds > 0 ? rawDocCount / windowSeconds : 0;
+    const failedDocsPerSec = windowSeconds > 0 ? rawFailedCount / windowSeconds : 0;
+
+    perNode[nodeId] = { docsPerSec };
+    if (rawFailedCount > 0) {
+      perNodeFailureRate[nodeId] = { docsPerSec: failedDocsPerSec, lastSeenAt: now };
+      perNodeHealth[nodeId] = { status: 'degraded' };
+    } else {
+      perNodeHealth[nodeId] = { status: 'healthy' };
+    }
+  }
+
+  // Cloud pipeline nodes
+  for (const pipeline of cloudPipelines) {
+    const nodeId = `cloud-pipeline-${pipeline.id}`;
+    const throughput = cloudPipelineMetrics.perPipeline[pipeline.id];
+    const health = cloudPipelineMetrics.health[pipeline.id];
+    if (throughput) {
+      perNode[nodeId] = { docsPerSec: throughput.docsPerSec, bytesPerSec: throughput.bytesPerSec };
+    }
+    if (health) {
+      perNodeHealth[nodeId] = { status: health.status, message: health.message };
+    }
+    // Edge throughput
+    if (pipeline.targetStreamName) {
+      const edgeKey = `${pipeline.id}->${pipeline.targetStreamName}`;
+      const edgeThroughput = cloudPipelineMetrics.perEdge[edgeKey];
+      if (edgeThroughput) {
+        perEdge[`pipeline-stream-edge-${pipeline.id}->${pipeline.targetStreamName}`] = {
+          docsPerSec: edgeThroughput.docsPerSec,
+        };
+      }
+    }
+  }
+
+  // Prometheus scraper nodes
+  for (const scraper of prometheusScrapers) {
+    const nodeId = `prom-scraper-${scraper.id}`;
+    const throughput = prometheusMetrics.perScraper[scraper.id];
+    const health = prometheusMetrics.health[scraper.id];
+    if (throughput) {
+      perNode[nodeId] = { docsPerSec: throughput.docsPerSec, bytesPerSec: throughput.bytesPerSec };
+    }
+    if (health) {
+      perNodeHealth[nodeId] = { status: health.status, message: health.message };
+    }
+  }
+
+  return {
+    perNode,
+    perNodeFailureRate,
+    perNodeHealth,
+    perEdge,
+    generatedAt: now,
+  };
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Returns the parent stream name for a dotted name, e.g. "logs.app" → "logs" */
+const getParentStreamName = (name: string): string | undefined => {
+  const lastDot = name.lastIndexOf('.');
+  return lastDot > 0 ? name.slice(0, lastDot) : undefined;
+};
+
+const mapAgentStatusToHealth = (
+  agentStatus: string
+): 'healthy' | 'degraded' | 'down' | 'unknown' => {
+  switch (agentStatus) {
+    case 'online':
+    case 'active':
+      return 'healthy';
+    case 'degraded':
+    case 'updating':
+    case 'enrolling':
+      return 'degraded';
+    case 'offline':
+    case 'error':
+    case 'inactive':
+    case 'unenrolled':
+    case 'disconnected':
+      return 'down';
+    default:
+      return 'unknown';
+  }
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/flow/assemble_flow_graph.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/flow/assemble_flow_graph.ts
@@ -173,28 +173,15 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
     }
   }
 
-  // ── Cloud pipeline nodes ──────────────────────────────────────────────────
-  for (const pipeline of cloudPipelines) {
-    const pipelineNodeId = `cloud-pipeline-${pipeline.id}`;
-    const pipelineThroughput = cloudPipelineMetrics.perPipeline[pipeline.id];
-    const pipelineHealth = cloudPipelineMetrics.health[pipeline.id];
+  // ── Root wired streams — used to assign fallback pipeline targets ─────────
+  // Computed after stream nodes are built (streamNodeIdByName is populated below),
+  // so we collect the raw info here and resolve the map reference after the stream loop.
+  // (Populated further down, after the stream-node loop.)
+  const rootWiredStreamNames: string[] = [];
 
-    nodes.push({
-      kind: 'cloudPipeline',
-      id: pipelineNodeId,
-      label: pipeline.name,
-      column: 'endpoints',
-      lane: 'pipelines',
-      pipelineId: pipeline.id,
-      targetStreamName: pipeline.targetStreamName,
-      throughput: pipelineThroughput
-        ? { docsPerSec: pipelineThroughput.docsPerSec, bytesPerSec: pipelineThroughput.bytesPerSec }
-        : undefined,
-      health: pipelineHealth
-        ? { status: pipelineHealth.status, message: pipelineHealth.message }
-        : undefined,
-    });
-  }
+  // ── Cloud pipeline nodes (throughput filled in after stream nodes are built) ─
+  // Stored for patching below.
+  const cloudPipelineNodeIds = new Map<string, string>(); // pipeline.id → nodeId
 
   // ── Bulk endpoint node ────────────────────────────────────────────────────
   nodes.push({
@@ -231,6 +218,7 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
 
   // ── Stream nodes ──────────────────────────────────────────────────────────
   const streamNodeIdByName = new Map<string, string>();
+  const streamDocsPerSecByName = new Map<string, number>();
 
   for (const { stream } of streams) {
     const streamNodeId = `stream-${stream.name}`;
@@ -241,9 +229,16 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
     const docsPerSec = windowSeconds > 0 ? rawDocCount / windowSeconds : 0;
     const failedDocsPerSec = windowSeconds > 0 ? rawFailedCount / windowSeconds : 0;
 
+    streamDocsPerSecByName.set(stream.name, docsPerSec);
+
     if (WiredStream.Definition.is(stream)) {
       const parentName = getParentStreamName(stream.name);
       const parentId = parentName ? `stream-${parentName}` : undefined;
+
+      // Track root wired streams for cloud pipeline fallback targeting
+      if (!parentName) {
+        rootWiredStreamNames.push(stream.name);
+      }
 
       nodes.push({
         kind: 'wiredStream',
@@ -275,6 +270,43 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
     }
   }
 
+  // ── Cloud pipeline nodes — built after streams so we can use real throughput ─
+  // Resolve target for each pipeline: use configured targetStreamName if it
+  // exists in the real stream set, otherwise fall back round-robin to root wired
+  // streams.  This makes fake metrics match actual ingest numbers.
+  const resolvedPipelineTargets = cloudPipelines.map((pipeline, idx) => {
+    const configured = pipeline.targetStreamName && streamNodeIdByName.has(pipeline.targetStreamName)
+      ? pipeline.targetStreamName
+      : undefined;
+    const fallback = rootWiredStreamNames.length > 0
+      ? rootWiredStreamNames[idx % rootWiredStreamNames.length]
+      : undefined;
+    return { pipeline, targetStreamName: configured ?? fallback };
+  });
+
+  for (const { pipeline, targetStreamName } of resolvedPipelineTargets) {
+    const pipelineNodeId = `cloud-pipeline-${pipeline.id}`;
+    cloudPipelineNodeIds.set(pipeline.id, pipelineNodeId);
+    const pipelineHealth = cloudPipelineMetrics.health[pipeline.id];
+
+    // Use the real target stream's throughput so numbers add up across the graph
+    const realDocsPerSec = targetStreamName ? streamDocsPerSecByName.get(targetStreamName) : undefined;
+
+    nodes.push({
+      kind: 'cloudPipeline',
+      id: pipelineNodeId,
+      label: pipeline.name,
+      column: 'endpoints',
+      lane: 'pipelines',
+      pipelineId: pipeline.id,
+      targetStreamName,
+      throughput: realDocsPerSec !== undefined ? { docsPerSec: realDocsPerSec } : undefined,
+      health: pipelineHealth
+        ? { status: pipelineHealth.status, message: pipelineHealth.message }
+        : undefined,
+    });
+  }
+
   // ── Wired stream → stream edges (routing rules) ───────────────────────────
   for (const { stream } of streams) {
     if (!WiredStream.Definition.is(stream)) continue;
@@ -297,21 +329,19 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
   }
 
   // ── Cloud pipeline → stream edges ────────────────────────────────────────
-  for (const pipeline of cloudPipelines) {
+  for (const { pipeline, targetStreamName } of resolvedPipelineTargets) {
     const pipelineNodeId = `cloud-pipeline-${pipeline.id}`;
-    if (pipeline.targetStreamName) {
-      const targetStreamNodeId = streamNodeIdByName.get(pipeline.targetStreamName);
+    if (targetStreamName) {
+      const targetStreamNodeId = streamNodeIdByName.get(targetStreamName);
       if (targetStreamNodeId) {
-        const edgeKey = `${pipeline.id}->${pipeline.targetStreamName}`;
-        const edgeThroughput = cloudPipelineMetrics.perEdge[edgeKey];
-
+        const realDocsPerSec = streamDocsPerSecByName.get(targetStreamName);
         edges.push({
-          id: `pipeline-stream-edge-${pipeline.id}->${pipeline.targetStreamName}`,
+          id: `pipeline-stream-edge-${pipeline.id}->${targetStreamName}`,
           source: pipelineNodeId,
           target: targetStreamNodeId,
           kind: 'pipeline->stream',
           isMock: true,
-          throughput: edgeThroughput ? { docsPerSec: edgeThroughput.docsPerSec } : undefined,
+          throughput: realDocsPerSec !== undefined ? { docsPerSec: realDocsPerSec } : undefined,
         });
       }
     }
@@ -343,7 +373,7 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
       kind: 'agent->endpoint',
     });
 
-    for (const pipeline of cloudPipelines) {
+    for (const { pipeline } of resolvedPipelineTargets) {
       const pipelineNodeId = `cloud-pipeline-${pipeline.id}`;
       edges.push({
         id: `agent-policy-edge-${policy.id}->${pipeline.id}`,
@@ -373,7 +403,10 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
   for (const scraper of prometheusScrapers) {
     const scraperNodeId = `prom-scraper-${scraper.id}`;
 
-    if (scraper.destination.kind === 'cloudPipeline') {
+    if (
+      scraper.destination.kind === 'cloudPipeline' &&
+      cloudPipelineNodeIds.has(scraper.destination.pipelineId)
+    ) {
       const pipelineNodeId = `cloud-pipeline-${scraper.destination.pipelineId}`;
       edges.push({
         id: `prom-edge-${scraper.id}->${scraper.destination.pipelineId}`,

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/flow/assemble_flow_graph.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/flow/assemble_flow_graph.ts
@@ -219,6 +219,7 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
   // ── Stream nodes ──────────────────────────────────────────────────────────
   const streamNodeIdByName = new Map<string, string>();
   const streamDocsPerSecByName = new Map<string, number>();
+  const streamNameSet = new Set(streams.map(({ stream }) => stream.name));
 
   for (const { stream } of streams) {
     const streamNodeId = `stream-${stream.name}`;
@@ -235,8 +236,10 @@ export const assembleFlowGraphPayload = (inputs: AssembleFlowGraphInputs): FlowG
       const parentName = getParentStreamName(stream.name);
       const parentId = parentName ? `stream-${parentName}` : undefined;
 
-      // Track root wired streams for cloud pipeline fallback targeting
-      if (!parentName) {
+      // "Root" = parent doesn't exist in the actual stream set (e.g. logs.ecs
+      // has parentName 'logs' but 'logs' itself is not a real stream).
+      const isRootInSet = !parentName || !streamNameSet.has(parentName);
+      if (isRootInSet) {
         rootWiredStreamNames.push(stream.name);
       }
 

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -73,6 +73,12 @@ import {
   createContinuousKiExtractionWorkflowService,
   type ContinuousKiExtractionWorkflowService,
 } from './lib/workflows/continuous_extraction_workflow';
+import { CloudPipelinesMockClient } from './lib/mock_ingest_sources/cloud_pipelines/client';
+import { CloudPipelinesStore } from './lib/mock_ingest_sources/cloud_pipelines/storage';
+import { seedCloudPipelines } from './lib/mock_ingest_sources/cloud_pipelines/seed';
+import { PrometheusMockClient } from './lib/mock_ingest_sources/prometheus/client';
+import { PrometheusStore } from './lib/mock_ingest_sources/prometheus/storage';
+import { seedPrometheusScrapers } from './lib/mock_ingest_sources/prometheus/seed';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
@@ -148,6 +154,16 @@ export class StreamsPlugin
     const contentService = new ContentService(core, this.logger);
     const queryService = new QueryService(core, this.logger);
     const taskService = new TaskService(plugins.taskManager);
+
+    // Mock ingest sources — in-memory only, resets on restart (by design)
+    const cloudPipelinesStore = new CloudPipelinesStore();
+    seedCloudPipelines(cloudPipelinesStore);
+    const cloudPipelinesMock = new CloudPipelinesMockClient(cloudPipelinesStore);
+
+    const prometheusStore = new PrometheusStore();
+    seedPrometheusScrapers(prometheusStore, cloudPipelinesStore);
+    const prometheusMock = new PrometheusMockClient(prometheusStore);
+
     const getScopedClients = async ({
       request,
     }: {
@@ -221,6 +237,9 @@ export class StreamsPlugin
         this.logger
       );
 
+      const fleetAgentClient = pluginsStart.fleet?.agentService.asScoped(request);
+      const fleetAgentPolicyService = pluginsStart.fleet?.agentPolicyService;
+
       return {
         scopedClusterClient,
         soClient,
@@ -239,6 +258,10 @@ export class StreamsPlugin
         streamsSettingsStorageClient,
         isSecurityEnabled,
         tuningConfig,
+        fleetAgentClient,
+        fleetAgentPolicyService,
+        cloudPipelinesMock,
+        prometheusMock,
       };
     };
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/index.ts
@@ -37,6 +37,7 @@ import { internalEligibleStreamsRoutes } from './internal/sig_events/extraction/
 import { internalSignificantEventsSettingsRoutes } from './internal/sig_events/significant_events_settings/route';
 import { timeSeriesRoutes } from './internal/streams/time_series/route';
 import { internalMemoryRoutes } from './internal/memory/route';
+import { flowRoutes } from './internal/streams/flow/route';
 
 export const streamsRouteRepository = {
   // internal APIs
@@ -62,6 +63,7 @@ export const streamsRouteRepository = {
   ...internalEligibleStreamsRoutes,
   ...internalSignificantEventsSettingsRoutes,
   ...internalMemoryRoutes,
+  ...flowRoutes,
   // public APIs
   ...docCountsRoutes,
   ...crudRoutes,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/flow/cloud_pipelines_routes.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/flow/cloud_pipelines_routes.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { notFound } from '@hapi/boom';
+import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
+import { createServerRoute } from '../../../create_server_route';
+
+export const listCloudPipelinesRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/_flow/cloud_pipelines',
+  options: { access: 'internal' },
+  params: z.object({}),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.read] },
+  },
+  handler: async ({ request, getScopedClients }) => {
+    const { cloudPipelinesMock } = await getScopedClients({ request });
+    return cloudPipelinesMock.list();
+  },
+});
+
+export const getCloudPipelineRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/_flow/cloud_pipelines/{id}',
+  options: { access: 'internal' },
+  params: z.object({
+    path: z.object({ id: z.string() }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.read] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { cloudPipelinesMock } = await getScopedClients({ request });
+    const pipeline = await cloudPipelinesMock.get(params.path.id);
+    if (!pipeline) {
+      throw notFound(`Cloud pipeline "${params.path.id}" not found`);
+    }
+    return pipeline;
+  },
+});
+
+export const createCloudPipelineRoute = createServerRoute({
+  endpoint: 'POST /internal/streams/_flow/cloud_pipelines',
+  options: { access: 'internal' },
+  params: z.object({
+    body: z.object({
+      name: z.string(),
+      targetStreamName: z.string().optional(),
+    }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.manage] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { cloudPipelinesMock } = await getScopedClients({ request });
+    return cloudPipelinesMock.create(params.body);
+  },
+});
+
+export const updateCloudPipelineRoute = createServerRoute({
+  endpoint: 'PUT /internal/streams/_flow/cloud_pipelines/{id}',
+  options: { access: 'internal' },
+  params: z.object({
+    path: z.object({ id: z.string() }),
+    body: z.object({
+      name: z.string().optional(),
+      targetStreamName: z.string().optional(),
+    }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.manage] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { cloudPipelinesMock } = await getScopedClients({ request });
+    return cloudPipelinesMock.update(params.path.id, params.body);
+  },
+});
+
+export const deleteCloudPipelineRoute = createServerRoute({
+  endpoint: 'DELETE /internal/streams/_flow/cloud_pipelines/{id}',
+  options: { access: 'internal' },
+  params: z.object({
+    path: z.object({ id: z.string() }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.manage] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { cloudPipelinesMock } = await getScopedClients({ request });
+    await cloudPipelinesMock.delete(params.path.id);
+    return { acknowledged: true };
+  },
+});
+
+export const duplicateCloudPipelineRoute = createServerRoute({
+  endpoint: 'POST /internal/streams/_flow/cloud_pipelines/{id}/_duplicate',
+  options: { access: 'internal' },
+  params: z.object({
+    path: z.object({ id: z.string() }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.manage] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { cloudPipelinesMock } = await getScopedClients({ request });
+    return cloudPipelinesMock.duplicate(params.path.id);
+  },
+});
+
+export const getCloudPipelineMetricsRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/_flow/cloud_pipelines/_metrics',
+  options: { access: 'internal' },
+  params: z.object({}),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.read] },
+  },
+  handler: async ({ request, getScopedClients }) => {
+    const { cloudPipelinesMock } = await getScopedClients({ request });
+    return cloudPipelinesMock.getMetrics(Date.now(), []);
+  },
+});
+
+export const cloudPipelinesRoutes = {
+  ...listCloudPipelinesRoute,
+  ...getCloudPipelineRoute,
+  ...createCloudPipelineRoute,
+  ...updateCloudPipelineRoute,
+  ...deleteCloudPipelineRoute,
+  ...duplicateCloudPipelineRoute,
+  ...getCloudPipelineMetricsRoute,
+};

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/flow/prometheus_routes.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/flow/prometheus_routes.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { notFound } from '@hapi/boom';
+import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
+import { createServerRoute } from '../../../create_server_route';
+
+const scrapeIntervalSchema = z.union([z.literal(15), z.literal(30), z.literal(60)]);
+
+const destinationSchema = z.union([
+  z.object({ kind: z.literal('cloudPipeline'), pipelineId: z.string() }),
+  z.object({ kind: z.literal('bulkEndpoint') }),
+]);
+
+export const listPrometheusScrapersRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/_flow/prometheus_scrapers',
+  options: { access: 'internal' },
+  params: z.object({}),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.read] },
+  },
+  handler: async ({ request, getScopedClients }) => {
+    const { prometheusMock } = await getScopedClients({ request });
+    return prometheusMock.list();
+  },
+});
+
+export const getPrometheusScraperRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/_flow/prometheus_scrapers/{id}',
+  options: { access: 'internal' },
+  params: z.object({
+    path: z.object({ id: z.string() }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.read] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { prometheusMock } = await getScopedClients({ request });
+    const scraper = await prometheusMock.get(params.path.id);
+    if (!scraper) {
+      throw notFound(`Prometheus scraper "${params.path.id}" not found`);
+    }
+    return scraper;
+  },
+});
+
+export const createPrometheusScraperRoute = createServerRoute({
+  endpoint: 'POST /internal/streams/_flow/prometheus_scrapers',
+  options: { access: 'internal' },
+  params: z.object({
+    body: z.object({
+      name: z.string(),
+      targetHost: z.string(),
+      scrapeIntervalSec: scrapeIntervalSchema,
+      destination: destinationSchema,
+    }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.manage] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { prometheusMock } = await getScopedClients({ request });
+    return prometheusMock.create(params.body);
+  },
+});
+
+export const updatePrometheusScraperRoute = createServerRoute({
+  endpoint: 'PUT /internal/streams/_flow/prometheus_scrapers/{id}',
+  options: { access: 'internal' },
+  params: z.object({
+    path: z.object({ id: z.string() }),
+    body: z.object({
+      name: z.string().optional(),
+      targetHost: z.string().optional(),
+      scrapeIntervalSec: scrapeIntervalSchema.optional(),
+      destination: destinationSchema.optional(),
+    }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.manage] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { prometheusMock } = await getScopedClients({ request });
+    return prometheusMock.update(params.path.id, params.body);
+  },
+});
+
+export const deletePrometheusScraperRoute = createServerRoute({
+  endpoint: 'DELETE /internal/streams/_flow/prometheus_scrapers/{id}',
+  options: { access: 'internal' },
+  params: z.object({
+    path: z.object({ id: z.string() }),
+  }),
+  security: {
+    authz: { requiredPrivileges: [STREAMS_API_PRIVILEGES.manage] },
+  },
+  handler: async ({ request, params, getScopedClients }) => {
+    const { prometheusMock } = await getScopedClients({ request });
+    await prometheusMock.delete(params.path.id);
+    return { acknowledged: true };
+  },
+});
+
+export const prometheusRoutes = {
+  ...listPrometheusScrapersRoute,
+  ...getPrometheusScraperRoute,
+  ...createPrometheusScraperRoute,
+  ...updatePrometheusScraperRoute,
+  ...deletePrometheusScraperRoute,
+};

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/flow/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/flow/route.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
+import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
+import type { FlowGraphPayload, FlowThroughputPayload } from '../../../../../common/flow';
+import { createServerRoute } from '../../../create_server_route';
+import { cloudPipelinesRoutes } from './cloud_pipelines_routes';
+import { prometheusRoutes } from './prometheus_routes';
+import {
+  getDocCountsForStreams,
+  getFailedDocCountsForStreams,
+} from '../../../streams/doc_counts/get_streams_doc_counts';
+import {
+  assembleFlowGraphPayload,
+  assembleFlowThroughputPayload,
+} from '../../../../lib/streams/flow/assemble_flow_graph';
+import type { StreamDocsStat } from '../../../../../common';
+
+const FLOW_WINDOW_SECONDS = 5 * 60; // 5 minutes
+
+export const flowGraphRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/_flow/graph',
+  options: {
+    access: 'internal',
+  },
+  params: z.object({}),
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  handler: async ({ getScopedClients, request, server }): Promise<FlowGraphPayload> => {
+    const now = Date.now();
+    const start = now - FLOW_WINDOW_SECONDS * 1000;
+    const end = now;
+
+    const {
+      streamsClient,
+      scopedClusterClient,
+      soClient,
+      isSecurityEnabled,
+      fleetAgentClient,
+      fleetAgentPolicyService,
+      cloudPipelinesMock,
+      prometheusMock,
+    } = await getScopedClients({ request });
+
+    const esClient = scopedClusterClient.asCurrentUser;
+    const esClientAsSecondaryAuthUser = isSecurityEnabled
+      ? scopedClusterClient.asSecondaryAuthUser
+      : undefined;
+
+    // Fetch stream topology
+    const streamsWithExistence = await streamsClient.listStreamsWithDataStreamExistence();
+    const streamNames = streamsWithExistence.map(({ stream }) => stream.name);
+
+    // Fleet data — fully optional, all Fleet calls wrapped in try/catch
+    let fleetAvailable = false;
+    let agents: Parameters<typeof assembleFlowGraphPayload>[0]['agents'] = [];
+    let agentPolicies: Parameters<typeof assembleFlowGraphPayload>[0]['agentPolicies'] = [];
+
+    if (fleetAgentClient && fleetAgentPolicyService) {
+      try {
+        const [agentsResult, agentPoliciesResult] = await Promise.all([
+          fleetAgentClient.listAgents({
+            showAgentless: true,
+            showInactive: false,
+            perPage: 1000,
+          }),
+          fleetAgentPolicyService.list(soClient, {
+            perPage: 1000,
+            withPackagePolicies: true,
+          }),
+        ]);
+
+        agents = agentsResult.agents as typeof agents;
+        agentPolicies = agentPoliciesResult.items as typeof agentPolicies;
+        fleetAvailable = true;
+      } catch {
+        // Fleet errors are non-fatal; graph renders with empty agent sections
+        fleetAvailable = false;
+        agents = [];
+        agentPolicies = [];
+      }
+    }
+
+    // Agentless policies fetched separately to avoid kuery parsing issues on older Fleet versions
+    if (fleetAvailable && fleetAgentPolicyService) {
+      try {
+        const agentlessResult = await fleetAgentPolicyService.list(soClient, {
+          kuery: `${AGENT_POLICY_SAVED_OBJECT_TYPE}.supports_agentless: true`,
+          perPage: 1000,
+          withPackagePolicies: true,
+        });
+        // Merge agentless policies into the list (avoid duplicates by id)
+        const existingIds = new Set(agentPolicies.map((p) => p.id));
+        for (const p of agentlessResult.items) {
+          if (!existingIds.has(p.id)) {
+            agentPolicies = [...agentPolicies, p as (typeof agentPolicies)[0]];
+          }
+        }
+      } catch {
+        // Non-fatal — agentless section will just be empty
+      }
+    }
+
+    // Real stream metrics + mock sources — run in parallel
+    const [
+      streamDocCounts,
+      streamFailedCounts,
+      cloudPipelines,
+      cloudPipelineMetrics,
+      prometheusScrapers,
+      prometheusMetrics,
+    ] = await Promise.all([
+      getDocCountsForStreams({
+        isServerless: server.isServerless,
+        esClient,
+        esClientAsSecondaryAuthUser,
+      }).catch((): StreamDocsStat[] => []),
+      getFailedDocCountsForStreams({ esClient, start, end }).catch((): StreamDocsStat[] => []),
+      cloudPipelinesMock.list(),
+      cloudPipelinesMock.getMetrics(now, streamNames),
+      prometheusMock.list(),
+      prometheusMock.getMetrics(now),
+    ]);
+
+    return assembleFlowGraphPayload({
+      streams: streamsWithExistence,
+      streamDocCounts,
+      streamFailedCounts,
+      windowSeconds: FLOW_WINDOW_SECONDS,
+      agents,
+      agentPolicies,
+      cloudPipelines,
+      cloudPipelineMetrics,
+      prometheusScrapers,
+      prometheusMetrics,
+      fleetAvailable,
+      now,
+    });
+  },
+});
+
+export const flowThroughputRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/_flow/throughput',
+  options: {
+    access: 'internal',
+  },
+  params: z.object({}),
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  handler: async ({ getScopedClients, request, server }): Promise<FlowThroughputPayload> => {
+    const now = Date.now();
+    const start = now - FLOW_WINDOW_SECONDS * 1000;
+    const end = now;
+
+    const {
+      streamsClient,
+      scopedClusterClient,
+      isSecurityEnabled,
+      cloudPipelinesMock,
+      prometheusMock,
+    } = await getScopedClients({ request });
+
+    const esClient = scopedClusterClient.asCurrentUser;
+    const esClientAsSecondaryAuthUser = isSecurityEnabled
+      ? scopedClusterClient.asSecondaryAuthUser
+      : undefined;
+
+    const streamsWithExistence = await streamsClient.listStreamsWithDataStreamExistence();
+    const streamNames = streamsWithExistence.map(({ stream }) => stream.name);
+
+    const [
+      streamDocCounts,
+      streamFailedCounts,
+      cloudPipelines,
+      cloudPipelineMetrics,
+      prometheusScrapers,
+      prometheusMetrics,
+    ] = await Promise.all([
+      getDocCountsForStreams({
+        isServerless: server.isServerless,
+        esClient,
+        esClientAsSecondaryAuthUser,
+      }).catch((): StreamDocsStat[] => []),
+      getFailedDocCountsForStreams({ esClient, start, end }).catch((): StreamDocsStat[] => []),
+      cloudPipelinesMock.list(),
+      cloudPipelinesMock.getMetrics(now, streamNames),
+      prometheusMock.list(),
+      prometheusMock.getMetrics(now),
+    ]);
+
+    return assembleFlowThroughputPayload({
+      streams: streamsWithExistence,
+      streamDocCounts,
+      streamFailedCounts,
+      windowSeconds: FLOW_WINDOW_SECONDS,
+      cloudPipelines,
+      cloudPipelineMetrics,
+      prometheusScrapers,
+      prometheusMetrics,
+      now,
+    });
+  },
+});
+
+export const flowRoutes = {
+  ...flowGraphRoute,
+  ...flowThroughputRoute,
+  ...cloudPipelinesRoutes,
+  ...prometheusRoutes,
+};

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/flow/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/flow/route.ts
@@ -6,7 +6,8 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
+// Inlined to avoid importing @kbn/fleet-plugin/* which pulls packages outside rootDir
+const AGENT_POLICY_SAVED_OBJECT_TYPE = 'ingest-agent-policies';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import type { FlowGraphPayload, FlowThroughputPayload } from '../../../../../common/flow';
 import { createServerRoute } from '../../../create_server_route';
@@ -75,7 +76,6 @@ export const flowGraphRoute = createServerRoute({
           }),
           fleetAgentPolicyService.list(soClient, {
             perPage: 1000,
-            withPackagePolicies: true,
           }),
         ]);
 
@@ -96,7 +96,6 @@ export const flowGraphRoute = createServerRoute({
         const agentlessResult = await fleetAgentPolicyService.list(soClient, {
           kuery: `${AGENT_POLICY_SAVED_OBJECT_TYPE}.supports_agentless: true`,
           perPage: 1000,
-          withPackagePolicies: true,
         });
         // Merge agentless policies into the list (avoid duplicates by id)
         const existingIds = new Set(agentPolicies.map((p) => p.id));

--- a/x-pack/platform/plugins/shared/streams/server/routes/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/types.ts
@@ -13,7 +13,38 @@ import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import type { DefaultRouteHandlerResources } from '@kbn/server-route-repository';
 import type { IUiSettingsClient } from '@kbn/core/server';
 import type { IFieldsMetadataClient } from '@kbn/fields-metadata-plugin/server/services/fields_metadata/types';
-import type { AgentClient, AgentPolicyServiceInterface } from '@kbn/fleet-plugin/server';
+// Minimal fleet interfaces — avoids importing @kbn/fleet-plugin/server which pulls in
+// packages outside this plugin's rootDir via its transitive dependency chain.
+export interface FleetAgentClient {
+  listAgents(options: {
+    showAgentless?: boolean;
+    showInactive?: boolean;
+    perPage?: number;
+  }): Promise<{
+    agents: Array<{
+      id: string;
+      status: string;
+      policy_id?: string;
+      local_metadata?: { host?: { hostname?: string } };
+      agent?: { version?: string };
+    }>;
+    total: number;
+  }>;
+}
+
+export interface FleetAgentPolicyService {
+  list(
+    soClient: SavedObjectsClientContract,
+    options?: { kuery?: string; perPage?: number }
+  ): Promise<{
+    items: Array<{
+      id: string;
+      name: string;
+      supports_agentless?: boolean | null;
+      package_policies?: string[];
+    }>;
+  }>;
+}
 import type { ContentClient } from '../lib/content/content_client';
 import type { AttachmentClient } from '../lib/streams/attachments/attachment_client';
 import type { QueryClient } from '../lib/streams/assets/query/query_client';
@@ -56,8 +87,8 @@ export interface RouteHandlerScopedClients {
   streamsSettingsStorageClient: StreamsSettingsStorageClient;
   isSecurityEnabled: boolean;
   tuningConfig: SigEventsTuningConfig;
-  fleetAgentClient?: AgentClient;
-  fleetAgentPolicyService?: AgentPolicyServiceInterface;
+  fleetAgentClient?: FleetAgentClient;
+  fleetAgentPolicyService?: FleetAgentPolicyService;
   cloudPipelinesMock: CloudPipelinesMockClient;
   prometheusMock: PrometheusMockClient;
 }

--- a/x-pack/platform/plugins/shared/streams/server/routes/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/types.ts
@@ -13,6 +13,7 @@ import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import type { DefaultRouteHandlerResources } from '@kbn/server-route-repository';
 import type { IUiSettingsClient } from '@kbn/core/server';
 import type { IFieldsMetadataClient } from '@kbn/fields-metadata-plugin/server/services/fields_metadata/types';
+import type { AgentClient, AgentPolicyServiceInterface } from '@kbn/fleet-plugin/server';
 import type { ContentClient } from '../lib/content/content_client';
 import type { AttachmentClient } from '../lib/streams/attachments/attachment_client';
 import type { QueryClient } from '../lib/streams/assets/query/query_client';
@@ -28,6 +29,8 @@ import type { InsightClient } from '../lib/sig_events/insights/client/insight_cl
 import type { StreamsSettingsStorageClient } from '../lib/streams/storage/streams_settings_storage_client';
 import type { ContinuousKiExtractionWorkflowService } from '../lib/workflows/continuous_extraction_workflow';
 import type { SigEventsTuningConfig } from '../../common/sig_events_tuning_config';
+import type { CloudPipelinesMockClient } from '../lib/mock_ingest_sources/cloud_pipelines/client';
+import type { PrometheusMockClient } from '../lib/mock_ingest_sources/prometheus/client';
 
 export type GetScopedClients = ({
   request,
@@ -53,6 +56,10 @@ export interface RouteHandlerScopedClients {
   streamsSettingsStorageClient: StreamsSettingsStorageClient;
   isSecurityEnabled: boolean;
   tuningConfig: SigEventsTuningConfig;
+  fleetAgentClient?: AgentClient;
+  fleetAgentPolicyService?: AgentPolicyServiceInterface;
+  cloudPipelinesMock: CloudPipelinesMockClient;
+  prometheusMock: PrometheusMockClient;
 }
 
 export interface RouteDependencies {

--- a/x-pack/platform/plugins/shared/streams/server/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/types.ts
@@ -42,6 +42,7 @@ import type {
   SearchInferenceEndpointsPluginSetup,
   SearchInferenceEndpointsPluginStart,
 } from '@kbn/search-inference-endpoints/server';
+import type { FleetStartContract } from '@kbn/fleet-plugin/server';
 import type { StreamsConfig } from '../common/config';
 import type { MemoryTriggerRegistry } from './lib/memory/triggers';
 
@@ -95,4 +96,5 @@ export interface StreamsPluginStartDependencies {
   agentBuilder?: AgentBuilderPluginStart;
   spaces?: SpacesPluginStart;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginStart;
+  fleet?: FleetStartContract;
 }

--- a/x-pack/platform/plugins/shared/streams/server/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/types.ts
@@ -42,7 +42,7 @@ import type {
   SearchInferenceEndpointsPluginSetup,
   SearchInferenceEndpointsPluginStart,
 } from '@kbn/search-inference-endpoints/server';
-import type { FleetStartContract } from '@kbn/fleet-plugin/server';
+import type { FleetAgentClient, FleetAgentPolicyService } from './routes/types';
 import type { StreamsConfig } from '../common/config';
 import type { MemoryTriggerRegistry } from './lib/memory/triggers';
 
@@ -96,5 +96,8 @@ export interface StreamsPluginStartDependencies {
   agentBuilder?: AgentBuilderPluginStart;
   spaces?: SpacesPluginStart;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginStart;
-  fleet?: FleetStartContract;
+  fleet?: {
+    agentService: { asScoped(request: unknown): FleetAgentClient };
+    agentPolicyService: FleetAgentPolicyService;
+  };
 }

--- a/x-pack/platform/plugins/shared/streams_app/INGEST_FLOW_POC_SPEC.md
+++ b/x-pack/platform/plugins/shared/streams_app/INGEST_FLOW_POC_SPEC.md
@@ -1,0 +1,550 @@
+# Streams Ingest Flow — POC Spec
+
+A single-screen graph view in the Streams app showing the end-to-end ingest topology: shippers (Fleet agents, agentless integrations, mock Prometheus scrapers) → ingest endpoints (mock Cloud Pipelines, ES bulk) → streams tree (wired + classic), with live throughput, failure-rate signals, health, and quick links into existing edit surfaces.
+
+POC quality. Not feature-flagged unless trivially. Cloud Pipelines and Prometheus are mocked end-to-end (in-memory, deterministic-but-noisy metrics). Fleet, agentless, streams topology, stream throughput, and failure rates are real.
+
+---
+
+## 1. Architecture at a glance
+
+```
+┌─────────────────────────┐    ┌──────────────────────────┐    ┌──────────────────────────────┐
+│  Shippers (left col)    │    │  Endpoints (middle col)  │    │  Streams (right col)         │
+│                         │    │                          │    │                              │
+│  ┌ Fleet Agents lane ┐  │ ─► │  Cloud Pipelines (mock)  │ ─► │  Wired stream root           │
+│  │ policy groups     │  │    │  (OTLP endpoints, CRUD)  │    │   ├─ child (routed)          │
+│  │ → agents          │  │ ─► │                          │    │   │   ├─ grandchild         │
+│  └───────────────────┘  │    │  ─────────────────────   │    │   └─ child (routed)         │
+│  ┌ Agentless lane ───┐  │    │  ES bulk endpoint        │    │  Classic streams (flat)      │
+│  │ pkg policies      │  │ ─► │                          │ ─► │                              │
+│  └───────────────────┘  │    │                          │    │  badges: failureRate         │
+│  ┌ Prometheus lane ──┐  │    │                          │    │  edges: throughput           │
+│  │ scrapers (mock)   │  │ ─► │                          │    │                              │
+│  └───────────────────┘  │    │                          │    │                              │
+└─────────────────────────┘    └──────────────────────────┘    └──────────────────────────────┘
+```
+
+**Single source of truth for the graph**: a typed `FlowGraphPayload` returned by `GET /internal/streams/_flow/graph`. The frontend is a pure renderer over that payload + a poll-driven `FlowThroughputPayload` overlay.
+
+---
+
+## 2. Technology choices
+
+| Layer | Pick | Why |
+|---|---|---|
+| Page host plugin | `streams_app` (existing) | Already mounted at `/app/streams`, has router + TanStack Query + EUI shell |
+| Server APIs | `streams` plugin (existing) + new `_flow/*` routes via `createServerRoute` | Existing typed `streamsRepositoryClient` auto-types the new endpoints |
+| Schema validation | `zod` via `@kbn/zod` | Already used by all `createServerRoute` definitions |
+| Graph lib | `@xyflow/react` v12 (already in `package.json`) | Reference impl: `fleet/public/components/otel_ui/collector_config_view/graph_view/` |
+| Layout lib | `@dagrejs/dagre` v1 (already in `package.json`) | Used in same Fleet OTel UI for compound LR layout |
+| State (query) | `useStreamsAppFetch` for graph topology; small `setInterval` hook for throughput poll | Match existing `streams_app` idiom; no new deps |
+| State (mutation) | Direct `streamsRepositoryClient.fetch(...)` then `.refresh()` | Same pattern as `ClassicStreamCreationFlyout` |
+| Forms | EUI + Emotion | Repo standard |
+| i18n | `@kbn/i18n` / `@kbn/i18n-react` | Repo standard |
+| Mock store | In-memory `Map`s, plugin-singleton lifetime | No persistence — resets on Kibana restart, by design |
+| Mock metrics | Pure deterministic function `f(id, floor(now/5000))` | Reproducible, no flicker between renders within a 5s bucket |
+| Fleet integration | `optionalPlugins: ["fleet"]` in `streams/kibana.jsonc`; consume `agentService` + `agentPolicyService` | Cross-plugin contract pattern already used by `content_connectors` |
+| Tests | `jest` for pure server logic + mock generators; `scout` UI test for one happy path | Repo standard |
+
+**Do not introduce**: cytoscape, elkjs, react-flow v11, Redux, alternative styling libs, alternative HTTP clients, persistence layers, new UI settings beyond a single optional gate.
+
+---
+
+## 3. Locked contract — `FlowGraphPayload`
+
+**This is the integration boundary.** Once this zod schema lands, every workstream can develop against it independently using fixtures. Owner: workstream **CONTRACT** (one engineer, day 1).
+
+Location: `x-pack/platform/plugins/shared/streams/common/flow/types.ts`, re-exported from `…/streams/common/index.ts` so server + client share the exact same type.
+
+```ts
+// ── Shared atoms ─────────────────────────────────────────────────────────────
+const flowHealthSchema = z.object({
+  status: z.enum(['healthy', 'degraded', 'down', 'unknown']),
+  message: z.string().optional(),
+});
+
+const flowThroughputSchema = z.object({
+  docsPerSec: z.number().nonnegative(),
+  bytesPerSec: z.number().nonnegative().optional(),
+});
+
+const flowFailureRateSchema = z.object({
+  docsPerSec: z.number().nonnegative(),
+  lastSeenAt: z.number().int().optional(), // epoch ms
+});
+
+// ── Node discriminated union ─────────────────────────────────────────────────
+const flowNodeBase = z.object({
+  id: z.string(),
+  label: z.string(),
+  column: z.enum(['shippers', 'endpoints', 'streams']),
+  lane: z.enum(['agents', 'agentless', 'prometheus', 'pipelines', 'bulk', 'streams']),
+  parentId: z.string().optional(), // grouping (agent → policy group, child stream → parent)
+  health: flowHealthSchema.optional(),
+  throughput: flowThroughputSchema.optional(),
+});
+
+const flowNodeSchema = z.discriminatedUnion('kind', [
+  flowNodeBase.extend({ kind: z.literal('agent'),
+    agentId: z.string(), policyId: z.string(), hostname: z.string(),
+    version: z.string(), agentStatus: z.string() }),
+  flowNodeBase.extend({ kind: z.literal('agentPolicy'),
+    policyId: z.string(), agentCount: z.number().int() }),
+  flowNodeBase.extend({ kind: z.literal('agentlessIntegration'),
+    packagePolicyId: z.string(), packageName: z.string(),
+    packageTitle: z.string(), autoPolicyId: z.string() }),
+  flowNodeBase.extend({ kind: z.literal('prometheusScraper'),
+    scraperId: z.string(), targetHost: z.string(), scrapeIntervalSec: z.number().int() }),
+  flowNodeBase.extend({ kind: z.literal('cloudPipeline'),
+    pipelineId: z.string(), targetStreamName: z.string().optional() }),
+  flowNodeBase.extend({ kind: z.literal('bulkEndpoint'),
+    url: z.string().optional() }),
+  flowNodeBase.extend({ kind: z.literal('wiredStream'),
+    streamName: z.string(), processingStepCount: z.number().int(),
+    routingRuleCount: z.number().int(),
+    failureRate: flowFailureRateSchema.optional() }),
+  flowNodeBase.extend({ kind: z.literal('classicStream'),
+    streamName: z.string(), dataStream: z.string(),
+    failureRate: flowFailureRateSchema.optional() }),
+]);
+
+// ── Edge schema ──────────────────────────────────────────────────────────────
+const flowEdgeSchema = z.object({
+  id: z.string(),
+  source: z.string(), // node id
+  target: z.string(),
+  kind: z.enum([
+    'agent->endpoint', 'agent->pipeline',
+    'agentless->endpoint',
+    'prometheus->pipeline', 'prometheus->endpoint',
+    'pipeline->stream', 'bulk->stream',
+    'stream->stream', // wired routing rule
+  ]),
+  routingRuleId: z.string().optional(), // only for stream->stream
+  isMock: z.boolean().optional(),       // true for any edge whose throughput comes from a mock
+  health: flowHealthSchema.optional(),
+  throughput: flowThroughputSchema.optional(),
+});
+
+// ── Top-level payload ────────────────────────────────────────────────────────
+export const flowGraphPayloadSchema = z.object({
+  nodes: z.array(flowNodeSchema),
+  edges: z.array(flowEdgeSchema),
+  meta: z.object({
+    generatedAt: z.number().int(),
+    fleetAvailable: z.boolean(),
+    cloudPipelinesMock: z.literal(true),
+    prometheusMock: z.literal(true),
+    timeWindow: z.object({ start: z.number().int(), end: z.number().int() }),
+  }),
+});
+
+export const flowThroughputPayloadSchema = z.object({
+  perNode: z.record(z.string(), flowThroughputSchema),
+  perNodeFailureRate: z.record(z.string(), flowFailureRateSchema),
+  perNodeHealth: z.record(z.string(), flowHealthSchema),
+  perEdge: z.record(z.string(), flowThroughputSchema),
+  generatedAt: z.number().int(),
+});
+```
+
+**Fixture**: ship `…/streams/common/flow/fixtures.ts` with one realistic `FlowGraphPayload` (3 agents, 1 agentless integration, 2 prometheus scrapers, 2 cloud pipelines, bulk endpoint, root + 4 child wired streams, 2 classic streams) and one `FlowThroughputPayload`. Frontend workstreams render against these fixtures while server workstreams build the real handlers.
+
+---
+
+## 4. Server-side spec
+
+### 4.1 Plugin wiring (`streams` plugin)
+
+- `kibana.jsonc`: add `"fleet"` to `optionalPlugins`. Re-bootstrap.
+- `server/types.ts` — extend `StreamsPluginStartDependencies` with `fleet?: FleetStartContract`.
+- `server/routes/types.ts` — extend `RouteHandlerScopedClients` with:
+  - `fleetAgentClient?: AgentClient` (per-request scoped)
+  - `fleetAgentPolicyService?: AgentPolicyServiceInterface` (singleton, takes `soClient` per call)
+  - `cloudPipelinesMock: CloudPipelinesMockClient` (always present; module-singleton)
+  - `prometheusMock: PrometheusMockClient` (always present)
+- `server/plugin.ts` — instantiate the two mock services in `setup()`, capture in closures, pass into `getScopedClients` factory built in `start()`. Mirror existing pattern for `StreamsService` / `QueryService`.
+
+### 4.2 Mock module: `mock_ingest_sources/`
+
+Path: `x-pack/platform/plugins/shared/streams/server/lib/mock_ingest_sources/`
+
+Tree:
+```
+mock_ingest_sources/
+  index.ts                          // re-exports
+  cloud_pipelines/
+    types.ts                        // OtlpEndpointConfig, OtlpEndpointHealth, OtlpEndpointThroughput
+    storage.ts                      // class CloudPipelinesStore { list/get/create/update/delete }
+    metrics.ts                      // generateMetricsForPipeline(id, now, downstreamStreamNames)
+    client.ts                       // class CloudPipelinesMockClient implements ICloudPipelinesClient
+    seed.ts                         // initial fixtures (2 pipelines)
+  prometheus/
+    types.ts                        // PrometheusScraper, PrometheusScraperHealth
+    storage.ts
+    metrics.ts                      // generateMetricsForScraper(id, now)
+    client.ts                       // class PrometheusMockClient
+    seed.ts                         // 3-4 scraper fixtures
+  shared/
+    seeded_noise.ts                 // hash(id) → phase; sin wave + jitter; helpers used by both
+```
+
+**Interface (lockable for parallel impl):**
+
+```ts
+// cloud_pipelines/client.ts
+export interface ICloudPipelinesClient {
+  list(): Promise<OtlpEndpointConfig[]>;
+  get(id: string): Promise<OtlpEndpointConfig | undefined>;
+  create(input: Omit<OtlpEndpointConfig, 'id' | 'createdAt' | 'updatedAt'>): Promise<OtlpEndpointConfig>;
+  update(id: string, patch: Partial<OtlpEndpointConfig>): Promise<OtlpEndpointConfig>;
+  delete(id: string): Promise<void>;
+  duplicate(id: string): Promise<OtlpEndpointConfig>;
+  getMetrics(now: number, streamNames: string[]): Promise<{
+    perPipeline: Record<string, OtlpEndpointThroughput>;
+    perEdge: Record<string, OtlpEndpointThroughput>; // key = `${pipelineId}->${streamName}`
+    health: Record<string, OtlpEndpointHealth>;
+  }>;
+}
+
+// prometheus/client.ts
+export interface IPrometheusMockClient {
+  list(): Promise<PrometheusScraper[]>;
+  get(id: string): Promise<PrometheusScraper | undefined>;
+  create(input: Omit<PrometheusScraper, 'id'>): Promise<PrometheusScraper>;
+  update(id: string, patch: Partial<PrometheusScraper>): Promise<PrometheusScraper>;
+  delete(id: string): Promise<void>;
+  getMetrics(now: number): Promise<{
+    perScraper: Record<string, { docsPerSec: number; bytesPerSec: number }>;
+    health: Record<string, { status: 'healthy' | 'degraded' | 'down'; message?: string }>;
+  }>;
+}
+```
+
+The interface is what makes future replacement with a real Cloud-side service a pure swap.
+
+**Determinism contract for `metrics.ts`**: `generateMetricsForX(id, t)` where `t = Math.floor(now / 5000)` — values change every 5s, identical between renders within the bucket, identical across processes.
+
+### 4.3 Routes
+
+All under `/internal/streams/_flow/`. `access: 'internal'`, `oasMode: 'never'`. Auth via `STREAMS_API_PRIVILEGES.read` (read paths) / `STREAMS_API_PRIVILEGES.manage` (write).
+
+| Method | Path | Returns | Notes |
+|---|---|---|---|
+| GET | `/_flow/graph` | `FlowGraphPayload` | The aggregator/BFF — full topology + initial throughput snapshot |
+| GET | `/_flow/throughput` | `FlowThroughputPayload` | Live poll target (5s) — small payload, only changing fields |
+| GET | `/_flow/cloud_pipelines` | `OtlpEndpointConfig[]` | |
+| GET | `/_flow/cloud_pipelines/{id}` | `OtlpEndpointConfig` | |
+| POST | `/_flow/cloud_pipelines` | `OtlpEndpointConfig` | |
+| PUT | `/_flow/cloud_pipelines/{id}` | `OtlpEndpointConfig` | |
+| DELETE | `/_flow/cloud_pipelines/{id}` | `{ acknowledged: true }` | |
+| POST | `/_flow/cloud_pipelines/{id}/duplicate` | `OtlpEndpointConfig` | |
+| GET | `/_flow/prometheus_scrapers` | `PrometheusScraper[]` | |
+| GET | `/_flow/prometheus_scrapers/{id}` | `PrometheusScraper` | |
+| POST | `/_flow/prometheus_scrapers` | `PrometheusScraper` | |
+| PUT | `/_flow/prometheus_scrapers/{id}` | `PrometheusScraper` | |
+| DELETE | `/_flow/prometheus_scrapers/{id}` | `{ acknowledged: true }` | |
+
+### 4.4 BFF handler — `/_flow/graph`
+
+Pseudo-flow (the actual handler is one function, top-down):
+
+```
+const start = now - 5*60_000; const end = now;
+const [streams, allAgents, agentlessPolicies, pipelines, scrapers,
+       streamRates, streamFailures, pipelineMetrics, scraperMetrics] = await Promise.all([
+  streamsClient.listStreamsWithDataStreamExistence(),
+  fleetAgentClient?.listAgents({ showAgentless: true, showInactive: false, perPage: 1000 })
+    ?? { agents: [] },
+  fleetAgentPolicyService?.list(soClient, {
+    kuery: `${AGENT_POLICY_SAVED_OBJECT_TYPE}.supports_agentless: true`, perPage: 1000,
+  }) ?? { items: [] },
+  cloudPipelinesMock.list(),
+  prometheusMock.list(),
+  getStreamRates({ esClient, streams, start, end }),       // new helper, see 4.5
+  getFailedDocCountsForStreams({ esClient, start, end }),  // existing
+  cloudPipelinesMock.getMetrics(now, streams.map(s => s.name)),
+  prometheusMock.getMetrics(now),
+]);
+
+return assembleFlowGraphPayload({...});  // pure function, easy to unit-test
+```
+
+The `assembleFlowGraphPayload` pure function is the heart of the workstream split: server impl owns its inputs, but the function itself is testable on fixtures and used by the frontend integration test.
+
+### 4.5 New ES helper — `getStreamRates`
+
+Path: `x-pack/platform/plugins/shared/streams/server/lib/streams/flow/get_stream_rates.ts`
+
+For each stream, return `{ name, docsPerSec }` over `[start, end]`. Implementation: single ES `_msearch` over each stream's data stream backing indices; query `range @timestamp` + `size: 0` + `aggs: { c: value_count(@timestamp) }`; divide by window seconds.
+
+(Existing `getDocCountsForStreams` returns totals over a window — close, but we want a clean rate. Either reuse it and divide, or write a slim helper. **Decision: reuse and divide.** Saves one round-trip and one new helper.)
+
+### 4.6 Failure-rate fetch
+
+Reuse `getFailedDocCountsForStreams({ esClient, start, end })` from `…/routes/streams/doc_counts/get_streams_doc_counts.ts`. Divide returned counts by window seconds. Privilege failures yield empty rows — graceful.
+
+---
+
+## 5. Client-side spec (`streams_app` plugin)
+
+### 5.1 Routing & nav
+
+- `public/routes/config.tsx`: add `'/_flow': { element: <RedirectTo path="/_flow/graph" />, … }` no — just a single route `'/_flow'` rendering `<IngestFlowView />`. Sibling of `/_discovery`.
+- `managementQueryParams` zod schema: extend with two new optional params used by deep-links from the flow page back into stream management:
+  ```ts
+  editRoutingRuleId: z.string().optional(),  // pre-open routing-rule editor
+  action: z.enum(['addChild']).optional(),   // pre-trigger "add child" affordance
+  ```
+- Nav entry: in `components/stream_list_view/index.tsx` near the "Significant Events" button (~line 196), add `<EuiButton iconType="visNetwork" onClick={() => router.push('/_flow', { path: {}, query: {} })}>Ingest flow</EuiButton>`.
+
+### 5.2 Component tree
+
+```
+public/components/ingest_flow_view/
+  index.tsx                          // <IngestFlowView />: page shell, fetch, providers
+  flow_canvas.tsx                    // <FlowCanvas payload throughput onSelectNode />: ReactFlowProvider + ReactFlow
+  layout.ts                          // applyCompoundLayout — adapted from fleet OTel graph_view
+  hooks/
+    use_flow_graph.ts                // useStreamsAppFetch wrapper for /_flow/graph
+    use_flow_throughput_poll.ts      // 5s setInterval against /_flow/throughput
+    use_stream_discover_link.ts      // extracted from streams_list/index.tsx
+  nodes/
+    agent_node.tsx
+    agent_policy_group_node.tsx
+    agentless_integration_node.tsx
+    prometheus_scraper_node.tsx
+    cloud_pipeline_node.tsx
+    bulk_endpoint_node.tsx
+    wired_stream_node.tsx
+    classic_stream_node.tsx
+    lane_label_node.tsx              // lightweight pseudo-node for "Fleet Agents" / "Agentless" / "Prometheus" labels
+  edges/
+    throughput_edge.tsx              // BaseEdge + label = formatRate(docsPerSec); strokeWidth = log10(rate+10)*2
+  panels/
+    detail_flyout.tsx                // dispatcher by selected node kind
+    panel_agent.tsx
+    panel_agent_policy.tsx
+    panel_agentless.tsx
+    panel_prometheus.tsx
+    panel_cloud_pipeline.tsx
+    panel_bulk_endpoint.tsx
+    panel_wired_stream.tsx
+    panel_classic_stream.tsx
+  flyouts/
+    cloud_pipeline_edit_flyout.tsx   // create / edit / duplicate
+    prometheus_scraper_edit_flyout.tsx
+  badges/
+    failure_rate_badge.tsx           // red EuiNotificationBadge; click → useFailureStoreRedirectLink
+    health_pill.tsx                  // EuiHealth wrapper
+  mock_banner.tsx                    // permanent EuiCallOut "Cloud Pipelines + Prometheus mocked"
+  legend.tsx                         // small legend for edge thickness, lanes
+```
+
+### 5.3 Internal interface — node renderer contract
+
+Every node component receives the same shape from React Flow:
+
+```ts
+// React Flow's <Node> data prop is typed via our discriminated union:
+type FlowNodeData = z.infer<typeof flowNodeSchema>;
+
+// Each node component:
+type NodeComponent<K extends FlowNodeData['kind']> = React.FC<NodeProps<Extract<FlowNodeData, { kind: K }>>>;
+```
+
+`flow_canvas.tsx` exposes a `nodeTypes` map: `{ agent: AgentNode, agentPolicy: AgentPolicyGroupNode, ... }`. Each node component is a self-contained EUI panel — workstreams D1–D8 (one per node type) can be developed independently against the fixture once the contract is locked.
+
+### 5.4 Internal interface — detail flyout dispatcher
+
+```ts
+function DetailFlyout({ node, onClose }: { node: FlowNodeData | null; onClose(): void }) {
+  if (!node) return null;
+  switch (node.kind) {
+    case 'agent':                return <PanelAgent node={node} onClose={onClose} />;
+    case 'agentPolicy':          return <PanelAgentPolicy node={node} onClose={onClose} />;
+    case 'agentlessIntegration': return <PanelAgentless node={node} onClose={onClose} />;
+    case 'prometheusScraper':    return <PanelPrometheus node={node} onClose={onClose} />;
+    case 'cloudPipeline':        return <PanelCloudPipeline node={node} onClose={onClose} />;
+    case 'bulkEndpoint':         return <PanelBulkEndpoint node={node} onClose={onClose} />;
+    case 'wiredStream':          return <PanelWiredStream node={node} onClose={onClose} />;
+    case 'classicStream':        return <PanelClassicStream node={node} onClose={onClose} />;
+  }
+}
+```
+
+Each panel component has the same prop signature: `{ node, onClose }`. Trivially parallelizable.
+
+### 5.5 Quick-link inventory (per panel)
+
+| Panel | Action button(s) | Implementation |
+|---|---|---|
+| Agent | "View agent", "View logs" | `application.navigateToApp('fleet', { path: pagePathGetters.agent_details({ agentId })[1] })` |
+| Agent policy | "View policy" | `pagePathGetters.policy_details({ policyId })` |
+| Agentless | "Edit integration" | `pagePathGetters.integration_policy_edit({ packagePolicyId })` (app id `'integrations'`) |
+| Prometheus | "Edit scraper", "Delete" | `PrometheusScraperEditFlyout` |
+| Cloud pipeline | "Edit", "Duplicate", "Delete" | `CloudPipelineEditFlyout` (with optional `focusField`) |
+| Bulk endpoint | "API keys" | `application.navigateToApp('management', { path: '/security/api_keys' })` |
+| Wired stream | "Overview", "Processing", "Routing", "Schema", "Retention", "Attachments", "Add child", "View in Discover", "View failures" | `streamsAppRouter.link('/{key}/management/{tab}', { path: { key, tab }, query: ... })`; "Add child" passes `?action=addChild`; "View failures" uses `useFailureStoreRedirectLink` |
+| Classic stream | Same as wired (subset of tabs) + Discover/failures | Same |
+| Edge: stream→stream | "Edit routing condition" | navigate to parent's `partitioning` tab with `?editRoutingRuleId=<rule.id>` |
+| Edge: pipeline→stream | "Edit pipeline" | `CloudPipelineEditFlyout` with `focusField: 'targetStream'` |
+| Edge: agent→endpoint | "Edit policy outputs" | `pagePathGetters.policy_details_settings({ policyId })` |
+| Edge: agentless→bulk | "Edit integration" | same as agentless panel |
+| Failure-rate badge | (click) | `useFailureStoreRedirectLink({ streamName }).href` |
+
+### 5.6 State + polling
+
+- Topology: `useFlowGraph()` → `useStreamsAppFetch('/internal/streams/_flow/graph', { withRefresh: true })`. Refetches on global timefilter refresh + after any cloud-pipeline / prometheus mutation (`.refresh()`).
+- Throughput: `useFlowThroughputPoll(intervalMs = 5000, paused: boolean)`. Internal `setInterval` + `AbortController`. Output is a `Map<nodeId, FlowThroughput>` and `Map<edgeId, FlowThroughput>` merged into React Flow `nodes` / `edges` via `setNodes((prev) => prev.map(...))`. Layout is **not** recomputed on poll.
+- Pause toggle (`EuiSwitch` in header) flips the `paused` flag.
+
+### 5.7 Layout
+
+`layout.ts` — port of `fleet/.../graph_view/layout.ts`:
+1. Group nodes by `column` (3 columns) and within `shippers` further by `lane` (3 lanes).
+2. Run a Dagre instance per column with `rankdir: 'LR'`, but constrain x to a fixed bucket per column.
+3. Within `shippers`, lanes get fixed y-bands; agents grouped by `parentId` (policy group) get tighter clustering.
+4. Edges get LR routing.
+5. Output `{ nodes: Node[], edges: Edge[] }` with explicit `position`.
+
+Re-run only on payload `nodes.length` / `edges.length` change, not on throughput poll.
+
+---
+
+## 6. Cross-cutting concerns
+
+### 6.1 i18n
+Every visible string wrapped in `i18n.translate('xpack.streams.ingestFlow.<key>', { defaultMessage })`. POC scope: only the new strings — don't touch existing translations.
+
+### 6.2 Privileges
+- Page mount: gate on `streamsPrivileges.ui.show` (existing).
+- Failure-rate badge: omit if `getFailedDocCountsForStreams` returned no row for the stream (privilege-driven empty result is indistinguishable from "no failures" — fine for POC).
+- Cloud pipeline + Prometheus CRUD: gated on `STREAMS_API_PRIVILEGES.manage` server-side; "Edit" / "Delete" buttons disabled client-side based on `streamsPrivileges.api.manage`.
+- Fleet calls: catch `FleetUnauthorizedError`, return empty arrays + `meta.fleetAvailable = false`. Banner shows "Fleet not available" if so.
+
+### 6.3 Spaces awareness
+`fleetAgentPolicyService.list` and `agentService.listAgents` are space-aware via the SO client and `getSpaceAwarenessFilterForAgents`. Pass `spaceId` from request context.
+
+### 6.4 Error handling
+Per-source resilience: each `Promise.all` slot wrapped in `.catch(() => fallback)`. The graph still renders if Fleet errors out — banner just notes degraded state via `meta`.
+
+### 6.5 Telemetry
+Out of scope for POC. Add `usageCollection` hooks later.
+
+### 6.6 Testing
+- Server: jest unit tests for `assembleFlowGraphPayload(fixtures)` — pure function, exhaustive coverage. Jest unit tests for both mock metrics generators (determinism + bounds).
+- Client: jest snapshot for one realistic payload → rendered nodes + edges. One Scout UI test: page loads, click agent node opens panel.
+
+---
+
+## 7. Workstream split (for parallel execution)
+
+Goal: 6 engineers × ~3 days each in parallel after day-1 contract lock.
+
+### Day 1 (single-threaded): **CONTRACT** workstream
+**Owner**: 1 eng. **Output**: PR landing
+- `streams/common/flow/types.ts` + `fixtures.ts` (zod schemas + realistic fixture)
+- Empty `_flow/graph` + `_flow/throughput` routes returning the fixture
+- Empty `_flow/cloud_pipelines/*` + `_flow/prometheus_scrapers/*` routes returning seeded fixtures
+- `streams_app` route registration + nav button + `<IngestFlowView />` shell that fetches `/internal/streams/_flow/graph` and dumps the JSON in a `<pre>` block
+- `routes/config.tsx` query param additions (`editRoutingRuleId`, `action`)
+
+After this PR merges, all six workstreams below run in parallel, each against the locked types and the fixture-served endpoints.
+
+### Workstream A — **SERVER REAL DATA**
+**Owner**: 1 eng (server-leaning). **PRs**: 2.
+- A1: Fleet plumbing (`optionalPlugins`, types, scoped clients, agent + agentless query, `assembleFlowGraphPayload` real impl wired in)
+- A2: Stream rates + failure rates wired into `_flow/graph` and `_flow/throughput`. Replace fixture data path-by-path.
+- **Boundary**: returns `FlowGraphPayload` exactly matching the fixture's shape. Frontend never sees this work.
+
+### Workstream B — **MOCK MODULES**
+**Owner**: 1 eng. **PRs**: 2.
+- B1: `mock_ingest_sources/cloud_pipelines/` — storage, metrics generator, client, routes wired up
+- B2: `mock_ingest_sources/prometheus/` — same pattern
+- **Boundary**: `ICloudPipelinesClient` + `IPrometheusMockClient` interfaces. Workstream A consumes them.
+
+### Workstream C — **CANVAS + LAYOUT**
+**Owner**: 1 eng (frontend, graph-leaning). **PRs**: 1.
+- `flow_canvas.tsx` + `layout.ts` (port from Fleet OTel) + `throughput_edge.tsx` + `lane_label_node.tsx` + legend
+- Renders the fixture payload in a recognizably correct three-column, three-lane layout
+- **Boundary**: receives `FlowGraphPayload` + `FlowThroughputPayload` props; emits `onSelectNode(nodeId)` / `onSelectEdge(edgeId)`. Renders placeholder boxes for node kinds (until Workstream D lands).
+
+### Workstream D — **NODE + PANEL COMPONENTS**
+**Owner**: 1–2 eng (D split into D1 nodes + D2 panels if desired). **PRs**: 1–2.
+- All 8 node components + 8 panel components against the fixture
+- `failure_rate_badge.tsx`, `health_pill.tsx`
+- Each node + panel pair is independent — internally further parallelizable
+- **Boundary**: node component API = React Flow `NodeProps<FlowNodeData>`; panel component API = `{ node, onClose }`.
+
+### Workstream E — **DEEP-LINK PLUMBING**
+**Owner**: 1 eng. **PRs**: 1.
+- `useStreamDiscoverLink` extraction from `streams_list/index.tsx`
+- `editRoutingRuleId` and `action: 'addChild'` consumed in `stream_detail_routing/index.tsx` (mount effect dispatching state-machine events)
+- Verify all `pagePathGetters.*` lookups resolve correctly and exist (smoke-test by clicking through each in dev)
+- **Boundary**: a small `links.ts` file exporting `getQuickLinks(node): QuickLink[]` consumed by panel components.
+
+### Workstream F — **EDIT FLYOUTS**
+**Owner**: 1 eng. **PRs**: 2.
+- F1: `CloudPipelineEditFlyout` (create/edit/duplicate, with optional `focusField` prop)
+- F2: `PrometheusScraperEditFlyout` (create/edit)
+- Wired to repository client mutations + `useFlowGraph().refresh()` on success
+- **Boundary**: `<CloudPipelineEditFlyout pipelineId={...} mode="edit"|"create" focusField={...} onClose={...} />` (and the analogous Prometheus one). Workstream D imports them by path.
+
+---
+
+### Dependency graph between workstreams
+
+```
+        ┌─────────────┐
+        │  CONTRACT   │ (day 1, single-threaded)
+        └──────┬──────┘
+               │
+   ┌──────┬────┴────┬──────┬──────┬──────┐
+   ▼      ▼         ▼      ▼      ▼      ▼
+   A      B         C      D      E      F
+              (B-client used by A)   (E-links consumed by D)
+                          (D imports F flyouts in panels)
+```
+
+A consumes B's client interfaces (so B should land first — about 1 day ahead of A2). Otherwise no cross-blocking.
+
+### Definition of Done per workstream
+
+| WS | DoD |
+|---|---|
+| CONTRACT | Page loads, dumps fixture JSON, nav button works, all routes registered |
+| A | Real Fleet + streams + failure rates flowing end-to-end; jest covers `assembleFlowGraphPayload` |
+| B | Mock CRUD reachable via `streamsRepositoryClient.fetch`, metrics deterministic in jest |
+| C | Fixture renders as recognizable graph; pause toggle works; legend visible |
+| D | Each node + panel renders fixture data correctly with EUI styling |
+| E | All quick-link buttons in panels navigate to existing surfaces; routing-rule edit deep-link opens the right rule |
+| F | Both flyouts perform CRUD against mock; refresh causes graph to update |
+
+### Integration day (after all merge)
+Half-day. Wire A's real payload through C's canvas, D's components, F's flyouts. Smoke test against a stateful Kibana with at least one Fleet agent + a stream tree. Fix layout / sizing bugs. Land the polish (mock banner, lane labels, legend tweaks) in a final PR.
+
+---
+
+## 8. Open questions tracked
+
+1. Failure-rate window — fixed 5m vs. global timefilter? **Default**: 5m; revisit.
+2. `routingRule.edit` deep-link — pass rule id or destination stream name? **Default**: destination stream name; resolve at mount.
+3. Prometheus icon — no `logoPrometheus` in EUI; use `logoMetrics` or inline SVG.
+4. Wired stream "View dashboards" tab doesn't exist; we route to `attachments`. Confirm with PM.
+5. Spaces — POC tested only in default space. Follow-up to verify.
+6. Live-poll rate — 5s is fine for demo; tune later if ES load matters.
+
+---
+
+## 9. Out of scope (for the POC)
+
+- Persistence of mock entities across Kibana restarts
+- Real Cloud Pipelines control plane integration
+- Real Prometheus ingestion path
+- Telemetry / usage collection
+- Audit logging for mock CRUD
+- RBAC fine-grained per-pipeline / per-scraper
+- Agent-to-pipeline edges driven by real policy output configs (we approximate with "all agents → bulk endpoint")
+- Migration / hardening of the `_flow/*` routes from `internal` to `public`

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/badges/failure_rate_badge.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/badges/failure_rate_badge.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiNotificationBadge, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { formatRate } from '../edges/throughput_edge';
+
+export interface FailureRateBadgeProps {
+  streamName: string;
+  failureRate: { docsPerSec: number };
+  onClickDiscover?: () => void;
+}
+
+export const FailureRateBadge: React.FC<FailureRateBadgeProps> = ({
+  failureRate,
+  onClickDiscover,
+}) => {
+  const formatted = formatRate(failureRate.docsPerSec).replace('/s', '');
+  const tooltipContent = i18n.translate('xpack.streams.ingestFlow.failureRateBadge.tooltip', {
+    defaultMessage: '{rate} docs/sec failing ingest. {clickText}',
+    values: {
+      rate: formatted,
+      clickText: onClickDiscover
+        ? i18n.translate('xpack.streams.ingestFlow.failureRateBadge.clickToView', {
+            defaultMessage: 'Click to view in Discover.',
+          })
+        : '',
+    },
+  });
+
+  const badge = (
+    <EuiNotificationBadge
+      color="danger"
+      onClick={onClickDiscover}
+      aria-label={i18n.translate('xpack.streams.ingestFlow.failureRateBadge.ariaLabel', {
+        defaultMessage: '{rate} docs/sec failing ingest',
+        values: { rate: formatted },
+      })}
+    >
+      {formatted}
+    </EuiNotificationBadge>
+  );
+
+  return (
+    <EuiToolTip content={tooltipContent} position="top">
+      {badge}
+    </EuiToolTip>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/badges/failure_rate_badge.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/badges/failure_rate_badge.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiNotificationBadge, EuiToolTip } from '@elastic/eui';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { formatRate } from '../edges/throughput_edge';
 
@@ -33,17 +33,23 @@ export const FailureRateBadge: React.FC<FailureRateBadgeProps> = ({
     },
   });
 
-  const badge = (
-    <EuiNotificationBadge
+  const ariaLabel = i18n.translate('xpack.streams.ingestFlow.failureRateBadge.ariaLabel', {
+    defaultMessage: '{rate} docs/sec failing ingest',
+    values: { rate: formatted },
+  });
+
+  const badge = onClickDiscover ? (
+    <EuiBadge
       color="danger"
-      onClick={onClickDiscover}
-      aria-label={i18n.translate('xpack.streams.ingestFlow.failureRateBadge.ariaLabel', {
-        defaultMessage: '{rate} docs/sec failing ingest',
-        values: { rate: formatted },
-      })}
+      onClick={() => onClickDiscover()}
+      onClickAriaLabel={ariaLabel}
     >
       {formatted}
-    </EuiNotificationBadge>
+    </EuiBadge>
+  ) : (
+    <EuiBadge color="danger" aria-label={ariaLabel}>
+      {formatted}
+    </EuiBadge>
   );
 
   return (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/badges/health_pill.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/badges/health_pill.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiHealth } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowHealth } from '@kbn/streams-plugin/common';
+
+type HealthStatus = FlowHealth['status'];
+
+const COLOR_MAP: Record<HealthStatus, 'success' | 'warning' | 'danger' | 'subdued'> = {
+  healthy: 'success',
+  degraded: 'warning',
+  down: 'danger',
+  unknown: 'subdued',
+};
+
+const LABEL_MAP: Record<HealthStatus, string> = {
+  healthy: i18n.translate('xpack.streams.ingestFlow.healthPill.healthy', {
+    defaultMessage: 'Healthy',
+  }),
+  degraded: i18n.translate('xpack.streams.ingestFlow.healthPill.degraded', {
+    defaultMessage: 'Degraded',
+  }),
+  down: i18n.translate('xpack.streams.ingestFlow.healthPill.down', {
+    defaultMessage: 'Down',
+  }),
+  unknown: i18n.translate('xpack.streams.ingestFlow.healthPill.unknown', {
+    defaultMessage: 'Unknown',
+  }),
+};
+
+interface HealthPillProps {
+  status: HealthStatus;
+  size?: 's' | 'm';
+}
+
+export const HealthPill: React.FC<HealthPillProps> = ({ status, size = 's' }) => {
+  return (
+    <EuiHealth color={COLOR_MAP[status]} textSize={size}>
+      {LABEL_MAP[status]}
+    </EuiHealth>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/edges/throughput_edge.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/edges/throughput_edge.tsx
@@ -6,12 +6,15 @@
  */
 
 import React from 'react';
-import { BaseEdge, EdgeLabelRenderer, getBezierPath, type EdgeProps } from '@xyflow/react';
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, type Edge, type EdgeProps } from '@xyflow/react';
 import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { FlowEdge } from '@kbn/streams-plugin/common';
 
-export type ThroughputEdgeData = Pick<FlowEdge, 'health' | 'throughput' | 'isMock' | 'kind'>;
+export type ThroughputEdgeData = Pick<FlowEdge, 'health' | 'throughput' | 'isMock' | 'kind'> &
+  Record<string, unknown>;
+
+export type ThroughputEdgeType = Edge<ThroughputEdgeData>;
 
 export const formatRate = (docsPerSec: number): string => {
   if (docsPerSec === 0) return '0/s';
@@ -36,7 +39,7 @@ const getEdgeColor = (
   }
 };
 
-export const ThroughputEdge: React.FC<EdgeProps<ThroughputEdgeData>> = ({
+export const ThroughputEdge: React.FC<EdgeProps<ThroughputEdgeType>> = ({
   id,
   sourceX,
   sourceY,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/edges/throughput_edge.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/edges/throughput_edge.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, type EdgeProps } from '@xyflow/react';
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { FlowEdge } from '@kbn/streams-plugin/common';
+
+export type ThroughputEdgeData = Pick<FlowEdge, 'health' | 'throughput' | 'isMock' | 'kind'>;
+
+export const formatRate = (docsPerSec: number): string => {
+  if (docsPerSec === 0) return '0/s';
+  if (docsPerSec < 1000) return `${Math.round(docsPerSec)}/s`;
+  if (docsPerSec < 1_000_000) return `${(docsPerSec / 1000).toFixed(1)}k/s`;
+  return `${(docsPerSec / 1_000_000).toFixed(1)}M/s`;
+};
+
+const getEdgeColor = (
+  status: FlowEdge['health'] extends { status: infer S } ? S : string | undefined,
+  euiTheme: ReturnType<typeof useEuiTheme>['euiTheme']
+): string => {
+  switch (status) {
+    case 'healthy':
+      return euiTheme.colors.success;
+    case 'degraded':
+      return euiTheme.colors.warning;
+    case 'down':
+      return euiTheme.colors.danger;
+    default:
+      return euiTheme.colors.subduedText;
+  }
+};
+
+export const ThroughputEdge: React.FC<EdgeProps<ThroughputEdgeData>> = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+}) => {
+  const { euiTheme } = useEuiTheme();
+
+  const docsPerSec = data?.throughput?.docsPerSec ?? 0;
+  const healthStatus = data?.health?.status;
+
+  const strokeWidth = Math.max(1, Math.log10(docsPerSec + 10) * 2);
+  const strokeColor = getEdgeColor(healthStatus, euiTheme);
+
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const showLabel = docsPerSec > 0;
+  const labelText = (data?.isMock ? '~' : '') + formatRate(docsPerSec);
+
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        style={{
+          stroke: strokeColor,
+          strokeWidth,
+          animation: showLabel ? 'dashdraw 0.5s linear infinite' : undefined,
+        }}
+      />
+      {showLabel && (
+        <EdgeLabelRenderer>
+          <div
+            css={css`
+              position: absolute;
+              transform: translate(-50%, -50%) translate(${labelX}px, ${labelY}px);
+              background: ${euiTheme.colors.backgroundBasePlain};
+              border: 1px solid ${euiTheme.colors.lightShade};
+              border-radius: ${euiTheme.border.radius.small};
+              padding: 1px 4px;
+              font-size: ${euiTheme.font.scale.xs}em;
+              color: ${euiTheme.colors.subduedText};
+              pointer-events: none;
+              white-space: nowrap;
+              z-index: ${euiTheme.levels.content};
+            `}
+          >
+            {labelText}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flow_canvas.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flow_canvas.tsx
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useMemo } from 'react';
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  MarkerType,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+  type Node,
+  type Edge,
+  type NodeMouseHandler,
+  type NodeTypes,
+  type EdgeTypes,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useEuiTheme } from '@elastic/eui';
+import type { FlowGraphPayload, FlowThroughputPayload, FlowNode } from '@kbn/streams-plugin/common';
+import { applyFlowLayout } from './layout';
+import { ThroughputEdge, type ThroughputEdgeData } from './edges/throughput_edge';
+import { AgentNode } from './nodes/agent_node';
+import { AgentPolicyGroupNode } from './nodes/agent_policy_group_node';
+import { AgentlessIntegrationNode } from './nodes/agentless_integration_node';
+import { PrometheusScraperNode } from './nodes/prometheus_scraper_node';
+import { CloudPipelineNode } from './nodes/cloud_pipeline_node';
+import { BulkEndpointNode } from './nodes/bulk_endpoint_node';
+import { WiredStreamNode } from './nodes/wired_stream_node';
+import { ClassicStreamNode } from './nodes/classic_stream_node';
+import { LaneLabelNode } from './nodes/lane_label_node';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+// FlowNodeData is the React Flow node `data` shape — carries the full FlowNode
+type FlowNodeData = FlowNode & { throughputOverride?: { docsPerSec: number } };
+
+const nodeTypes: NodeTypes = {
+  agent: AgentNode,
+  agentPolicy: AgentPolicyGroupNode,
+  agentlessIntegration: AgentlessIntegrationNode,
+  prometheusScraper: PrometheusScraperNode,
+  cloudPipeline: CloudPipelineNode,
+  bulkEndpoint: BulkEndpointNode,
+  wiredStream: WiredStreamNode,
+  classicStream: ClassicStreamNode,
+  laneLabel: LaneLabelNode,
+};
+
+const edgeTypes: EdgeTypes = {
+  throughput: ThroughputEdge,
+};
+
+// ── Converters ────────────────────────────────────────────────────────────────
+
+const payloadNodeToFlowNode = (node: FlowNode): Node<FlowNodeData> => ({
+  id: node.id,
+  type: node.kind,
+  position: { x: 0, y: 0 }, // layout will set real positions
+  data: node as FlowNodeData,
+  width: NODE_WIDTH,
+  height: NODE_HEIGHT,
+  ...(node.parentId ? { parentId: node.parentId } : {}),
+});
+
+const payloadEdgeToFlowEdge = (
+  edge: FlowGraphPayload['edges'][number]
+): Edge<ThroughputEdgeData> => ({
+  id: edge.id,
+  source: edge.source,
+  target: edge.target,
+  type: 'throughput',
+  data: {
+    health: edge.health,
+    throughput: edge.throughput,
+    isMock: edge.isMock,
+    kind: edge.kind,
+  },
+});
+
+// ── Merge throughput overlay into nodes without re-running layout ─────────────
+
+const mergeNodeThroughput = (
+  node: Node<FlowNodeData>,
+  throughput: FlowThroughputPayload | null
+): Node<FlowNodeData> => {
+  if (!throughput) return node;
+  const perNode = throughput.perNode[node.id];
+  const perNodeHealth = throughput.perNodeHealth[node.id];
+  if (!perNode && !perNodeHealth) return node;
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      ...(perNode ? { throughput: perNode } : {}),
+      ...(perNodeHealth ? { health: perNodeHealth } : {}),
+    },
+  };
+};
+
+const mergeEdgeThroughput = (
+  edge: Edge<ThroughputEdgeData>,
+  throughput: FlowThroughputPayload | null
+): Edge<ThroughputEdgeData> => {
+  if (!throughput) return edge;
+  const perEdge = throughput.perEdge[edge.id];
+  if (!perEdge) return edge;
+  return {
+    ...edge,
+    data: {
+      ...edge.data,
+      throughput: perEdge,
+      kind: edge.data?.kind ?? 'bulk->stream',
+    },
+  };
+};
+
+// ── Inner component (needs ReactFlowProvider in parent) ───────────────────────
+
+interface FlowCanvasInnerProps {
+  payload: FlowGraphPayload;
+  throughput: FlowThroughputPayload | null;
+  selectedNodeId: string | null;
+  onSelectNode: (nodeId: string | null) => void;
+}
+
+const FlowCanvasInner: React.FC<FlowCanvasInnerProps> = ({
+  payload,
+  throughput,
+  selectedNodeId,
+  onSelectNode,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const { fitView } = useReactFlow();
+
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node<FlowNodeData>>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge<ThroughputEdgeData>>([]);
+
+  // Re-run layout only when the topology changes (not on throughput poll)
+  const nodeCount = payload.nodes.length;
+  const edgeCount = payload.edges.length;
+
+  useEffect(() => {
+    const rawNodes = payload.nodes.map(payloadNodeToFlowNode);
+    const rawEdges = payload.edges.map(payloadEdgeToFlowEdge);
+    const { nodes: laidOutNodes } = applyFlowLayout(rawNodes, rawEdges);
+    setNodes(laidOutNodes);
+    setEdges(rawEdges);
+    // fitView is called after nodes are placed
+    requestAnimationFrame(() => {
+      fitView({ padding: 0.1 });
+    });
+    // Only re-run when topology changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeCount, edgeCount, setNodes, setEdges, fitView]);
+
+  // Merge throughput overlay without re-running layout
+  useEffect(() => {
+    if (!throughput) return;
+    setNodes((prev) => prev.map((n) => mergeNodeThroughput(n, throughput)));
+    setEdges((prev) => prev.map((e) => mergeEdgeThroughput(e, throughput)));
+  }, [throughput, setNodes, setEdges]);
+
+  // Reflect external selectedNodeId changes (e.g. deep-link)
+  useEffect(() => {
+    setNodes((prev) =>
+      prev.map((n) => ({
+        ...n,
+        selected: n.id === selectedNodeId,
+      }))
+    );
+  }, [selectedNodeId, setNodes]);
+
+  const handleNodeClick: NodeMouseHandler = useCallback(
+    (_, node) => {
+      onSelectNode(node.id);
+    },
+    [onSelectNode]
+  );
+
+  const handlePaneClick = useCallback(() => {
+    onSelectNode(null);
+  }, [onSelectNode]);
+
+  const defaultEdgeOptions = useMemo(
+    () => ({
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 10,
+        height: 10,
+        color: euiTheme.colors.subduedText,
+      },
+    }),
+    [euiTheme]
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      edgeTypes={edgeTypes}
+      defaultEdgeOptions={defaultEdgeOptions}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onNodeClick={handleNodeClick}
+      onPaneClick={handlePaneClick}
+      fitView
+      fitViewOptions={{ padding: 0.1 }}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      proOptions={{ hideAttribution: true }}
+      css={css`
+        background: ${euiTheme.colors.backgroundBasePlain};
+      `}
+    >
+      <Background />
+      <Controls showInteractive={false} />
+    </ReactFlow>
+  );
+};
+
+// ── Public component (provides ReactFlowProvider) ─────────────────────────────
+
+export interface FlowCanvasProps {
+  payload: FlowGraphPayload;
+  throughput: FlowThroughputPayload | null;
+  selectedNodeId: string | null;
+  onSelectNode: (nodeId: string | null) => void;
+}
+
+export const FlowCanvas: React.FC<FlowCanvasProps> = (props) => {
+  return (
+    <ReactFlowProvider>
+      <FlowCanvasInner {...props} />
+    </ReactFlowProvider>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flow_canvas.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flow_canvas.tsx
@@ -16,16 +16,16 @@ import {
   useEdgesState,
   useReactFlow,
   type Node,
-  type Edge,
   type NodeMouseHandler,
   type NodeTypes,
   type EdgeTypes,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 import type { FlowGraphPayload, FlowThroughputPayload, FlowNode } from '@kbn/streams-plugin/common';
-import { applyFlowLayout } from './layout';
-import { ThroughputEdge, type ThroughputEdgeData } from './edges/throughput_edge';
+import { applyFlowLayout, NODE_WIDTH, NODE_HEIGHT } from './layout';
+import { ThroughputEdge, type ThroughputEdgeType } from './edges/throughput_edge';
 import { AgentNode } from './nodes/agent_node';
 import { AgentPolicyGroupNode } from './nodes/agent_policy_group_node';
 import { AgentlessIntegrationNode } from './nodes/agentless_integration_node';
@@ -71,7 +71,7 @@ const payloadNodeToFlowNode = (node: FlowNode): Node<FlowNodeData> => ({
 
 const payloadEdgeToFlowEdge = (
   edge: FlowGraphPayload['edges'][number]
-): Edge<ThroughputEdgeData> => ({
+): ThroughputEdgeType => ({
   id: edge.id,
   source: edge.source,
   target: edge.target,
@@ -105,9 +105,9 @@ const mergeNodeThroughput = (
 };
 
 const mergeEdgeThroughput = (
-  edge: Edge<ThroughputEdgeData>,
+  edge: ThroughputEdgeType,
   throughput: FlowThroughputPayload | null
-): Edge<ThroughputEdgeData> => {
+): ThroughputEdgeType => {
   if (!throughput) return edge;
   const perEdge = throughput.perEdge[edge.id];
   if (!perEdge) return edge;
@@ -140,7 +140,7 @@ const FlowCanvasInner: React.FC<FlowCanvasInnerProps> = ({
   const { fitView } = useReactFlow();
 
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<FlowNodeData>>([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge<ThroughputEdgeData>>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<ThroughputEdgeType>([]);
 
   // Re-run layout only when the topology changes (not on throughput poll)
   const nodeCount = payload.nodes.length;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flow_canvas.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flow_canvas.tsx
@@ -66,7 +66,9 @@ const payloadNodeToFlowNode = (node: FlowNode): Node<FlowNodeData> => ({
   data: node as FlowNodeData,
   width: NODE_WIDTH,
   height: NODE_HEIGHT,
-  ...(node.parentId ? { parentId: node.parentId } : {}),
+  // Do NOT set parentId here: React Flow would treat the node as a child with
+  // position relative to the parent, conflicting with Dagre's absolute coords.
+  // Parent grouping is handled purely inside the layout function for clustering.
 });
 
 const payloadEdgeToFlowEdge = (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flyouts/cloud_pipeline_edit_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flyouts/cloud_pipeline_edit_flyout.tsx
@@ -1,0 +1,395 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiConfirmModal,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiForm,
+  EuiFormRow,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '../../../hooks/use_kibana';
+import { getFormattedError } from '../../../util/errors';
+
+// TODO: import from @kbn/streams-plugin/server once workstream B types are public
+interface OtlpEndpointConfig {
+  id: string;
+  name: string;
+  targetStreamName?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CloudPipelineEditFlyoutProps {
+  mode: 'create' | 'edit';
+  /** Required when mode === 'edit' */
+  pipelineId?: string;
+  /** Auto-focus this field when the flyout opens */
+  focusField?: 'targetStream';
+  onClose: () => void;
+  /** Parent should trigger graph refresh */
+  onSuccess: () => void;
+}
+
+export const CloudPipelineEditFlyout: React.FC<CloudPipelineEditFlyoutProps> = ({
+  mode,
+  pipelineId,
+  focusField,
+  onClose,
+  onSuccess,
+}) => {
+  const {
+    core,
+    dependencies: {
+      start: {
+        streams: { streamsRepositoryClient },
+      },
+    },
+  } = useKibana();
+
+  const [name, setName] = useState('');
+  const [targetStreamName, setTargetStreamName] = useState('');
+  const [nameError, setNameError] = useState<string | undefined>();
+  const [submitError, setSubmitError] = useState<string | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(mode === 'edit');
+  const [fetchError, setFetchError] = useState<string | undefined>();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const flyoutTitleId = useGeneratedHtmlId({ prefix: 'cloudPipelineEditFlyout' });
+  const targetStreamRef = useRef<HTMLInputElement | null>(null);
+
+  // Fetch existing config for edit mode
+  useEffect(() => {
+    if (mode !== 'edit' || !pipelineId) return;
+
+    const abortController = new AbortController();
+
+    const fetchPipeline = async () => {
+      setIsFetching(true);
+      setFetchError(undefined);
+      try {
+        const pipeline = await streamsRepositoryClient.fetch(
+          'GET /internal/streams/_flow/cloud_pipelines/{id}',
+          {
+            signal: abortController.signal,
+            params: { path: { id: pipelineId } },
+          }
+        );
+        setName(pipeline.name);
+        setTargetStreamName(pipeline.targetStreamName ?? '');
+      } catch (err) {
+        if (!abortController.signal.aborted) {
+          setFetchError(getFormattedError(err).message);
+        }
+      } finally {
+        if (!abortController.signal.aborted) {
+          setIsFetching(false);
+        }
+      }
+    };
+
+    fetchPipeline();
+    return () => abortController.abort();
+  }, [mode, pipelineId, streamsRepositoryClient]);
+
+  // Auto-focus the target stream field if requested
+  useEffect(() => {
+    if (focusField === 'targetStream' && !isFetching) {
+      targetStreamRef.current?.focus();
+    }
+  }, [focusField, isFetching]);
+
+  const validate = useCallback((): boolean => {
+    if (!name.trim()) {
+      setNameError(
+        i18n.translate('xpack.streams.ingestFlow.cloudPipelineEditFlyout.nameRequiredError', {
+          defaultMessage: 'Name is required.',
+        })
+      );
+      return false;
+    }
+    setNameError(undefined);
+    return true;
+  }, [name]);
+
+  const handleSave = useCallback(async () => {
+    if (!validate()) return;
+
+    setIsLoading(true);
+    setSubmitError(undefined);
+
+    try {
+      const body = {
+        name: name.trim(),
+        ...(targetStreamName.trim() ? { targetStreamName: targetStreamName.trim() } : {}),
+      };
+
+      if (mode === 'create') {
+        await streamsRepositoryClient.fetch('POST /internal/streams/_flow/cloud_pipelines', {
+          params: { body },
+        });
+      } else {
+        await streamsRepositoryClient.fetch('PUT /internal/streams/_flow/cloud_pipelines/{id}', {
+          params: { path: { id: pipelineId! }, body },
+        });
+      }
+
+      core.notifications.toasts.addSuccess(
+        i18n.translate('xpack.streams.ingestFlow.cloudPipelineEditFlyout.savedSuccessToast', {
+          defaultMessage: 'Endpoint saved',
+        })
+      );
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setSubmitError(getFormattedError(err).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    validate,
+    name,
+    targetStreamName,
+    mode,
+    pipelineId,
+    streamsRepositoryClient,
+    core.notifications.toasts,
+    onSuccess,
+    onClose,
+  ]);
+
+  const handleDelete = useCallback(async () => {
+    if (!pipelineId) return;
+
+    setIsDeleting(true);
+    try {
+      await streamsRepositoryClient.fetch('DELETE /internal/streams/_flow/cloud_pipelines/{id}', {
+        params: { path: { id: pipelineId } },
+      });
+      core.notifications.toasts.addSuccess(
+        i18n.translate('xpack.streams.ingestFlow.cloudPipelineEditFlyout.deletedSuccessToast', {
+          defaultMessage: 'Endpoint deleted',
+        })
+      );
+      onSuccess();
+      onClose();
+    } catch (err) {
+      core.notifications.toasts.addError(getFormattedError(err), {
+        title: i18n.translate(
+          'xpack.streams.ingestFlow.cloudPipelineEditFlyout.deleteErrorToastTitle',
+          { defaultMessage: 'Failed to delete endpoint' }
+        ),
+      });
+    } finally {
+      setIsDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  }, [pipelineId, streamsRepositoryClient, core.notifications.toasts, onSuccess, onClose]);
+
+  const isEdit = mode === 'edit';
+  const title = isEdit
+    ? i18n.translate('xpack.streams.ingestFlow.cloudPipelineEditFlyout.editTitle', {
+        defaultMessage: 'Edit OTLP endpoint',
+      })
+    : i18n.translate('xpack.streams.ingestFlow.cloudPipelineEditFlyout.createTitle', {
+        defaultMessage: 'New OTLP endpoint',
+      });
+
+  return (
+    <>
+      <EuiFlyout onClose={onClose} size="s" ownFocus aria-labelledby={flyoutTitleId}>
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m" id={flyoutTitleId}>
+            <h2>
+              {title}{' '}
+              <EuiBadge color="warning">
+                {i18n.translate('xpack.streams.ingestFlow.cloudPipelineEditFlyout.mockBadge', {
+                  defaultMessage: 'MOCK',
+                })}
+              </EuiBadge>
+            </h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+
+        <EuiFlyoutBody>
+          {isFetching ? (
+            <EuiFlexGroup justifyContent="center" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner size="l" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : fetchError ? (
+            <EuiCallOut
+              announceOnMount
+              color="danger"
+              iconType="error"
+              title={i18n.translate(
+                'xpack.streams.ingestFlow.cloudPipelineEditFlyout.fetchErrorTitle',
+                { defaultMessage: 'Failed to load endpoint' }
+              )}
+            >
+              {fetchError}
+            </EuiCallOut>
+          ) : (
+            <EuiForm component="form" fullWidth>
+              {submitError && (
+                <>
+                  <EuiCallOut
+                    announceOnMount
+                    color="danger"
+                    iconType="error"
+                    title={i18n.translate(
+                      'xpack.streams.ingestFlow.cloudPipelineEditFlyout.submitErrorTitle',
+                      { defaultMessage: 'Save failed' }
+                    )}
+                  >
+                    {submitError}
+                  </EuiCallOut>
+                  <EuiSpacer size="m" />
+                </>
+              )}
+
+              <EuiFormRow
+                label={i18n.translate(
+                  'xpack.streams.ingestFlow.cloudPipelineEditFlyout.nameLabel',
+                  { defaultMessage: 'Name' }
+                )}
+                isInvalid={!!nameError}
+                error={nameError}
+                fullWidth
+              >
+                <EuiFieldText
+                  data-test-subj="streamsCloudPipelineEditFlyoutName"
+                  value={name}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                    if (nameError) setNameError(undefined);
+                  }}
+                  isInvalid={!!nameError}
+                  fullWidth
+                />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label={i18n.translate(
+                  'xpack.streams.ingestFlow.cloudPipelineEditFlyout.targetStreamLabel',
+                  { defaultMessage: 'Target stream' }
+                )}
+                fullWidth
+              >
+                <EuiFieldText
+                  data-test-subj="streamsCloudPipelineEditFlyoutTargetStream"
+                  inputRef={(ref) => {
+                    targetStreamRef.current = ref;
+                  }}
+                  value={targetStreamName}
+                  onChange={(e) => setTargetStreamName(e.target.value)}
+                  placeholder={i18n.translate(
+                    'xpack.streams.ingestFlow.cloudPipelineEditFlyout.targetStreamPlaceholder',
+                    { defaultMessage: 'e.g. logs.app' }
+                  )}
+                  fullWidth
+                />
+              </EuiFormRow>
+            </EuiForm>
+          )}
+        </EuiFlyoutBody>
+
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    data-test-subj="streamsCloudPipelineEditFlyoutCancel"
+                    onClick={onClose}
+                  >
+                    {i18n.translate(
+                      'xpack.streams.ingestFlow.cloudPipelineEditFlyout.cancelButton',
+                      { defaultMessage: 'Cancel' }
+                    )}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                {isEdit && pipelineId && (
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonEmpty
+                      data-test-subj="streamsCloudPipelineEditFlyoutDelete"
+                      color="danger"
+                      onClick={() => setShowDeleteConfirm(true)}
+                      isDisabled={isFetching || isDeleting}
+                    >
+                      {i18n.translate(
+                        'xpack.streams.ingestFlow.cloudPipelineEditFlyout.deleteButton',
+                        { defaultMessage: 'Delete' }
+                      )}
+                    </EuiButtonEmpty>
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                data-test-subj="streamsCloudPipelineEditFlyoutSave"
+                fill
+                onClick={handleSave}
+                isLoading={isLoading}
+                isDisabled={isFetching || !!fetchError}
+              >
+                {i18n.translate('xpack.streams.ingestFlow.cloudPipelineEditFlyout.saveButton', {
+                  defaultMessage: 'Save',
+                })}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      </EuiFlyout>
+
+      {showDeleteConfirm && (
+        <EuiConfirmModal
+          title={i18n.translate(
+            'xpack.streams.ingestFlow.cloudPipelineEditFlyout.deleteConfirmTitle',
+            { defaultMessage: 'Delete OTLP endpoint' }
+          )}
+          onCancel={() => setShowDeleteConfirm(false)}
+          onConfirm={handleDelete}
+          cancelButtonText={i18n.translate(
+            'xpack.streams.ingestFlow.cloudPipelineEditFlyout.deleteConfirmCancel',
+            { defaultMessage: 'Cancel' }
+          )}
+          confirmButtonText={i18n.translate(
+            'xpack.streams.ingestFlow.cloudPipelineEditFlyout.deleteConfirmConfirm',
+            { defaultMessage: 'Delete' }
+          )}
+          buttonColor="danger"
+          isLoading={isDeleting}
+        >
+          {i18n.translate('xpack.streams.ingestFlow.cloudPipelineEditFlyout.deleteConfirmBody', {
+            defaultMessage:
+              'Are you sure you want to delete this OTLP endpoint? This action cannot be undone.',
+          })}
+        </EuiConfirmModal>
+      )}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flyouts/cloud_pipeline_edit_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flyouts/cloud_pipeline_edit_flyout.tsx
@@ -30,14 +30,6 @@ import { i18n } from '@kbn/i18n';
 import { useKibana } from '../../../hooks/use_kibana';
 import { getFormattedError } from '../../../util/errors';
 
-// TODO: import from @kbn/streams-plugin/server once workstream B types are public
-interface OtlpEndpointConfig {
-  id: string;
-  name: string;
-  targetStreamName?: string;
-  createdAt: number;
-  updatedAt: number;
-}
 
 export interface CloudPipelineEditFlyoutProps {
   mode: 'create' | 'edit';
@@ -147,10 +139,12 @@ export const CloudPipelineEditFlyout: React.FC<CloudPipelineEditFlyoutProps> = (
 
       if (mode === 'create') {
         await streamsRepositoryClient.fetch('POST /internal/streams/_flow/cloud_pipelines', {
+          signal: null,
           params: { body },
         });
       } else {
         await streamsRepositoryClient.fetch('PUT /internal/streams/_flow/cloud_pipelines/{id}', {
+          signal: null,
           params: { path: { id: pipelineId! }, body },
         });
       }
@@ -185,6 +179,7 @@ export const CloudPipelineEditFlyout: React.FC<CloudPipelineEditFlyoutProps> = (
     setIsDeleting(true);
     try {
       await streamsRepositoryClient.fetch('DELETE /internal/streams/_flow/cloud_pipelines/{id}', {
+        signal: null,
         params: { path: { id: pipelineId } },
       });
       core.notifications.toasts.addSuccess(

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flyouts/prometheus_scraper_edit_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flyouts/prometheus_scraper_edit_flyout.tsx
@@ -1,0 +1,554 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiConfirmModal,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiForm,
+  EuiFormRow,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiLoadingSpinner,
+  EuiRadioGroup,
+  EuiSelect,
+  EuiSpacer,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '../../../hooks/use_kibana';
+import { getFormattedError } from '../../../util/errors';
+
+// TODO: import from @kbn/streams-plugin/server once workstream B types are public
+type ScrapeIntervalSec = 15 | 30 | 60;
+
+type PrometheusDestination =
+  | { kind: 'cloudPipeline'; pipelineId: string }
+  | { kind: 'bulkEndpoint' };
+
+const DESTINATION_RADIO_ID_CLOUD_PIPELINE = 'cloudPipeline';
+const DESTINATION_RADIO_ID_BULK_ENDPOINT = 'bulkEndpoint';
+
+const SCRAPE_INTERVAL_OPTIONS: Array<{ value: string; text: string }> = [
+  {
+    value: '15',
+    text: i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.scrapeInterval15s', {
+      defaultMessage: '15s',
+    }),
+  },
+  {
+    value: '30',
+    text: i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.scrapeInterval30s', {
+      defaultMessage: '30s',
+    }),
+  },
+  {
+    value: '60',
+    text: i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.scrapeInterval60s', {
+      defaultMessage: '60s',
+    }),
+  },
+];
+
+export interface PrometheusScraperEditFlyoutProps {
+  mode: 'create' | 'edit';
+  scraperId?: string;
+  onClose: () => void;
+  /** Parent should trigger graph refresh */
+  onSuccess: () => void;
+}
+
+export const PrometheusScraperEditFlyout: React.FC<PrometheusScraperEditFlyoutProps> = ({
+  mode,
+  scraperId,
+  onClose,
+  onSuccess,
+}) => {
+  const {
+    core,
+    dependencies: {
+      start: {
+        streams: { streamsRepositoryClient },
+      },
+    },
+  } = useKibana();
+
+  const [name, setName] = useState('');
+  const [targetHost, setTargetHost] = useState('');
+  const [scrapeIntervalSec, setScrapeIntervalSec] = useState<ScrapeIntervalSec>(30);
+  const [destinationKind, setDestinationKind] = useState<'cloudPipeline' | 'bulkEndpoint'>(
+    'bulkEndpoint'
+  );
+  const [pipelineId, setPipelineId] = useState('');
+
+  const [nameError, setNameError] = useState<string | undefined>();
+  const [targetHostError, setTargetHostError] = useState<string | undefined>();
+  const [pipelineIdError, setPipelineIdError] = useState<string | undefined>();
+  const [submitError, setSubmitError] = useState<string | undefined>();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(mode === 'edit');
+  const [fetchError, setFetchError] = useState<string | undefined>();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const flyoutTitleId = useGeneratedHtmlId({ prefix: 'prometheusScraperEditFlyout' });
+
+  // Fetch existing config for edit mode
+  useEffect(() => {
+    if (mode !== 'edit' || !scraperId) return;
+
+    const abortController = new AbortController();
+
+    const fetchScraper = async () => {
+      setIsFetching(true);
+      setFetchError(undefined);
+      try {
+        const scraper = await streamsRepositoryClient.fetch(
+          'GET /internal/streams/_flow/prometheus_scrapers/{id}',
+          {
+            signal: abortController.signal,
+            params: { path: { id: scraperId } },
+          }
+        );
+        setName(scraper.name);
+        setTargetHost(scraper.targetHost);
+        setScrapeIntervalSec(scraper.scrapeIntervalSec);
+        setDestinationKind(scraper.destination.kind);
+        if (scraper.destination.kind === 'cloudPipeline') {
+          setPipelineId(scraper.destination.pipelineId);
+        }
+      } catch (err) {
+        if (!abortController.signal.aborted) {
+          setFetchError(getFormattedError(err).message);
+        }
+      } finally {
+        if (!abortController.signal.aborted) {
+          setIsFetching(false);
+        }
+      }
+    };
+
+    fetchScraper();
+    return () => abortController.abort();
+  }, [mode, scraperId, streamsRepositoryClient]);
+
+  const validate = useCallback((): boolean => {
+    let valid = true;
+
+    if (!name.trim()) {
+      setNameError(
+        i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.nameRequiredError', {
+          defaultMessage: 'Name is required.',
+        })
+      );
+      valid = false;
+    } else {
+      setNameError(undefined);
+    }
+
+    if (!targetHost.trim()) {
+      setTargetHostError(
+        i18n.translate(
+          'xpack.streams.ingestFlow.prometheusScraperEditFlyout.targetHostRequiredError',
+          { defaultMessage: 'Target host is required.' }
+        )
+      );
+      valid = false;
+    } else {
+      setTargetHostError(undefined);
+    }
+
+    if (destinationKind === 'cloudPipeline' && !pipelineId.trim()) {
+      setPipelineIdError(
+        i18n.translate(
+          'xpack.streams.ingestFlow.prometheusScraperEditFlyout.pipelineIdRequiredError',
+          { defaultMessage: 'Pipeline ID is required when using Cloud Pipelines.' }
+        )
+      );
+      valid = false;
+    } else {
+      setPipelineIdError(undefined);
+    }
+
+    return valid;
+  }, [name, targetHost, destinationKind, pipelineId]);
+
+  const buildDestination = useCallback((): PrometheusDestination => {
+    if (destinationKind === 'cloudPipeline') {
+      return { kind: 'cloudPipeline', pipelineId: pipelineId.trim() };
+    }
+    return { kind: 'bulkEndpoint' };
+  }, [destinationKind, pipelineId]);
+
+  const handleSave = useCallback(async () => {
+    if (!validate()) return;
+
+    setIsLoading(true);
+    setSubmitError(undefined);
+
+    try {
+      const body = {
+        name: name.trim(),
+        targetHost: targetHost.trim(),
+        scrapeIntervalSec,
+        destination: buildDestination(),
+      };
+
+      if (mode === 'create') {
+        await streamsRepositoryClient.fetch('POST /internal/streams/_flow/prometheus_scrapers', {
+          params: { body },
+        });
+      } else {
+        await streamsRepositoryClient.fetch(
+          'PUT /internal/streams/_flow/prometheus_scrapers/{id}',
+          {
+            params: { path: { id: scraperId! }, body },
+          }
+        );
+      }
+
+      core.notifications.toasts.addSuccess(
+        i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.savedSuccessToast', {
+          defaultMessage: 'Scraper saved',
+        })
+      );
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setSubmitError(getFormattedError(err).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    validate,
+    name,
+    targetHost,
+    scrapeIntervalSec,
+    buildDestination,
+    mode,
+    scraperId,
+    streamsRepositoryClient,
+    core.notifications.toasts,
+    onSuccess,
+    onClose,
+  ]);
+
+  const handleDelete = useCallback(async () => {
+    if (!scraperId) return;
+
+    setIsDeleting(true);
+    try {
+      await streamsRepositoryClient.fetch(
+        'DELETE /internal/streams/_flow/prometheus_scrapers/{id}',
+        {
+          params: { path: { id: scraperId } },
+        }
+      );
+      core.notifications.toasts.addSuccess(
+        i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.deletedSuccessToast', {
+          defaultMessage: 'Scraper deleted',
+        })
+      );
+      onSuccess();
+      onClose();
+    } catch (err) {
+      core.notifications.toasts.addError(getFormattedError(err), {
+        title: i18n.translate(
+          'xpack.streams.ingestFlow.prometheusScraperEditFlyout.deleteErrorToastTitle',
+          { defaultMessage: 'Failed to delete scraper' }
+        ),
+      });
+    } finally {
+      setIsDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  }, [scraperId, streamsRepositoryClient, core.notifications.toasts, onSuccess, onClose]);
+
+  const isEdit = mode === 'edit';
+  const title = isEdit
+    ? i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.editTitle', {
+        defaultMessage: 'Edit Prometheus scraper',
+      })
+    : i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.createTitle', {
+        defaultMessage: 'New Prometheus scraper',
+      });
+
+  const destinationRadioOptions = [
+    {
+      id: DESTINATION_RADIO_ID_CLOUD_PIPELINE,
+      label: i18n.translate(
+        'xpack.streams.ingestFlow.prometheusScraperEditFlyout.destinationCloudPipeline',
+        { defaultMessage: 'Via Cloud Pipelines (OTLP)' }
+      ),
+    },
+    {
+      id: DESTINATION_RADIO_ID_BULK_ENDPOINT,
+      label: i18n.translate(
+        'xpack.streams.ingestFlow.prometheusScraperEditFlyout.destinationBulkEndpoint',
+        { defaultMessage: 'Direct to Elasticsearch (_bulk)' }
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyout onClose={onClose} size="s" ownFocus aria-labelledby={flyoutTitleId}>
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m" id={flyoutTitleId}>
+            <h2>
+              {title}{' '}
+              <EuiBadge color="warning">
+                {i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.mockBadge', {
+                  defaultMessage: 'MOCK',
+                })}
+              </EuiBadge>
+            </h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+
+        <EuiFlyoutBody>
+          {isFetching ? (
+            <EuiFlexGroup justifyContent="center" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner size="l" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : fetchError ? (
+            <EuiCallOut
+              announceOnMount
+              color="danger"
+              iconType="error"
+              title={i18n.translate(
+                'xpack.streams.ingestFlow.prometheusScraperEditFlyout.fetchErrorTitle',
+                { defaultMessage: 'Failed to load scraper' }
+              )}
+            >
+              {fetchError}
+            </EuiCallOut>
+          ) : (
+            <EuiForm component="form" fullWidth>
+              {submitError && (
+                <>
+                  <EuiCallOut
+                    announceOnMount
+                    color="danger"
+                    iconType="error"
+                    title={i18n.translate(
+                      'xpack.streams.ingestFlow.prometheusScraperEditFlyout.submitErrorTitle',
+                      { defaultMessage: 'Save failed' }
+                    )}
+                  >
+                    {submitError}
+                  </EuiCallOut>
+                  <EuiSpacer size="m" />
+                </>
+              )}
+
+              <EuiFormRow
+                label={i18n.translate(
+                  'xpack.streams.ingestFlow.prometheusScraperEditFlyout.nameLabel',
+                  { defaultMessage: 'Name' }
+                )}
+                isInvalid={!!nameError}
+                error={nameError}
+                fullWidth
+              >
+                <EuiFieldText
+                  data-test-subj="streamsPrometheusScraperEditFlyoutName"
+                  value={name}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                    if (nameError) setNameError(undefined);
+                  }}
+                  isInvalid={!!nameError}
+                  fullWidth
+                />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label={i18n.translate(
+                  'xpack.streams.ingestFlow.prometheusScraperEditFlyout.targetHostLabel',
+                  { defaultMessage: 'Target host' }
+                )}
+                isInvalid={!!targetHostError}
+                error={targetHostError}
+                fullWidth
+              >
+                <EuiFieldText
+                  data-test-subj="streamsPrometheusScraperEditFlyoutTargetHost"
+                  value={targetHost}
+                  onChange={(e) => {
+                    setTargetHost(e.target.value);
+                    if (targetHostError) setTargetHostError(undefined);
+                  }}
+                  isInvalid={!!targetHostError}
+                  placeholder={i18n.translate(
+                    'xpack.streams.ingestFlow.prometheusScraperEditFlyout.targetHostPlaceholder',
+                    { defaultMessage: 'prometheus.svc.cluster.local:9090' }
+                  )}
+                  fullWidth
+                />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label={i18n.translate(
+                  'xpack.streams.ingestFlow.prometheusScraperEditFlyout.scrapeIntervalLabel',
+                  { defaultMessage: 'Scrape interval' }
+                )}
+                fullWidth
+              >
+                <EuiSelect
+                  data-test-subj="streamsPrometheusScraperEditFlyoutScrapeInterval"
+                  options={SCRAPE_INTERVAL_OPTIONS}
+                  value={String(scrapeIntervalSec)}
+                  onChange={(e) => {
+                    setScrapeIntervalSec(Number(e.target.value) as ScrapeIntervalSec);
+                  }}
+                  fullWidth
+                />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label={i18n.translate(
+                  'xpack.streams.ingestFlow.prometheusScraperEditFlyout.destinationLabel',
+                  { defaultMessage: 'Destination' }
+                )}
+                fullWidth
+              >
+                <EuiRadioGroup
+                  data-test-subj="streamsPrometheusScraperEditFlyoutDestination"
+                  options={destinationRadioOptions}
+                  idSelected={destinationKind}
+                  onChange={(id) => {
+                    setDestinationKind(id as 'cloudPipeline' | 'bulkEndpoint');
+                    if (id !== 'cloudPipeline') {
+                      setPipelineIdError(undefined);
+                    }
+                  }}
+                />
+              </EuiFormRow>
+
+              {destinationKind === DESTINATION_RADIO_ID_CLOUD_PIPELINE && (
+                <EuiFormRow
+                  label={i18n.translate(
+                    'xpack.streams.ingestFlow.prometheusScraperEditFlyout.pipelineIdLabel',
+                    { defaultMessage: 'Pipeline ID' }
+                  )}
+                  isInvalid={!!pipelineIdError}
+                  error={pipelineIdError}
+                  fullWidth
+                >
+                  <EuiFieldText
+                    data-test-subj="streamsPrometheusScraperEditFlyoutPipelineId"
+                    value={pipelineId}
+                    onChange={(e) => {
+                      setPipelineId(e.target.value);
+                      if (pipelineIdError) setPipelineIdError(undefined);
+                    }}
+                    isInvalid={!!pipelineIdError}
+                    placeholder={i18n.translate(
+                      'xpack.streams.ingestFlow.prometheusScraperEditFlyout.pipelineIdPlaceholder',
+                      { defaultMessage: 'e.g. pipeline-abc123' }
+                    )}
+                    fullWidth
+                  />
+                </EuiFormRow>
+              )}
+            </EuiForm>
+          )}
+        </EuiFlyoutBody>
+
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    data-test-subj="streamsPrometheusScraperEditFlyoutCancel"
+                    onClick={onClose}
+                  >
+                    {i18n.translate(
+                      'xpack.streams.ingestFlow.prometheusScraperEditFlyout.cancelButton',
+                      { defaultMessage: 'Cancel' }
+                    )}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                {isEdit && scraperId && (
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonEmpty
+                      data-test-subj="streamsPrometheusScraperEditFlyoutDelete"
+                      color="danger"
+                      onClick={() => setShowDeleteConfirm(true)}
+                      isDisabled={isFetching || isDeleting}
+                    >
+                      {i18n.translate(
+                        'xpack.streams.ingestFlow.prometheusScraperEditFlyout.deleteButton',
+                        { defaultMessage: 'Delete' }
+                      )}
+                    </EuiButtonEmpty>
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                data-test-subj="streamsPrometheusScraperEditFlyoutSave"
+                fill
+                onClick={handleSave}
+                isLoading={isLoading}
+                isDisabled={isFetching || !!fetchError}
+              >
+                {i18n.translate('xpack.streams.ingestFlow.prometheusScraperEditFlyout.saveButton', {
+                  defaultMessage: 'Save',
+                })}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      </EuiFlyout>
+
+      {showDeleteConfirm && (
+        <EuiConfirmModal
+          title={i18n.translate(
+            'xpack.streams.ingestFlow.prometheusScraperEditFlyout.deleteConfirmTitle',
+            { defaultMessage: 'Delete Prometheus scraper' }
+          )}
+          onCancel={() => setShowDeleteConfirm(false)}
+          onConfirm={handleDelete}
+          cancelButtonText={i18n.translate(
+            'xpack.streams.ingestFlow.prometheusScraperEditFlyout.deleteConfirmCancel',
+            { defaultMessage: 'Cancel' }
+          )}
+          confirmButtonText={i18n.translate(
+            'xpack.streams.ingestFlow.prometheusScraperEditFlyout.deleteConfirmConfirm',
+            { defaultMessage: 'Delete' }
+          )}
+          buttonColor="danger"
+          isLoading={isDeleting}
+        >
+          {i18n.translate(
+            'xpack.streams.ingestFlow.prometheusScraperEditFlyout.deleteConfirmBody',
+            {
+              defaultMessage:
+                'Are you sure you want to delete this Prometheus scraper? This action cannot be undone.',
+            }
+          )}
+        </EuiConfirmModal>
+      )}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flyouts/prometheus_scraper_edit_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/flyouts/prometheus_scraper_edit_flyout.tsx
@@ -210,12 +210,14 @@ export const PrometheusScraperEditFlyout: React.FC<PrometheusScraperEditFlyoutPr
 
       if (mode === 'create') {
         await streamsRepositoryClient.fetch('POST /internal/streams/_flow/prometheus_scrapers', {
+          signal: null,
           params: { body },
         });
       } else {
         await streamsRepositoryClient.fetch(
           'PUT /internal/streams/_flow/prometheus_scrapers/{id}',
           {
+            signal: null,
             params: { path: { id: scraperId! }, body },
           }
         );
@@ -255,6 +257,7 @@ export const PrometheusScraperEditFlyout: React.FC<PrometheusScraperEditFlyoutPr
       await streamsRepositoryClient.fetch(
         'DELETE /internal/streams/_flow/prometheus_scrapers/{id}',
         {
+          signal: null,
           params: { path: { id: scraperId } },
         }
       );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/hooks/use_flow_throughput_poll.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/hooks/use_flow_throughput_poll.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { FlowThroughputPayload } from '@kbn/streams-plugin/common';
+import { useKibana } from '../../../hooks/use_kibana';
+
+/**
+ * Polls GET /internal/streams/_flow/throughput every `intervalMs` milliseconds
+ * and returns the latest payload. Stops when `paused` is true or on unmount.
+ */
+export const useFlowThroughputPoll = (
+  intervalMs: number = 5000,
+  paused: boolean
+): FlowThroughputPayload | null => {
+  const { core } = useKibana();
+  const [throughput, setThroughput] = useState<FlowThroughputPayload | null>(null);
+
+  // Keep a stable ref so the interval callback always uses the latest core.http
+  const httpRef = useRef(core.http);
+  httpRef.current = core.http;
+
+  useEffect(() => {
+    if (paused) return;
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+
+    const poll = async () => {
+      const controller = new AbortController();
+
+      try {
+        const result = await httpRef.current.get<FlowThroughputPayload>(
+          '/internal/streams/_flow/throughput',
+          { signal: controller.signal }
+        );
+        if (!cancelled) {
+          setThroughput(result);
+        }
+      } catch {
+        // Silently ignore errors (network blip, abort) — next poll will retry
+      }
+
+      if (!cancelled) {
+        timeoutId = setTimeout(poll, intervalMs);
+      }
+
+      return () => {
+        controller.abort();
+      };
+    };
+
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [intervalMs, paused]);
+
+  return throughput;
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/index.tsx
@@ -22,6 +22,7 @@ import { FlowCanvas } from './flow_canvas';
 import { SimulatedSourcesBanner } from './simulated_sources_banner';
 import { Legend } from './legend';
 import { useFlowThroughputPoll } from './hooks/use_flow_throughput_poll';
+import { DetailFlyout } from './panels/detail_flyout';
 
 export function IngestFlowView() {
   const {
@@ -84,6 +85,13 @@ export function IngestFlowView() {
           <EuiFlexItem grow={false}>
             <SimulatedSourcesBanner />
           </EuiFlexItem>
+
+          {selectedNodeId && flowGraphFetch.value && (
+            <DetailFlyout
+              node={flowGraphFetch.value.nodes.find((n) => n.id === selectedNodeId) ?? null}
+              onClose={() => setSelectedNodeId(null)}
+            />
+          )}
 
           <EuiFlexItem grow>
             {flowGraphFetch.loading && flowGraphFetch.value === undefined ? (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/index.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiSwitch,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import React, { useState } from 'react';
+import { useKibana } from '../../hooks/use_kibana';
+import { useStreamsAppFetch } from '../../hooks/use_streams_app_fetch';
+import { StreamsAppPageTemplate } from '../streams_app_page_template';
+import { FlowCanvas } from './flow_canvas';
+import { SimulatedSourcesBanner } from './simulated_sources_banner';
+import { Legend } from './legend';
+import { useFlowThroughputPoll } from './hooks/use_flow_throughput_poll';
+
+export function IngestFlowView() {
+  const {
+    dependencies: {
+      start: {
+        streams: { streamsRepositoryClient },
+      },
+    },
+  } = useKibana();
+
+  const [isPaused, setIsPaused] = useState(false);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const flowGraphFetch = useStreamsAppFetch(
+    async ({ signal }) =>
+      streamsRepositoryClient.fetch('GET /internal/streams/_flow/graph', {
+        signal,
+      }),
+    [streamsRepositoryClient]
+  );
+
+  const throughputData = useFlowThroughputPoll(5000, isPaused);
+
+  return (
+    <>
+      <StreamsAppPageTemplate.Header
+        pageTitle={
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
+            gutterSize="s"
+            responsive={false}
+            alignItems="center"
+          >
+            <EuiFlexItem>
+              {i18n.translate('xpack.streams.ingestFlow.pageHeaderTitle', {
+                defaultMessage: 'Ingest flow (POC)',
+              })}
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiSwitch
+                label={i18n.translate('xpack.streams.ingestFlow.pauseLiveUpdatesLabel', {
+                  defaultMessage: 'Pause live updates',
+                })}
+                checked={isPaused}
+                onChange={(e) => setIsPaused(e.target.checked)}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        bottomBorder="extended"
+      />
+      <StreamsAppPageTemplate.Body grow>
+        <EuiFlexGroup
+          direction="column"
+          gutterSize="none"
+          css={css`
+            height: 100%;
+          `}
+        >
+          <EuiFlexItem grow={false}>
+            <SimulatedSourcesBanner />
+          </EuiFlexItem>
+
+          <EuiFlexItem grow>
+            {flowGraphFetch.loading && flowGraphFetch.value === undefined ? (
+              <EuiFlexGroup
+                justifyContent="center"
+                alignItems="center"
+                css={css`
+                  min-height: 200px;
+                `}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiLoadingSpinner size="xl" />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            ) : flowGraphFetch.error ? (
+              <EuiEmptyPrompt
+                color="danger"
+                iconType="error"
+                title={
+                  <h2>
+                    {i18n.translate('xpack.streams.ingestFlow.errorTitle', {
+                      defaultMessage: 'Failed to load ingest flow',
+                    })}
+                  </h2>
+                }
+                body={<p>{String(flowGraphFetch.error)}</p>}
+              />
+            ) : flowGraphFetch.value ? (
+              <FlowCanvas
+                payload={flowGraphFetch.value}
+                throughput={throughputData}
+                selectedNodeId={selectedNodeId}
+                onSelectNode={setSelectedNodeId}
+              />
+            ) : null}
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false}>
+            <Legend />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </StreamsAppPageTemplate.Body>
+    </>
+  );
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
@@ -124,28 +124,46 @@ const orderAgentNodes = <T extends Node<FlowNodeData>>(nodes: T[]): T[] => {
   return result;
 };
 
-const STREAM_INDENT = 28; // px per depth level in the streams tree
+// Each depth level is offset by slightly more than one node-width so that a
+// parent's right-side handle (x + NODE_WIDTH) sits to the LEFT of its child's
+// left-side handle (x + STREAM_INDENT * relDepth).  This ensures tree edges
+// always flow left-to-right rather than backward.
+const STREAM_INDENT = NODE_WIDTH + 30;
+
+const getStreamDepth = (streamName: string) =>
+  streamName ? streamName.split('.').length - 1 : 0;
 
 /**
- * Stack stream nodes vertically, indenting each by its depth in the hierarchy.
- * Depth is derived from the number of dots in the stream name
- * (e.g. "logs" → 0, "logs.otel" → 1, "logs.otel.abc" → 2).
+ * Stack stream nodes vertically, indenting each level by STREAM_INDENT px.
+ *
+ * Indentation is relative to the shallowest depth in the set so that root
+ * streams start flush at xBase regardless of their absolute dot-count.
  */
 const stackStreamNodes = <T extends Node<FlowNodeData>>(
   nodeList: T[],
   xBase: number,
   yStart: number
 ): { nodes: T[]; nextY: number } => {
+  if (nodeList.length === 0) return { nodes: nodeList, nextY: yStart };
+
+  const getDepth = (node: T) => {
+    const name =
+      (node.data as { streamName?: string }).streamName ??
+      (node.data as { label?: string }).label ??
+      '';
+    return getStreamDepth(name);
+  };
+
+  const minDepth = Math.min(...nodeList.map(getDepth));
+
   let y = yStart;
   const positioned = nodeList.map((node) => {
-    const streamName =
-      (node.data as { streamName?: string }).streamName ?? (node.data as { label?: string }).label ?? '';
-    const depth = streamName ? streamName.split('.').length - 1 : 0;
+    const relDepth = getDepth(node) - minDepth;
     const result = {
       ...node,
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
-      position: { x: xBase + depth * STREAM_INDENT, y },
+      position: { x: xBase + relDepth * STREAM_INDENT, y },
     };
     y += NODE_HEIGHT + NODE_GAP;
     return result;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
@@ -9,14 +9,16 @@ import Dagre from '@dagrejs/dagre';
 import { Position, type Node, type Edge } from '@xyflow/react';
 
 // Fixed x positions for each column (left edge of the column band)
-const COLUMN_X = { shippers: 0, endpoints: 500, streams: 900 } as const;
+const COLUMN_X = { shippers: 0, endpoints: 600, streams: 1050 } as const;
 
-export const NODE_WIDTH = 200;
-export const NODE_HEIGHT = 80;
+export const NODE_WIDTH = 220;
+// Use a generous height estimate for Dagre so nodes don't overlap even when
+// rendered content is taller than the minimum (EuiPanel padding + badges etc.)
+export const NODE_HEIGHT = 130;
 
-const LANE_GAP = 40;
-const RANKSEP = 40;
-const NODESEP = 20;
+const LANE_GAP = 60;
+const RANKSEP = 60;
+const NODESEP = 40;
 const MARGINX = 10;
 const MARGINY = 10;
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
@@ -5,22 +5,16 @@
  * 2.0.
  */
 
-import Dagre from '@dagrejs/dagre';
 import { Position, type Node, type Edge } from '@xyflow/react';
 
-// Fixed x positions for each column (left edge of the column band)
+// Fixed x positions for each column
 const COLUMN_X = { shippers: 0, endpoints: 600, streams: 1050 } as const;
 
 export const NODE_WIDTH = 220;
-// Use a generous height estimate for Dagre so nodes don't overlap even when
-// rendered content is taller than the minimum (EuiPanel padding + badges etc.)
-export const NODE_HEIGHT = 130;
+export const NODE_HEIGHT = 110;
 
-const LANE_GAP = 60;
-const RANKSEP = 60;
-const NODESEP = 40;
-const MARGINX = 10;
-const MARGINY = 10;
+const NODE_GAP = 20; // vertical gap between nodes in the same lane
+const LANE_GAP = 50; // extra vertical gap between lanes within shippers
 
 type FlowColumn = 'shippers' | 'endpoints' | 'streams';
 type FlowLane = 'agents' | 'agentless' | 'prometheus' | 'pipelines' | 'bulk' | 'streams';
@@ -33,153 +27,113 @@ interface FlowNodeData {
 }
 
 /**
- * Layout a set of nodes in a single Dagre TB graph.
- * Returns the Dagre-positioned y values and sets x to the provided columnX.
+ * Stack a list of nodes vertically starting at yOffset.
+ * Returns positioned nodes and the y value after the last node.
  */
-const layoutColumnNodes = <T extends Node<FlowNodeData>>(
-  columnNodes: T[],
-  edges: Edge[],
-  columnX: number
-): T[] => {
-  if (columnNodes.length === 0) return columnNodes;
-
-  const g = new Dagre.graphlib.Graph({ directed: true, compound: false })
-    .setGraph({
-      rankdir: 'TB',
-      ranksep: RANKSEP,
-      nodesep: NODESEP,
-      marginx: MARGINX,
-      marginy: MARGINY,
-    })
-    .setDefaultEdgeLabel(() => ({}));
-
-  columnNodes.forEach((node) => {
-    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
-  });
-
-  const nodeIds = new Set(columnNodes.map((n) => n.id));
-  edges.forEach((edge) => {
-    if (nodeIds.has(edge.source) && nodeIds.has(edge.target)) {
-      g.setEdge(edge.source, edge.target);
-    }
-  });
-
-  Dagre.layout(g);
-
-  return columnNodes.map((node) => {
-    const dagreNode = g.node(node.id);
-    if (!dagreNode) return node;
-    return {
+const stackNodes = <T extends Node<FlowNodeData>>(
+  nodeList: T[],
+  x: number,
+  yStart: number
+): { nodes: T[]; nextY: number } => {
+  let y = yStart;
+  const nodes = nodeList.map((node) => {
+    const positioned = {
       ...node,
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
-      position: {
-        x: columnX,
-        y: Math.round(dagreNode.y - NODE_HEIGHT / 2),
-      },
+      position: { x, y },
     };
+    y += NODE_HEIGHT + NODE_GAP;
+    return positioned;
   });
+  return { nodes, nextY: y };
 };
 
 /**
- * Layout nodes within a single lane using Dagre TB, returning y positions
- * relative to yOffset.
+ * Order stream nodes so parents always come before their children,
+ * and siblings are grouped together (depth-first tree walk).
  */
-const layoutLaneNodes = <T extends Node<FlowNodeData>>(
-  laneNodes: T[],
-  edges: Edge[],
-  columnX: number,
-  yOffset: number
-): T[] => {
-  if (laneNodes.length === 0) return laneNodes;
+const orderStreamNodes = <T extends Node<FlowNodeData>>(nodes: T[]): T[] => {
+  // Build children map from the data.parentId field
+  const children = new Map<string | undefined, T[]>();
+  for (const node of nodes) {
+    const pid = (node.data as FlowNodeData).parentId;
+    const list = children.get(pid) ?? [];
+    list.push(node);
+    children.set(pid, list);
+  }
 
-  const g = new Dagre.graphlib.Graph({ directed: true, compound: false })
-    .setGraph({
-      rankdir: 'TB',
-      ranksep: RANKSEP,
-      nodesep: NODESEP,
-      marginx: MARGINX,
-      marginy: MARGINY,
-    })
-    .setDefaultEdgeLabel(() => ({}));
-
-  // Group agents by their parentId (policy group) to cluster them together
-  // by adding virtual edges between siblings under the same parent
-  const nodeIds = new Set(laneNodes.map((n) => n.id));
-
-  laneNodes.forEach((node) => {
-    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
-  });
-
-  // Add real edges within the lane
-  edges.forEach((edge) => {
-    if (nodeIds.has(edge.source) && nodeIds.has(edge.target)) {
-      g.setEdge(edge.source, edge.target);
+  const result: T[] = [];
+  const visit = (id: string | undefined) => {
+    const kids = children.get(id) ?? [];
+    for (const kid of kids) {
+      result.push(kid);
+      visit(kid.id);
     }
+  };
+
+  // Roots: nodes whose parentId doesn't exist in the set
+  const ids = new Set(nodes.map((n) => n.id));
+  const roots = nodes.filter((n) => {
+    const pid = (n.data as FlowNodeData).parentId;
+    return !pid || !ids.has(pid);
   });
 
-  // Add sibling edges for nodes that share a parentId (agents under same policy)
-  // so Dagre keeps them adjacent in y
-  const byParent = new Map<string, T[]>();
-  for (const node of laneNodes) {
+  for (const root of roots) {
+    result.push(root);
+    visit(root.id);
+  }
+
+  // Safety: add any nodes not yet visited (shouldn't happen)
+  const visited = new Set(result.map((n) => n.id));
+  for (const node of nodes) {
+    if (!visited.has(node.id)) result.push(node);
+  }
+
+  return result;
+};
+
+/**
+ * Order agent/agentPolicy nodes so each policy group is immediately
+ * followed by its agent children.
+ */
+const orderAgentNodes = <T extends Node<FlowNodeData>>(nodes: T[]): T[] => {
+  const groups = nodes.filter((n) => !(n.data as FlowNodeData).parentId);
+  const agentsByPolicy = new Map<string, T[]>();
+  for (const node of nodes) {
     const pid = (node.data as FlowNodeData).parentId;
     if (pid) {
-      const list = byParent.get(pid) ?? [];
+      const list = agentsByPolicy.get(pid) ?? [];
       list.push(node);
-      byParent.set(pid, list);
+      agentsByPolicy.set(pid, list);
     }
   }
-  for (const siblings of byParent.values()) {
-    for (let i = 0; i < siblings.length - 1; i++) {
-      const src = siblings[i].id;
-      const tgt = siblings[i + 1].id;
-      if (g.hasNode(src) && g.hasNode(tgt) && !g.hasEdge(src, tgt)) {
-        g.setEdge(src, tgt);
-      }
+  const result: T[] = [];
+  for (const group of groups) {
+    result.push(group);
+    for (const agent of agentsByPolicy.get(group.id) ?? []) {
+      result.push(agent);
     }
   }
-
-  Dagre.layout(g);
-
-  return laneNodes.map((node) => {
-    const dagreNode = g.node(node.id);
-    if (!dagreNode) return node;
-    return {
-      ...node,
-      sourcePosition: Position.Right,
-      targetPosition: Position.Left,
-      position: {
-        x: columnX,
-        y: yOffset + Math.round(dagreNode.y - NODE_HEIGHT / 2),
-      },
-    };
-  });
-};
-
-/**
- * Compute the bounding-box height of a set of already-positioned nodes.
- */
-const getBoundingHeight = (nodes: Array<Node<FlowNodeData>>): number => {
-  if (nodes.length === 0) return 0;
-  let maxBottom = 0;
+  // Standalone agents (no group)
   for (const node of nodes) {
-    const bottom = node.position.y + NODE_HEIGHT;
-    if (bottom > maxBottom) maxBottom = bottom;
+    if (!(node.data as FlowNodeData).parentId && !result.includes(node)) {
+      result.push(node);
+    }
   }
-  return maxBottom;
+  return result;
 };
 
 /**
- * Main layout function — port / adaptation of Fleet's applyCompoundLayout for
- * the 3-column (shippers / endpoints / streams), 3-lane-in-shippers topology.
+ * Main layout function.
  *
- * Algorithm:
- * 1. Shippers column: split into 3 lanes (agents / agentless / prometheus).
- *    Each lane gets its own Dagre TB run. Lanes are stacked vertically with
- *    LANE_GAP between them.
- * 2. Endpoints column: single Dagre TB run.
- * 3. Streams column: single Dagre TB run (parent→child edges give tree shape).
- * 4. All x values are fixed to COLUMN_X bucket — Dagre only determines y.
+ * Uses simple vertical stacking per column/lane — Dagre is not used here
+ * because columns are vertical lists, not graphs, and Dagre places all
+ * disconnected nodes at y=0 (same rank), causing overlap.
+ *
+ * Shippers column: 3 lanes (agents → agentless → prometheus) stacked top-to-bottom.
+ * Endpoints column: cloud pipelines then bulk, stacked.
+ * Streams column: tree-ordered (depth-first) and stacked.
  */
 export const applyFlowLayout = <T extends Node<FlowNodeData>>(
   nodes: T[],
@@ -187,65 +141,64 @@ export const applyFlowLayout = <T extends Node<FlowNodeData>>(
 ): { nodes: T[]; edges: Edge[] } => {
   if (nodes.length === 0) return { nodes, edges };
 
-  // ── Partition by column ────────────────────────────────────────────────────
-  const shippersNodes = nodes.filter((n) => n.data.column === 'shippers');
-  const endpointsNodes = nodes.filter((n) => n.data.column === 'endpoints');
-  const streamsNodes = nodes.filter((n) => n.data.column === 'streams');
+  const byColumn = (col: FlowColumn) => nodes.filter((n) => n.data.column === col);
+  const byLane = (lane: FlowLane) => nodes.filter((n) => n.data.lane === lane);
 
-  // ── Shippers: 3 lanes ──────────────────────────────────────────────────────
-  const agentsLane = shippersNodes.filter((n) => n.data.lane === 'agents');
-  const agentlessLane = shippersNodes.filter((n) => n.data.lane === 'agentless');
-  const prometheusLane = shippersNodes.filter((n) => n.data.lane === 'prometheus');
+  // ── Shippers ──────────────────────────────────────────────────────────────
+  const agentNodes = orderAgentNodes(byLane('agents'));
+  const agentlessNodes = byLane('agentless');
+  const prometheusNodes = byLane('prometheus');
 
-  const laidOutAgents = layoutLaneNodes(agentsLane, edges, COLUMN_X.shippers, 0);
-  const agentsHeight = getBoundingHeight(laidOutAgents);
+  let y = 0;
+  const { nodes: posAgents, nextY: afterAgents } = stackNodes(agentNodes, COLUMN_X.shippers, y);
+  y = afterAgents + (agentNodes.length > 0 && agentlessNodes.length > 0 ? LANE_GAP : 0);
 
-  const agentlessOffset = agentsHeight > 0 ? agentsHeight + LANE_GAP : 0;
-  const laidOutAgentless = layoutLaneNodes(
-    agentlessLane,
-    edges,
+  const { nodes: posAgentless, nextY: afterAgentless } = stackNodes(
+    agentlessNodes,
     COLUMN_X.shippers,
-    agentlessOffset
+    y
   );
-  const agentlessHeight = getBoundingHeight(
-    laidOutAgentless.map((n) => ({ ...n, position: { x: 0, y: n.position.y - agentlessOffset } }))
+  y = afterAgentless + (agentlessNodes.length > 0 && prometheusNodes.length > 0 ? LANE_GAP : 0);
+
+  const { nodes: posPrometheus } = stackNodes(prometheusNodes, COLUMN_X.shippers, y);
+
+  // ── Endpoints ─────────────────────────────────────────────────────────────
+  const pipelineNodes = byLane('pipelines');
+  const bulkNodes = byLane('bulk');
+
+  let ey = 0;
+  const { nodes: posPipelines, nextY: afterPipelines } = stackNodes(
+    pipelineNodes,
+    COLUMN_X.endpoints,
+    ey
   );
+  ey = afterPipelines + (pipelineNodes.length > 0 && bulkNodes.length > 0 ? NODE_GAP : 0);
+  const { nodes: posBulk } = stackNodes(bulkNodes, COLUMN_X.endpoints, ey);
 
-  const prometheusOffset = agentlessOffset + (agentlessHeight > 0 ? agentlessHeight + LANE_GAP : 0);
-  const laidOutPrometheus = layoutLaneNodes(
-    prometheusLane,
-    edges,
-    COLUMN_X.shippers,
-    prometheusOffset
-  );
+  // ── Streams ───────────────────────────────────────────────────────────────
+  const streamNodes = orderStreamNodes(byColumn('streams'));
+  const { nodes: posStreams } = stackNodes(streamNodes, COLUMN_X.streams, 0);
 
-  const laidOutShippers = [...laidOutAgents, ...laidOutAgentless, ...laidOutPrometheus];
-
-  // ── Endpoints column ───────────────────────────────────────────────────────
-  const laidOutEndpoints = layoutColumnNodes(endpointsNodes, edges, COLUMN_X.endpoints);
-
-  // ── Streams column ─────────────────────────────────────────────────────────
-  const laidOutStreams = layoutColumnNodes(streamsNodes, edges, COLUMN_X.streams);
-
-  // ── Reassemble in original order ───────────────────────────────────────────
+  // ── Reassemble preserving original order ──────────────────────────────────
   const positionById = new Map<string, { x: number; y: number }>();
-  const handleById = new Map<string, { sourcePosition: Position; targetPosition: Position }>();
-
-  for (const n of [...laidOutShippers, ...laidOutEndpoints, ...laidOutStreams]) {
+  for (const n of [
+    ...posAgents,
+    ...posAgentless,
+    ...posPrometheus,
+    ...posPipelines,
+    ...posBulk,
+    ...posStreams,
+  ]) {
     positionById.set(n.id, n.position);
-    handleById.set(n.id, {
-      sourcePosition: (n as { sourcePosition?: Position }).sourcePosition ?? Position.Right,
-      targetPosition: (n as { targetPosition?: Position }).targetPosition ?? Position.Left,
-    });
   }
 
   const resultNodes = nodes.map((node) => {
     const pos = positionById.get(node.id);
-    const handles = handleById.get(node.id);
     if (!pos) return node;
     return {
       ...node,
-      ...handles,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
       position: pos,
     };
   });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
@@ -124,6 +124,35 @@ const orderAgentNodes = <T extends Node<FlowNodeData>>(nodes: T[]): T[] => {
   return result;
 };
 
+const STREAM_INDENT = 28; // px per depth level in the streams tree
+
+/**
+ * Stack stream nodes vertically, indenting each by its depth in the hierarchy.
+ * Depth is derived from the number of dots in the stream name
+ * (e.g. "logs" → 0, "logs.otel" → 1, "logs.otel.abc" → 2).
+ */
+const stackStreamNodes = <T extends Node<FlowNodeData>>(
+  nodeList: T[],
+  xBase: number,
+  yStart: number
+): { nodes: T[]; nextY: number } => {
+  let y = yStart;
+  const positioned = nodeList.map((node) => {
+    const streamName =
+      (node.data as { streamName?: string }).streamName ?? (node.data as { label?: string }).label ?? '';
+    const depth = streamName ? streamName.split('.').length - 1 : 0;
+    const result = {
+      ...node,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+      position: { x: xBase + depth * STREAM_INDENT, y },
+    };
+    y += NODE_HEIGHT + NODE_GAP;
+    return result;
+  });
+  return { nodes: positioned, nextY: y };
+};
+
 /**
  * Main layout function.
  *
@@ -133,7 +162,7 @@ const orderAgentNodes = <T extends Node<FlowNodeData>>(nodes: T[]): T[] => {
  *
  * Shippers column: 3 lanes (agents → agentless → prometheus) stacked top-to-bottom.
  * Endpoints column: cloud pipelines then bulk, stacked.
- * Streams column: tree-ordered (depth-first) and stacked.
+ * Streams column: depth-first tree order with x-indentation per hierarchy level.
  */
 export const applyFlowLayout = <T extends Node<FlowNodeData>>(
   nodes: T[],
@@ -175,9 +204,9 @@ export const applyFlowLayout = <T extends Node<FlowNodeData>>(
   ey = afterPipelines + (pipelineNodes.length > 0 && bulkNodes.length > 0 ? NODE_GAP : 0);
   const { nodes: posBulk } = stackNodes(bulkNodes, COLUMN_X.endpoints, ey);
 
-  // ── Streams ───────────────────────────────────────────────────────────────
+  // ── Streams (tree with x-indentation per depth level) ────────────────────
   const streamNodes = orderStreamNodes(byColumn('streams'));
-  const { nodes: posStreams } = stackNodes(streamNodes, COLUMN_X.streams, 0);
+  const { nodes: posStreams } = stackStreamNodes(streamNodes, COLUMN_X.streams, 0);
 
   // ── Reassemble preserving original order ──────────────────────────────────
   const positionById = new Map<string, { x: number; y: number }>();

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/layout.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Dagre from '@dagrejs/dagre';
+import { Position, type Node, type Edge } from '@xyflow/react';
+
+// Fixed x positions for each column (left edge of the column band)
+const COLUMN_X = { shippers: 0, endpoints: 500, streams: 900 } as const;
+
+export const NODE_WIDTH = 200;
+export const NODE_HEIGHT = 80;
+
+const LANE_GAP = 40;
+const RANKSEP = 40;
+const NODESEP = 20;
+const MARGINX = 10;
+const MARGINY = 10;
+
+type FlowColumn = 'shippers' | 'endpoints' | 'streams';
+type FlowLane = 'agents' | 'agentless' | 'prometheus' | 'pipelines' | 'bulk' | 'streams';
+
+interface FlowNodeData {
+  column: FlowColumn;
+  lane: FlowLane;
+  parentId?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Layout a set of nodes in a single Dagre TB graph.
+ * Returns the Dagre-positioned y values and sets x to the provided columnX.
+ */
+const layoutColumnNodes = <T extends Node<FlowNodeData>>(
+  columnNodes: T[],
+  edges: Edge[],
+  columnX: number
+): T[] => {
+  if (columnNodes.length === 0) return columnNodes;
+
+  const g = new Dagre.graphlib.Graph({ directed: true, compound: false })
+    .setGraph({
+      rankdir: 'TB',
+      ranksep: RANKSEP,
+      nodesep: NODESEP,
+      marginx: MARGINX,
+      marginy: MARGINY,
+    })
+    .setDefaultEdgeLabel(() => ({}));
+
+  columnNodes.forEach((node) => {
+    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  });
+
+  const nodeIds = new Set(columnNodes.map((n) => n.id));
+  edges.forEach((edge) => {
+    if (nodeIds.has(edge.source) && nodeIds.has(edge.target)) {
+      g.setEdge(edge.source, edge.target);
+    }
+  });
+
+  Dagre.layout(g);
+
+  return columnNodes.map((node) => {
+    const dagreNode = g.node(node.id);
+    if (!dagreNode) return node;
+    return {
+      ...node,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+      position: {
+        x: columnX,
+        y: Math.round(dagreNode.y - NODE_HEIGHT / 2),
+      },
+    };
+  });
+};
+
+/**
+ * Layout nodes within a single lane using Dagre TB, returning y positions
+ * relative to yOffset.
+ */
+const layoutLaneNodes = <T extends Node<FlowNodeData>>(
+  laneNodes: T[],
+  edges: Edge[],
+  columnX: number,
+  yOffset: number
+): T[] => {
+  if (laneNodes.length === 0) return laneNodes;
+
+  const g = new Dagre.graphlib.Graph({ directed: true, compound: false })
+    .setGraph({
+      rankdir: 'TB',
+      ranksep: RANKSEP,
+      nodesep: NODESEP,
+      marginx: MARGINX,
+      marginy: MARGINY,
+    })
+    .setDefaultEdgeLabel(() => ({}));
+
+  // Group agents by their parentId (policy group) to cluster them together
+  // by adding virtual edges between siblings under the same parent
+  const nodeIds = new Set(laneNodes.map((n) => n.id));
+
+  laneNodes.forEach((node) => {
+    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  });
+
+  // Add real edges within the lane
+  edges.forEach((edge) => {
+    if (nodeIds.has(edge.source) && nodeIds.has(edge.target)) {
+      g.setEdge(edge.source, edge.target);
+    }
+  });
+
+  // Add sibling edges for nodes that share a parentId (agents under same policy)
+  // so Dagre keeps them adjacent in y
+  const byParent = new Map<string, T[]>();
+  for (const node of laneNodes) {
+    const pid = (node.data as FlowNodeData).parentId;
+    if (pid) {
+      const list = byParent.get(pid) ?? [];
+      list.push(node);
+      byParent.set(pid, list);
+    }
+  }
+  for (const siblings of byParent.values()) {
+    for (let i = 0; i < siblings.length - 1; i++) {
+      const src = siblings[i].id;
+      const tgt = siblings[i + 1].id;
+      if (g.hasNode(src) && g.hasNode(tgt) && !g.hasEdge(src, tgt)) {
+        g.setEdge(src, tgt);
+      }
+    }
+  }
+
+  Dagre.layout(g);
+
+  return laneNodes.map((node) => {
+    const dagreNode = g.node(node.id);
+    if (!dagreNode) return node;
+    return {
+      ...node,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+      position: {
+        x: columnX,
+        y: yOffset + Math.round(dagreNode.y - NODE_HEIGHT / 2),
+      },
+    };
+  });
+};
+
+/**
+ * Compute the bounding-box height of a set of already-positioned nodes.
+ */
+const getBoundingHeight = (nodes: Array<Node<FlowNodeData>>): number => {
+  if (nodes.length === 0) return 0;
+  let maxBottom = 0;
+  for (const node of nodes) {
+    const bottom = node.position.y + NODE_HEIGHT;
+    if (bottom > maxBottom) maxBottom = bottom;
+  }
+  return maxBottom;
+};
+
+/**
+ * Main layout function — port / adaptation of Fleet's applyCompoundLayout for
+ * the 3-column (shippers / endpoints / streams), 3-lane-in-shippers topology.
+ *
+ * Algorithm:
+ * 1. Shippers column: split into 3 lanes (agents / agentless / prometheus).
+ *    Each lane gets its own Dagre TB run. Lanes are stacked vertically with
+ *    LANE_GAP between them.
+ * 2. Endpoints column: single Dagre TB run.
+ * 3. Streams column: single Dagre TB run (parent→child edges give tree shape).
+ * 4. All x values are fixed to COLUMN_X bucket — Dagre only determines y.
+ */
+export const applyFlowLayout = <T extends Node<FlowNodeData>>(
+  nodes: T[],
+  edges: Edge[]
+): { nodes: T[]; edges: Edge[] } => {
+  if (nodes.length === 0) return { nodes, edges };
+
+  // ── Partition by column ────────────────────────────────────────────────────
+  const shippersNodes = nodes.filter((n) => n.data.column === 'shippers');
+  const endpointsNodes = nodes.filter((n) => n.data.column === 'endpoints');
+  const streamsNodes = nodes.filter((n) => n.data.column === 'streams');
+
+  // ── Shippers: 3 lanes ──────────────────────────────────────────────────────
+  const agentsLane = shippersNodes.filter((n) => n.data.lane === 'agents');
+  const agentlessLane = shippersNodes.filter((n) => n.data.lane === 'agentless');
+  const prometheusLane = shippersNodes.filter((n) => n.data.lane === 'prometheus');
+
+  const laidOutAgents = layoutLaneNodes(agentsLane, edges, COLUMN_X.shippers, 0);
+  const agentsHeight = getBoundingHeight(laidOutAgents);
+
+  const agentlessOffset = agentsHeight > 0 ? agentsHeight + LANE_GAP : 0;
+  const laidOutAgentless = layoutLaneNodes(
+    agentlessLane,
+    edges,
+    COLUMN_X.shippers,
+    agentlessOffset
+  );
+  const agentlessHeight = getBoundingHeight(
+    laidOutAgentless.map((n) => ({ ...n, position: { x: 0, y: n.position.y - agentlessOffset } }))
+  );
+
+  const prometheusOffset = agentlessOffset + (agentlessHeight > 0 ? agentlessHeight + LANE_GAP : 0);
+  const laidOutPrometheus = layoutLaneNodes(
+    prometheusLane,
+    edges,
+    COLUMN_X.shippers,
+    prometheusOffset
+  );
+
+  const laidOutShippers = [...laidOutAgents, ...laidOutAgentless, ...laidOutPrometheus];
+
+  // ── Endpoints column ───────────────────────────────────────────────────────
+  const laidOutEndpoints = layoutColumnNodes(endpointsNodes, edges, COLUMN_X.endpoints);
+
+  // ── Streams column ─────────────────────────────────────────────────────────
+  const laidOutStreams = layoutColumnNodes(streamsNodes, edges, COLUMN_X.streams);
+
+  // ── Reassemble in original order ───────────────────────────────────────────
+  const positionById = new Map<string, { x: number; y: number }>();
+  const handleById = new Map<string, { sourcePosition: Position; targetPosition: Position }>();
+
+  for (const n of [...laidOutShippers, ...laidOutEndpoints, ...laidOutStreams]) {
+    positionById.set(n.id, n.position);
+    handleById.set(n.id, {
+      sourcePosition: (n as { sourcePosition?: Position }).sourcePosition ?? Position.Right,
+      targetPosition: (n as { targetPosition?: Position }).targetPosition ?? Position.Left,
+    });
+  }
+
+  const resultNodes = nodes.map((node) => {
+    const pos = positionById.get(node.id);
+    const handles = handleById.get(node.id);
+    if (!pos) return node;
+    return {
+      ...node,
+      ...handles,
+      position: pos,
+    };
+  });
+
+  return { nodes: resultNodes, edges };
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/legend.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/legend.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+
+interface DotProps {
+  color: string;
+}
+
+const Dot: React.FC<DotProps> = ({ color }) => (
+  <span
+    css={css`
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: ${color};
+      margin-right: 4px;
+      vertical-align: middle;
+    `}
+  />
+);
+
+interface LineProps {
+  color: string;
+  strokeWidth: number;
+}
+
+const Line: React.FC<LineProps> = ({ color, strokeWidth }) => (
+  <span
+    css={css`
+      display: inline-block;
+      width: 20px;
+      height: ${strokeWidth}px;
+      background-color: ${color};
+      margin-right: 4px;
+      vertical-align: middle;
+    `}
+  />
+);
+
+export const Legend: React.FC = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiFlexGroup
+      gutterSize="l"
+      alignItems="center"
+      wrap
+      css={css`
+        padding: ${euiTheme.size.s} ${euiTheme.size.m};
+        border-top: 1px solid ${euiTheme.colors.lightShade};
+      `}
+    >
+      {/* Lane section */}
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <strong>
+            {i18n.translate('xpack.streams.ingestFlow.legend.lanesLabel', {
+              defaultMessage: 'Lanes:',
+            })}
+          </strong>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <Dot color={euiTheme.colors.vis.euiColorVis0} />
+          {i18n.translate('xpack.streams.ingestFlow.legend.fleetAgentsLane', {
+            defaultMessage: 'Fleet Agents',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <Dot color={euiTheme.colors.vis.euiColorVis1} />
+          {i18n.translate('xpack.streams.ingestFlow.legend.agentlessLane', {
+            defaultMessage: 'Agentless',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <Dot color={euiTheme.colors.vis.euiColorVis2} />
+          {i18n.translate('xpack.streams.ingestFlow.legend.prometheusLane', {
+            defaultMessage: 'Prometheus',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+
+      {/* Divider */}
+      <EuiFlexItem grow={false}>
+        <span
+          css={css`
+            width: 1px;
+            height: 16px;
+            background: ${euiTheme.colors.lightShade};
+          `}
+        />
+      </EuiFlexItem>
+
+      {/* Edge thickness key */}
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <strong>
+            {i18n.translate('xpack.streams.ingestFlow.legend.throughputLabel', {
+              defaultMessage: 'Throughput:',
+            })}
+          </strong>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <Line color={euiTheme.colors.subduedText} strokeWidth={1} />
+          {i18n.translate('xpack.streams.ingestFlow.legend.lowThroughput', {
+            defaultMessage: 'Low',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <Line color={euiTheme.colors.subduedText} strokeWidth={4} />
+          {i18n.translate('xpack.streams.ingestFlow.legend.highThroughput', {
+            defaultMessage: 'High',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+
+      {/* Divider */}
+      <EuiFlexItem grow={false}>
+        <span
+          css={css`
+            width: 1px;
+            height: 16px;
+            background: ${euiTheme.colors.lightShade};
+          `}
+        />
+      </EuiFlexItem>
+
+      {/* Health key */}
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <strong>
+            {i18n.translate('xpack.streams.ingestFlow.legend.healthLabel', {
+              defaultMessage: 'Health:',
+            })}
+          </strong>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <Dot color={euiTheme.colors.success} />
+          {i18n.translate('xpack.streams.ingestFlow.legend.healthHealthy', {
+            defaultMessage: 'Healthy',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <Dot color={euiTheme.colors.warning} />
+          {i18n.translate('xpack.streams.ingestFlow.legend.healthDegraded', {
+            defaultMessage: 'Degraded',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <Dot color={euiTheme.colors.danger} />
+          {i18n.translate('xpack.streams.ingestFlow.legend.healthDown', {
+            defaultMessage: 'Down',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/agent_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/agent_node.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { HealthPill } from '../badges/health_pill';
+
+type AgentNodeData = Extract<FlowNode, { kind: 'agent' }>;
+type AgentNodeType = Node<AgentNodeData, 'agent'>;
+
+const nodeStyles = css`
+  width: 200px;
+`;
+
+const handleStyles = css`
+  visibility: hidden;
+`;
+
+const truncate = (str: string, maxLen: number): string =>
+  str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
+
+export const AgentNode = memo(({ data, selected }: NodeProps<AgentNodeType>) => {
+  const agentStatusColor =
+    data.agentStatus === 'online'
+      ? 'success'
+      : data.agentStatus === 'error' || data.agentStatus === 'degraded'
+      ? 'warning'
+      : 'default';
+
+  return (
+    <EuiPanel
+      paddingSize="s"
+      hasBorder
+      borderRadius="m"
+      css={[
+        nodeStyles,
+        css`
+          outline: ${selected ? '2px solid currentColor' : 'none'};
+          outline-offset: -1px;
+        `,
+      ]}
+    >
+      <Handle type="target" position={Position.Left} css={handleStyles} />
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="dot" size="s" color={agentStatusColor} aria-hidden="true" />
+        </EuiFlexItem>
+        <EuiFlexItem grow>
+          <EuiText
+            size="xs"
+            style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
+          >
+            <strong>{truncate(data.hostname, 24)}</strong>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} style={{ marginTop: 4 }}>
+        <EuiFlexItem>
+          <EuiText size="xs" color="subdued">{`v${data.version}`}</EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          {data.health ? (
+            <HealthPill status={data.health.status} />
+          ) : (
+            <EuiBadge color="default">
+              {i18n.translate('xpack.streams.ingestFlow.agentNode.unknownStatus', {
+                defaultMessage: 'unknown',
+              })}
+            </EuiBadge>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <Handle type="source" position={Position.Right} css={handleStyles} />
+    </EuiPanel>
+  );
+});
+
+AgentNode.displayName = 'AgentNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/agent_policy_group_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/agent_policy_group_node.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+
+type AgentPolicyNodeData = Extract<FlowNode, { kind: 'agentPolicy' }>;
+type AgentPolicyNodeType = Node<AgentPolicyNodeData, 'agentPolicy'>;
+
+const nodeStyles = css`
+  width: 240px;
+`;
+
+const handleStyles = css`
+  visibility: hidden;
+`;
+
+export const AgentPolicyGroupNode = memo(({ data, selected }: NodeProps<AgentPolicyNodeType>) => {
+  return (
+    <EuiPanel
+      color="subdued"
+      paddingSize="s"
+      hasBorder
+      borderRadius="m"
+      css={[
+        nodeStyles,
+        css`
+          outline: ${selected ? '2px solid currentColor' : 'none'};
+          outline-offset: -1px;
+        `,
+      ]}
+    >
+      <Handle type="target" position={Position.Left} css={handleStyles} />
+      <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+        <EuiFlexItem>
+          <EuiText size="s">
+            <strong>{data.label}</strong>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('xpack.streams.ingestFlow.agentPolicyNode.agentCount', {
+              defaultMessage: '{count} {count, plural, one {agent} other {agents}}',
+              values: { count: data.agentCount },
+            })}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <Handle type="source" position={Position.Right} css={handleStyles} />
+    </EuiPanel>
+  );
+});
+
+AgentPolicyGroupNode.displayName = 'AgentPolicyGroupNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/agentless_integration_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/agentless_integration_node.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { HealthPill } from '../badges/health_pill';
+
+type AgentlessIntegrationNodeData = Extract<FlowNode, { kind: 'agentlessIntegration' }>;
+type AgentlessIntegrationNodeType = Node<AgentlessIntegrationNodeData, 'agentlessIntegration'>;
+
+const nodeStyles = css`
+  width: 200px;
+`;
+
+const handleStyles = css`
+  visibility: hidden;
+`;
+
+export const AgentlessIntegrationNode = memo(
+  ({ data, selected }: NodeProps<AgentlessIntegrationNodeType>) => {
+    return (
+      <EuiPanel
+        paddingSize="s"
+        hasBorder
+        borderRadius="m"
+        css={[
+          nodeStyles,
+          css`
+            outline: ${selected ? '2px solid currentColor' : 'none'};
+            outline-offset: -1px;
+          `,
+        ]}
+      >
+        <Handle type="target" position={Position.Left} css={handleStyles} />
+        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="cloud" size="s" aria-hidden="true" />
+          </EuiFlexItem>
+          <EuiFlexItem grow>
+            <EuiText
+              size="xs"
+              style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
+            >
+              <strong>{data.packageTitle}</strong>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiFlexGroup
+          gutterSize="xs"
+          alignItems="center"
+          responsive={false}
+          style={{ marginTop: 4 }}
+        >
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="hollow">
+              {i18n.translate('xpack.streams.ingestFlow.agentlessNode.agentlessBadge', {
+                defaultMessage: 'agentless',
+              })}
+            </EuiBadge>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            {data.health ? <HealthPill status={data.health.status} /> : null}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <Handle type="source" position={Position.Right} css={handleStyles} />
+      </EuiPanel>
+    );
+  }
+);
+
+AgentlessIntegrationNode.displayName = 'AgentlessIntegrationNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/bulk_endpoint_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/bulk_endpoint_node.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { EuiCode, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+
+type BulkEndpointNodeData = Extract<FlowNode, { kind: 'bulkEndpoint' }>;
+type BulkEndpointNodeType = Node<BulkEndpointNodeData, 'bulkEndpoint'>;
+
+const nodeStyles = css`
+  width: 200px;
+`;
+
+const handleStyles = css`
+  visibility: hidden;
+`;
+
+export const BulkEndpointNode = memo(({ selected }: NodeProps<BulkEndpointNodeType>) => {
+  return (
+    <EuiPanel
+      paddingSize="s"
+      hasBorder
+      borderRadius="m"
+      css={[
+        nodeStyles,
+        css`
+          outline: ${selected ? '2px solid currentColor' : 'none'};
+          outline-offset: -1px;
+        `,
+      ]}
+    >
+      <Handle type="target" position={Position.Left} css={handleStyles} />
+      <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+        <EuiFlexItem>
+          <EuiText size="s">
+            <strong>
+              {i18n.translate('xpack.streams.ingestFlow.bulkEndpointNode.title', {
+                defaultMessage: 'Elasticsearch',
+              })}
+            </strong>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiCode>_bulk</EuiCode>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="xs" color="subdued">
+                {i18n.translate('xpack.streams.ingestFlow.bulkEndpointNode.subtitle', {
+                  defaultMessage: 'endpoint',
+                })}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <Handle type="source" position={Position.Right} css={handleStyles} />
+    </EuiPanel>
+  );
+});
+
+BulkEndpointNode.displayName = 'BulkEndpointNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/classic_stream_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/classic_stream_node.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { HealthPill } from '../badges/health_pill';
+import { formatRate } from '../edges/throughput_edge';
+
+type ClassicStreamNodeData = Extract<FlowNode, { kind: 'classicStream' }>;
+type ClassicStreamNodeType = Node<ClassicStreamNodeData, 'classicStream'>;
+
+const nodeStyles = css`
+  width: 200px;
+`;
+
+const handleStyles = css`
+  visibility: hidden;
+`;
+
+const getFailureLabel = (docsPerSec: number): string => {
+  const n = docsPerSec < 1000 ? `${Math.round(docsPerSec)}` : `${(docsPerSec / 1000).toFixed(1)}k`;
+  return `⚠ ${n}/s`;
+};
+
+export const ClassicStreamNode = memo(({ data, selected }: NodeProps<ClassicStreamNodeType>) => {
+  const hasFailures = (data.failureRate?.docsPerSec ?? 0) > 0;
+
+  return (
+    <EuiPanel
+      paddingSize="s"
+      hasBorder
+      borderRadius="m"
+      css={[
+        nodeStyles,
+        css`
+          outline: ${selected ? '2px solid currentColor' : 'none'};
+          outline-offset: -1px;
+        `,
+      ]}
+    >
+      <Handle type="target" position={Position.Left} css={handleStyles} />
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexItem grow>
+          <EuiText
+            size="xs"
+            style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
+          >
+            <strong>{data.streamName}</strong>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiBadge color="hollow">
+            {i18n.translate('xpack.streams.ingestFlow.classicStreamNode.classicBadge', {
+              defaultMessage: 'CLASSIC',
+            })}
+          </EuiBadge>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} style={{ marginTop: 4 }}>
+        <EuiFlexItem grow>
+          {data.throughput ? (
+            <EuiText size="xs" color="subdued">
+              {formatRate(data.throughput.docsPerSec)}
+            </EuiText>
+          ) : null}
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          {data.health ? <HealthPill status={data.health.status} /> : null}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {hasFailures && data.failureRate ? (
+        <div style={{ marginTop: 4 }}>
+          <EuiBadge color="danger">{getFailureLabel(data.failureRate.docsPerSec)}</EuiBadge>
+          <EuiText size="xs" color="danger" style={{ display: 'inline', marginLeft: 4 }}>
+            {i18n.translate('xpack.streams.ingestFlow.classicStreamNode.failingLabel', {
+              defaultMessage: 'failing',
+            })}
+          </EuiText>
+        </div>
+      ) : null}
+      <Handle type="source" position={Position.Right} css={handleStyles} />
+    </EuiPanel>
+  );
+});
+
+ClassicStreamNode.displayName = 'ClassicStreamNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/cloud_pipeline_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/cloud_pipeline_node.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { HealthPill } from '../badges/health_pill';
+import { formatRate } from '../edges/throughput_edge';
+
+type CloudPipelineNodeData = Extract<FlowNode, { kind: 'cloudPipeline' }>;
+type CloudPipelineNodeType = Node<CloudPipelineNodeData, 'cloudPipeline'>;
+
+const nodeStyles = css`
+  width: 200px;
+`;
+
+const handleStyles = css`
+  visibility: hidden;
+`;
+
+export const CloudPipelineNode = memo(({ data, selected }: NodeProps<CloudPipelineNodeType>) => {
+  const isDegraded = data.health?.status === 'degraded' || data.health?.status === 'down';
+
+  return (
+    <EuiPanel
+      paddingSize="s"
+      hasBorder
+      borderRadius="m"
+      css={[
+        nodeStyles,
+        css`
+          outline: ${selected ? '2px solid currentColor' : 'none'};
+          outline-offset: -1px;
+        `,
+      ]}
+    >
+      <Handle type="target" position={Position.Left} css={handleStyles} />
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexItem grow>
+          <EuiText
+            size="xs"
+            style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
+          >
+            <strong>{data.label}</strong>
+          </EuiText>
+        </EuiFlexItem>
+        {isDegraded && (
+          <EuiFlexItem grow={false}>
+            <EuiIcon
+              type="warning"
+              size="s"
+              color="warning"
+              aria-label={i18n.translate('xpack.streams.ingestFlow.cloudPipelineNode.degraded', {
+                defaultMessage: 'Pipeline degraded',
+              })}
+            />
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} style={{ marginTop: 4 }}>
+        <EuiFlexItem grow={false}>
+          <EuiBadge color="hollow">
+            {i18n.translate('xpack.streams.ingestFlow.cloudPipelineNode.otlpBadge', {
+              defaultMessage: 'OTLP',
+            })}
+          </EuiBadge>
+        </EuiFlexItem>
+        <EuiFlexItem grow>
+          {data.throughput ? (
+            <EuiText size="xs" color="subdued">
+              {formatRate(data.throughput.docsPerSec)}
+            </EuiText>
+          ) : null}
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          {data.health ? <HealthPill status={data.health.status} /> : null}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <Handle type="source" position={Position.Right} css={handleStyles} />
+    </EuiPanel>
+  );
+});
+
+CloudPipelineNode.displayName = 'CloudPipelineNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/lane_label_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/lane_label_node.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { type NodeProps, type Node } from '@xyflow/react';
+import { EuiText } from '@elastic/eui';
+
+export interface LaneLabelNodeData extends Record<string, unknown> {
+  label: string;
+}
+
+type LaneLabelNodeType = Node<LaneLabelNodeData, 'laneLabel'>;
+
+export const LaneLabelNode = memo(({ data }: NodeProps<LaneLabelNodeType>) => {
+  return (
+    <EuiText size="s" color="subdued">
+      <strong>{data.label}</strong>
+    </EuiText>
+  );
+});
+
+LaneLabelNode.displayName = 'LaneLabelNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/prometheus_scraper_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/prometheus_scraper_node.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { HealthPill } from '../badges/health_pill';
+
+type PrometheusScraperNodeData = Extract<FlowNode, { kind: 'prometheusScraper' }>;
+type PrometheusScraperNodeType = Node<PrometheusScraperNodeData, 'prometheusScraper'>;
+
+const nodeStyles = css`
+  width: 200px;
+`;
+
+const handleStyles = css`
+  visibility: hidden;
+`;
+
+const truncate = (str: string, maxLen: number): string =>
+  str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
+
+export const PrometheusScraperNode = memo(
+  ({ data, selected }: NodeProps<PrometheusScraperNodeType>) => {
+    return (
+      <EuiPanel
+        paddingSize="s"
+        hasBorder
+        borderRadius="m"
+        css={[
+          nodeStyles,
+          css`
+            outline: ${selected ? '2px solid currentColor' : 'none'};
+            outline-offset: -1px;
+          `,
+        ]}
+      >
+        <Handle type="target" position={Position.Left} css={handleStyles} />
+        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="logoMetrics" size="s" aria-hidden="true" />
+          </EuiFlexItem>
+          <EuiFlexItem grow>
+            <EuiText
+              size="xs"
+              style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
+            >
+              <strong>{data.label}</strong>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiFlexGroup
+          gutterSize="xs"
+          alignItems="center"
+          responsive={false}
+          style={{ marginTop: 4 }}
+        >
+          <EuiFlexItem grow>
+            <EuiText size="xs" color="subdued">
+              {truncate(data.targetHost, 22)}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            {data.health ? <HealthPill status={data.health.status} /> : null}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <Handle type="source" position={Position.Right} css={handleStyles} />
+      </EuiPanel>
+    );
+  }
+);
+
+PrometheusScraperNode.displayName = 'PrometheusScraperNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/wired_stream_node.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/nodes/wired_stream_node.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { HealthPill } from '../badges/health_pill';
+import { formatRate } from '../edges/throughput_edge';
+
+type WiredStreamNodeData = Extract<FlowNode, { kind: 'wiredStream' }>;
+type WiredStreamNodeType = Node<WiredStreamNodeData, 'wiredStream'>;
+
+const nodeStyles = css`
+  width: 200px;
+`;
+
+const handleStyles = css`
+  visibility: hidden;
+`;
+
+const getFailureLabel = (docsPerSec: number): string => {
+  const n = docsPerSec < 1000 ? `${Math.round(docsPerSec)}` : `${(docsPerSec / 1000).toFixed(1)}k`;
+  return `⚠ ${n}/s`;
+};
+
+export const WiredStreamNode = memo(({ data, selected }: NodeProps<WiredStreamNodeType>) => {
+  const hasFailures = (data.failureRate?.docsPerSec ?? 0) > 0;
+
+  return (
+    <EuiPanel
+      paddingSize="s"
+      hasBorder
+      borderRadius="m"
+      css={[
+        nodeStyles,
+        css`
+          outline: ${selected ? '2px solid currentColor' : 'none'};
+          outline-offset: -1px;
+        `,
+      ]}
+    >
+      <Handle type="target" position={Position.Left} css={handleStyles} />
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexItem grow>
+          <EuiText
+            size="xs"
+            style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
+          >
+            <strong>{data.streamName}</strong>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiBadge color="primary">
+            {i18n.translate('xpack.streams.ingestFlow.wiredStreamNode.wiredBadge', {
+              defaultMessage: 'WIRED',
+            })}
+          </EuiBadge>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} style={{ marginTop: 4 }}>
+        <EuiFlexItem grow>
+          {data.throughput ? (
+            <EuiText size="xs" color="subdued">
+              {formatRate(data.throughput.docsPerSec)}
+            </EuiText>
+          ) : null}
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          {data.health ? <HealthPill status={data.health.status} /> : null}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {hasFailures && data.failureRate ? (
+        <div style={{ marginTop: 4 }}>
+          <EuiBadge color="danger">{getFailureLabel(data.failureRate.docsPerSec)}</EuiBadge>
+          <EuiText size="xs" color="danger" style={{ display: 'inline', marginLeft: 4 }}>
+            {i18n.translate('xpack.streams.ingestFlow.wiredStreamNode.failingLabel', {
+              defaultMessage: 'failing',
+            })}
+          </EuiText>
+        </div>
+      ) : null}
+      <Handle type="source" position={Position.Right} css={handleStyles} />
+    </EuiPanel>
+  );
+});
+
+WiredStreamNode.displayName = 'WiredStreamNode';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/detail_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/detail_flyout.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlyout } from '@elastic/eui';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { PanelAgent } from './panel_agent';
+import { PanelAgentPolicy } from './panel_agent_policy';
+import { PanelAgentless } from './panel_agentless';
+import { PanelPrometheus } from './panel_prometheus';
+import { PanelCloudPipeline } from './panel_cloud_pipeline';
+import { PanelBulkEndpoint } from './panel_bulk_endpoint';
+import { PanelWiredStream } from './panel_wired_stream';
+import { PanelClassicStream } from './panel_classic_stream';
+
+interface DetailFlyoutProps {
+  node: FlowNode | null;
+  onClose: () => void;
+}
+
+const PanelBody: React.FC<{ node: FlowNode; onClose: () => void }> = ({ node, onClose }) => {
+  switch (node.kind) {
+    case 'agent':
+      return <PanelAgent node={node} onClose={onClose} />;
+    case 'agentPolicy':
+      return <PanelAgentPolicy node={node} onClose={onClose} />;
+    case 'agentlessIntegration':
+      return <PanelAgentless node={node} onClose={onClose} />;
+    case 'prometheusScraper':
+      return <PanelPrometheus node={node} onClose={onClose} />;
+    case 'cloudPipeline':
+      return <PanelCloudPipeline node={node} onClose={onClose} />;
+    case 'bulkEndpoint':
+      return <PanelBulkEndpoint node={node} onClose={onClose} />;
+    case 'wiredStream':
+      return <PanelWiredStream node={node} onClose={onClose} />;
+    case 'classicStream':
+      return <PanelClassicStream node={node} onClose={onClose} />;
+    default:
+      return null;
+  }
+};
+
+export const DetailFlyout: React.FC<DetailFlyoutProps> = ({ node, onClose }) => {
+  if (!node) return null;
+
+  return (
+    <EuiFlyout type="push" size="m" onClose={onClose} aria-labelledby="detail-flyout-title">
+      <PanelBody node={node} onClose={onClose} />
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_agent.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_agent.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { useKibana } from '../../../hooks/use_kibana';
+
+type AgentNode = Extract<FlowNode, { kind: 'agent' }>;
+
+interface PanelAgentProps {
+  node: AgentNode;
+  onClose: () => void;
+}
+
+export const PanelAgent: React.FC<PanelAgentProps> = ({ node }) => {
+  const {
+    core: { application },
+  } = useKibana();
+
+  const listItems = [
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgent.agentId', {
+        defaultMessage: 'Agent ID',
+      }),
+      description: node.agentId,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgent.policyId', {
+        defaultMessage: 'Policy ID',
+      }),
+      description: node.policyId,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgent.hostname', {
+        defaultMessage: 'Hostname',
+      }),
+      description: node.hostname,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgent.version', {
+        defaultMessage: 'Version',
+      }),
+      description: `v${node.version}`,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgent.status', {
+        defaultMessage: 'Status',
+      }),
+      description: node.agentStatus,
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>
+            {i18n.translate('xpack.streams.ingestFlow.panelAgent.title', {
+              defaultMessage: 'Agent: {hostname}',
+              values: { hostname: node.hostname },
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiDescriptionList listItems={listItems} type="column" columnWidths={[1, 2]} />
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              iconType="popout"
+              onClick={() =>
+                application.navigateToApp('fleet', { path: `/agents/${node.agentId}` })
+              }
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelAgent.viewInFleetButton', {
+                defaultMessage: 'View in Fleet',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_agent_policy.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_agent_policy.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { useKibana } from '../../../hooks/use_kibana';
+
+type AgentPolicyNode = Extract<FlowNode, { kind: 'agentPolicy' }>;
+
+interface PanelAgentPolicyProps {
+  node: AgentPolicyNode;
+  onClose: () => void;
+}
+
+export const PanelAgentPolicy: React.FC<PanelAgentPolicyProps> = ({ node }) => {
+  const {
+    core: { application },
+  } = useKibana();
+
+  const listItems = [
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgentPolicy.policyId', {
+        defaultMessage: 'Policy ID',
+      }),
+      description: node.policyId,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgentPolicy.agentCount', {
+        defaultMessage: 'Agent count',
+      }),
+      description: String(node.agentCount),
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>{node.policyId}</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiDescriptionList listItems={listItems} type="column" columnWidths={[1, 2]} />
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              iconType="popout"
+              onClick={() =>
+                application.navigateToApp('fleet', { path: `/policies/${node.policyId}` })
+              }
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelAgentPolicy.viewPolicyButton', {
+                defaultMessage: 'View policy',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_agentless.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_agentless.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { useKibana } from '../../../hooks/use_kibana';
+
+type AgentlessIntegrationNode = Extract<FlowNode, { kind: 'agentlessIntegration' }>;
+
+interface PanelAgentlessProps {
+  node: AgentlessIntegrationNode;
+  onClose: () => void;
+}
+
+export const PanelAgentless: React.FC<PanelAgentlessProps> = ({ node }) => {
+  const {
+    core: { application },
+  } = useKibana();
+
+  const listItems = [
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgentless.packageName', {
+        defaultMessage: 'Package name',
+      }),
+      description: node.packageName,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgentless.autoPolicyId', {
+        defaultMessage: 'Auto policy ID',
+      }),
+      description: node.autoPolicyId,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelAgentless.status', {
+        defaultMessage: 'Status',
+      }),
+      description: node.health?.status ?? 'unknown',
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>
+            {i18n.translate('xpack.streams.ingestFlow.panelAgentless.title', {
+              defaultMessage: '{title} (agentless)',
+              values: { title: node.packageTitle },
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiDescriptionList listItems={listItems} type="column" columnWidths={[1, 2]} />
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              iconType="pencil"
+              onClick={() =>
+                application.navigateToApp('integrations', {
+                  path: `/edit-integration/${node.packagePolicyId}`,
+                })
+              }
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelAgentless.editIntegrationButton', {
+                defaultMessage: 'Edit integration',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_bulk_endpoint.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_bulk_endpoint.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { useKibana } from '../../../hooks/use_kibana';
+
+type BulkEndpointNode = Extract<FlowNode, { kind: 'bulkEndpoint' }>;
+
+interface PanelBulkEndpointProps {
+  node: BulkEndpointNode;
+  onClose: () => void;
+}
+
+export const PanelBulkEndpoint: React.FC<PanelBulkEndpointProps> = ({ node }) => {
+  const {
+    core: { application },
+  } = useKibana();
+
+  const listItems = [
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelBulkEndpoint.url', {
+        defaultMessage: 'URL',
+      }),
+      description:
+        node.url ??
+        i18n.translate('xpack.streams.ingestFlow.panelBulkEndpoint.defaultEndpoint', {
+          defaultMessage: 'Default Elasticsearch endpoint',
+        }),
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelBulkEndpoint.description', {
+        defaultMessage: 'Description',
+      }),
+      description: i18n.translate('xpack.streams.ingestFlow.panelBulkEndpoint.descriptionValue', {
+        defaultMessage: 'Accepts direct document ingestion via _bulk API',
+      }),
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>
+            {i18n.translate('xpack.streams.ingestFlow.panelBulkEndpoint.title', {
+              defaultMessage: 'Elasticsearch Bulk API',
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiDescriptionList listItems={listItems} type="column" columnWidths={[1, 2]} />
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              iconType="popout"
+              onClick={() =>
+                application.navigateToApp('management', { path: '/security/api_keys' })
+              }
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelBulkEndpoint.manageApiKeysButton', {
+                defaultMessage: 'Manage API keys',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_classic_stream.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_classic_stream.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { useStreamsAppRouter } from '../../../hooks/use_streams_app_router';
+import { formatRate } from '../edges/throughput_edge';
+
+type ClassicStreamNode = Extract<FlowNode, { kind: 'classicStream' }>;
+
+interface PanelClassicStreamProps {
+  node: ClassicStreamNode;
+  onClose: () => void;
+}
+
+export const PanelClassicStream: React.FC<PanelClassicStreamProps> = ({ node }) => {
+  const router = useStreamsAppRouter();
+  const { streamName } = node;
+  const hasFailures = (node.failureRate?.docsPerSec ?? 0) > 0;
+
+  const managementLink = (tab: string) =>
+    router.link('/{key}/management/{tab}', {
+      path: { key: streamName, tab },
+    });
+
+  const listItems = [
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelClassicStream.streamName', {
+        defaultMessage: 'Stream name',
+      }),
+      description: streamName,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelClassicStream.dataStream', {
+        defaultMessage: 'Data stream',
+      }),
+      description: node.dataStream,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelClassicStream.throughput', {
+        defaultMessage: 'Throughput',
+      }),
+      description: node.throughput ? formatRate(node.throughput.docsPerSec) : '—',
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>
+            {streamName}{' '}
+            <EuiBadge color="hollow">
+              {i18n.translate('xpack.streams.ingestFlow.panelClassicStream.classicBadge', {
+                defaultMessage: 'CLASSIC',
+              })}
+            </EuiBadge>
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiDescriptionList listItems={listItems} type="column" columnWidths={[1, 2]} />
+        {hasFailures && node.failureRate ? (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              announceOnMount
+              color="danger"
+              iconType="warning"
+              title={i18n.translate(
+                'xpack.streams.ingestFlow.panelClassicStream.failureCalloutTitle',
+                {
+                  defaultMessage: '{rate} docs/sec failing ingest',
+                  values: { rate: formatRate(node.failureRate.docsPerSec) },
+                }
+              )}
+            />
+          </>
+        ) : null}
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup gutterSize="s" wrap responsive={false} justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('processing')} iconType="indexSettings">
+              {i18n.translate('xpack.streams.ingestFlow.panelClassicStream.processingButton', {
+                defaultMessage: 'Processing',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('schema')} iconType="list">
+              {i18n.translate('xpack.streams.ingestFlow.panelClassicStream.schemaButton', {
+                defaultMessage: 'Schema',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('retention')} iconType="clock">
+              {i18n.translate('xpack.streams.ingestFlow.panelClassicStream.retentionButton', {
+                defaultMessage: 'Retention',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('attachments')} iconType="dashboardApp">
+              {i18n.translate('xpack.streams.ingestFlow.panelClassicStream.dashboardsButton', {
+                defaultMessage: 'Dashboards',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              iconType="discoverApp"
+              onClick={() => {
+                // TODO: use useStreamDiscoverLink (workstream E)
+              }}
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelClassicStream.viewInDiscoverButton', {
+                defaultMessage: 'View in Discover',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+          {hasFailures ? (
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                size="s"
+                color="danger"
+                iconType="discoverApp"
+                onClick={() => {
+                  // TODO: use useFailureStoreRedirectLink (workstream E)
+                }}
+              >
+                {i18n.translate(
+                  'xpack.streams.ingestFlow.panelClassicStream.viewFailuresInDiscoverButton',
+                  {
+                    defaultMessage: 'View failures in Discover',
+                  }
+                )}
+              </EuiButton>
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_cloud_pipeline.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_cloud_pipeline.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { formatRate } from '../edges/throughput_edge';
+
+type CloudPipelineNode = Extract<FlowNode, { kind: 'cloudPipeline' }>;
+
+interface PanelCloudPipelineProps {
+  node: CloudPipelineNode;
+  onClose: () => void;
+}
+
+export const PanelCloudPipeline: React.FC<PanelCloudPipelineProps> = ({ node, onClose }) => {
+  const listItems = [
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelCloudPipeline.pipelineId', {
+        defaultMessage: 'Pipeline ID',
+      }),
+      description: node.pipelineId,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelCloudPipeline.targetStream', {
+        defaultMessage: 'Target stream',
+      }),
+      description: node.targetStreamName ?? '—',
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelCloudPipeline.healthStatus', {
+        defaultMessage: 'Health',
+      }),
+      description: node.health?.status ?? 'unknown',
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelCloudPipeline.throughput', {
+        defaultMessage: 'Throughput',
+      }),
+      description: node.throughput ? formatRate(node.throughput.docsPerSec) : '—',
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>
+            {node.label}{' '}
+            <EuiBadge color="warning">
+              {i18n.translate('xpack.streams.ingestFlow.panelCloudPipeline.mockBadge', {
+                defaultMessage: 'MOCK',
+              })}
+            </EuiBadge>
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiDescriptionList listItems={listItems} type="column" columnWidths={[1, 2]} />
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="s"
+              color="danger"
+              iconType="trash"
+              onClick={() => {
+                // TODO: open CloudPipelineEditFlyout in delete mode (workstream F)
+                onClose();
+              }}
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelCloudPipeline.deleteButton', {
+                defaultMessage: 'Delete',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="s"
+              iconType="copy"
+              onClick={() => {
+                // TODO: open CloudPipelineEditFlyout in duplicate mode (workstream F)
+              }}
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelCloudPipeline.duplicateButton', {
+                defaultMessage: 'Duplicate',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              iconType="pencil"
+              onClick={() => {
+                // TODO: open CloudPipelineEditFlyout in edit mode (workstream F)
+              }}
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelCloudPipeline.editButton', {
+                defaultMessage: 'Edit',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_prometheus.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_prometheus.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+
+type PrometheusScraperNode = Extract<FlowNode, { kind: 'prometheusScraper' }>;
+
+interface PanelPrometheusProps {
+  node: PrometheusScraperNode;
+  onClose: () => void;
+}
+
+export const PanelPrometheus: React.FC<PanelPrometheusProps> = ({ node, onClose }) => {
+  const listItems = [
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelPrometheus.targetHost', {
+        defaultMessage: 'Target host',
+      }),
+      description: node.targetHost,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelPrometheus.scrapeInterval', {
+        defaultMessage: 'Scrape interval',
+      }),
+      description: `${node.scrapeIntervalSec}s`,
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelPrometheus.status', {
+        defaultMessage: 'Status',
+      }),
+      description: node.health?.status ?? 'unknown',
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelPrometheus.destinationKind', {
+        defaultMessage: 'Destination',
+      }),
+      description: i18n.translate('xpack.streams.ingestFlow.panelPrometheus.destinationValue', {
+        defaultMessage: 'Cloud pipeline / bulk endpoint',
+      }),
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>{node.label}</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiDescriptionList listItems={listItems} type="column" columnWidths={[1, 2]} />
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="s"
+              color="danger"
+              iconType="trash"
+              onClick={() => {
+                // TODO: open PrometheusScraperEditFlyout in delete mode (workstream F)
+                onClose();
+              }}
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelPrometheus.deleteButton', {
+                defaultMessage: 'Delete',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              iconType="pencil"
+              onClick={() => {
+                // TODO: open PrometheusScraperEditFlyout (workstream F)
+              }}
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelPrometheus.editScraperButton', {
+                defaultMessage: 'Edit scraper',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_wired_stream.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/panels/panel_wired_stream.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { FlowNode } from '@kbn/streams-plugin/common';
+import { useStreamsAppRouter } from '../../../hooks/use_streams_app_router';
+import { formatRate } from '../edges/throughput_edge';
+
+type WiredStreamNode = Extract<FlowNode, { kind: 'wiredStream' }>;
+
+interface PanelWiredStreamProps {
+  node: WiredStreamNode;
+  onClose: () => void;
+}
+
+export const PanelWiredStream: React.FC<PanelWiredStreamProps> = ({ node }) => {
+  const router = useStreamsAppRouter();
+  const { streamName } = node;
+  const hasFailures = (node.failureRate?.docsPerSec ?? 0) > 0;
+
+  const managementLink = (tab: string, extraQuery?: { action?: 'addChild' }) =>
+    router.link('/{key}/management/{tab}', {
+      path: { key: streamName, tab },
+      query: extraQuery ?? {},
+    });
+
+  const listItems = [
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelWiredStream.processingSteps', {
+        defaultMessage: 'Processing steps',
+      }),
+      description: String(node.processingStepCount),
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelWiredStream.routingRules', {
+        defaultMessage: 'Routing rules',
+      }),
+      description: String(node.routingRuleCount),
+    },
+    {
+      title: i18n.translate('xpack.streams.ingestFlow.panelWiredStream.throughput', {
+        defaultMessage: 'Throughput',
+      }),
+      description: node.throughput ? formatRate(node.throughput.docsPerSec) : '—',
+    },
+  ];
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>
+            {streamName}{' '}
+            <EuiBadge color="primary">
+              {i18n.translate('xpack.streams.ingestFlow.panelWiredStream.wiredBadge', {
+                defaultMessage: 'WIRED',
+              })}
+            </EuiBadge>
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiDescriptionList listItems={listItems} type="column" columnWidths={[1, 2]} />
+        {hasFailures && node.failureRate ? (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              announceOnMount
+              color="danger"
+              iconType="warning"
+              title={i18n.translate(
+                'xpack.streams.ingestFlow.panelWiredStream.failureCalloutTitle',
+                {
+                  defaultMessage: '{rate} docs/sec failing ingest',
+                  values: { rate: formatRate(node.failureRate.docsPerSec) },
+                }
+              )}
+            />
+          </>
+        ) : null}
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup gutterSize="s" wrap responsive={false} justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('processing')} iconType="indexSettings">
+              {i18n.translate('xpack.streams.ingestFlow.panelWiredStream.processingButton', {
+                defaultMessage: 'Processing',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('partitioning')} iconType="branch">
+              {i18n.translate('xpack.streams.ingestFlow.panelWiredStream.routingButton', {
+                defaultMessage: 'Routing',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('schema')} iconType="list">
+              {i18n.translate('xpack.streams.ingestFlow.panelWiredStream.schemaButton', {
+                defaultMessage: 'Schema',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('retention')} iconType="clock">
+              {i18n.translate('xpack.streams.ingestFlow.panelWiredStream.retentionButton', {
+                defaultMessage: 'Retention',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="s" href={managementLink('attachments')} iconType="dashboardApp">
+              {i18n.translate('xpack.streams.ingestFlow.panelWiredStream.dashboardsButton', {
+                defaultMessage: 'Dashboards',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="s"
+              href={managementLink('partitioning', { action: 'addChild' as const })}
+              iconType="plusInCircle"
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelWiredStream.addChildButton', {
+                defaultMessage: 'Add child stream',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              iconType="discoverApp"
+              onClick={() => {
+                // TODO: use useStreamDiscoverLink (workstream E)
+              }}
+            >
+              {i18n.translate('xpack.streams.ingestFlow.panelWiredStream.viewInDiscoverButton', {
+                defaultMessage: 'View in Discover',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+          {hasFailures ? (
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                size="s"
+                color="danger"
+                iconType="discoverApp"
+                onClick={() => {
+                  // TODO: use useFailureStoreRedirectLink (workstream E)
+                }}
+              >
+                {i18n.translate(
+                  'xpack.streams.ingestFlow.panelWiredStream.viewFailuresInDiscoverButton',
+                  {
+                    defaultMessage: 'View failures in Discover',
+                  }
+                )}
+              </EuiButton>
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/simulated_sources_banner.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/ingest_flow_view/simulated_sources_banner.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export const SimulatedSourcesBanner: React.FC = () => {
+  return (
+    <EuiCallOut
+      color="warning"
+      iconType="warning"
+      title={i18n.translate('xpack.streams.ingestFlow.mockBanner.title', {
+        defaultMessage: 'Simulated data sources active',
+      })}
+    >
+      <EuiText size="s">
+        <p>
+          {i18n.translate('xpack.streams.ingestFlow.mockBanner.body', {
+            defaultMessage:
+              'Cloud Pipelines OTLP endpoints and Prometheus scrapers are simulated with synthetic metrics. Fleet agents, stream topology, throughput rates, and failure rates are real data.',
+          })}
+        </p>
+      </EuiText>
+    </EuiCallOut>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -192,6 +192,18 @@ export function StreamListView() {
                 })}
               </EuiButton>
             </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                href={router.link('/_flow')}
+                iconType="visNetwork"
+                size="s"
+                data-test-subj="streamsIngestFlowButton"
+              >
+                {i18n.translate('xpack.streams.streamsListView.ingestFlowButtonLabel', {
+                  defaultMessage: 'Ingest flow',
+                })}
+              </EuiButton>
+            </EuiFlexItem>
             {significantEventsDiscovery?.available && significantEventsDiscovery.enabled && (
               <EuiFlexItem grow={false}>
                 <EuiButton

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_routing/index.tsx
@@ -18,6 +18,7 @@ import { useKibana } from '../../../../hooks/use_kibana';
 import { useStreamsAppFetch } from '../../../../hooks/use_streams_app_fetch';
 import type { StatefulStreamsAppRouter } from '../../../../hooks/use_streams_app_router';
 import { useStreamsAppRouter } from '../../../../hooks/use_streams_app_router';
+import { useStreamsAppParams } from '../../../../hooks/use_streams_app_params';
 import { useTimefilter } from '../../../../hooks/use_timefilter';
 import { ManagementBottomBar } from '../management_bottom_bar';
 import { RequestPreviewFlyout } from '../request_preview_flyout';
@@ -77,7 +78,9 @@ export function StreamDetailRoutingImpl() {
     },
   } = useKibana();
 
-  const { cancelChanges, saveChanges } = useStreamRoutingEvents();
+  const { cancelChanges, saveChanges, createNewRule, editRule } = useStreamRoutingEvents();
+
+  const { query: routeQuery } = useStreamsAppParams('/{key}/management/{tab}');
 
   const definition = useStreamsRoutingSelector((snapshot) => snapshot.context.definition);
   // StreamDetailRoutingImpl is only rendered for wired streams (classic uses ClassicStreamPartitioningImpl)
@@ -143,6 +146,26 @@ export function StreamDetailRoutingImpl() {
     openConfirm: core.overlays.openConfirm,
     shouldPromptOnReplace: false,
   });
+
+  // Deep-link: pre-trigger routing actions when query params are present.
+  // Only fires once on mount; additive — no-ops when params are absent.
+  const { action: deepLinkAction, editRoutingRuleId } = routeQuery ?? {};
+  useEffect(() => {
+    if (!deepLinkAction && !editRoutingRuleId) return;
+
+    if (deepLinkAction === 'addChild') {
+      createNewRule();
+      return;
+    }
+
+    if (editRoutingRuleId) {
+      const matchingRule = routing.find((rule) => rule.destination === editRoutingRuleId);
+      if (matchingRule) {
+        editRule(matchingRule.id);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const availableStreams = streamsListFetch.value?.streams.map((stream) => stream.name) ?? [];
   const {

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_failure_store_redirect_link.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_failure_store_redirect_link.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { useFailureStoreRedirectLink } from '../components/stream_management/data_management/stream_detail_lifecycle/hooks/use_failure_store_redirect_link';

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_discover_link.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_discover_link.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
+import { DISCOVER_APP_LOCATOR } from '@kbn/discover-plugin/common';
+import type React from 'react';
+import { useKibana } from './use_kibana';
+
+/**
+ * Returns a stable href and onClick handler for opening Discover with
+ * `FROM <streamName> | SORT @timestamp DESC`.
+ */
+export const useStreamDiscoverLink = (
+  streamName: string
+): { href: string | undefined; onClick: (e?: React.MouseEvent) => void } => {
+  const {
+    dependencies: {
+      start: { share },
+    },
+  } = useKibana();
+
+  const discoverLocator = share.url.locators.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
+
+  const esqlQuery = `FROM ${streamName} | SORT @timestamp DESC`;
+
+  const params: DiscoverAppLocatorParams = {
+    query: { esql: esqlQuery },
+  };
+
+  const href = discoverLocator?.getRedirectUrl(params);
+
+  const onClick = (e?: React.MouseEvent) => {
+    e?.preventDefault();
+    discoverLocator?.navigate(params);
+  };
+
+  return { href, onClick };
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/routes/config.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/routes/config.tsx
@@ -17,6 +17,7 @@ import { StreamListView } from '../components/stream_list_view';
 import { StreamDetailRoot } from '../components/stream_root';
 import { StreamDetailManagement } from '../components/stream_management/data_management/stream_detail_management';
 import { SignificantEventsDiscoveryPage } from '../components/sig_events/significant_events_discovery/page';
+import { IngestFlowView } from '../components/ingest_flow_view';
 
 /**
  * Optional time range query params.
@@ -38,6 +39,9 @@ const managementQueryParams = t.partial({
   openFlyout: t.string,
   // Data quality page state
   pageState: t.string,
+  // Ingest flow deep-link params
+  editRoutingRuleId: t.string,
+  action: t.literal('addChild'),
 });
 
 /**
@@ -64,6 +68,12 @@ const streamsAppRoutes = {
     children: {
       '/': {
         element: <StreamListView />,
+        params: t.partial({
+          query: timeRangeQueryParams,
+        }),
+      },
+      '/_flow': {
+        element: <IngestFlowView />,
         params: t.partial({
           query: timeRangeQueryParams,
         }),


### PR DESCRIPTION
## Summary


<img width="1512" height="746" alt="Screenshot 2026-05-05 at 11 10 21" src="https://github.com/user-attachments/assets/e2e39421-d7db-4b58-aa95-e1e985968d70" />

POC for a new \"Ingest flow\" page at \`/_flow\` in the Streams app showing the full data ingestion topology as a live graph.

**Left — Shippers:** Fleet agents (real) + agentless integrations (real) + mock Prometheus scrapers
**Middle — Endpoints:** Mock Cloud Pipelines OTLP endpoints + ES bulk endpoint
**Right — Streams:** Wired + classic stream tree with real throughput rates and failure-rate badges

Key details:
- 5s live throughput poll without layout re-run
- Click any node → detail flyout with quick-links into Fleet / Integrations / stream management tabs
- Deep-links: \`?action=addChild\` and \`?editRoutingRuleId\` pre-open routing editor states
- Cloud Pipeline + Prometheus create/edit/delete flyouts
- Warning banner permanently marking mocked sources

Tech: \`@xyflow/react\` + \`@dagrejs/dagre\` (already in repo), three-column swim-lane layout ported from Fleet OTel graph view. Fleet is an optional plugin dependency using minimal local interfaces to avoid transitive \`rootDir\` type errors.

## Test plan

- [ ] Streams → \"Ingest flow\" button → page loads
- [ ] Graph renders with three-column swim-lane layout
- [ ] Click a stream node → detail flyout opens with correct tab links
- [ ] Cloud Pipeline edit flyout saves and refreshes graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)