### PR TITLE
[9.4] [Entity Analytics] 17084 ea homepage privileges banner (#266523)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -118,4 +118,5 @@ export {
   getEntityIndexPattern,
   getEntitiesAlias,
   getLatestEntitiesIndexName,
+  getLatestEntityIndexPattern,
 } from './domain/entity_index';

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/check_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/check_privileges.ts
@@ -10,6 +10,7 @@ import {
   API_VERSIONS,
   ENTITY_STORE_ROUTES,
   getEntitiesAlias,
+  getLatestEntityIndexPattern,
   ENTITY_LATEST,
 } from '../../../common';
 import { DEFAULT_ENTITY_STORE_PERMISSIONS } from '../constants';
@@ -46,17 +47,19 @@ export function registerCheckPrivileges(router: EntityStorePluginRouter) {
         const entityStoreCtx = await ctx.entityStore;
         const security = entityStoreCtx.security;
         const spaceId = entityStoreCtx.namespace;
-        const entitiesIndexPattern = getEntitiesAlias(ENTITY_LATEST, spaceId);
+        const entitiesAliasPattern = getEntitiesAlias(ENTITY_LATEST, spaceId);
+        const latestEntityIndexPattern = getLatestEntityIndexPattern(spaceId);
 
         const response = await checkAndFormatPrivileges({
-          indexPattern: entitiesIndexPattern,
+          indexPatterns: [entitiesAliasPattern, latestEntityIndexPattern],
           request: req,
           security,
           privilegesToCheck: {
             elasticsearch: {
               cluster: [],
               index: {
-                [entitiesIndexPattern]: ['read', 'write'],
+                [entitiesAliasPattern]: ['read', 'write'],
+                [latestEntityIndexPattern]: ['read', 'write'],
               },
             },
           },

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.test.ts
@@ -196,7 +196,7 @@ describe('formatPrivileges', () => {
       kibana: [],
     };
 
-    const result = hasReadWritePermissions(privileges.elasticsearch, TEST_INDEX_PATTERN);
+    const result = hasReadWritePermissions(privileges.elasticsearch, [TEST_INDEX_PATTERN]);
 
     expect(result).toEqual({
       has_read_permissions: true,

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.ts
@@ -71,7 +71,7 @@ export const formatPrivileges = (
 };
 
 interface CheckAndFormatPrivilegesOpts {
-  indexPattern: string;
+  indexPatterns: string[];
   request: KibanaRequest;
   security: SecurityPluginStart;
   privilegesToCheck: CheckPrivilegesPayload;
@@ -81,7 +81,7 @@ export async function checkAndFormatPrivileges({
   request,
   security,
   privilegesToCheck,
-  indexPattern,
+  indexPatterns,
 }: CheckAndFormatPrivilegesOpts): Promise<Privileges> {
   const checkPrivileges = security.authz.checkPrivilegesDynamicallyWithRequest(request);
   const { privileges, hasAllRequested } = await checkPrivileges(privilegesToCheck);
@@ -89,21 +89,22 @@ export async function checkAndFormatPrivileges({
   return {
     privileges: formatPrivileges(privileges),
     has_all_required: hasAllRequested,
-    ...hasReadWritePermissions(privileges.elasticsearch, indexPattern),
+    ...hasReadWritePermissions(privileges.elasticsearch, indexPatterns),
   };
 }
 
 export const hasReadWritePermissions = (
   { index, cluster }: CheckPrivilegesResponse['privileges']['elasticsearch'],
-  indexKey = ''
+  indexKeys: string[] = []
 ) => {
   const has =
     (type: string) =>
     ({ privilege, authorized }: { privilege: string; authorized: boolean }) =>
       privilege === type && authorized;
+  const hasOnAllIndices = (type: string) =>
+    indexKeys.length > 0 && indexKeys.every((key) => index[key]?.some(has(type)));
   return {
-    has_read_permissions: index[indexKey]?.some(has('read')) || cluster.some(has('read')),
-
-    has_write_permissions: index[indexKey]?.some(has('write')) || cluster.some(has('write')),
+    has_read_permissions: hasOnAllIndices('read') || cluster.some(has('read')),
+    has_write_permissions: hasOnAllIndices('write') || cluster.some(has('write')),
   };
 };

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/check_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/check_privileges.spec.ts
@@ -8,10 +8,16 @@
 import { apiTest } from '@kbn/scout-security';
 import { expect } from '@kbn/scout-security/api';
 import { INTERNAL_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
-import { FF_ENABLE_ENTITY_STORE_V2, getEntitiesAlias, ENTITY_LATEST } from '../../../../common';
+import {
+  FF_ENABLE_ENTITY_STORE_V2,
+  getEntitiesAlias,
+  ENTITY_LATEST,
+  getLatestEntityIndexPattern,
+} from '../../../../common';
 
 apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }, () => {
-  const ENTITIES_INDEX = getEntitiesAlias(ENTITY_LATEST, 'default');
+  const ENTITIES_ALIAS_INDEX = getEntitiesAlias(ENTITY_LATEST, 'default');
+  const LATEST_ENTITY_INDEX = getLatestEntityIndexPattern('default');
 
   apiTest.beforeAll(async ({ kbnClient }) => {
     await kbnClient.uiSettings.update({
@@ -81,12 +87,46 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
   );
 
   apiTest(
+    'Should return has_read_permissions: false when user has read access to only one of the two required indices',
+    async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asInteractiveUser({
+        elasticsearch: {
+          cluster: [],
+          indices: [{ names: [ENTITIES_ALIAS_INDEX], privileges: ['read'] }],
+        },
+        kibana: [
+          {
+            base: [],
+            feature: { siemV5: ['all'] },
+            spaces: ['*'],
+          },
+        ],
+      });
+
+      const response = await apiClient.get(ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES, {
+        headers: { ...cookieHeader, ...INTERNAL_HEADERS },
+        responseType: 'json',
+      });
+
+      expect(response).toHaveStatusCode(200);
+      expect(response.body).toMatchObject({
+        has_all_required: false,
+        has_read_permissions: false,
+        has_write_permissions: false,
+      });
+    }
+  );
+
+  apiTest(
     'Should return limited privileges for user with read-only access to entities index',
     async ({ apiClient, samlAuth }) => {
       const { cookieHeader } = await samlAuth.asInteractiveUser({
         elasticsearch: {
           cluster: [],
-          indices: [{ names: [ENTITIES_INDEX], privileges: ['read'] }],
+          indices: [
+            { names: [ENTITIES_ALIAS_INDEX], privileges: ['read'] },
+            { names: [LATEST_ENTITY_INDEX], privileges: ['read'] },
+          ],
         },
         kibana: [
           {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/missing_privileges/translations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/missing_privileges/translations.tsx
@@ -8,7 +8,7 @@
 import { EuiCode } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React from 'react';
+import React, { type ComponentProps } from 'react';
 import {
   DEFAULT_ITEMS_INDEX,
   DEFAULT_LISTS_INDEX,
@@ -17,7 +17,8 @@ import {
 } from '../../../../common/constants';
 import { CommaSeparatedValues } from './comma_separated_values';
 import type { MissingPrivileges } from '../../hooks/use_missing_privileges';
-import { DetectionsRequirementsLink, SecuritySolutionRequirementsLink } from '../links_to_docs';
+import { DocLink } from '../links_to_docs/doc_link';
+import * as linksI18n from '../links_to_docs/links_translations';
 
 export const PRIVILEGES_MISSING_TITLE = i18n.translate(
   'xpack.securitySolution.common.onboarding.assistantCard.missingPrivileges.title',
@@ -68,63 +69,83 @@ const CANNOT_EDIT_ALERTS = i18n.translate(
   }
 );
 
+const DEFAULT_DOC_LINKS = [
+  {
+    docPath: linksI18n.DETECTIONS_REQUIREMENTS_LINK_PATH,
+    linkText: linksI18n.DETECTIONS_REQUIREMENTS_LINK_TEXT,
+  },
+  {
+    docPath: linksI18n.SOLUTION_REQUIREMENTS_LINK_PATH,
+    linkText: linksI18n.SOLUTION_REQUIREMENTS_LINK_TEXT,
+  },
+];
+
 export const missingPrivilegesCallOutBody = ({
   indexPrivileges,
   featurePrivileges = [],
-}: MissingPrivileges) => (
-  <FormattedMessage
-    id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.messageDetail"
-    defaultMessage="{essence} {indexPrivileges} {featurePrivileges} Related documentation: {docs}"
-    values={{
-      essence: (
-        <p>
-          <FormattedMessage
-            id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.essenceDescription"
-            defaultMessage="You need the following privileges to fully access this functionality. Contact your administrator for further assistance."
-          />
-        </p>
-      ),
-      indexPrivileges:
-        indexPrivileges.length > 0 ? (
-          <>
+  docs = DEFAULT_DOC_LINKS,
+}: MissingPrivileges & { docs?: Array<ComponentProps<typeof DocLink>> }) => {
+  return (
+    <FormattedMessage
+      id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.messageDetail"
+      defaultMessage="{essence} {indexPrivileges} {featurePrivileges} {docs}"
+      values={{
+        essence: (
+          <p>
             <FormattedMessage
-              id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.indexPrivilegesTitle"
-              defaultMessage="Missing Elasticsearch index privileges:"
+              id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.essenceDescription"
+              defaultMessage="You need the following privileges to fully access this functionality. Contact your administrator for further assistance."
             />
-            <ul>
-              {indexPrivileges.map(([index, missingPrivileges]) => (
-                <li key={index}>{missingPrivilegesMessage(index, missingPrivileges)}</li>
-              ))}
-            </ul>
-          </>
-        ) : null,
-      featurePrivileges:
-        featurePrivileges.length > 0 ? (
-          <>
-            <FormattedMessage
-              id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.featurePrivilegesTitle"
-              defaultMessage="Missing Kibana feature privileges:"
-            />
-            <ul>
-              {featurePrivileges.map(([feature, missingPrivileges]) => (
-                <li key={feature}>{missingFeaturePrivileges(feature, missingPrivileges)}</li>
-              ))}
-            </ul>
-          </>
-        ) : null,
-      docs: (
-        <ul>
-          <li>
-            <DetectionsRequirementsLink />
-          </li>
-          <li>
-            <SecuritySolutionRequirementsLink />
-          </li>
-        </ul>
-      ),
-    }}
-  />
-);
+          </p>
+        ),
+        indexPrivileges:
+          indexPrivileges.length > 0 ? (
+            <>
+              <FormattedMessage
+                id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.indexPrivilegesTitle"
+                defaultMessage="Missing Elasticsearch index privileges:"
+              />
+              <ul>
+                {indexPrivileges.map(([index, missingPrivileges]) => (
+                  <li key={index}>{missingPrivilegesMessage(index, missingPrivileges)}</li>
+                ))}
+              </ul>
+            </>
+          ) : null,
+        featurePrivileges:
+          featurePrivileges.length > 0 ? (
+            <>
+              <FormattedMessage
+                id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.featurePrivilegesTitle"
+                defaultMessage="Missing Kibana feature privileges:"
+              />
+              <ul>
+                {featurePrivileges.map(([feature, missingPrivileges]) => (
+                  <li key={feature}>{missingFeaturePrivileges(feature, missingPrivileges)}</li>
+                ))}
+              </ul>
+            </>
+          ) : null,
+        docs:
+          docs.length > 0 ? (
+            <>
+              <FormattedMessage
+                id="xpack.securitySolution.common.missingPrivilegesCallOut.messageBody.docsTitle"
+                defaultMessage="Related documentation:"
+              />
+              <ul>
+                {docs.map(({ docPath, linkText }) => (
+                  <li key={docPath}>
+                    <DocLink docPath={docPath} linkText={linkText} />
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null,
+      }}
+    />
+  );
+};
 
 interface PrivilegeExplanations {
   [key: string]: {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_read_privileges_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_read_privileges_callout.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TestProviders } from '../../common/mock';
+import { EntityAnalyticsReadPrivilegesCallout } from './entity_analytics_read_privileges_callout';
+import type { RiskEngineMissingPrivilegesResponse } from '../hooks/use_missing_risk_engine_privileges';
+import type { EntityAnalyticsPrivileges } from '../../../common/api/entity_analytics';
+
+jest.mock('../../common/components/callouts/use_callout_storage', () => ({
+  useCallOutStorage: () => ({
+    isVisible: () => true,
+    dismiss: jest.fn(),
+  }),
+}));
+
+const ALL_PRIVILEGES_GRANTED: RiskEngineMissingPrivilegesResponse = {
+  isLoading: false,
+  hasAllRequiredPrivileges: true,
+};
+
+const RISK_ENGINE_PRIVILEGE = 'risk-score-index-pattern';
+const ENTITY_ENGINE_PRIVILEGE = 'entities-store-index-pattern';
+const CALLOUT_TITLE = 'Insufficient privileges';
+
+const makeEntityEnginePrivileges = (
+  indexPrivileges: Record<string, Record<string, boolean>>
+): EntityAnalyticsPrivileges => ({
+  has_all_required: true,
+  has_read_permissions: true,
+  privileges: {
+    elasticsearch: { index: indexPrivileges },
+  },
+});
+
+const renderCallout = (
+  riskEngineReadPrivileges: RiskEngineMissingPrivilegesResponse,
+  entityEnginePrivileges: EntityAnalyticsPrivileges | undefined
+) =>
+  render(
+    <TestProviders>
+      <EntityAnalyticsReadPrivilegesCallout
+        riskEngineReadPrivileges={riskEngineReadPrivileges}
+        entityEnginePrivileges={entityEnginePrivileges}
+      />
+    </TestProviders>
+  );
+
+describe('EntityAnalyticsReadPrivilegesCallout', () => {
+  it('renders nothing when all privileges are granted', () => {
+    renderCallout(ALL_PRIVILEGES_GRANTED, makeEntityEnginePrivileges({}));
+
+    expect(screen.queryByText(CALLOUT_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing while risk engine privileges are loading', () => {
+    renderCallout({ isLoading: true }, makeEntityEnginePrivileges({}));
+
+    expect(screen.queryByText(CALLOUT_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when entityEnginePrivileges is undefined', () => {
+    renderCallout(ALL_PRIVILEGES_GRANTED, undefined);
+
+    expect(screen.queryByText(CALLOUT_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('shows callout when risk engine has missing read index privileges', () => {
+    const missingPrivileges: RiskEngineMissingPrivilegesResponse = {
+      isLoading: false,
+      hasAllRequiredPrivileges: false,
+      missingPrivileges: {
+        indexPrivileges: [[RISK_ENGINE_PRIVILEGE, ['read']]],
+        clusterPrivileges: { enable: [], run: [] },
+      },
+    };
+
+    renderCallout(missingPrivileges, makeEntityEnginePrivileges({}));
+
+    expect(screen.getByText(CALLOUT_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(RISK_ENGINE_PRIVILEGE)).toBeInTheDocument();
+  });
+
+  it('shows callout when entity store index is missing read privilege', () => {
+    const entityPrivileges = makeEntityEnginePrivileges({
+      [ENTITY_ENGINE_PRIVILEGE]: { read: false, view_index_metadata: false },
+    });
+
+    renderCallout(ALL_PRIVILEGES_GRANTED, entityPrivileges);
+
+    expect(screen.getByText(CALLOUT_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(ENTITY_ENGINE_PRIVILEGE)).toBeInTheDocument();
+  });
+
+  it('combines missing privileges from both risk engine and entity store', () => {
+    const missingRiskPrivileges: RiskEngineMissingPrivilegesResponse = {
+      isLoading: false,
+      hasAllRequiredPrivileges: false,
+      missingPrivileges: {
+        indexPrivileges: [[RISK_ENGINE_PRIVILEGE, ['read']]],
+        clusterPrivileges: { enable: [], run: [] },
+      },
+    };
+    const entityPrivileges = makeEntityEnginePrivileges({
+      [ENTITY_ENGINE_PRIVILEGE]: { read: false, view_index_metadata: false },
+    });
+
+    renderCallout(missingRiskPrivileges, entityPrivileges);
+
+    expect(screen.getByText(CALLOUT_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(RISK_ENGINE_PRIVILEGE)).toBeInTheDocument();
+    expect(screen.getByText(ENTITY_ENGINE_PRIVILEGE)).toBeInTheDocument();
+  });
+
+  it('shows callout when entity store index is missing view_index_metadata even if read is true', () => {
+    const entityPrivileges = makeEntityEnginePrivileges({
+      [ENTITY_ENGINE_PRIVILEGE]: { read: true, view_index_metadata: false },
+    });
+
+    renderCallout(ALL_PRIVILEGES_GRANTED, entityPrivileges);
+
+    expect(screen.getByText(CALLOUT_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(ENTITY_ENGINE_PRIVILEGE)).toBeInTheDocument();
+  });
+
+  it('renders nothing when risk engine has missing privileges but empty index list', () => {
+    const missingPrivileges: RiskEngineMissingPrivilegesResponse = {
+      isLoading: false,
+      hasAllRequiredPrivileges: false,
+      missingPrivileges: {
+        indexPrivileges: [],
+        clusterPrivileges: { enable: ['cluster-privilege'], run: [] },
+      },
+    };
+
+    renderCallout(missingPrivileges, makeEntityEnginePrivileges({}));
+
+    expect(screen.queryByText(CALLOUT_TITLE)).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_read_privileges_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_read_privileges_callout.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import hash from 'object-hash';
+import { CallOutSwitcher } from '../../common/components/callouts';
+import { missingPrivilegesCallOutBody } from '../../common/components/missing_privileges';
+import { MISSING_PRIVILEGES_CALLOUT_TITLE } from '../../common/components/missing_privileges/translations';
+import type { MissingIndexPrivileges } from '../../common/hooks/use_missing_privileges';
+import type { RiskEngineMissingPrivilegesResponse } from '../hooks/use_missing_risk_engine_privileges';
+import type { EntityAnalyticsPrivileges } from '../../../common/api/entity_analytics';
+
+/**
+ * Displays a Callout section when the user has missing privileges to view the Entity Analytics home page.
+ */
+export const EntityAnalyticsReadPrivilegesCallout = React.memo(
+  ({
+    riskEngineReadPrivileges,
+    entityEnginePrivileges,
+  }: {
+    riskEngineReadPrivileges: RiskEngineMissingPrivilegesResponse;
+    entityEnginePrivileges: EntityAnalyticsPrivileges | undefined;
+  }) => {
+    const message = useMemo(() => {
+      const indexPrivileges: MissingIndexPrivileges[] = [
+        ...getRiskEngineMissingReadPrivileges(riskEngineReadPrivileges),
+        ...getEntityStoreMissingReadPrivileges(entityEnginePrivileges),
+      ];
+
+      if (indexPrivileges.length === 0) return null;
+
+      return {
+        type: 'primary' as const,
+        id: `entity-analytics-home-missing-privileges-${hash(indexPrivileges)}`,
+        title: MISSING_PRIVILEGES_CALLOUT_TITLE,
+        description: missingPrivilegesCallOutBody({
+          indexPrivileges,
+          featurePrivileges: [],
+          docs: [],
+        }),
+      };
+    }, [riskEngineReadPrivileges, entityEnginePrivileges]);
+
+    if (!message) return null;
+
+    return <CallOutSwitcher namespace="entity-analytics-home" condition={true} message={message} />;
+  }
+);
+EntityAnalyticsReadPrivilegesCallout.displayName = 'EntityAnalyticsPrivilegesCallout';
+
+const READ_RELEVANT_PRIVILEGES = new Set(['read', 'view_index_metadata']);
+
+const getEntityStoreMissingReadPrivileges = (
+  privileges: EntityAnalyticsPrivileges | undefined
+): MissingIndexPrivileges[] => {
+  if (!privileges) return [];
+
+  return Object.entries(privileges.privileges.elasticsearch.index ?? {})
+    .map(
+      ([indexName, privs]): MissingIndexPrivileges => [
+        indexName,
+        Object.entries(privs)
+          .filter(([priv, authorized]) => !authorized && READ_RELEVANT_PRIVILEGES.has(priv))
+          .map(([priv]) => priv),
+      ]
+    )
+    .filter(([, missingPrivs]) => missingPrivs.length > 0);
+};
+
+const getRiskEngineMissingReadPrivileges = (
+  privileges: RiskEngineMissingPrivilegesResponse
+): MissingIndexPrivileges[] => {
+  if (privileges.isLoading || privileges.hasAllRequiredPrivileges) return [];
+
+  return privileges.missingPrivileges.indexPrivileges
+    .filter(([, missingPrivs]) => missingPrivs.length > 0)
+    .map(([indexName, missingPrivs]) => [indexName, [...missingPrivs]]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_engine_privileges.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_engine_privileges.ts
@@ -8,8 +8,10 @@
 import type { UseQueryResult } from '@kbn/react-query';
 import { useQuery } from '@kbn/react-query';
 import type { SecurityAppError } from '@kbn/securitysolution-t-grid';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/common';
 import type { EntityAnalyticsPrivileges } from '../../../../../common/api/entity_analytics';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
+import { useKibana } from '../../../../common/lib/kibana';
 
 export const GET_ENTITY_ENGINE_PRIVILEGES = ['get_entity_engine_privileges'] as const;
 
@@ -17,6 +19,12 @@ export const useEntityEnginePrivileges = (): UseQueryResult<
   EntityAnalyticsPrivileges,
   SecurityAppError
 > => {
-  const { fetchEntityStorePrivileges } = useEntityAnalyticsRoutes();
-  return useQuery(GET_ENTITY_ENGINE_PRIVILEGES, fetchEntityStorePrivileges);
+  const { fetchEntityStorePrivileges, fetchEntityStoreV2Privileges } = useEntityAnalyticsRoutes();
+  const { uiSettings } = useKibana().services;
+  const isEntityStoreV2Enabled = uiSettings?.get<boolean>(FF_ENABLE_ENTITY_STORE_V2);
+
+  return useQuery(
+    [...GET_ENTITY_ENGINE_PRIVILEGES, isEntityStoreV2Enabled],
+    isEntityStoreV2Enabled ? fetchEntityStoreV2Privileges : fetchEntityStorePrivileges
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
@@ -14,6 +14,8 @@ import { useSourcererDataView } from '../../sourcerer/containers';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { useEntityStoreStatus } from '../components/entity_store/hooks/use_entity_store';
+import { useMissingRiskEnginePrivileges } from '../hooks/use_missing_risk_engine_privileges';
+import { useEntityEnginePrivileges } from '../components/entity_store/hooks/use_entity_engine_privileges';
 
 jest.mock('../../common/components/links/link_props', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -117,6 +119,20 @@ jest.mock('../components/entity_store/hooks/use_entity_store', () => ({
   })),
 }));
 
+jest.mock('../hooks/use_missing_risk_engine_privileges', () => ({
+  useMissingRiskEnginePrivileges: jest.fn(() => ({
+    isLoading: false,
+    hasAllRequiredPrivileges: true,
+  })),
+}));
+
+jest.mock('../components/entity_store/hooks/use_entity_engine_privileges', () => ({
+  useEntityEnginePrivileges: jest.fn(() => ({
+    isLoading: false,
+    data: { has_read_permissions: true, privileges: { elasticsearch: { index: {} }, kibana: [] } },
+  })),
+}));
+
 // useEntityURLState is already mocked inside the entities_table mock above
 
 jest.mock('../../common/hooks/use_space_id', () => ({
@@ -133,6 +149,8 @@ const mockUseSourcererDataView = useSourcererDataView as jest.Mock;
 const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 const mockUseDataView = useDataView as jest.Mock;
 const mockUseEntityStoreStatus = useEntityStoreStatus as jest.Mock;
+const mockUseMissingRiskEnginePrivileges = useMissingRiskEnginePrivileges as jest.Mock;
+const mockUseEntityEnginePrivileges = useEntityEnginePrivileges as jest.Mock;
 
 describe('EntityAnalyticsHomePage', () => {
   beforeEach(() => {
@@ -156,6 +174,19 @@ describe('EntityAnalyticsHomePage', () => {
 
     mockUseEntityStoreStatus.mockReturnValue({
       data: { status: 'running', engines: [] },
+    });
+
+    mockUseMissingRiskEnginePrivileges.mockReturnValue({
+      isLoading: false,
+      hasAllRequiredPrivileges: true,
+    });
+
+    mockUseEntityEnginePrivileges.mockReturnValue({
+      isLoading: false,
+      data: {
+        has_read_permissions: true,
+        privileges: { elasticsearch: { index: {} }, kibana: [] },
+      },
     });
   });
 
@@ -262,8 +293,9 @@ describe('EntityAnalyticsHomePage', () => {
       { wrapper: TestProviders }
     );
 
-    // EmptyPrompt should be rendered
-    expect(screen.queryByTestId('entityAnalyticsHomePage')).not.toBeInTheDocument();
+    // EmptyPrompt should be rendered; main content should not
+    expect(screen.queryByTestId('entity-analytics-home-entities-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dynamic-risk-level-panel')).not.toBeInTheDocument();
   });
 
   it("renders entity store disabled empty prompt when status is 'not_installed'", () => {
@@ -282,7 +314,7 @@ describe('EntityAnalyticsHomePage', () => {
     expect(screen.getByRole('heading', { name: 'Entity analytics' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Enable Entity analytics' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Read the docs/ })).toBeInTheDocument();
-    expect(screen.queryByTestId('entityAnalyticsHomePage')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entity-analytics-home-entities-table')).not.toBeInTheDocument();
   });
 
   it("renders entity store disabled empty prompt when status is 'stopped'", () => {
@@ -301,7 +333,7 @@ describe('EntityAnalyticsHomePage', () => {
     expect(screen.getByRole('heading', { name: 'Entity analytics' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Enable Entity analytics' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Read the docs/ })).toBeInTheDocument();
-    expect(screen.queryByTestId('entityAnalyticsHomePage')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entity-analytics-home-entities-table')).not.toBeInTheDocument();
   });
 
   it("does not render disabled empty prompt when status is 'running'", () => {
@@ -355,6 +387,95 @@ describe('EntityAnalyticsHomePage', () => {
     expect(docsLink).toHaveAttribute('target', '_blank');
   });
 
+  it('renders full-page loader when entity engine privileges are loading', () => {
+    mockUseEntityEnginePrivileges.mockReturnValue({ isLoading: true, data: undefined });
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
+    );
+
+    expect(screen.getByRole('progressbar', { name: 'Loading' })).toBeInTheDocument();
+    expect(screen.queryByTestId('entityAnalyticsHomePage')).not.toBeInTheDocument();
+  });
+
+  it('renders full-page loader when risk engine privileges are loading', () => {
+    mockUseMissingRiskEnginePrivileges.mockReturnValue({ isLoading: true });
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
+    );
+
+    expect(screen.getByRole('progressbar', { name: 'Loading' })).toBeInTheDocument();
+    expect(screen.queryByTestId('entityAnalyticsHomePage')).not.toBeInTheDocument();
+  });
+
+  it('renders NoPrivileges when user lacks entity engine read permissions', () => {
+    mockUseEntityEnginePrivileges.mockReturnValue({
+      isLoading: false,
+      data: {
+        has_read_permissions: false,
+        privileges: { elasticsearch: { index: {} }, kibana: [] },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
+    );
+
+    expect(screen.getByTestId('noPrivilegesPage')).toBeInTheDocument();
+    expect(screen.queryByTestId('entity-analytics-home-entities-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dynamic-risk-level-panel')).not.toBeInTheDocument();
+  });
+
+  it('does not render NoPrivileges when entity engine privileges query errors', () => {
+    mockUseEntityEnginePrivileges.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      data: undefined,
+    });
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
+    );
+
+    expect(screen.queryByTestId('noPrivilegesPage')).not.toBeInTheDocument();
+    expect(screen.getByTestId('entityAnalyticsHomePage')).toBeInTheDocument();
+  });
+
+  it('renders Privileges Callout when user lacks risk engine read permissions', () => {
+    mockUseMissingRiskEnginePrivileges.mockReturnValue({
+      isLoading: false,
+      hasAllRequiredPrivileges: false,
+      missingPrivileges: {
+        indexPrivileges: [['risk-score-index-pattern', ['read']]],
+        clusterPrivileges: { enable: [], run: [] },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
+    );
+
+    expect(screen.getByText('Insufficient privileges')).toBeInTheDocument();
+    expect(screen.queryByTestId('entity-analytics-home-entities-table')).toBeInTheDocument();
+    expect(screen.queryByTestId('dynamic-risk-level-panel')).toBeInTheDocument();
+  });
+
   it('indicesExist=false still wins over entity store disabled state', () => {
     mockUseSourcererDataView.mockReturnValue({
       indicesExist: false,
@@ -379,6 +500,6 @@ describe('EntityAnalyticsHomePage', () => {
     );
 
     expect(screen.queryByTestId('entityStoreDisabledEmptyPrompt')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('entityAnalyticsHomePage')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entity-analytics-home-entities-table')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -60,6 +60,14 @@ import { useHuntingLeads } from '../components/threat_hunting/top_threat_hunting
 import { useLeadAttachment } from '../components/threat_hunting/top_threat_hunting_leads/use_lead_attachment';
 import { useAgentBuilderAvailability } from '../../agent_builder/hooks/use_agent_builder_availability';
 import type { HuntingLead } from '../components/threat_hunting/top_threat_hunting_leads/types';
+import { useMissingRiskEnginePrivileges } from '../hooks/use_missing_risk_engine_privileges';
+import { useEntityEnginePrivileges } from '../components/entity_store/hooks/use_entity_engine_privileges';
+import { EntityAnalyticsReadPrivilegesCallout } from '../components/entity_analytics_read_privileges_callout';
+import { NoPrivileges } from '../../common/components/no_privileges';
+
+const PAGE_TITLE = i18n.translate('xpack.securitySolution.entityAnalytics.homePage.pageTitle', {
+  defaultMessage: 'Entity analytics',
+});
 
 const getDefaultQuery = ({ query, filters }: EntitiesBaseURLQuery): URLQuery => ({
   query,
@@ -78,6 +86,40 @@ const anomaliesPanelFlexItemStyle = css`
 `;
 
 export const EntityAnalyticsHomePage = () => {
+  const riskEngineReadPrivileges = useMissingRiskEnginePrivileges({ readonly: true });
+  const entityEnginePrivilegesQuery = useEntityEnginePrivileges();
+
+  if (entityEnginePrivilegesQuery.isLoading || riskEngineReadPrivileges.isLoading) {
+    return <PageLoader />;
+  }
+
+  const noPrivileges =
+    !entityEnginePrivilegesQuery.isError && !entityEnginePrivilegesQuery.data?.has_read_permissions;
+
+  return (
+    <>
+      <EntityAnalyticsReadPrivilegesCallout
+        riskEngineReadPrivileges={riskEngineReadPrivileges}
+        entityEnginePrivileges={entityEnginePrivilegesQuery.data}
+      />
+      <SecuritySolutionPageWrapper data-test-subj="entityAnalyticsHomePage">
+        {noPrivileges ? (
+          <NoPrivileges
+            pageName={PAGE_TITLE.toLowerCase()}
+            docLinkSelector={(docLinks) =>
+              docLinks.securitySolution.entityAnalytics.riskScorePrerequisites
+            }
+          />
+        ) : (
+          <EntityAnalyticsHomePageContent />
+        )}
+      </SecuritySolutionPageWrapper>
+      <SpyRoute pageName={SecurityPageName.entityAnalyticsHomePage} />
+    </>
+  );
+};
+
+const EntityAnalyticsHomePageContent = () => {
   const { telemetry, agentBuilder, http } = useKibana().services;
   const { isAgentChatExperienceEnabled } = useAgentBuilderAvailability();
   const { data: availableConnectors } = useLoadConnectors({ http, featureId: 'lead_generation' });
@@ -215,105 +257,96 @@ export const EntityAnalyticsHomePage = () => {
         />
       </FiltersGlobal>
 
-      <SecuritySolutionPageWrapper data-test-subj="entityAnalyticsHomePage">
-        <HeaderPage
-          title={
-            <FormattedMessage
-              id="xpack.securitySolution.entityAnalytics.homePage.pageTitle"
-              defaultMessage="Entity analytics"
-            />
-          }
-          rightSideItems={[
-            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <WatchlistFilter
-                  selectedId={selectedWatchlistId ?? ''}
-                  onChangeSelectedId={setSelectedWatchlist}
-                />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  display="base"
-                  iconType="gear"
-                  size="m"
-                  aria-label={i18n.translate(
-                    'xpack.securitySolution.entityAnalytics.homePage.watchlistsSettingsButtonAriaLabel',
-                    { defaultMessage: 'Watchlists settings' }
-                  )}
-                  href={getSecuritySolutionUrl({
-                    deepLinkId: SecurityPageName.entityAnalyticsManagement,
-                    path: `/${TabId.Watchlists}`,
-                  })}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>,
-          ]}
-        />
-
-        {isSourcererLoading ? (
-          <EuiLoadingSpinner size="l" data-test-subj="entityAnalyticsHomePageLoader" />
-        ) : (
-          <EuiFlexGroup direction="column" gutterSize="l">
-            {leadGenerationEnabled && !leadsReadPermissionError && (
-              <EuiFlexItem>
-                <TopThreatHuntingLeads
-                  leads={leads}
-                  totalCount={totalCount}
-                  isLoading={isLeadsLoading}
-                  isGenerating={isGenerating}
-                  hasGenerated={hasGenerated}
-                  lastRunTimestamp={lastRunTimestamp}
-                  isScheduled={isScheduled}
-                  onToggleSchedule={toggleSchedule}
-                  onSeeAll={handleOpenFlyout}
-                  onLeadClick={handleOpenLeadInChat}
-                  onHuntInChat={handleHuntInChat}
-                  onGenerate={generate}
-                  connectorId={connectorId}
-                  hasValidConnector={hasValidConnector}
-                  onConnectorIdSelected={safeSetConnectorId}
-                  isAgentChatExperienceEnabled={isAgentChatExperienceEnabled}
-                  hasWritePermissionError={leadsWritePermissionError}
-                />
-              </EuiFlexItem>
-            )}
-
-            <EuiFlexItem>
-              <EuiFlexGroup wrap gutterSize="m">
-                <EuiFlexItem grow={3} css={riskPanelFlexItemStyle}>
-                  <EuiPanel hasBorder>
-                    <DynamicRiskLevelPanel
-                      watchlistId={selectedWatchlistId}
-                      watchlistName={selectedWatchlistName}
-                      entityDataView={entityDataView}
-                    />
-                  </EuiPanel>
-                </EuiFlexItem>
-                <EuiFlexItem grow={5} css={anomaliesPanelFlexItemStyle}>
-                  <EuiPanel hasBorder>
-                    <EntityAnalyticsRecentAnomalies watchlistId={selectedWatchlistId} />
-                  </EuiPanel>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-
-            <EuiPanel hasBorder>
-              <EntityAnalyticsEntitiesTable
-                watchlistId={selectedWatchlistId}
-                watchlistName={selectedWatchlistName}
-                entityDataView={entityDataView}
-                entityDataViewLoading={entityDataViewLoading}
+      <HeaderPage
+        title={PAGE_TITLE}
+        rightSideItems={[
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <WatchlistFilter
+                selectedId={selectedWatchlistId ?? ''}
+                onChangeSelectedId={setSelectedWatchlist}
               />
-            </EuiPanel>
-          </EuiFlexGroup>
-        )}
-      </SecuritySolutionPageWrapper>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonIcon
+                display="base"
+                iconType="gear"
+                size="m"
+                aria-label={i18n.translate(
+                  'xpack.securitySolution.entityAnalytics.homePage.watchlistsSettingsButtonAriaLabel',
+                  { defaultMessage: 'Watchlists settings' }
+                )}
+                href={getSecuritySolutionUrl({
+                  deepLinkId: SecurityPageName.entityAnalyticsManagement,
+                  path: `/${TabId.Watchlists}`,
+                })}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>,
+        ]}
+      />
+
+      {isSourcererLoading ? (
+        <EuiLoadingSpinner size="l" data-test-subj="entityAnalyticsHomePageLoader" />
+      ) : (
+        <EuiFlexGroup direction="column" gutterSize="l">
+          {leadGenerationEnabled && !leadsReadPermissionError && (
+            <EuiFlexItem>
+              <TopThreatHuntingLeads
+                leads={leads}
+                totalCount={totalCount}
+                isLoading={isLeadsLoading}
+                isGenerating={isGenerating}
+                hasGenerated={hasGenerated}
+                lastRunTimestamp={lastRunTimestamp}
+                isScheduled={isScheduled}
+                onToggleSchedule={toggleSchedule}
+                onSeeAll={handleOpenFlyout}
+                onLeadClick={handleOpenLeadInChat}
+                onHuntInChat={handleHuntInChat}
+                onGenerate={generate}
+                connectorId={connectorId}
+                hasValidConnector={hasValidConnector}
+                onConnectorIdSelected={safeSetConnectorId}
+                isAgentChatExperienceEnabled={isAgentChatExperienceEnabled}
+                hasWritePermissionError={leadsWritePermissionError}
+              />
+            </EuiFlexItem>
+          )}
+
+          <EuiFlexItem>
+            <EuiFlexGroup wrap gutterSize="m">
+              <EuiFlexItem grow={3} css={riskPanelFlexItemStyle}>
+                <EuiPanel hasBorder>
+                  <DynamicRiskLevelPanel
+                    watchlistId={selectedWatchlistId}
+                    watchlistName={selectedWatchlistName}
+                    entityDataView={entityDataView}
+                  />
+                </EuiPanel>
+              </EuiFlexItem>
+              <EuiFlexItem grow={5} css={anomaliesPanelFlexItemStyle}>
+                <EuiPanel hasBorder>
+                  <EntityAnalyticsRecentAnomalies watchlistId={selectedWatchlistId} />
+                </EuiPanel>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+
+          <EuiPanel hasBorder>
+            <EntityAnalyticsEntitiesTable
+              watchlistId={selectedWatchlistId}
+              watchlistName={selectedWatchlistName}
+              entityDataView={entityDataView}
+              entityDataViewLoading={entityDataViewLoading}
+            />
+          </EuiPanel>
+        </EuiFlexGroup>
+      )}
 
       {leadGenerationEnabled && isFlyoutOpen && (
         <ThreatHuntingLeadsFlyout onClose={handleCloseFlyout} onSelectLead={handleOpenLeadInChat} />
       )}
-
-      <SpyRoute pageName={SecurityPageName.entityAnalyticsHomePage} />
     </>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Analytics] 17084 ea homepage privileges banner (#266523)](https://github.com/elastic/kibana/pull/266523)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"tcalopes","email":"tatiana.lopes@elastic.co"},"sourceCommit":{"committedDate":"2026-05-04T16:08:06Z","message":"[Entity Analytics] 17084 ea homepage privileges banner (#266523)\n\n## Summary\n\nThis PR adds privilege handling to the Entity Analytics homepage,\nfollowing the same pattern used by the alerts page.\n\n### What changed\n- **EntityAnalyticsReadPrivilegesCallout** — new component that\naggregates missing read privileges from both the Risk Engine and the\nEntity Store, and renders a dismissible callout listing the affected\nindices. Only read and view_index_metadata privileges are being\nconsidered for the homepage\n- **EntityAnalyticsHomePage** — now checks two privilege sources at load\ntime:\n- `useEntityEnginePrivileges` — if `has_read_permissions` is false,\n`NoPrivileges` banner is shown and no dashboard content is rendered.\n- `useMissingRiskEnginePrivileges` — missing risk engine privileges only\naffect part of the data (e.g. flyout content), so the UI is still\nrendered but the `EntityAnalyticsReadPrivilegesCallout` is shown at the\ntop.\n  - Both hooks show a loading spinner while their requests are loading\n- **useEntityEnginePrivileges** — previously always called\n`fetchEntityStorePrivileges`. It now reads the `entityStoreEnableV2` UI\nsetting and dispatches to `fetchEntityStoreV2Privileges` when Entity\nStore V2 is active. This also fixes the privilege list shown on the\n`/security/entity_analytics_management page`.\n- **check_privileges** route — previously the privilege check only\ncovered the entities alias (`getEntitiesAlias`) but some queries — like\nthe one for the recent anomalies data and entity flyout content — target\nthe index directly rather than the alias so those pages would silently\nreturn no data for users missing index-level access. The route now\nchecks privileges for both the alias pattern and the concrete\nlatest-entity index pattern (`getLatestEntityIndexPattern`).\n- I did not update the queries to use the alias because from what I\nunderstood from https://github.com/elastic/kibana/pull/260706 we still\nneed to use the index for some scenarios\n\n## How to test\n1. Enable entity store V2 and the new EA home page\n``` \nuiSettings:\n  overrides:\n    securitySolution:entityStoreEnableV2: true\n\nxpack.securitySolution.enableExperimental:\n  - entityAnalyticsEntityStoreV2\n  - entityAnalyticsNewHomePageEnabled\n```\n2. Start Elasticsearch and Kibana locally.\n3. In Stack Management → Roles, create a new role with only the Kibana\n**read** privilege and no Elasticsearch index privileges.\n4. In Stack Management → Users, create a new user and assign the role\nfrom step 3.\n5. Log in to Kibana as the new user and navigate to Security → Entity\nAnalytics.\n6. Verify the \"Insufficient privileges\" callout is visible, listing the\nmissing index privileges.\n7. Verify the No Privileges banner is shown and the entities table /\nrisk panels are hidden.\n8. Navigate to `/security/entity_analytics_management` — confirm the\nprivilege list there now reflects Entity Store V2 indices\n9. Back in your superuser session, edit the role from step 3 and grant\nread access to the indices listed in the callout.\n10. Log back in as the custom user, refresh the Entity Analytics\nhomepage, and confirm the callout is gone and the full dashboard is now\ndisplayed.\n\n<img width=\"1919\" height=\"789\" alt=\"Screenshot 2026-04-29 at 5 15 19 PM\"\nsrc=\"https://github.com/user-attachments/assets/1792cd92-7a57-4baa-993c-c09292ab318f\"\n/>\n<img width=\"1370\" height=\"788\" alt=\"Screenshot 2026-04-29 at 5 16 15 PM\"\nsrc=\"https://github.com/user-attachments/assets/1be4e73f-9a3f-4ca8-a360-3a6d8b4bbb5e\"\n/>\n<img width=\"1913\" height=\"769\" alt=\"Screenshot 2026-04-29 at 5 16 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/8cf30268-d7de-4e0d-a0da-e614c2328556\"\n/>","sha":"a61c31271ab26a578108866e4b7404e9806fe85c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Entity Analytics","backport:version","v9.4.0","v9.5.0"],"title":"[Entity Analytics] 17084 ea homepage privileges banner","number":266523,"url":"https://github.com/elastic/kibana/pull/266523","mergeCommit":{"message":"[Entity Analytics] 17084 ea homepage privileges banner (#266523)\n\n## Summary\n\nThis PR adds privilege handling to the Entity Analytics homepage,\nfollowing the same pattern used by the alerts page.\n\n### What changed\n- **EntityAnalyticsReadPrivilegesCallout** — new component that\naggregates missing read privileges from both the Risk Engine and the\nEntity Store, and renders a dismissible callout listing the affected\nindices. Only read and view_index_metadata privileges are being\nconsidered for the homepage\n- **EntityAnalyticsHomePage** — now checks two privilege sources at load\ntime:\n- `useEntityEnginePrivileges` — if `has_read_permissions` is false,\n`NoPrivileges` banner is shown and no dashboard content is rendered.\n- `useMissingRiskEnginePrivileges` — missing risk engine privileges only\naffect part of the data (e.g. flyout content), so the UI is still\nrendered but the `EntityAnalyticsReadPrivilegesCallout` is shown at the\ntop.\n  - Both hooks show a loading spinner while their requests are loading\n- **useEntityEnginePrivileges** — previously always called\n`fetchEntityStorePrivileges`. It now reads the `entityStoreEnableV2` UI\nsetting and dispatches to `fetchEntityStoreV2Privileges` when Entity\nStore V2 is active. This also fixes the privilege list shown on the\n`/security/entity_analytics_management page`.\n- **check_privileges** route — previously the privilege check only\ncovered the entities alias (`getEntitiesAlias`) but some queries — like\nthe one for the recent anomalies data and entity flyout content — target\nthe index directly rather than the alias so those pages would silently\nreturn no data for users missing index-level access. The route now\nchecks privileges for both the alias pattern and the concrete\nlatest-entity index pattern (`getLatestEntityIndexPattern`).\n- I did not update the queries to use the alias because from what I\nunderstood from https://github.com/elastic/kibana/pull/260706 we still\nneed to use the index for some scenarios\n\n## How to test\n1. Enable entity store V2 and the new EA home page\n``` \nuiSettings:\n  overrides:\n    securitySolution:entityStoreEnableV2: true\n\nxpack.securitySolution.enableExperimental:\n  - entityAnalyticsEntityStoreV2\n  - entityAnalyticsNewHomePageEnabled\n```\n2. Start Elasticsearch and Kibana locally.\n3. In Stack Management → Roles, create a new role with only the Kibana\n**read** privilege and no Elasticsearch index privileges.\n4. In Stack Management → Users, create a new user and assign the role\nfrom step 3.\n5. Log in to Kibana as the new user and navigate to Security → Entity\nAnalytics.\n6. Verify the \"Insufficient privileges\" callout is visible, listing the\nmissing index privileges.\n7. Verify the No Privileges banner is shown and the entities table /\nrisk panels are hidden.\n8. Navigate to `/security/entity_analytics_management` — confirm the\nprivilege list there now reflects Entity Store V2 indices\n9. Back in your superuser session, edit the role from step 3 and grant\nread access to the indices listed in the callout.\n10. Log back in as the custom user, refresh the Entity Analytics\nhomepage, and confirm the callout is gone and the full dashboard is now\ndisplayed.\n\n<img width=\"1919\" height=\"789\" alt=\"Screenshot 2026-04-29 at 5 15 19 PM\"\nsrc=\"https://github.com/user-attachments/assets/1792cd92-7a57-4baa-993c-c09292ab318f\"\n/>\n<img width=\"1370\" height=\"788\" alt=\"Screenshot 2026-04-29 at 5 16 15 PM\"\nsrc=\"https://github.com/user-attachments/assets/1be4e73f-9a3f-4ca8-a360-3a6d8b4bbb5e\"\n/>\n<img width=\"1913\" height=\"769\" alt=\"Screenshot 2026-04-29 at 5 16 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/8cf30268-d7de-4e0d-a0da-e614c2328556\"\n/>","sha":"a61c31271ab26a578108866e4b7404e9806fe85c"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266523","number":266523,"mergeCommit":{"message":"[Entity Analytics] 17084 ea homepage privileges banner (#266523)\n\n## Summary\n\nThis PR adds privilege handling to the Entity Analytics homepage,\nfollowing the same pattern used by the alerts page.\n\n### What changed\n- **EntityAnalyticsReadPrivilegesCallout** — new component that\naggregates missing read privileges from both the Risk Engine and the\nEntity Store, and renders a dismissible callout listing the affected\nindices. Only read and view_index_metadata privileges are being\nconsidered for the homepage\n- **EntityAnalyticsHomePage** — now checks two privilege sources at load\ntime:\n- `useEntityEnginePrivileges` — if `has_read_permissions` is false,\n`NoPrivileges` banner is shown and no dashboard content is rendered.\n- `useMissingRiskEnginePrivileges` — missing risk engine privileges only\naffect part of the data (e.g. flyout content), so the UI is still\nrendered but the `EntityAnalyticsReadPrivilegesCallout` is shown at the\ntop.\n  - Both hooks show a loading spinner while their requests are loading\n- **useEntityEnginePrivileges** — previously always called\n`fetchEntityStorePrivileges`. It now reads the `entityStoreEnableV2` UI\nsetting and dispatches to `fetchEntityStoreV2Privileges` when Entity\nStore V2 is active. This also fixes the privilege list shown on the\n`/security/entity_analytics_management page`.\n- **check_privileges** route — previously the privilege check only\ncovered the entities alias (`getEntitiesAlias`) but some queries — like\nthe one for the recent anomalies data and entity flyout content — target\nthe index directly rather than the alias so those pages would silently\nreturn no data for users missing index-level access. The route now\nchecks privileges for both the alias pattern and the concrete\nlatest-entity index pattern (`getLatestEntityIndexPattern`).\n- I did not update the queries to use the alias because from what I\nunderstood from https://github.com/elastic/kibana/pull/260706 we still\nneed to use the index for some scenarios\n\n## How to test\n1. Enable entity store V2 and the new EA home page\n``` \nuiSettings:\n  overrides:\n    securitySolution:entityStoreEnableV2: true\n\nxpack.securitySolution.enableExperimental:\n  - entityAnalyticsEntityStoreV2\n  - entityAnalyticsNewHomePageEnabled\n```\n2. Start Elasticsearch and Kibana locally.\n3. In Stack Management → Roles, create a new role with only the Kibana\n**read** privilege and no Elasticsearch index privileges.\n4. In Stack Management → Users, create a new user and assign the role\nfrom step 3.\n5. Log in to Kibana as the new user and navigate to Security → Entity\nAnalytics.\n6. Verify the \"Insufficient privileges\" callout is visible, listing the\nmissing index privileges.\n7. Verify the No Privileges banner is shown and the entities table /\nrisk panels are hidden.\n8. Navigate to `/security/entity_analytics_management` — confirm the\nprivilege list there now reflects Entity Store V2 indices\n9. Back in your superuser session, edit the role from step 3 and grant\nread access to the indices listed in the callout.\n10. Log back in as the custom user, refresh the Entity Analytics\nhomepage, and confirm the callout is gone and the full dashboard is now\ndisplayed.\n\n<img width=\"1919\" height=\"789\" alt=\"Screenshot 2026-04-29 at 5 15 19 PM\"\nsrc=\"https://github.com/user-attachments/assets/1792cd92-7a57-4baa-993c-c09292ab318f\"\n/>\n<img width=\"1370\" height=\"788\" alt=\"Screenshot 2026-04-29 at 5 16 15 PM\"\nsrc=\"https://github.com/user-attachments/assets/1be4e73f-9a3f-4ca8-a360-3a6d8b4bbb5e\"\n/>\n<img width=\"1913\" height=\"769\" alt=\"Screenshot 2026-04-29 at 5 16 44 PM\"\nsrc=\"https://github.com/user-attachments/assets/8cf30268-d7de-4e0d-a0da-e614c2328556\"\n/>","sha":"a61c31271ab26a578108866e4b7404e9806fe85c"}}]}] BACKPORT-->