### PR TITLE
fix(oas): update cross-page anchor links for split dashboards/visualizations API pages

### DIFF
--- a/oas_docs/overlays/dashboards.overlays.yaml
+++ b/oas_docs/overlays/dashboards.overlays.yaml
@@ -15,7 +15,7 @@ actions:
         ## When to use this API
 
         - Use this API to define a complete, self-contained dashboard in a single payload, including inline visualizations (both data view and ES|QL based), controls, and filters.
-        - Use the [Visualizations API](#operation/post-visualizations) to create reusable charts saved to your [visualization library](https://www.elastic.co/docs/explore-analyze/visualize/visualize-library). You can then embed them in dashboards as linked panels using their ID.
+        - Use the [Visualizations API](visualizations#tag/Visualizations/operation/post-visualizations) to create reusable charts saved to your [visualization library](https://www.elastic.co/docs/explore-analyze/visualize/visualize-library). You can then embed them in dashboards as linked panels using their ID.
 
         ## Get started
 
@@ -126,7 +126,7 @@ actions:
 
         `vis`, `discover_session`, and `markdown` panels can be embedded **inline** (full config stored in the dashboard) or **linked from library** (references a library item by ID).
 
-        For the full `config` schema for visualization panels, including chart types, metric operations, and breakdowns, refer to the [Visualizations API](#operation/post-visualizations).
+        For the full `config` schema for visualization panels, including chart types, metric operations, and breakdowns, refer to the [Visualizations API](visualizations#tag/Visualizations/operation/post-visualizations).
 
         - **Inline**: use when the panel is specific to this dashboard or must work across Kibana spaces. The panel configuration goes directly inside `config`:
 
@@ -158,7 +158,7 @@ actions:
           }
           ```
 
-        - **Linked from library**: references an item in your library by its ID. Use `ref_id` with any supported panel type (`vis`, `discover_session`, `markdown`). Use the [Visualizations API](#operation/post-visualizations) to create and retrieve IDs for visualization items.
+        - **Linked from library**: references an item in your library by its ID. Use `ref_id` with any supported panel type (`vis`, `discover_session`, `markdown`). Use the [Visualizations API](visualizations#tag/Visualizations/operation/post-visualizations) to create and retrieve IDs for visualization items.
 
           ```json
           {

--- a/oas_docs/overlays/visualizations.overlays.yaml
+++ b/oas_docs/overlays/visualizations.overlays.yaml
@@ -14,8 +14,8 @@ actions:
 
         ## When to use this API
 
-        - Use this API to create reusable charts saved to the visualization library. You can then embed them in dashboards by referencing their ID from the [Dashboards API](#operation/post-dashboards).
-        - Use the [Dashboards API](#operation/post-dashboards) when you want to define a complete dashboard in one request, or when you need ES|QL-based visualizations.
+        - Use this API to create reusable charts saved to the visualization library. You can then embed them in dashboards by referencing their ID from the [Dashboards API](dashboards#tag/Dashboards/operation/post-dashboards).
+        - Use the [Dashboards API](dashboards#tag/Dashboards/operation/post-dashboards) when you want to define a complete dashboard in one request, or when you need ES|QL-based visualizations.
 
         ## Get started
 
@@ -66,7 +66,7 @@ actions:
         Every visualization requires at minimum:
 
         - **`type`**: the chart to render. Each chart type has its own required fields, so the full structure of the request body depends on which `type` you specify.
-        - **`data_source`**: how data is fetched. You can reference an existing Kibana data view by ID (`"type": "data_view_reference"`), define a data view inline using an index pattern (`"type": "data_view_spec"`), or use an ES|QL query (`"type": "esql"`). Note that ES|QL is only supported via the [Dashboards API](#operation/post-dashboards). For most chart types, `data_source` is a top-level field. For XY charts, it belongs inside each layer in `layers[]`.
+        - **`data_source`**: how data is fetched. You can reference an existing Kibana data view by ID (`"type": "data_view_reference"`), define a data view inline using an index pattern (`"type": "data_view_spec"`), or use an ES|QL query (`"type": "esql"`). Note that ES|QL is only supported via the [Dashboards API](dashboards#tag/Dashboards/operation/post-dashboards). For most chart types, `data_source` is a top-level field. For XY charts, it belongs inside each layer in `layers[]`.
 
         You can also include `query` and `filters` to apply KQL or Lucene filters to all chart data. Both are optional and can be omitted.
 


### PR DESCRIPTION
## Summary

Fixes 6 broken cross-page anchor links in the dashboards and visualizations API overlays, following the split of the combined spec into separate pages (see elastic/dashboards-api-spec#7).

Previously both pages were rendered together, so `#operation/post-visualizations` and `#operation/post-dashboards` worked as same-page anchors. Now that each API has its own page, cross-references need to include the sibling page in the URL.

**`dashboards.overlays.yaml`** — 3 links updated:
- `#operation/post-visualizations` → `visualizations#tag/Visualizations/operation/post-visualizations`

**`visualizations.overlays.yaml`** — 3 links updated:
- `#operation/post-dashboards` → `dashboards#tag/Dashboards/operation/post-dashboards`

Same-page self-links (`#operation/post-dashboards` on the dashboards page and `#operation/post-visualizations` on the visualizations page) are unchanged.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->