### PR TITLE
chore(axios,workflows-eng): remove axios from workflows connector utils

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -423,7 +423,6 @@ const AXIOS_LEGACY_CONSUMERS = [
   'src/platform/packages/shared/kbn-kbn-client/**/*.{js,mjs,ts,tsx}',
   'src/platform/packages/shared/kbn-mcp-dev-server/**/*.{js,mjs,ts,tsx}',
   'src/platform/packages/shared/kbn-test-saml-auth/**/*.{js,mjs,ts,tsx}',
-  'src/platform/plugins/shared/workflows_management/server/connectors/workflows/**/*.{js,mjs,ts,tsx}',
   'src/platform/test/api_integration/apis/telemetry/**/*.{js,mjs,ts,tsx}',
   'x-pack/examples/alerting_example/server/rule_types/**/*.{js,mjs,ts,tsx}',
   'x-pack/packages/kbn-synthetics-private-location/**/*.{js,mjs,ts,tsx}',

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.test.ts
@@ -7,48 +7,47 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { AxiosError } from 'axios';
 import { createServiceError } from './utils';
 
 describe('Workflows Utils', () => {
   describe('createServiceError', () => {
-    it('should create error with Axios error message', () => {
-      const axiosError = {
-        isAxiosError: true,
+    it('should create error with HTTP error message', () => {
+      const httpError = {
+        name: 'Error',
         response: {
           data: {
             message: 'API Error: Invalid request',
           },
         },
         message: 'Request failed',
-      } as AxiosError;
+      } as Error;
 
-      const result = createServiceError(axiosError, 'Operation failed');
+      const result = createServiceError(httpError, 'Operation failed');
 
       expect(result.message).toBe('Operation failed. Error: API Error: Invalid request');
     });
 
-    it('should use Axios error message when response data has no message', () => {
-      const axiosError = {
-        isAxiosError: true,
+    it('should use HTTP error message when response data has no message', () => {
+      const httpError = {
+        name: 'Error',
         response: {
           data: {},
         },
         message: 'Network error',
-      } as AxiosError;
+      } as Error;
 
-      const result = createServiceError(axiosError, 'Operation failed');
+      const result = createServiceError(httpError, 'Operation failed');
 
       expect(result.message).toBe('Operation failed. Error: Network error');
     });
 
-    it('should handle Axios error without response data', () => {
-      const axiosError = {
-        isAxiosError: true,
+    it('should handle HTTP error without response data', () => {
+      const httpError = {
+        name: 'Error',
         message: 'Connection timeout',
-      } as AxiosError;
+      } as Error;
 
-      const result = createServiceError(axiosError, 'Operation failed');
+      const result = createServiceError(httpError, 'Operation failed');
 
       expect(result.message).toBe('Operation failed. Error: Connection timeout');
     });

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.ts
@@ -7,14 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isAxiosError } from 'axios';
-
 export const createServiceError = (error: Error, message: string) => {
-  if (isAxiosError(error)) {
-    const responseData = error.response?.data;
-    const errorMessage = responseData?.message || error.message;
-    return new Error(`${message}. Error: ${errorMessage}`);
-  }
-
-  return new Error(`${message}. Error: ${error.message}`);
+  // Some HTTP clients attach the parsed response body on `error.response.data`;
+  // prefer the upstream `message` field if it is present.
+  const responseData = (error as { response?: { data?: { message?: string } } }).response?.data;
+  const errorMessage = responseData?.message || error.message;
+  return new Error(`${message}. Error: ${errorMessage}`);
 };


### PR DESCRIPTION
## Summary

This PR removes the `axios` dependency for files owned by `@elastic/workflows-eng`. Phase 2 of the axios migration tracked under #266556.

### Why

Node.js 22 ships a native `fetch` API built on undici, and every browser Kibana targets supports `fetch` natively. Removing axios cuts one runtime dependency and continues the per-team rollout that mirrors the earlier node-fetch migration ([#250719](https://github.com/elastic/kibana/pull/250719) and siblings).

### Changes

- `src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.ts` previously imported `isAxiosError` from `axios` to decide whether to extract `error.response.data.message`. The production caller (`service.ts`) feeds errors thrown by the injected workflow services, never AxiosError; the axios-specific branch was effectively dead defensive code. Replaced the type-guard with duck-typed access to `response?.data?.message` so any HTTP-client error of similar shape still gets the upstream message extracted.
- `utils.test.ts` updated correspondingly: dropped the `AxiosError` type-only import, renamed mocks to `httpError`, added `name: 'Error'` so `as Error` casts type-check. All 5 existing test cases still pass.
- Removed the `workflows_management/server/connectors/workflows/**` entry from `AXIOS_LEGACY_CONSUMERS` in `.eslintrc.js`. New axios usage in this directory is now blocked by the existing global ban. The broader `workflows_management/**` override that bans `*legacy*` imports still applies.

### Behavior parity

The duck-typed access preserves the exact extraction logic: when the error has `response.data.message`, that string is used; otherwise it falls back to `error.message`. All five test cases (HTTP error with `data.message`, HTTP error with empty `data`, HTTP error without `response`, regular `Error`, error without message) pass without change to expected output.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.2","9.3","9.4"]} ONMERGE-->