### PR TITLE
[9.2] [Scout] Disallow `Promise.all` with Playwright wait APIs (skills + docs + rule) (#266158)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2606,6 +2606,7 @@ module.exports = {
         '@kbn/eslint/scout_expect_import': 'error',
         '@kbn/eslint/scout_no_deprecated_tags': 'error',
         '@kbn/eslint/scout_no_locators': ['error', { restricted: ['globalLoadingIndicator'] }],
+        '@kbn/eslint/scout_no_promise_all_with_playwright_apis': 'error',
         '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
     },

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -32,6 +32,7 @@ module.exports = {
     scout_no_deprecated_tags: require('./rules/scout_no_deprecated_tags'),
     scout_no_cross_boundary_imports: require('./rules/scout_no_cross_boundary_imports'),
     scout_no_locators: require('./rules/scout_no_locators'),
+    scout_no_promise_all_with_playwright_apis: require('./rules/scout_no_promise_all_with_playwright_apis'),
     require_kbn_fs: require('./rules/require_kbn_fs'),
     require_include_in_check_a11y: require('./rules/require_include_in_check_a11y'),
   },

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_promise_all_with_playwright_apis.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_promise_all_with_playwright_apis.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+
+// Playwright wait method names that signal the bad `Promise.all([wait, wait, ...])`
+// pattern when used as entries in `Promise.all`. Listener-style waits used in the
+// documented `Promise.all([listener, action])` pattern (`waitForEvent`,
+// `waitForURL`, `waitForResponse`, `waitForRequest`, `waitForNavigation`) are
+// intentionally NOT included here so the listener-then-trigger pattern still works.
+const DISALLOWED_METHODS = new Set(['waitFor', 'waitForSelector', 'waitForLoadState']);
+
+function getCalledName(node) {
+  if (!node || node.type !== 'CallExpression') return undefined;
+  const callee = node.callee;
+  if (callee.type === 'Identifier') return callee.name;
+  if (callee.type === 'MemberExpression' && callee.property.type === 'Identifier') {
+    return callee.property.name;
+  }
+  return undefined;
+}
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Promise.all over Playwright wait APIs in Scout tests; await sequentially instead.',
+      category: 'Best Practices',
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noPromiseAll:
+        "Don't use `Promise.all` with Playwright wait APIs. Parallel waits share one timeout window and amplify backend contention, producing flaky timeouts. Await sequentially or iterate with a `for` loop.",
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        // Match `Promise.all(...)`.
+        const callee = node.callee;
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.object.type !== 'Identifier' ||
+          callee.object.name !== 'Promise' ||
+          callee.property.type !== 'Identifier' ||
+          callee.property.name !== 'all'
+        ) {
+          return;
+        }
+
+        const arg = node.arguments[0];
+        if (!arg || arg.type !== 'ArrayExpression') return;
+
+        const hasDisallowed = arg.elements.some((el) => {
+          const name = getCalledName(el);
+          return name !== undefined && DISALLOWED_METHODS.has(name);
+        });
+        if (hasDisallowed) {
+          context.report({ node, messageId: 'noPromiseAll' });
+        }
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_promise_all_with_playwright_apis.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_promise_all_with_playwright_apis.test.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_no_promise_all_with_playwright_apis');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2020,
+  },
+});
+
+const errors = [{ messageId: 'noPromiseAll' }];
+
+ruleTester.run('@kbn/eslint/scout_no_promise_all_with_playwright_apis', rule, {
+  valid: [
+    // Sequential awaits — the recommended pattern.
+    {
+      code: `
+        await this.latencyChart.waitFor();
+        await this.throughputChart.waitFor();
+      `,
+    },
+    // Promise.all over non-Playwright work (apiServices / kbnClient) is fine.
+    {
+      code: `
+        await Promise.all([
+          apiServices.sampleData.install('logs'),
+          apiServices.sampleData.install('flights'),
+        ]);
+      `,
+    },
+    // Listener-then-trigger pattern — listener method names are deliberately
+    // not in the denylist so this works without a special case.
+    {
+      code: `
+        const [popup] = await Promise.all([
+          page.waitForEvent('popup'),
+          link.click(),
+        ]);
+      `,
+    },
+    {
+      code: `
+        await Promise.all([
+          page.waitForURL('**/app/discover**'),
+          locator.click(),
+        ]);
+      `,
+    },
+    {
+      code: `
+        await Promise.all([
+          page.waitForResponse('**/api/foo'),
+          button.click(),
+        ]);
+      `,
+    },
+    // Promise.all over generic / custom helpers (not Playwright methods).
+    {
+      code: `
+        await Promise.all([
+          waitForChartToLoad(this.page, this.latencyChart),
+          waitForChartToLoad(this.page, this.throughputChart),
+        ]);
+      `,
+    },
+    {
+      code: `
+        await Promise.all(promises);
+      `,
+    },
+  ],
+
+  invalid: [
+    // Multiple locator waits — the canonical bad pattern.
+    {
+      code: `
+        await Promise.all([
+          this.latencyChart.waitFor({ state: 'visible' }),
+          this.throughputChart.waitFor({ state: 'visible' }),
+        ]);
+      `,
+      errors,
+    },
+    // Mixed locator wait and waitForSelector.
+    {
+      code: `
+        await Promise.all([
+          this.chart.waitFor(),
+          page.waitForSelector('mainContent'),
+        ]);
+      `,
+      errors,
+    },
+  ],
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Scout] Disallow `Promise.all` with Playwright wait APIs (skills + docs + rule) (#266158)](https://github.com/elastic/kibana/pull/266158)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-04T19:20:32Z","message":"[Scout] Disallow `Promise.all` with Playwright wait APIs (skills + docs + rule) (#266158)\n\n## Summary\n\nAdds an ESLint rule plus supporting documentation/skills to prevent\n`Promise.all` over Playwright wait APIs in Scout tests. Parallel waits\nshare one timeout window and amplify backend contention against\nKibana/ES, producing flaky timeouts. Sequential awaits give each\noperation its own timeout budget without changing happy-path runtime,\nsince the browser renders things in parallel regardless of how the test\ncode awaits.\n\n## Changes\n\n- New ESLint rule\n`@kbn/eslint/scout_no_promise_all_with_playwright_apis` flagging\n`Promise.all([...])` whose entries call `waitFor` / `waitForSelector` /\n`waitForLoadState`. Listener-then-trigger functions (`waitForEvent`,\n`waitForURL`, `waitForResponse`, etc.) are deliberately not on the\ndenylist, so the documented `Promise.all([listener, action])` pattern\nstill passes.\n- Best-practices guidance added to\n[docs/extend/scout/ui-best-practices.md](docs/extend/scout/ui-best-practices.md)\nwith rationale, examples, and the listener-then-trigger exception.\n- Scout skills (`scout-ui-testing`, `scout-best-practices-reviewer`,\n`scout-migrate-from-ftr`, `cypress-to-scout-migration`) updated with\none-line pointers to the doc, plus a triage entry added to\n`flakiness-risk-patterns.md`.\n- Two existing apm violations fixed by sequentialising parallel\n`loc.waitFor()` calls:\n  - `service_details/overview_tab.ts`\n  - `service_map/service_map_embeddable.spec.ts`","sha":"ff5d990b95bfe68525c187767cc597f5ac6fd8dd","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","Team:obs-presentation","v9.5.0"],"title":"[Scout] Disallow `Promise.all` with Playwright wait APIs (skills + docs + rule)","number":266158,"url":"https://github.com/elastic/kibana/pull/266158","mergeCommit":{"message":"[Scout] Disallow `Promise.all` with Playwright wait APIs (skills + docs + rule) (#266158)\n\n## Summary\n\nAdds an ESLint rule plus supporting documentation/skills to prevent\n`Promise.all` over Playwright wait APIs in Scout tests. Parallel waits\nshare one timeout window and amplify backend contention against\nKibana/ES, producing flaky timeouts. Sequential awaits give each\noperation its own timeout budget without changing happy-path runtime,\nsince the browser renders things in parallel regardless of how the test\ncode awaits.\n\n## Changes\n\n- New ESLint rule\n`@kbn/eslint/scout_no_promise_all_with_playwright_apis` flagging\n`Promise.all([...])` whose entries call `waitFor` / `waitForSelector` /\n`waitForLoadState`. Listener-then-trigger functions (`waitForEvent`,\n`waitForURL`, `waitForResponse`, etc.) are deliberately not on the\ndenylist, so the documented `Promise.all([listener, action])` pattern\nstill passes.\n- Best-practices guidance added to\n[docs/extend/scout/ui-best-practices.md](docs/extend/scout/ui-best-practices.md)\nwith rationale, examples, and the listener-then-trigger exception.\n- Scout skills (`scout-ui-testing`, `scout-best-practices-reviewer`,\n`scout-migrate-from-ftr`, `cypress-to-scout-migration`) updated with\none-line pointers to the doc, plus a triage entry added to\n`flakiness-risk-patterns.md`.\n- Two existing apm violations fixed by sequentialising parallel\n`loc.waitFor()` calls:\n  - `service_details/overview_tab.ts`\n  - `service_map/service_map_embeddable.spec.ts`","sha":"ff5d990b95bfe68525c187767cc597f5ac6fd8dd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266158","number":266158,"mergeCommit":{"message":"[Scout] Disallow `Promise.all` with Playwright wait APIs (skills + docs + rule) (#266158)\n\n## Summary\n\nAdds an ESLint rule plus supporting documentation/skills to prevent\n`Promise.all` over Playwright wait APIs in Scout tests. Parallel waits\nshare one timeout window and amplify backend contention against\nKibana/ES, producing flaky timeouts. Sequential awaits give each\noperation its own timeout budget without changing happy-path runtime,\nsince the browser renders things in parallel regardless of how the test\ncode awaits.\n\n## Changes\n\n- New ESLint rule\n`@kbn/eslint/scout_no_promise_all_with_playwright_apis` flagging\n`Promise.all([...])` whose entries call `waitFor` / `waitForSelector` /\n`waitForLoadState`. Listener-then-trigger functions (`waitForEvent`,\n`waitForURL`, `waitForResponse`, etc.) are deliberately not on the\ndenylist, so the documented `Promise.all([listener, action])` pattern\nstill passes.\n- Best-practices guidance added to\n[docs/extend/scout/ui-best-practices.md](docs/extend/scout/ui-best-practices.md)\nwith rationale, examples, and the listener-then-trigger exception.\n- Scout skills (`scout-ui-testing`, `scout-best-practices-reviewer`,\n`scout-migrate-from-ftr`, `cypress-to-scout-migration`) updated with\none-line pointers to the doc, plus a triage entry added to\n`flakiness-risk-patterns.md`.\n- Two existing apm violations fixed by sequentialising parallel\n`loc.waitFor()` calls:\n  - `service_details/overview_tab.ts`\n  - `service_map/service_map_embeddable.spec.ts`","sha":"ff5d990b95bfe68525c187767cc597f5ac6fd8dd"}}]}] BACKPORT-->