### PR TITLE
[Core] Unskip Browser apps execution context tests

### DIFF
--- a/x-pack/platform/test/functional_execution_context/tests/browser.ts
+++ b/x-pack/platform/test/functional_execution_context/tests/browser.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Ecs, KibanaExecutionContext } from '@kbn/core/server';
+import { encode } from '@kbn/rison';
 import type { FtrProviderContext } from '../ftr_provider_context';
 import { assertLogContains, isExecutionContextLog, readLogFile } from '../test_utils';
 
@@ -19,8 +20,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'timePicker',
   ]);
 
-  // Failing: See https://github.com/elastic/kibana/issues/258554
-  describe.skip('Browser apps', () => {
+  describe('Browser apps', () => {
     let logs: Ecs[];
     let discoverSessionFirstTabId = '';
     const retry = getService('retry');
@@ -340,7 +340,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
                 name: 'discover',
                 id: '571aaf70-4c88-11e8-b3d7-01146121b73d',
                 description: '[Flights] Flight Log',
-                url: `/app/discover#/view/571aaf70-4c88-11e8-b3d7-01146121b73d?_tab=(tabId:'${discoverSessionFirstTabId}')`,
+                url: `/app/discover#/view/571aaf70-4c88-11e8-b3d7-01146121b73d?_tab=${encode({
+                  tabId: discoverSessionFirstTabId,
+                })}`,
               },
             }),
           });


### PR DESCRIPTION
## Summary

Re-enables the `Browser apps` execution-context FTR suite and fixes the tab-id encoding in the dashboard / built-in Discover assertion.

The expected URL was built with a hardcoded `(tabId:'<uuid>')` template, but rison only quotes string values that start with a digit. When the generated tab id starts with `a`-`f`, the locator emits `(tabId:abc...)` without quotes and the deep-equality match in `isExecutionContextLog` fails. Building the segment with `@kbn/rison`'s `encode` matches whatever the locator produces, regardless of the first character.

Fixes #258554.

## Credit

Fix approach is from Jesús Wahrman's earlier #265087.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->