### PR TITLE
[9.2] chore(axios,workflows-eng): remove axios from workflows connector utils (#267512)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -416,7 +416,6 @@ const AXIOS_LEGACY_CONSUMERS = [
   'src/platform/packages/shared/kbn-kbn-client/**/*.{js,mjs,ts,tsx}',
   'src/platform/packages/shared/kbn-test-saml-auth/**/*.{js,mjs,ts,tsx}',
   'src/platform/plugins/shared/workflows_execution_engine/server/step/http_step/**/*.{js,mjs,ts,tsx}',
-  'src/platform/plugins/shared/workflows_management/server/connectors/workflows/**/*.{js,mjs,ts,tsx}',
   'src/platform/test/api_integration/apis/telemetry/**/*.{js,mjs,ts,tsx}',
   'x-pack/examples/alerting_example/server/rule_types/**/*.{js,mjs,ts,tsx}',
   'x-pack/packages/kbn-synthetics-private-location/**/*.{js,mjs,ts,tsx}',

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.test.ts
@@ -7,48 +7,47 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { AxiosError } from 'axios';
 import { createServiceError } from './utils';
 
 describe('Workflows Utils', () => {
   describe('createServiceError', () => {
-    it('should create error with Axios error message', () => {
-      const axiosError = {
-        isAxiosError: true,
+    it('should create error with HTTP error message', () => {
+      const httpError = {
+        name: 'Error',
         response: {
           data: {
             message: 'API Error: Invalid request',
           },
         },
         message: 'Request failed',
-      } as AxiosError;
+      } as Error;
 
-      const result = createServiceError(axiosError, 'Operation failed');
+      const result = createServiceError(httpError, 'Operation failed');
 
       expect(result.message).toBe('Operation failed. Error: API Error: Invalid request');
     });
 
-    it('should use Axios error message when response data has no message', () => {
-      const axiosError = {
-        isAxiosError: true,
+    it('should use HTTP error message when response data has no message', () => {
+      const httpError = {
+        name: 'Error',
         response: {
           data: {},
         },
         message: 'Network error',
-      } as AxiosError;
+      } as Error;
 
-      const result = createServiceError(axiosError, 'Operation failed');
+      const result = createServiceError(httpError, 'Operation failed');
 
       expect(result.message).toBe('Operation failed. Error: Network error');
     });
 
-    it('should handle Axios error without response data', () => {
-      const axiosError = {
-        isAxiosError: true,
+    it('should handle HTTP error without response data', () => {
+      const httpError = {
+        name: 'Error',
         message: 'Connection timeout',
-      } as AxiosError;
+      } as Error;
 
-      const result = createServiceError(axiosError, 'Operation failed');
+      const result = createServiceError(httpError, 'Operation failed');
 
       expect(result.message).toBe('Operation failed. Error: Connection timeout');
     });

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.ts
@@ -7,14 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isAxiosError } from 'axios';
-
 export const createServiceError = (error: Error, message: string) => {
-  if (isAxiosError(error)) {
-    const responseData = error.response?.data;
-    const errorMessage = responseData?.message || error.message;
-    return new Error(`${message}. Error: ${errorMessage}`);
-  }
-
-  return new Error(`${message}. Error: ${error.message}`);
+  // Some HTTP clients attach the parsed response body on `error.response.data`;
+  // prefer the upstream `message` field if it is present.
+  const responseData = (error as { response?: { data?: { message?: string } } }).response?.data;
+  const errorMessage = responseData?.message || error.message;
+  return new Error(`${message}. Error: ${errorMessage}`);
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [chore(axios,workflows-eng): remove axios from workflows connector utils (#267512)](https://github.com/elastic/kibana/pull/267512)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-05-05T08:05:42Z","message":"chore(axios,workflows-eng): remove axios from workflows connector utils (#267512)\n\n## Summary\n\nThis PR removes the `axios` dependency for files owned by\n`@elastic/workflows-eng`. Phase 2 of the axios migration tracked under\n#266556.\n\n### Why\n\nNode.js 22 ships a native `fetch` API built on undici, and every browser\nKibana targets supports `fetch` natively. Removing axios cuts one\nruntime dependency and continues the per-team rollout that mirrors the\nearlier node-fetch migration\n([#250719](https://github.com/elastic/kibana/pull/250719) and siblings).\n\n### Changes\n\n-\n`src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.ts`\npreviously imported `isAxiosError` from `axios` to decide whether to\nextract `error.response.data.message`. The production caller\n(`service.ts`) feeds errors thrown by the injected workflow services,\nnever AxiosError; the axios-specific branch was effectively dead\ndefensive code. Replaced the type-guard with duck-typed access to\n`response?.data?.message` so any HTTP-client error of similar shape\nstill gets the upstream message extracted.\n- `utils.test.ts` updated correspondingly: dropped the `AxiosError`\ntype-only import, renamed mocks to `httpError`, added `name: 'Error'` so\n`as Error` casts type-check. All 5 existing test cases still pass.\n- Removed the `workflows_management/server/connectors/workflows/**`\nentry from `AXIOS_LEGACY_CONSUMERS` in `.eslintrc.js`. New axios usage\nin this directory is now blocked by the existing global ban. The broader\n`workflows_management/**` override that bans `*legacy*` imports still\napplies.\n\n### Behavior parity\n\nThe duck-typed access preserves the exact extraction logic: when the\nerror has `response.data.message`, that string is used; otherwise it\nfalls back to `error.message`. All five test cases (HTTP error with\n`data.message`, HTTP error with empty `data`, HTTP error without\n`response`, regular `Error`, error without message) pass without change\nto expected output.","sha":"5f51f6c8463974089a6d781c56dcdb928557c52b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","dependencies","backport:all-open","Team:One Workflow","v9.4.0","v9.5.0"],"title":"chore(axios,workflows-eng): remove axios from workflows connector utils","number":267512,"url":"https://github.com/elastic/kibana/pull/267512","mergeCommit":{"message":"chore(axios,workflows-eng): remove axios from workflows connector utils (#267512)\n\n## Summary\n\nThis PR removes the `axios` dependency for files owned by\n`@elastic/workflows-eng`. Phase 2 of the axios migration tracked under\n#266556.\n\n### Why\n\nNode.js 22 ships a native `fetch` API built on undici, and every browser\nKibana targets supports `fetch` natively. Removing axios cuts one\nruntime dependency and continues the per-team rollout that mirrors the\nearlier node-fetch migration\n([#250719](https://github.com/elastic/kibana/pull/250719) and siblings).\n\n### Changes\n\n-\n`src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.ts`\npreviously imported `isAxiosError` from `axios` to decide whether to\nextract `error.response.data.message`. The production caller\n(`service.ts`) feeds errors thrown by the injected workflow services,\nnever AxiosError; the axios-specific branch was effectively dead\ndefensive code. Replaced the type-guard with duck-typed access to\n`response?.data?.message` so any HTTP-client error of similar shape\nstill gets the upstream message extracted.\n- `utils.test.ts` updated correspondingly: dropped the `AxiosError`\ntype-only import, renamed mocks to `httpError`, added `name: 'Error'` so\n`as Error` casts type-check. All 5 existing test cases still pass.\n- Removed the `workflows_management/server/connectors/workflows/**`\nentry from `AXIOS_LEGACY_CONSUMERS` in `.eslintrc.js`. New axios usage\nin this directory is now blocked by the existing global ban. The broader\n`workflows_management/**` override that bans `*legacy*` imports still\napplies.\n\n### Behavior parity\n\nThe duck-typed access preserves the exact extraction logic: when the\nerror has `response.data.message`, that string is used; otherwise it\nfalls back to `error.message`. All five test cases (HTTP error with\n`data.message`, HTTP error with empty `data`, HTTP error without\n`response`, regular `Error`, error without message) pass without change\nto expected output.","sha":"5f51f6c8463974089a6d781c56dcdb928557c52b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/267665","number":267665,"state":"MERGED","mergeCommit":{"sha":"de5f2b8ecdfd4db23cafcabe81d376f0b54f251f","message":"[9.4] chore(axios,workflows-eng): remove axios from workflows connector utils (#267512) (#267665)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [chore(axios,workflows-eng): remove axios from workflows connector\nutils (#267512)](https://github.com/elastic/kibana/pull/267512)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Aleh Zasypkin <aleh.zasypkin@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267512","number":267512,"mergeCommit":{"message":"chore(axios,workflows-eng): remove axios from workflows connector utils (#267512)\n\n## Summary\n\nThis PR removes the `axios` dependency for files owned by\n`@elastic/workflows-eng`. Phase 2 of the axios migration tracked under\n#266556.\n\n### Why\n\nNode.js 22 ships a native `fetch` API built on undici, and every browser\nKibana targets supports `fetch` natively. Removing axios cuts one\nruntime dependency and continues the per-team rollout that mirrors the\nearlier node-fetch migration\n([#250719](https://github.com/elastic/kibana/pull/250719) and siblings).\n\n### Changes\n\n-\n`src/platform/plugins/shared/workflows_management/server/connectors/workflows/utils.ts`\npreviously imported `isAxiosError` from `axios` to decide whether to\nextract `error.response.data.message`. The production caller\n(`service.ts`) feeds errors thrown by the injected workflow services,\nnever AxiosError; the axios-specific branch was effectively dead\ndefensive code. Replaced the type-guard with duck-typed access to\n`response?.data?.message` so any HTTP-client error of similar shape\nstill gets the upstream message extracted.\n- `utils.test.ts` updated correspondingly: dropped the `AxiosError`\ntype-only import, renamed mocks to `httpError`, added `name: 'Error'` so\n`as Error` casts type-check. All 5 existing test cases still pass.\n- Removed the `workflows_management/server/connectors/workflows/**`\nentry from `AXIOS_LEGACY_CONSUMERS` in `.eslintrc.js`. New axios usage\nin this directory is now blocked by the existing global ban. The broader\n`workflows_management/**` override that bans `*legacy*` imports still\napplies.\n\n### Behavior parity\n\nThe duck-typed access preserves the exact extraction logic: when the\nerror has `response.data.message`, that string is used; otherwise it\nfalls back to `error.message`. All five test cases (HTTP error with\n`data.message`, HTTP error with empty `data`, HTTP error without\n`response`, regular `Error`, error without message) pass without change\nto expected output.","sha":"5f51f6c8463974089a6d781c56dcdb928557c52b"}}]}] BACKPORT-->