### PR TITLE
[Discover] Show alerts menu when user only has alerting v2 access

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.test.tsx
@@ -449,4 +449,128 @@ describe('useTopNavLinks', () => {
       expect(classicConfig.items?.find((item) => item.id === AppMenuActionId.alerts)).toBeDefined();
     });
   });
+
+  describe('alerts menu when only alerting v2 capability is granted', () => {
+    /**
+     * Users with v2 access but no v1 rule-type authorization should still see
+     * the Alerts menu (containing only the v2 ES|QL rule entry) when in ES|QL
+     * mode. Verifies the parent gate considers v2 access independently.
+     */
+    const setupV2OnlyServices = (
+      overrides: { alertingVTwoEnabled?: boolean } = {}
+    ): DiscoverServices => {
+      const baseMock = createDiscoverServicesMock();
+      const { alertingVTwoEnabled = true } = overrides;
+      return createTestServices({
+        capabilities: {
+          ...baseMock.capabilities,
+          discover_v2: {
+            save: true,
+            storeSearchSession: true,
+          },
+          ...(alertingVTwoEnabled ? { alertingVTwo: {} } : {}),
+          // No v1 management.insightsAndAlerting.triggersActions capability.
+          management: {
+            ...baseMock.capabilities.management,
+            insightsAndAlerting: {},
+          },
+        },
+        triggersActionsUi: triggersActionsUiMock.createStart(),
+      });
+    };
+
+    beforeEach(() => {
+      jest.requireMock('@kbn/alerts-ui-shared').useGetRuleTypesPermissions.mockReturnValue({
+        authorizedRuleTypes: [],
+      });
+    });
+
+    afterEach(() => {
+      jest.requireMock('@kbn/alerts-ui-shared').useGetRuleTypesPermissions.mockReturnValue({
+        authorizedRuleTypes: [
+          {
+            id: '.es-query',
+            authorizedConsumers: {
+              discover: { all: true, read: true },
+            },
+          },
+        ],
+      });
+    });
+
+    it('should include the alerts menu in ES|QL mode when only alerting v2 is granted', async () => {
+      const services = setupV2OnlyServices();
+      const toolkit = getDiscoverInternalStateMock({ services });
+      await toolkit.initializeTabs();
+      await toolkit.initializeSingleTab({ tabId: toolkit.getCurrentTab().id });
+
+      const appMenuConfig = renderHook(
+        () =>
+          useTopNavLinks({
+            dataView: dataViewMock,
+            services,
+            hasUnsavedChanges: false,
+            isEsqlMode: true,
+            adHocDataViews: [],
+            hasShareIntegration: false,
+            persistedDiscoverSession: undefined,
+            onOpenInspector: jest.fn(),
+            onOpenSaveModal: jest.fn(),
+            onOpenSaveAsModal: jest.fn(),
+          }),
+        {
+          wrapper: ({ children }) => (
+            <DiscoverToolkitTestProvider toolkit={toolkit}>{children}</DiscoverToolkitTestProvider>
+          ),
+        }
+      ).result.current;
+
+      const alertsItem = appMenuConfig.items?.find((item) => item.id === AppMenuActionId.alerts);
+      expect(alertsItem).toBeDefined();
+
+      const v2Row = alertsItem?.items?.find((item) => item.id === 'create-esql-rule-v2');
+      expect(v2Row).toBeDefined();
+
+      // v1 entries must remain hidden because the user has no v1 capabilities.
+      const manageRow = alertsItem?.items?.find(
+        (item) => item.testId === 'discoverManageAlertsButton'
+      );
+      const createSearchThresholdRow = alertsItem?.items?.find(
+        (item) => item.testId === 'discoverCreateAlertButton'
+      );
+      expect(manageRow).toBeUndefined();
+      expect(createSearchThresholdRow).toBeUndefined();
+    });
+
+    it('should NOT include the alerts menu when neither v1 nor v2 access is granted', async () => {
+      const services = setupV2OnlyServices({ alertingVTwoEnabled: false });
+      const toolkit = getDiscoverInternalStateMock({ services });
+      await toolkit.initializeTabs();
+      await toolkit.initializeSingleTab({ tabId: toolkit.getCurrentTab().id });
+
+      const appMenuConfig = renderHook(
+        () =>
+          useTopNavLinks({
+            dataView: dataViewMock,
+            services,
+            hasUnsavedChanges: false,
+            isEsqlMode: true,
+            adHocDataViews: [],
+            hasShareIntegration: false,
+            persistedDiscoverSession: undefined,
+            onOpenInspector: jest.fn(),
+            onOpenSaveModal: jest.fn(),
+            onOpenSaveAsModal: jest.fn(),
+          }),
+        {
+          wrapper: ({ children }) => (
+            <DiscoverToolkitTestProvider toolkit={toolkit}>{children}</DiscoverToolkitTestProvider>
+          ),
+        }
+      ).result.current;
+
+      const alertsItem = appMenuConfig.items?.find((item) => item.id === AppMenuActionId.alerts);
+      expect(alertsItem).toBeUndefined();
+    });
+  });
 });

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -151,7 +151,10 @@ export const useTopNavLinks = ({
       items.push(inspectAppMenuItem);
     }
 
-    if (services.triggersActionsUi && discoverParams.authorizedRuleTypeIds.length) {
+    const hasV1AlertsAccess = discoverParams.authorizedRuleTypeIds.length > 0;
+    const shouldShowAlertsMenu = hasV1AlertsAccess || showCreateRuleV2;
+
+    if (services.triggersActionsUi && shouldShowAlertsMenu) {
       const alertsAppMenuItem = getAlertsAppMenuItem({
         discoverParams,
         services,


### PR DESCRIPTION
## Summary

The Alerts menu in the Discover top nav was hidden whenever the current user had no v1 rule-type authorization, even when alerting v2 access was granted. As a result, users who could only create v2 ES|QL rules had no entry point to do so from Discover.

This PR gates the menu on a combined check: it renders when the user has either v1 rule-type authorization **or** v2 access (`showCreateRuleV2`), so the v2 ES|QL rule row remains reachable independently of v1 permissions.

Extracted from #267363 to keep the production fix reviewable on its own.

## Changes

- `use_top_nav_links.tsx`: replace the v1-only `discoverParams.authorizedRuleTypeIds.length` gate with `hasV1AlertsAccess || showCreateRuleV2`.
- `use_top_nav_links.test.tsx`: add a new `describe` block covering the v2-only capability path (existing tests untouched).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->