### PR TITLE
[9.3] Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-visualizations files (#264929)

### DIFF
--- a/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/__stories__/color_mapping.stories.tsx
+++ b/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/__stories__/color_mapping.stories.tsx
@@ -13,6 +13,7 @@ import { getKbnPalettes } from '@kbn/palettes';
 import { EuiFlyout, EuiForm, EuiPage, isColorDark } from '@elastic/eui';
 import type { StoryFn } from '@storybook/react';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import type { RawValue } from '@kbn/data-plugin/common';
 import { deserializeField } from '@kbn/data-plugin/common';
 import type { ColorMappingProps } from '../categorical_color_mapping';
@@ -70,6 +71,9 @@ const Template: StoryFn<FC<ColorMappingProps>> = (args) => {
           })}
       </ol>
       <EuiFlyout
+        aria-label={i18n.translate('coloring.colorMapping.stories.flyoutAriaLabel', {
+          defaultMessage: 'Color mapping',
+        })}
         style={{ width: 350, minInlineSize: 366, padding: '8px', overflow: 'auto' }}
         onClose={() => {}}
         hideCloseButton

--- a/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/__stories__/raw_color_mapping.stories.tsx
+++ b/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/__stories__/raw_color_mapping.stories.tsx
@@ -13,6 +13,7 @@ import { getKbnPalettes } from '@kbn/palettes';
 import { EuiFlyout, EuiForm, EuiPage, isColorDark } from '@elastic/eui';
 import type { StoryFn } from '@storybook/react';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import type { MultiFieldKey, RawValue, SerializedValue } from '@kbn/data-plugin/common';
 import { deserializeField } from '@kbn/data-plugin/common';
 import type { IFieldFormat } from '@kbn/field-formats-plugin/common';
@@ -75,6 +76,9 @@ const Template: StoryFn<FC<ColorMappingProps>> = (args) => {
           })}
       </ol>
       <EuiFlyout
+        aria-label={i18n.translate('coloring.colorMapping.stories.rawFlyoutAriaLabel', {
+          defaultMessage: 'Color mapping',
+        })}
         css={{ width: 350, minInlineSize: 366, padding: '8px', overflow: 'auto' }}
         onClose={() => {}}
         hideCloseButton

--- a/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/components/color_picker/color_swatch.tsx
+++ b/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/components/color_picker/color_swatch.tsx
@@ -71,6 +71,9 @@ export const ColorSwatch = ({
   const euiTheme = useEuiTheme();
   return assignmentColor.type !== 'gradient' ? (
     <EuiPopover
+      aria-label={i18n.translate('coloring.colorMapping.colorPicker.popoverAriaLabel', {
+        defaultMessage: 'Color picker',
+      })}
       panelPaddingSize="none"
       isOpen={colorPickerVisible}
       repositionOnScroll={true}

--- a/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/components/container/assignments.tsx
+++ b/src/platform/packages/shared/kbn-coloring/src/shared_components/color_mapping/components/container/assignments.tsx
@@ -234,6 +234,12 @@ export function Assignments({
             </EuiButton>
             {data.type === 'categories' && (
               <EuiPopover
+                aria-label={i18n.translate(
+                  'coloring.colorMapping.container.additionalActionsPopoverAriaLabel',
+                  {
+                    defaultMessage: 'Additional assignments actions',
+                  }
+                )}
                 button={
                   <EuiButtonIcon
                     iconType="boxesVertical"

--- a/src/platform/packages/shared/kbn-visualization-ui-components/components/query_input/filter_query_input.tsx
+++ b/src/platform/packages/shared/kbn-visualization-ui-components/components/query_input/filter_query_input.tsx
@@ -114,6 +114,7 @@ export function FilterQueryInput({
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem>
           <EuiPopover
+            aria-label={label}
             isOpen={filterPopoverOpen}
             closePopover={onClosePopup}
             display="block"

--- a/src/platform/plugins/private/event_annotation_listing/public/components/group_editor_flyout/group_editor_flyout.tsx
+++ b/src/platform/plugins/private/event_annotation_listing/public/components/group_editor_flyout/group_editor_flyout.tsx
@@ -111,6 +111,7 @@ export const GroupEditorFlyout = ({
 
   return (
     <EuiFlyout
+      aria-labelledby={flyoutHeadingId}
       onClose={onClose}
       paddingSize="m"
       size="l"

--- a/src/platform/plugins/private/vis_default_editor/public/components/agg_add.tsx
+++ b/src/platform/plugins/private/vis_default_editor/public/components/agg_add.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlexItem,
   EuiPopover,
   EuiPopoverTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -42,6 +43,7 @@ function DefaultEditorAggAdd({
   stats,
 }: DefaultEditorAggAddProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
   const onSelectSchema = (schema: Schema) => {
     setIsPopoverOpen(false);
     addSchema(schema);
@@ -84,13 +86,14 @@ function DefaultEditorAggAdd({
       <EuiFlexItem grow={false}>
         <EuiPopover
           id={`addGroupButtonPopover_${groupName}`}
+          aria-labelledby={popoverTitleId}
           button={addButton}
           isOpen={isPopoverOpen}
           panelPaddingSize="none"
           repositionOnScroll={true}
           closePopover={() => setIsPopoverOpen(false)}
         >
-          <EuiPopoverTitle paddingSize="s">
+          <EuiPopoverTitle id={popoverTitleId} paddingSize="s">
             {(groupName !== AggGroupNames.Buckets || !stats.count) && (
               <FormattedMessage
                 id="visDefaultEditor.aggAdd.addGroupButtonLabel"

--- a/src/platform/plugins/private/vis_default_editor/public/components/sidebar/sidebar_title.tsx
+++ b/src/platform/plugins/private/vis_default_editor/public/components/sidebar/sidebar_title.tsx
@@ -22,6 +22,7 @@ import {
   EuiTitle,
   EuiToolTip,
   type UseEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -70,6 +71,7 @@ interface SidebarTitleProps {
 export function LinkedSearch({ savedSearch, eventEmitter }: LinkedSearchProps) {
   const styles = useMemoCss(linkedSearchStyles);
   const [showPopover, setShowPopover] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
   const {
     services: { application },
   } = useKibana<{ application: ApplicationStart }>();
@@ -122,6 +124,7 @@ export function LinkedSearch({ savedSearch, eventEmitter }: LinkedSearchProps) {
 
       <EuiFlexItem grow={false}>
         <EuiPopover
+          aria-labelledby={popoverTitleId}
           anchorPosition="downRight"
           button={
             <EuiToolTip content={linkButtonAriaLabel} disableScreenReaderOutput>
@@ -137,7 +140,7 @@ export function LinkedSearch({ savedSearch, eventEmitter }: LinkedSearchProps) {
           closePopover={closePopover}
           panelPaddingSize="s"
         >
-          <EuiPopoverTitle>
+          <EuiPopoverTitle id={popoverTitleId}>
             <FormattedMessage
               id="visDefaultEditor.sidebar.savedSearch.popoverTitle"
               defaultMessage="Linked to Discover session"

--- a/src/platform/plugins/private/vis_types/table/public/components/table_vis_controls.tsx
+++ b/src/platform/plugins/private/vis_types/table/public/components/table_vis_controls.tsx
@@ -123,6 +123,7 @@ export const TableVisControls = memo(
 
     return (
       <EuiPopover
+        aria-label={exportBtnAriaLabel}
         id="dataTableExportData"
         button={downloadButton}
         isOpen={isPopoverOpen}

--- a/src/platform/plugins/private/vis_types/vega/public/components/vega_actions_menu.tsx
+++ b/src/platform/plugins/private/vis_types/vega/public/components/vega_actions_menu.tsx
@@ -60,6 +60,9 @@ function VegaActionsMenu({ formatHJson, formatJson }: VegaActionsMenuProps) {
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('visTypeVega.editor.vegaEditorOptionsPopoverAriaLabel', {
+        defaultMessage: 'Vega editor options',
+      })}
       id="actionsMenu"
       button={button}
       isOpen={isPopoverOpen}

--- a/src/platform/plugins/private/vis_types/vega/public/components/vega_help_menu.tsx
+++ b/src/platform/plugins/private/vis_types/vega/public/components/vega_help_menu.tsx
@@ -68,6 +68,9 @@ function VegaHelpMenu() {
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('visTypeVega.editor.vegaHelpPopoverAriaLabel', {
+        defaultMessage: 'Vega help',
+      })}
       id="helpMenu"
       button={button}
       isOpen={isPopoverOpen}

--- a/src/platform/plugins/private/vis_types/vislib/public/vislib/components/legend/legend_item.tsx
+++ b/src/platform/plugins/private/vis_types/vislib/public/vislib/components/legend/legend_item.tsx
@@ -132,6 +132,10 @@ const VisLegendItemComponent = ({
 
   const renderDetails = () => (
     <EuiPopover
+      aria-label={i18n.translate('visTypeVislib.vislib.legend.toggleOptionsPopoverAriaLabel', {
+        defaultMessage: '{legendDataLabel}, legend options',
+        values: { legendDataLabel: item.label },
+      })}
       display="block"
       button={button}
       isOpen={selected}

--- a/src/platform/plugins/shared/chart_expressions/expression_heatmap/public/utils/get_color_picker.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_heatmap/public/utils/get_color_picker.tsx
@@ -14,6 +14,7 @@ import type { PopoverAnchorPosition } from '@elastic/eui';
 import { EuiWrappingPopover, EuiOutsideClickDetector } from '@elastic/eui';
 import type { PersistedState } from '@kbn/visualizations-common';
 import { ColorPicker } from '@kbn/charts-plugin/public';
+import { i18n } from '@kbn/i18n';
 
 const KEY_CODE_ENTER = 13;
 
@@ -84,6 +85,9 @@ export const LegendColorPickerWrapper: LegendColorPicker = ({
   return (
     <EuiOutsideClickDetector onOutsideClick={handleOutsideClick}>
       <EuiWrappingPopover
+        aria-label={i18n.translate('expressionHeatmap.legendColorPicker.popoverAriaLabel', {
+          defaultMessage: 'Legend color picker',
+        })}
         isOpen={true}
         ownFocus
         display="block"

--- a/src/platform/plugins/shared/chart_expressions/expression_partition_vis/public/utils/get_color_picker.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_partition_vis/public/utils/get_color_picker.tsx
@@ -16,6 +16,7 @@ import { EuiWrappingPopover, EuiOutsideClickDetector } from '@elastic/eui';
 import type { DatatableRow } from '@kbn/expressions-plugin/public';
 import type { PersistedState } from '@kbn/visualizations-common';
 import { ColorPicker } from '@kbn/charts-plugin/public';
+import { i18n } from '@kbn/i18n';
 import type { BucketColumns } from '../../common/types';
 
 const KEY_CODE_ENTER = 13;
@@ -116,6 +117,9 @@ export const LegendColorPickerWrapper: LegendColorPicker = ({
   return (
     <EuiOutsideClickDetector onOutsideClick={handleOutsideClick}>
       <EuiWrappingPopover
+        aria-label={i18n.translate('expressionPartitionVis.legendColorPicker.popoverAriaLabel', {
+          defaultMessage: 'Legend color picker',
+        })}
         isOpen
         ownFocus
         display="block"

--- a/src/platform/plugins/shared/chart_expressions/expression_partition_vis/public/utils/get_legend_actions.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_partition_vis/public/utils/get_legend_actions.tsx
@@ -149,6 +149,10 @@ export const getLegendActions = (
 
     return (
       <EuiPopover
+        aria-label={i18n.translate('expressionPartitionVis.legend.filterOptionsLegend', {
+          defaultMessage: '{legendDataLabel}, filter options',
+          values: { legendDataLabel: title },
+        })}
         button={Button}
         isOpen={popoverOpen}
         closePopover={() => {

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/legend_action_popover.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/legend_action_popover.tsx
@@ -124,6 +124,10 @@ export const LegendActionPopover: React.FunctionComponent<LegendActionPopoverPro
   );
   return (
     <EuiPopover
+      aria-label={i18n.translate('expressionXY.legend.filterOptionsLegend', {
+        defaultMessage: '{legendDataLabel}, filter options',
+        values: { legendDataLabel: label },
+      })}
       button={Button}
       isOpen={popoverOpen}
       closePopover={() => {

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/legend_color_picker.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/legend_color_picker.tsx
@@ -14,6 +14,7 @@ import type { PopoverAnchorPosition } from '@elastic/eui';
 import { EuiWrappingPopover, EuiOutsideClickDetector } from '@elastic/eui';
 import type { PersistedState } from '@kbn/visualizations-common';
 import { ColorPicker } from '@kbn/charts-plugin/public';
+import { i18n } from '@kbn/i18n';
 import type {
   DatatablesWithFormatInfo,
   LayersAccessorsTitles,
@@ -123,6 +124,9 @@ export const LegendColorPickerWrapper: LegendColorPicker = ({
   return (
     <EuiOutsideClickDetector onOutsideClick={handleOutsideClick}>
       <EuiWrappingPopover
+        aria-label={i18n.translate('expressionXY.legendColorPicker.popoverAriaLabel', {
+          defaultMessage: 'Legend color picker',
+        })}
         isOpen={true}
         ownFocus
         display="block"

--- a/src/platform/plugins/shared/charts/public/static/components/warnings.tsx
+++ b/src/platform/plugins/shared/charts/public/static/components/warnings.tsx
@@ -42,6 +42,9 @@ export function Warnings({
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate('charts.warning.warningPopoverAriaLabel', {
+          defaultMessage: 'Visualization warnings',
+        })}
         isOpen={open}
         panelPaddingSize="none"
         closePopover={() => setOpen(false)}

--- a/src/platform/plugins/shared/vis_types/timeseries/public/application/components/last_value_mode_popover.tsx
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/application/components/last_value_mode_popover.tsx
@@ -8,7 +8,13 @@
  */
 import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiButtonIcon, EuiPopover, EuiPopoverTitle, EuiSwitch } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSwitch,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 
 interface LastValueModePopoverProps {
@@ -21,11 +27,13 @@ export const LastValueModePopover = ({
   toggleIndicatorDisplay,
 }: LastValueModePopoverProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
   const onButtonClick = useCallback(() => setIsPopoverOpen((isOpen) => !isOpen), []);
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
   return (
     <EuiPopover
+      aria-labelledby={popoverTitleId}
       className="tvbLastValueModePopover"
       css={css`
         height: auto;
@@ -48,7 +56,7 @@ export const LastValueModePopover = ({
           width: 360px;
         `}
       >
-        <EuiPopoverTitle>
+        <EuiPopoverTitle id={popoverTitleId}>
           {i18n.translate('visTypeTimeseries.lastValueModePopover.title', {
             defaultMessage: 'Last value options',
           })}

--- a/src/platform/plugins/shared/vis_types/timeseries/public/application/components/lib/index_pattern_select/switch_mode_popover.tsx
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/application/components/lib/index_pattern_select/switch_mode_popover.tsx
@@ -19,6 +19,7 @@ import {
   EuiSwitch,
   EuiText,
   EuiLink,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import type { PopoverProps } from './types';
@@ -32,6 +33,7 @@ const allowStringIndicesMessage = i18n.translate(
 
 export const SwitchModePopover = ({ onModeChange, useKibanaIndices }: PopoverProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
   const onButtonClick = useCallback(() => setIsPopoverOpen((isOpen) => !isOpen), []);
 
@@ -74,6 +76,7 @@ export const SwitchModePopover = ({ onModeChange, useKibanaIndices }: PopoverPro
 
   return (
     <EuiPopover
+      aria-labelledby={popoverTitleId}
       button={
         <EuiButtonIcon
           iconType={'gear'}
@@ -92,7 +95,7 @@ export const SwitchModePopover = ({ onModeChange, useKibanaIndices }: PopoverPro
       css={{ height: 'auto' }}
     >
       <div css={{ width: '360px' }} data-test-subj="switchIndexPatternSelectionModePopoverContent">
-        <EuiPopoverTitle>
+        <EuiPopoverTitle id={popoverTitleId}>
           {i18n.translate('visTypeTimeseries.indexPatternSelect.switchModePopover.title', {
             defaultMessage: 'Data view mode',
           })}

--- a/x-pack/examples/lens_embeddable_inline_editing_example/public/flyout.tsx
+++ b/x-pack/examples/lens_embeddable_inline_editing_example/public/flyout.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import { EuiFlexGroup, EuiFlexItem, EuiFlyout, EuiPanel } from '@elastic/eui';
 import { euiThemeVars } from '@kbn/ui-theme';
+import { i18n } from '@kbn/i18n';
 
 interface MainContent {
   content: JSX.Element;
@@ -40,6 +41,9 @@ export function MultiPaneFlyout({
 
   return (
     <EuiFlyout
+      aria-label={i18n.translate('lensEmbeddableInlineEditingExample.flyout.ariaLabel', {
+        defaultMessage: 'Lens inline editing',
+      })}
       onClose={onClose}
       size={inlineEditingContent && inlineEditingContent?.visible ? 'l' : 'm'}
       ownFocus={false}

--- a/x-pack/examples/testing_embedded_lens/moon.yml
+++ b/x-pack/examples/testing_embedded_lens/moon.yml
@@ -26,6 +26,7 @@ dependsOn:
   - '@kbn/core-ui-settings-browser'
   - '@kbn/code-editor'
   - '@kbn/react-kibana-context-render'
+  - '@kbn/i18n'
 tags:
   - plugin
   - prod

--- a/x-pack/examples/testing_embedded_lens/public/controls.tsx
+++ b/x-pack/examples/testing_embedded_lens/public/controls.tsx
@@ -20,7 +20,9 @@ import {
   EuiIcon,
   EuiToolTip,
   EuiPopoverTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
 
 export type LensAttributesByType<VizType> = Extract<
@@ -195,6 +197,9 @@ export function AttributesMenu({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('testingEmbeddedLens.attributesMenu.ariaLabel', {
+        defaultMessage: 'Lens Attributes',
+      })}
       button={
         <EuiButton
           data-test-subj="lns-example-change-attributes"
@@ -344,9 +349,11 @@ export function OverridesMenu({
   setOverrides: (overrides: AllOverrides | undefined) => void;
 }) {
   const [overridesPopoverOpen, setOverridesPopoverOpen] = useState(false);
+  const overridesPopoverTitleId = useGeneratedHtmlId();
   const hasOverridesEnabled = Boolean(overrides) && !isDatatable(currentAttributes);
   return (
     <EuiPopover
+      aria-labelledby={overridesPopoverTitleId}
       button={
         <EuiButton
           data-test-subj="lns-example-change-overrides"
@@ -364,7 +371,7 @@ export function OverridesMenu({
       closePopover={() => setOverridesPopoverOpen(false)}
     >
       <div style={{ width: 400 }}>
-        <EuiPopoverTitle>Overrides</EuiPopoverTitle>
+        <EuiPopoverTitle id={overridesPopoverTitleId}>Overrides</EuiPopoverTitle>
         <EuiText size="s">
           <p>
             Overrides are local to the Embeddable and forgotten when the visualization is open in
@@ -496,8 +503,10 @@ export function PanelMenu({
   setEnableExtraAction: (v: boolean) => void;
 }) {
   const [panelPopoverOpen, setPanelPopoverOpen] = useState(false);
+  const panelPopoverTitleId = useGeneratedHtmlId();
   return (
     <EuiPopover
+      aria-labelledby={panelPopoverTitleId}
       button={
         <EuiButton
           data-test-subj="lns-example-change-overrides"
@@ -512,7 +521,7 @@ export function PanelMenu({
       closePopover={() => setPanelPopoverOpen(false)}
     >
       <div style={{ width: 400 }}>
-        <EuiPopoverTitle>Embeddable settings</EuiPopoverTitle>
+        <EuiPopoverTitle id={panelPopoverTitleId}>Embeddable settings</EuiPopoverTitle>
         <EuiText size="s">
           <p>
             It is possible to control and customize how the Embeddables is shown, disabling the

--- a/x-pack/examples/testing_embedded_lens/tsconfig.json
+++ b/x-pack/examples/testing_embedded_lens/tsconfig.json
@@ -23,5 +23,6 @@
     "@kbn/core-ui-settings-browser",
     "@kbn/code-editor",
     "@kbn/react-kibana-context-render",
+    "@kbn/i18n",
   ]
 }

--- a/x-pack/platform/plugins/private/graph/public/components/field_manager/field_editor.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/field_manager/field_editor.tsx
@@ -128,6 +128,10 @@ export function FieldEditor({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.graph.fieldManager.fieldEditorPopoverAriaLabel', {
+        defaultMessage: 'Edit field {fieldName}',
+        values: { fieldName: initialField.name },
+      })}
       id={`graphFieldEditor-${initialField.name}`}
       anchorPosition="downCenter"
       ownFocus

--- a/x-pack/platform/plugins/private/graph/public/components/field_manager/field_picker.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/field_manager/field_picker.tsx
@@ -74,6 +74,7 @@ export function FieldPicker({
 
   return (
     <EuiPopover
+      aria-label={badgeDescription}
       id="graphFieldPicker"
       anchorPosition="downCenter"
       ownFocus

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/settings_menu.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/settings_menu.tsx
@@ -53,6 +53,9 @@ export function SettingsMenu({
 
   return (
     <EuiWrappingPopover
+      aria-label={i18n.translate('xpack.lens.settings.popoverAriaLabel', {
+        defaultMessage: 'Lens settings',
+      })}
       data-test-subj="lnsApp__settingsMenu"
       ownFocus
       button={anchorElement}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/help_popover.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/help_popover.tsx
@@ -79,6 +79,7 @@ export const HelpPopover = ({
 }) => {
   return (
     <EuiPopover
+      aria-label={title}
       anchorPosition={anchorPosition}
       button={button}
       closePopover={closePopover}
@@ -112,6 +113,7 @@ export const WrappingHelpPopover = ({
   return (
     <KibanaRenderContextProvider {...startServices}>
       <EuiWrappingPopover
+        aria-label={title}
         anchorPosition={anchorPosition}
         button={button}
         closePopover={closePopover}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/filters/filter_popover.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/filters/filter_popover.tsx
@@ -10,6 +10,7 @@ import { EuiPopover, EuiSpacer } from '@elastic/eui';
 import type { Query } from '@kbn/es-query';
 import { isQueryValid, QueryInput } from '@kbn/visualization-ui-components';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { i18n } from '@kbn/i18n';
 import type {
   LensAggFilterValue as FilterValue,
   IndexPattern,
@@ -64,6 +65,9 @@ export const FilterPopover = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.lens.indexPattern.filtersEditor.filterPopoverAriaLabel', {
+        defaultMessage: 'Filter query editor',
+      })}
       data-test-subj="indexPattern-filters-existingFilterContainer"
       panelStyle={{
         width: '960px',

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/formula/editor/formula_editor.tsx
@@ -893,6 +893,12 @@ export function FormulaEditor({
               {errorCount || warningCount ? (
                 <EuiFlexItem grow={false}>
                   <EuiPopover
+                    aria-label={i18n.translate(
+                      'xpack.lens.formula.editorWarningsPopoverAriaLabel',
+                      {
+                        defaultMessage: 'Formula errors and warnings',
+                      }
+                    )}
                     ownFocus={false}
                     isOpen={isWarningOpen}
                     closePopover={() => setIsWarningOpen(false)}

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/advanced_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/ranges/advanced_editor.tsx
@@ -92,6 +92,9 @@ export const RangePopover = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.lens.indexPattern.ranges.popoverAriaLabel', {
+        defaultMessage: 'Range editor',
+      })}
       display="block"
       ownFocus
       isOpen={isOpen}

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/chart_switch/chart_switch_popover.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/chart_switch/chart_switch_popover.tsx
@@ -34,6 +34,9 @@ export const ChartSwitchPopover = memo(function ChartSwitchPopover(
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.lens.configPanel.chartSwitchPopoverAriaLabel', {
+        defaultMessage: 'Chart type popover',
+      })}
       css={css`
         display: flex;
       `}

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_actions/layer_actions.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_actions/layer_actions.tsx
@@ -105,6 +105,9 @@ const InContextMenuActions = (props: LayerActionsProps) => {
   return (
     <EuiOutsideClickDetector onOutsideClick={closePopover}>
       <EuiPopover
+        aria-label={i18n.translate('xpack.lens.layer.actions.contextMenuAriaLabel', {
+          defaultMessage: `Layer actions`,
+        })}
         id={splitButtonPopoverId}
         button={
           <EuiButtonIcon

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/workspace_panel/message_list.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/workspace_panel/message_list.tsx
@@ -70,6 +70,7 @@ export const MessageList = ({
 
   return (
     <EuiPopover
+      aria-label={buttonLabel}
       panelPaddingSize="none"
       button={
         <EuiToolTip content={buttonLabel}>

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/user_messages/info_badges.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/user_messages/info_badges.tsx
@@ -45,6 +45,7 @@ export const EmbeddableFeatureBadge = ({ messages }: { messages: UserMessage[] }
   }
   return (
     <EuiPopover
+      aria-label={iconTitle}
       panelPaddingSize="none"
       button={
         <EuiToolTip content={iconTitle}>

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/dataview_picker/dataview_picker.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/dataview_picker/dataview_picker.tsx
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { calculateWidthFromEntries } from '@kbn/calculate-width-from-char-count';
 import React, { useState } from 'react';
 import type { EuiSelectableProps } from '@elastic/eui';
-import { EuiPopover, EuiPopoverTitle } from '@elastic/eui';
+import { EuiPopover, EuiPopoverTitle, useGeneratedHtmlId } from '@elastic/eui';
 import { DataViewsList } from '@kbn/unified-search-plugin/public';
 import { css } from '@emotion/react';
 import { type IndexPatternRef } from '@kbn/lens-common';
@@ -34,9 +34,11 @@ export function ChangeIndexPattern({
   selectableProps?: EuiSelectableProps;
 }) {
   const [isPopoverOpen, setPopoverIsOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   return (
     <EuiPopover
+      aria-labelledby={popoverTitleId}
       button={
         <TriggerButton
           {...trigger}
@@ -62,7 +64,7 @@ export function ChangeIndexPattern({
           })}px;
         `}
       >
-        <EuiPopoverTitle paddingSize="s">
+        <EuiPopoverTitle id={popoverTitleId} paddingSize="s">
           {i18n.translate('xpack.lens.indexPattern.changeDataViewTitle', {
             defaultMessage: 'Data view',
           })}

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/add_layer.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/add_layer.tsx
@@ -122,6 +122,7 @@ export function AddLayerButton({
       key="lsnLayerAdd"
     >
       <EuiPopover
+        aria-label={buttonLabel}
         data-test-subj="lnsConfigPanel__addLayerPopover"
         button={
           <EuiToolTip content={buttonLabel} disableScreenReaderOutput>

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/visualization.tsx
@@ -1411,6 +1411,9 @@ const SubtypeSwitch = ({
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate('xpack.lens.xyChart.stackingOptionsPopoverAriaLabel', {
+          defaultMessage: 'Stacking options',
+        })}
         ownFocus
         panelPaddingSize="none"
         button={


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-visualizations files (#264929)](https://github.com/elastic/kibana/pull/264929)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-23T16:21:38Z","message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-visualizations files (#264929)\n\nCloses: https://github.com/elastic/kibana/issues/264924\n\nAdds missing `aria-label` or `aria-labelledby` props to 36 `EuiPopover`,\n`EuiFlyout`, and `EuiWrappingPopover` components to satisfy the\n`@elastic/eui/require-aria-label-for-modals` ESLint rule.\n\n### Approach\n\n- **`aria-labelledby` + `useGeneratedHtmlId`** for components with an\nexisting `EuiPopoverTitle` (preferred per rule guidance):\n- `agg_add.tsx`, `sidebar_title.tsx`, `last_value_mode_popover.tsx`,\n`switch_mode_popover.tsx`, `dataview_picker.tsx`, `controls.tsx`\n\n- **`aria-labelledby`** for flyouts with existing heading IDs:\n  - `group_editor_flyout.tsx` (reuses `flyoutHeadingId`)\n\n- **`aria-label`** with `i18n.translate()` for all other components\nwithout a title element\n\n```tsx\n// Before\n<EuiPopover button={button} isOpen={isOpen} closePopover={close}>\n\n// After (with existing EuiPopoverTitle)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId} button={button} isOpen={isOpen} closePopover={close}>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n\n// After (without title)\n<EuiPopover aria-label={i18n.translate('plugin.popoverAriaLabel', { defaultMessage: '...' })} ...>\n```\n\n### Files changed\n\n- 4 `kbn-coloring` (stories, color_swatch, assignments)\n- 1 `kbn-visualization-ui-components` (filter_query_input)\n- 1 `event_annotation_listing` (group_editor_flyout)\n- 2 `vis_default_editor` (agg_add, sidebar_title)\n- 5 `vis_types` (table, vega ×2, vislib, timeseries ×2)\n- 5 `chart_expressions` (heatmap, partition_vis ×2, expression_xy ×2)\n- 1 `charts` (warnings)\n- 2 x-pack examples (flyout, controls)\n- 2 `graph` (field_editor, field_picker)\n- 12 `lens` (settings_menu, help_popover, filter_popover,\nformula_editor, advanced_editor, chart_switch_popover, layer_actions,\nmessage_list, info_badges, dataview_picker, add_layer, visualization)\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\n/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nscripts/yarn_install_scripts.js run bash 0.8.2 rt` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nnode scripts/kbn bootstrap` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nnode install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"c807d98590cf2cd7eb0e990fa71a5bf6f3088265","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","v9.4.0","a11y:agent-pr","v9.5.0","v9.3.4"],"title":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-visualizations files","number":264929,"url":"https://github.com/elastic/kibana/pull/264929","mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-visualizations files (#264929)\n\nCloses: https://github.com/elastic/kibana/issues/264924\n\nAdds missing `aria-label` or `aria-labelledby` props to 36 `EuiPopover`,\n`EuiFlyout`, and `EuiWrappingPopover` components to satisfy the\n`@elastic/eui/require-aria-label-for-modals` ESLint rule.\n\n### Approach\n\n- **`aria-labelledby` + `useGeneratedHtmlId`** for components with an\nexisting `EuiPopoverTitle` (preferred per rule guidance):\n- `agg_add.tsx`, `sidebar_title.tsx`, `last_value_mode_popover.tsx`,\n`switch_mode_popover.tsx`, `dataview_picker.tsx`, `controls.tsx`\n\n- **`aria-labelledby`** for flyouts with existing heading IDs:\n  - `group_editor_flyout.tsx` (reuses `flyoutHeadingId`)\n\n- **`aria-label`** with `i18n.translate()` for all other components\nwithout a title element\n\n```tsx\n// Before\n<EuiPopover button={button} isOpen={isOpen} closePopover={close}>\n\n// After (with existing EuiPopoverTitle)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId} button={button} isOpen={isOpen} closePopover={close}>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n\n// After (without title)\n<EuiPopover aria-label={i18n.translate('plugin.popoverAriaLabel', { defaultMessage: '...' })} ...>\n```\n\n### Files changed\n\n- 4 `kbn-coloring` (stories, color_swatch, assignments)\n- 1 `kbn-visualization-ui-components` (filter_query_input)\n- 1 `event_annotation_listing` (group_editor_flyout)\n- 2 `vis_default_editor` (agg_add, sidebar_title)\n- 5 `vis_types` (table, vega ×2, vislib, timeseries ×2)\n- 5 `chart_expressions` (heatmap, partition_vis ×2, expression_xy ×2)\n- 1 `charts` (warnings)\n- 2 x-pack examples (flyout, controls)\n- 2 `graph` (field_editor, field_picker)\n- 12 `lens` (settings_menu, help_popover, filter_popover,\nformula_editor, advanced_editor, chart_switch_popover, layer_actions,\nmessage_list, info_badges, dataview_picker, add_layer, visualization)\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\n/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nscripts/yarn_install_scripts.js run bash 0.8.2 rt` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nnode scripts/kbn bootstrap` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nnode install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"c807d98590cf2cd7eb0e990fa71a5bf6f3088265"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264929","number":264929,"mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-visualizations files (#264929)\n\nCloses: https://github.com/elastic/kibana/issues/264924\n\nAdds missing `aria-label` or `aria-labelledby` props to 36 `EuiPopover`,\n`EuiFlyout`, and `EuiWrappingPopover` components to satisfy the\n`@elastic/eui/require-aria-label-for-modals` ESLint rule.\n\n### Approach\n\n- **`aria-labelledby` + `useGeneratedHtmlId`** for components with an\nexisting `EuiPopoverTitle` (preferred per rule guidance):\n- `agg_add.tsx`, `sidebar_title.tsx`, `last_value_mode_popover.tsx`,\n`switch_mode_popover.tsx`, `dataview_picker.tsx`, `controls.tsx`\n\n- **`aria-labelledby`** for flyouts with existing heading IDs:\n  - `group_editor_flyout.tsx` (reuses `flyoutHeadingId`)\n\n- **`aria-label`** with `i18n.translate()` for all other components\nwithout a title element\n\n```tsx\n// Before\n<EuiPopover button={button} isOpen={isOpen} closePopover={close}>\n\n// After (with existing EuiPopoverTitle)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId} button={button} isOpen={isOpen} closePopover={close}>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n\n// After (without title)\n<EuiPopover aria-label={i18n.translate('plugin.popoverAriaLabel', { defaultMessage: '...' })} ...>\n```\n\n### Files changed\n\n- 4 `kbn-coloring` (stories, color_swatch, assignments)\n- 1 `kbn-visualization-ui-components` (filter_query_input)\n- 1 `event_annotation_listing` (group_editor_flyout)\n- 2 `vis_default_editor` (agg_add, sidebar_title)\n- 5 `vis_types` (table, vega ×2, vislib, timeseries ×2)\n- 5 `chart_expressions` (heatmap, partition_vis ×2, expression_xy ×2)\n- 1 `charts` (warnings)\n- 2 x-pack examples (flyout, controls)\n- 2 `graph` (field_editor, field_picker)\n- 12 `lens` (settings_menu, help_popover, filter_popover,\nformula_editor, advanced_editor, chart_switch_popover, layer_actions,\nmessage_list, info_badges, dataview_picker, add_layer, visualization)\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\n/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nscripts/yarn_install_scripts.js run bash 0.8.2 rt` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nnode scripts/kbn bootstrap` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack bash 0.8.2 --noprofile lizations/xy/visualization.tsx\nx86-64.so.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/22.22.2/x64/bin/node\nnode install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"c807d98590cf2cd7eb0e990fa71a5bf6f3088265"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->