### PR TITLE
[Streams] Stabilize Scout query-stream save flows

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -1360,6 +1360,16 @@ export class StreamsApp {
     await this.queryStreamUpdatedSuccessToast.waitFor({ state: 'visible' });
   }
 
+  async saveFlyoutQueryStreamCreate() {
+    await this.clickQueryStreamFlyoutSaveButton();
+    await this.queryStreamCreatedSuccessToast.waitFor({ state: 'visible' });
+  }
+
+  async saveFlyoutQueryStreamEdit() {
+    await this.clickQueryStreamFlyoutSaveButton();
+    await this.queryStreamUpdatedSuccessToast.waitFor({ state: 'visible' });
+  }
+
   async clickQueryStreamFormDeleteButton() {
     await this.page.getByTestId('streamsAppQueryStreamFormDeleteButton').click();
   }
@@ -1369,8 +1379,7 @@ export class StreamsApp {
     await this.fillRoutingRuleName(name);
     await this.kibanaMonacoEditor.waitCodeEditorReady('streamsEsqlEditor');
     await this.kibanaMonacoEditor.setCodeEditorValue(esqlQuery);
-    await this.clickQueryStreamFlyoutSaveButton();
-    await this.queryStreamCreatedSuccessToast.waitFor({ state: 'visible' });
+    await this.saveFlyoutQueryStreamCreate();
   }
 
   async openCreateChildQueryStreamForm() {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -1355,6 +1355,11 @@ export class StreamsApp {
     await this.page.getByTestId('streamsAppQueryStreamFormSaveButton').click();
   }
 
+  async saveInlineQueryStreamEdit() {
+    await this.clickQueryStreamFormSaveButton();
+    await this.queryStreamUpdatedSuccessToast.waitFor({ state: 'visible' });
+  }
+
   async clickQueryStreamFormDeleteButton() {
     await this.page.getByTestId('streamsAppQueryStreamFormDeleteButton').click();
   }
@@ -1365,6 +1370,7 @@ export class StreamsApp {
     await this.kibanaMonacoEditor.waitCodeEditorReady('streamsEsqlEditor');
     await this.kibanaMonacoEditor.setCodeEditorValue(esqlQuery);
     await this.clickQueryStreamFlyoutSaveButton();
+    await this.queryStreamCreatedSuccessToast.waitFor({ state: 'visible' });
   }
 
   async openCreateChildQueryStreamForm() {
@@ -1372,15 +1378,20 @@ export class StreamsApp {
     await this.kibanaMonacoEditor.waitCodeEditorReady('streamsEsqlEditor');
   }
 
-  async fillAndSaveChildQueryStream(childName: string, esqlQuery: string) {
+  async fillChildQueryStreamForm(childName: string, esqlQuery: string) {
     await this.fillRoutingRuleName(childName);
     await this.kibanaMonacoEditor.setCodeEditorValue(esqlQuery);
+  }
+
+  async saveChildQueryStream() {
     await this.clickQueryStreamFormCreateButton();
+    await this.childQueryStreamCreatedSuccessToast.waitFor({ state: 'visible' });
   }
 
   async createChildQueryStreamFromPartitioningTab(childName: string, esqlQuery: string) {
     await this.openCreateChildQueryStreamForm();
-    await this.fillAndSaveChildQueryStream(childName, esqlQuery);
+    await this.fillChildQueryStreamForm(childName, esqlQuery);
+    await this.saveChildQueryStream();
   }
 
   async deleteQueryStreamFromAdvancedTab(streamName: string) {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/edit_query_stream.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/edit_query_stream.spec.ts
@@ -64,8 +64,7 @@ test.describe('Query streams - Edit query stream', { tag: tags.stateful.classic 
     expect(editorValue).toBe(INITIAL_ESQL_QUERY);
     const UPDATED_ESQL_QUERY = 'FROM $.logs.ecs | WHERE host.name == "host-2"';
     await pageObjects.streams.kibanaMonacoEditor.setCodeEditorValue(UPDATED_ESQL_QUERY);
-    await pageObjects.streams.clickQueryStreamFlyoutSaveButton();
-    await expect(pageObjects.streams.queryStreamUpdatedSuccessToast).toBeVisible();
+    await pageObjects.streams.saveFlyoutQueryStreamEdit();
     await expect(pageObjects.streams.queryStreamDetailsQueryViewerCodeBlock).toHaveText(
       UPDATED_ESQL_QUERY
     );

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/edit_query_stream_classic_partitioning.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/edit_query_stream_classic_partitioning.spec.ts
@@ -82,8 +82,7 @@ test.describe(
 
       await test.step('update the query and save', async () => {
         await pageObjects.streams.kibanaMonacoEditor.setCodeEditorValue(UPDATED_ESQL_QUERY);
-        await pageObjects.streams.clickQueryStreamFormSaveButton();
-        await expect(pageObjects.streams.queryStreamUpdatedSuccessToast).toBeVisible();
+        await pageObjects.streams.saveInlineQueryStreamEdit();
       });
 
       await test.step('verify the ES|QL view was updated', async () => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/edit_query_stream_partitioning.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/edit_query_stream_partitioning.spec.ts
@@ -72,8 +72,7 @@ test.describe(
 
       await test.step('update the query and save', async () => {
         await pageObjects.streams.kibanaMonacoEditor.setCodeEditorValue(UPDATED_ESQL_QUERY);
-        await pageObjects.streams.clickQueryStreamFormSaveButton();
-        await expect(pageObjects.streams.queryStreamUpdatedSuccessToast).toBeVisible();
+        await pageObjects.streams.saveInlineQueryStreamEdit();
       });
 
       await test.step('verify the ES|QL view was updated', async () => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/query_stream_nesting_delete.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/query_stream_nesting_delete.spec.ts
@@ -56,29 +56,28 @@ test.describe(
         PARENT_STREAM_NAME,
         `FROM $.logs.ecs | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.clickStreamNameLink(PARENT_STREAM_NAME);
       await pageObjects.streams.gotoPartitioningTab(PARENT_STREAM_NAME);
       await pageObjects.streams.selectChildStreamType('Query');
       await pageObjects.streams.openCreateChildQueryStreamForm();
-      await pageObjects.streams.fillAndSaveChildQueryStream(
+      await pageObjects.streams.fillChildQueryStreamForm(
         CHILD_STREAM_NAME,
         `FROM $.${PARENT_STREAM_NAME} | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
+      await pageObjects.streams.saveChildQueryStream();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.clickStreamNameLink(CHILD_FULL_NAME);
       await pageObjects.streams.gotoPartitioningTab(CHILD_FULL_NAME);
       await pageObjects.streams.selectChildStreamType('Query');
       await pageObjects.streams.openCreateChildQueryStreamForm();
-      await pageObjects.streams.fillAndSaveChildQueryStream(
+      await pageObjects.streams.fillChildQueryStreamForm(
         GRANDCHILD_STREAM_NAME,
         `FROM $.${CHILD_FULL_NAME} | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
+      await pageObjects.streams.saveChildQueryStream();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.deleteQueryStreamFromAdvancedTab(CHILD_FULL_NAME);

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/query_stream_nesting_error.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/query_stream_nesting_error.spec.ts
@@ -54,17 +54,17 @@ test.describe(
         PARENT_STREAM_NAME,
         `FROM $.logs.ecs | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.clickStreamNameLink(PARENT_STREAM_NAME);
       await pageObjects.streams.gotoPartitioningTab(PARENT_STREAM_NAME);
       await pageObjects.streams.selectChildStreamType('Query');
       await pageObjects.streams.openCreateChildQueryStreamForm();
-      await pageObjects.streams.fillAndSaveChildQueryStream(
-        CHILD_STREAM_NAME,
+      await pageObjects.streams.fillRoutingRuleName(CHILD_STREAM_NAME);
+      await pageObjects.streams.kibanaMonacoEditor.setCodeEditorValue(
         'FROM $.wrong-parent | LIMIT 100'
       );
+      await pageObjects.streams.clickQueryStreamFormCreateButton();
 
       await expect(page.getByText(/must reference its parent stream/)).toBeVisible();
     });

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/query_stream_nesting_ingest_parent.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/query_stream_nesting_ingest_parent.spec.ts
@@ -59,11 +59,11 @@ test.describe(
       const initialChildEsqlQuery =
         await pageObjects.streams.kibanaMonacoEditor.getCodeEditorValue();
       expect(initialChildEsqlQuery).toBe(`FROM $.${INGEST_PARENT_STREAM_NAME}`);
-      await pageObjects.streams.fillAndSaveChildQueryStream(
+      await pageObjects.streams.fillChildQueryStreamForm(
         CHILD_STREAM_NAME,
         `FROM $.${INGEST_PARENT_STREAM_NAME} | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
+      await pageObjects.streams.saveChildQueryStream();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.clickStreamNameLink(CHILD_FULL_NAME);
@@ -73,11 +73,11 @@ test.describe(
       const initialGrandchildEsqlQuery =
         await pageObjects.streams.kibanaMonacoEditor.getCodeEditorValue();
       expect(initialGrandchildEsqlQuery).toBe(`FROM $.${CHILD_FULL_NAME}`);
-      await pageObjects.streams.fillAndSaveChildQueryStream(
+      await pageObjects.streams.fillChildQueryStreamForm(
         GRANDCHILD_STREAM_NAME,
         `FROM $.${CHILD_FULL_NAME} | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
+      await pageObjects.streams.saveChildQueryStream();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.clickStreamNameLink(GRANDCHILD_FULL_NAME);

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/query_stream_nesting_query_parent.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/query_stream_nesting_query_parent.spec.ts
@@ -56,7 +56,6 @@ test.describe(
         PARENT_STREAM_NAME,
         `FROM $.logs.ecs | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.clickStreamNameLink(PARENT_STREAM_NAME);
@@ -66,11 +65,11 @@ test.describe(
       const initialChildEsqlQuery =
         await pageObjects.streams.kibanaMonacoEditor.getCodeEditorValue();
       expect(initialChildEsqlQuery).toBe(`FROM $.${PARENT_STREAM_NAME}`);
-      await pageObjects.streams.fillAndSaveChildQueryStream(
+      await pageObjects.streams.fillChildQueryStreamForm(
         CHILD_STREAM_NAME,
         `FROM $.${PARENT_STREAM_NAME} | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
+      await pageObjects.streams.saveChildQueryStream();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.clickStreamNameLink(CHILD_FULL_NAME);
@@ -80,11 +79,11 @@ test.describe(
       const initialGrandchildEsqlQuery =
         await pageObjects.streams.kibanaMonacoEditor.getCodeEditorValue();
       expect(initialGrandchildEsqlQuery).toBe(`FROM $.${CHILD_FULL_NAME}`);
-      await pageObjects.streams.fillAndSaveChildQueryStream(
+      await pageObjects.streams.fillChildQueryStreamForm(
         GRANDCHILD_STREAM_NAME,
         `FROM $.${CHILD_FULL_NAME} | LIMIT 100`
       );
-      await expect(pageObjects.streams.queryStreamFlyout).toBeHidden();
+      await pageObjects.streams.saveChildQueryStream();
 
       await pageObjects.streams.gotoStreamMainPage();
       await pageObjects.streams.clickStreamNameLink(GRANDCHILD_FULL_NAME);


### PR DESCRIPTION
closes :
- #267362 
- #267353 
- #265291 

## Summary

Root cause is shared, not three separate bugs. Three `StreamsApp` page object methods (`createRootQueryStream`, `fillAndSaveChildQueryStream`, `clickQueryStreamFormSaveButton`) clicked Save and returned without waiting for the matching success toast. The next test action raced the save API call and failed several actions later with a confusing locator timeout.

This PR makes those save flows synchronous from the test's point of view. Each page object method now waits for its specific success-toast locator with `locator.waitFor({ state: 'visible' })`. The pattern mirrors the already-stable `deleteQueryStreamFromAdvancedTab` helper. The child save method is split into a fill helper and a save helper so the existing error-path test can keep failing fast on the form's error toast.
