### PR TITLE
[9.2] Improve solution nav responsiveness at s and xs breakpoints (#267465)

### DIFF
--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/__snapshots__/solution_nav.test.tsx.snap
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/__snapshots__/solution_nav.test.tsx.snap
@@ -2,102 +2,10 @@
 
 exports[`SolutionNav accepts EuiSideNavProps 1`] = `
 <Fragment>
-  <EuiCollapsibleNavGroup
-    background="none"
-    className="kbnSolutionNav kbnSolutionNav--hidden"
-    initialIsOpen={false}
-    isCollapsible={true}
-    paddingSize="none"
-    title={
-      <EuiTitle
-        css="unknown styles"
-        id="SolutionNav_generated-id_heading"
-        size="xs"
-      >
-        <h2>
-          <strong>
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="{solutionName} {menuText}"
-              id="sharedUXPackages.solutionNav.mobileTitleText"
-              values={
-                Object {
-                  "menuText": "menu",
-                  "solutionName": "Solution",
-                }
-              }
-            />
-          </strong>
-        </h2>
-      </EuiTitle>
-    }
-    titleElement="span"
-  >
-    <EuiPanel
-      color="transparent"
-      paddingSize="s"
-    >
-      <EuiSideNavClass
-        aria-hidden={true}
-        aria-labelledby="SolutionNav_generated-id_heading"
-        data-test-subj="DTS"
-        items={
-          Array [
-            Object {
-              "id": "1",
-              "items": Array [
-                Object {
-                  "id": "1.1",
-                  "items": undefined,
-                  "name": "Ingest Node Pipelines",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "1.2",
-                  "items": undefined,
-                  "name": "Logstash Pipelines",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "1.3",
-                  "items": undefined,
-                  "name": "Beats Central Management",
-                  "tabIndex": -1,
-                },
-              ],
-              "name": "Ingest",
-              "tabIndex": -1,
-            },
-            Object {
-              "id": "2",
-              "items": Array [
-                Object {
-                  "id": "2.1",
-                  "items": undefined,
-                  "name": "Index Management",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "2.2",
-                  "items": undefined,
-                  "name": "Index Lifecycle Policies",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "2.3",
-                  "items": undefined,
-                  "name": "Snapshot and Restore",
-                  "tabIndex": -1,
-                },
-              ],
-              "name": "Data",
-              "tabIndex": -1,
-            },
-          ]
-        }
-        mobileBreakpoints={Array []}
-      />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
+  <SolutionNavCollapseButton
+    isCollapsed={true}
+    onClick={[Function]}
+  />
   <div
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
@@ -193,101 +101,10 @@ exports[`SolutionNav accepts EuiSideNavProps 1`] = `
 
 exports[`SolutionNav accepts canBeCollapsed prop 1`] = `
 <Fragment>
-  <EuiCollapsibleNavGroup
-    background="none"
-    className="kbnSolutionNav kbnSolutionNav--hidden"
-    initialIsOpen={false}
-    isCollapsible={true}
-    paddingSize="none"
-    title={
-      <EuiTitle
-        css="unknown styles"
-        id="SolutionNav_generated-id_heading"
-        size="xs"
-      >
-        <h2>
-          <strong>
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="{solutionName} {menuText}"
-              id="sharedUXPackages.solutionNav.mobileTitleText"
-              values={
-                Object {
-                  "menuText": "menu",
-                  "solutionName": "Solution",
-                }
-              }
-            />
-          </strong>
-        </h2>
-      </EuiTitle>
-    }
-    titleElement="span"
-  >
-    <EuiPanel
-      color="transparent"
-      paddingSize="s"
-    >
-      <EuiSideNavClass
-        aria-hidden={true}
-        aria-labelledby="SolutionNav_generated-id_heading"
-        items={
-          Array [
-            Object {
-              "id": "1",
-              "items": Array [
-                Object {
-                  "id": "1.1",
-                  "items": undefined,
-                  "name": "Ingest Node Pipelines",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "1.2",
-                  "items": undefined,
-                  "name": "Logstash Pipelines",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "1.3",
-                  "items": undefined,
-                  "name": "Beats Central Management",
-                  "tabIndex": -1,
-                },
-              ],
-              "name": "Ingest",
-              "tabIndex": -1,
-            },
-            Object {
-              "id": "2",
-              "items": Array [
-                Object {
-                  "id": "2.1",
-                  "items": undefined,
-                  "name": "Index Management",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "2.2",
-                  "items": undefined,
-                  "name": "Index Lifecycle Policies",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "2.3",
-                  "items": undefined,
-                  "name": "Snapshot and Restore",
-                  "tabIndex": -1,
-                },
-              ],
-              "name": "Data",
-              "tabIndex": -1,
-            },
-          ]
-        }
-        mobileBreakpoints={Array []}
-      />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
+  <SolutionNavCollapseButton
+    isCollapsed={true}
+    onClick={[Function]}
+  />
   <div
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
@@ -382,13 +199,20 @@ exports[`SolutionNav accepts canBeCollapsed prop 1`] = `
 
 exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
 <Fragment>
-  <EuiCollapsibleNavGroup
-    background="none"
-    className="kbnSolutionNav"
-    initialIsOpen={false}
-    isCollapsible={false}
-    paddingSize="none"
-    title={
+  <EuiFlyout
+    closeButtonPosition="outside"
+    css="unknown styles"
+    hideCloseButton={true}
+    onClose={[Function]}
+    outsideClickCloses={true}
+    ownFocus={false}
+    side="left"
+    size={248}
+  >
+    <EuiPageSidebar
+      className="kbnSolutionNav"
+      hasEmbellish={true}
+    >
       <EuiTitle
         css="unknown styles"
         id="SolutionNav_generated-id_heading"
@@ -396,7 +220,7 @@ exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
       >
         <h2>
           <strong>
-            <Memo(MemoizedFormattedMessage)
+            <MemoizedFormattedMessage
               defaultMessage="{solutionName} {menuText}"
               id="sharedUXPackages.solutionNav.mobileTitleText"
               values={
@@ -409,13 +233,9 @@ exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
           </strong>
         </h2>
       </EuiTitle>
-    }
-    titleElement="span"
-  >
-    <EuiPanel
-      color="transparent"
-      paddingSize="s"
-    >
+      <EuiSpacer
+        size="l"
+      />
       <EuiSideNavClass
         aria-hidden={false}
         aria-labelledby="SolutionNav_generated-id_heading"
@@ -475,8 +295,8 @@ exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
         }
         mobileBreakpoints={Array []}
       />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
+    </EuiPageSidebar>
+  </EuiFlyout>
   <div
     className="kbnSolutionNav"
   >
@@ -568,41 +388,10 @@ exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
 
 exports[`SolutionNav heading accepts more headingProps 1`] = `
 <Fragment>
-  <EuiCollapsibleNavGroup
-    background="none"
-    className="kbnSolutionNav kbnSolutionNav--hidden"
-    initialIsOpen={false}
-    isCollapsible={true}
-    paddingSize="none"
-    title={
-      <EuiTitle
-        css="unknown styles"
-        id="testID"
-        size="xs"
-      >
-        <h3>
-          <strong>
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="{solutionName} {menuText}"
-              id="sharedUXPackages.solutionNav.mobileTitleText"
-              values={
-                Object {
-                  "menuText": "menu",
-                  "solutionName": "Solution",
-                }
-              }
-            />
-          </strong>
-        </h3>
-      </EuiTitle>
-    }
-    titleElement="span"
-  >
-    <EuiPanel
-      color="transparent"
-      paddingSize="s"
-    />
-  </EuiCollapsibleNavGroup>
+  <SolutionNavCollapseButton
+    isCollapsed={true}
+    onClick={[Function]}
+  />
   <div
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
@@ -638,101 +427,10 @@ exports[`SolutionNav heading accepts more headingProps 1`] = `
 
 exports[`SolutionNav renders 1`] = `
 <Fragment>
-  <EuiCollapsibleNavGroup
-    background="none"
-    className="kbnSolutionNav kbnSolutionNav--hidden"
-    initialIsOpen={false}
-    isCollapsible={true}
-    paddingSize="none"
-    title={
-      <EuiTitle
-        css="unknown styles"
-        id="SolutionNav_generated-id_heading"
-        size="xs"
-      >
-        <h2>
-          <strong>
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="{solutionName} {menuText}"
-              id="sharedUXPackages.solutionNav.mobileTitleText"
-              values={
-                Object {
-                  "menuText": "menu",
-                  "solutionName": "Solution",
-                }
-              }
-            />
-          </strong>
-        </h2>
-      </EuiTitle>
-    }
-    titleElement="span"
-  >
-    <EuiPanel
-      color="transparent"
-      paddingSize="s"
-    >
-      <EuiSideNavClass
-        aria-hidden={true}
-        aria-labelledby="SolutionNav_generated-id_heading"
-        items={
-          Array [
-            Object {
-              "id": "1",
-              "items": Array [
-                Object {
-                  "id": "1.1",
-                  "items": undefined,
-                  "name": "Ingest Node Pipelines",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "1.2",
-                  "items": undefined,
-                  "name": "Logstash Pipelines",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "1.3",
-                  "items": undefined,
-                  "name": "Beats Central Management",
-                  "tabIndex": -1,
-                },
-              ],
-              "name": "Ingest",
-              "tabIndex": -1,
-            },
-            Object {
-              "id": "2",
-              "items": Array [
-                Object {
-                  "id": "2.1",
-                  "items": undefined,
-                  "name": "Index Management",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "2.2",
-                  "items": undefined,
-                  "name": "Index Lifecycle Policies",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "2.3",
-                  "items": undefined,
-                  "name": "Snapshot and Restore",
-                  "tabIndex": -1,
-                },
-              ],
-              "name": "Data",
-              "tabIndex": -1,
-            },
-          ]
-        }
-        mobileBreakpoints={Array []}
-      />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
+  <SolutionNavCollapseButton
+    isCollapsed={true}
+    onClick={[Function]}
+  />
   <div
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
@@ -827,106 +525,10 @@ exports[`SolutionNav renders 1`] = `
 
 exports[`SolutionNav renders with icon 1`] = `
 <Fragment>
-  <EuiCollapsibleNavGroup
-    background="none"
-    className="kbnSolutionNav kbnSolutionNav--hidden"
-    initialIsOpen={false}
-    isCollapsible={true}
-    paddingSize="none"
-    title={
-      <EuiTitle
-        css="unknown styles"
-        id="SolutionNav_generated-id_heading"
-        size="xs"
-      >
-        <h2>
-          <KibanaSolutionAvatar
-            css="unknown styles"
-            iconType="logoElastic"
-            name="Solution"
-          />
-          <strong>
-            <Memo(MemoizedFormattedMessage)
-              defaultMessage="{solutionName} {menuText}"
-              id="sharedUXPackages.solutionNav.mobileTitleText"
-              values={
-                Object {
-                  "menuText": "menu",
-                  "solutionName": "Solution",
-                }
-              }
-            />
-          </strong>
-        </h2>
-      </EuiTitle>
-    }
-    titleElement="span"
-  >
-    <EuiPanel
-      color="transparent"
-      paddingSize="s"
-    >
-      <EuiSideNavClass
-        aria-hidden={true}
-        aria-labelledby="SolutionNav_generated-id_heading"
-        items={
-          Array [
-            Object {
-              "id": "1",
-              "items": Array [
-                Object {
-                  "id": "1.1",
-                  "items": undefined,
-                  "name": "Ingest Node Pipelines",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "1.2",
-                  "items": undefined,
-                  "name": "Logstash Pipelines",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "1.3",
-                  "items": undefined,
-                  "name": "Beats Central Management",
-                  "tabIndex": -1,
-                },
-              ],
-              "name": "Ingest",
-              "tabIndex": -1,
-            },
-            Object {
-              "id": "2",
-              "items": Array [
-                Object {
-                  "id": "2.1",
-                  "items": undefined,
-                  "name": "Index Management",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "2.2",
-                  "items": undefined,
-                  "name": "Index Lifecycle Policies",
-                  "tabIndex": -1,
-                },
-                Object {
-                  "id": "2.3",
-                  "items": undefined,
-                  "name": "Snapshot and Restore",
-                  "tabIndex": -1,
-                },
-              ],
-              "name": "Data",
-              "tabIndex": -1,
-            },
-          ]
-        }
-        mobileBreakpoints={Array []}
-      />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
+  <SolutionNavCollapseButton
+    isCollapsed={true}
+    onClick={[Function]}
+  />
   <div
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >

--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/__snapshots__/with_solution_nav.test.tsx.snap
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/__snapshots__/with_solution_nav.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`WithSolutionNav renders wrapped component 1`] = `
       "hasEmbellish": true,
       "minWidth": undefined,
       "paddingSize": "none",
+      "responsive": Array [],
     }
   }
 />
@@ -117,6 +118,7 @@ exports[`WithSolutionNav with children 1`] = `
       "hasEmbellish": true,
       "minWidth": undefined,
       "paddingSize": "none",
+      "responsive": Array [],
     }
   }
 >

--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.tsx
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.tsx
@@ -19,9 +19,7 @@ import type {
   EuiSideNavProps,
 } from '@elastic/eui';
 import {
-  EuiCollapsibleNavGroup,
   EuiFlyout,
-  EuiPanel,
   EuiSideNav,
   EuiSpacer,
   EuiTitle,
@@ -32,7 +30,6 @@ import {
   useEuiThemeCSSVariables,
   EuiPageSidebar,
   useEuiOverflowScroll,
-  useEuiMinBreakpoint,
   euiCanAnimate,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -197,7 +194,7 @@ export const SolutionNav: FC<SolutionNavProps> = ({
     if (isLargerBreakpoint) {
       return isOpenOnDesktop ? FLYOUT_SIZE_CSS : euiTheme.size.xxl;
     }
-    if (isMediumBreakpoint) {
+    if (isMediumBreakpoint || isSmallerBreakpoint) {
       return isSideNavOpenOnMobile || !canBeCollapsed ? FLYOUT_SIZE_CSS : euiTheme.size.xxl;
     }
     return '0';
@@ -206,6 +203,7 @@ export const SolutionNav: FC<SolutionNavProps> = ({
     isOpenOnDesktop,
     isSideNavOpenOnMobile,
     canBeCollapsed,
+    isSmallerBreakpoint,
     isMediumBreakpoint,
     isLargerBreakpoint,
   ]);
@@ -225,10 +223,9 @@ export const SolutionNav: FC<SolutionNavProps> = ({
 
       ${useEuiOverflowScroll('y')};
 
-      ${useEuiMinBreakpoint('m')} {
-        width: ${FLYOUT_SIZE_CSS};
-        padding: ${euiTheme.size.l};
-      }
+      width: ${FLYOUT_SIZE_CSS};
+      padding: ${euiTheme.size.l};
+      height: 100%;
     `,
     solutionNavHidden: css`
       pointer-events: none;
@@ -241,24 +238,7 @@ export const SolutionNav: FC<SolutionNavProps> = ({
   };
   return (
     <>
-      {isSmallerBreakpoint && (
-        // @ts-expect-error Mismatch in collapsible vs unconllapsible props
-        <EuiCollapsibleNavGroup
-          className={sideNavClasses}
-          css={[styles.solutionNav, isHidden && styles.solutionNavHidden]}
-          paddingSize="none"
-          background="none"
-          title={titleText}
-          titleElement="span"
-          isCollapsible={canBeCollapsed}
-          initialIsOpen={false}
-        >
-          <EuiPanel color="transparent" paddingSize="s">
-            {sideNavContent}
-          </EuiPanel>
-        </EuiCollapsibleNavGroup>
-      )}
-      {isMediumBreakpoint && (
+      {(isSmallerBreakpoint || isMediumBreakpoint) && (
         <>
           {(isSideNavOpenOnMobile || !canBeCollapsed) && (
             <EuiFlyout

--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/with_solution_nav.tsx
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/with_solution_nav.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ComponentType, ReactNode } from 'react';
+import type { ComponentType, CSSProperties, ReactNode } from 'react';
 import React, { useState } from 'react';
 import classNames from 'classnames';
 import type { EuiPageSidebarProps } from '@elastic/eui';
@@ -25,6 +25,7 @@ export interface TemplateProps {
   children?: ReactNode;
   pageSideBar?: ReactNode;
   pageSideBarProps?: EuiPageSidebarProps;
+  style?: CSSProperties;
 }
 
 type Props<P> = P &
@@ -36,6 +37,7 @@ const SOLUTION_NAV_COLLAPSED_KEY = 'solutionNavIsCollapsed';
 
 export const withSolutionNav = <P extends TemplateProps>(WrappedComponent: ComponentType<P>) => {
   const WithSolutionNav = (props: Props<P>) => {
+    const isSmallerBreakpoint = useIsWithinBreakpoints(['xs', 's']);
     const isMediumBreakpoint = useIsWithinBreakpoints(['m']);
     const isLargerBreakpoint = useIsWithinMinBreakpoint('l');
     const [isSideNavOpenOnDesktop, setisSideNavOpenOnDesktop] = useState(
@@ -53,7 +55,9 @@ export const withSolutionNav = <P extends TemplateProps>(WrappedComponent: Compo
     // Default navigation to allow collapsing
     const { canBeCollapsed = true } = solutionNav;
     const isSidebarShrunk =
-      isMediumBreakpoint || (canBeCollapsed && isLargerBreakpoint && !isSideNavOpenOnDesktop);
+      isSmallerBreakpoint ||
+      isMediumBreakpoint ||
+      (canBeCollapsed && isLargerBreakpoint && !isSideNavOpenOnDesktop);
     const withSolutionNavStyles = WithSolutionNavStyles(euiTheme);
     const sideBarClasses = classNames(
       'kbnSolutionNav__sidebar',
@@ -73,10 +77,23 @@ export const withSolutionNav = <P extends TemplateProps>(WrappedComponent: Compo
     const pageSideBarProps: TemplateProps['pageSideBarProps'] = {
       paddingSize: 'none' as 'none',
       ...props.pageSideBarProps,
+      /**
+       * Disable EuiPageSidebar's default responsive behavior (min-width: 100% at xs/s)
+       * so the sidenav can be collapsed at small breakpoints.
+       */
+      responsive: [],
       minWidth: isSidebarShrunk ? euiTheme.size.xxl : undefined,
       className: sideBarClasses,
       hasEmbellish: !isSidebarShrunk,
     };
+
+    /**
+     * At small breakpoints, EuiPageTemplate switches to 'flex-direction: column'
+     * which stacks the sidenav on top. Force row layout so the sidenav stays on the left.
+     */
+    const templateStyle: CSSProperties | undefined = isSmallerBreakpoint
+      ? { ...propagatedProps.style, flexDirection: 'row' }
+      : propagatedProps.style;
 
     return (
       <WrappedComponent
@@ -84,6 +101,7 @@ export const withSolutionNav = <P extends TemplateProps>(WrappedComponent: Compo
           ...(propagatedProps as P),
           pageSideBar,
           pageSideBarProps,
+          style: templateStyle,
         }}
       >
         {children}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Improve solution nav responsiveness at s and xs breakpoints (#267465)](https://github.com/elastic/kibana/pull/267465)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Krzysztof Kowalczyk","email":"krzysztof.kowalczyk@elastic.co"},"sourceCommit":{"committedDate":"2026-05-04T13:21:21Z","message":"Improve solution nav responsiveness at s and xs breakpoints (#267465)\n\n## Summary\n\nThis PR improves classic navigation solution nav at lower resolutions (<\n`s`) by keeping the behavior of the `m` breakpoint - rendering the\ncollapsed solution nav. This requires overriding the wrapped page\ntemplate default behavior of switching to `flex: column`.\n\nCloses: https://github.com/elastic/kibana/issues/242857\n\n### Visuals\n\n**Before:**\n\n\nhttps://github.com/user-attachments/assets/61f88ec9-3d63-414f-90e4-696bb8545d9e\n\n**After:**\n\n\nhttps://github.com/user-attachments/assets/c766d601-7b45-4805-b8b6-5e48a0f1760b","sha":"be4574fa856c44806aa2261e47df68710e86b573","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:all-open","a11y","v9.5.0"],"title":"Improve solution nav responsiveness at s and xs breakpoints","number":267465,"url":"https://github.com/elastic/kibana/pull/267465","mergeCommit":{"message":"Improve solution nav responsiveness at s and xs breakpoints (#267465)\n\n## Summary\n\nThis PR improves classic navigation solution nav at lower resolutions (<\n`s`) by keeping the behavior of the `m` breakpoint - rendering the\ncollapsed solution nav. This requires overriding the wrapped page\ntemplate default behavior of switching to `flex: column`.\n\nCloses: https://github.com/elastic/kibana/issues/242857\n\n### Visuals\n\n**Before:**\n\n\nhttps://github.com/user-attachments/assets/61f88ec9-3d63-414f-90e4-696bb8545d9e\n\n**After:**\n\n\nhttps://github.com/user-attachments/assets/c766d601-7b45-4805-b8b6-5e48a0f1760b","sha":"be4574fa856c44806aa2261e47df68710e86b573"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267465","number":267465,"mergeCommit":{"message":"Improve solution nav responsiveness at s and xs breakpoints (#267465)\n\n## Summary\n\nThis PR improves classic navigation solution nav at lower resolutions (<\n`s`) by keeping the behavior of the `m` breakpoint - rendering the\ncollapsed solution nav. This requires overriding the wrapped page\ntemplate default behavior of switching to `flex: column`.\n\nCloses: https://github.com/elastic/kibana/issues/242857\n\n### Visuals\n\n**Before:**\n\n\nhttps://github.com/user-attachments/assets/61f88ec9-3d63-414f-90e4-696bb8545d9e\n\n**After:**\n\n\nhttps://github.com/user-attachments/assets/c766d601-7b45-4805-b8b6-5e48a0f1760b","sha":"be4574fa856c44806aa2261e47df68710e86b573"}},{"url":"https://github.com/elastic/kibana/pull/267486","number":267486,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/267510","number":267510,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->