### PR TITLE
[9.4] Fix `@elastic/eui/tooltip-focusable-anchor` lint violations in kbn-developer-toolbar (#267696)

### DIFF
--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/environment/environment_indicator.tsx
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/environment/environment_indicator.tsx
@@ -72,7 +72,13 @@ export const EnvironmentIndicator: React.FC<EnvironmentIndicatorProps> = ({
 
   return (
     <EuiToolTip content={tooltipContent}>
-      <EuiBadge color={badgeColor} css={badgeStyles} iconType={iconType} iconSide="left">
+      <EuiBadge
+        color={badgeColor}
+        css={badgeStyles}
+        iconType={iconType}
+        iconSide="left"
+        tabIndex={0}
+      >
         {displayText}
       </EuiBadge>
     </EuiToolTip>

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/frame_jank/frame_jank_indicator.tsx
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/frame_jank/frame_jank_indicator.tsx
@@ -241,7 +241,7 @@ export const FrameJankIndicator: React.FC = () => {
 
   return (
     <EuiToolTip content={tooltipContent}>
-      <div css={getContainerStyles(euiTheme)}>
+      <div css={getContainerStyles(euiTheme)} tabIndex={0}>
         <EuiBadge color={'default'} css={getBadgeStyles(euiTheme)}>
           Jank {perfInfo ? `${perfInfo.jankPercentage}%` : '-%'}
         </EuiBadge>

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/memory/memory_usage_indicator.tsx
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/memory/memory_usage_indicator.tsx
@@ -43,7 +43,7 @@ export const MemoryUsageIndicator: React.FC = () => {
 
     return (
       <EuiToolTip content={tooltipContent}>
-        <EuiBadge color="#0B1628" css={badgeStyles}>
+        <EuiBadge color="#0B1628" css={badgeStyles} tabIndex={0}>
           {displayText}
         </EuiBadge>
       </EuiToolTip>
@@ -77,6 +77,7 @@ export const MemoryUsageIndicator: React.FC = () => {
         css={badgeStyles}
         iconType={memoryInfo.leak ? 'warningFill' : undefined}
         iconSide={'right'}
+        tabIndex={0}
       >
         {displayText}
       </EuiBadge>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix `@elastic/eui/tooltip-focusable-anchor` lint violations in kbn-developer-toolbar (#267696)](https://github.com/elastic/kibana/pull/267696)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-05T12:02:43Z","message":"Fix `@elastic/eui/tooltip-focusable-anchor` lint violations in kbn-developer-toolbar (#267696)\n\nCloses: https://github.com/elastic/kibana/issues/267695\n\nAdds `tabIndex={0}` to non-focusable `EuiToolTip` anchor elements so\nkeyboard users can trigger tooltips.\n\n- `environment_indicator.tsx` — `EuiBadge` anchor\n- `frame_jank_indicator.tsx` — `div` anchor\n- `memory_usage_indicator.tsx` — two `EuiBadge` anchors\n\n```tsx\n<EuiToolTip content={tooltipContent}>\n  <EuiBadge tabIndex={0} ...>...</EuiBadge>\n</EuiToolTip>\n```\n\nCloses #225189\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"8e309b49044e1d6583a8920ea5a984c509a7c638","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","💝community","backport:version","v9.4.0","a11y:agent-pr","v9.5.0","v9.3.5"],"title":"Fix `@elastic/eui/tooltip-focusable-anchor` lint violations in kbn-developer-toolbar","number":267696,"url":"https://github.com/elastic/kibana/pull/267696","mergeCommit":{"message":"Fix `@elastic/eui/tooltip-focusable-anchor` lint violations in kbn-developer-toolbar (#267696)\n\nCloses: https://github.com/elastic/kibana/issues/267695\n\nAdds `tabIndex={0}` to non-focusable `EuiToolTip` anchor elements so\nkeyboard users can trigger tooltips.\n\n- `environment_indicator.tsx` — `EuiBadge` anchor\n- `frame_jank_indicator.tsx` — `div` anchor\n- `memory_usage_indicator.tsx` — two `EuiBadge` anchors\n\n```tsx\n<EuiToolTip content={tooltipContent}>\n  <EuiBadge tabIndex={0} ...>...</EuiBadge>\n</EuiToolTip>\n```\n\nCloses #225189\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"8e309b49044e1d6583a8920ea5a984c509a7c638"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267696","number":267696,"mergeCommit":{"message":"Fix `@elastic/eui/tooltip-focusable-anchor` lint violations in kbn-developer-toolbar (#267696)\n\nCloses: https://github.com/elastic/kibana/issues/267695\n\nAdds `tabIndex={0}` to non-focusable `EuiToolTip` anchor elements so\nkeyboard users can trigger tooltips.\n\n- `environment_indicator.tsx` — `EuiBadge` anchor\n- `frame_jank_indicator.tsx` — `div` anchor\n- `memory_usage_indicator.tsx` — two `EuiBadge` anchors\n\n```tsx\n<EuiToolTip content={tooltipContent}>\n  <EuiBadge tabIndex={0} ...>...</EuiBadge>\n</EuiToolTip>\n```\n\nCloses #225189\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"8e309b49044e1d6583a8920ea5a984c509a7c638"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->