### PR TITLE
[Discover] Table row height is collapsed for no values

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.test.tsx
@@ -118,7 +118,7 @@ describe('Unified data table source document cell rendering', function () {
         columnsMeta={undefined}
       />
     );
-    expect(container.innerHTML).toBe('<span class="unifiedDataTable__cellValue">—</span>');
+    expect(container.textContent).toBe('—');
   });
 
   describe('with columnsMeta', () => {

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.test.tsx
@@ -97,6 +97,30 @@ describe('Unified data table source document cell rendering', function () {
     expect(component.html()).toContain('my bar value');
   });
 
+  it('renders a dash in ES|QL mode when all field values are null', () => {
+    const row = build({
+      _id: '1',
+      _index: 'test',
+      _score: null,
+      _source: { bytes: null, extension: null },
+    });
+
+    const { container } = render(
+      <SourceDocument
+        useTopLevelObjectColumns={false}
+        row={row}
+        dataView={dataViewMock}
+        columnId="_source"
+        fieldFormats={mockServices.fieldFormats as unknown as FieldFormatsStart}
+        shouldShowFieldHandler={() => false}
+        maxEntries={100}
+        isPlainRecord={true}
+        columnsMeta={undefined}
+      />
+    );
+    expect(container.innerHTML).toBe('<span class="unifiedDataTable__cellValue">—</span>');
+  });
+
   describe('with columnsMeta', () => {
     it('should use data view field type when columnsMeta is undefined', () => {
       const formatFieldValueReactSpy = createFormatFieldValueReactSpy();

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
@@ -72,12 +72,26 @@ export function SourceDocument({
       ).slice(0, maxEntries)
     : formatHitReact(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats, columnsMeta);
 
-  const hasVisiblePairs =
-    !isPlainRecord ||
-    pairs.some(([, , fieldName]) => !(fieldName && (row.flattened[fieldName] ?? null) === null));
+  const renderedPairs: ReactNode[] = [];
 
-  if (!hasVisiblePairs) {
-    return <span className={CELL_CLASS}>—</span>;
+  for (const [fieldDisplayName, value, fieldName] of pairs) {
+    // temporary solution for text based mode. As there are a lot of unsupported fields we want to
+    // hide the empty one from the Document view
+    if (isPlainRecord && fieldName && (row.flattened[fieldName] ?? null) === null) continue;
+    renderedPairs.push(
+      <Fragment key={fieldDisplayName}>
+        <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">
+          {fieldDisplayName}
+        </EuiDescriptionListTitle>
+        <EuiDescriptionListDescription className="unifiedDataTable__descriptionListDescription">
+          {value}
+        </EuiDescriptionListDescription>
+      </Fragment>
+    );
+  }
+
+  if (renderedPairs.length === 0) {
+    return <span className={classnames(CELL_CLASS, className)}>—</span>;
   }
 
   return (
@@ -88,21 +102,7 @@ export function SourceDocument({
       css={styles.descriptionList}
       data-test-subj={dataTestSubj}
     >
-      {pairs.map(([fieldDisplayName, value, fieldName]) => {
-        // temporary solution for text based mode. As there are a lot of unsupported fields we want to
-        // hide the empty one from the Document view
-        if (isPlainRecord && fieldName && (row.flattened[fieldName] ?? null) === null) return null;
-        return (
-          <Fragment key={fieldDisplayName}>
-            <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">
-              {fieldDisplayName}
-            </EuiDescriptionListTitle>
-            <EuiDescriptionListDescription className="unifiedDataTable__descriptionListDescription">
-              {value}
-            </EuiDescriptionListDescription>
-          </Fragment>
-        );
-      })}
+      {renderedPairs}
     </EuiDescriptionList>
   );
 }

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
@@ -72,10 +72,9 @@ export function SourceDocument({
       ).slice(0, maxEntries)
     : formatHitReact(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats, columnsMeta);
 
-  const hasVisiblePairs = pairs.some(
-    ([, , fieldName]) =>
-      !(isPlainRecord && fieldName && (row.flattened[fieldName] ?? null) === null)
-  );
+  const hasVisiblePairs =
+    !isPlainRecord ||
+    pairs.some(([, , fieldName]) => !(fieldName && (row.flattened[fieldName] ?? null) === null));
 
   if (!hasVisiblePairs) {
     return <span className={CELL_CLASS}>—</span>;

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
@@ -72,6 +72,15 @@ export function SourceDocument({
       ).slice(0, maxEntries)
     : formatHitReact(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats, columnsMeta);
 
+  const hasVisiblePairs = pairs.some(
+    ([, , fieldName]) =>
+      !(isPlainRecord && fieldName && (row.flattened[fieldName] ?? null) === null)
+  );
+
+  if (!hasVisiblePairs) {
+    return <span className={CELL_CLASS}>—</span>;
+  }
+
   return (
     <EuiDescriptionList
       type="inline"

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
@@ -90,7 +90,7 @@ export function SourceDocument({
     );
   }
 
-  if (renderedPairs.length === 0) {
+  if (isPlainRecord && renderedPairs.length === 0) {
     return <span className={classnames(CELL_CLASS, className)}>—</span>;
   }
 


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/251597

## Summary

In Discover when a row, in Summary, doesn't have any value the height is collapsed when Auto setting for the cell height is set. This PR fixes this issue by adding a placeholder (up for discussion). Using that approach the row always has a height.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
