### PR TITLE
[ci-stats] Skip bundle metrics shipping for rspack builds

### DIFF
--- a/.buildkite/scripts/post_build_kibana.sh
+++ b/.buildkite/scripts/post_build_kibana.sh
@@ -3,18 +3,23 @@
 set -euo pipefail
 
 if [[ ! "${DISABLE_CI_STATS_SHIPPING:-}" ]]; then
-  cmd=(
-    "node" "scripts/ship_ci_stats"
-      "--metrics" "target/optimizer_bundle_metrics.json"
-      "--metrics" "build/kibana/node_modules/@kbn/ui-shared-deps-src/shared_built_assets/metrics.json"
-  )
+  # [rspack-transition] avoid shipping bundle sizes while RSPack is not the default
+  if [[ "${KBN_USE_RSPACK:-}" == "true" ]]; then
+    echo "--- Skip Ship Kibana Distribution Metrics to CI Stats (rspack build)"
+  else
+    cmd=(
+      "node" "scripts/ship_ci_stats"
+        "--metrics" "target/optimizer_bundle_metrics.json"
+        "--metrics" "build/kibana/node_modules/@kbn/ui-shared-deps-src/shared_built_assets/metrics.json"
+    )
 
-  if [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-on-merge" ]] || [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-pull-request" ]]; then
-    cmd+=("--validate")
+    if [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-on-merge" ]] || [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-pull-request" ]]; then
+      cmd+=("--validate")
+    fi
+
+    echo "--- Ship Kibana Distribution Metrics to CI Stats"
+    "${cmd[@]}"
   fi
-
-  echo "--- Ship Kibana Distribution Metrics to CI Stats"
-  "${cmd[@]}"
 fi
 
 echo "--- Upload Build Artifacts"

--- a/.buildkite/scripts/post_build_kibana.sh
+++ b/.buildkite/scripts/post_build_kibana.sh
@@ -2,24 +2,26 @@
 
 set -euo pipefail
 
+
+# [rspack-transition] avoid shipping bundle sizes while RSPack is not the default
+if [[ "${KBN_USE_RSPACK:-}" == "true" ]]; then
+  echo "Skipping shipping bundle sizes to CI Stats (rspack build)"
+  export DISABLE_CI_STATS_SHIPPING=true
+fi
+
 if [[ ! "${DISABLE_CI_STATS_SHIPPING:-}" ]]; then
-  # [rspack-transition] avoid shipping bundle sizes while RSPack is not the default
-  if [[ "${KBN_USE_RSPACK:-}" == "true" ]]; then
-    echo "--- Skip Ship Kibana Distribution Metrics to CI Stats (rspack build)"
-  else
-    cmd=(
-      "node" "scripts/ship_ci_stats"
-        "--metrics" "target/optimizer_bundle_metrics.json"
-        "--metrics" "build/kibana/node_modules/@kbn/ui-shared-deps-src/shared_built_assets/metrics.json"
-    )
+  cmd=(
+    "node" "scripts/ship_ci_stats"
+      "--metrics" "target/optimizer_bundle_metrics.json"
+      "--metrics" "build/kibana/node_modules/@kbn/ui-shared-deps-src/shared_built_assets/metrics.json"
+  )
 
-    if [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-on-merge" ]] || [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-pull-request" ]]; then
-      cmd+=("--validate")
-    fi
-
-    echo "--- Ship Kibana Distribution Metrics to CI Stats"
-    "${cmd[@]}"
+  if [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-on-merge" ]] || [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-pull-request" ]]; then
+    cmd+=("--validate")
   fi
+
+  echo "--- Ship Kibana Distribution Metrics to CI Stats"
+  "${cmd[@]}"
 fi
 
 echo "--- Upload Build Artifacts"


### PR DESCRIPTION
## Summary

The `kibana-rspack-e2e-test` pipeline runs every 3h on `main` with `KBN_USE_RSPACK=true` and ships its bundle metrics to ci-stats under the same group names as legacy. Rspack's chunk layout differs (named shared chunks, different module counting), so legacy PR builds were being diffed against an incompatible rspack baseline — producing nonsense PR comments like [#267631](https://github.com/elastic/kibana/pull/267631#issuecomment-4375764614) (+62.7MB async / -14.4MB page-load for a docs cleanup).

Skip ci-stats shipping when `KBN_USE_RSPACK=true`. Drop the guard once rspack is the default.

## Test plan

- [x] Next `kibana-rspack-e2e-test` run skips the ship step
- [x] PR comments resume diffing against the legacy baseline