### PR TITLE
Update contextMenuPanel condition to check that at least one panel has actual items

### DIFF
--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/panel_header/presentation_panel_hover_actions.tsx
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/panel_header/presentation_panel_hover_actions.tsx
@@ -427,14 +427,13 @@ export const PresentationPanelHoverActions = ({
     [setDragHandle, euiTheme.size.xs]
   );
 
-  const hasHoverActions = useMemo(() => {
-    if (quickActionElements.length) return true;
-    return contextMenuPanels.every(({ items }) => items?.length);
-  }, [quickActionElements, contextMenuPanels]);
+  const showContextMenu = useMemo(() => {
+    return contextMenuPanels.some(({ items }) => items?.length);
+  }, [contextMenuPanels]);
 
   return (
     <>
-      {api && hasHoverActions && (
+      {api && (quickActionElements.length || showContextMenu) && (
         <div
           className={classNames('embPanel__hoverActions', className)}
           data-test-subj={`hover-actions-${api.uuid}`}
@@ -472,7 +471,7 @@ export const PresentationPanelHoverActions = ({
                 </EuiToolTip>
               )
             )}
-            {contextMenuPanels.some(({ items }) => items?.length) ? (
+            {showContextMenu ? (
               <EuiPopover
                 repositionOnScroll
                 panelPaddingSize="none"

--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/panel_header/presentation_panel_hover_actions.tsx
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/panel_header/presentation_panel_hover_actions.tsx
@@ -472,7 +472,7 @@ export const PresentationPanelHoverActions = ({
                 </EuiToolTip>
               )
             )}
-            {contextMenuPanels.length ? (
+            {contextMenuPanels.some(({ items }) => items?.length) ? (
               <EuiPopover
                 repositionOnScroll
                 panelPaddingSize="none"


### PR DESCRIPTION
## Summary

`buildContextMenuForActions` (in src/platform/plugins/shared/ui_actions/public/context_menu/build_eui_context_menu_panels.tsx) always initializes a `mainMenu` panel object and returns it in the result array, even when zero actions are passed to it (always `[{ id: 'mainMenu', items: [] }]`). 

Because of this,  checking `contextMenuPanels.length` was always truthy (1) even when the context menu contained no real items.  This caused the kebab menu button (`embeddablePanelToggleMenuIcon`) to render when it shouldn't.

This PR updates the length check on the panels array to a check that at least one panel has actual items to ensure the button with popover only shows up when there are actual items to show. This is also consistent with how `hasHoverActions `already evaluates the same contextMenuPanels array.

Before --> clicking on the kebab button does nothing:
<img width="366" height="103" alt="image" src="https://github.com/user-attachments/assets/2aba5410-53e0-47b4-89f9-04f8624dd066" />



After --> kebab button does not appear when there are no items for that menu:
<img width="381" height="332" alt="image" src="https://github.com/user-attachments/assets/ba052a99-a277-41a9-8e4f-4539e8cf643e" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



