### PR TITLE
[Alerting v2] Catch invalid KQL matchers in dispatcher pipeline

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.test.ts
@@ -110,7 +110,7 @@ function buildDispatcherService(deps: {
     new ApplySuppressionStep(),
     new FetchRulesStep(deps.rulesSoService),
     new FetchPoliciesStep(deps.npSoService),
-    new EvaluateMatchersStep(),
+    new EvaluateMatchersStep(loggerService),
     new BuildGroupsStep(),
     new ApplyThrottlingStep(deps.queryService, loggerService),
     new DispatchStep(loggerService, deps.workflowsManagement),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/dispatcher.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/dispatcher.test.ts
@@ -536,7 +536,7 @@ describe('DispatcherService integration tests', () => {
       new ApplySuppressionStep(),
       new FetchRulesStep(rulesSoService),
       new FetchPoliciesStep(npSoService),
-      new EvaluateMatchersStep(),
+      new EvaluateMatchersStep(mockLoggerService),
       new BuildGroupsStep(),
       new ApplyThrottlingStep(queryService, mockLoggerService),
       new DispatchStep(mockLoggerService, mockWfm),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.test.ts
@@ -5,16 +5,30 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
+import type { LoggerService } from '../../services/logger_service/logger_service';
+import { createLoggerService } from '../../services/logger_service/logger_service.mock';
 import {
+  createActionPolicy,
   createAlertEpisode,
   createDispatcherPipelineState,
-  createActionPolicy,
   createRule,
 } from '../fixtures/test_utils';
 import { EvaluateMatchersStep, evaluateMatchers } from './evaluate_matchers_step';
 
+let loggerService: LoggerService;
+let mockLogger: jest.Mocked<Logger>;
+
+beforeEach(() => {
+  ({ loggerService, mockLogger } = createLoggerService());
+});
+
 describe('EvaluateMatchersStep', () => {
-  const step = new EvaluateMatchersStep();
+  let step: EvaluateMatchersStep;
+
+  beforeEach(() => {
+    step = new EvaluateMatchersStep(loggerService);
+  });
 
   it('returns matched pairs for episodes with global catch-all policies', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1' });
@@ -64,7 +78,8 @@ describe('evaluateMatchers', () => {
       new Map([
         ['p1', p1],
         ['p2', p2],
-      ])
+      ]),
+      loggerService
     );
 
     expect(matched).toHaveLength(2);
@@ -73,7 +88,7 @@ describe('evaluateMatchers', () => {
   it('skips episodes whose rule is not found', () => {
     const episode = createAlertEpisode({ rule_id: 'unknown-rule' });
 
-    const matched = evaluateMatchers([episode], new Map(), new Map());
+    const matched = evaluateMatchers([episode], new Map(), new Map(), loggerService);
 
     expect(matched).toHaveLength(0);
   });
@@ -83,7 +98,12 @@ describe('evaluateMatchers', () => {
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1', matcher: 'episode_status: active' });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(0);
   });
@@ -93,7 +113,12 @@ describe('evaluateMatchers', () => {
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1', matcher: 'episode_status: active' });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(1);
     expect(matched[0].episode).toBe(episode);
@@ -112,7 +137,12 @@ describe('evaluateMatchers', () => {
       matcher: 'episode_status: active and group_hash: critical-group',
     });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(1);
   });
@@ -125,7 +155,12 @@ describe('evaluateMatchers', () => {
       matcher: 'episode_status: active or episode_status: recovering',
     });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(1);
   });
@@ -142,7 +177,12 @@ describe('evaluateMatchers', () => {
       matcher: 'episode_status: active and group_hash: critical-group',
     });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(0);
   });
@@ -152,7 +192,12 @@ describe('evaluateMatchers', () => {
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1', enabled: false });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(0);
   });
@@ -163,7 +208,12 @@ describe('evaluateMatchers', () => {
     const futureDate = new Date(Date.now() + 3_600_000).toISOString();
     const policy = createActionPolicy({ id: 'p1', snoozedUntil: futureDate });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(0);
   });
@@ -174,7 +224,12 @@ describe('evaluateMatchers', () => {
     const pastDate = new Date(Date.now() - 3_600_000).toISOString();
     const policy = createActionPolicy({ id: 'p1', snoozedUntil: pastDate });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(1);
   });
@@ -184,9 +239,112 @@ describe('evaluateMatchers', () => {
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1', enabled: true });
 
-    const matched = evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
 
     expect(matched).toHaveLength(1);
+  });
+
+  it('skips policies with invalid KQL matchers and logs a warning', () => {
+    const episode = createAlertEpisode({ rule_id: 'r1' });
+    const rule = createRule({ id: 'r1' });
+    const policy = createActionPolicy({ id: 'p1', matcher: 'invalid kql (((' });
+
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p1', policy]]),
+      loggerService
+    );
+
+    expect(matched).toHaveLength(0);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues evaluating sibling policies when one matcher throws', () => {
+    const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'active' });
+    const rule = createRule({ id: 'r1' });
+    const badPolicy = createActionPolicy({ id: 'p-bad', matcher: 'invalid kql (((' });
+    const goodPolicy = createActionPolicy({
+      id: 'p-good',
+      matcher: 'episode_status: active',
+    });
+
+    const matched = evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([
+        ['p-bad', badPolicy],
+        ['p-good', goodPolicy],
+      ]),
+      loggerService
+    );
+
+    expect(matched).toHaveLength(1);
+    expect(matched[0].policy).toBe(goodPolicy);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues evaluating subsequent episodes when a matcher throws on a previous episode', () => {
+    const e1 = createAlertEpisode({ episode_id: 'e1', rule_id: 'r1' });
+    const e2 = createAlertEpisode({ episode_id: 'e2', rule_id: 'r1' });
+    const rule = createRule({ id: 'r1' });
+    const badPolicy = createActionPolicy({ id: 'p-bad', matcher: 'invalid kql (((' });
+    const catchAllPolicy = createActionPolicy({ id: 'p-catchall' });
+
+    const matched = evaluateMatchers(
+      [e1, e2],
+      new Map([['r1', rule]]),
+      new Map([
+        ['p-bad', badPolicy],
+        ['p-catchall', catchAllPolicy],
+      ]),
+      loggerService
+    );
+
+    expect(matched).toHaveLength(2);
+    expect(matched.map(({ episode }) => episode)).toEqual([e1, e2]);
+    expect(matched.every(({ policy }) => policy === catchAllPolicy)).toBe(true);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('warn message includes policy id, rule id, episode id, and matcher', () => {
+    const episode = createAlertEpisode({ episode_id: 'ep-42', rule_id: 'r1' });
+    const rule = createRule({ id: 'r1' });
+    const policy = createActionPolicy({ id: 'p-broken', matcher: 'invalid kql (((' });
+
+    evaluateMatchers(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([['p-broken', policy]]),
+      loggerService
+    );
+
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    const messageArg = mockLogger.warn.mock.calls[0][0];
+    const rendered = typeof messageArg === 'function' ? messageArg() : String(messageArg);
+    expect(rendered).toContain('p-broken');
+    expect(rendered).toContain('r1');
+    expect(rendered).toContain('ep-42');
+    expect(rendered).toContain('invalid kql (((');
+  });
+
+  it('truncates matchers longer than 500 chars in the warn message', () => {
+    const longMatcher = '('.repeat(600);
+    const episode = createAlertEpisode({ rule_id: 'r1' });
+    const rule = createRule({ id: 'r1' });
+    const policy = createActionPolicy({ id: 'p1', matcher: longMatcher });
+
+    evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]), loggerService);
+
+    const messageArg = mockLogger.warn.mock.calls[0][0];
+    const rendered = typeof messageArg === 'function' ? messageArg() : String(messageArg);
+    expect(rendered).toContain(`${longMatcher.slice(0, 500)}…`);
+    expect(rendered).not.toContain(longMatcher);
   });
 
   describe('rule-aware KQL matching', () => {
@@ -201,7 +359,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(1);
@@ -218,7 +377,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(1);
@@ -235,7 +395,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(1);
@@ -252,7 +413,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(0);
@@ -269,7 +431,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(0);
@@ -291,7 +454,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(1);
@@ -311,7 +475,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(0);
@@ -328,7 +493,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(0);
@@ -348,7 +514,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(1);
@@ -368,7 +535,8 @@ describe('evaluateMatchers', () => {
       const matched = evaluateMatchers(
         [episode],
         new Map([['r1', rule]]),
-        new Map([['p1', policy]])
+        new Map([['p1', policy]]),
+        loggerService
       );
 
       expect(matched).toHaveLength(1);

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.test.ts
@@ -14,118 +14,105 @@ import {
   createDispatcherPipelineState,
   createRule,
 } from '../fixtures/test_utils';
-import { EvaluateMatchersStep, evaluateMatchers } from './evaluate_matchers_step';
-
-let loggerService: LoggerService;
-let mockLogger: jest.Mocked<Logger>;
-
-beforeEach(() => {
-  ({ loggerService, mockLogger } = createLoggerService());
-});
+import type {
+  AlertEpisode,
+  ActionPolicy,
+  ActionPolicyId,
+  MatchedPair,
+  Rule,
+  RuleId,
+} from '../types';
+import { EvaluateMatchersStep } from './evaluate_matchers_step';
 
 describe('EvaluateMatchersStep', () => {
+  let loggerService: LoggerService;
+  let mockLogger: jest.Mocked<Logger>;
   let step: EvaluateMatchersStep;
 
   beforeEach(() => {
+    ({ loggerService, mockLogger } = createLoggerService());
     step = new EvaluateMatchersStep(loggerService);
   });
+
+  const runStep = async (
+    dispatchable: AlertEpisode[],
+    rules: Map<RuleId, Rule>,
+    policies: Map<ActionPolicyId, ActionPolicy>
+  ): Promise<MatchedPair[]> => {
+    const state = createDispatcherPipelineState({ dispatchable, rules, policies });
+    const result = await step.execute(state);
+    if (result.type !== 'continue') {
+      throw new Error(`expected step output 'continue', got '${result.type}'`);
+    }
+    return result.data?.matched ?? [];
+  };
 
   it('returns matched pairs for episodes with global catch-all policies', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1' });
 
-    const state = createDispatcherPipelineState({
-      dispatchable: [episode],
-      rules: new Map([['r1', rule]]),
-      policies: new Map([['p1', policy]]),
-    });
-
-    const result = await step.execute(state);
-
-    expect(result.type).toBe('continue');
-    if (result.type !== 'continue') return;
-    expect(result.data?.matched).toHaveLength(1);
-    expect(result.data?.matched?.[0].episode).toBe(episode);
-    expect(result.data?.matched?.[0].policy).toBe(policy);
-  });
-
-  it('returns empty when no episodes', async () => {
-    const state = createDispatcherPipelineState({
-      dispatchable: [],
-      rules: new Map(),
-      policies: new Map(),
-    });
-
-    const result = await step.execute(state);
-
-    expect(result.type).toBe('continue');
-    if (result.type !== 'continue') return;
-    expect(result.data?.matched).toHaveLength(0);
-  });
-});
-
-describe('evaluateMatchers', () => {
-  it('matches episode to all global catch-all policies', () => {
-    const episode = createAlertEpisode({ rule_id: 'r1' });
-    const rule = createRule({ id: 'r1' });
-    const p1 = createActionPolicy({ id: 'p1' });
-    const p2 = createActionPolicy({ id: 'p2' });
-
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([
-        ['p1', p1],
-        ['p2', p2],
-      ]),
-      loggerService
-    );
-
-    expect(matched).toHaveLength(2);
-  });
-
-  it('skips episodes whose rule is not found', () => {
-    const episode = createAlertEpisode({ rule_id: 'unknown-rule' });
-
-    const matched = evaluateMatchers([episode], new Map(), new Map(), loggerService);
-
-    expect(matched).toHaveLength(0);
-  });
-
-  it('does not match when KQL matcher evaluates to false', () => {
-    const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'inactive' });
-    const rule = createRule({ id: 'r1' });
-    const policy = createActionPolicy({ id: 'p1', matcher: 'episode_status: active' });
-
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
-
-    expect(matched).toHaveLength(0);
-  });
-
-  it('matches when KQL matcher evaluates to true', () => {
-    const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'active' });
-    const rule = createRule({ id: 'r1' });
-    const policy = createActionPolicy({ id: 'p1', matcher: 'episode_status: active' });
-
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(1);
     expect(matched[0].episode).toBe(episode);
     expect(matched[0].policy).toBe(policy);
   });
 
-  it('matches with complex KQL using AND operator', () => {
+  it('returns empty when no episodes', async () => {
+    const matched = await runStep([], new Map(), new Map());
+    expect(matched).toHaveLength(0);
+  });
+
+  it('matches episode to all global catch-all policies', async () => {
+    const episode = createAlertEpisode({ rule_id: 'r1' });
+    const rule = createRule({ id: 'r1' });
+    const p1 = createActionPolicy({ id: 'p1' });
+    const p2 = createActionPolicy({ id: 'p2' });
+
+    const matched = await runStep(
+      [episode],
+      new Map([['r1', rule]]),
+      new Map([
+        ['p1', p1],
+        ['p2', p2],
+      ])
+    );
+
+    expect(matched).toHaveLength(2);
+  });
+
+  it('skips episodes whose rule is not found', async () => {
+    const episode = createAlertEpisode({ rule_id: 'unknown-rule' });
+
+    const matched = await runStep([episode], new Map(), new Map());
+
+    expect(matched).toHaveLength(0);
+  });
+
+  it('does not match when KQL matcher evaluates to false', async () => {
+    const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'inactive' });
+    const rule = createRule({ id: 'r1' });
+    const policy = createActionPolicy({ id: 'p1', matcher: 'episode_status: active' });
+
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+
+    expect(matched).toHaveLength(0);
+  });
+
+  it('matches when KQL matcher evaluates to true', async () => {
+    const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'active' });
+    const rule = createRule({ id: 'r1' });
+    const policy = createActionPolicy({ id: 'p1', matcher: 'episode_status: active' });
+
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
+
+    expect(matched).toHaveLength(1);
+    expect(matched[0].episode).toBe(episode);
+    expect(matched[0].policy).toBe(policy);
+  });
+
+  it('matches with complex KQL using AND operator', async () => {
     const episode = createAlertEpisode({
       rule_id: 'r1',
       episode_status: 'active',
@@ -137,17 +124,12 @@ describe('evaluateMatchers', () => {
       matcher: 'episode_status: active and group_hash: critical-group',
     });
 
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(1);
   });
 
-  it('matches with complex KQL using OR operator', () => {
+  it('matches with complex KQL using OR operator', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'recovering' });
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({
@@ -155,17 +137,12 @@ describe('evaluateMatchers', () => {
       matcher: 'episode_status: active or episode_status: recovering',
     });
 
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(1);
   });
 
-  it('does not match when AND condition is partially met', () => {
+  it('does not match when AND condition is partially met', async () => {
     const episode = createAlertEpisode({
       rule_id: 'r1',
       episode_status: 'active',
@@ -177,95 +154,65 @@ describe('evaluateMatchers', () => {
       matcher: 'episode_status: active and group_hash: critical-group',
     });
 
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(0);
   });
 
-  it('skips disabled policies', () => {
+  it('skips disabled policies', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1', enabled: false });
 
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(0);
   });
 
-  it('skips snoozed policies when snoozedUntil is in the future', () => {
+  it('skips snoozed policies when snoozedUntil is in the future', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const futureDate = new Date(Date.now() + 3_600_000).toISOString();
     const policy = createActionPolicy({ id: 'p1', snoozedUntil: futureDate });
 
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(0);
   });
 
-  it('matches policies when snoozedUntil is in the past', () => {
+  it('matches policies when snoozedUntil is in the past', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const pastDate = new Date(Date.now() - 3_600_000).toISOString();
     const policy = createActionPolicy({ id: 'p1', snoozedUntil: pastDate });
 
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(1);
   });
 
-  it('matches enabled policies without snooze', () => {
+  it('matches enabled policies without snooze', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1', enabled: true });
 
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(1);
   });
 
-  it('skips policies with invalid KQL matchers and logs a warning', () => {
+  it('skips policies with invalid KQL matchers and logs a warning', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1', matcher: 'invalid kql (((' });
 
-    const matched = evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p1', policy]]),
-      loggerService
-    );
+    const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     expect(matched).toHaveLength(0);
     expect(mockLogger.warn).toHaveBeenCalledTimes(1);
   });
 
-  it('continues evaluating sibling policies when one matcher throws', () => {
+  it('continues evaluating sibling policies when one matcher throws', async () => {
     const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'active' });
     const rule = createRule({ id: 'r1' });
     const badPolicy = createActionPolicy({ id: 'p-bad', matcher: 'invalid kql (((' });
@@ -274,14 +221,13 @@ describe('evaluateMatchers', () => {
       matcher: 'episode_status: active',
     });
 
-    const matched = evaluateMatchers(
+    const matched = await runStep(
       [episode],
       new Map([['r1', rule]]),
       new Map([
         ['p-bad', badPolicy],
         ['p-good', goodPolicy],
-      ]),
-      loggerService
+      ])
     );
 
     expect(matched).toHaveLength(1);
@@ -289,21 +235,20 @@ describe('evaluateMatchers', () => {
     expect(mockLogger.warn).toHaveBeenCalledTimes(1);
   });
 
-  it('continues evaluating subsequent episodes when a matcher throws on a previous episode', () => {
+  it('continues evaluating subsequent episodes when a matcher throws on a previous episode', async () => {
     const e1 = createAlertEpisode({ episode_id: 'e1', rule_id: 'r1' });
     const e2 = createAlertEpisode({ episode_id: 'e2', rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const badPolicy = createActionPolicy({ id: 'p-bad', matcher: 'invalid kql (((' });
     const catchAllPolicy = createActionPolicy({ id: 'p-catchall' });
 
-    const matched = evaluateMatchers(
+    const matched = await runStep(
       [e1, e2],
       new Map([['r1', rule]]),
       new Map([
         ['p-bad', badPolicy],
         ['p-catchall', catchAllPolicy],
-      ]),
-      loggerService
+      ])
     );
 
     expect(matched).toHaveLength(2);
@@ -312,17 +257,12 @@ describe('evaluateMatchers', () => {
     expect(mockLogger.warn).toHaveBeenCalledTimes(2);
   });
 
-  it('warn message includes policy id, rule id, episode id, and matcher', () => {
+  it('warn message includes policy id, rule id, episode id, and matcher', async () => {
     const episode = createAlertEpisode({ episode_id: 'ep-42', rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p-broken', matcher: 'invalid kql (((' });
 
-    evaluateMatchers(
-      [episode],
-      new Map([['r1', rule]]),
-      new Map([['p-broken', policy]]),
-      loggerService
-    );
+    await runStep([episode], new Map([['r1', rule]]), new Map([['p-broken', policy]]));
 
     expect(mockLogger.warn).toHaveBeenCalledTimes(1);
     const messageArg = mockLogger.warn.mock.calls[0][0];
@@ -333,13 +273,13 @@ describe('evaluateMatchers', () => {
     expect(rendered).toContain('invalid kql (((');
   });
 
-  it('truncates matchers longer than 500 chars in the warn message', () => {
+  it('truncates matchers longer than 500 chars in the warn message', async () => {
     const longMatcher = '('.repeat(600);
     const episode = createAlertEpisode({ rule_id: 'r1' });
     const rule = createRule({ id: 'r1' });
     const policy = createActionPolicy({ id: 'p1', matcher: longMatcher });
 
-    evaluateMatchers([episode], new Map([['r1', rule]]), new Map([['p1', policy]]), loggerService);
+    await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
     const messageArg = mockLogger.warn.mock.calls[0][0];
     const rendered = typeof messageArg === 'function' ? messageArg() : String(messageArg);
@@ -348,7 +288,7 @@ describe('evaluateMatchers', () => {
   });
 
   describe('rule-aware KQL matching', () => {
-    it('matches rule.name via KQL', () => {
+    it('matches rule.name via KQL', async () => {
       const episode = createAlertEpisode({ rule_id: 'r1' });
       const rule = createRule({ id: 'r1', name: 'Test rule' });
       const policy = createActionPolicy({
@@ -356,17 +296,12 @@ describe('evaluateMatchers', () => {
         matcher: 'rule.name: "Test rule"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(1);
     });
 
-    it('matches rule.tags via array membership', () => {
+    it('matches rule.tags via array membership', async () => {
       const episode = createAlertEpisode({ rule_id: 'r1' });
       const rule = createRule({ id: 'r1', tags: ['production', 'critical'] });
       const policy = createActionPolicy({
@@ -374,17 +309,12 @@ describe('evaluateMatchers', () => {
         matcher: 'rule.tags: "production"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(1);
     });
 
-    it('matches combined episode and rule conditions', () => {
+    it('matches combined episode and rule conditions', async () => {
       const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'active' });
       const rule = createRule({ id: 'r1', tags: ['production'] });
       const policy = createActionPolicy({
@@ -392,17 +322,12 @@ describe('evaluateMatchers', () => {
         matcher: 'episode_status: active and rule.tags: "production"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(1);
     });
 
-    it('does not match rule.tags when rule has no matching tags', () => {
+    it('does not match rule.tags when rule has no matching tags', async () => {
       const episode = createAlertEpisode({ rule_id: 'r1' });
       const rule = createRule({ id: 'r1', tags: [] });
       const policy = createActionPolicy({
@@ -410,17 +335,12 @@ describe('evaluateMatchers', () => {
         matcher: 'rule.tags: "production"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(0);
     });
 
-    it('does not match when combined condition is partially met', () => {
+    it('does not match when combined condition is partially met', async () => {
       const episode = createAlertEpisode({ rule_id: 'r1', episode_status: 'inactive' });
       const rule = createRule({ id: 'r1', tags: ['production'] });
       const policy = createActionPolicy({
@@ -428,19 +348,14 @@ describe('evaluateMatchers', () => {
         matcher: 'episode_status: active and rule.tags: "production"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(0);
     });
   });
 
   describe('data field KQL matching', () => {
-    it('matches on data.severity', () => {
+    it('matches on data.severity', async () => {
       const episode = createAlertEpisode({
         rule_id: 'r1',
         data: { severity: 'critical' },
@@ -451,17 +366,12 @@ describe('evaluateMatchers', () => {
         matcher: 'data.severity: "critical"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(1);
     });
 
-    it('does not match when data field value differs', () => {
+    it('does not match when data field value differs', async () => {
       const episode = createAlertEpisode({
         rule_id: 'r1',
         data: { env: 'staging' },
@@ -472,17 +382,12 @@ describe('evaluateMatchers', () => {
         matcher: 'data.env: "production"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(0);
     });
 
-    it('does not match when episode has no data', () => {
+    it('does not match when episode has no data', async () => {
       const episode = createAlertEpisode({ rule_id: 'r1' });
       const rule = createRule({ id: 'r1' });
       const policy = createActionPolicy({
@@ -490,17 +395,12 @@ describe('evaluateMatchers', () => {
         matcher: 'data.severity: "critical"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(0);
     });
 
-    it('matches combined data and rule conditions', () => {
+    it('matches combined data and rule conditions', async () => {
       const episode = createAlertEpisode({
         rule_id: 'r1',
         data: { severity: 'critical' },
@@ -511,17 +411,12 @@ describe('evaluateMatchers', () => {
         matcher: 'data.severity: "critical" and rule.name: "CPU Alert"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(1);
     });
 
-    it('matches on nested data fields (unflattened dot-separated keys)', () => {
+    it('matches on nested data fields (unflattened dot-separated keys)', async () => {
       const episode = createAlertEpisode({
         rule_id: 'r1',
         data: { host: { name: 'my-host.com' } },
@@ -532,12 +427,7 @@ describe('evaluateMatchers', () => {
         matcher: 'data.host.name: "my-host.com"',
       });
 
-      const matched = evaluateMatchers(
-        [episode],
-        new Map([['r1', rule]]),
-        new Map([['p1', policy]]),
-        loggerService
-      );
+      const matched = await runStep([episode], new Map([['r1', rule]]), new Map([['p1', policy]]));
 
       expect(matched).toHaveLength(1);
     });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.ts
@@ -7,7 +7,11 @@
 
 import type { MatcherContext } from '@kbn/alerting-v2-schemas';
 import { evaluateKql } from '@kbn/eval-kql';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
+import {
+  LoggerServiceToken,
+  type LoggerServiceContract,
+} from '../../services/logger_service/logger_service';
 import type {
   AlertEpisode,
   DispatcherPipelineState,
@@ -24,10 +28,12 @@ import type {
 export class EvaluateMatchersStep implements DispatcherStep {
   public readonly name = 'evaluate_matchers';
 
+  constructor(@inject(LoggerServiceToken) private readonly logger: LoggerServiceContract) {}
+
   public async execute(state: Readonly<DispatcherPipelineState>): Promise<DispatcherStepOutput> {
     const { dispatchable = [], rules = new Map(), policies = new Map() } = state;
 
-    const matched = evaluateMatchers(dispatchable, rules, policies);
+    const matched = evaluateMatchers(dispatchable, rules, policies, this.logger);
 
     return { type: 'continue', data: { matched } };
   }
@@ -36,7 +42,8 @@ export class EvaluateMatchersStep implements DispatcherStep {
 export function evaluateMatchers(
   dispatchable: readonly AlertEpisode[],
   rules: ReadonlyMap<RuleId, Rule>,
-  policies: ReadonlyMap<ActionPolicyId, ActionPolicy>
+  policies: ReadonlyMap<ActionPolicyId, ActionPolicy>,
+  logger: LoggerServiceContract
 ): MatchedPair[] {
   const matched: MatchedPair[] = [];
 
@@ -59,7 +66,20 @@ export function evaluateMatchers(
       }
 
       context ??= createMatcherContext(episode, rule);
-      const isMatch = evaluateKql(policy.matcher, context);
+      let isMatch = false;
+      try {
+        isMatch = evaluateKql(policy.matcher, context);
+      } catch (err) {
+        const rawReason = err instanceof Error ? err.message : String(err);
+        const reason = truncate(rawReason, MAX_LOGGED_TEXT_LENGTH);
+        const truncatedMatcher = truncate(policy.matcher, MAX_LOGGED_TEXT_LENGTH);
+        logger.warn({
+          message: () =>
+            `Failed to evaluate KQL matcher for policy ${policy.id} (rule ${rule.id}, episode ${episode.episode_id}): ${reason}. Matcher: ${truncatedMatcher}. Treating as no-match.`,
+        });
+        continue;
+      }
+
       if (isMatch) {
         matched.push({ episode, policy });
       }
@@ -67,6 +87,12 @@ export function evaluateMatchers(
   }
 
   return matched;
+}
+
+const MAX_LOGGED_TEXT_LENGTH = 500;
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
 }
 
 function createMatcherContext(episode: AlertEpisode, rule: Rule): MatcherContext {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/evaluate_matchers_step.ts
@@ -33,60 +33,59 @@ export class EvaluateMatchersStep implements DispatcherStep {
   public async execute(state: Readonly<DispatcherPipelineState>): Promise<DispatcherStepOutput> {
     const { dispatchable = [], rules = new Map(), policies = new Map() } = state;
 
-    const matched = evaluateMatchers(dispatchable, rules, policies, this.logger);
+    const matched = this.evaluateMatchers(dispatchable, rules, policies);
 
     return { type: 'continue', data: { matched } };
   }
-}
 
-export function evaluateMatchers(
-  dispatchable: readonly AlertEpisode[],
-  rules: ReadonlyMap<RuleId, Rule>,
-  policies: ReadonlyMap<ActionPolicyId, ActionPolicy>,
-  logger: LoggerServiceContract
-): MatchedPair[] {
-  const matched: MatchedPair[] = [];
+  private evaluateMatchers(
+    dispatchable: readonly AlertEpisode[],
+    rules: ReadonlyMap<RuleId, Rule>,
+    policies: ReadonlyMap<ActionPolicyId, ActionPolicy>
+  ): MatchedPair[] {
+    const matched: MatchedPair[] = [];
 
-  const policiesBySpace = Map.groupBy(policies.values(), (policy) => policy.spaceId);
+    const policiesBySpace = Map.groupBy(policies.values(), (policy) => policy.spaceId);
 
-  for (const episode of dispatchable) {
-    const rule = rules.get(episode.rule_id);
-    if (!rule) continue;
+    for (const episode of dispatchable) {
+      const rule = rules.get(episode.rule_id);
+      if (!rule) continue;
 
-    const spacePolicies = policiesBySpace.get(rule.spaceId) ?? [];
-    let context: MatcherContext | undefined;
+      const spacePolicies = policiesBySpace.get(rule.spaceId) ?? [];
+      let context: MatcherContext | undefined;
 
-    for (const policy of spacePolicies) {
-      if (!policy.enabled) continue;
-      if (policy.snoozedUntil && new Date(policy.snoozedUntil) > new Date()) continue;
+      for (const policy of spacePolicies) {
+        if (!policy.enabled) continue;
+        if (policy.snoozedUntil && new Date(policy.snoozedUntil) > new Date()) continue;
 
-      if (!policy.matcher) {
-        matched.push({ episode, policy });
-        continue;
-      }
+        if (!policy.matcher) {
+          matched.push({ episode, policy });
+          continue;
+        }
 
-      context ??= createMatcherContext(episode, rule);
-      let isMatch = false;
-      try {
-        isMatch = evaluateKql(policy.matcher, context);
-      } catch (err) {
-        const rawReason = err instanceof Error ? err.message : String(err);
-        const reason = truncate(rawReason, MAX_LOGGED_TEXT_LENGTH);
-        const truncatedMatcher = truncate(policy.matcher, MAX_LOGGED_TEXT_LENGTH);
-        logger.warn({
-          message: () =>
-            `Failed to evaluate KQL matcher for policy ${policy.id} (rule ${rule.id}, episode ${episode.episode_id}): ${reason}. Matcher: ${truncatedMatcher}. Treating as no-match.`,
-        });
-        continue;
-      }
+        context ??= createMatcherContext(episode, rule);
+        let isMatch = false;
+        try {
+          isMatch = evaluateKql(policy.matcher, context);
+        } catch (err) {
+          const rawReason = err instanceof Error ? err.message : String(err);
+          const reason = truncate(rawReason, MAX_LOGGED_TEXT_LENGTH);
+          const truncatedMatcher = truncate(policy.matcher, MAX_LOGGED_TEXT_LENGTH);
+          this.logger.warn({
+            message: () =>
+              `Failed to evaluate KQL matcher for policy ${policy.id} (rule ${rule.id}, episode ${episode.episode_id}): ${reason}. Matcher: ${truncatedMatcher}. Treating as no-match.`,
+          });
+          continue;
+        }
 
-      if (isMatch) {
-        matched.push({ episode, policy });
+        if (isMatch) {
+          matched.push({ episode, policy });
+        }
       }
     }
-  }
 
-  return matched;
+    return matched;
+  }
 }
 
 const MAX_LOGGED_TEXT_LENGTH = 500;


### PR DESCRIPTION
## Summary

Closes elastic/rna-program#460.

- Wraps `evaluateKql` in `EvaluateMatchersStep` with a try/catch so a single invalid policy matcher no longer crashes the entire dispatcher tick. The dispatcher orchestrator does not catch step exceptions, so previously one bad KQL string halted every downstream step (`build_groups`, `apply_throttling`, `dispatch`, `store_*`) for every episode and every policy in the run.
- On throw: logs a `warn` with the policy id, rule id, episode id, the matcher (truncated to 500 chars with `…` suffix), and the error reason; treats the matcher as no-match and continues. Log level matches `dispatch_step.ts:75` for analogous user-config issues.
- Refactor: moves the previously-exported `evaluateMatchers` free function into a `private` method on `EvaluateMatchersStep`. Now that it uses `this.logger` and has only one caller, the "exported for testability" rationale no longer applied. Tests now exercise the class through `step.execute()`.

Note: write-time validation of `policy.matcher` (rejecting invalid KQL at the API boundary) is the proper hardening and is tracked separately. This PR is the runtime defense-in-depth net.

## Test plan

- [ ] Confirm an action policy with invalid KQL syntax no longer halts the dispatcher tick — other policies and episodes still dispatch
- [ ] Confirm the failing policy emits a single `warn` log per affected (episode, policy) pair, including the offending matcher (truncated for very long inputs)
- [ ] Confirm a policy with valid KQL continues to match as before — no behavior regression on the happy path
- [ ] Run integration suite (`integration_tests/dispatcher.test.ts`) against a real cluster — the constructor signature change is wired through, but only verified locally via typecheck and unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)