### PR TITLE
[Synthetics] Fix space selector not loading spaces when creating project api keys

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/components/spaces_select.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/components/spaces_select.tsx
@@ -14,6 +14,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 import usePrevious from 'react-use/lib/usePrevious';
 import { ALL_SPACES_ID } from '@kbn/security-plugin/public';
+import { ALL_SPACES_LABEL } from '../../monitor_add_edit/fields/monitor_spaces';
 import { selectAgentPolicies } from '../../../state/agent_policies';
 import type { ClientPluginsStart } from '../../../../../plugin';
 
@@ -41,6 +42,28 @@ export const SpaceSelector = <T extends FieldValues>({
   });
 
   const prevAgentPolicyId = usePrevious(selectedAgentPolicyId);
+
+  const hasAgentPolicyField = selectedAgentPolicyId !== undefined;
+
+  // When there is no agent policy field (e.g. Project API Keys), load all spaces unconditionally
+  useEffect(() => {
+    if (hasAgentPolicyField || !data?.spacesDataPromise) return;
+    let cancelled = false;
+
+    data.spacesDataPromise.then(({ spacesMap }) => {
+      if (cancelled) return;
+      const allSpacesOption = { id: ALL_SPACES_ID, label: ALL_SPACES_LABEL };
+      const spaceOptions = [...spacesMap].map(([spaceId, spaceData]) => ({
+        id: spaceId,
+        label: spaceData.name,
+      }));
+      setSpacesList([allSpacesOption, ...spaceOptions]);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasAgentPolicyField, data?.spacesDataPromise]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/267453

Adds a separate effect to load all spaces when SpaceSelector is used without an agent policy.

<img width="1212" height="528" alt="Screenshot 2026-05-04 at 1 21 19 PM" src="https://github.com/user-attachments/assets/d0291442-7f8b-4a51-a20e-aaf00cc46d0a" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->