### PR TITLE
[Entity Analytics] Swallow alert enrichment errors due to entity store permissions errors

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.test.ts
@@ -229,7 +229,7 @@ describe('createEntityStoreEnrichment', () => {
     expect(Object.keys(result).length).toBe(totalEvents);
   });
 
-  it('returns empty object and logs an error when listEntities throws', async () => {
+  it('returns empty object and does not throw when listEntities throws', async () => {
     mockGetEuidFromObject.mockReturnValue('host:server1');
 
     const crudClient = {
@@ -247,6 +247,28 @@ describe('createEntityStoreEnrichment', () => {
     });
 
     expect(result).toEqual({});
-    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Host Risk'));
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns empty object and logs a warning when an error is thrown outside listEntities', async () => {
+    mockGetEuidFromObject.mockImplementation(() => {
+      throw new Error('unexpected error');
+    });
+
+    const crudClient = makeEntityStoreCrudClient();
+
+    const result = await createEntityStoreEnrichment({
+      name: 'Host Risk',
+      entityType: 'host',
+      entityStoreCrudClient: crudClient,
+      logger,
+      events: [createAlert('1', { host: { name: 'server1' } })],
+      enrichmentFields: ['entity.risk.calculated_level'],
+      createEnrichmentFunction: () => enrichFn,
+    });
+
+    expect(result).toEqual({});
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Host Risk'));
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.test.ts
@@ -269,6 +269,6 @@ describe('createEntityStoreEnrichment', () => {
     });
 
     expect(result).toEqual({});
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Host Risk'));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Host Risk'));
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.ts
@@ -18,6 +18,27 @@ import type { IRuleExecutionLogForExecutors } from '../../../rule_monitoring';
 
 const CHUNK_SIZE = 1000;
 
+interface ListEntitiesForEuidChunkOpts {
+  euids: string[];
+  entityStoreCrudClient: EntityStoreCRUDClient;
+  enrichmentFields: string[];
+}
+const listEntitiesForEuidChunk = async ({
+  euids,
+  entityStoreCrudClient,
+  enrichmentFields,
+}: ListEntitiesForEuidChunkOpts) => {
+  try {
+    return await entityStoreCrudClient.listEntities({
+      filter: { terms: { 'entity.id': euids } },
+      size: euids.length,
+      fields: ['entity.id', ...enrichmentFields],
+    });
+  } catch (e) {
+    // Swallow errors from the entity store and return an empty result, since enrichment failure shouldn't block the rule execution. The enrichment will simply be skipped for all events in this chunk.
+    return { entities: [], fields: [] };
+  }
+};
 /**
  * Enriches alert events with data from the entity store V2, using the EUID translation
  * layer to identify entities. Queries via the entity store's `listEntities` API with a
@@ -68,10 +89,10 @@ export const createEntityStoreEnrichment = async <T extends DetectionAlertLatest
     const eventsMapById: EventsMapByEnrichments = {};
 
     for (const euidChunk of chunk(euids, CHUNK_SIZE)) {
-      const chunkResults = await entityStoreCrudClient.listEntities({
-        filter: { terms: { 'entity.id': euidChunk } },
-        size: euidChunk.length,
-        fields: ['entity.id', ...enrichmentFields],
+      const chunkResults = await listEntitiesForEuidChunk({
+        euids: euidChunk,
+        entityStoreCrudClient,
+        enrichmentFields,
       });
 
       const enrichableEntities: Array<{ entityId: string; fields: Record<string, unknown[]> }> =
@@ -97,7 +118,7 @@ export const createEntityStoreEnrichment = async <T extends DetectionAlertLatest
     );
     return eventsMapById;
   } catch (error) {
-    logger.error(`Enrichment ${name} failed: ${error}`);
+    logger.warn(`Enrichment ${name} failed: ${error}`);
     return {};
   }
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/create_entity_store_risk_enrichment.ts
@@ -118,7 +118,7 @@ export const createEntityStoreEnrichment = async <T extends DetectionAlertLatest
     );
     return eventsMapById;
   } catch (error) {
-    logger.warn(`Enrichment ${name} failed: ${error}`);
+    logger.info(`Enrichment ${name} failed: ${error}`);
     return {};
   }
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/index.test.ts
@@ -359,9 +359,6 @@ describe('enrichEvents', () => {
       });
 
       expect(enrichedEvents).toEqual(events);
-      expect(ruleExecutionLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('entityStoreCrudClient')
-      );
     });
 
     it('return the same events, if entity store index is not available', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/index.ts
@@ -42,12 +42,9 @@ import { getRiskIndex } from '../../../../../../common/search_strategy';
 const resolveV2Enrichments = async <T extends DetectionAlertLatest>(
   opts: EnrichmentOptions<T>
 ): Promise<Array<Promise<EventsMapByEnrichments>>> => {
-  const { services, spaceId, logger, entityStoreCrudClient } = opts;
+  const { services, spaceId, entityStoreCrudClient } = opts;
 
   if (entityStoreCrudClient === undefined) {
-    logger.warn(
-      'Enrichments: entityStoreCrudClient is not available, skipping entity store enrichments'
-    );
     return [];
   }
 


### PR DESCRIPTION
## Summary

Adds a try/catch directly around the `entityStore.listEntities` function which will throw if the user does not have permissions to read from the entity store index. This prevents rule execution errors due to user permission to the entity store indices.

## To Verify
1. Start ES and Kibana with the following feature flags:

```
uiSettings.overrides:
  securitySolution:entityStoreEnableV2: true

xpack.securitySolution.enableExperimental:
  - entityAnalyticsEntityStoreV2
  - entityAnalyticsNewHomePageEnabled
  - leadGenerationEnabled
  - entityAnalyticsWatchlistEnabled
```

Verify the entity store is enabled on https://localhost:5601/app/security/entity_analytics_management

2. Create a role and a user that has Security solution permission to create rules and access to the `.alerts` index + any source indices. Do not add access to entity store indices. I used these:

<img width="1618" height="809" alt="Screenshot 2026-05-05 at 2 56 49 PM" src="https://github.com/user-attachments/assets/11ae7f43-a94b-43d5-a3a9-7298357102c1" />
<img width="774" height="1012" alt="Screenshot 2026-05-05 at 2 57 04 PM" src="https://github.com/user-attachments/assets/5f60d019-8531-44d5-a8a5-5ff761840902" />

3. Log in as your limited permission user and create a detection rule against your source indices. Please note, your source indices should have some sort of `user.*` and or `host.*` fields populated as the enrichment only tries to run if an Entity ID (EUID) can be generated from the source data.

4. Verify your detection rule runs with no warnings or errors. 


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->