### PR TITLE
Fixes space roles jest tests

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/public/management/edit_space/roles/component/space_assign_role_privilege_form.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/edit_space/roles/component/space_assign_role_privilege_form.test.tsx
@@ -131,8 +131,7 @@ const renderPrivilegeRolesForm = ({
   );
 };
 
-// Failing: See https://github.com/elastic/kibana/issues/253823
-describe.skip('PrivilegesRolesForm', () => {
+describe('PrivilegesRolesForm', () => {
   let getRolesSpy: jest.SpiedFunction<ReturnType<typeof createRolesAPIClientMock>['getRoles']>;
   let getAllKibanaPrivilegeSpy: jest.SpiedFunction<
     ReturnType<typeof createPrivilegeAPIClientMock>['getAll']
@@ -335,6 +334,8 @@ describe.skip('PrivilegesRolesForm', () => {
 
   describe('applying custom privileges', () => {
     it('for a selection of roles pre-assigned to a space, the first encountered privilege with a custom privilege is used as the starting point', async () => {
+      const user = userEvent.setup({ delay: null });
+
       getRolesSpy.mockResolvedValue([]);
       getAllKibanaPrivilegeSpy.mockResolvedValue(createRawKibanaPrivileges(kibanaFeatures));
 
@@ -363,11 +364,16 @@ describe.skip('PrivilegesRolesForm', () => {
         preSelectedRoles: roles,
       });
 
+      // Wait for KibanaPrivilegeTable to render — it only appears once kibanaPrivileges is loaded
+      // from the async fetchRequiredData call. custom-privilege-button renders immediately when
+      // roles are selected, so it is not a reliable sentinel for data-load completion.
       await waitFor(() =>
-        expect(screen.getByTestId('custom-privilege-button')).toBeInTheDocument()
+        expect(
+          screen.getByTestId(`${featureIds[0]}_${FEATURE_PRIVILEGES_READ}`)
+        ).toBeInTheDocument()
       );
 
-      await userEvent.click(screen.getByTestId('custom-privilege-button'));
+      await user.click(screen.getByTestId('custom-privilege-button'));
 
       expect(screen.getByTestId(`${FEATURE_PRIVILEGES_CUSTOM}-privilege-button`)).toHaveAttribute(
         'aria-pressed',
@@ -390,7 +396,7 @@ describe.skip('PrivilegesRolesForm', () => {
     });
 
     it('allows modifying individual features after selecting a base privilege within the customize table', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
 
       getRolesSpy.mockResolvedValue([]);
       getAllKibanaPrivilegeSpy.mockResolvedValue(createRawKibanaPrivileges(kibanaFeatures));
@@ -461,7 +467,7 @@ describe.skip('PrivilegesRolesForm', () => {
     });
 
     it('prevents customization up to sub privilege level by default', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
 
       const roles: Role[] = [
         createRole('test_role_1', [
@@ -475,13 +481,17 @@ describe.skip('PrivilegesRolesForm', () => {
       const featuresWithSubFeatures = kibanaFeatures.filter((kibanaFeature) =>
         Boolean(kibanaFeature.subFeatures.length)
       );
+      const featureUT = featuresWithSubFeatures[0];
 
       renderPrivilegeRolesForm({
         preSelectedRoles: roles,
       });
 
+      // Wait for KibanaPrivilegeTable to render — it only appears once kibanaPrivileges is loaded
+      // from the async fetchRequiredData call. custom-privilege-button renders immediately when
+      // roles are selected, so it is not a reliable sentinel for data-load completion.
       await waitFor(() =>
-        expect(screen.getByTestId('custom-privilege-button')).toBeInTheDocument()
+        expect(screen.getByTestId(`${featureUT.id}_${FEATURE_PRIVILEGES_READ}`)).toBeInTheDocument()
       );
 
       await user.click(screen.getByTestId('custom-privilege-button'));
@@ -489,8 +499,6 @@ describe.skip('PrivilegesRolesForm', () => {
       expect(
         screen.getByTestId('space-assign-role-privilege-customization-form')
       ).toBeInTheDocument();
-
-      const featureUT = featuresWithSubFeatures[0];
 
       // change a single feature with sub features to read from default privilege "none"
       await user.click(screen.getByTestId(`${featureUT.id}_${FEATURE_PRIVILEGES_READ}`));
@@ -503,11 +511,13 @@ describe.skip('PrivilegesRolesForm', () => {
       );
 
       // sub feature table renders
-      expect(
-        screen.getByTestId(`${featureUT.category.id}_${featureUT.id}_subFeaturesTable`)
-      ).toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByTestId(`${featureUT.category.id}_${featureUT.id}_subFeaturesTable`)
+        ).toBeInTheDocument()
+      );
 
-      // assert switch to customize sub feature can toggled
+      // assert switch to customize sub feature cannot be toggled
       expect(
         within(
           screen.getByTestId(
@@ -518,7 +528,7 @@ describe.skip('PrivilegesRolesForm', () => {
     });
 
     it('supports customization up to sub privilege level only when security license allows', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
 
       const roles: Role[] = [
         createRole('test_role_1', [
@@ -537,13 +547,17 @@ describe.skip('PrivilegesRolesForm', () => {
       const featuresWithSubFeatures = kibanaFeatures.filter((kibanaFeature) =>
         Boolean(kibanaFeature.subFeatures.length)
       );
+      const featureUT = featuresWithSubFeatures[0];
 
       renderPrivilegeRolesForm({
         preSelectedRoles: roles,
       });
 
+      // Wait for KibanaPrivilegeTable to render — it only appears once kibanaPrivileges is loaded
+      // from the async fetchRequiredData call. custom-privilege-button renders immediately when
+      // roles are selected, so it is not a reliable sentinel for data-load completion.
       await waitFor(() =>
-        expect(screen.getByTestId('custom-privilege-button')).toBeInTheDocument()
+        expect(screen.getByTestId(`${featureUT.id}_${FEATURE_PRIVILEGES_READ}`)).toBeInTheDocument()
       );
 
       await user.click(screen.getByTestId('custom-privilege-button'));
@@ -551,8 +565,6 @@ describe.skip('PrivilegesRolesForm', () => {
       expect(
         screen.getByTestId('space-assign-role-privilege-customization-form')
       ).toBeInTheDocument();
-
-      const featureUT = featuresWithSubFeatures[0];
 
       // change a single feature with sub features to read from default privilege "none"
       await user.click(screen.getByTestId(`${featureUT.id}_${FEATURE_PRIVILEGES_READ}`));
@@ -565,11 +577,13 @@ describe.skip('PrivilegesRolesForm', () => {
       );
 
       // sub feature table renders
-      expect(
-        screen.getByTestId(`${featureUT.category.id}_${featureUT.id}_subFeaturesTable`)
-      ).toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByTestId(`${featureUT.category.id}_${featureUT.id}_subFeaturesTable`)
+        ).toBeInTheDocument()
+      );
 
-      // assert switch to customize sub feature can toggled
+      // assert switch to customize sub feature can be toggled
       expect(
         within(
           screen.getByTestId(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/253663
Closes https://github.com/elastic/kibana/issues/253823

## Summary

This PR resolves spaces role privileges form test timeout failures by increasing performance and determinism of the tests.

- Uses null delay for user events for efficiency: `userEvent.setup({ delay: null });`
- Changes check for render completion

These changes were made with Claude Code. 

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->