### PR TITLE
[Streams] Fix flaky `streams_table_values` should display correct data quality badge test

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_table_values.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_table_values.spec.ts
@@ -16,8 +16,7 @@ const GOOD_QUALITY_STREAM = 'logs-good-quality';
 const DEGRADED_QUALITY_STREAM = 'logs-degraded-quality';
 const POOR_QUALITY_STREAM = 'logs-poor-quality';
 
-// Failing: See https://github.com/elastic/kibana/issues/244894
-test.describe.skip(
+test.describe(
   'Stream list view - table values',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
@@ -116,29 +115,53 @@ test.describe.skip(
     });
 
     test('should display correct doc count in the table', async ({ pageObjects, page }) => {
-      // Poll until GOOD_QUALITY_STREAM reaches expected count (proxy for indexing completion)
+      // Poll all three counts together: failure-store settling lags indexing on serverless.
       await expect
         .poll(
           async () => {
             await page.reload();
             await pageObjects.streams.expectStreamsTableVisible();
-            return page
-              .locator(`[data-test-subj="streamsDocCount-${GOOD_QUALITY_STREAM}"]`)
-              .textContent();
+            const [good, degraded, poor] = await Promise.all([
+              page
+                .locator(`[data-test-subj="streamsDocCount-${GOOD_QUALITY_STREAM}"]`)
+                .textContent(),
+              page
+                .locator(`[data-test-subj="streamsDocCount-${DEGRADED_QUALITY_STREAM}"]`)
+                .textContent(),
+              page
+                .locator(`[data-test-subj="streamsDocCount-${POOR_QUALITY_STREAM}"]`)
+                .textContent(),
+            ]);
+            return { good, degraded, poor };
           },
           { timeout: 90_000, intervals: [5000] }
         )
-        .toBe('50');
-
-      // Remaining counts are verified on the already-loaded page
-      await pageObjects.streams.verifyDocCount(DEGRADED_QUALITY_STREAM, 52);
-      await pageObjects.streams.verifyDocCount(POOR_QUALITY_STREAM, 60);
+        .toEqual({ good: '50', degraded: '52', poor: '60' });
     });
 
-    test('should display correct data quality badge', async ({ pageObjects }) => {
-      await pageObjects.streams.verifyDataQuality(GOOD_QUALITY_STREAM, 'Good');
-      await pageObjects.streams.verifyDataQuality(DEGRADED_QUALITY_STREAM, 'Degraded');
-      await pageObjects.streams.verifyDataQuality(POOR_QUALITY_STREAM, 'Poor');
+    test('should display correct data quality badge', async ({ pageObjects, page }) => {
+      // Reload between iterations: the list view caches doc-count promises per page mount.
+      await expect
+        .poll(
+          async () => {
+            await page.reload();
+            await pageObjects.streams.expectStreamsTableVisible();
+            const [good, degraded, poor] = await Promise.all([
+              page
+                .locator(`[data-test-subj="dataQualityIndicator-${GOOD_QUALITY_STREAM}"]`)
+                .textContent(),
+              page
+                .locator(`[data-test-subj="dataQualityIndicator-${DEGRADED_QUALITY_STREAM}"]`)
+                .textContent(),
+              page
+                .locator(`[data-test-subj="dataQualityIndicator-${POOR_QUALITY_STREAM}"]`)
+                .textContent(),
+            ]);
+            return { good, degraded, poor };
+          },
+          { timeout: 90_000, intervals: [5000] }
+        )
+        .toEqual({ good: 'Good', degraded: 'Degraded', poor: 'Poor' });
     });
 
     test('should display correct retention in the table', async ({ pageObjects, config }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_table_values.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_table_values.spec.ts
@@ -136,7 +136,7 @@ test.describe(
           },
           { timeout: 90_000, intervals: [5000] }
         )
-        .toEqual({ good: '50', degraded: '52', poor: '60' });
+        .toStrictEqual({ good: '50', degraded: '52', poor: '60' });
     });
 
     test('should display correct data quality badge', async ({ pageObjects, page }) => {
@@ -161,7 +161,7 @@ test.describe(
           },
           { timeout: 90_000, intervals: [5000] }
         )
-        .toEqual({ good: 'Good', degraded: 'Degraded', poor: 'Poor' });
+        .toStrictEqual({ good: 'Good', degraded: 'Degraded', poor: 'Poor' });
     });
 
     test('should display correct retention in the table', async ({ pageObjects, config }) => {


### PR DESCRIPTION
closes #244894

## Summary

On serverless, the failure-store contribution to the metering total settles slower than regular indexing, and the streams list view caches the doc-count promises for the lifetime of the page mount. The doc-count and data-quality tests assumed the first fetch already saw the final state, so a stale value got locked in.

Two changes:

1. The doc-count test now polls until **all three** streams report their expected counts together, instead of polling only the good-quality stream and asserting the others without retry.
2. The data-quality badge test now uses the same poll-and-reload pattern already used in `streams_header.spec.ts`, instead of a single `toHaveText` against a cached badge value.

