### PR TITLE
[Agent Builder] Dashboards in chat: Validate new dashboard metadata before operations

### DIFF
--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/manage_dashboard.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/manage_dashboard.ts
@@ -65,7 +65,7 @@ Use operations[] to:
 
         if (isNewDashboard && !hasValidCreateMetadataOperations(operations)) {
           logger.error(newDashboardMetadataErrorMessage);
-          return noTitleOrDescriptionErrorResult;
+          return missingNewDashboardMetadataErrorResult;
         }
 
         const dashboardAttachmentId = previousAttachmentId ?? uuidv4();
@@ -182,7 +182,7 @@ Use operations[] to:
   };
 };
 
-const noTitleOrDescriptionErrorResult = {
+const missingNewDashboardMetadataErrorResult = {
   results: [
     {
       type: ToolResultType.error,

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/manage_dashboard.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/manage_dashboard.ts
@@ -25,7 +25,7 @@ import { createVisualizationResolver } from './inline_visualization';
 import { dashboardOperationSchema, executeDashboardOperations } from './operations';
 
 const newDashboardMetadataErrorMessage =
-  'New dashboards require a set_metadata operation with non-empty title and description.';
+  'New dashboards require a set_metadata operation with a non-empty title.';
 
 const manageDashboardSchema = z.object({
   dashboardAttachmentId: z

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/manage_dashboard.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/manage_dashboard.ts
@@ -18,10 +18,14 @@ import {
   retrieveLatestVersion,
   getErrorMessage,
   resolvePanelsFromAttachments,
+  hasValidCreateMetadataOperations,
   type VisualizationFailure,
 } from './utils';
 import { createVisualizationResolver } from './inline_visualization';
 import { dashboardOperationSchema, executeDashboardOperations } from './operations';
+
+const newDashboardMetadataErrorMessage =
+  'New dashboards require a set_metadata operation with non-empty title and description.';
 
 const manageDashboardSchema = z.object({
   dashboardAttachmentId: z
@@ -59,6 +63,11 @@ Use operations[] to:
         const latestVersion = retrieveLatestVersion(attachments, previousAttachmentId);
         const isNewDashboard = !latestVersion;
 
+        if (isNewDashboard && !hasValidCreateMetadataOperations(operations)) {
+          logger.error(newDashboardMetadataErrorMessage);
+          return noTitleOrDescriptionErrorResult;
+        }
+
         const dashboardAttachmentId = previousAttachmentId ?? uuidv4();
         const resolveVisualizationConfig = createVisualizationResolver({
           logger,
@@ -82,11 +91,6 @@ Use operations[] to:
 
         const failures: VisualizationFailure[] = operationResult.failures;
         const updatedDashboardData = operationResult.dashboardData;
-
-        if (isNewDashboard && (!updatedDashboardData.title || !updatedDashboardData.description)) {
-          logger.error('Title and description are required when creating a new dashboard.');
-          return noTitleOrDescriptionErrorResult;
-        }
 
         const attachmentInput = {
           id: dashboardAttachmentId,
@@ -183,7 +187,7 @@ const noTitleOrDescriptionErrorResult = {
     {
       type: ToolResultType.error,
       data: {
-        message: 'Title and description are required when creating a new dashboard.',
+        message: newDashboardMetadataErrorMessage,
       },
     },
   ],

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/utils.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/utils.ts
@@ -35,28 +35,22 @@ export const getErrorMessage = (error: unknown): string => {
 const hasNonEmptyValue = (value: string | undefined): value is string =>
   value !== undefined && value.trim().length > 0;
 
-const hasRequiredCreateMetadataOperation = (operations: DashboardOperation[]): boolean =>
+const hasRequiredCreateTitleOperation = (operations: DashboardOperation[]): boolean =>
   operations.some(
-    (operation) =>
-      operation.operation === 'set_metadata' &&
-      hasNonEmptyValue(operation.title) &&
-      hasNonEmptyValue(operation.description)
+    (operation) => operation.operation === 'set_metadata' && hasNonEmptyValue(operation.title)
   );
 
-const hasBlankMetadataUpdate = (operations: DashboardOperation[]): boolean =>
+const hasBlankTitleUpdate = (operations: DashboardOperation[]): boolean =>
   operations.some((operation) => {
     if (operation.operation !== 'set_metadata') {
       return false;
     }
 
-    return (
-      (operation.title !== undefined && !hasNonEmptyValue(operation.title)) ||
-      (operation.description !== undefined && !hasNonEmptyValue(operation.description))
-    );
+    return operation.title !== undefined && !hasNonEmptyValue(operation.title);
   });
 
 export const hasValidCreateMetadataOperations = (operations: DashboardOperation[]): boolean =>
-  hasRequiredCreateMetadataOperation(operations) && !hasBlankMetadataUpdate(operations);
+  hasRequiredCreateTitleOperation(operations) && !hasBlankTitleUpdate(operations);
 
 const visualizationAttachmentDataSchema = z.object({
   visualization: z.record(z.string(), z.unknown()),

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/utils.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/tools/manage_dashboard/utils.ts
@@ -14,6 +14,7 @@ import type { Logger } from '@kbn/core/server';
 import { type AttachmentVersion, getLatestVersion } from '@kbn/agent-builder-common/attachments';
 import { z } from '@kbn/zod/v4';
 import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-common';
+import type { DashboardOperation } from './operations';
 
 /**
  * Failure record for tracking visualization errors.
@@ -30,6 +31,32 @@ export interface VisualizationFailure {
 export const getErrorMessage = (error: unknown): string => {
   return error instanceof Error ? error.message : String(error);
 };
+
+const hasNonEmptyValue = (value: string | undefined): value is string =>
+  value !== undefined && value.trim().length > 0;
+
+const hasRequiredCreateMetadataOperation = (operations: DashboardOperation[]): boolean =>
+  operations.some(
+    (operation) =>
+      operation.operation === 'set_metadata' &&
+      hasNonEmptyValue(operation.title) &&
+      hasNonEmptyValue(operation.description)
+  );
+
+const hasBlankMetadataUpdate = (operations: DashboardOperation[]): boolean =>
+  operations.some((operation) => {
+    if (operation.operation !== 'set_metadata') {
+      return false;
+    }
+
+    return (
+      (operation.title !== undefined && !hasNonEmptyValue(operation.title)) ||
+      (operation.description !== undefined && !hasNonEmptyValue(operation.description))
+    );
+  });
+
+export const hasValidCreateMetadataOperations = (operations: DashboardOperation[]): boolean =>
+  hasRequiredCreateMetadataOperation(operations) && !hasBlankMetadataUpdate(operations);
 
 const visualizationAttachmentDataSchema = z.object({
   visualization: z.record(z.string(), z.unknown()),


### PR DESCRIPTION
## Summary

This PR:
- Adds a fail-fast validation for new dashboard creation requests that are missing complete `set_metadata`.
- Rejects blank `title` or `description` metadata updates before dashboard operations run.
- Prevents unnecessary inline visualization work for requests that cannot produce a valid new dashboard.

