### PR TITLE
[Security Solution] Add Scout UI test for detection rule creation common flows

### DIFF
--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
@@ -73,6 +73,7 @@ export class CreateRulePage {
   }
 
   async fillRuleName(name: string) {
+    await this.ruleNameInput.waitFor();
     await this.ruleNameInput.fill(name);
   }
 

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
@@ -64,7 +64,7 @@ export class CreateRulePage {
 
   async navigate() {
     await this.page.gotoApp(PAGE_URL);
-    await this.importQueryFromTimelineLink.waitFor({ state: 'visible' });
+    await this.importQueryFromTimelineLink.waitFor({ state: 'visible', timeout: 30000 });
   }
 
   async importQueryFromTimeline(timelineId: string) {

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
@@ -64,10 +64,10 @@ export class CreateRulePage {
 
   async navigate() {
     await this.page.gotoApp(PAGE_URL);
+    await this.importQueryFromTimelineLink.waitFor({ state: 'visible' });
   }
 
   async importQueryFromTimeline(timelineId: string) {
-    await this.importQueryFromTimelineLink.waitFor({ state: 'visible' });
     await this.importQueryFromTimelineLink.click();
     await this.page.testSubj.locator(`timeline-title-${timelineId}`).click();
   }

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
@@ -64,7 +64,7 @@ export class CreateRulePage {
 
   async navigate() {
     await this.page.gotoApp(PAGE_URL);
-    await this.importQueryFromTimelineLink.waitFor({ state: 'visible', timeout: 30000 });
+    await this.importQueryFromTimelineLink.waitFor({ timeout: 30000 });
   }
 
   async importQueryFromTimeline(timelineId: string) {

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage, Locator } from '@kbn/scout';
+
+const PAGE_URL = 'security/rules/create';
+
+export class CreateRulePage {
+  // --- Define step ---
+  readonly importQueryFromTimelineLink: Locator;
+  readonly defineContinueButton: Locator;
+  readonly defineEditButton: Locator;
+  readonly customQueryInput: Locator;
+
+  // --- About step ---
+  readonly ruleNameInput: Locator;
+  readonly ruleDescriptionInput: Locator;
+  readonly aboutContinueButton: Locator;
+  readonly advancedSettingsButton: Locator;
+  readonly maxSignalsInput: Locator;
+  readonly setupGuideTextarea: Locator;
+
+  // --- Schedule step ---
+  readonly lookBackInterval: Locator;
+  readonly lookBackTimeType: Locator;
+  readonly scheduleContinueButton: Locator;
+
+  // --- Final step ---
+  readonly createAndEnableButton: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.importQueryFromTimelineLink = this.page.testSubj.locator('importQueryFromSavedTimeline');
+    this.defineContinueButton = this.page.testSubj.locator('define-continue');
+    this.defineEditButton = this.page.testSubj.locator('edit-define-rule');
+    this.customQueryInput = this.page.testSubj.locator('queryInput');
+
+    this.ruleNameInput = this.page.testSubj
+      .locator('detectionEngineStepAboutRuleName')
+      .locator('[data-test-subj="input"]');
+    this.ruleDescriptionInput = this.page.testSubj
+      .locator('detectionEngineStepAboutRuleDescription')
+      .locator('[data-test-subj="input"]');
+    this.aboutContinueButton = this.page.testSubj.locator('about-continue');
+    this.advancedSettingsButton = this.page.testSubj.locator('advancedSettings');
+    this.maxSignalsInput = this.page.testSubj.locator('detectionEngineStepAboutRuleMaxSignals');
+    this.setupGuideTextarea = this.page.testSubj
+      .locator('detectionEngineStepAboutRuleSetup')
+      .locator('textarea');
+
+    this.lookBackInterval = this.page.testSubj
+      .locator('detectionEngineStepScheduleRuleFrom')
+      .locator('[data-test-subj="interval"]');
+    this.lookBackTimeType = this.page.testSubj
+      .locator('detectionEngineStepScheduleRuleFrom')
+      .locator('[data-test-subj="timeType"]');
+    this.scheduleContinueButton = this.page.testSubj.locator('schedule-continue');
+
+    this.createAndEnableButton = this.page.testSubj.locator('create-enable');
+  }
+
+  async navigate() {
+    await this.page.gotoApp(PAGE_URL);
+  }
+
+  async importQueryFromTimeline(timelineId: string) {
+    await this.importQueryFromTimelineLink.click();
+    await this.page.testSubj.locator(`timeline-title-${timelineId}`).click();
+  }
+
+  async fillRuleName(name: string) {
+    await this.ruleNameInput.fill(name);
+  }
+
+  async fillRuleDescription(description: string) {
+    await this.ruleDescriptionInput.fill(description);
+  }
+
+  async fillMaxSignals(value: number) {
+    await this.maxSignalsInput.fill(value.toString());
+  }
+
+  async fillSetupGuide(text: string) {
+    await this.setupGuideTextarea.fill(text);
+  }
+
+  async expandAdvancedSettings() {
+    await this.advancedSettingsButton.click();
+  }
+
+  async fillLookBack(value: string, unit: string) {
+    await this.lookBackInterval.fill(value);
+    await this.lookBackTimeType.selectOption(unit);
+  }
+
+  async createAndEnable() {
+    await this.createAndEnableButton.click();
+    await this.createAndEnableButton.waitFor({ state: 'hidden' });
+  }
+}

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/create_rule_page.ts
@@ -67,6 +67,7 @@ export class CreateRulePage {
   }
 
   async importQueryFromTimeline(timelineId: string) {
+    await this.importQueryFromTimelineLink.waitFor({ state: 'visible' });
     await this.importQueryFromTimelineLink.click();
     await this.page.testSubj.locator(`timeline-title-${timelineId}`).click();
   }

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/index.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/index.ts
@@ -16,6 +16,8 @@ import { TimelinePage } from './timeline';
 import { DetectionsAttackDiscoveryPage } from './detections_attack_discovery';
 import { AttackDetailsRightPanelPage } from './attack_details_right_panel';
 import { ServerlessProjectChromePage } from './serverless_project_chrome_page';
+import { CreateRulePage } from './create_rule_page';
+import { RuleDetailsPage } from './rule_details_page';
 
 export interface SecurityPageObjects extends PageObjects {
   alertsTablePage: AlertsTablePage;
@@ -27,6 +29,8 @@ export interface SecurityPageObjects extends PageObjects {
   detectionsAttackDiscoveryPage: DetectionsAttackDiscoveryPage;
   attackDetailsRightPanelPage: AttackDetailsRightPanelPage;
   serverlessProjectChromePage: ServerlessProjectChromePage;
+  createRulePage: CreateRulePage;
+  ruleDetailsPage: RuleDetailsPage;
 }
 
 export function extendPageObjects(
@@ -49,5 +53,7 @@ export function extendPageObjects(
     ),
     attackDetailsRightPanelPage: createLazyPageObject(AttackDetailsRightPanelPage, page),
     serverlessProjectChromePage: createLazyPageObject(ServerlessProjectChromePage, page),
+    createRulePage: createLazyPageObject(CreateRulePage, page),
+    ruleDetailsPage: createLazyPageObject(RuleDetailsPage, page),
   };
 }

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/rule_details_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/rule_details_page.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage, Locator } from '@kbn/scout';
+
+export class RuleDetailsPage {
+  readonly ruleNameHeader: Locator;
+  readonly maxSignalsDetail: Locator;
+  readonly setupGuideButton: Locator;
+  readonly setupGuideContent: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.ruleNameHeader = this.page.testSubj.locator('header-page-title');
+    this.maxSignalsDetail = this.page.testSubj.locator('maxSignalsPropertyValue');
+    this.setupGuideButton = this.page.testSubj.locator('stepAboutDetailsToggle-setup');
+    this.setupGuideContent = this.page.testSubj.locator('stepAboutDetailsSetupContent');
+  }
+
+  async openSetupGuide() {
+    await this.setupGuideButton.click();
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
@@ -8,7 +8,6 @@
 import { spaceTest, tags } from '@kbn/scout-security';
 import { expect } from '@kbn/scout-security/ui';
 
-// Test data — same values as the Cypress ruleFields object
 const RULE_NAME = 'Test Rule';
 const RULE_DESCRIPTION = 'Test Rule Description';
 const MAX_SIGNALS = '200';
@@ -52,10 +51,10 @@ spaceTest.describe(
           await createRulePage.importQueryFromTimeline(timelineId);
           await expect(createRulePage.customQueryInput).toHaveValue(TIMELINE_QUERY);
           await createRulePage.defineContinueButton.click();
+          await expect(createRulePage.ruleNameInput).toBeVisible();
         });
 
         await spaceTest.step('fill about section and continue', async () => {
-          await createRulePage.ruleNameInput.waitFor();
           await createRulePage.fillRuleName(RULE_NAME);
           await createRulePage.fillRuleDescription(RULE_DESCRIPTION);
           await createRulePage.expandAdvancedSettings();
@@ -63,10 +62,10 @@ spaceTest.describe(
           await createRulePage.fillSetupGuide(SETUP_GUIDE_TEXT);
           await createRulePage.aboutContinueButton.scrollIntoViewIfNeeded();
           await createRulePage.aboutContinueButton.click();
+          await expect(createRulePage.scheduleContinueButton).toBeVisible();
         });
 
         await spaceTest.step('fill schedule and verify state persistence', async () => {
-          await createRulePage.scheduleContinueButton.waitFor();
           await createRulePage.lookBackInterval.scrollIntoViewIfNeeded();
           await createRulePage.fillLookBack(LOOK_BACK_VALUE, LOOK_BACK_UNIT);
           await expect(createRulePage.lookBackInterval).toHaveValue(LOOK_BACK_VALUE);
@@ -75,14 +74,15 @@ spaceTest.describe(
           await createRulePage.defineEditButton.click();
           await expect(createRulePage.customQueryInput).toHaveValue(TIMELINE_QUERY);
           await createRulePage.defineContinueButton.click();
+          await expect(createRulePage.ruleNameInput).toBeVisible();
 
           // Go back to about step and verify rule name is still there
-          await createRulePage.ruleNameInput.waitFor();
+          await expect(createRulePage.ruleNameInput).toBeVisible();
           await expect(createRulePage.ruleNameInput).toHaveValue(RULE_NAME);
           await createRulePage.aboutContinueButton.scrollIntoViewIfNeeded();
           await createRulePage.aboutContinueButton.click();
-          await createRulePage.scheduleContinueButton.waitFor();
           await createRulePage.scheduleContinueButton.click();
+          await expect(createRulePage.createAndEnableButton).toBeVisible();
         });
 
         await spaceTest.step('create rule and verify details page', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
@@ -77,7 +77,9 @@ spaceTest.describe(
           // Go back to about step and verify rule name is still there
           await createRulePage.ruleNameInput.waitFor();
           await expect(createRulePage.ruleNameInput).toHaveValue(RULE_NAME);
+          await createRulePage.aboutContinueButton.scrollIntoViewIfNeeded();
           await createRulePage.aboutContinueButton.click();
+          await createRulePage.scheduleContinueButton.waitFor({ state: 'visible' });
           await createRulePage.scheduleContinueButton.click();
         });
 

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
@@ -22,17 +22,19 @@ spaceTest.describe(
   () => {
     let timelineId: string;
 
-    spaceTest.beforeAll(async ({ apiServices }) => {
+    spaceTest.beforeAll(async ({ apiServices, scoutSpace }) => {
       // Clean up any leftover rules from a previous failed run
       await apiServices.detectionRule.deleteAll();
+      await apiServices.timeline.deleteAll();
       // Create a timeline to import its query in the Define step
       timelineId = await apiServices.timeline.createTimeline();
     });
 
-    spaceTest.afterAll(async ({ apiServices }) => {
+    spaceTest.afterAll(async ({ apiServices, scoutSpace }) => {
       // Clean up everything created by this test
       await apiServices.detectionRule.deleteAll();
       await apiServices.timeline.deleteAll();
+      await scoutSpace.savedObjects.cleanStandardList();
     });
 
     spaceTest(

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
@@ -11,10 +11,11 @@ import { expect } from '@kbn/scout-security/ui';
 // Test data — same values as the Cypress ruleFields object
 const RULE_NAME = 'Test Rule';
 const RULE_DESCRIPTION = 'Test Rule Description';
-const MAX_SIGNALS = '100';
+const MAX_SIGNALS = '200';
 const SETUP_GUIDE_TEXT = '# test setup markdown';
 const LOOK_BACK_VALUE = '50000';
 const LOOK_BACK_UNIT = 'h';
+const TIMELINE_QUERY = 'host.name: *';
 
 spaceTest.describe(
   'Common rule creation flows',
@@ -49,12 +50,12 @@ spaceTest.describe(
 
         await spaceTest.step('fill define section and continue', async () => {
           await createRulePage.importQueryFromTimeline(timelineId);
-          await expect(createRulePage.customQueryInput).not.toBeEmpty();
+          await expect(createRulePage.customQueryInput).toHaveValue(TIMELINE_QUERY);
           await createRulePage.defineContinueButton.click();
         });
 
         await spaceTest.step('fill about section and continue', async () => {
-          await createRulePage.ruleNameInput.waitFor({ state: 'visible' });
+          await createRulePage.ruleNameInput.waitFor();
           await createRulePage.fillRuleName(RULE_NAME);
           await createRulePage.fillRuleDescription(RULE_DESCRIPTION);
           await createRulePage.expandAdvancedSettings();
@@ -65,13 +66,14 @@ spaceTest.describe(
         });
 
         await spaceTest.step('fill schedule and verify state persistence', async () => {
-          await createRulePage.scheduleContinueButton.waitFor({ state: 'visible' });
+          await createRulePage.scheduleContinueButton.waitFor();
           await createRulePage.lookBackInterval.scrollIntoViewIfNeeded();
           await createRulePage.fillLookBack(LOOK_BACK_VALUE, LOOK_BACK_UNIT);
+          await expect(createRulePage.lookBackInterval).toHaveValue(LOOK_BACK_VALUE);
 
           // Go back to define step and verify query is still there
           await createRulePage.defineEditButton.click();
-          await expect(createRulePage.customQueryInput).not.toBeEmpty();
+          await expect(createRulePage.customQueryInput).toHaveValue(TIMELINE_QUERY);
           await createRulePage.defineContinueButton.click();
 
           // Go back to about step and verify rule name is still there
@@ -79,7 +81,7 @@ spaceTest.describe(
           await expect(createRulePage.ruleNameInput).toHaveValue(RULE_NAME);
           await createRulePage.aboutContinueButton.scrollIntoViewIfNeeded();
           await createRulePage.aboutContinueButton.click();
-          await createRulePage.scheduleContinueButton.waitFor({ state: 'visible' });
+          await createRulePage.scheduleContinueButton.waitFor();
           await createRulePage.scheduleContinueButton.click();
         });
 

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { spaceTest, tags } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/ui';
+
+// Test data — same values as the Cypress ruleFields object
+const RULE_NAME = 'Test Rule';
+const RULE_DESCRIPTION = 'Test Rule Description';
+const MAX_SIGNALS = '100';
+const SETUP_GUIDE_TEXT = '# test setup markdown';
+const LOOK_BACK_VALUE = '50000';
+const LOOK_BACK_UNIT = 'h';
+
+spaceTest.describe(
+  'Common rule creation flows',
+  { tag: [...tags.stateful.classic, ...tags.serverless.security.complete] },
+  () => {
+    let timelineId: string;
+
+    spaceTest.beforeAll(async ({ apiServices }) => {
+      // Clean up any leftover rules from a previous failed run
+      await apiServices.detectionRule.deleteAll();
+      // Create a timeline to import its query in the Define step
+      timelineId = await apiServices.timeline.createTimeline();
+    });
+
+    spaceTest.afterAll(async ({ apiServices }) => {
+      // Clean up everything created by this test
+      await apiServices.detectionRule.deleteAll();
+      await apiServices.timeline.deleteAll();
+    });
+
+    spaceTest(
+      'creates and enables a rule with all common fields',
+      async ({ pageObjects, browserAuth }) => {
+        await browserAuth.loginAsPlatformEngineer();
+        const { createRulePage, ruleDetailsPage } = pageObjects;
+
+        await spaceTest.step('navigate to rule creation page', async () => {
+          await createRulePage.navigate();
+        });
+
+        await spaceTest.step('fill define section and continue', async () => {
+          await createRulePage.importQueryFromTimeline(timelineId);
+          await expect(createRulePage.customQueryInput).not.toBeEmpty();
+          await createRulePage.defineContinueButton.click();
+        });
+
+        await spaceTest.step('fill about section and continue', async () => {
+          await createRulePage.ruleNameInput.waitFor({ state: 'visible' });
+          await createRulePage.fillRuleName(RULE_NAME);
+          await createRulePage.fillRuleDescription(RULE_DESCRIPTION);
+          await createRulePage.expandAdvancedSettings();
+          await createRulePage.fillMaxSignals(Number(MAX_SIGNALS));
+          await createRulePage.fillSetupGuide(SETUP_GUIDE_TEXT);
+          await createRulePage.aboutContinueButton.scrollIntoViewIfNeeded();
+          await createRulePage.aboutContinueButton.click();
+        });
+
+        await spaceTest.step('fill schedule and verify state persistence', async () => {
+          await createRulePage.scheduleContinueButton.waitFor({ state: 'visible' });
+          await createRulePage.lookBackInterval.scrollIntoViewIfNeeded();
+          await createRulePage.fillLookBack(LOOK_BACK_VALUE, LOOK_BACK_UNIT);
+
+          // Go back to define step and verify query is still there
+          await createRulePage.defineEditButton.click();
+          await expect(createRulePage.customQueryInput).not.toBeEmpty();
+          await createRulePage.defineContinueButton.click();
+
+          // Go back to about step and verify rule name is still there
+          await createRulePage.ruleNameInput.waitFor();
+          await expect(createRulePage.ruleNameInput).toHaveValue(RULE_NAME);
+          await createRulePage.aboutContinueButton.click();
+          await createRulePage.scheduleContinueButton.click();
+        });
+
+        await spaceTest.step('create rule and verify details page', async () => {
+          await createRulePage.createAndEnable();
+
+          await expect(ruleDetailsPage.ruleNameHeader).toContainText(RULE_NAME);
+          await expect(ruleDetailsPage.maxSignalsDetail).toContainText(MAX_SIGNALS);
+
+          await ruleDetailsPage.openSetupGuide();
+          await expect(ruleDetailsPage.setupGuideContent).toContainText('test setup markdown');
+        });
+      }
+    );
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts
@@ -22,7 +22,7 @@ spaceTest.describe(
   () => {
     let timelineId: string;
 
-    spaceTest.beforeAll(async ({ apiServices, scoutSpace }) => {
+    spaceTest.beforeAll(async ({ apiServices }) => {
       // Clean up any leftover rules from a previous failed run
       await apiServices.detectionRule.deleteAll();
       await apiServices.timeline.deleteAll();


### PR DESCRIPTION
## Summary

- Migrates `common_flows.cy.ts` (Detection Engine rule creation) from Cypress to Scout UI tests
- Adds two new page objects to `@kbn/scout-security`: `CreateRulePage` and `RuleDetailsPage`
- Adds a parallel Scout UI spec covering the full rule creation wizard flow

## What is tested

The spec (`common_flows_rule_creation.spec.ts`) verifies the UI-specific behaviour that must live at the UI layer:

- Importing a query from a saved Timeline in the Define step
- Filling all required and optional fields in the About step (name, description, max signals, setup guide)
- **State persistence**: navigating back to previous steps and verifying entered values are preserved
- Creating and enabling the rule and verifying the Rule Details page shows the correct values

Alert generation and rule execution logic are already covered by API-level tests and are intentionally excluded from this spec.

## Test plan

- [x] `node scripts/scout.js run-tests --arch stateful --domain classic --testFiles x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/detection_engine/common_flows_rule_creation.spec.ts` → 2 passed (1 spec + 1 worker warmup)
- [x] `node scripts/check_changes.ts` → clean
- [x] CI green
- [x] Flaky Test Runner Pass
   

## Notes

- `CreateRulePage` and `RuleDetailsPage` are registered in `kbn-scout-security`'s page object fixture so they are available to any Security Solution Scout UI test via `pageObjects`
- The equivalent Cypress test (`common_flows.cy.ts`) is not removed in this PR to allow iterative review; it should be deleted in a follow-up once this spec is confirmed green in CI.
    ⚠️ Cypress test should not be deleted at this point, refer to [comment](https://github.com/elastic/kibana/pull/267629#issuecomment-4401550017)
