### PR TITLE
[9.4] [Log threshold] Quote phrase values in alert details preview KQL (#266783)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fromKueryExpression } from '@kbn/es-query';
+import { Comparator } from '../../../../../common/alerting/logs/log_threshold';
+import { convertCriteriaToKQL } from '.';
+
+describe('convertCriteriaToKQL', () => {
+  const field = 'message';
+
+  describe('quoting', () => {
+    const cases: Array<[Comparator, string, string]> = [
+      [Comparator.EQ, 'simple', `${field} : "simple"`],
+      [Comparator.MATCH, 'simple', `${field} : "simple"`],
+      [Comparator.MATCH_PHRASE, 'simple', `${field} : "simple"`],
+      [Comparator.NOT_EQ, 'simple', `NOT ${field} : "simple"`],
+      [Comparator.NOT_MATCH, 'simple', `NOT ${field} : "simple"`],
+      [Comparator.NOT_MATCH_PHRASE, 'simple', `NOT ${field} : "simple"`],
+    ];
+
+    it.each(cases)('quotes the value for %s', (comparator, value, expected) => {
+      expect(convertCriteriaToKQL({ field, comparator, value })).toBe(expected);
+    });
+  });
+
+  describe('values containing KQL special characters', () => {
+    // Regression test for https://github.com/elastic/kibana/issues/203071.
+    // Phrase values containing characters such as `:` were previously
+    // interpolated unquoted, producing unparseable KQL.
+    const specialValues = [
+      'foo: bar',
+      'something with (parens)',
+      'tag<value>',
+      'wild*card',
+      'has "inner" quotes',
+      'back\\slash',
+    ];
+
+    it.each(specialValues)(
+      'produces parseable KQL for "does not match phrase" with value %p',
+      (value) => {
+        const kql = convertCriteriaToKQL({
+          field,
+          comparator: Comparator.NOT_MATCH_PHRASE,
+          value,
+        });
+
+        expect(() => fromKueryExpression(kql)).not.toThrow();
+      }
+    );
+
+    it.each(specialValues)('produces parseable KQL for "matches phrase" with value %p', (value) => {
+      const kql = convertCriteriaToKQL({
+        field,
+        comparator: Comparator.MATCH_PHRASE,
+        value,
+      });
+
+      expect(() => fromKueryExpression(kql)).not.toThrow();
+    });
+
+    it('escapes embedded backslashes and double quotes', () => {
+      const value = 'has "quote" and \\backslash';
+
+      expect(
+        convertCriteriaToKQL({
+          field,
+          comparator: Comparator.NOT_MATCH_PHRASE,
+          value,
+        })
+      ).toBe(`NOT ${field} : "has \\"quote\\" and \\\\backslash"`);
+    });
+  });
+
+  describe('range comparators', () => {
+    it('renders numeric values without quotes', () => {
+      expect(convertCriteriaToKQL({ field: 'count', comparator: Comparator.GT, value: 5 })).toBe(
+        'count > 5'
+      );
+      expect(
+        convertCriteriaToKQL({ field: 'count', comparator: Comparator.GT_OR_EQ, value: 5 })
+      ).toBe('count >= 5');
+      expect(convertCriteriaToKQL({ field: 'count', comparator: Comparator.LT, value: 5 })).toBe(
+        'count < 5'
+      );
+      expect(
+        convertCriteriaToKQL({ field: 'count', comparator: Comparator.LT_OR_EQ, value: 5 })
+      ).toBe('count <= 5');
+    });
+  });
+
+  describe('incomplete criteria', () => {
+    it('returns an empty string when the value is missing', () => {
+      expect(convertCriteriaToKQL({ field, comparator: Comparator.EQ })).toBe('');
+    });
+
+    it('returns an empty string when the comparator is missing', () => {
+      expect(convertCriteriaToKQL({ field, value: 'x' })).toBe('');
+    });
+
+    it('returns an empty string when the field is missing', () => {
+      expect(convertCriteriaToKQL({ comparator: Comparator.EQ, value: 'x' })).toBe('');
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx
@@ -19,6 +19,7 @@ import { i18n } from '@kbn/i18n';
 import { getPaddedAlertTimeRange } from '@kbn/observability-get-padded-alert-time-range-util';
 import { get, identity } from 'lodash';
 import { useElasticChartsTheme } from '@kbn/charts-theme';
+import { escapeQuotes } from '@kbn/es-query';
 import { useLogView } from '@kbn/logs-shared-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useKibanaContextForPlugin } from '../../../../hooks/use_kibana';
@@ -215,22 +216,26 @@ function convertComparatorToFill(comparator: Comparator) {
   }
 }
 
-function convertCriteriaToKQL(criteria: PartialCriterion) {
+// Exported for unit testing.
+export function convertCriteriaToKQL(criteria: PartialCriterion) {
   if (!criteria.value || !criteria.comparator || !criteria.field) {
     return '';
   }
 
+  // Phrase / equality / match values are interpolated into a quoted KQL string,
+  // so any embedded backslashes or double quotes need to be escaped to keep the
+  // resulting expression parseable. See https://github.com/elastic/kibana/issues/203071.
+  const quotedValue = `"${escapeQuotes(String(criteria.value))}"`;
+
   switch (criteria.comparator) {
     case Comparator.MATCH:
     case Comparator.EQ:
-      return `${criteria.field} : "${criteria.value}"`;
+    case Comparator.MATCH_PHRASE:
+      return `${criteria.field} : ${quotedValue}`;
     case Comparator.NOT_MATCH:
     case Comparator.NOT_EQ:
-      return `NOT ${criteria.field} : "${criteria.value}"`;
-    case Comparator.MATCH_PHRASE:
-      return `${criteria.field} : ${criteria.value}`;
     case Comparator.NOT_MATCH_PHRASE:
-      return `NOT ${criteria.field} : ${criteria.value}`;
+      return `NOT ${criteria.field} : ${quotedValue}`;
     case Comparator.GT:
       return `${criteria.field} > ${criteria.value}`;
     case Comparator.GT_OR_EQ:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Log threshold] Quote phrase values in alert details preview KQL (#266783)](https://github.com/elastic/kibana/pull/266783)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Adam Kasztenny","email":"adam.kasztenny@elastic.co"},"sourceCommit":{"committedDate":"2026-05-01T14:21:34Z","message":"[Log threshold] Quote phrase values in alert details preview KQL (#266783)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/203071.\n\nThe Lens preview chart on the Log threshold rule alert details page\nrenders unparseable KQL when a criterion uses `matches phrase` / `does\nnot match phrase` and the value contains a KQL special character (e.g.\n`:`, `(`, `)`, `<`, `>`, `*`, `\"`, `\\`). For example, a criterion\nconfigured as:\n\n- field: `message`\n- comparator: `does not match phrase`\n- value: `foo: bar`\n\n…produced this KQL:\n\n```\nNOT message : foo: bar\n```\n\n…which the parser rejects with:\n\n```\nLayer 1 error: Expected AND, OR, end of input but \":\" found.\nNOT message : foo: bar\n-------------------^\n```\n\n### Root cause\n\n`convertCriteriaToKQL` in\n`x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx`\ninterpolated `criteria.value` straight into the KQL string for the\n`MATCH_PHRASE` / `NOT_MATCH_PHRASE` cases, without wrapping it in quotes\nand without escaping special characters. The other equality / match\ncomparators wrapped the value in `\"…\"` but did not escape embedded\nquotes or backslashes either, so the same class of bug existed for any\nvalue containing a `\"` or `\\`.\n\n### Fix\n\nQuote the interpolated value for every comparator that takes a phrase /\nequality / match value, and run it through the existing `escapeQuotes`\nhelper (`@kbn/es-query`) so embedded `\"` and `\\` are escaped. The same\nexample now generates:\n\n```\nNOT message : \"foo: bar\"\n```\n\n…which the KQL parser accepts.\n\nThis is a UI-only change; alert rule execution is unaffected because the\nexecutor builds Elasticsearch DSL directly and does not go through this\nhelper.\n\n### Tests\n\nA new unit test file co-located with the helper covers:\n\n- All comparators wrap their value in double quotes (regression for the\nmissing quoting on phrase comparators).\n- For each `KQL` special character (`:`, `()`, `<>`, `*`, `\"`, `\\`),\n`convertCriteriaToKQL` produces an expression that `fromKueryExpression`\nfrom `@kbn/es-query` can parse. This is the same parser the Lens chart\nuses, so a passing test means the chart will accept the output.\n- Embedded `\"` and `\\` are escaped using the standard `escapeQuotes`\nrules.\n- Range comparators (`>`, `>=`, `<`, `<=`) still render numeric values\nwithout quotes.\n- Incomplete criteria still return an empty string.\n\nI also confirmed the test suite catches the regression: temporarily\nreverting just the `MATCH_PHRASE` / `NOT_MATCH_PHRASE` branches to the\nprevious behaviour produces `KQLSyntaxError: Expected AND, OR, end of\ninput but \":\" found.` — the exact error from the linked issue — on the\nnew tests. With the fix applied, all 23 cases pass.\n\n```\nPASS x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts\n  convertCriteriaToKQL\n    quoting\n      ✓ quotes the value for equals\n      ✓ quotes the value for matches\n      ✓ quotes the value for matches phrase\n      ✓ quotes the value for does not equal\n      ✓ quotes the value for does not match\n      ✓ quotes the value for does not match phrase\n    values containing KQL special characters\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"foo: bar\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"something with (parens)\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"tag<value>\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"wild*card\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"has \\\"inner\\\" quotes\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"back\\\\slash\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"foo: bar\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"something with (parens)\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"tag<value>\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"wild*card\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"has \\\"inner\\\" quotes\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"back\\\\slash\"\n      ✓ escapes embedded backslashes and double quotes\n    range comparators\n      ✓ renders numeric values without quotes\n    incomplete criteria\n      ✓ returns an empty string when the value is missing\n      ✓ returns an empty string when the comparator is missing\n      ✓ returns an empty string when the field is missing\n\nTest Suites: 1 passed, 1 total\nTests:       23 passed, 23 total\n```\n\n`node scripts/type_check --project\nx-pack/solutions/observability/plugins/infra/tsconfig.json` also passes.\n\n### Manual verification\n\nI followed the exact reproduction steps from the issue against a local\nKibana built from `main` plus this fix, with an Elasticsearch snapshot\nof matching version:\n\n1. Created a log view (`test-logs`) backed by a `logs-test-*` data\nstream with a few error-level documents.\n2. Created a Log threshold rule with these criteria:\n   - `log.level` `equals` `error`\n   - `message` `does not match phrase` `something: with a colon`\n3. Indexed enough error logs to trigger the rule (count > 0 over 5m).\n4. Opened the alert details page for the resulting alert.\n\n**Before the fix** (rebuilt with the `MATCH_PHRASE` / `NOT_MATCH_PHRASE`\nbranches reverted to their previous behaviour):\n\nThe Lens preview chart fails to render and shows the exact error from\nissue #203071:\n\n> Layer 1 error: Expected AND, OR, end of input but \":\" found.\n> log.level : \"error\" AND NOT message : something: with a colon\n> ----------------------------------------------------^\n\n<img width=\"1600\" height=\"1100\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/31444aef-2ba9-4734-a9bf-4058389252e5\"\n/>\n\n**After the fix:**\n\nThe KQL syntax error is gone — the criterion is rendered as `NOT message\n: \"something: with a colon\"` and the chart layer is no longer in an\nerror state from this code path.\n\n<img width=\"1600\" height=\"1100\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4343221c-3c70-4c26-a049-27065b280c15\"\n/>\n\n#### Note on a separate, pre-existing chart error\n\nIn the after screenshot, the Lens chart still shows a different error:\n\n> [layeredXyVis] > [event_annotations_result] >\n[extendedAnnotationLayer] > [manual_point_event_annotation] > Value\n'warning' is not among the allowed options for argument 'icon'\n\nThis is unrelated to issue #203071 — it comes from the threshold\nannotation expression building a `manual_point_event_annotation` with\n`icon: 'warning'`, which is not in the current allowed set on `main`. It\nhappens regardless of whether a colon is present in any criterion value.\nIt was also present before the fix, but masked by the KQL parse failure\noccurring earlier in the pipeline. Filing/finding a separate issue for\nthat is out of scope for this PR; it does not affect the correctness of\nthe change here.\n\n### Programmatic verification\n\nThe new unit tests pipe `convertCriteriaToKQL` output through\n`fromKueryExpression` from `@kbn/es-query` — the same parser the Lens\nchart uses to validate KQL — for every problematic special character.\nBefore the fix, those assertions throw `KQLSyntaxError: Expected AND,\nOR, end of input but \":\" found.` (the exact error from the issue). After\nthe fix, they pass.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Existing workarounds**: users who applied the documented workaround\non the issue (wrapping the value in literal double quotes, e.g. `\"foo:\nbar\"`) will, after this fix, generate KQL like `NOT message : \"\\\"foo:\nbar\\\"\"` from the alert details preview chart. The actual alert rule\nexecution is unaffected (it does not pass through this helper). For\npreview-chart purposes the embedded quotes will be treated as part of\nthe phrase text, which is more accurate to what the user typed than\nbefore but may cause the preview to show no matches if the underlying\nfield tokenises punctuation. Users on the workaround can drop the extra\nquotes once they pick up this fix. No known data-loss or alert-firing\nimpact.\n- Severity: low. The change is contained to a single string helper that\nis used only for generating the KQL passed to the alert details Lens\nchart.\n\n### Release Notes\n\nFixes a bug where the Log threshold rule's alert details preview chart\nwould fail to render with a KQL syntax error when a criterion used\n`matches phrase` or `does not match phrase` with a value containing\ncharacters such as `:`.\n\n---\n\nCreated with Cursor using Claude Opus 4.7\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d21d3439de5d9fd904f1e4c7036982da41f38ed7","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Logs UI","backport missing","Team:obs-ux-management","backport:prev-minor","v9.5.0"],"title":"[Log threshold] Quote phrase values in alert details preview KQL","number":266783,"url":"https://github.com/elastic/kibana/pull/266783","mergeCommit":{"message":"[Log threshold] Quote phrase values in alert details preview KQL (#266783)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/203071.\n\nThe Lens preview chart on the Log threshold rule alert details page\nrenders unparseable KQL when a criterion uses `matches phrase` / `does\nnot match phrase` and the value contains a KQL special character (e.g.\n`:`, `(`, `)`, `<`, `>`, `*`, `\"`, `\\`). For example, a criterion\nconfigured as:\n\n- field: `message`\n- comparator: `does not match phrase`\n- value: `foo: bar`\n\n…produced this KQL:\n\n```\nNOT message : foo: bar\n```\n\n…which the parser rejects with:\n\n```\nLayer 1 error: Expected AND, OR, end of input but \":\" found.\nNOT message : foo: bar\n-------------------^\n```\n\n### Root cause\n\n`convertCriteriaToKQL` in\n`x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx`\ninterpolated `criteria.value` straight into the KQL string for the\n`MATCH_PHRASE` / `NOT_MATCH_PHRASE` cases, without wrapping it in quotes\nand without escaping special characters. The other equality / match\ncomparators wrapped the value in `\"…\"` but did not escape embedded\nquotes or backslashes either, so the same class of bug existed for any\nvalue containing a `\"` or `\\`.\n\n### Fix\n\nQuote the interpolated value for every comparator that takes a phrase /\nequality / match value, and run it through the existing `escapeQuotes`\nhelper (`@kbn/es-query`) so embedded `\"` and `\\` are escaped. The same\nexample now generates:\n\n```\nNOT message : \"foo: bar\"\n```\n\n…which the KQL parser accepts.\n\nThis is a UI-only change; alert rule execution is unaffected because the\nexecutor builds Elasticsearch DSL directly and does not go through this\nhelper.\n\n### Tests\n\nA new unit test file co-located with the helper covers:\n\n- All comparators wrap their value in double quotes (regression for the\nmissing quoting on phrase comparators).\n- For each `KQL` special character (`:`, `()`, `<>`, `*`, `\"`, `\\`),\n`convertCriteriaToKQL` produces an expression that `fromKueryExpression`\nfrom `@kbn/es-query` can parse. This is the same parser the Lens chart\nuses, so a passing test means the chart will accept the output.\n- Embedded `\"` and `\\` are escaped using the standard `escapeQuotes`\nrules.\n- Range comparators (`>`, `>=`, `<`, `<=`) still render numeric values\nwithout quotes.\n- Incomplete criteria still return an empty string.\n\nI also confirmed the test suite catches the regression: temporarily\nreverting just the `MATCH_PHRASE` / `NOT_MATCH_PHRASE` branches to the\nprevious behaviour produces `KQLSyntaxError: Expected AND, OR, end of\ninput but \":\" found.` — the exact error from the linked issue — on the\nnew tests. With the fix applied, all 23 cases pass.\n\n```\nPASS x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts\n  convertCriteriaToKQL\n    quoting\n      ✓ quotes the value for equals\n      ✓ quotes the value for matches\n      ✓ quotes the value for matches phrase\n      ✓ quotes the value for does not equal\n      ✓ quotes the value for does not match\n      ✓ quotes the value for does not match phrase\n    values containing KQL special characters\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"foo: bar\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"something with (parens)\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"tag<value>\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"wild*card\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"has \\\"inner\\\" quotes\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"back\\\\slash\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"foo: bar\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"something with (parens)\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"tag<value>\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"wild*card\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"has \\\"inner\\\" quotes\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"back\\\\slash\"\n      ✓ escapes embedded backslashes and double quotes\n    range comparators\n      ✓ renders numeric values without quotes\n    incomplete criteria\n      ✓ returns an empty string when the value is missing\n      ✓ returns an empty string when the comparator is missing\n      ✓ returns an empty string when the field is missing\n\nTest Suites: 1 passed, 1 total\nTests:       23 passed, 23 total\n```\n\n`node scripts/type_check --project\nx-pack/solutions/observability/plugins/infra/tsconfig.json` also passes.\n\n### Manual verification\n\nI followed the exact reproduction steps from the issue against a local\nKibana built from `main` plus this fix, with an Elasticsearch snapshot\nof matching version:\n\n1. Created a log view (`test-logs`) backed by a `logs-test-*` data\nstream with a few error-level documents.\n2. Created a Log threshold rule with these criteria:\n   - `log.level` `equals` `error`\n   - `message` `does not match phrase` `something: with a colon`\n3. Indexed enough error logs to trigger the rule (count > 0 over 5m).\n4. Opened the alert details page for the resulting alert.\n\n**Before the fix** (rebuilt with the `MATCH_PHRASE` / `NOT_MATCH_PHRASE`\nbranches reverted to their previous behaviour):\n\nThe Lens preview chart fails to render and shows the exact error from\nissue #203071:\n\n> Layer 1 error: Expected AND, OR, end of input but \":\" found.\n> log.level : \"error\" AND NOT message : something: with a colon\n> ----------------------------------------------------^\n\n<img width=\"1600\" height=\"1100\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/31444aef-2ba9-4734-a9bf-4058389252e5\"\n/>\n\n**After the fix:**\n\nThe KQL syntax error is gone — the criterion is rendered as `NOT message\n: \"something: with a colon\"` and the chart layer is no longer in an\nerror state from this code path.\n\n<img width=\"1600\" height=\"1100\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4343221c-3c70-4c26-a049-27065b280c15\"\n/>\n\n#### Note on a separate, pre-existing chart error\n\nIn the after screenshot, the Lens chart still shows a different error:\n\n> [layeredXyVis] > [event_annotations_result] >\n[extendedAnnotationLayer] > [manual_point_event_annotation] > Value\n'warning' is not among the allowed options for argument 'icon'\n\nThis is unrelated to issue #203071 — it comes from the threshold\nannotation expression building a `manual_point_event_annotation` with\n`icon: 'warning'`, which is not in the current allowed set on `main`. It\nhappens regardless of whether a colon is present in any criterion value.\nIt was also present before the fix, but masked by the KQL parse failure\noccurring earlier in the pipeline. Filing/finding a separate issue for\nthat is out of scope for this PR; it does not affect the correctness of\nthe change here.\n\n### Programmatic verification\n\nThe new unit tests pipe `convertCriteriaToKQL` output through\n`fromKueryExpression` from `@kbn/es-query` — the same parser the Lens\nchart uses to validate KQL — for every problematic special character.\nBefore the fix, those assertions throw `KQLSyntaxError: Expected AND,\nOR, end of input but \":\" found.` (the exact error from the issue). After\nthe fix, they pass.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Existing workarounds**: users who applied the documented workaround\non the issue (wrapping the value in literal double quotes, e.g. `\"foo:\nbar\"`) will, after this fix, generate KQL like `NOT message : \"\\\"foo:\nbar\\\"\"` from the alert details preview chart. The actual alert rule\nexecution is unaffected (it does not pass through this helper). For\npreview-chart purposes the embedded quotes will be treated as part of\nthe phrase text, which is more accurate to what the user typed than\nbefore but may cause the preview to show no matches if the underlying\nfield tokenises punctuation. Users on the workaround can drop the extra\nquotes once they pick up this fix. No known data-loss or alert-firing\nimpact.\n- Severity: low. The change is contained to a single string helper that\nis used only for generating the KQL passed to the alert details Lens\nchart.\n\n### Release Notes\n\nFixes a bug where the Log threshold rule's alert details preview chart\nwould fail to render with a KQL syntax error when a criterion used\n`matches phrase` or `does not match phrase` with a value containing\ncharacters such as `:`.\n\n---\n\nCreated with Cursor using Claude Opus 4.7\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d21d3439de5d9fd904f1e4c7036982da41f38ed7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266783","number":266783,"mergeCommit":{"message":"[Log threshold] Quote phrase values in alert details preview KQL (#266783)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/203071.\n\nThe Lens preview chart on the Log threshold rule alert details page\nrenders unparseable KQL when a criterion uses `matches phrase` / `does\nnot match phrase` and the value contains a KQL special character (e.g.\n`:`, `(`, `)`, `<`, `>`, `*`, `\"`, `\\`). For example, a criterion\nconfigured as:\n\n- field: `message`\n- comparator: `does not match phrase`\n- value: `foo: bar`\n\n…produced this KQL:\n\n```\nNOT message : foo: bar\n```\n\n…which the parser rejects with:\n\n```\nLayer 1 error: Expected AND, OR, end of input but \":\" found.\nNOT message : foo: bar\n-------------------^\n```\n\n### Root cause\n\n`convertCriteriaToKQL` in\n`x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/index.tsx`\ninterpolated `criteria.value` straight into the KQL string for the\n`MATCH_PHRASE` / `NOT_MATCH_PHRASE` cases, without wrapping it in quotes\nand without escaping special characters. The other equality / match\ncomparators wrapped the value in `\"…\"` but did not escape embedded\nquotes or backslashes either, so the same class of bug existed for any\nvalue containing a `\"` or `\\`.\n\n### Fix\n\nQuote the interpolated value for every comparator that takes a phrase /\nequality / match value, and run it through the existing `escapeQuotes`\nhelper (`@kbn/es-query`) so embedded `\"` and `\\` are escaped. The same\nexample now generates:\n\n```\nNOT message : \"foo: bar\"\n```\n\n…which the KQL parser accepts.\n\nThis is a UI-only change; alert rule execution is unaffected because the\nexecutor builds Elasticsearch DSL directly and does not go through this\nhelper.\n\n### Tests\n\nA new unit test file co-located with the helper covers:\n\n- All comparators wrap their value in double quotes (regression for the\nmissing quoting on phrase comparators).\n- For each `KQL` special character (`:`, `()`, `<>`, `*`, `\"`, `\\`),\n`convertCriteriaToKQL` produces an expression that `fromKueryExpression`\nfrom `@kbn/es-query` can parse. This is the same parser the Lens chart\nuses, so a passing test means the chart will accept the output.\n- Embedded `\"` and `\\` are escaped using the standard `escapeQuotes`\nrules.\n- Range comparators (`>`, `>=`, `<`, `<=`) still render numeric values\nwithout quotes.\n- Incomplete criteria still return an empty string.\n\nI also confirmed the test suite catches the regression: temporarily\nreverting just the `MATCH_PHRASE` / `NOT_MATCH_PHRASE` branches to the\nprevious behaviour produces `KQLSyntaxError: Expected AND, OR, end of\ninput but \":\" found.` — the exact error from the linked issue — on the\nnew tests. With the fix applied, all 23 cases pass.\n\n```\nPASS x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/convert_criteria_to_kql.test.ts\n  convertCriteriaToKQL\n    quoting\n      ✓ quotes the value for equals\n      ✓ quotes the value for matches\n      ✓ quotes the value for matches phrase\n      ✓ quotes the value for does not equal\n      ✓ quotes the value for does not match\n      ✓ quotes the value for does not match phrase\n    values containing KQL special characters\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"foo: bar\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"something with (parens)\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"tag<value>\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"wild*card\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"has \\\"inner\\\" quotes\"\n      ✓ produces parseable KQL for \"does not match phrase\" with value \"back\\\\slash\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"foo: bar\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"something with (parens)\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"tag<value>\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"wild*card\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"has \\\"inner\\\" quotes\"\n      ✓ produces parseable KQL for \"matches phrase\" with value \"back\\\\slash\"\n      ✓ escapes embedded backslashes and double quotes\n    range comparators\n      ✓ renders numeric values without quotes\n    incomplete criteria\n      ✓ returns an empty string when the value is missing\n      ✓ returns an empty string when the comparator is missing\n      ✓ returns an empty string when the field is missing\n\nTest Suites: 1 passed, 1 total\nTests:       23 passed, 23 total\n```\n\n`node scripts/type_check --project\nx-pack/solutions/observability/plugins/infra/tsconfig.json` also passes.\n\n### Manual verification\n\nI followed the exact reproduction steps from the issue against a local\nKibana built from `main` plus this fix, with an Elasticsearch snapshot\nof matching version:\n\n1. Created a log view (`test-logs`) backed by a `logs-test-*` data\nstream with a few error-level documents.\n2. Created a Log threshold rule with these criteria:\n   - `log.level` `equals` `error`\n   - `message` `does not match phrase` `something: with a colon`\n3. Indexed enough error logs to trigger the rule (count > 0 over 5m).\n4. Opened the alert details page for the resulting alert.\n\n**Before the fix** (rebuilt with the `MATCH_PHRASE` / `NOT_MATCH_PHRASE`\nbranches reverted to their previous behaviour):\n\nThe Lens preview chart fails to render and shows the exact error from\nissue #203071:\n\n> Layer 1 error: Expected AND, OR, end of input but \":\" found.\n> log.level : \"error\" AND NOT message : something: with a colon\n> ----------------------------------------------------^\n\n<img width=\"1600\" height=\"1100\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/31444aef-2ba9-4734-a9bf-4058389252e5\"\n/>\n\n**After the fix:**\n\nThe KQL syntax error is gone — the criterion is rendered as `NOT message\n: \"something: with a colon\"` and the chart layer is no longer in an\nerror state from this code path.\n\n<img width=\"1600\" height=\"1100\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4343221c-3c70-4c26-a049-27065b280c15\"\n/>\n\n#### Note on a separate, pre-existing chart error\n\nIn the after screenshot, the Lens chart still shows a different error:\n\n> [layeredXyVis] > [event_annotations_result] >\n[extendedAnnotationLayer] > [manual_point_event_annotation] > Value\n'warning' is not among the allowed options for argument 'icon'\n\nThis is unrelated to issue #203071 — it comes from the threshold\nannotation expression building a `manual_point_event_annotation` with\n`icon: 'warning'`, which is not in the current allowed set on `main`. It\nhappens regardless of whether a colon is present in any criterion value.\nIt was also present before the fix, but masked by the KQL parse failure\noccurring earlier in the pipeline. Filing/finding a separate issue for\nthat is out of scope for this PR; it does not affect the correctness of\nthe change here.\n\n### Programmatic verification\n\nThe new unit tests pipe `convertCriteriaToKQL` output through\n`fromKueryExpression` from `@kbn/es-query` — the same parser the Lens\nchart uses to validate KQL — for every problematic special character.\nBefore the fix, those assertions throw `KQLSyntaxError: Expected AND,\nOR, end of input but \":\" found.` (the exact error from the issue). After\nthe fix, they pass.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Existing workarounds**: users who applied the documented workaround\non the issue (wrapping the value in literal double quotes, e.g. `\"foo:\nbar\"`) will, after this fix, generate KQL like `NOT message : \"\\\"foo:\nbar\\\"\"` from the alert details preview chart. The actual alert rule\nexecution is unaffected (it does not pass through this helper). For\npreview-chart purposes the embedded quotes will be treated as part of\nthe phrase text, which is more accurate to what the user typed than\nbefore but may cause the preview to show no matches if the underlying\nfield tokenises punctuation. Users on the workaround can drop the extra\nquotes once they pick up this fix. No known data-loss or alert-firing\nimpact.\n- Severity: low. The change is contained to a single string helper that\nis used only for generating the KQL passed to the alert details Lens\nchart.\n\n### Release Notes\n\nFixes a bug where the Log threshold rule's alert details preview chart\nwould fail to render with a KQL syntax error when a criterion used\n`matches phrase` or `does not match phrase` with a value containing\ncharacters such as `:`.\n\n---\n\nCreated with Cursor using Claude Opus 4.7\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d21d3439de5d9fd904f1e4c7036982da41f38ed7"}}]}] BACKPORT-->