### PR TITLE
[Fleet] Fix headers field in readonly for download source/kafka

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/download_source_headers.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/download_source_headers.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { createFleetTestRendererMock } from '../../../../../../mock';
+
+import type { DownloadSourceFormInputsType } from './use_download_source_flyout_form';
+import { DownloadSourceHeaders } from './download_source_headers';
+
+jest.mock('@elastic/eui', () => ({
+  ...jest.requireActual('@elastic/eui'),
+  useGeneratedHtmlId: () => 'mocked-id',
+}));
+
+const createMockInputs = (
+  overrides: {
+    disabled?: boolean;
+    keyValuePairs?: Array<{ key: string; value: string }>;
+    errors?: any[];
+  } = {}
+): DownloadSourceFormInputsType => {
+  const { disabled = false, keyValuePairs = [{ key: '', value: '' }], errors = [] } = overrides;
+  const headersInput = {
+    props: { onChange: jest.fn(), disabled },
+    value: keyValuePairs,
+    formRowProps: { error: errors },
+  };
+  const stubInput = { props: {}, value: '', formRowProps: {} };
+  return {
+    nameInput: stubInput,
+    defaultDownloadSourceInput: stubInput,
+    hostInput: stubInput,
+    proxyIdInput: stubInput,
+    sslCertificateInput: stubInput,
+    sslKeyInput: stubInput,
+    sslKeySecretInput: stubInput,
+    sslCertificateAuthoritiesInput: stubInput,
+    authTypeInput: stubInput,
+    usernameInput: stubInput,
+    passwordInput: stubInput,
+    passwordSecretInput: stubInput,
+    apiKeyInput: stubInput,
+    apiKeySecretInput: stubInput,
+    headersInput,
+  } as unknown as DownloadSourceFormInputsType;
+};
+
+describe('DownloadSourceHeaders', () => {
+  it('renders key/value fields and buttons', () => {
+    const inputs = createMockInputs({
+      keyValuePairs: [{ key: 'X-Custom', value: 'val' }],
+    });
+    const renderer = createFleetTestRendererMock();
+    const result = renderer.render(<DownloadSourceHeaders inputs={inputs} />);
+
+    expect(result.getByTestId('downloadSourceHeadersKeyInput0')).not.toBeDisabled();
+    expect(result.getByTestId('downloadSourceHeadersValueInput0')).not.toBeDisabled();
+    expect(result.getByTestId('downloadSourceHeadersDeleteButton0')).not.toBeDisabled();
+    expect(result.getByTestId('downloadSourceHeaders.addRowButton')).not.toBeDisabled();
+  });
+
+  it('disables all inputs when disabled is true', () => {
+    const inputs = createMockInputs({
+      disabled: true,
+      keyValuePairs: [{ key: 'X-Custom', value: 'val' }],
+    });
+    const renderer = createFleetTestRendererMock();
+    const result = renderer.render(<DownloadSourceHeaders inputs={inputs} />);
+
+    expect(result.getByTestId('downloadSourceHeadersKeyInput0')).toBeDisabled();
+    expect(result.getByTestId('downloadSourceHeadersValueInput0')).toBeDisabled();
+    expect(result.getByTestId('downloadSourceHeadersDeleteButton0')).toBeDisabled();
+    expect(result.getByTestId('downloadSourceHeaders.addRowButton')).toBeDisabled();
+  });
+
+  it('disables add button when there is an empty row', () => {
+    const inputs = createMockInputs({
+      keyValuePairs: [{ key: '', value: '' }],
+    });
+    const renderer = createFleetTestRendererMock();
+    const result = renderer.render(<DownloadSourceHeaders inputs={inputs} />);
+
+    expect(result.getByTestId('downloadSourceHeaders.addRowButton')).toBeDisabled();
+  });
+
+  it('enables add button when no empty row and not disabled', () => {
+    const inputs = createMockInputs({
+      keyValuePairs: [{ key: 'X-Custom', value: 'val' }],
+    });
+    const renderer = createFleetTestRendererMock();
+    const result = renderer.render(<DownloadSourceHeaders inputs={inputs} />);
+
+    expect(result.getByTestId('downloadSourceHeaders.addRowButton')).not.toBeDisabled();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/download_source_headers.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/download_source_headers.tsx
@@ -25,10 +25,9 @@ import type { DownloadSourceFormInputsType } from './use_download_source_flyout_
 
 export const DownloadSourceHeaders: React.FunctionComponent<{
   inputs: DownloadSourceFormInputsType;
-}> = (props) => {
-  const { inputs } = props;
+}> = ({ inputs }) => {
   const {
-    props: { onChange },
+    props: { onChange, disabled },
     value: keyValuePairs,
     formRowProps: { error: errors },
   } = inputs.headersInput;
@@ -65,9 +64,9 @@ export const DownloadSourceHeaders: React.FunctionComponent<{
     [keyValuePairs, onChange]
   );
 
-  const deleteButtonDisabled = false;
+  const deleteButtonDisabled = disabled;
   const hasEmptyRow = keyValuePairs.some((pair) => pair.key === '' && pair.value === '');
-  const addKeyValuePairButtonDisabled = hasEmptyRow;
+  const addKeyValuePairButtonDisabled = disabled || hasEmptyRow;
 
   const displayErrors = (errorMessages?: string[]) => {
     return errorMessages?.length
@@ -126,6 +125,7 @@ export const DownloadSourceHeaders: React.FunctionComponent<{
               <EuiFlexItem>
                 <EuiFormRow
                   fullWidth
+                  isDisabled={disabled}
                   label={
                     index === 0 ? (
                       <FormattedMessage
@@ -155,6 +155,7 @@ export const DownloadSourceHeaders: React.FunctionComponent<{
               <EuiFlexItem>
                 <EuiFormRow
                   fullWidth
+                  isDisabled={disabled}
                   label={
                     index === 0 ? (
                       <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_headers.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_headers.tsx
@@ -24,12 +24,11 @@ import { i18n } from '@kbn/i18n';
 
 import type { OutputFormInputsType } from './use_output_form';
 
-export const OutputFormKafkaHeaders: React.FunctionComponent<{ inputs: OutputFormInputsType }> = (
-  props
-) => {
-  const { inputs } = props;
+export const OutputFormKafkaHeaders: React.FunctionComponent<{ inputs: OutputFormInputsType }> = ({
+  inputs,
+}) => {
   const {
-    props: { onChange },
+    props: { onChange, disabled },
     value: keyValuePairs,
     formRowProps: { error: errors },
   } = inputs.kafkaHeadersInput;
@@ -66,9 +65,10 @@ export const OutputFormKafkaHeaders: React.FunctionComponent<{ inputs: OutputFor
     [keyValuePairs, onChange]
   );
 
-  const deleteButtonDisabled = keyValuePairs.length === 1;
+  const deleteButtonDisabled = disabled || keyValuePairs.length === 1;
   const addKeyValuePairButtonDisabled =
-    keyValuePairs.length === 1 && (keyValuePairs[0].key === '' || keyValuePairs[0].value === '');
+    disabled ||
+    (keyValuePairs.length === 1 && (keyValuePairs[0].key === '' || keyValuePairs[0].value === ''));
 
   const displayErrors = (errorMessages?: string[]) => {
     return errorMessages?.length
@@ -127,6 +127,7 @@ export const OutputFormKafkaHeaders: React.FunctionComponent<{ inputs: OutputFor
               <EuiFlexItem>
                 <EuiFormRow
                   fullWidth
+                  isDisabled={disabled}
                   label={
                     <FormattedMessage
                       id="xpack.fleet.settings.editOutputFlyout.kafkaHeaderKeyInputLabel"
@@ -150,6 +151,7 @@ export const OutputFormKafkaHeaders: React.FunctionComponent<{ inputs: OutputFor
               <EuiFlexItem>
                 <EuiFormRow
                   fullWidth
+                  isDisabled={disabled}
                   label={
                     <FormattedMessage
                       id="xpack.fleet.settings.editOutputFlyout.kafkaHeaderValueInputLabel"


### PR DESCRIPTION
  Resolve https://github.com/elastic/kibana/issues/257869

## Description 

  Fix the download source headers fields to be disabled in read-only mode. The disabled prop from useKeyValueInput was already being passed through but was not wired up to the form rows, text fields, and buttons.

  While looking at the code, I found the same issue in the Kafka output headers component (`OutputFormKafkaHeaders`), so I fixed it there too.

  - Thread disabled from `headersInput.props` to `EuiFormRow`, delete button, and add button in `DownloadSourceHeaders`
  - Apply the same fix to `OutputFormKafkaHeaders` for `kafkaHeadersInput`

##  Test plan

  - Open a managed download source in Fleet settings and verify the headers fields are disabled / read-only
  - Open a Kafka output in Fleet settings with headers and verify disabled state is respected
  - Verify headers fields remain functional (add/delete/edit) when not in read-only mode

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->