### PR TITLE
[DoNotReview/FeatureBranch][Chrome Next] Add Spaces context switcher footer links

### DIFF
--- a/src/platform/packages/shared/context-switcher-components/src/components/context_switcher.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/context_switcher.tsx
@@ -25,7 +25,7 @@ import type { ContextMenuViewProps } from './views/context_menu';
 import { ContextSubmenuView } from './views/context_submenu';
 import type { ContextSubmenuViewProps } from './views/context_submenu';
 import { ContextSwitcherTriggerButton } from './context_switcher_trigger_button';
-import type { ActionConfig } from './types';
+import type { ActionConfig, LinksListItem } from './types';
 import { POPOVER_WIDTH, type ContextSwitcherProps, type SpaceItem } from './types';
 import type { SelectableListItem } from './selectable_list';
 
@@ -142,17 +142,31 @@ export const ContextSwitcher = ({
   );
 
   const withClosePopover = useCallback(
-    (action?: ActionConfig): ActionConfig | undefined => {
-      if (!action) return undefined;
-      return {
-        ...action,
-        onClick: () => {
-          closePopover();
-          action?.onClick?.();
-        },
-      };
+    (onClick?: () => void) => () => {
+      closePopover();
+      onClick?.();
     },
     [closePopover]
+  );
+
+  const withClosePopoverAction = useCallback(
+    (action?: ActionConfig): ActionConfig | undefined =>
+      action ? { ...action, onClick: withClosePopover(action.onClick) } : undefined,
+    [withClosePopover]
+  );
+  const withClosePopoverLink = useCallback(
+    (item: LinksListItem): LinksListItem => ({ ...item, onClick: withClosePopover(item.onClick) }),
+    [withClosePopover]
+  );
+
+  const footerLinksWithClose = useMemo(
+    () => footerLinks?.map(withClosePopoverLink),
+    [footerLinks, withClosePopoverLink]
+  );
+
+  const environmentItemsWithClose = useMemo(
+    () => environmentContext?.submenuItems.map(withClosePopoverLink) ?? [],
+    [environmentContext, withClosePopoverLink]
   );
 
   const searchConfig =
@@ -174,12 +188,12 @@ export const ContextSwitcher = ({
   const spacesViewProps = {
     id: 'contextSwitcherSpacesList',
     title: SPACES_TITLE,
-    headerAction: withClosePopover(spaces.headerAction),
+    headerAction: withClosePopoverAction(spaces.headerAction),
     items: selectableItems,
     onSelect: handleSpaceSelect,
     search: searchConfig,
     isLoading: spaces.isLoading,
-    footerAction: withClosePopover(spaces.footerAction),
+    footerAction: withClosePopoverAction(spaces.footerAction),
   };
 
   const environmentDescription = isProject
@@ -263,12 +277,12 @@ export const ContextSwitcher = ({
               ),
               value: spacesDescription,
             },
-            footerLinks,
+            footerLinks: footerLinksWithClose,
           }}
           environmentSubmenuView={{
             title: SUBMENU_TITLES[environmentContext.environmentType],
-            items: environmentContext.submenuItems,
-            footerAction: withClosePopover(environmentContext.submenuFooterAction),
+            items: environmentItemsWithClose,
+            footerAction: withClosePopoverAction(environmentContext.submenuFooterAction),
           }}
           spacesSubmenuView={spacesViewProps}
         />

--- a/src/platform/packages/shared/context-switcher-components/src/components/views/spaces_list.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/views/spaces_list.tsx
@@ -130,6 +130,8 @@ export const SpacesListView = ({
                       size="s"
                       onClick={headerAction.onClick}
                       data-test-subj={headerAction['data-test-subj']}
+                      isDisabled={headerAction.disabled}
+                      target={headerAction.external ? '_blank' : undefined}
                     >
                       {headerAction.label}
                     </EuiButtonEmpty>

--- a/src/platform/packages/shared/deeplinks/shared/index.ts
+++ b/src/platform/packages/shared/deeplinks/shared/index.ts
@@ -7,4 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { AppId, DeepLinkId } from './deep_links';
+export const HOME_APP_ID = 'home';
+
+export type AppId = typeof HOME_APP_ID;
+
+export type DeepLinkId = AppId;

--- a/x-pack/platform/plugins/shared/cloud/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cloud/public/plugin.tsx
@@ -32,7 +32,9 @@ export interface CloudConfigType {
   profile_url?: string;
   deployments_url?: string;
   deployment_url?: string;
+  create_deployment_url?: string;
   projects_url?: string;
+  create_project_url?: string;
   billing_url?: string;
   organization_url?: string;
   users_and_roles_url?: string;

--- a/x-pack/platform/plugins/shared/cloud/public/types.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/types.ts
@@ -34,6 +34,12 @@ export interface CloudBasicUrls {
    */
   deploymentUrl?: string;
   /**
+   * This is the path to the Cloud deployment creation page. The value is already prepended with `baseUrl`.
+   *
+   * @example `{baseUrl}/deployments/create`
+   */
+  createDeploymentUrl?: string;
+  /**
    * The full URL to the user profile page on Elastic Cloud. Undefined if not running on Cloud.
    */
   profileUrl?: string;
@@ -49,6 +55,12 @@ export interface CloudBasicUrls {
    * The full URL to the serverless projects page on Elastic Cloud. Undefined if not running in Serverless.
    */
   projectsUrl?: string;
+  /**
+   * This is the path to the Cloud project creation page. The value is already prepended with `baseUrl`.
+   *
+   * @example `{baseUrl}/projects/create`
+   */
+  createProjectUrl?: string;
   /**
    * This is the path to the Snapshots page for the deployment to which the Kibana instance belongs. The value is already prepended with `deploymentUrl`.
    *

--- a/x-pack/platform/plugins/shared/cloud/public/urls.ts
+++ b/x-pack/platform/plugins/shared/cloud/public/urls.ts
@@ -40,16 +40,20 @@ export class CloudUrlsService {
       organization_url: organizationUrl,
       deployments_url: deploymentsUrl,
       deployment_url: deploymentUrl,
+      create_deployment_url: createDeploymentUrl,
       performance_url: performanceUrl,
       projects_url: projectsUrl,
+      create_project_url: createProjectUrl,
     } = this.config;
 
     const fullCloudDeploymentsUrl = getFullCloudUrl(baseUrl, deploymentsUrl);
     const fullCloudDeploymentUrl = getFullCloudUrl(baseUrl, deploymentUrl);
+    const fullCloudCreateDeploymentUrl = getFullCloudUrl(baseUrl, createDeploymentUrl);
     const fullCloudProfileUrl = getFullCloudUrl(baseUrl, profileUrl);
     const fullCloudOrganizationUrl = getFullCloudUrl(baseUrl, organizationUrl);
     const fullCloudPerformanceUrl = getFullCloudUrl(baseUrl, performanceUrl);
     const fullCloudProjectsUrl = getFullCloudUrl(baseUrl, projectsUrl);
+    const fullCloudCreateProjectUrl = getFullCloudUrl(baseUrl, createProjectUrl);
     const fullCloudSnapshotsUrl = `${fullCloudDeploymentUrl}/${CLOUD_SNAPSHOTS_PATH}`;
 
     return {
@@ -57,11 +61,13 @@ export class CloudUrlsService {
       kibanaUrl,
       deploymentsUrl: fullCloudDeploymentsUrl,
       deploymentUrl: fullCloudDeploymentUrl,
+      createDeploymentUrl: fullCloudCreateDeploymentUrl,
       profileUrl: fullCloudProfileUrl,
       organizationUrl: fullCloudOrganizationUrl,
       snapshotsUrl: fullCloudSnapshotsUrl,
       performanceUrl: fullCloudPerformanceUrl,
       projectsUrl: fullCloudProjectsUrl,
+      createProjectUrl: fullCloudCreateProjectUrl,
     };
   }
 

--- a/x-pack/platform/plugins/shared/cloud/server/config.ts
+++ b/x-pack/platform/plugins/shared/cloud/server/config.ts
@@ -72,6 +72,7 @@ const configSchema = schema.object({
   csp: schema.maybe(schema.string()),
   deployments_url: schema.string({ defaultValue: '/deployments' }),
   deployment_url: schema.maybe(schema.string()),
+  create_deployment_url: schema.string({ defaultValue: '/deployments/create' }),
   id: schema.maybe(schema.string()),
   isSaasContainer: schema.maybe(schema.boolean()),
   organization_id: schema.maybe(schema.string()),
@@ -82,6 +83,9 @@ const configSchema = schema.object({
   profile_url: schema.maybe(schema.string()),
   projects_url: offeringBasedSchema({ serverless: schema.string({ defaultValue: '/projects/' }) }),
   trial_end_date: schema.maybe(schema.string()),
+  create_project_url: offeringBasedSchema({
+    serverless: schema.string({ defaultValue: '/projects/create' }),
+  }),
   is_elastic_staff_owned: schema.maybe(schema.boolean()),
   onboarding: schema.maybe(
     schema.object({
@@ -119,6 +123,7 @@ export const config: PluginConfigDescriptor<CloudConfigType> = {
     csp: true,
     deployments_url: true,
     deployment_url: true,
+    create_deployment_url: true,
     id: true,
     isSaasContainer: true,
     organization_id: true,
@@ -128,6 +133,7 @@ export const config: PluginConfigDescriptor<CloudConfigType> = {
     organization_url: true,
     profile_url: true,
     projects_url: true,
+    create_project_url: true,
     trial_end_date: true,
     is_elastic_staff_owned: true,
     serverless: {

--- a/x-pack/platform/plugins/shared/spaces/public/context_switcher/context_switcher_component.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/context_switcher/context_switcher_component.tsx
@@ -15,6 +15,7 @@ import {
 import type { CoreStart } from '@kbn/core/public';
 import { useQueryClient } from '@kbn/react-query';
 
+import { useFooterLinks } from './hooks';
 import { useActiveSpace } from './hooks/use_active_space';
 import { useEnvironmentContext } from './hooks/use_environment_context';
 import { useManagementActions } from './hooks/use_management_actions';
@@ -57,6 +58,13 @@ export const ContextSwitcherComponent = ({
     isServerless,
   });
 
+  const footerLinks = useFooterLinks({
+    application: core.application,
+    cloud,
+    isServerless,
+    activeSpaceSolution: activeSpace?.solution,
+  });
+
   const managementActions = useManagementActions({
     application: core.application,
     canManageSpaces: core.application.capabilities.spaces?.manage === true,
@@ -92,6 +100,7 @@ export const ContextSwitcherComponent = ({
       spaces={spacesConfig}
       environmentContext={environmentContext}
       onOpen={handleOpen}
+      footerLinks={footerLinks}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/index.ts
+++ b/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/index.ts
@@ -9,3 +9,4 @@ export { useActiveSpace } from './use_active_space';
 export { useEnvironmentContext } from './use_environment_context';
 export { useManagementActions } from './use_management_actions';
 export { useSpaceItems } from './use_space_items';
+export { useFooterLinks } from './use_footer_links';

--- a/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_environment_context.ts
+++ b/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_environment_context.ts
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 import type {
+  ActionConfig,
   ContextSwitcherEnvironmentConfig,
   LinksListItem,
 } from '@kbn/context-switcher-components';
@@ -92,6 +93,20 @@ export const useEnvironmentContext = ({
       });
     }
 
-    return { environmentType, name, submenuItems };
+    const isProject = environmentType === 'project';
+    const createUrl = isProject ? cloud.createProjectUrl : cloud.createDeploymentUrl;
+
+    const submenuFooterAction: ActionConfig | undefined = createUrl
+      ? {
+          id: isProject ? 'createProject' : 'createDeployment',
+          label: i18n.translate('xpack.spaces.contextSwitcher.createUrlLabel', {
+            defaultMessage: 'Create {environmentType}',
+            values: { environmentType },
+          }),
+          href: createUrl,
+        }
+      : undefined;
+
+    return { environmentType, name, submenuItems, submenuFooterAction };
   }, [cloud, environmentName, isCloud, isServerless]);
 };

--- a/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_footer_links.ts
+++ b/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_footer_links.ts
@@ -11,28 +11,42 @@ import { openWiredConnectionDetails } from '@kbn/cloud/connection_details';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 import type { LinksListItem } from '@kbn/context-switcher-components';
 import type { CoreStart } from '@kbn/core/public';
+import { OBSERVABILITY_ONBOARDING_APP_ID } from '@kbn/deeplinks-observability';
+import { SEARCH_GETTING_STARTED } from '@kbn/deeplinks-search';
+import { SECURITY_APP_ID } from '@kbn/deeplinks-security';
+import { HOME_APP_ID } from '@kbn/deeplinks-shared';
+import type { WorkplaceAIApp } from '@kbn/deeplinks-workplace-ai';
 import { i18n } from '@kbn/i18n';
 
 import type { Space } from '../../../common';
 
+type GetStartedAppId =
+  | typeof HOME_APP_ID
+  | typeof OBSERVABILITY_ONBOARDING_APP_ID
+  | typeof SEARCH_GETTING_STARTED
+  | typeof SECURITY_APP_ID
+  | WorkplaceAIApp;
+
 interface GetStartedTarget {
-  appId: string;
+  appId: GetStartedAppId;
   path?: string;
 }
 
+const WORKPLACE_AI_APP_ID: WorkplaceAIApp = 'workplace_ai';
+
 const SERVERLESS_TARGETS: Record<string, GetStartedTarget> = {
-  observability: { appId: 'observabilityOnboarding' },
-  search: { appId: 'searchGettingStarted' },
-  security: { appId: 'securitySolutionUI', path: '/get_started' },
-  workplaceai: { appId: 'workplace_ai' },
+  observability: { appId: OBSERVABILITY_ONBOARDING_APP_ID },
+  search: { appId: SEARCH_GETTING_STARTED },
+  security: { appId: SECURITY_APP_ID, path: '/get_started' },
+  workplaceai: { appId: WORKPLACE_AI_APP_ID },
 };
 
 const SPACE_SOLUTION_TARGETS: Record<string, GetStartedTarget> = {
-  oblt: { appId: 'observabilityOnboarding' },
-  es: { appId: 'searchGettingStarted' },
-  security: { appId: 'securitySolutionUI', path: '/get_started' },
-  workplaceai: { appId: 'workplace_ai' },
-  classic: { appId: 'home' },
+  oblt: { appId: OBSERVABILITY_ONBOARDING_APP_ID },
+  es: { appId: SEARCH_GETTING_STARTED },
+  security: { appId: SECURITY_APP_ID, path: '/get_started' },
+  workplaceai: { appId: WORKPLACE_AI_APP_ID },
+  classic: { appId: HOME_APP_ID },
 };
 
 export const useFooterLinks = ({
@@ -83,7 +97,9 @@ export const useFooterLinks = ({
     const serverlessProjectType = isServerless === true ? cloud?.serverless.projectType : undefined;
 
     const preferredTarget = (serverlessProjectType && SERVERLESS_TARGETS[serverlessProjectType]) ??
-      (activeSpaceSolution && SPACE_SOLUTION_TARGETS[activeSpaceSolution]) ?? { appId: 'home' };
+      (activeSpaceSolution && SPACE_SOLUTION_TARGETS[activeSpaceSolution]) ?? {
+        appId: HOME_APP_ID,
+      };
 
     const isObservability =
       serverlessProjectType === 'observability' || activeSpaceSolution === 'oblt';

--- a/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_footer_links.ts
+++ b/x-pack/platform/plugins/shared/spaces/public/context_switcher/hooks/use_footer_links.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { openWiredConnectionDetails } from '@kbn/cloud/connection_details';
+import type { CloudStart } from '@kbn/cloud-plugin/public';
+import type { LinksListItem } from '@kbn/context-switcher-components';
+import type { CoreStart } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+
+import type { Space } from '../../../common';
+
+interface GetStartedTarget {
+  appId: string;
+  path?: string;
+}
+
+const SERVERLESS_TARGETS: Record<string, GetStartedTarget> = {
+  observability: { appId: 'observabilityOnboarding' },
+  search: { appId: 'searchGettingStarted' },
+  security: { appId: 'securitySolutionUI', path: '/get_started' },
+  workplaceai: { appId: 'workplace_ai' },
+};
+
+const SPACE_SOLUTION_TARGETS: Record<string, GetStartedTarget> = {
+  oblt: { appId: 'observabilityOnboarding' },
+  es: { appId: 'searchGettingStarted' },
+  security: { appId: 'securitySolutionUI', path: '/get_started' },
+  workplaceai: { appId: 'workplace_ai' },
+  classic: { appId: 'home' },
+};
+
+export const useFooterLinks = ({
+  application,
+  cloud,
+  isServerless,
+  activeSpaceSolution,
+}: {
+  application: CoreStart['application'];
+  cloud?: CloudStart;
+  isServerless?: boolean;
+  activeSpaceSolution?: Space['solution'];
+}): LinksListItem[] => {
+  const [usersAndRolesUrl, setUsersAndRolesUrl] = useState<string | undefined>(undefined);
+
+  const canAccessApp = useCallback(
+    (appId: string): boolean => application.capabilities.navLinks?.[appId] === true,
+    [application.capabilities.navLinks]
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!cloud || isServerless !== true) {
+      setUsersAndRolesUrl(undefined);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    cloud
+      .getPrivilegedUrls()
+      .then((urls) => {
+        if (isMounted) setUsersAndRolesUrl(urls.usersAndRolesUrl);
+      })
+      .catch(() => {
+        if (isMounted) setUsersAndRolesUrl(undefined);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [cloud, isServerless]);
+
+  return useMemo(() => {
+    const items: LinksListItem[] = [];
+
+    const serverlessProjectType = isServerless === true ? cloud?.serverless.projectType : undefined;
+
+    const preferredTarget = (serverlessProjectType && SERVERLESS_TARGETS[serverlessProjectType]) ??
+      (activeSpaceSolution && SPACE_SOLUTION_TARGETS[activeSpaceSolution]) ?? { appId: 'home' };
+
+    const isObservability =
+      serverlessProjectType === 'observability' || activeSpaceSolution === 'oblt';
+
+    const getStartedHref = canAccessApp(preferredTarget.appId)
+      ? application.getUrlForApp(preferredTarget.appId, { path: preferredTarget.path })
+      : undefined;
+
+    // "Get started" link ("Add data" for Observability projects)
+    if (getStartedHref) {
+      items.push({
+        id: isObservability ? 'addData' : 'getStarted',
+        label: isObservability
+          ? i18n.translate('xpack.spaces.contextSwitcher.footerLinks.addDataLabel', {
+              defaultMessage: 'Add data',
+            })
+          : i18n.translate('xpack.spaces.contextSwitcher.footerLinks.getStartedLabel', {
+              defaultMessage: 'Get started',
+            }),
+        href: getStartedHref,
+        iconType: isObservability ? 'plus' : 'rocket',
+        'data-test-subj': `contextSwitcherFooterGetStarted-${preferredTarget.appId}`,
+      });
+    }
+
+    // "Connection details" link
+    if (isServerless === true && cloud?.isCloudEnabled === true) {
+      items.push({
+        id: 'connectionDetails',
+        label: i18n.translate('xpack.spaces.contextSwitcher.footerLinks.connectionDetailsLabel', {
+          defaultMessage: 'Connection details',
+        }),
+        onClick: () => {
+          void openWiredConnectionDetails();
+        },
+        iconType: 'plugs',
+        'data-test-subj': 'contextSwitcherFooterConnectionDetails',
+      });
+    }
+
+    const canInviteUsersViaCloud = isServerless === true && Boolean(usersAndRolesUrl);
+    const canInviteUsersViaKibana =
+      isServerless !== true &&
+      canAccessApp('management') &&
+      application.capabilities.users?.save === true;
+
+    const inviteUsersHref = canInviteUsersViaCloud
+      ? usersAndRolesUrl
+      : canInviteUsersViaKibana
+      ? application.getUrlForApp('management', { path: 'security/users' })
+      : undefined;
+
+    // "Invite users" link
+    if (inviteUsersHref) {
+      items.push({
+        id: 'inviteUsers',
+        label: i18n.translate('xpack.spaces.contextSwitcher.footerLinks.inviteUsersLabel', {
+          defaultMessage: 'Invite users',
+        }),
+        href: inviteUsersHref,
+        iconType: 'user',
+        external: canInviteUsersViaCloud,
+        'data-test-subj': 'contextSwitcherFooterInviteUsers',
+      });
+    }
+
+    return items;
+  }, [application, canAccessApp, cloud, isServerless, usersAndRolesUrl, activeSpaceSolution]);
+};


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/259992?reload=1

## Summary

- Added footer links to the context switcher view:
  - [Root] Get started ( or Add data for Obs only): based on either project type (Serverless) or current solution (ECH), navigates to relevant get started page. Gated only by the Kibana's `navLinks` capability.
  - [Root] Connection details (Serverless): opens flyout, flyout content is internally gated, some flyout parts might not rendered based on Kibana's `api_keys.save` capability. 
  - [Root] Invite users: for Serverless it navigates to Cloud console users, gated by privileged URL internally based on `hasManageSecurity` gated by Kibana's `users.save` capability. For ECH it navigates to Kibana user management, gated by Kibana's `users.save` and `navLinks` capabilities.
  - [Submenu] Create project/deployment: no Kibana-side permission check, TBD.
- Ensured the switcher popover closes on link/action clicks

Still to do:
- Manage deployment/project gating + View all deployments/projects gating (related to https://github.com/elastic/kibana/issues/253828)
- Create project/deployment gating (related M2 https://github.com/elastic/kibana/issues/267742)

### Testing

| Root view | Submenu view | 
| --- | --- | 
| <img width="449" height="384" alt="Screenshot 2026-05-05 at 11 05 32" src="https://github.com/user-attachments/assets/0b5e1190-23a0-4f94-9b4c-66456b6f2e03" /> | <img width="243" height="194" alt="Screenshot 2026-05-05 at 11 05 42" src="https://github.com/user-attachments/assets/39eff88f-4afc-47cb-adf7-59221dd5f6df" /> | 
| <img width="467" height="365" alt="Screenshot 2026-05-05 at 11 10 56" src="https://github.com/user-attachments/assets/43c4ee2d-4950-4425-bbdf-8a5d287e2030" /> | <img width="458" height="357" alt="Screenshot 2026-05-05 at 11 11 02" src="https://github.com/user-attachments/assets/e5259e5d-1207-4ab1-a867-d64f46fa5ca4" /> | 
| <img width="480" height="348" alt="Screenshot 2026-05-05 at 11 18 52" src="https://github.com/user-attachments/assets/78bba9da-8288-4ef5-8365-259eddb7aaff" /> | <img width="494" height="353" alt="Screenshot 2026-05-05 at 11 18 58" src="https://github.com/user-attachments/assets/b551f664-45fd-40f5-921b-208e9f8a5cad" /> | 




