### PR TITLE
[9.3] [Discover][Logs] Fix multi-value field array delimiters rendering as raw HTML in resource badges (#267436)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.test.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.test.ts
@@ -32,6 +32,25 @@ describe('truncateAndPreserveHighlightTags', () => {
     });
   });
 
+  describe('when there are <span class="ffArray__highlight"> tags', () => {
+    const SPAN = '<span class="ffArray__highlight">';
+    const CLOSE = '</span>';
+    const ARRAY_SHORT = `${SPAN}[${CLOSE}ab${SPAN}]${CLOSE}`;
+    const ARRAY_LONG = `${SPAN}[${CLOSE}elastic-agent-service${SPAN},${CLOSE} filebeat${SPAN}]${CLOSE}`;
+
+    describe('and text is shorter than maxLength', () => {
+      it('should return the original string with the tags', () => {
+        expect(truncateAndPreserveHighlightTags(ARRAY_SHORT, MAX_LENGTH)).toBe(ARRAY_SHORT);
+      });
+    });
+
+    describe('and text is longer than or equal to maxLength', () => {
+      it('should truncate and strip the array spans', () => {
+        expect(truncateAndPreserveHighlightTags(ARRAY_LONG, MAX_LENGTH)).toBe('[elas...beat]');
+      });
+    });
+  });
+
   describe('when there are <mark> tags', () => {
     describe('and text is shorter than maxLength', () => {
       const result = truncateAndPreserveHighlightTags(`<mark>${SHORT_TEXT}</mark>`, MAX_LENGTH);

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.ts
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/utils/truncate_preserve_highlight_tags.ts
@@ -9,10 +9,12 @@
 
 export function extractTextAndMarkTags(html: string) {
   const markTags: string[] = [];
-  const cleanText = html.replace(/<\/?mark[^>]*>/g, (match) => {
-    markTags.push(match);
-    return '';
-  });
+  const cleanText = html
+    .replace(/<\/?mark[^>]*>/g, (match) => {
+      markTags.push(match);
+      return '';
+    })
+    .replace(/<span class="ffArray__highlight">|<\/span>/g, '');
 
   return { cleanText, markTags };
 }

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.test.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.test.ts
@@ -47,6 +47,17 @@ describe('escapeAndPreserveHighlightTags', () => {
       `${ES_PRE}test${ES_POST}`
     );
   });
+
+  it('preserves ffArray__highlight spans for array-valued fields', () => {
+    const SPAN = '<span class="ffArray__highlight">';
+    const CLOSE = '</span>';
+    const input = `${SPAN}[${CLOSE}elastic-agent-service${SPAN},${CLOSE} filebeat${SPAN}]${CLOSE}`;
+    expect(escapeAndPreserveHighlightTags(input)).toBe(input);
+  });
+
+  it('escapes orphaned </span> that has no matching ffArray__highlight opening tag', () => {
+    expect(escapeAndPreserveHighlightTags('foo</span>bar')).toBe('foo&lt;/span&gt;bar');
+  });
 });
 
 describe('getHighlightedFieldValue', () => {

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/highlight_utils.ts
@@ -20,29 +20,41 @@ const HTML_HIGHLIGHT_POST_TAG = '</mark>';
 const ES_HIGHLIGHT_PRE_TAG = '@kibana-highlighted-field@';
 const ES_HIGHLIGHT_POST_TAG = '@/kibana-highlighted-field@';
 
+const ARRAY_HIGHLIGHT_PRE_TAG = '<span class="ffArray__highlight">';
+
+const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Matches complete known tag pairs. Groups 1-3 capture mark open/content/close;
+// group 0 is used as-is for array spans (content is only [ ] , — no HTML-special chars).
+const PRESERVED_TAGS_PATTERN = new RegExp(
+  `(${esc(HTML_HIGHLIGHT_PRE_TAG)})([\\s\\S]*?)(${esc(HTML_HIGHLIGHT_POST_TAG)})` +
+    `|${esc(ARRAY_HIGHLIGHT_PRE_TAG)}[^<]*${esc('</span>')}`,
+  'g'
+);
+
 /**
- * Escapes HTML in a string while preserving field-format highlight <mark> tags.
+ * Escapes HTML in a string while preserving field-format highlight <mark> tags
+ * and array-formatting <span class="ffArray__highlight"> tags.
  * Used for values already processed by formatFieldValue / getHighlightHtml (e.g. resource badges).
  */
 export function escapeAndPreserveHighlightTags(value: string): string {
-  if (!value.includes(HTML_HIGHLIGHT_PRE_TAG)) {
-    return escape(value);
+  const parts: string[] = [];
+  let lastIndex = 0;
+
+  for (const match of value.matchAll(PRESERVED_TAGS_PATTERN)) {
+    parts.push(escape(value.slice(lastIndex, match.index!)));
+    if (match[1]) {
+      // mark tag: preserve open/close, escape inner content
+      parts.push(match[1], escape(match[2]), match[3]);
+    } else {
+      // array span: preserve as-is
+      parts.push(match[0]);
+    }
+    lastIndex = match.index! + match[0].length;
   }
 
-  return value
-    .split(HTML_HIGHLIGHT_PRE_TAG)
-    .map((segment, index) => {
-      if (index === 0) return escape(segment);
-
-      const postTagIndex = segment.indexOf(HTML_HIGHLIGHT_POST_TAG);
-      if (postTagIndex === -1) return escape(segment);
-
-      const highlighted = segment.substring(0, postTagIndex);
-      const rest = segment.substring(postTagIndex + HTML_HIGHLIGHT_POST_TAG.length);
-
-      return HTML_HIGHLIGHT_PRE_TAG + escape(highlighted) + HTML_HIGHLIGHT_POST_TAG + escape(rest);
-    })
-    .join('');
+  parts.push(escape(value.slice(lastIndex)));
+  return parts.join('');
 }
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.4` to `9.3`:
 - [[Discover][Logs] Fix multi-value field array delimiters rendering as raw HTML in resource badges (#267436)](https://github.com/elastic/kibana/pull/267436)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Irene Blanco","email":"irene.blanco@elastic.co"},"sourceCommit":{"committedDate":"2026-05-05T06:09:08Z","message":"[Discover][Logs] Fix multi-value field array delimiters rendering as raw HTML in resource badges (#267436)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/267474 (flagged in\nv9.3.3)\n\nWhen a field like `service.name` holds a multi-value array, the HTML\nfield formatter wraps the delimiters (`[`, `]`, `,`) with `<span\nclass=\"ffArray__highlight\">` spans. These were passed through\n`escapeAndPreserveHighlightTags`, which only knew to preserve\nsearch-highlight`<mark>` tags, everything else was escaped, so the span\ntags appeared as literal text in the resource badge.\n\nTwo files are changed:\n\n- `escapeAndPreserveHighlightTags` is updated to also preserve `<span\nclass=\"ffArray__highlight\">` pairs.\n- `extractTextAndMarkTags` is updated to strip array spans before\nmeasuring length, so `truncateAndPreserveHighlightTags` slices at the\ncorrect character position rather than cutting through HTML tag strings.\n\n> [!NOTE]\n> This is a 9.4.x-9.3.x workaround. \n> In `main` the issue no longer exists, the badge was refactored to use\n`formatFieldValueReact` (ReactNode) instead of an HTML string, so this\ncode path is never reached.\n\n\n\n\n|Before|After|\n|-|-|\n|<img width=\"1918\" height=\"970\" alt=\"array_before\"\nsrc=\"https://github.com/user-attachments/assets/bec4d0a2-283b-4abf-99e6-6a57592753f8\"\n/>|<img width=\"1920\" height=\"968\" alt=\"array_after\"\nsrc=\"https://github.com/user-attachments/assets/8a42fe18-6288-4757-a492-971cb98ba2d9\"\n/>|","sha":"e67a0c97b21c205759cb20e94aa73e9391cdee8f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Project:OneDiscover","backport:version","v9.3.0","Team:obs-exploration","v9.4.0"],"title":"[Discover][Logs] Fix multi-value field array delimiters rendering as raw HTML in resource badges","number":267436,"url":"https://github.com/elastic/kibana/pull/267436","mergeCommit":{"message":"[Discover][Logs] Fix multi-value field array delimiters rendering as raw HTML in resource badges (#267436)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/267474 (flagged in\nv9.3.3)\n\nWhen a field like `service.name` holds a multi-value array, the HTML\nfield formatter wraps the delimiters (`[`, `]`, `,`) with `<span\nclass=\"ffArray__highlight\">` spans. These were passed through\n`escapeAndPreserveHighlightTags`, which only knew to preserve\nsearch-highlight`<mark>` tags, everything else was escaped, so the span\ntags appeared as literal text in the resource badge.\n\nTwo files are changed:\n\n- `escapeAndPreserveHighlightTags` is updated to also preserve `<span\nclass=\"ffArray__highlight\">` pairs.\n- `extractTextAndMarkTags` is updated to strip array spans before\nmeasuring length, so `truncateAndPreserveHighlightTags` slices at the\ncorrect character position rather than cutting through HTML tag strings.\n\n> [!NOTE]\n> This is a 9.4.x-9.3.x workaround. \n> In `main` the issue no longer exists, the badge was refactored to use\n`formatFieldValueReact` (ReactNode) instead of an HTML string, so this\ncode path is never reached.\n\n\n\n\n|Before|After|\n|-|-|\n|<img width=\"1918\" height=\"970\" alt=\"array_before\"\nsrc=\"https://github.com/user-attachments/assets/bec4d0a2-283b-4abf-99e6-6a57592753f8\"\n/>|<img width=\"1920\" height=\"968\" alt=\"array_after\"\nsrc=\"https://github.com/user-attachments/assets/8a42fe18-6288-4757-a492-971cb98ba2d9\"\n/>|","sha":"e67a0c97b21c205759cb20e94aa73e9391cdee8f"}},"sourceBranch":"9.4","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->