### PR TITLE
[failed-test-reporter] avoid opening issues for scout env failures

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_scout_failures.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_scout_failures.ts
@@ -68,9 +68,20 @@ interface ScoutFailureTrackingEntry {
   };
 }
 
+// Failure substrings that indicate environmental/infrastructure issues rather than
+// real test failures. Matches mark the failure as "likely irrelevant" so we skip
+// filing GitHub issues for them.
+const LIKELY_IRRELEVANT_FAILURE_SUBSTRINGS: readonly string[] = [
+  // SAML response parsing failures are environmental (cloud IAM service, test account).
+  'Failed to parse SAML response value',
+  // Cloud session creation failures are environmental (cloud login endpoint unavailable, MFA, etc.).
+  'Failed to create the new cloud session',
+  // Network connection refused errors are environmental (target host/service unreachable).
+  'connect ECONNREFUSED',
+];
+
 const isLikelyIrrelevant = (name: string, failure: string) => {
-  // no filters for Scout failures at the moment
-  return false;
+  return LIKELY_IRRELEVANT_FAILURE_SUBSTRINGS.some((substring) => failure.includes(substring));
 };
 
 export async function getScoutFailures(reportPath: string): Promise<ScoutTestFailureExtended[]> {


### PR DESCRIPTION
## Summary

Similar to FTR, we shouldn't create GH issues assigned to teams when tests failed due to infra / env issues:

example: https://github.com/elastic/kibana/issues?q=state%3Aopen%20label%3A%22scout-playwright%22%20%22Failed%20to%20parse%20SAML%22




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->