### PR TITLE
[Inference] Filter .gp-llm-v2* and .rainbow-sprinkles from UIs

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_eis_models.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_eis_models.ts
@@ -6,13 +6,16 @@
  */
 
 import { useMemo } from 'react';
-import { isEisEndpoint } from '../utils/eis_utils';
+import { isEisEndpoint, isHiddenEisEndpoint } from '../utils/eis_utils';
 import { useQueryInferenceEndpoints } from './use_inference_endpoints';
 
 export const useEisModels = () => {
   const { data: allEndpoints, ...rest } = useQueryInferenceEndpoints();
 
-  const data = useMemo(() => allEndpoints?.filter(isEisEndpoint), [allEndpoints]);
+  const data = useMemo(
+    () => allEndpoints?.filter(isEisEndpoint).filter((ep) => !isHiddenEisEndpoint(ep)),
+    [allEndpoints]
+  );
 
   return { data, ...rest };
 };

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/eis_utils.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/eis_utils.ts
@@ -23,6 +23,13 @@ export type EisInferenceEndpoint = InferenceAPIConfigResponse & {
 export const isEisEndpoint = (ep: InferenceAPIConfigResponse): ep is EisInferenceEndpoint =>
   ep.service === 'elastic';
 
+// Inference ID prefixes for internal Elastic endpoints kept for backwards
+// compatibility that must not be surfaced in the UI.
+const HIDDEN_EIS_INFERENCE_ID_PREFIXES = ['.gp-llm-v2', '.rainbow-sprinkles'];
+
+export const isHiddenEisEndpoint = (ep: InferenceAPIConfigResponse): boolean =>
+  HIDDEN_EIS_INFERENCE_ID_PREFIXES.some((prefix) => ep.inference_id.startsWith(prefix));
+
 export type TaskTypeCategory = 'LLM' | 'Embedding' | 'Rerank';
 
 export const TASK_TYPE_CATEGORY: Partial<Record<InferenceTaskType, TaskTypeCategory>> = {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/dynamic_connectors.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/dynamic_connectors.test.ts
@@ -226,7 +226,7 @@ describe('DynamicConnectorsPoller', () => {
       await wait();
 
       expect(mockClient.inference.get).toHaveBeenCalledTimes(2);
-      expect(mockActions.registerDynamicConnector).toHaveBeenCalledTimes(13);
+      expect(mockActions.registerDynamicConnector).toHaveBeenCalledTimes(11);
       expect(mockLogger.error).toHaveBeenCalledTimes(2);
     })
   );

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/utils/in_memory_connectors.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/utils/in_memory_connectors.test.ts
@@ -89,6 +89,30 @@ describe('filterPreconfiguredEndpoints', () => {
     expect(filterPreconfiguredEndpoints([])).toEqual([]);
   });
 
+  it('filters out endpoints with inference IDs starting with .gp-llm-v2', () => {
+    const endpoint = makeEndpoint({ inference_id: '.gp-llm-v2-chat_completion' });
+    expect(filterPreconfiguredEndpoints([endpoint])).toEqual([]);
+  });
+
+  it('filters out all .gp-llm-v2 variant inference IDs', () => {
+    const endpoint1 = makeEndpoint({ inference_id: '.gp-llm-v2' });
+    const endpoint2 = makeEndpoint({ inference_id: '.gp-llm-v2-chat_completion' });
+    const endpoint3 = makeEndpoint({ inference_id: '.gp-llm-v2-completion' });
+    expect(filterPreconfiguredEndpoints([endpoint1, endpoint2, endpoint3])).toEqual([]);
+  });
+
+  it('filters out endpoints with inference IDs starting with .rainbow-sprinkles', () => {
+    const endpoint = makeEndpoint({ inference_id: '.rainbow-sprinkles-elastic' });
+    expect(filterPreconfiguredEndpoints([endpoint])).toEqual([]);
+  });
+
+  it('does not filter out non-blocked endpoints that otherwise qualify', () => {
+    const valid = makeEndpoint();
+    const gp = makeEndpoint({ inference_id: '.gp-llm-v2-chat_completion' });
+    const rainbow = makeEndpoint({ inference_id: '.rainbow-sprinkles-elastic' });
+    expect(filterPreconfiguredEndpoints([valid, gp, rainbow])).toEqual([valid]);
+  });
+
   it('filters the EIS mock endpoints to only chat_completion endpoints with kibana-connector property', () => {
     const results = filterPreconfiguredEndpoints(mockEISPreconfiguredEndpoints);
     expect(results.length).toBeGreaterThan(0);
@@ -97,6 +121,13 @@ describe('filterPreconfiguredEndpoints', () => {
       expect(ep.metadata?.heuristics?.properties).toContain('kibana-connector');
       expect(endpoint.task_type).toBe('chat_completion');
     });
+  });
+
+  it('excludes .gp-llm-v2 and .rainbow-sprinkles endpoints from the EIS mock list', () => {
+    const results = filterPreconfiguredEndpoints(mockEISPreconfiguredEndpoints);
+    const resultIds = results.map((ep) => ep.inference_id);
+    expect(resultIds.every((id) => !id.startsWith('.gp-llm-v2'))).toBe(true);
+    expect(resultIds.every((id) => !id.startsWith('.rainbow-sprinkles'))).toBe(true);
   });
 });
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/utils/in_memory_connectors.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/utils/in_memory_connectors.ts
@@ -15,11 +15,19 @@ import {
 const CHAT_COMPLETION_TASK_TYPE = 'chat_completion';
 const KIBANA_CONNECTOR_PROPERTY = 'kibana-connector';
 
+// Inference ID prefixes for internal Elastic endpoints kept for backwards
+// compatibility that must not be surfaced in the UI.
+const HIDDEN_INFERENCE_ID_PREFIXES = ['.gp-llm-v2', '.rainbow-sprinkles'];
+
+const isHiddenInferenceEndpoint = (inferenceId: string): boolean =>
+  HIDDEN_INFERENCE_ID_PREFIXES.some((prefix) => inferenceId.startsWith(prefix));
+
 export function filterPreconfiguredEndpoints(
   endpoints: InferenceInferenceEndpointInfo[]
 ): InferenceInferenceEndpointInfo[] {
   return endpoints.filter(
     (endpoint) =>
+      !isHiddenInferenceEndpoint(endpoint.inference_id) &&
       isInferenceEndpointWithMetadata(endpoint) &&
       endpoint.metadata?.heuristics?.properties?.includes(KIBANA_CONNECTOR_PROPERTY) &&
       endpoint.task_type === CHAT_COMPLETION_TASK_TYPE


### PR DESCRIPTION
## Summary

Hides the legacy `.gp-llm-v2*` and `.rainbow-sprinkles*` inference endpoint families from all Kibana UIs. These endpoints are kept in Elasticsearch for backwards compatibility but must not surface to users.

### Changes

**Server (`in_memory_connectors.ts`)**
- Added `isHiddenInferenceEndpoint` predicate (module-private) checked before any other condition in `filterPreconfiguredEndpoints`, so these IDs are never promoted to dynamic AI connectors.

**Public (`eis_utils.ts`, `use_eis_models.ts`)**
- Exported `isHiddenEisEndpoint` that checks the same prefix list.
- Applied the filter in `useEisModels` so the AI model catalogue never includes these endpoints.

**Tests (`in_memory_connectors.test.ts`, `dynamic_connectors.test.ts`)**
- Added unit tests that verify the new server-side filter rejects `.gp-llm-v2*` and `.rainbow-sprinkles*` IDs whether encountered individually or mixed with valid endpoints, and that the full EIS mock list produces no such IDs after filtering.
- Updated the hardcoded connector-registration call count in `dynamic_connectors.test.ts` from `13` (1 failed + 12 qualified) to `11` (1 failed + 10 qualified) after the two hidden families are excluded from the mock.
