### PR TITLE
[Discover][Scout] Bump selectTextBaseLang timeout 

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -489,8 +489,10 @@ export class DiscoverApp {
   }
 
   async selectTextBaseLang() {
-    if (await this.page.testSubj.isEnabled('select-text-based-language-btn')) {
-      await this.page.testSubj.click('select-text-based-language-btn');
+    const btn = this.page.testSubj.locator('select-text-based-language-btn');
+    await btn.waitFor({ timeout: 30_000 });
+    if (await btn.isEnabled()) {
+      await btn.click();
       await this.waitUntilSearchingHasFinished();
       await this.codeEditor.waitCodeEditorReady('ESQLEditor');
     }


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/267001

`selectTextBaseLang` in `DiscoverApp` called `testSubj.isEnabled()` with Playwright's default 10s timeout. On `cloud-serverless-observability_complete`, the Discover top nav can mount after `dscPage` becomes visible, causing the locator to time out before the button is attached. This is the same root cause already fixed in `waitForDiscoverPage` and `waitForDocTableRendered` in the same file.

The fix extracts the button into a locator and calls `waitFor({ timeout: 30_000 })` before probing `isEnabled`, aligning with the 30s budget used throughout the rest of the file.
