### PR TITLE
[Entity Analytics] Fixed default flags on main for entity store v2

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
@@ -137,7 +137,7 @@ const getMaintainerRouteWithId = (route: string, id: string): string =>
 export const useEntityAnalyticsRoutes = () => {
   const { http, uiSettings } = useKibana().services;
   const isEntityStoreV2UiSettingEnabled =
-    uiSettings?.get<boolean>(FF_ENABLE_ENTITY_STORE_V2) ?? false;
+    uiSettings?.get<boolean>(FF_ENABLE_ENTITY_STORE_V2, false) ?? false;
   const isEntityAnalyticsEntityStoreV2Enabled = useIsExperimentalFeatureEnabled(
     'entityAnalyticsEntityStoreV2'
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_engine_privileges.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_engine_privileges.ts
@@ -21,7 +21,7 @@ export const useEntityEnginePrivileges = (): UseQueryResult<
 > => {
   const { fetchEntityStorePrivileges, fetchEntityStoreV2Privileges } = useEntityAnalyticsRoutes();
   const { uiSettings } = useKibana().services;
-  const isEntityStoreV2Enabled = uiSettings?.get<boolean>(FF_ENABLE_ENTITY_STORE_V2);
+  const isEntityStoreV2Enabled = uiSettings?.get<boolean>(FF_ENABLE_ENTITY_STORE_V2, false);
 
   return useQuery(
     [...GET_ENTITY_ENGINE_PRIVILEGES, isEntityStoreV2Enabled],


### PR DESCRIPTION
Setting recently introduced default flags to `false` for entity store v2. 

This change is not intended to be backported, and will eventually be updated to true across all usages of this flag. 