### PR TITLE
[scout] test-only selection cli

### DIFF
--- a/.buildkite/pipeline-utils/scout/index.ts
+++ b/.buildkite/pipeline-utils/scout/index.ts
@@ -12,3 +12,4 @@ export * from './pick_scout_flaky_run_order';
 export * from './paths';
 export * from './test_tracks';
 export * from './test_distribution_strategies';
+export * from './tests_only';

--- a/.buildkite/pipeline-utils/scout/tests_only.test.ts
+++ b/.buildkite/pipeline-utils/scout/tests_only.test.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  SCOUT_TESTS_ONLY_NOISE_PATTERNS,
+  SCOUT_TESTS_ONLY_PATTERNS,
+  allFilesMatch,
+  anyFileMatches,
+  deriveScoutConfigsForFile,
+  deriveScoutConfigsForFiles,
+} from './tests_only';
+
+describe('allFilesMatch', () => {
+  it('returns false for empty file list', () => {
+    expect(allFilesMatch([], ['**/*.ts'])).toBe(false);
+  });
+
+  it('returns true when every file matches at least one pattern', () => {
+    const files = [
+      'x/test/scout/ui/tests/a.spec.ts',
+      'y/test/scout/api/fixtures/b.ts',
+      'z/test/scout_custom/ui/parallel_tests/c.spec.ts',
+    ];
+    expect(allFilesMatch(files, SCOUT_TESTS_ONLY_PATTERNS)).toBe(true);
+  });
+
+  it('returns false when even one file does not match', () => {
+    const files = ['x/test/scout/ui/tests/a.spec.ts', 'src/foo.ts'];
+    expect(allFilesMatch(files, SCOUT_TESTS_ONLY_PATTERNS)).toBe(false);
+  });
+
+  it('treats dotfiles as matchable', () => {
+    const files = ['pkg/test/scout/.meta/ui/standard.json'];
+    expect(allFilesMatch(files, SCOUT_TESTS_ONLY_PATTERNS)).toBe(true);
+  });
+});
+
+describe('anyFileMatches', () => {
+  it('returns false for empty file list', () => {
+    expect(anyFileMatches([], ['**/*.ts'])).toBe(false);
+  });
+
+  it('returns true when at least one file matches', () => {
+    expect(anyFileMatches(['src/foo.ts', 'README.md'], SCOUT_TESTS_ONLY_NOISE_PATTERNS)).toBe(true);
+  });
+
+  it('returns false when no file matches', () => {
+    expect(anyFileMatches(['src/foo.ts', 'src/bar.ts'], SCOUT_TESTS_ONLY_NOISE_PATTERNS)).toBe(
+      false
+    );
+  });
+});
+
+describe('deriveScoutConfigsForFile', () => {
+  let tmpRoot: string;
+
+  const touch = (rel: string) => {
+    const abs = path.join(tmpRoot, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '');
+  };
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-tests-only-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns [] for paths outside any Scout scope', () => {
+    expect(deriveScoutConfigsForFile('src/core/server/foo.ts', tmpRoot)).toEqual([]);
+    expect(deriveScoutConfigsForFile('test/scout/foo.ts', tmpRoot)).toEqual([]);
+  });
+
+  it('maps a single-thread spec to playwright.config.ts', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    expect(deriveScoutConfigsForFile('pkg/test/scout/ui/tests/a.spec.ts', tmpRoot)).toEqual([
+      'pkg/test/scout/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('maps a parallel spec to parallel.playwright.config.ts', () => {
+    touch('pkg/test/scout/ui/parallel.playwright.config.ts');
+    expect(
+      deriveScoutConfigsForFile('pkg/test/scout/ui/parallel_tests/a.spec.ts', tmpRoot)
+    ).toEqual(['pkg/test/scout/ui/parallel.playwright.config.ts']);
+  });
+
+  it('maps shared scope files (fixtures/page_objects/helpers) to both configs when both exist', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    touch('pkg/test/scout/ui/parallel.playwright.config.ts');
+
+    const configs = deriveScoutConfigsForFile(
+      'pkg/test/scout/ui/fixtures/page_objects/foo.ts',
+      tmpRoot
+    );
+    expect(configs.sort()).toEqual([
+      'pkg/test/scout/ui/parallel.playwright.config.ts',
+      'pkg/test/scout/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('drops configs that do not exist on disk', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    // No parallel config exists.
+    const configs = deriveScoutConfigsForFile('pkg/test/scout/ui/helpers.ts', tmpRoot);
+    expect(configs).toEqual(['pkg/test/scout/ui/playwright.config.ts']);
+  });
+
+  it('never crosses ui ↔ api scopes', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    touch('pkg/test/scout/api/playwright.config.ts');
+
+    const uiChange = deriveScoutConfigsForFile('pkg/test/scout/ui/fixtures/foo.ts', tmpRoot);
+    expect(uiChange.every((c) => c.includes('/ui/'))).toBe(true);
+
+    const apiChange = deriveScoutConfigsForFile('pkg/test/scout/api/helpers.ts', tmpRoot);
+    expect(apiChange.every((c) => c.includes('/api/'))).toBe(true);
+  });
+
+  it('never crosses scout ↔ scout_<custom> scopes', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    touch('pkg/test/scout_custom/ui/playwright.config.ts');
+
+    expect(deriveScoutConfigsForFile('pkg/test/scout/ui/tests/a.spec.ts', tmpRoot)).toEqual([
+      'pkg/test/scout/ui/playwright.config.ts',
+    ]);
+    expect(deriveScoutConfigsForFile('pkg/test/scout_custom/ui/tests/a.spec.ts', tmpRoot)).toEqual([
+      'pkg/test/scout_custom/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('handles custom-server scopes (test/scout_<custom>) symmetrically', () => {
+    touch('pkg/test/scout_oas_schema/ui/playwright.config.ts');
+    expect(
+      deriveScoutConfigsForFile('pkg/test/scout_oas_schema/ui/tests/a.spec.ts', tmpRoot)
+    ).toEqual(['pkg/test/scout_oas_schema/ui/playwright.config.ts']);
+  });
+
+  it('maps .meta/(ui|api) manifests to the matching scope', () => {
+    touch('pkg/test/scout/api/playwright.config.ts');
+    touch('pkg/test/scout/api/parallel.playwright.config.ts');
+
+    const configs = deriveScoutConfigsForFile('pkg/test/scout/.meta/api/standard.json', tmpRoot);
+    expect(configs.sort()).toEqual([
+      'pkg/test/scout/api/parallel.playwright.config.ts',
+      'pkg/test/scout/api/playwright.config.ts',
+    ]);
+  });
+
+  it('maps .meta under custom-server scopes too', () => {
+    touch('pkg/test/scout_examples/ui/playwright.config.ts');
+    const configs = deriveScoutConfigsForFile(
+      'pkg/test/scout_examples/.meta/ui/standard.json',
+      tmpRoot
+    );
+    expect(configs).toEqual(['pkg/test/scout_examples/ui/playwright.config.ts']);
+  });
+
+  it('maps an edit to the playwright config itself to that single config', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    touch('pkg/test/scout/ui/parallel.playwright.config.ts');
+
+    const configs = deriveScoutConfigsForFile('pkg/test/scout/ui/playwright.config.ts', tmpRoot);
+    expect(configs.sort()).toEqual([
+      'pkg/test/scout/ui/parallel.playwright.config.ts',
+      'pkg/test/scout/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('handles deeply-nested package roots', () => {
+    touch('x-pack/solutions/observability/plugins/foo/test/scout/ui/playwright.config.ts');
+    expect(
+      deriveScoutConfigsForFile(
+        'x-pack/solutions/observability/plugins/foo/test/scout/ui/tests/a.spec.ts',
+        tmpRoot
+      )
+    ).toEqual(['x-pack/solutions/observability/plugins/foo/test/scout/ui/playwright.config.ts']);
+  });
+});
+
+describe('deriveScoutConfigsForFiles', () => {
+  let tmpRoot: string;
+
+  const touch = (rel: string) => {
+    const abs = path.join(tmpRoot, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '');
+  };
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-tests-only-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('unions configs across multiple files and dedupes', () => {
+    touch('a/test/scout/ui/playwright.config.ts');
+    touch('a/test/scout/api/playwright.config.ts');
+    touch('b/test/scout_custom/ui/playwright.config.ts');
+
+    const result = deriveScoutConfigsForFiles(
+      [
+        'a/test/scout/ui/tests/x.spec.ts',
+        'a/test/scout/ui/tests/y.spec.ts', // dedupes with previous
+        'a/test/scout/api/helpers.ts',
+        'b/test/scout_custom/ui/parallel_tests/z.spec.ts', // no parallel config -> dropped
+      ],
+      tmpRoot
+    );
+
+    expect([...result].sort()).toEqual([
+      'a/test/scout/api/playwright.config.ts',
+      'a/test/scout/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('returns an empty set when no file maps to a Scout scope', () => {
+    expect(deriveScoutConfigsForFiles(['src/foo.ts', 'README.md'], tmpRoot).size).toBe(0);
+  });
+});

--- a/.buildkite/pipeline-utils/scout/tests_only.ts
+++ b/.buildkite/pipeline-utils/scout/tests_only.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import minimatch from 'minimatch';
+
+/**
+ * Documentation-only files inside Scout test scopes that should be ignored when
+ * deciding whether a PR's diff is "Scout tests only". A README or markdown change
+ * next to a Playwright config is noise — it must not block the fast path nor
+ * schedule any Playwright config to run.
+ */
+export const SCOUT_TESTS_ONLY_NOISE_PATTERNS: readonly string[] = [
+  '**/README*',
+  '**/*.md',
+  '**/CHANGELOG*',
+];
+
+/**
+ * Path globs that uniquely identify a Scout test scope — i.e. a directory
+ * containing a Playwright config and its co-located tests/fixtures/helpers.
+ *
+ * A "scope" is `<package-root>/test/(scout|scout_<custom>)/(ui|api)`, owning at
+ * most two configs:
+ *   - <scope>/playwright.config.ts          (single-thread, tests under tests/)
+ *   - <scope>/parallel.playwright.config.ts (parallel, tests under parallel_tests/)
+ *
+ * The `.meta/(ui|api)` patterns cover auto-generated manifests that belong to
+ * the matching scope.
+ */
+export const SCOUT_TESTS_ONLY_PATTERNS: readonly string[] = [
+  '**/test/scout/ui/**',
+  '**/test/scout/api/**',
+  '**/test/scout_*/ui/**',
+  '**/test/scout_*/api/**',
+  '**/test/scout/.meta/ui/**',
+  '**/test/scout/.meta/api/**',
+  '**/test/scout_*/.meta/ui/**',
+  '**/test/scout_*/.meta/api/**',
+];
+
+/**
+ * Returns true when EVERY file matches at least one of the given patterns.
+ * An empty file list returns false (nothing to gate on).
+ */
+export function allFilesMatch(files: readonly string[], patterns: readonly string[]): boolean {
+  if (files.length === 0) {
+    return false;
+  }
+  return files.every((file) => patterns.some((p) => minimatch(file, p, { dot: true })));
+}
+
+/**
+ * Returns true when AT LEAST ONE file matches one of the given patterns.
+ */
+export function anyFileMatches(files: readonly string[], patterns: readonly string[]): boolean {
+  return files.some((file) => patterns.some((p) => minimatch(file, p, { dot: true })));
+}
+
+/**
+ * Captures `<prefix>/test/(scout|scout_<custom>)/(ui|api)/<rest?>` and the
+ * `.meta/` variant `<prefix>/test/(scout|scout_<custom>)/.meta/(ui|api)/<rest?>`.
+ */
+const SCOUT_SCOPE_PATTERN = /^(.+?)\/test\/(scout(?:_[^/]+)?)\/(?:\.meta\/)?(ui|api)(?:\/(.*))?$/;
+
+const PLAYWRIGHT_CONFIG = 'playwright.config.ts';
+const PARALLEL_PLAYWRIGHT_CONFIG = 'parallel.playwright.config.ts';
+
+const filterExisting = (configs: readonly string[], repoRoot: string): string[] =>
+  configs.filter((rel) => fs.existsSync(path.join(repoRoot, rel)));
+
+/**
+ * Map a single changed file path to the Playwright config(s) that own it.
+ *
+ * Returns 0–2 repo-relative config paths:
+ *   - 0 when the file is outside any Scout scope
+ *   - 1 when the file is under `tests/` or `parallel_tests/` (single config)
+ *   - 1–2 for shared scope files (fixtures, helpers, page objects, .meta, etc.)
+ *     filtered against `repoRoot` to drop configs that don't exist on disk.
+ */
+export function deriveScoutConfigsForFile(file: string, repoRoot: string): string[] {
+  const match = file.match(SCOUT_SCOPE_PATTERN);
+  if (!match) {
+    return [];
+  }
+
+  const [, prefix, scoutDir, type, rest = ''] = match;
+  const scope = `${prefix}/test/${scoutDir}/${type}`;
+
+  if (rest.startsWith('tests/')) {
+    return filterExisting([`${scope}/${PLAYWRIGHT_CONFIG}`], repoRoot);
+  }
+
+  if (rest.startsWith('parallel_tests/')) {
+    return filterExisting([`${scope}/${PARALLEL_PLAYWRIGHT_CONFIG}`], repoRoot);
+  }
+
+  // Shared scope file (fixtures/, helpers, constants, page_objects/, .meta/, ...)
+  // or the playwright config itself: map to whichever configs exist in the scope.
+  return filterExisting(
+    [`${scope}/${PLAYWRIGHT_CONFIG}`, `${scope}/${PARALLEL_PLAYWRIGHT_CONFIG}`],
+    repoRoot
+  );
+}
+
+/**
+ * Map a list of changed file paths to the union of owning Playwright configs.
+ * The returned set is suitable for `discover-playwright-configs --affected-configs`.
+ */
+export function deriveScoutConfigsForFiles(
+  files: readonly string[],
+  repoRoot: string
+): Set<string> {
+  const configs = new Set<string>();
+  for (const file of files) {
+    for (const config of deriveScoutConfigsForFile(file, repoRoot)) {
+      configs.add(config);
+    }
+  }
+  return configs;
+}

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -321,13 +321,99 @@ describe('runDiscoverPlaywrightConfigs', () => {
     expect(foundMessage![0]).toContain('1 package(s)'); // packageA
   });
 
-  it('fails when --selective-testing is set without --affected-modules', () => {
+  it('fails when --selective-testing is set without --affected-modules or --affected-configs', () => {
     flagsReader.boolean.mockImplementation((flag: string) => flag === 'selective-testing');
     flagsReader.string.mockReturnValue('');
 
     expect(() => runDiscoverPlaywrightConfigs(flagsReader, log)).toThrow(
-      '--selective-testing requires --affected-modules'
+      '--selective-testing requires exactly one of --affected-modules'
     );
+  });
+
+  it('fails when --selective-testing is set with both --affected-modules and --affected-configs', () => {
+    flagsReader.boolean.mockImplementation((flag: string) => flag === 'selective-testing');
+    flagsReader.string.mockImplementation((name: string) => {
+      if (name === 'affected-modules') return '/mock/affected_modules.json';
+      if (name === 'affected-configs') return '/mock/affected_configs.json';
+      return '';
+    });
+
+    expect(() => runDiscoverPlaywrightConfigs(flagsReader, log)).toThrow(
+      '--selective-testing accepts exactly one of --affected-modules or --affected-configs (got both).'
+    );
+  });
+
+  it('fails when --affected-configs is set without --selective-testing', () => {
+    flagsReader.boolean.mockReturnValue(false);
+    flagsReader.string.mockImplementation((name: string) =>
+      name === 'affected-configs' ? '/mock/affected_configs.json' : ''
+    );
+
+    expect(() => runDiscoverPlaywrightConfigs(flagsReader, log)).toThrow(
+      '--affected-configs requires --selective-testing.'
+    );
+  });
+
+  it('with --selective-testing and --affected-configs, narrows to listed configs and skips module dep walk', () => {
+    flagsReader.enum.mockReturnValue('all');
+    flagsReader.boolean.mockImplementation((flag: string) => flag === 'selective-testing');
+    flagsReader.string.mockImplementation((name: string) =>
+      name === 'affected-configs' ? '/mock/affected_configs.json' : ''
+    );
+
+    // Allowlist: only the parallel config of pluginA + packageA's api config.
+    // pluginA's non-parallel ui config and pluginB's api config should be dropped.
+    const allowedConfigs = [
+      'x-pack/platform/plugins/private/pluginA/test/scout/ui/parallel.playwright.config.ts',
+      'src/platform/packages/shared/packageA/test/scout/api/playwright.config.ts',
+    ];
+
+    (fs.readFileSync as jest.Mock).mockImplementation((readPath: string) => {
+      if (readPath === '/mock/affected_configs.json') {
+        return JSON.stringify(allowedConfigs);
+      }
+      if (typeof readPath === 'string' && readPath.endsWith('package.json')) {
+        return JSON.stringify({ name: 'kibana', version: '1.0.0' });
+      }
+      if (typeof readPath === 'string' && readPath.endsWith('.yml')) {
+        return 'mock yaml content';
+      }
+      return '';
+    });
+
+    // Mirror the test fixture's structure but include both ui configs of pluginA so the filter
+    // has something to drop, and ensure the affected-configs path *intersects* with what survives
+    // tag/CI filters. filterModulesByScoutCiConfig is a passthrough mock here.
+    (filterModulesByScoutCiConfig as jest.Mock).mockImplementation(
+      (_l: ToolingLog, mods: ModuleDiscoveryInfo[]) => mods
+    );
+
+    runDiscoverPlaywrightConfigs(flagsReader, log);
+
+    // markModulesAffectedStatus is the only caller of findPackageForPath in this CLI;
+    // --affected-configs must skip that walk.
+    expect(findPackageForPath).not.toHaveBeenCalled();
+
+    const infoCalls = log.info.mock.calls;
+    const narrowedLog = infoCalls.find((call) =>
+      String(call[0]).includes(
+        'Selective testing: Scout discovery limited to affected Playwright configs'
+      )
+    );
+    expect(narrowedLog).toBeDefined();
+
+    const summaryLog = infoCalls.find((call) =>
+      String(call[0]).match(/Affected configs: \d+ kept, \d+ dropped, \d+ module\(s\) survived/)
+    );
+    expect(summaryLog).toBeDefined();
+
+    // Standard "Found Playwright config files in X plugin(s) and Y package(s)" output.
+    const foundMessage = infoCalls.find((call) =>
+      String(call[0]).includes('Found Playwright config files')
+    );
+    expect(foundMessage).toBeDefined();
+    expect(foundMessage![0]).toContain('1 plugin(s)'); // only pluginA survives
+    expect(foundMessage![0]).toContain('1 package(s)'); // packageA
   });
 
   it('with --selective-testing and --affected-modules, limits discovery to affected modules only', () => {

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
@@ -14,6 +14,7 @@ import { testableModules } from '@kbn/scout-reporting/src/registry';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { saveFlattenedConfigGroups, saveModuleDiscoveryInfo } from '../tests_discovery/file_utils';
 import { markModulesAffectedStatus } from '../tests_discovery/affected_modules';
+import { filterModulesByAffectedConfigs } from '../tests_discovery/affected_configs';
 import {
   filterModulesByScoutCiConfig,
   getScoutCiExcludedConfigs,
@@ -255,11 +256,22 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
   const includeCustomServers = flagsReader.boolean('include-custom-servers');
   const selectiveTesting = flagsReader.boolean('selective-testing');
   const affectedModulesPath = flagsReader.string('affected-modules');
+  const affectedConfigsPath = flagsReader.string('affected-configs');
 
-  if (selectiveTesting && !affectedModulesPath) {
+  if (selectiveTesting && !affectedModulesPath && !affectedConfigsPath) {
     throw createFailError(
-      '--selective-testing requires --affected-modules (JSON array of @kbn/ IDs from list_affected).'
+      '--selective-testing requires exactly one of --affected-modules (JSON array of @kbn/ IDs) or --affected-configs (JSON array of Playwright config paths).'
     );
+  }
+
+  if (selectiveTesting && affectedModulesPath && affectedConfigsPath) {
+    throw createFailError(
+      '--selective-testing accepts exactly one of --affected-modules or --affected-configs (got both).'
+    );
+  }
+
+  if (!selectiveTesting && affectedConfigsPath) {
+    throw createFailError('--affected-configs requires --selective-testing.');
   }
 
   // Build initial module discovery info
@@ -267,12 +279,16 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
 
   // --affected-modules: keep every Scout module that passes target/CI filters; set isAffected
   // per module so CI step labels can use an "affected " prefix where the PR touched that @kbn/ ID.
-  const modulesAfterAffectedMark = affectedModulesPath
-    ? markModulesAffectedStatus(modulesWithTests, affectedModulesPath, log)
-    : modulesWithTests;
+  // Skipped entirely when --affected-configs is in use (no module/dep walk needed).
+  const modulesAfterAffectedMark =
+    affectedModulesPath && !affectedConfigsPath
+      ? markModulesAffectedStatus(modulesWithTests, affectedModulesPath, log)
+      : modulesWithTests;
 
-  // --selective-testing: narrow to affected module groups only.
-  const limitDiscoveryToAffectedModules = selectiveTesting;
+  // --selective-testing with --affected-modules: narrow to affected module groups before tag filtering.
+  // --selective-testing with --affected-configs: keep all modules here; narrow by config path *after*
+  // tag/CI filters so we don't accidentally re-include configs that those filters intentionally drop.
+  const limitDiscoveryToAffectedModules = selectiveTesting && !affectedConfigsPath;
 
   const modulesForTargetTags = limitDiscoveryToAffectedModules
     ? modulesAfterAffectedMark.filter((m) => m.isAffected === true)
@@ -281,6 +297,10 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
   if (limitDiscoveryToAffectedModules) {
     log.info(
       `Selective testing: Scout discovery limited to affected modules (${modulesForTargetTags.length} of ${modulesAfterAffectedMark.length})`
+    );
+  } else if (selectiveTesting && affectedConfigsPath) {
+    log.info(
+      `Selective testing: Scout discovery limited to affected Playwright configs (will narrow ${modulesAfterAffectedMark.length} module(s) after tag/CI filters)`
     );
   } else {
     log.info(
@@ -297,16 +317,20 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
   const filteredModulesWithExcludedConfigs = process.env.CI
     ? filterModulesByExcludedConfigPaths(filteredModules, getScoutCiExcludedConfigs())
     : filteredModules;
+
+  // --affected-configs: narrow each module's configs to the allow-list, drop modules with no
+  // remaining configs, and mark survivors as affected. Runs *after* the tag/CI filters above
+  // so that a config the CI explicitly excludes can never be force-included via this flag.
+  const finalModules =
+    selectiveTesting && affectedConfigsPath
+      ? filterModulesByAffectedConfigs(filteredModulesWithExcludedConfigs, affectedConfigsPath, log)
+      : filteredModulesWithExcludedConfigs;
+
   // Handle output based on flatten flag
   if (flatten) {
-    handleFlattenedOutput(filteredModulesWithExcludedConfigs, flagsReader, log);
+    handleFlattenedOutput(finalModules, flagsReader, log);
   } else {
-    handleNonFlattenedOutput(
-      filteredModulesWithExcludedConfigs,
-      flagsReader,
-      log,
-      selectiveTesting
-    );
+    handleNonFlattenedOutput(finalModules, flagsReader, log, selectiveTesting);
   }
 };
 
@@ -328,10 +352,13 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
  * - Standard: Lists modules grouped by plugin/package with their configs and tags
  * - Flattened: Groups configs by deployment mode (stateful/serverless), group, and run mode
  *
- * Affected modules:
+ * Affected modules / configs:
  * - With --affected-modules, all modules are still considered; isAffected flags drive the
  *   "affected " Buildkite step prefix. With --selective-testing, only affected module groups
  *   are emitted; those steps keep the same prefix.
+ * - With --selective-testing --affected-configs, the module/dependency walk is skipped entirely
+ *   and discovery is narrowed to the listed Playwright config paths after tag/CI filters apply.
+ *   --affected-modules and --affected-configs are mutually exclusive.
  */
 export const discoverPlaywrightConfigsCmd: Command<void> = {
   name: 'discover-playwright-configs',
@@ -354,8 +381,14 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
                               isAffected so CI can prefix steps with "affected " when the PR
                               touches that module. Combine with --selective-testing to emit only
                               affected module groups.
-    --selective-testing       Requires --affected-modules.
-                              Limits output / Scout CI steps to affected modules; labels unchanged.
+    --affected-configs <file>  Path to a JSON file of affected Playwright config paths (Scout
+                              tests-only fast path). Requires --selective-testing. Skips the
+                              module dependency walk entirely; narrows discovery to the listed
+                              configs after tag/CI filters apply. Mutually exclusive with
+                              --affected-modules.
+    --selective-testing       Requires exactly one of --affected-modules or --affected-configs.
+                              Limits output / Scout CI steps to affected modules or configs;
+                              labels unchanged.
     --include-custom-servers  Include configs under 'test/scout_*' paths for custom server setups
     --validate                Validate that all discovered modules are registered in Scout CI config
     --save                    Validate and save enabled modules to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'
@@ -395,9 +428,12 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
 
     # Only affected module groups (selective testing for PRs)
     node scripts/scout discover-playwright-configs --affected-modules .scout/affected_modules.json --selective-testing --save
+
+    # Only affected Playwright configs (Scout tests-only fast path for PRs)
+    node scripts/scout discover-playwright-configs --affected-configs .scout/affected_configs.json --selective-testing --save
   `,
   flags: {
-    string: ['target', 'affected-modules'],
+    string: ['target', 'affected-modules', 'affected-configs'],
     boolean: ['save', 'validate', 'flatten', 'include-custom-servers', 'selective-testing'],
     default: {
       target: 'all',

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_configs.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_configs.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ToolingLog } from '@kbn/tooling-log';
+import fs from 'fs';
+import type { ModuleDiscoveryInfo } from './types';
+
+jest.mock('@kbn/repo-info', () => ({
+  REPO_ROOT: '/mock/repo/root',
+}));
+
+jest.mock('fs');
+
+import { filterModulesByAffectedConfigs, readAffectedConfigs } from './affected_configs';
+
+const createConfig = (configPath: string) => ({
+  path: configPath,
+  hasTests: true,
+  tags: ['@local-stateful-classic'],
+  serverRunFlags: ['--arch stateful --domain classic'],
+  usesParallelWorkers: false,
+});
+
+const createModule = (
+  name: string,
+  type: 'plugin' | 'package',
+  configPaths: string[]
+): ModuleDiscoveryInfo => ({
+  name,
+  group: 'test-group',
+  type,
+  configs: configPaths.map(createConfig),
+});
+
+describe('affected_configs', () => {
+  let mockLog: ToolingLog;
+
+  beforeEach(() => {
+    mockLog = new ToolingLog({ level: 'verbose', writeTo: process.stdout });
+    jest.spyOn(mockLog, 'info').mockImplementation(jest.fn());
+    jest.spyOn(mockLog, 'warning').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('readAffectedConfigs', () => {
+    it('reads and parses a valid JSON array file', () => {
+      const configs = [
+        'a/test/scout/ui/playwright.config.ts',
+        'b/test/scout/api/playwright.config.ts',
+      ];
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(configs));
+
+      const result = readAffectedConfigs('/some/path.json', mockLog);
+
+      expect(result).toEqual(new Set(configs));
+    });
+
+    it('returns null for non-array JSON', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ not: 'an array' }));
+
+      const result = readAffectedConfigs('/some/path.json', mockLog);
+
+      expect(result).toBeNull();
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining('does not contain a JSON array')
+      );
+    });
+
+    it('returns null when array contains non-string entries', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(['ok.ts', 42, null]));
+
+      const result = readAffectedConfigs('/some/path.json', mockLog);
+
+      expect(result).toBeNull();
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining('contains non-string entries')
+      );
+    });
+
+    it('returns null when the file cannot be read', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory');
+      });
+
+      const result = readAffectedConfigs('/missing/file.json', mockLog);
+
+      expect(result).toBeNull();
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to read affected configs file')
+      );
+    });
+
+    it('returns null for invalid JSON', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue('not valid json');
+
+      const result = readAffectedConfigs('/some/path.json', mockLog);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('filterModulesByAffectedConfigs', () => {
+    const moduleA = createModule('a', 'plugin', [
+      'a/test/scout/ui/playwright.config.ts',
+      'a/test/scout/ui/parallel.playwright.config.ts',
+      'a/test/scout/api/playwright.config.ts',
+    ]);
+    const moduleB = createModule('b', 'plugin', ['b/test/scout/ui/playwright.config.ts']);
+    const moduleC = createModule('c', 'package', ['c/test/scout/api/playwright.config.ts']);
+    const modules = [moduleA, moduleB, moduleC];
+
+    it('keeps only allow-listed configs and marks survivors as affected', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify([
+          'a/test/scout/ui/parallel.playwright.config.ts',
+          'b/test/scout/ui/playwright.config.ts',
+        ])
+      );
+
+      const result = filterModulesByAffectedConfigs(modules, '/affected.json', mockLog);
+
+      expect(result.map((m) => m.name).sort()).toEqual(['a', 'b']);
+      const a = result.find((m) => m.name === 'a')!;
+      expect(a.isAffected).toBe(true);
+      expect(a.configs.map((c) => c.path)).toEqual([
+        'a/test/scout/ui/parallel.playwright.config.ts',
+      ]);
+      const b = result.find((m) => m.name === 'b')!;
+      expect(b.isAffected).toBe(true);
+      expect(b.configs.map((c) => c.path)).toEqual(['b/test/scout/ui/playwright.config.ts']);
+    });
+
+    it('drops modules with zero remaining configs', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify(['a/test/scout/ui/playwright.config.ts'])
+      );
+
+      const result = filterModulesByAffectedConfigs(modules, '/affected.json', mockLog);
+
+      expect(result.map((m) => m.name)).toEqual(['a']);
+    });
+
+    it('returns [] and warns when allowlist is empty', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify([]));
+
+      const result = filterModulesByAffectedConfigs(modules, '/affected.json', mockLog);
+
+      expect(result).toEqual([]);
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Affected configs file is empty')
+      );
+    });
+
+    it('does not bleed across modules: matching path in one module never affects siblings', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify(['c/test/scout/api/playwright.config.ts'])
+      );
+
+      const result = filterModulesByAffectedConfigs(modules, '/affected.json', mockLog);
+
+      expect(result.map((m) => m.name)).toEqual(['c']);
+      expect(result[0].configs.map((c) => c.path)).toEqual([
+        'c/test/scout/api/playwright.config.ts',
+      ]);
+    });
+
+    it('throws when the affected configs file cannot be read', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      expect(() => filterModulesByAffectedConfigs(modules, '/missing.json', mockLog)).toThrow(
+        'Selective testing: could not load affected configs file'
+      );
+    });
+
+    it('logs kept/dropped/survivor counts', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify([
+          'a/test/scout/ui/playwright.config.ts',
+          'a/test/scout/ui/parallel.playwright.config.ts',
+        ])
+      );
+
+      filterModulesByAffectedConfigs(modules, '/affected.json', mockLog);
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        expect.stringMatching(/Affected configs: 2 kept, \d+ dropped, 1 module\(s\) survived/)
+      );
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_configs.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_configs.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createFailError } from '@kbn/dev-cli-errors';
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { ModuleDiscoveryInfo } from './types';
+
+/**
+ * Read the affected configs JSON file (an array of repo-relative Playwright config paths)
+ * produced by the Scout selective-testing resolver when the PR diff is "Scout tests only".
+ * Returns null on any error so the CLI can fail fast with a clearer message.
+ */
+export const readAffectedConfigs = (filePath: string, log: ToolingLog): Set<string> | null => {
+  try {
+    const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(REPO_ROOT, filePath);
+    const content = fs.readFileSync(absolutePath, 'utf-8');
+    const parsed = JSON.parse(content);
+
+    if (!Array.isArray(parsed)) {
+      log.warning(`Affected configs file does not contain a JSON array: ${filePath}`);
+      return null;
+    }
+
+    if (parsed.some((entry) => typeof entry !== 'string')) {
+      log.warning(`Affected configs file contains non-string entries: ${filePath}`);
+      return null;
+    }
+
+    return new Set<string>(parsed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warning(`Failed to read affected configs file '${filePath}': ${message}`);
+    return null;
+  }
+};
+
+/**
+ * Narrow modules to only the configs whose path is in the affected-configs allowlist.
+ * Used by `discover-playwright-configs --selective-testing --affected-configs <file>`,
+ * where the PR's diff is exclusively under Scout test scopes (no module dep walk needed).
+ *
+ * Behavior:
+ * - Each module's `configs` array is filtered to keep only allow-listed paths.
+ * - Modules with zero remaining configs are dropped.
+ * - Surviving modules are marked `isAffected: true` so CI step labels keep the
+ *   "affected " prefix.
+ * - If the file cannot be read or is invalid -> throw (fail fast).
+ */
+export const filterModulesByAffectedConfigs = (
+  modules: ModuleDiscoveryInfo[],
+  affectedConfigsPath: string,
+  log: ToolingLog
+): ModuleDiscoveryInfo[] => {
+  const affectedConfigs = readAffectedConfigs(affectedConfigsPath, log);
+
+  if (affectedConfigs === null) {
+    throw createFailError(
+      'Selective testing: could not load affected configs file. Check that the resolver produced a valid JSON array of config paths.'
+    );
+  }
+
+  if (affectedConfigs.size === 0) {
+    log.warning('Affected configs file is empty — no Scout configs will be scheduled.');
+    return [];
+  }
+
+  let keptConfigCount = 0;
+  let droppedConfigCount = 0;
+
+  const narrowed = modules.flatMap((module) => {
+    const keptConfigs = module.configs.filter((c) => affectedConfigs.has(c.path));
+    droppedConfigCount += module.configs.length - keptConfigs.length;
+    keptConfigCount += keptConfigs.length;
+
+    if (keptConfigs.length === 0) {
+      return [];
+    }
+
+    return [{ ...module, isAffected: true, configs: keptConfigs }];
+  });
+
+  log.info(
+    `Affected configs: ${keptConfigCount} kept, ${droppedConfigCount} dropped, ${narrowed.length} module(s) survived`
+  );
+
+  return narrowed;
+};

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/index.ts
@@ -13,3 +13,4 @@ export * from './transform_utils';
 export * from './file_utils';
 export * from './search_configs';
 export * from './affected_modules';
+export * from './affected_configs';


### PR DESCRIPTION
## Summary

Adds `--affected-configs <file>` to `node scripts/scout discover-playwright-configs`, enabling Playwright-config-level selective testing for PRs whose diff is exclusively under Scout test scopes. The flag is mutually exclusive with `--affected-modules`, both nested under `--selective-testing`.

When set, the module dependency walk is skipped entirely; discovery is narrowed to the listed Playwright config paths only after the existing tag, custom-server, and CI-excluded-config filters apply (so CI exclusions cannot be force-overridden).
Surviving modules keep `isAffected: true` so Buildkite step labels stay consistent with the existing affected-modules flow.

No callers yet — this is the CLI surface only. The Scout selective-testing resolver
(separate PR) will produce the JSON allowlist for PR builds.


