### PR TITLE
[Security] Fix timeline template popover closing on Tab/Shift+Tab

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_super_select/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_super_select/index.tsx
@@ -123,6 +123,7 @@ const SearchTimelineSuperSelectComponent: React.FC<SearchTimelineSuperSelectProp
       isOpen={isPopoverOpen}
       closePopover={handleClosePopover}
       className="rightArrowIcon"
+      ownFocus={true}
     >
       <SelectableTimeline
         hideUntitled={hideUntitled}


### PR DESCRIPTION
## Summary

Fixes #226573

The timeline template popover on the Create New Rule page was closing unexpectedly when pressing Tab from the last focusable element or Shift+Tab from the first — a WCAG 2.1.1 (Level A) violation.

**Root cause:** `EuiInputPopover` has a built-in `handleTabNavigation` handler that explicitly calls `closePopover()` at Tab/Shift+Tab focus boundaries unless `ownFocus={true}` is set. With `ownFocus={true}`, that handler is bypassed and EuiPopover's built-in focus trap handles Tab key events by cycling focus within the popover instead.

**Change:** One line — `ownFocus={true}` on `EuiInputPopover` in `SearchTimelineSuperSelect`.

## Test plan

- [ ] Security → Rules → Detection rules (SIEM) → Create new rule (Custom query)
- [ ] Open timeline template picker, Tab through all items — focus should cycle, popover should stay open
- [ ] Shift+Tab from the first item — focus should cycle, popover should stay open
- [ ] Escape still closes the popover
- [ ] Selecting a timeline still closes the popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)