### PR TITLE
Improve Elastic Ramen setup page layout

### DIFF
--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -7,9 +7,11 @@
 
 import React, { useCallback, useRef, useState } from 'react';
 import {
+  EuiAccordion,
   EuiBetaBadge,
   EuiButton,
   EuiCallOut,
+  EuiCode,
   EuiCodeBlock,
   EuiFieldText,
   EuiFlexGroup,
@@ -83,22 +85,44 @@ export const SetupPage: React.FC = () => {
 
         <EuiSpacer />
 
-        <EuiFlexGroup gutterSize="m" alignItems="center">
-          <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={handleSetup} isLoading={isLoading}>
-              Generate credentials
-            </EuiButton>
-          </EuiFlexItem>
-          {setupData && (
-            <EuiFlexItem grow={false}>
-              <EuiButton onClick={() => formRef.current?.submit()} iconType="popout">
-                Connect local agent
-              </EuiButton>
-            </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
+        {!setupData && (
+          <EuiButton fill onClick={handleSetup} isLoading={isLoading}>
+            Generate credentials
+          </EuiButton>
+        )}
 
-        <EuiSpacer />
+        {setupData && (
+          <>
+            <EuiCallOut title="Credentials generated" color="success" iconType="check">
+              <p>
+                Your API key and connection details are ready. Click{' '}
+                <strong>Connect local agent</strong> to send them automatically to your local agent,
+                or copy them manually below.
+              </p>
+            </EuiCallOut>
+
+            <EuiSpacer />
+
+            <EuiFlexGroup alignItems="center" gutterSize="m">
+              <EuiFlexItem grow={false}>
+                <EuiButton fill onClick={() => formRef.current?.submit()} iconType="popout">
+                  Connect local agent
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+
+            <EuiSpacer size="s" />
+
+            <EuiText size="s" color="subdued">
+              <p>
+                The <strong>Connect local agent</strong> button will POST your credentials to{' '}
+                <EuiCode>{LOCAL_AGENT_URL}</EuiCode>. Make sure your agent is running.
+              </p>
+            </EuiText>
+
+            <EuiSpacer size="l" />
+          </>
+        )}
 
         {error && (
           <>
@@ -158,44 +182,52 @@ export const SetupPage: React.FC = () => {
               />
               <input type="hidden" name="model" value="kibana/default" />
             </form>
-            <EuiFlexGroup direction="column" gutterSize="m">
-              <EuiFlexItem>
-                <EuiFormRow label="Kibana URL" fullWidth>
-                  <EuiFieldText value={setupData.kibanaUrl} readOnly fullWidth />
-                </EuiFormRow>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiFormRow label="Elasticsearch URL" fullWidth>
-                  <EuiFieldText value={setupData.elasticsearchUrl} readOnly fullWidth />
-                </EuiFormRow>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiFormRow label="API Key (Base64)" fullWidth>
-                  <EuiCodeBlock language="text" paddingSize="s" isCopyable>
-                    {setupData.apiKeyEncoded}
-                  </EuiCodeBlock>
-                </EuiFormRow>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiCopy
-                  textToCopy={JSON.stringify(
-                    {
-                      kibanaUrl: setupData.kibanaUrl,
-                      elasticsearchUrl: setupData.elasticsearchUrl,
-                      apiKey: setupData.apiKeyEncoded,
-                    },
-                    null,
-                    2
-                  )}
-                >
-                  {(copy) => (
-                    <EuiButton onClick={copy} iconType="copy">
-                      Copy all as JSON
-                    </EuiButton>
-                  )}
-                </EuiCopy>
-              </EuiFlexItem>
-            </EuiFlexGroup>
+
+            <EuiAccordion
+              id="connectionCredentials"
+              buttonContent="Connection credentials"
+              initialIsOpen={false}
+            >
+              <EuiSpacer />
+              <EuiFlexGroup direction="column" gutterSize="m">
+                <EuiFlexItem>
+                  <EuiFormRow label="Kibana URL" fullWidth>
+                    <EuiFieldText value={setupData.kibanaUrl} readOnly fullWidth />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiFormRow label="Elasticsearch URL" fullWidth>
+                    <EuiFieldText value={setupData.elasticsearchUrl} readOnly fullWidth />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiFormRow label="API Key (Base64)" fullWidth>
+                    <EuiCodeBlock language="text" paddingSize="s" isCopyable>
+                      {setupData.apiKeyEncoded}
+                    </EuiCodeBlock>
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiCopy
+                    textToCopy={JSON.stringify(
+                      {
+                        kibanaUrl: setupData.kibanaUrl,
+                        elasticsearchUrl: setupData.elasticsearchUrl,
+                        apiKey: setupData.apiKeyEncoded,
+                      },
+                      null,
+                      2
+                    )}
+                  >
+                    {(copy) => (
+                      <EuiButton onClick={copy} iconType="copy">
+                        Copy all as JSON
+                      </EuiButton>
+                    )}
+                  </EuiCopy>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiAccordion>
           </>
         )}
       </EuiPageTemplate.Section>


### PR DESCRIPTION

<img width="780" height="599" alt="Screenshot 2026-05-05 at 10 21 38" src="https://github.com/user-attachments/assets/7d0125b2-c04d-4901-b583-151ffb077ad6" />


Improves the layout and clarity of the Elastic Ramen setup page:

- Show Generate credentials button alone before creation, avoiding confusing side-by-side buttons
- Add success callout with clear next steps after credentials are created
- Make Connect local agent a primary button with explanation of where credentials are sent (localhost:14642)
- Add Connection credentials heading above manual copy fields

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->