### PR TITLE
[8.19] chore(axios,security-generative-ai) Remove axios dependency in favor … (#266771)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -341,7 +341,6 @@ const AXIOS_LEGACY_CONSUMERS = [
   'x-pack/solutions/observability/test/profiling_cypress/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/search/test/functional_enterprise_search/artifact_manager.ts',
   'x-pack/solutions/security/packages/kbn-securitysolution-utils/src/axios/**/*.{js,mjs,ts,tsx}',
-  'x-pack/solutions/security/plugins/elastic_assistant/scripts/**/*.{js,mjs,ts,tsx,jsx}',
   'x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/common/endpoint/format_axios_error.ts',
   'x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/**/*.{js,mjs,ts,tsx}',

--- a/x-pack/solutions/security/plugins/elastic_assistant/scripts/create_conversations_script.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/scripts/create_conversations_script.ts
@@ -9,7 +9,6 @@ import { randomBytes } from 'node:crypto';
 import yargs from 'yargs/yargs';
 import { ToolingLog } from '@kbn/tooling-log';
 import { Client } from '@elastic/elasticsearch';
-import axios from 'axios';
 import pLimit from 'p-limit';
 import { API_VERSIONS } from '@kbn/elastic-assistant-common';
 import { CreateMessageSchema } from '../server/ai_assistant_data_clients/conversations/types';
@@ -52,12 +51,20 @@ export const create = async () => {
 
   try {
     logger.info(`Fetching available connectors...`);
-    const { data: connectors } = await axios.get(connectorsApiUrl, {
+    const connectorsResponse = await fetch(connectorsApiUrl, {
       headers: requestHeaders,
     });
-    const aiConnectors = connectors.filter(
-      ({ connector_type_id: connectorTypeId }: { connector_type_id: string }) =>
-        AllowedActionTypeIds.includes(connectorTypeId)
+    if (!connectorsResponse.ok) {
+      throw new Error(
+        `Failed to fetch connectors from ${connectorsApiUrl}: ${connectorsResponse.status} ${connectorsResponse.statusText}`
+      );
+    }
+    const connectors = (await connectorsResponse.json()) as Array<{
+      id: string;
+      connector_type_id: string;
+    }>;
+    const aiConnectors = connectors.filter(({ connector_type_id: connectorTypeId }) =>
+      AllowedActionTypeIds.includes(connectorTypeId)
     );
     if (aiConnectors.length === 0) {
       throw new Error('No AI connectors found, create an AI connector to use this script');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(axios,security-generative-ai) Remove axios dependency in favor … (#266771)](https://github.com/elastic/kibana/pull/266771)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-05-04T12:08:41Z","message":"chore(axios,security-generative-ai) Remove axios dependency in favor … (#266771)\n\n## Summary\n\nThis PR removes the `axios` dependency for files owned by\n`@elastic/security-generative-ai`. Phase 1.1 of the axios migration\ntracked under #266556.\n\n### Why\n\nNode.js 22 ships a native `fetch` API built on undici, and every browser\nKibana targets supports `fetch` natively. Removing axios cuts one\nruntime dependency and continues the per-team rollout that mirrors the\nearlier node-fetch migration\n([#250719](https://github.com/elastic/kibana/pull/250719) and siblings).\n\n### Changes\n\n- Migrated `create_conversations_script.ts` (a developer seed script\nfetching the connector list) from `axios.get` to `fetch`.\n- Migrated `create_and_login_users.js` (a developer script that creates\ntest users via the Elasticsearch security API) from `axios.get` /\n`axios.put` to `fetch`. Three call sites: role lookup, role create, user\ncreate. Basic auth was previously passed via axios's `auth: { username,\npassword }` option; native fetch strips `user:pass@` URL credentials, so\nit now goes through an `Authorization: Basic <base64>` header.\n- Removed the entire\n`x-pack/solutions/security/plugins/elastic_assistant/scripts/` entry\nfrom `AXIOS_LEGACY_CONSUMERS` in `.eslintrc.js`. New axios usage\nanywhere in this directory is now blocked by the existing global ban.\n\n### Behavior parity\n\nNative fetch does not throw on non-2xx, so each call site explicitly\nchecks `res.ok` / `res.status`. The previous status-based branches (404\nfall-through on role check, 409 informational on user create) are\npreserved with the same logging and `return err` shape. The diff is\nintentionally minimal: variable names, comment placement, try-catch\nstructure, and error-return semantics from the original axios code are\nkept.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0643d49acfbfd8dfdc758e88ecfa0c767f02a30f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","dependencies","backport:all-open","v9.5.0"],"title":"chore(axios,security-generative-ai) Remove axios dependency in favor …","number":266771,"url":"https://github.com/elastic/kibana/pull/266771","mergeCommit":{"message":"chore(axios,security-generative-ai) Remove axios dependency in favor … (#266771)\n\n## Summary\n\nThis PR removes the `axios` dependency for files owned by\n`@elastic/security-generative-ai`. Phase 1.1 of the axios migration\ntracked under #266556.\n\n### Why\n\nNode.js 22 ships a native `fetch` API built on undici, and every browser\nKibana targets supports `fetch` natively. Removing axios cuts one\nruntime dependency and continues the per-team rollout that mirrors the\nearlier node-fetch migration\n([#250719](https://github.com/elastic/kibana/pull/250719) and siblings).\n\n### Changes\n\n- Migrated `create_conversations_script.ts` (a developer seed script\nfetching the connector list) from `axios.get` to `fetch`.\n- Migrated `create_and_login_users.js` (a developer script that creates\ntest users via the Elasticsearch security API) from `axios.get` /\n`axios.put` to `fetch`. Three call sites: role lookup, role create, user\ncreate. Basic auth was previously passed via axios's `auth: { username,\npassword }` option; native fetch strips `user:pass@` URL credentials, so\nit now goes through an `Authorization: Basic <base64>` header.\n- Removed the entire\n`x-pack/solutions/security/plugins/elastic_assistant/scripts/` entry\nfrom `AXIOS_LEGACY_CONSUMERS` in `.eslintrc.js`. New axios usage\nanywhere in this directory is now blocked by the existing global ban.\n\n### Behavior parity\n\nNative fetch does not throw on non-2xx, so each call site explicitly\nchecks `res.ok` / `res.status`. The previous status-based branches (404\nfall-through on role check, 409 informational on user create) are\npreserved with the same logging and `return err` shape. The diff is\nintentionally minimal: variable names, comment placement, try-catch\nstructure, and error-return semantics from the original axios code are\nkept.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0643d49acfbfd8dfdc758e88ecfa0c767f02a30f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266771","number":266771,"mergeCommit":{"message":"chore(axios,security-generative-ai) Remove axios dependency in favor … (#266771)\n\n## Summary\n\nThis PR removes the `axios` dependency for files owned by\n`@elastic/security-generative-ai`. Phase 1.1 of the axios migration\ntracked under #266556.\n\n### Why\n\nNode.js 22 ships a native `fetch` API built on undici, and every browser\nKibana targets supports `fetch` natively. Removing axios cuts one\nruntime dependency and continues the per-team rollout that mirrors the\nearlier node-fetch migration\n([#250719](https://github.com/elastic/kibana/pull/250719) and siblings).\n\n### Changes\n\n- Migrated `create_conversations_script.ts` (a developer seed script\nfetching the connector list) from `axios.get` to `fetch`.\n- Migrated `create_and_login_users.js` (a developer script that creates\ntest users via the Elasticsearch security API) from `axios.get` /\n`axios.put` to `fetch`. Three call sites: role lookup, role create, user\ncreate. Basic auth was previously passed via axios's `auth: { username,\npassword }` option; native fetch strips `user:pass@` URL credentials, so\nit now goes through an `Authorization: Basic <base64>` header.\n- Removed the entire\n`x-pack/solutions/security/plugins/elastic_assistant/scripts/` entry\nfrom `AXIOS_LEGACY_CONSUMERS` in `.eslintrc.js`. New axios usage\nanywhere in this directory is now blocked by the existing global ban.\n\n### Behavior parity\n\nNative fetch does not throw on non-2xx, so each call site explicitly\nchecks `res.ok` / `res.status`. The previous status-based branches (404\nfall-through on role check, 409 informational on user create) are\npreserved with the same logging and `return err` shape. The diff is\nintentionally minimal: variable names, comment placement, try-catch\nstructure, and error-return semantics from the original axios code are\nkept.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0643d49acfbfd8dfdc758e88ecfa0c767f02a30f"}},{"url":"https://github.com/elastic/kibana/pull/267466","number":267466,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/267467","number":267467,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/267468","number":267468,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->