### PR TITLE
[ES|QL] FORK now can be run on only one branch

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/types.ts
@@ -453,10 +453,6 @@ export interface ValidationErrors {
     message: string;
     type: {};
   };
-  forkTooFewBranches: {
-    message: string;
-    type: {};
-  };
   forkNotAllowedWithSubqueries: {
     message: string;
     type: {};

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/errors.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/errors.ts
@@ -433,13 +433,6 @@ Expected one of:
         }),
         type: 'error',
       };
-    case 'forkTooFewBranches':
-      return {
-        message: i18n.translate('kbn-esql-language.esql.validation.forkTooFewBranches', {
-          defaultMessage: '[FORK] Must include at least two branches.',
-        }),
-        type: 'error',
-      };
     case 'forkNotAllowedWithSubqueries':
       return {
         message: i18n.translate('kbn-esql-language.esql.validation.forkNotAllowedWithSubqueries', {
@@ -753,9 +746,6 @@ export const errors = {
 
   forkTooManyBranches: (command: ESQLAstAllCommands): ESQLMessage =>
     errors.byId('forkTooManyBranches', command.location, {}),
-
-  forkTooFewBranches: (command: ESQLAstAllCommands): ESQLMessage =>
-    errors.byId('forkTooFewBranches', command.location, {}),
 
   forkNotAllowedWithSubqueries: (command: ESQLAstAllCommands): ESQLMessage =>
     errors.byId('forkNotAllowedWithSubqueries', command.location, {}),

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/fork/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/fork/autocomplete.test.ts
@@ -145,7 +145,7 @@ describe('FORK Autocomplete', () => {
     });
 
     test('suggests pipe and new branch after complete branch', async () => {
-      await forkExpectSuggestions('FROM a | FORK (LIMIT 100) ', ['($0)']);
+      await forkExpectSuggestions('FROM a | FORK (LIMIT 100) ', ['($0)', '| ']);
       await forkExpectSuggestions('FROM a | FORK (LIMIT 100) (SORT keywordField ASC) ', [
         '($0)',
         '| ',

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/fork/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/fork/autocomplete.ts
@@ -41,7 +41,7 @@ export async function autocomplete(
 
   if (!withinActiveBranch && /\)\s+$/i.test(innerText)) {
     const suggestions = [newBranchSuggestion];
-    if (forkCommand.args.length > 1) {
+    if (forkCommand.args.length > 0) {
       suggestions.push(pipeCompleteItem);
     }
     return suggestions;

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/fork/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/fork/validate.test.ts
@@ -38,12 +38,12 @@ describe('FORK Validation', () => {
     );
   });
 
-  test('requires at least two branches', () => {
+  test('Allows FORK with one branch', () => {
     forkExpectErrors(
       `FROM index
 | FORK
     (WHERE keywordField != "")`,
-      [`[FORK] Must include at least two branches.`]
+      []
     );
   });
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/fork/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/fork/validate.ts
@@ -13,7 +13,6 @@ import { validateCommandArguments } from '../../definitions/utils/validation';
 import { errors } from '../../definitions/utils';
 import type { ESQLMessage } from '../../definitions/types';
 
-const MIN_BRANCHES = 2;
 const MAX_BRANCHES = 8;
 
 export const validate = (
@@ -24,10 +23,6 @@ export const validate = (
 ): ESQLMessage[] => {
   const forkCommand = command as ESQLAstForkCommand;
   const messages: ESQLMessage[] = [];
-
-  if (forkCommand.args.length < MIN_BRANCHES) {
-    messages.push(errors.forkTooFewBranches(forkCommand));
-  }
 
   if (forkCommand.args.length > MAX_BRANCHES) {
     messages.push(errors.forkTooManyBranches(forkCommand));

--- a/src/platform/plugins/shared/esql/ADD_COMMAND_GUIDE.md
+++ b/src/platform/plugins/shared/esql/ADD_COMMAND_GUIDE.md
@@ -162,11 +162,6 @@ export const validate = (
   const messages: ESQLMessage[] = [];
 
   // custom check specific to FORK
-  if (command.args.length < MIN_BRANCHES) {
-    messages.push(errors.forkTooFewBranches(command));
-  }
-
-  // custom check specific to FORK
   if (command.args.length > MAX_BRANCHES) {
     messages.push(errors.forkTooManyBranches(command));
   }


### PR DESCRIPTION
## Summary
After https://github.com/elastic/elasticsearch/pull/136805, FORK can be run using a single branch.

Removed the "Must include at least two branches" validation.
<img width="1144" height="360" alt="image" src="https://github.com/user-attachments/assets/2ce81fec-51d6-46c5-b562-8f068ab5ee40" />

The pipe is now suggested after the first branch.

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->