### PR TITLE
Server-side pagination for Synthetics overview status !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/state.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/state.ts
@@ -44,6 +44,9 @@ export type FetchMonitorManagementListQueryArgs = t.TypeOf<
 
 export const FetchMonitorOverviewQueryArgsCodec = t.partial({
   ...FetchMonitorQueryArgsCommon,
+  page: t.number,
+  perPage: t.number,
+  statusFilter: t.string,
 });
 
 export type FetchMonitorOverviewQueryArgs = t.TypeOf<typeof FetchMonitorOverviewQueryArgsCodec>;

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/synthetics_overview_status.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/synthetics_overview_status.ts
@@ -97,7 +97,18 @@ export const OverviewStatusCodec = t.interface({
   allIds: t.array(t.string),
 });
 
+export const PaginatedOverviewStatusCodec = t.intersection([
+  OverviewStatusCodec,
+  t.partial({
+    configs: t.array(OverviewStatusMetaDataCodec),
+    total: t.number,
+    page: t.number,
+    perPage: t.number,
+  }),
+]);
+
 export type OverviewPing = t.TypeOf<typeof OverviewPingCodec>;
 export type OverviewStatus = t.TypeOf<typeof OverviewStatusCodec>;
 export type OverviewStatusState = t.TypeOf<typeof OverviewStatusCodec>;
+export type PaginatedOverviewStatus = t.TypeOf<typeof PaginatedOverviewStatusCodec>;
 export type OverviewStatusMetaData = t.TypeOf<typeof OverviewStatusMetaDataCodec>;

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
@@ -9,6 +9,7 @@ import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSyntheticsRefreshContext } from '../../../contexts/synthetics_refresh_context';
 import { selectOverviewPageState } from '../../../state';
+import { setOverviewPageStateAction } from '../../../state/overview';
 import {
   fetchOverviewStatusAction,
   quietFetchOverviewStatusAction,
@@ -22,13 +23,14 @@ import { useGetUrlParams } from '../../../hooks';
  * The fetch is triggered once by `useOverviewStatus` in the page-level component.
  */
 export function useOverviewStatusState() {
-  const { status, error, loaded, loading, allConfigs } = useSelector(selectOverviewStatus);
+  const { status, error, loaded, loading, allConfigs, total } = useSelector(selectOverviewStatus);
   return {
     status,
     error,
     loading,
     loaded,
     allConfigs: allConfigs ?? [],
+    total,
   };
 }
 
@@ -39,15 +41,25 @@ export function useOverviewStatusState() {
  */
 export function useOverviewStatus({ scopeStatusByLocation }: { scopeStatusByLocation: boolean }) {
   const pageState = useSelector(selectOverviewPageState);
-  const { status, error, loaded, loading, allConfigs } = useSelector(selectOverviewStatus);
+  const { status, error, loaded, loading, allConfigs, total } = useSelector(selectOverviewStatus);
   const isInitialMount = useRef(true);
 
   const { lastRefresh } = useSyntheticsRefreshContext();
+  const { statusFilter } = useGetUrlParams();
 
   const dispatch = useDispatch();
 
   const paramsRef = useRef({ pageState, scopeStatusByLocation, loaded });
   paramsRef.current = { pageState, scopeStatusByLocation, loaded };
+
+  // When the status filter changes, reset to page 1.
+  const prevStatusFilterRef = useRef(statusFilter);
+  useEffect(() => {
+    if (prevStatusFilterRef.current !== statusFilter) {
+      prevStatusFilterRef.current = statusFilter;
+      dispatch(setOverviewPageStateAction({ page: 1 }));
+    }
+  }, [dispatch, statusFilter]);
 
   const { query: urlQuery } = useGetUrlParams();
   const hasUnsyncedUrlQuery = Boolean(urlQuery) && urlQuery !== (pageState.query || '');
@@ -55,28 +67,43 @@ export function useOverviewStatus({ scopeStatusByLocation }: { scopeStatusByLoca
   useEffect(() => {
     if (!isInitialMount.current) {
       const { pageState: ps, scopeStatusByLocation: scope } = paramsRef.current;
-      dispatch(quietFetchOverviewStatusAction.get({ pageState: ps, scopeStatusByLocation: scope }));
+      dispatch(
+        quietFetchOverviewStatusAction.get({
+          pageState: ps,
+          scopeStatusByLocation: scope,
+          statusFilter,
+        })
+      );
     }
-  }, [dispatch, lastRefresh]);
+  }, [dispatch, lastRefresh, statusFilter]);
 
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
       if (hasUnsyncedUrlQuery) {
-        // URL query param hasn't been synced to Redux yet (the sync runs in
-        // a separate useEffect in useMonitorFiltersState). Skip this stale
-        // fetch — the sync will update pageState and re-trigger this effect.
         return;
       }
     }
 
     const { loaded: isLoaded } = paramsRef.current;
     if (isLoaded) {
-      dispatch(quietFetchOverviewStatusAction.get({ pageState, scopeStatusByLocation }));
+      dispatch(
+        quietFetchOverviewStatusAction.get({
+          pageState,
+          scopeStatusByLocation,
+          statusFilter,
+        })
+      );
     } else {
-      dispatch(fetchOverviewStatusAction.get({ pageState, scopeStatusByLocation }));
+      dispatch(
+        fetchOverviewStatusAction.get({
+          pageState,
+          scopeStatusByLocation,
+          statusFilter,
+        })
+      );
     }
-  }, [dispatch, pageState, scopeStatusByLocation, hasUnsyncedUrlQuery]);
+  }, [dispatch, pageState, scopeStatusByLocation, hasUnsyncedUrlQuery, statusFilter]);
 
   return {
     status,
@@ -84,5 +111,6 @@ export function useOverviewStatus({ scopeStatusByLocation }: { scopeStatusByLoca
     loading,
     loaded,
     allConfigs: allConfigs ?? [],
+    total,
   };
 }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
@@ -45,42 +45,54 @@ export function useOverviewStatus({ scopeStatusByLocation }: { scopeStatusByLoca
   const isInitialMount = useRef(true);
 
   const { lastRefresh } = useSyntheticsRefreshContext();
-  const { statusFilter } = useGetUrlParams();
+  // Normalize the empty-string default to `undefined` so "no filter" is omitted
+  // from the fetch payload (matching the API contract) rather than sent as "".
+  const { statusFilter: statusFilterParam } = useGetUrlParams();
+  const statusFilter = statusFilterParam || undefined;
 
   const dispatch = useDispatch();
 
-  const paramsRef = useRef({ pageState, scopeStatusByLocation, loaded });
-  paramsRef.current = { pageState, scopeStatusByLocation, loaded };
+  const paramsRef = useRef({ pageState, scopeStatusByLocation, loaded, statusFilter });
+  paramsRef.current = { pageState, scopeStatusByLocation, loaded, statusFilter };
 
-  // When the status filter changes, reset to page 1.
+  // Tracks the last status filter the fetch effect reconciled, so it can detect
+  // a filter change and reset pagination in the same pass (avoiding a cross-effect race).
   const prevStatusFilterRef = useRef(statusFilter);
-  useEffect(() => {
-    if (prevStatusFilterRef.current !== statusFilter) {
-      prevStatusFilterRef.current = statusFilter;
-      dispatch(setOverviewPageStateAction({ page: 1 }));
-    }
-  }, [dispatch, statusFilter]);
 
   const { query: urlQuery } = useGetUrlParams();
   const hasUnsyncedUrlQuery = Boolean(urlQuery) && urlQuery !== (pageState.query || '');
 
+  // Auto-refresh path: quietly re-fetch the current page when the refresh timer
+  // ticks. Params are read from the ref (not deps) so this never re-runs on
+  // filter/pageState changes — which would otherwise fetch with a stale page.
   useEffect(() => {
     if (!isInitialMount.current) {
-      const { pageState: ps, scopeStatusByLocation: scope } = paramsRef.current;
+      const { pageState: ps, scopeStatusByLocation: scope, statusFilter: sf } = paramsRef.current;
       dispatch(
         quietFetchOverviewStatusAction.get({
           pageState: ps,
           scopeStatusByLocation: scope,
-          statusFilter,
+          statusFilter: sf,
         })
       );
     }
-  }, [dispatch, lastRefresh, statusFilter]);
+  }, [dispatch, lastRefresh]);
 
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
+      prevStatusFilterRef.current = statusFilter;
       if (hasUnsyncedUrlQuery) {
+        return;
+      }
+    } else if (prevStatusFilterRef.current !== statusFilter) {
+      prevStatusFilterRef.current = statusFilter;
+      // When not already on page 1, reset it and let the resulting pageState
+      // change re-run this effect to fetch the correct page — skipping the
+      // stale-page fetch. When already on page 1 the reset is a Redux no-op, so
+      // fall through and fetch with the new filter immediately.
+      if (pageState.page !== 1) {
+        dispatch(setOverviewPageStateAction({ page: 1 }));
         return;
       }
     }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitors_table.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitors_table.tsx
@@ -46,23 +46,32 @@ export const MonitorsTable = ({
   items: OverviewStatusMetaData[];
   setFlyoutConfigCallback: (params: FlyoutParamProps) => void;
 }) => {
-  const { loaded, status, loading } = useOverviewStatusState();
+  const { loaded, status, loading, total } = useOverviewStatusState();
+  const isPaginated = status?.configs != null;
+
   const {
-    pageOfItems,
-    pagination,
-    onTableChange: onPaginationChange,
+    pageOfItems: localPageOfItems,
+    pagination: localPagination,
+    onTableChange: onLocalPaginationChange,
   } = useMonitorsTablePagination({
     totalItems: items,
   });
 
+  const pageState = useSelector(selectOverviewPageState);
   const flyoutConfig = useSelector(selectOverviewFlyoutConfig);
   const isFlyoutOpen = Boolean(flyoutConfig?.configId);
-  const { sortField, sortOrder } = useSelector(selectOverviewPageState);
+  const { sortField, sortOrder } = pageState;
 
-  // While the flyout is open we hide the columns that consume trend stats and
-  // the down-history sparkline, so paying for those fetches just feeds caches
-  // the user can't see. Pass an empty stable list to short-circuit the trends
-  // dispatch; the histogram gate is plumbed via `enabled` below.
+  const pageOfItems = isPaginated ? items : localPageOfItems;
+  const pagination = isPaginated
+    ? {
+        pageIndex: (pageState.page ?? 1) - 1,
+        pageSize: pageState.perPage ?? 20,
+        totalItemCount: total ?? items.length,
+        pageSizeOptions: [10, 20, 50, 100],
+      }
+    : localPagination;
+
   useOverviewTrendsRequests(isFlyoutOpen ? EMPTY_ITEMS : pageOfItems);
 
   const { columns } = useMonitorsTableColumns({
@@ -86,20 +95,37 @@ export const MonitorsTable = ({
 
   const onTableChange = useCallback(
     (criteria: Criteria<OverviewStatusMetaData>) => {
-      onPaginationChange(criteria);
-      const nextSort = criteria.sort;
-      if (!nextSort) return;
-      const mappedSortField = COLUMN_TO_SORT_FIELD[nextSort.field as string];
-      if (!mappedSortField) return;
-      if (mappedSortField === sortField && nextSort.direction === sortOrder) return;
-      dispatch(
-        setOverviewPageStateAction({
-          sortField: mappedSortField,
-          sortOrder: nextSort.direction,
-        })
-      );
+      if (isPaginated) {
+        const updates: Partial<MonitorOverviewPageState> = {};
+        if (criteria.page) {
+          updates.page = criteria.page.index + 1;
+          updates.perPage = criteria.page.size;
+        }
+        const nextSort = criteria.sort;
+        if (nextSort) {
+          const mappedSortField = COLUMN_TO_SORT_FIELD[nextSort.field as string];
+          if (mappedSortField) {
+            updates.sortField = mappedSortField;
+            updates.sortOrder = nextSort.direction;
+          }
+        }
+        dispatch(setOverviewPageStateAction(updates));
+      } else {
+        onLocalPaginationChange(criteria);
+        const nextSort = criteria.sort;
+        if (!nextSort) return;
+        const mappedSortField = COLUMN_TO_SORT_FIELD[nextSort.field as string];
+        if (!mappedSortField) return;
+        if (mappedSortField === sortField && nextSort.direction === sortOrder) return;
+        dispatch(
+          setOverviewPageStateAction({
+            sortField: mappedSortField,
+            sortOrder: nextSort.direction,
+          })
+        );
+      }
     },
-    [dispatch, onPaginationChange, sortField, sortOrder]
+    [dispatch, isPaginated, onLocalPaginationChange, sortField, sortOrder]
   );
 
   const getRowProps = useCallback(

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_grid.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_grid.tsx
@@ -31,7 +31,7 @@ export const OverviewGrid = memo(
   ({ view, isEmbeddable }: { view: OverviewView; isEmbeddable?: boolean }) => {
     const dispatch = useDispatch();
 
-    const { status, loaded: isInitialized, loading } = useOverviewStatusState();
+    const { status, loaded: isInitialized, loading, total } = useOverviewStatusState();
     const monitorsSortedByStatus: OverviewStatusMetaData[] = useMonitorsSortedByStatus();
 
     const setFlyoutConfigCallback = useCallback(
@@ -64,7 +64,9 @@ export const OverviewGrid = memo(
           wrap={true}
         >
           <EuiFlexItem grow={true}>
-            <OverviewPaginationInfo total={status ? monitorsSortedByStatus.length : undefined} />
+            <OverviewPaginationInfo
+              total={status ? total ?? monitorsSortedByStatus.length : undefined}
+            />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <ShowAllSpaces />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/sort_fields.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/sort_fields.tsx
@@ -32,6 +32,7 @@ export const SortFields = () => {
         handleSortChange(
           setOverviewPageStateAction({
             sortOrder: 'asc',
+            page: 1,
           })
         );
       },
@@ -44,6 +45,7 @@ export const SortFields = () => {
         handleSortChange(
           setOverviewPageStateAction({
             sortOrder: 'desc',
+            page: 1,
           })
         );
       },
@@ -60,6 +62,7 @@ export const SortFields = () => {
           setOverviewPageStateAction({
             sortField: 'status',
             sortOrder: 'asc',
+            page: 1,
           })
         );
       },
@@ -74,6 +77,7 @@ export const SortFields = () => {
           setOverviewPageStateAction({
             sortField: `${ConfigKey.NAME}.keyword`,
             sortOrder: 'asc',
+            page: 1,
           })
         );
       },
@@ -88,6 +92,7 @@ export const SortFields = () => {
           setOverviewPageStateAction({
             sortField: 'urls',
             sortOrder: 'asc',
+            page: 1,
           })
         );
       },
@@ -102,6 +107,7 @@ export const SortFields = () => {
           setOverviewPageStateAction({
             sortField: `${ConfigKey.MONITOR_TYPE}.keyword`,
             sortOrder: 'asc',
+            page: 1,
           })
         );
       },
@@ -116,6 +122,7 @@ export const SortFields = () => {
           setOverviewPageStateAction({
             sortField: 'updated_at',
             sortOrder: 'desc',
+            page: 1,
           })
         );
       },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.tsx
@@ -15,7 +15,7 @@ import { useGetUrlParams } from './use_url_params';
 
 export function useMonitorsSortedByStatus(): OverviewStatusMetaData[] {
   const { statusFilter } = useGetUrlParams();
-  const { status, disabledConfigs } = useSelector(selectOverviewStatus);
+  const { status, disabledConfigs, allConfigs } = useSelector(selectOverviewStatus);
 
   const {
     pageState: { sortOrder, sortField },
@@ -26,6 +26,13 @@ export function useMonitorsSortedByStatus(): OverviewStatusMetaData[] {
       return [];
     }
 
+    // When the server returns a paginated response (configs array), the data
+    // is already sorted, filtered by status, and sliced to the requested page.
+    if (status.configs) {
+      return allConfigs ?? [];
+    }
+
+    // Legacy non-paginated path: sort and filter client-side.
     let result: OverviewStatusMetaData[] = [];
 
     const { downConfigs, pendingConfigs, upConfigs } = status;
@@ -72,22 +79,15 @@ export function useMonitorsSortedByStatus(): OverviewStatusMetaData[] {
         });
         return sortOrder === 'asc' ? result : result.reverse();
       case 'urls': {
-        // Monitors without a URL (e.g. ICMP/TCP, or browser checks where the
-        // url field is empty) are always sorted last regardless of direction —
-        // an alphabetical run that ends with a wall of "—" is more useful for
-        // triage than letting empty strings flip to the top in desc order.
         const withUrl = result.filter((m) => m.urls);
         const withoutUrl = result.filter((m) => !m.urls);
         withUrl.sort((a, b) => (a.urls ?? '').localeCompare(b.urls ?? ''));
         return [...(sortOrder === 'asc' ? withUrl : withUrl.reverse()), ...withoutUrl];
       }
       case 'type.keyword':
-        // Group same-type monitors together (asc gives browser → http → icmp
-        // → tcp). `localeCompare` is overkill for short type tokens but keeps
-        // behaviour consistent with the other alphabetical sorts.
         result = result.sort((a, b) => (a.type ?? '').localeCompare(b.type ?? ''));
         return sortOrder === 'asc' ? result : result.reverse();
     }
     return result;
-  }, [disabledConfigs, sortField, sortOrder, status, statusFilter]);
+  }, [allConfigs, disabledConfigs, sortField, sortOrder, status, statusFilter]);
 }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/index.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/index.test.ts
@@ -156,17 +156,27 @@ describe('monitorOverviewReducer', () => {
   });
 
   describe('setOverviewViewAction', () => {
-    it('produces a new pageState reference on a real view switch even when pagination is already at defaults', () => {
+    it("produces a new pageState reference on a real view switch and applies that view's own default perPage", () => {
       const initial = monitorOverviewReducer(undefined, { type: '@@INIT' });
       expect(initial.view).toBe('cardView');
       expect(initial.pageState.page).toBe(1);
+      expect(initial.pageState.perPage).toBe(20);
 
       const next = monitorOverviewReducer(initial, setOverviewViewAction('compactView'));
 
       expect(next.view).toBe('compactView');
       expect(next.pageState).not.toBe(initial.pageState);
       expect(next.pageState.page).toBe(1);
-      expect(next.pageState.perPage).toBe(initial.pageState.perPage);
+      // Compact view's own default (10), not carried over from card view (20).
+      expect(next.pageState.perPage).toBe(10);
+    });
+
+    it('switching back to card view restores its own default perPage', () => {
+      const initial = monitorOverviewReducer(undefined, { type: '@@INIT' });
+      const compact = monitorOverviewReducer(initial, setOverviewViewAction('compactView'));
+      const back = monitorOverviewReducer(compact, setOverviewViewAction('cardView'));
+
+      expect(back.pageState.perPage).toBe(20);
     });
 
     it('preserves pageState identity when the view is unchanged', () => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
@@ -24,7 +24,8 @@ export const DEFAULT_OVERVIEW_VIEW = overviewViews[0];
 
 const initialState: MonitorOverviewState = {
   pageState: {
-    perPage: 16,
+    page: 1,
+    perPage: 20,
     sortOrder: 'asc',
     sortField: 'status',
     showFromAllSpaces: getInitialShowFromAllSpaces(),
@@ -43,11 +44,23 @@ export const monitorOverviewReducer = createReducer(initialState, (builder) => {
       // ShowAllSpaces re-sending the same value, or [] filter arrays from
       // mount effects) don't create a new pageState reference and re-trigger
       // the useDebounce fetch in useOverviewStatus.
+      const paginationKeys = new Set(['page', 'perPage']);
+      let hasNonPaginationChange = false;
+
       for (const key of Object.keys(action.payload) as Array<keyof typeof action.payload>) {
         const value = action.payload[key];
         if (!isPageStateSlotEqual((state.pageState as Record<string, unknown>)[key], value)) {
           (state.pageState as Record<string, unknown>)[key] = value;
+          if (!paginationKeys.has(key)) {
+            hasNonPaginationChange = true;
+          }
         }
+      }
+
+      // Reset to first page when any non-pagination field changes (e.g.
+      // filters, sort, query) unless the caller already set page explicitly.
+      if (hasNonPaginationChange && !('page' in action.payload)) {
+        state.pageState.page = 1;
       }
     })
     .addCase(setOverviewGroupByAction, (state, action) => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
@@ -9,6 +9,7 @@ import { createReducer } from 'redux-toolkit-v1';
 import { CLIENT_DEFAULTS_SYNTHETICS } from '../../../../../common/constants/synthetics/client_defaults';
 import { OVERVIEW_PAGINATION_DEFAULTS } from '../../../../../common/constants/monitor_management';
 import type { MonitorOverviewState } from './models';
+import type { OverviewView } from './models';
 import { overviewViews } from './models';
 import { isPageStateSlotEqual } from '../utils/page_state_equality';
 import { getInitialShowFromAllSpaces } from '../utils/get_initial_show_from_all_spaces';
@@ -27,11 +28,18 @@ import {
 
 export const DEFAULT_OVERVIEW_VIEW = overviewViews[0];
 export const DEFAULT_OVERVIEW_PER_PAGE = OVERVIEW_PAGINATION_DEFAULTS.perPage;
+// Compact table rows are far shorter than cards, but a page of 20 still runs
+// well past the fold on common viewport heights — 10 keeps a page scannable
+// without scrolling.
+export const DEFAULT_COMPACT_VIEW_PER_PAGE = 10;
+
+const getDefaultPerPageForView = (view: OverviewView): number =>
+  view === 'compactView' ? DEFAULT_COMPACT_VIEW_PER_PAGE : DEFAULT_OVERVIEW_PER_PAGE;
 
 const initialState: MonitorOverviewState = {
   pageState: {
     page: OVERVIEW_PAGINATION_DEFAULTS.page,
-    perPage: DEFAULT_OVERVIEW_PER_PAGE,
+    perPage: getDefaultPerPageForView(DEFAULT_OVERVIEW_VIEW),
     sortOrder: OVERVIEW_PAGINATION_DEFAULTS.sortOrder,
     sortField: OVERVIEW_PAGINATION_DEFAULTS.sortField,
     showFromAllSpaces: getInitialShowFromAllSpaces(),
@@ -141,7 +149,7 @@ export const monitorOverviewReducer = createReducer(initialState, (builder) => {
         state.pageState = {
           ...state.pageState,
           page: 1,
-          perPage: DEFAULT_OVERVIEW_PER_PAGE,
+          perPage: getDefaultPerPageForView(action.payload),
         };
       }
       state.view = action.payload;

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/models.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/models.ts
@@ -13,6 +13,7 @@ import type { ConfigKey } from '../../../../../common/runtime_types';
 import type { MonitorFilterState } from '../monitor_list';
 
 export interface MonitorOverviewPageState extends MonitorFilterState {
+  page: number;
   perPage: number;
   sortOrder: 'asc' | 'desc';
   sortField: MonitorListSortField;

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/actions.ts
@@ -8,16 +8,16 @@ import { createAction } from '@reduxjs/toolkit';
 import type { MonitorOverviewPageState } from '..';
 import { createAsyncAction } from '../utils/actions';
 
-import type { OverviewStatus } from '../../../../../common/runtime_types';
+import type { PaginatedOverviewStatus } from '../../../../../common/runtime_types';
 
 export const fetchOverviewStatusAction = createAsyncAction<
-  { pageState: MonitorOverviewPageState; scopeStatusByLocation?: boolean },
-  OverviewStatus
+  { pageState: MonitorOverviewPageState; scopeStatusByLocation?: boolean; statusFilter?: string },
+  PaginatedOverviewStatus
 >('fetchOverviewStatusAction');
 
 export const quietFetchOverviewStatusAction = createAsyncAction<
-  { pageState: MonitorOverviewPageState; scopeStatusByLocation?: boolean },
-  OverviewStatus
+  { pageState: MonitorOverviewPageState; scopeStatusByLocation?: boolean; statusFilter?: string },
+  PaginatedOverviewStatus
 >('quietFetchOverviewStatusAction');
 
 export const clearOverviewStatusErrorAction = createAction<void>('clearOverviewStatusErrorAction');

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/api.ts
@@ -9,9 +9,9 @@ import type { MonitorOverviewPageState } from '..';
 import { SYNTHETICS_API_URLS } from '../../../../../common/constants';
 import type {
   FetchMonitorOverviewQueryArgs,
-  OverviewStatus,
+  PaginatedOverviewStatus,
 } from '../../../../../common/runtime_types';
-import { OverviewStatusCodec } from '../../../../../common/runtime_types';
+import { PaginatedOverviewStatusCodec } from '../../../../../common/runtime_types';
 import { apiService } from '../../../../utils/api_service';
 
 export function toStatusOverviewQueryArgs(
@@ -28,20 +28,26 @@ export function toStatusOverviewQueryArgs(
     showFromAllSpaces: pageState.showFromAllSpaces,
     searchFields: [],
     useLogicalAndFor: pageState.useLogicalAndFor,
+    page: pageState.page,
+    perPage: pageState.perPage,
+    sortField: pageState.sortField,
+    sortOrder: pageState.sortOrder,
   };
 }
 
 export const fetchOverviewStatus = async ({
   pageState,
   scopeStatusByLocation,
+  statusFilter,
 }: {
   pageState: MonitorOverviewPageState;
   scopeStatusByLocation?: boolean;
-}): Promise<OverviewStatus> => {
+  statusFilter?: string;
+}): Promise<PaginatedOverviewStatus> => {
   const params = toStatusOverviewQueryArgs(pageState);
   return apiService.get(
     SYNTHETICS_API_URLS.OVERVIEW_STATUS,
-    { ...params, scopeStatusByLocation },
-    OverviewStatusCodec
+    { ...params, scopeStatusByLocation, ...(statusFilter ? { statusFilter } : {}) },
+    PaginatedOverviewStatusCodec
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/index.ts
@@ -9,7 +9,7 @@ import { createReducer } from '@reduxjs/toolkit';
 
 import type {
   OverviewStatusMetaData,
-  OverviewStatusState,
+  PaginatedOverviewStatus,
 } from '../../../../../common/runtime_types';
 import type { IHttpSerializedFetchError } from '..';
 import {
@@ -22,11 +22,12 @@ import {
 export interface OverviewStatusStateReducer {
   loading: boolean;
   loaded: boolean;
-  status: OverviewStatusState | null;
+  status: PaginatedOverviewStatus | null;
   allConfigs?: OverviewStatusMetaData[];
   disabledConfigs?: OverviewStatusMetaData[];
   error: IHttpSerializedFetchError | null;
   isInitialLoad: boolean;
+  total?: number;
 }
 
 const initialState: OverviewStatusStateReducer = {
@@ -43,18 +44,24 @@ export const overviewStatusReducer = createReducer(initialState, (builder) => {
       state.status = null;
       state.loading = true;
     })
-    .addCase(quietFetchOverviewStatusAction.get, (_state) => {
-      // intentionally no loading state for quiet/background refreshes
+    .addCase(quietFetchOverviewStatusAction.get, (state) => {
+      state.loading = true;
     })
     .addCase(fetchOverviewStatusAction.success, (state, action) => {
       state.status = action.payload;
 
-      state.allConfigs = Object.values({
-        ...state.status.upConfigs,
-        ...state.status.downConfigs,
-        ...state.status.pendingConfigs,
-        ...state.status.disabledConfigs,
-      });
+      if (action.payload.configs) {
+        state.allConfigs = action.payload.configs;
+        state.total = action.payload.total;
+      } else {
+        state.allConfigs = Object.values({
+          ...state.status.upConfigs,
+          ...state.status.downConfigs,
+          ...state.status.pendingConfigs,
+          ...state.status.disabledConfigs,
+        });
+        state.total = state.allConfigs.length;
+      }
       state.disabledConfigs = state.allConfigs.filter((monitor) => !monitor.isEnabled);
       state.loaded = true;
       state.loading = false;

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/selectors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview_status/selectors.ts
@@ -10,12 +10,13 @@ import { MONITOR_STATUS_ENUM } from '../../../../../common/constants/monitor_man
 import type {
   OverviewStatusMetaData,
   OverviewStatusState,
+  PaginatedOverviewStatus,
 } from '../../../../../common/runtime_types';
 import type { SyntheticsAppState } from '../root_reducer';
 
 export const getStatusByConfig = (
   configId: string,
-  status?: OverviewStatusState | null,
+  status?: PaginatedOverviewStatus | null,
   locId?: string
 ) => {
   if (!status) {
@@ -50,6 +51,29 @@ export const selectOverviewStatus = createSelector(
     if (!overviewStatus.status) {
       return overviewStatus;
     }
+
+    const isPaginated = overviewStatus.status.configs != null;
+
+    // When paginated, the server already sorted and sliced the data. The
+    // config maps contain only the current page's items so counts are global
+    // (from the server) rather than derived from the maps.
+    if (isPaginated) {
+      const status =
+        groupByField === 'monitor'
+          ? overviewStatus.status
+          : formatStatus(overviewStatus.status, groupByField);
+      return {
+        ...overviewStatus,
+        status: {
+          ...status,
+          up: overviewStatus.status.up,
+          down: overviewStatus.status.down,
+          pending: overviewStatus.status.pending,
+          disabledCount: overviewStatus.status.disabledCount,
+        },
+      };
+    }
+
     const status =
       groupByField === 'monitor'
         ? overviewStatus.status

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
@@ -94,6 +94,7 @@ export const mockState: SyntheticsAppState = {
   },
   overview: {
     pageState: {
+      page: 1,
       perPage: 10,
       sortOrder: 'asc',
       sortField: 'name.keyword',

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/common.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/common.ts
@@ -62,6 +62,18 @@ export const OverviewStatusSchema = schema.object({
   ...CommonQuerySchema,
   scopeStatusByLocation: schema.maybe(schema.boolean()),
   groupByMonitor: schema.maybe(schema.boolean()),
+  page: schema.maybe(schema.number({ min: 1 })),
+  perPage: schema.maybe(schema.number({ min: 1, max: 500 })),
+  sortField: MonitorSortFieldSchema,
+  sortOrder: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
+  statusFilter: schema.maybe(
+    schema.oneOf([
+      schema.literal('up'),
+      schema.literal('down'),
+      schema.literal('pending'),
+      schema.literal('disabled'),
+    ])
+  ),
 });
 
 export type OverviewStatusQuery = TypeOf<typeof OverviewStatusSchema>;

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status.ts
@@ -6,7 +6,7 @@
  */
 import { OverviewStatusService } from './overview_status_service';
 import type { SyntheticsRestApiRouteFactory } from '../types';
-import type { OverviewStatusState } from '../../../common/runtime_types';
+import type { OverviewStatusState, PaginatedOverviewStatus } from '../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { OverviewStatusSchema } from '../common';
 
@@ -16,7 +16,7 @@ export const createGetCurrentStatusRoute: SyntheticsRestApiRouteFactory = () => 
   validate: {
     query: OverviewStatusSchema,
   },
-  handler: async (routeContext): Promise<OverviewStatusState> => {
+  handler: async (routeContext): Promise<OverviewStatusState | PaginatedOverviewStatus> => {
     const statusOverview = new OverviewStatusService(routeContext);
     return await statusOverview.getOverviewStatus();
   },

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
@@ -1661,6 +1661,244 @@ describe('current status route', () => {
       expect(result.upConfigs.id1.remote).toBeUndefined();
     });
   });
+  describe('paginateConfigs', () => {
+    const makeMeta = (
+      id: string,
+      overrides: Partial<{
+        overallStatus: string;
+        name: string;
+        urls: string;
+        type: string;
+        updated_at: string;
+      }> = {}
+    ): any => ({
+      configId: id,
+      monitorQueryId: id,
+      name: overrides.name ?? `monitor-${id}`,
+      schedule: '3',
+      tags: [],
+      isEnabled: overrides.overallStatus !== 'disabled',
+      isStatusAlertEnabled: false,
+      type: overrides.type ?? 'http',
+      overallStatus: overrides.overallStatus ?? 'up',
+      locations: [{ id: 'loc1', label: 'Loc 1', status: overrides.overallStatus ?? 'up' }],
+      urls: overrides.urls,
+      updated_at: overrides.updated_at,
+    });
+
+    const upConfigs: Record<string, any> = {
+      m1: makeMeta('m1', { name: 'Alpha', urls: 'https://alpha.io', updated_at: '2025-01-01T00:00:00Z' }),
+      m2: makeMeta('m2', { name: 'Beta', urls: 'https://beta.io', updated_at: '2025-03-01T00:00:00Z' }),
+      m3: makeMeta('m3', { name: 'Gamma', updated_at: '2025-02-01T00:00:00Z' }),
+    };
+    const downConfigs: Record<string, any> = {
+      m4: makeMeta('m4', { overallStatus: 'down', name: 'Delta', urls: 'https://delta.io', updated_at: '2025-04-01T00:00:00Z' }),
+      m5: makeMeta('m5', { overallStatus: 'down', name: 'Epsilon', updated_at: '2025-05-01T00:00:00Z' }),
+    };
+    const pendingConfigs: Record<string, any> = {
+      m6: makeMeta('m6', { overallStatus: 'pending', name: 'Zeta' }),
+    };
+    const disabledConfigs: Record<string, any> = {
+      m7: makeMeta('m7', { overallStatus: 'disabled', name: 'Eta' }),
+    };
+
+    const allBuckets = { upConfigs, downConfigs, pendingConfigs, disabledConfigs };
+
+    const createService = (query: Record<string, any> = {}) => {
+      const routeContext: any = {
+        request: { query },
+        server: {
+          isElasticsearchServerless: false,
+          config: { experimental: { ccs: { enabled: false } } },
+        },
+      };
+      return new OverviewStatusService(routeContext);
+    };
+
+    it('returns the first page with correct total', () => {
+      const service = createService({ page: 1, perPage: 3 });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(7);
+      expect(result.configs).toHaveLength(3);
+    });
+
+    it('returns the second page', () => {
+      const service = createService({ page: 2, perPage: 3 });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(7);
+      expect(result.configs).toHaveLength(3);
+    });
+
+    it('returns a partial last page', () => {
+      const service = createService({ page: 3, perPage: 3 });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(7);
+      expect(result.configs).toHaveLength(1);
+    });
+
+    it('returns empty configs when page is beyond range', () => {
+      const service = createService({ page: 10, perPage: 3 });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(7);
+      expect(result.configs).toHaveLength(0);
+    });
+
+    it('sorts by status asc: down first, then up, disabled, pending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'status', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const statuses = result.configs.map((c: any) => c.overallStatus);
+      expect(statuses).toEqual(['down', 'down', 'up', 'up', 'up', 'disabled', 'pending']);
+    });
+
+    it('sorts by status desc: up first, then down, disabled, pending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'status', sortOrder: 'desc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const statuses = result.configs.map((c: any) => c.overallStatus);
+      expect(statuses).toEqual(['up', 'up', 'up', 'down', 'down', 'disabled', 'pending']);
+    });
+
+    it('sorts by name ascending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'name.keyword', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const names = result.configs.map((c: any) => c.name);
+      expect(names).toEqual(['Alpha', 'Beta', 'Delta', 'Epsilon', 'Eta', 'Gamma', 'Zeta']);
+    });
+
+    it('sorts by name descending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'name.keyword', sortOrder: 'desc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const names = result.configs.map((c: any) => c.name);
+      expect(names).toEqual(['Zeta', 'Gamma', 'Eta', 'Epsilon', 'Delta', 'Beta', 'Alpha']);
+    });
+
+    it('sorts by updated_at ascending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'updated_at', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const names = result.configs.map((c: any) => c.name);
+      // Monitors without updated_at (0) sort first in asc, then by date
+      expect(names.indexOf('Alpha')).toBeLessThan(names.indexOf('Beta'));
+      expect(names.indexOf('Beta')).toBeLessThan(names.indexOf('Delta'));
+    });
+
+    it('sorts by urls with empty urls last', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'urls', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const urls = result.configs.map((c: any) => c.urls ?? '(none)');
+      const withUrls = urls.filter((u: string) => u !== '(none)');
+      const withoutUrls = urls.filter((u: string) => u === '(none)');
+      // URLs are sorted alphabetically, then entries without URLs come last
+      expect(withUrls).toEqual(['https://alpha.io', 'https://beta.io', 'https://delta.io']);
+      expect(withoutUrls).toHaveLength(4);
+      // All url-less entries are at the end
+      expect(urls.indexOf(withoutUrls[0])).toBeGreaterThan(urls.lastIndexOf(withUrls[withUrls.length - 1]));
+    });
+
+    it('sorts by type ascending', () => {
+      const mixedTypes = {
+        upConfigs: {
+          t1: makeMeta('t1', { type: 'http', name: 'HTTP Mon' }),
+          t2: makeMeta('t2', { type: 'browser', name: 'Browser Mon' }),
+        },
+        downConfigs: {
+          t3: makeMeta('t3', { overallStatus: 'down', type: 'tcp', name: 'TCP Mon' }),
+        },
+        pendingConfigs: {},
+        disabledConfigs: {},
+      };
+      const service = createService({ page: 1, perPage: 20, sortField: 'type.keyword', sortOrder: 'asc' });
+      const result = service.paginateConfigs(mixedTypes);
+
+      const types = result.configs.map((c: any) => c.type);
+      expect(types).toEqual(['browser', 'http', 'tcp']);
+    });
+
+    it('filters by statusFilter=down', () => {
+      const service = createService({ page: 1, perPage: 20, statusFilter: 'down' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(2);
+      expect(result.configs.every((c: any) => c.overallStatus === 'down')).toBe(true);
+    });
+
+    it('filters by statusFilter=up', () => {
+      const service = createService({ page: 1, perPage: 20, statusFilter: 'up' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(3);
+      expect(result.configs.every((c: any) => c.overallStatus === 'up')).toBe(true);
+    });
+
+    it('filters by statusFilter=disabled', () => {
+      const service = createService({ page: 1, perPage: 20, statusFilter: 'disabled' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(1);
+      expect(result.configs[0].configId).toBe('m7');
+    });
+
+    it('filters by statusFilter=pending', () => {
+      const service = createService({ page: 1, perPage: 20, statusFilter: 'pending' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(1);
+      expect(result.configs[0].configId).toBe('m6');
+    });
+
+    it('populates page config maps matching the page items', () => {
+      const service = createService({ page: 1, perPage: 3, sortField: 'status', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      // Page 1 with status asc: first 3 items are m4 (down), m5 (down), then one up
+      expect(Object.keys(result.pageDownConfigs)).toHaveLength(2);
+      expect(result.pageDownConfigs.m4).toBeDefined();
+      expect(result.pageDownConfigs.m5).toBeDefined();
+      expect(Object.keys(result.pageUpConfigs)).toHaveLength(1);
+      expect(Object.keys(result.pagePendingConfigs)).toHaveLength(0);
+      expect(Object.keys(result.pageDisabledConfigs)).toHaveLength(0);
+    });
+
+    it('combines statusFilter with pagination', () => {
+      const service = createService({ page: 1, perPage: 2, statusFilter: 'up' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(3);
+      expect(result.configs).toHaveLength(2);
+      expect(result.configs.every((c: any) => c.overallStatus === 'up')).toBe(true);
+    });
+
+    it('combines statusFilter with sort by name', () => {
+      const service = createService({
+        page: 1, perPage: 20, statusFilter: 'up', sortField: 'name.keyword', sortOrder: 'asc',
+      });
+      const result = service.paginateConfigs(allBuckets);
+
+      const names = result.configs.map((c: any) => c.name);
+      expect(names).toEqual(['Alpha', 'Beta', 'Gamma']);
+    });
+
+    it('handles empty config maps', () => {
+      const service = createService({ page: 1, perPage: 20 });
+      const result = service.paginateConfigs({
+        upConfigs: {},
+        downConfigs: {},
+        pendingConfigs: {},
+        disabledConfigs: {},
+      });
+
+      expect(result.total).toBe(0);
+      expect(result.configs).toHaveLength(0);
+    });
+  });
 });
 
 function getEsResponse({ buckets, after }: { buckets: any[]; after?: any }) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
@@ -1960,6 +1960,244 @@ describe('current status route', () => {
       expect(result.upConfigs.id1.remote).toBeUndefined();
     });
   });
+  describe('paginateConfigs', () => {
+    const makeMeta = (
+      id: string,
+      overrides: Partial<{
+        overallStatus: string;
+        name: string;
+        urls: string;
+        type: string;
+        updated_at: string;
+      }> = {}
+    ): any => ({
+      configId: id,
+      monitorQueryId: id,
+      name: overrides.name ?? `monitor-${id}`,
+      schedule: '3',
+      tags: [],
+      isEnabled: overrides.overallStatus !== 'disabled',
+      isStatusAlertEnabled: false,
+      type: overrides.type ?? 'http',
+      overallStatus: overrides.overallStatus ?? 'up',
+      locations: [{ id: 'loc1', label: 'Loc 1', status: overrides.overallStatus ?? 'up' }],
+      urls: overrides.urls,
+      updated_at: overrides.updated_at,
+    });
+
+    const upConfigs: Record<string, any> = {
+      m1: makeMeta('m1', { name: 'Alpha', urls: 'https://alpha.io', updated_at: '2025-01-01T00:00:00Z' }),
+      m2: makeMeta('m2', { name: 'Beta', urls: 'https://beta.io', updated_at: '2025-03-01T00:00:00Z' }),
+      m3: makeMeta('m3', { name: 'Gamma', updated_at: '2025-02-01T00:00:00Z' }),
+    };
+    const downConfigs: Record<string, any> = {
+      m4: makeMeta('m4', { overallStatus: 'down', name: 'Delta', urls: 'https://delta.io', updated_at: '2025-04-01T00:00:00Z' }),
+      m5: makeMeta('m5', { overallStatus: 'down', name: 'Epsilon', updated_at: '2025-05-01T00:00:00Z' }),
+    };
+    const pendingConfigs: Record<string, any> = {
+      m6: makeMeta('m6', { overallStatus: 'pending', name: 'Zeta' }),
+    };
+    const disabledConfigs: Record<string, any> = {
+      m7: makeMeta('m7', { overallStatus: 'disabled', name: 'Eta' }),
+    };
+
+    const allBuckets = { upConfigs, downConfigs, pendingConfigs, disabledConfigs };
+
+    const createService = (query: Record<string, any> = {}) => {
+      const routeContext: any = {
+        request: { query },
+        server: {
+          isElasticsearchServerless: false,
+          config: { experimental: { ccs: { enabled: false } } },
+        },
+      };
+      return new OverviewStatusService(routeContext);
+    };
+
+    it('returns the first page with correct total', () => {
+      const service = createService({ page: 1, perPage: 3 });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(7);
+      expect(result.configs).toHaveLength(3);
+    });
+
+    it('returns the second page', () => {
+      const service = createService({ page: 2, perPage: 3 });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(7);
+      expect(result.configs).toHaveLength(3);
+    });
+
+    it('returns a partial last page', () => {
+      const service = createService({ page: 3, perPage: 3 });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(7);
+      expect(result.configs).toHaveLength(1);
+    });
+
+    it('returns empty configs when page is beyond range', () => {
+      const service = createService({ page: 10, perPage: 3 });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(7);
+      expect(result.configs).toHaveLength(0);
+    });
+
+    it('sorts by status asc: down first, then up, disabled, pending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'status', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const statuses = result.configs.map((c: any) => c.overallStatus);
+      expect(statuses).toEqual(['down', 'down', 'up', 'up', 'up', 'disabled', 'pending']);
+    });
+
+    it('sorts by status desc: up first, then down, disabled, pending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'status', sortOrder: 'desc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const statuses = result.configs.map((c: any) => c.overallStatus);
+      expect(statuses).toEqual(['up', 'up', 'up', 'down', 'down', 'disabled', 'pending']);
+    });
+
+    it('sorts by name ascending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'name.keyword', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const names = result.configs.map((c: any) => c.name);
+      expect(names).toEqual(['Alpha', 'Beta', 'Delta', 'Epsilon', 'Eta', 'Gamma', 'Zeta']);
+    });
+
+    it('sorts by name descending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'name.keyword', sortOrder: 'desc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const names = result.configs.map((c: any) => c.name);
+      expect(names).toEqual(['Zeta', 'Gamma', 'Eta', 'Epsilon', 'Delta', 'Beta', 'Alpha']);
+    });
+
+    it('sorts by updated_at ascending', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'updated_at', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const names = result.configs.map((c: any) => c.name);
+      // Monitors without updated_at (0) sort first in asc, then by date
+      expect(names.indexOf('Alpha')).toBeLessThan(names.indexOf('Beta'));
+      expect(names.indexOf('Beta')).toBeLessThan(names.indexOf('Delta'));
+    });
+
+    it('sorts by urls with empty urls last', () => {
+      const service = createService({ page: 1, perPage: 20, sortField: 'urls', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      const urls = result.configs.map((c: any) => c.urls ?? '(none)');
+      const withUrls = urls.filter((u: string) => u !== '(none)');
+      const withoutUrls = urls.filter((u: string) => u === '(none)');
+      // URLs are sorted alphabetically, then entries without URLs come last
+      expect(withUrls).toEqual(['https://alpha.io', 'https://beta.io', 'https://delta.io']);
+      expect(withoutUrls).toHaveLength(4);
+      // All url-less entries are at the end
+      expect(urls.indexOf(withoutUrls[0])).toBeGreaterThan(urls.lastIndexOf(withUrls[withUrls.length - 1]));
+    });
+
+    it('sorts by type ascending', () => {
+      const mixedTypes = {
+        upConfigs: {
+          t1: makeMeta('t1', { type: 'http', name: 'HTTP Mon' }),
+          t2: makeMeta('t2', { type: 'browser', name: 'Browser Mon' }),
+        },
+        downConfigs: {
+          t3: makeMeta('t3', { overallStatus: 'down', type: 'tcp', name: 'TCP Mon' }),
+        },
+        pendingConfigs: {},
+        disabledConfigs: {},
+      };
+      const service = createService({ page: 1, perPage: 20, sortField: 'type.keyword', sortOrder: 'asc' });
+      const result = service.paginateConfigs(mixedTypes);
+
+      const types = result.configs.map((c: any) => c.type);
+      expect(types).toEqual(['browser', 'http', 'tcp']);
+    });
+
+    it('filters by statusFilter=down', () => {
+      const service = createService({ page: 1, perPage: 20, statusFilter: 'down' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(2);
+      expect(result.configs.every((c: any) => c.overallStatus === 'down')).toBe(true);
+    });
+
+    it('filters by statusFilter=up', () => {
+      const service = createService({ page: 1, perPage: 20, statusFilter: 'up' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(3);
+      expect(result.configs.every((c: any) => c.overallStatus === 'up')).toBe(true);
+    });
+
+    it('filters by statusFilter=disabled', () => {
+      const service = createService({ page: 1, perPage: 20, statusFilter: 'disabled' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(1);
+      expect(result.configs[0].configId).toBe('m7');
+    });
+
+    it('filters by statusFilter=pending', () => {
+      const service = createService({ page: 1, perPage: 20, statusFilter: 'pending' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(1);
+      expect(result.configs[0].configId).toBe('m6');
+    });
+
+    it('populates page config maps matching the page items', () => {
+      const service = createService({ page: 1, perPage: 3, sortField: 'status', sortOrder: 'asc' });
+      const result = service.paginateConfigs(allBuckets);
+
+      // Page 1 with status asc: first 3 items are m4 (down), m5 (down), then one up
+      expect(Object.keys(result.pageDownConfigs)).toHaveLength(2);
+      expect(result.pageDownConfigs.m4).toBeDefined();
+      expect(result.pageDownConfigs.m5).toBeDefined();
+      expect(Object.keys(result.pageUpConfigs)).toHaveLength(1);
+      expect(Object.keys(result.pagePendingConfigs)).toHaveLength(0);
+      expect(Object.keys(result.pageDisabledConfigs)).toHaveLength(0);
+    });
+
+    it('combines statusFilter with pagination', () => {
+      const service = createService({ page: 1, perPage: 2, statusFilter: 'up' });
+      const result = service.paginateConfigs(allBuckets);
+
+      expect(result.total).toBe(3);
+      expect(result.configs).toHaveLength(2);
+      expect(result.configs.every((c: any) => c.overallStatus === 'up')).toBe(true);
+    });
+
+    it('combines statusFilter with sort by name', () => {
+      const service = createService({
+        page: 1, perPage: 20, statusFilter: 'up', sortField: 'name.keyword', sortOrder: 'asc',
+      });
+      const result = service.paginateConfigs(allBuckets);
+
+      const names = result.configs.map((c: any) => c.name);
+      expect(names).toEqual(['Alpha', 'Beta', 'Gamma']);
+    });
+
+    it('handles empty config maps', () => {
+      const service = createService({ page: 1, perPage: 20 });
+      const result = service.paginateConfigs({
+        upConfigs: {},
+        downConfigs: {},
+        pendingConfigs: {},
+        disabledConfigs: {},
+      });
+
+      expect(result.total).toBe(0);
+      expect(result.configs).toHaveLength(0);
+    });
+  });
 });
 
 function getEsResponse({ buckets, after }: { buckets: any[]; after?: any }) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
@@ -1986,13 +1986,30 @@ describe('current status route', () => {
     });
 
     const upConfigs: Record<string, any> = {
-      m1: makeMeta('m1', { name: 'Alpha', urls: 'https://alpha.io', updated_at: '2025-01-01T00:00:00Z' }),
-      m2: makeMeta('m2', { name: 'Beta', urls: 'https://beta.io', updated_at: '2025-03-01T00:00:00Z' }),
+      m1: makeMeta('m1', {
+        name: 'Alpha',
+        urls: 'https://alpha.io',
+        updated_at: '2025-01-01T00:00:00Z',
+      }),
+      m2: makeMeta('m2', {
+        name: 'Beta',
+        urls: 'https://beta.io',
+        updated_at: '2025-03-01T00:00:00Z',
+      }),
       m3: makeMeta('m3', { name: 'Gamma', updated_at: '2025-02-01T00:00:00Z' }),
     };
     const downConfigs: Record<string, any> = {
-      m4: makeMeta('m4', { overallStatus: 'down', name: 'Delta', urls: 'https://delta.io', updated_at: '2025-04-01T00:00:00Z' }),
-      m5: makeMeta('m5', { overallStatus: 'down', name: 'Epsilon', updated_at: '2025-05-01T00:00:00Z' }),
+      m4: makeMeta('m4', {
+        overallStatus: 'down',
+        name: 'Delta',
+        urls: 'https://delta.io',
+        updated_at: '2025-04-01T00:00:00Z',
+      }),
+      m5: makeMeta('m5', {
+        overallStatus: 'down',
+        name: 'Epsilon',
+        updated_at: '2025-05-01T00:00:00Z',
+      }),
     };
     const pendingConfigs: Record<string, any> = {
       m6: makeMeta('m6', { overallStatus: 'pending', name: 'Zeta' }),
@@ -2047,7 +2064,12 @@ describe('current status route', () => {
     });
 
     it('sorts by status asc: down first, then up, disabled, pending', () => {
-      const service = createService({ page: 1, perPage: 20, sortField: 'status', sortOrder: 'asc' });
+      const service = createService({
+        page: 1,
+        perPage: 20,
+        sortField: 'status',
+        sortOrder: 'asc',
+      });
       const result = service.paginateConfigs(allBuckets);
 
       const statuses = result.configs.map((c: any) => c.overallStatus);
@@ -2055,7 +2077,12 @@ describe('current status route', () => {
     });
 
     it('sorts by status desc: up first, then down, disabled, pending', () => {
-      const service = createService({ page: 1, perPage: 20, sortField: 'status', sortOrder: 'desc' });
+      const service = createService({
+        page: 1,
+        perPage: 20,
+        sortField: 'status',
+        sortOrder: 'desc',
+      });
       const result = service.paginateConfigs(allBuckets);
 
       const statuses = result.configs.map((c: any) => c.overallStatus);
@@ -2063,7 +2090,12 @@ describe('current status route', () => {
     });
 
     it('sorts by name ascending', () => {
-      const service = createService({ page: 1, perPage: 20, sortField: 'name.keyword', sortOrder: 'asc' });
+      const service = createService({
+        page: 1,
+        perPage: 20,
+        sortField: 'name.keyword',
+        sortOrder: 'asc',
+      });
       const result = service.paginateConfigs(allBuckets);
 
       const names = result.configs.map((c: any) => c.name);
@@ -2071,7 +2103,12 @@ describe('current status route', () => {
     });
 
     it('sorts by name descending', () => {
-      const service = createService({ page: 1, perPage: 20, sortField: 'name.keyword', sortOrder: 'desc' });
+      const service = createService({
+        page: 1,
+        perPage: 20,
+        sortField: 'name.keyword',
+        sortOrder: 'desc',
+      });
       const result = service.paginateConfigs(allBuckets);
 
       const names = result.configs.map((c: any) => c.name);
@@ -2079,7 +2116,12 @@ describe('current status route', () => {
     });
 
     it('sorts by updated_at ascending', () => {
-      const service = createService({ page: 1, perPage: 20, sortField: 'updated_at', sortOrder: 'asc' });
+      const service = createService({
+        page: 1,
+        perPage: 20,
+        sortField: 'updated_at',
+        sortOrder: 'asc',
+      });
       const result = service.paginateConfigs(allBuckets);
 
       const names = result.configs.map((c: any) => c.name);
@@ -2099,7 +2141,9 @@ describe('current status route', () => {
       expect(withUrls).toEqual(['https://alpha.io', 'https://beta.io', 'https://delta.io']);
       expect(withoutUrls).toHaveLength(4);
       // All url-less entries are at the end
-      expect(urls.indexOf(withoutUrls[0])).toBeGreaterThan(urls.lastIndexOf(withUrls[withUrls.length - 1]));
+      expect(urls.indexOf(withoutUrls[0])).toBeGreaterThan(
+        urls.lastIndexOf(withUrls[withUrls.length - 1])
+      );
     });
 
     it('sorts by type ascending', () => {
@@ -2114,7 +2158,12 @@ describe('current status route', () => {
         pendingConfigs: {},
         disabledConfigs: {},
       };
-      const service = createService({ page: 1, perPage: 20, sortField: 'type.keyword', sortOrder: 'asc' });
+      const service = createService({
+        page: 1,
+        perPage: 20,
+        sortField: 'type.keyword',
+        sortOrder: 'asc',
+      });
       const result = service.paginateConfigs(mixedTypes);
 
       const types = result.configs.map((c: any) => c.type);
@@ -2177,7 +2226,11 @@ describe('current status route', () => {
 
     it('combines statusFilter with sort by name', () => {
       const service = createService({
-        page: 1, perPage: 20, statusFilter: 'up', sortField: 'name.keyword', sortOrder: 'asc',
+        page: 1,
+        perPage: 20,
+        statusFilter: 'up',
+        sortField: 'name.keyword',
+        sortOrder: 'asc',
       });
       const result = service.paginateConfigs(allBuckets);
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.ts
@@ -67,6 +67,9 @@ export class OverviewStatusService {
 
   async getOverviewStatus() {
     this.filterData = await getMonitorFilters(this.routeContext);
+    const params = this.routeContext.request.query || {};
+    const { page, perPage } = params;
+    const isPaginated = page != null && perPage != null;
 
     const [allConfigs, statusResult] = await Promise.all([
       this.getMonitorConfigs(),
@@ -85,6 +88,34 @@ export class OverviewStatusService {
       projectMonitorsCount,
     } = processMonitors(allConfigs, this.filterData?.locationIds);
 
+    if (!isPaginated) {
+      return {
+        allIds,
+        allMonitorsCount: allConfigs.length,
+        disabledMonitorsCount,
+        projectMonitorsCount,
+        enabledMonitorQueryIds,
+        disabledMonitorQueryIds,
+        disabledCount,
+        up,
+        down,
+        pending,
+        upConfigs,
+        downConfigs,
+        pendingConfigs,
+        disabledConfigs,
+      };
+    }
+
+    const {
+      configs,
+      total,
+      pageUpConfigs,
+      pageDownConfigs,
+      pagePendingConfigs,
+      pageDisabledConfigs,
+    } = this.paginateConfigs({ upConfigs, downConfigs, pendingConfigs, disabledConfigs });
+
     return {
       allIds,
       allMonitorsCount: allConfigs.length,
@@ -96,11 +127,139 @@ export class OverviewStatusService {
       up,
       down,
       pending,
-      upConfigs,
-      downConfigs,
-      pendingConfigs,
-      disabledConfigs,
+      upConfigs: pageUpConfigs,
+      downConfigs: pageDownConfigs,
+      pendingConfigs: pagePendingConfigs,
+      disabledConfigs: pageDisabledConfigs,
+      configs,
+      total,
+      page,
+      perPage,
     };
+  }
+
+  paginateConfigs({
+    upConfigs,
+    downConfigs,
+    pendingConfigs,
+    disabledConfigs,
+  }: {
+    upConfigs: Record<string, OverviewStatusMetaData>;
+    downConfigs: Record<string, OverviewStatusMetaData>;
+    pendingConfigs: Record<string, OverviewStatusMetaData>;
+    disabledConfigs: Record<string, OverviewStatusMetaData>;
+  }) {
+    const params = this.routeContext.request.query || {};
+    const {
+      page = 1,
+      perPage = 20,
+      sortField = 'status',
+      sortOrder = 'asc',
+      statusFilter,
+    } = params;
+
+    let allConfigs: OverviewStatusMetaData[];
+
+    if (statusFilter) {
+      switch (statusFilter) {
+        case 'down':
+          allConfigs = Object.values(downConfigs);
+          break;
+        case 'up':
+          allConfigs = Object.values(upConfigs);
+          break;
+        case 'disabled':
+          allConfigs = Object.values(disabledConfigs);
+          break;
+        case 'pending':
+          allConfigs = Object.values(pendingConfigs);
+          break;
+        default:
+          allConfigs = [];
+      }
+    } else {
+      const upAndDown =
+        sortOrder === 'asc'
+          ? [...Object.values(downConfigs), ...Object.values(upConfigs)]
+          : [...Object.values(upConfigs), ...Object.values(downConfigs)];
+      allConfigs = [
+        ...upAndDown,
+        ...Object.values(disabledConfigs),
+        ...Object.values(pendingConfigs),
+      ];
+    }
+
+    this.sortConfigs(allConfigs, sortField, sortOrder);
+
+    const total = allConfigs.length;
+    const start = (page - 1) * perPage;
+    const pageConfigs = allConfigs.slice(start, start + perPage);
+
+    const pageUpConfigs: Record<string, OverviewStatusMetaData> = {};
+    const pageDownConfigs: Record<string, OverviewStatusMetaData> = {};
+    const pagePendingConfigs: Record<string, OverviewStatusMetaData> = {};
+    const pageDisabledConfigs: Record<string, OverviewStatusMetaData> = {};
+
+    for (const config of pageConfigs) {
+      const key = config.configId;
+      switch (config.overallStatus) {
+        case MONITOR_STATUS_ENUM.DOWN:
+          pageDownConfigs[key] = config;
+          break;
+        case MONITOR_STATUS_ENUM.UP:
+          pageUpConfigs[key] = config;
+          break;
+        case MONITOR_STATUS_ENUM.DISABLED:
+          pageDisabledConfigs[key] = config;
+          break;
+        default:
+          pagePendingConfigs[key] = config;
+      }
+    }
+
+    return {
+      configs: pageConfigs,
+      total,
+      pageUpConfigs,
+      pageDownConfigs,
+      pagePendingConfigs,
+      pageDisabledConfigs,
+    };
+  }
+
+  private sortConfigs(
+    configs: OverviewStatusMetaData[],
+    sortField: string | undefined,
+    sortOrder: string | undefined
+  ) {
+    const dir = sortOrder === 'desc' ? -1 : 1;
+
+    switch (sortField) {
+      case 'name.keyword':
+        configs.sort((a, b) => dir * a.name.localeCompare(b.name));
+        break;
+      case 'updated_at':
+        configs.sort((a, b) => {
+          const aTime = a.updated_at ? new Date(a.updated_at).getTime() : 0;
+          const bTime = b.updated_at ? new Date(b.updated_at).getTime() : 0;
+          return dir * (aTime - bTime);
+        });
+        break;
+      case 'urls': {
+        const withUrl = configs.filter((m) => m.urls);
+        const withoutUrl = configs.filter((m) => !m.urls);
+        withUrl.sort((a, b) => dir * (a.urls ?? '').localeCompare(b.urls ?? ''));
+        configs.length = 0;
+        configs.push(...withUrl, ...withoutUrl);
+        break;
+      }
+      case 'type.keyword':
+        configs.sort((a, b) => dir * (a.type ?? '').localeCompare(b.type ?? ''));
+        break;
+      case 'status':
+      default:
+        break;
+    }
   }
 
   getEsDataFilters() {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.ts
@@ -100,6 +100,10 @@ export class OverviewStatusService {
     >,
     statusResult: Map<string, LocationStatus>
   ) {
+    const params = this.routeContext.request.query || {};
+    const { page, perPage } = params;
+    const isPaginated = page != null && perPage != null;
+
     const { up, down, pending, upConfigs, downConfigs, pendingConfigs, disabledConfigs } =
       this.processOverviewStatus(allConfigs, statusResult);
 
@@ -112,6 +116,34 @@ export class OverviewStatusService {
       projectMonitorsCount,
     } = processMonitors(allConfigs, this.filterData?.locationIds);
 
+    if (!isPaginated) {
+      return {
+        allIds,
+        allMonitorsCount: allConfigs.length,
+        disabledMonitorsCount,
+        projectMonitorsCount,
+        enabledMonitorQueryIds,
+        disabledMonitorQueryIds,
+        disabledCount,
+        up,
+        down,
+        pending,
+        upConfigs,
+        downConfigs,
+        pendingConfigs,
+        disabledConfigs,
+      };
+    }
+
+    const {
+      configs,
+      total,
+      pageUpConfigs,
+      pageDownConfigs,
+      pagePendingConfigs,
+      pageDisabledConfigs,
+    } = this.paginateConfigs({ upConfigs, downConfigs, pendingConfigs, disabledConfigs });
+
     return {
       allIds,
       allMonitorsCount: allConfigs.length,
@@ -123,11 +155,139 @@ export class OverviewStatusService {
       up,
       down,
       pending,
-      upConfigs,
-      downConfigs,
-      pendingConfigs,
-      disabledConfigs,
+      upConfigs: pageUpConfigs,
+      downConfigs: pageDownConfigs,
+      pendingConfigs: pagePendingConfigs,
+      disabledConfigs: pageDisabledConfigs,
+      configs,
+      total,
+      page,
+      perPage,
     };
+  }
+
+  paginateConfigs({
+    upConfigs,
+    downConfigs,
+    pendingConfigs,
+    disabledConfigs,
+  }: {
+    upConfigs: Record<string, OverviewStatusMetaData>;
+    downConfigs: Record<string, OverviewStatusMetaData>;
+    pendingConfigs: Record<string, OverviewStatusMetaData>;
+    disabledConfigs: Record<string, OverviewStatusMetaData>;
+  }) {
+    const params = this.routeContext.request.query || {};
+    const {
+      page = 1,
+      perPage = 20,
+      sortField = 'status',
+      sortOrder = 'asc',
+      statusFilter,
+    } = params;
+
+    let allConfigs: OverviewStatusMetaData[];
+
+    if (statusFilter) {
+      switch (statusFilter) {
+        case 'down':
+          allConfigs = Object.values(downConfigs);
+          break;
+        case 'up':
+          allConfigs = Object.values(upConfigs);
+          break;
+        case 'disabled':
+          allConfigs = Object.values(disabledConfigs);
+          break;
+        case 'pending':
+          allConfigs = Object.values(pendingConfigs);
+          break;
+        default:
+          allConfigs = [];
+      }
+    } else {
+      const upAndDown =
+        sortOrder === 'asc'
+          ? [...Object.values(downConfigs), ...Object.values(upConfigs)]
+          : [...Object.values(upConfigs), ...Object.values(downConfigs)];
+      allConfigs = [
+        ...upAndDown,
+        ...Object.values(disabledConfigs),
+        ...Object.values(pendingConfigs),
+      ];
+    }
+
+    this.sortConfigs(allConfigs, sortField, sortOrder);
+
+    const total = allConfigs.length;
+    const start = (page - 1) * perPage;
+    const pageConfigs = allConfigs.slice(start, start + perPage);
+
+    const pageUpConfigs: Record<string, OverviewStatusMetaData> = {};
+    const pageDownConfigs: Record<string, OverviewStatusMetaData> = {};
+    const pagePendingConfigs: Record<string, OverviewStatusMetaData> = {};
+    const pageDisabledConfigs: Record<string, OverviewStatusMetaData> = {};
+
+    for (const config of pageConfigs) {
+      const key = config.configId;
+      switch (config.overallStatus) {
+        case MONITOR_STATUS_ENUM.DOWN:
+          pageDownConfigs[key] = config;
+          break;
+        case MONITOR_STATUS_ENUM.UP:
+          pageUpConfigs[key] = config;
+          break;
+        case MONITOR_STATUS_ENUM.DISABLED:
+          pageDisabledConfigs[key] = config;
+          break;
+        default:
+          pagePendingConfigs[key] = config;
+      }
+    }
+
+    return {
+      configs: pageConfigs,
+      total,
+      pageUpConfigs,
+      pageDownConfigs,
+      pagePendingConfigs,
+      pageDisabledConfigs,
+    };
+  }
+
+  private sortConfigs(
+    configs: OverviewStatusMetaData[],
+    sortField: string | undefined,
+    sortOrder: string | undefined
+  ) {
+    const dir = sortOrder === 'desc' ? -1 : 1;
+
+    switch (sortField) {
+      case 'name.keyword':
+        configs.sort((a, b) => dir * a.name.localeCompare(b.name));
+        break;
+      case 'updated_at':
+        configs.sort((a, b) => {
+          const aTime = a.updated_at ? new Date(a.updated_at).getTime() : 0;
+          const bTime = b.updated_at ? new Date(b.updated_at).getTime() : 0;
+          return dir * (aTime - bTime);
+        });
+        break;
+      case 'urls': {
+        const withUrl = configs.filter((m) => m.urls);
+        const withoutUrl = configs.filter((m) => !m.urls);
+        withUrl.sort((a, b) => dir * (a.urls ?? '').localeCompare(b.urls ?? ''));
+        configs.length = 0;
+        configs.push(...withUrl, ...withoutUrl);
+        break;
+      }
+      case 'type.keyword':
+        configs.sort((a, b) => dir * (a.type ?? '').localeCompare(b.type ?? ''));
+        break;
+      case 'status':
+      default:
+        break;
+    }
   }
 
   async getEsDataFilters() {


### PR DESCRIPTION
## Summary

Adds server-side pagination to the Synthetics overview status API (`/internal/synthetics/overview_status`) to support scalability up to 30k+ monitors.

**Key changes:**

- **Server-side pagination** — the `overview_status` route now accepts `page`, `perPage`, `sortField`, `sortOrder`, and `statusFilter` query params. Pagination is applied after the SO + ES join so that counts (`up`, `down`, `pending`, `disabled`) remain globally accurate while only returning one page of monitor configs.
- **Sorting** — supports sorting by `name`, `status`, `updated_at`, `monitor.type`, and `urls` directly in the paginated response.
- **Status filtering** — when a `statusFilter` is provided (e.g. `up`, `down`, `pending`, `disabled`), only monitors matching that status are included in the paginated results, while global counts still reflect all monitors.
- **Client-side wiring** — Redux state (`MonitorOverviewPageState`) extended with `page`, `perPage`, `sortField`, `sortOrder`; the overview grid and compact table consume paginated data directly instead of client-side slicing.
- **Unit tests** — added tests for `paginateConfigs` covering basic pagination, status filtering, multi-field sorting, and edge cases.

## Test plan

- [ ] Verify the overview page loads with default pagination (page 1, 10 per page)
- [ ] Verify changing page navigates correctly and shows loading state
- [ ] Verify sorting by name, status, type, URL works
- [ ] Verify status filter badges (up/down/pending/disabled) filter the table while global counts remain correct
- [ ] Verify CCS remote monitors still appear in counts and results
- [ ] Run unit tests: `node scripts/jest x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts`


Made with [Cursor](https://cursor.com)