### PR TITLE
[One workflow] Validate workflow trigger payload against eventSchema, not enriched event context

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/trigger_event_handler.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/trigger_event_handler.ts
@@ -203,7 +203,7 @@ export class TriggerEventHandler {
       eventChainDepth: nextScheduledEventChainDepth(eventChainContext),
     };
 
-    this.validateTrigger(triggerId, spaceId, eventContextForResolution);
+    this.validateTrigger(triggerId, spaceId, payload);
 
     const resolutionStartMs = Date.now();
     const { workflows, stats: resolutionStats } = await this.resolveMatchingWorkflowSubscriptions(


### PR DESCRIPTION
When we introduced https://github.com/elastic/kibana/pull/260656 we introduced this bug:

Instead of validating event payload against event schema we were trying to validate against the event + context, this resulting in the event being rejected.

## Summary
`TriggerEventHandler.handleEvent` was calling `validateTrigger` with `eventContextForResolution` (payload merged with timestamp, spaceId, and eventChainDepth). That object is built for KQL resolution and scheduling. This change passes the original payload into `validateTrigger` so the trigger’s optional `eventSchema` validates the emitted event body only, not server-added metadata.


### Behavior
Unchanged: `resolveMatchingWorkflowSubscriptions` still receives `eventContextForResolution` with timestamp, spaceId, and eventChainDepth.
Changed: Schema validation (eventSchema.safeParse) runs on payload only.


