### PR TITLE
[Entity Analytics] Exclude v2 specs from v1 evals run

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/config/create_playwright_eval_config.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/config/create_playwright_eval_config.ts
@@ -24,11 +24,13 @@ export interface EvaluationTestOptions extends ScoutTestOptions {
  */
 export function createPlaywrightEvalsConfig({
   testDir,
+  testIgnore,
   repetitions,
   timeout,
   runGlobalSetup,
 }: {
   testDir: string;
+  testIgnore?: PlaywrightTestConfig['testIgnore'];
   repetitions?: number;
   timeout?: number;
   runGlobalSetup?: boolean;
@@ -106,5 +108,6 @@ export function createPlaywrightEvalsConfig({
     globalSetup: require.resolve('./setup.js'),
     globalTeardown: require.resolve('./teardown.js'),
     timeout: timeout ?? 5 * 60_000,
+    ...(testIgnore !== undefined ? { testIgnore } : {}),
   });
 }

--- a/x-pack/platform/packages/shared/kbn-evals/src/config/create_playwright_eval_config.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/config/create_playwright_eval_config.ts
@@ -24,13 +24,11 @@ export interface EvaluationTestOptions extends ScoutTestOptions {
  */
 export function createPlaywrightEvalsConfig({
   testDir,
-  testIgnore,
   repetitions,
   timeout,
   runGlobalSetup,
 }: {
   testDir: string;
-  testIgnore?: PlaywrightTestConfig['testIgnore'];
   repetitions?: number;
   timeout?: number;
   runGlobalSetup?: boolean;
@@ -108,6 +106,5 @@ export function createPlaywrightEvalsConfig({
     globalSetup: require.resolve('./setup.js'),
     globalTeardown: require.resolve('./teardown.js'),
     timeout: timeout ?? 5 * 60_000,
-    ...(testIgnore !== undefined ? { testIgnore } : {}),
   });
 }

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/anomalous_behavior_active_jobs.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/anomalous_behavior_active_jobs.spec.ts
@@ -9,7 +9,7 @@ import { tags } from '@kbn/scout-security';
 import { deleteAllRules } from '@kbn/detections-response-ftr-services/rules';
 import { DEFAULT_ANOMALY_SCORE } from '@kbn/security-solution-plugin/common/constants';
 import { deleteAllAlerts, createAlertsIndex } from '@kbn/detections-response-ftr-services/alerts';
-import { evaluate } from '../src/evaluate';
+import { evaluate } from '../../src/evaluate';
 import {
   securityAuthModule,
   securityAuthJobIds,
@@ -26,7 +26,7 @@ import {
   installIntegrationAndCreatePolicy,
   setupMlModulesWithRetry,
   waitForAllJobsToStart,
-} from '../src/ml_helpers';
+} from '../../src/ml_helpers';
 
 evaluate.describe(
   'SIEM ML Jobs Skill - Anomalous Behavior with Active ML Jobs',

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/anomalous_behavior_no_jobs.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/anomalous_behavior_no_jobs.spec.ts
@@ -6,8 +6,8 @@
  */
 
 import { tags } from '@kbn/scout-security';
-import { evaluate } from '../src/evaluate';
-import { dedJobIds, securityAuthJobIds, lmdJobIds, padJobIds } from '../src/ml_helpers';
+import { evaluate } from '../../src/evaluate';
+import { dedJobIds, securityAuthJobIds, lmdJobIds, padJobIds } from '../../src/ml_helpers';
 
 evaluate.describe(
   'SIEM ML Jobs Skill - Anomalous Behavior without ML Jobs',

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/asset_criticality.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/asset_criticality.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { tags } from '@kbn/scout-security';
-import { evaluate } from '../src/evaluate';
+import { evaluate } from '../../src/evaluate';
 
 /**
  * Asset criticality prompts (P-AC1, P-AC2). Uses security.entity_analytics.asset_criticality tool.

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/boundary_cases.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/boundary_cases.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { tags } from '@kbn/scout-security';
-import { evaluate } from '../src/evaluate';
+import { evaluate } from '../../src/evaluate';
 
 /**
  * Tier 3 negative/boundary prompts. The system cannot answer these; the AI must

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/multi_skill_routing.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/multi_skill_routing.spec.ts
@@ -6,8 +6,8 @@
  */
 
 import { tags } from '@kbn/scout-security';
-import { evaluate } from '../src/evaluate';
-import { lmdJobIds, padJobIds } from '../src/ml_helpers';
+import { evaluate } from '../../src/evaluate';
+import { lmdJobIds, padJobIds } from '../../src/ml_helpers';
 
 /**
  * Multi-skill routing prompts (P-MS1, P-MS2, and new cross-domain prompts).

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/partial_feasibility.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/partial_feasibility.spec.ts
@@ -6,8 +6,8 @@
  */
 
 import { tags } from '@kbn/scout-security';
-import { evaluate } from '../src/evaluate';
-import { padJobIds, lmdJobIds } from '../src/ml_helpers';
+import { evaluate } from '../../src/evaluate';
+import { padJobIds, lmdJobIds } from '../../src/ml_helpers';
 
 /**
  * Tier 2b partial-feasibility prompts. The system may produce a reasonable answer;

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/risk_score_engine_off.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/risk_score_engine_off.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { tags } from '@kbn/scout-security';
-import { evaluate } from '../src/evaluate';
+import { evaluate } from '../../src/evaluate';
 
 evaluate.describe(
   'SIEM Entity Analytics Skill - Risk Score Tests Without Data',

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/risk_score_engine_on.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/risk_score_engine_on.spec.ts
@@ -17,7 +17,7 @@ import {
 import { deleteAllRules } from '@kbn/detections-response-ftr-services/rules';
 import { dataGeneratorFactory } from '@kbn/test-suites-security-solution-apis/test_suites/detections_response/utils';
 import { deleteAllAlerts, createAlertsIndex } from '@kbn/detections-response-ftr-services/alerts';
-import { evaluate } from '../src/evaluate';
+import { evaluate } from '../../src/evaluate';
 
 evaluate.describe(
   'SIEM Entity Analytics Skill - Risk Score Tests',

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/risk_score_grounding.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v1/risk_score_grounding.spec.ts
@@ -17,7 +17,7 @@ import {
 import { deleteAllRules } from '@kbn/detections-response-ftr-services/rules';
 import { dataGeneratorFactory } from '@kbn/test-suites-security-solution-apis/test_suites/detections_response/utils';
 import { deleteAllAlerts, createAlertsIndex } from '@kbn/detections-response-ftr-services/alerts';
-import { evaluate } from '../src/evaluate';
+import { evaluate } from '../../src/evaluate';
 
 /**
  * Risk score grounding evals with deterministic seeded data.

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/playwright.config.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/playwright.config.ts
@@ -7,12 +7,7 @@
 import { createPlaywrightEvalsConfig } from '@kbn/evals';
 
 export default createPlaywrightEvalsConfig({
-  testDir: `${__dirname}/evals`,
-  // The v2 suite (`playwright.v2.config.ts`) owns specs under `evals/v2/` and
-  // requires the `evals_entity_analytics_v2` Scout configSet. Excluding them
-  // here prevents the v1 run from picking them up via recursive testDir walk
-  // and failing them under the wrong configSet.
-  testIgnore: ['**/v2/**'],
+  testDir: `${__dirname}/evals/v1`,
   repetitions: 1,
   timeout: 60 * 60_000,
 });

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/playwright.config.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/playwright.config.ts
@@ -8,6 +8,11 @@ import { createPlaywrightEvalsConfig } from '@kbn/evals';
 
 export default createPlaywrightEvalsConfig({
   testDir: `${__dirname}/evals`,
+  // The v2 suite (`playwright.v2.config.ts`) owns specs under `evals/v2/` and
+  // requires the `evals_entity_analytics_v2` Scout configSet. Excluding them
+  // here prevents the v1 run from picking them up via recursive testDir walk
+  // and failing them under the wrong configSet.
+  testIgnore: ['**/v2/**'],
   repetitions: 1,
   timeout: 60 * 60_000,
 });


### PR DESCRIPTION
## Summary

The v1 entity-analytics evals suite (`playwright.config.ts`) uses `testDir: ${__dirname}/evals`, which Playwright walks recursively. That picks up `evals/v2/*.spec.ts` — but those specs require the `evals_entity_analytics_v2` Scout configSet (which enables the `entityAnalyticsEntityStoreV2` feature flag). Under v1's `evals_entity_analytics` configSet the V2 feature is off, so the 3 V2 specs **always fail** in every v1 child run and pollute the v1 pass-rate signal.

Confirmed in raw log of `kibana-evals-weekly-llm-evals/build_12 / eis-anthropic-claude-4-6-opus`:
- Final result: `1 failed, 11 passed (1.5h)`
- Failed test: `evals/v2/entity_store_v2_get_entity.spec.ts`

This artificially depresses v1's 14-day pass rate to ~23% even when the actual v1 work succeeds.

### Changes

- `x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/playwright.config.ts` — adds `testIgnore: ['**/v2/**']`. The v2 suite continues to own those specs via `playwright.v2.config.ts` (which has `testDir: evals/v2`).
- `x-pack/platform/packages/shared/kbn-evals/src/config/create_playwright_eval_config.ts` — extends `createPlaywrightEvalsConfig` to accept an optional `testIgnore` and forward it to the Playwright config.

### Why this first

Required before any v1 timing measurement, sharding work, or per-test timeout tuning can be interpreted — current pass-rate signal is meaningless until v2 noise is removed.

Refs `elastic/security-team#17138`. Companion follow-up will drop the v1 per-test timeout from 60→30 min after one weekly cycle confirms a stable signal.

## Test plan

- [x] `node scripts/type_check --project x-pack/platform/packages/shared/kbn-evals/tsconfig.json` (passed locally)
- [x] `node scripts/type_check --project x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/tsconfig.json` (passed locally)
- [ ] One CI run of the entity-analytics suite (e.g. trigger via `evals:entity-analytics` label) confirms no `evals/v2/**` specs appear in the Playwright report.
- [ ] Next weekly `kibana-evals-weekly-llm-evals` run shows the v2-spec failures are gone from v1 children.