### PR TITLE
Fix flaky muted alerts test

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/common/lib/alert_utils.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/lib/alert_utils.ts
@@ -531,13 +531,16 @@ export class AlertUtils {
     return response;
   }
 
-  public async runSoon(ruleId: string) {
+  public async runSoon(ruleId: string, options?: { force?: boolean }) {
     let request = this.supertestWithoutAuth
       .post(`${getUrlPrefix(this.space.id)}/internal/alerting/rule/${ruleId}/_run_soon`)
       .set('kbn-xsrf', 'foo');
 
     if (this.user) {
       request = request.auth(this.user.username, this.user.password);
+    }
+    if (options?.force) {
+      request = request.query({ force: true });
     }
     return await request.send();
   }

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/muted_alerts.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/muted_alerts.ts
@@ -291,6 +291,7 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
       // Wait for alerts to be muted
       await retry.try(async () => {
         const alerts = await getAlertsByRuleId(ruleId);
+        expect(alerts.length).greaterThan(0);
         alerts.forEach((alert: any) => {
           expect(alert._source[ALERT_MUTED]).to.be(true);
         });
@@ -299,8 +300,9 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
       // Now unmute all alerts
       await alertUtils.getUnmuteAllRequest(ruleId);
 
-      // Run the rule to trigger reconciliation
-      await alertUtils.runSoon(ruleId);
+      // Run the rule to trigger reconciliation. Use force so we do not get "Rule is already
+      // running" without queueing a run; muted flags only reconcile on execution.
+      await alertUtils.runSoon(ruleId, { force: true });
 
       // Wait for all alert documents to be updated
       await retry.try(async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/247714

## Summary

Forcing the run soon to see if it fixes flakiness.



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->