### PR TITLE
chore(NA): remove branch 9.2 from being used

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-console-definitions-sync.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-console-definitions-sync.yml
@@ -22,7 +22,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-management'
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: false
-      branch_configuration: main 9.4 9.3 9.2 8.19
+      branch_configuration: main 9.4 9.3 8.19
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/console_definitions_sync.yml

--- a/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-3.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-3.yml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: bk-kibana-es-forward-compatibility-testing-9-dot-2
+  name: bk-kibana-es-forward-compatibility-testing-9-dot-3
   description: Forward compatibility testing between Kibana 8.19 and ES 9+
   links:
-    - url: 'https://buildkite.com/elastic/kibana-es-forward-compatibility-testing-9-dot-2'
+    - url: 'https://buildkite.com/elastic/kibana-es-forward-compatibility-testing-9-dot-3'
       title: Pipeline link
 spec:
   type: buildkite-pipeline
@@ -15,7 +15,7 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: kibana / ES Forward Compatibility Testing 9.2
+      name: kibana / ES Forward Compatibility Testing 9.3
       description: Forward compatibility testing between Kibana 8.19 and ES 9+
     spec:
       env:
@@ -26,7 +26,7 @@ spec:
       branch_configuration: main
       default_branch: main
       repository: elastic/kibana
-      pipeline_file: .buildkite/pipelines/es_forward_9_dot_2.yml
+      pipeline_file: .buildkite/pipelines/es_forward_9_dot_3.yml
       skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false

--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -22,7 +22,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.4 9.3 9.2 8.19
+      branch_configuration: main 9.4 9.3 8.19
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/build.yml
@@ -56,10 +56,6 @@ spec:
           cronline: 0 22 * * * America/New_York
           message: Daily build
           branch: '9.3'
-        Daily build (9.2):
-          cronline: 0 22 * * * America/New_York
-          message: Daily build
-          branch: '9.2'
         Daily build (8.19):
           cronline: 0 22 * * * America/New_York
           message: Daily build
@@ -91,7 +87,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.4 9.3 9.2 8.19
+      branch_configuration: main 9.4 9.3 8.19
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/promote.yml
@@ -141,7 +137,7 @@ spec:
         REPORT_FAILED_TESTS_TO_GITHUB: 'true'
         SCOUT_REPORTER_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.4 9.3 9.2 8.19
+      branch_configuration: main 9.4 9.3 8.19
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/verify.yml

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -26,7 +26,7 @@ spec:
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SCOUT_REPORTER_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.4 9.3 9.2 8.19
+      branch_configuration: main 9.4 9.3 8.19
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/on_merge.yml

--- a/.buildkite/pipeline-resource-definitions/kibana-scout-update-metadata.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-scout-update-metadata.yml
@@ -23,7 +23,7 @@ spec:
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
       # Schedules set BUILDKITE_BRANCH; the step uses it as the PR base. Add a schedule per target branch.
-      branch_configuration: main 9.3 8.19
+      branch_configuration: main 9.4 9.3 8.19
       cancel_intermediate_builds: true
       default_branch: main
       repository: elastic/kibana
@@ -49,6 +49,10 @@ spec:
           cronline: 0 0 * * * America/New_York
           message: Daily Scout metadata update
           branch: main
+        Daily (9.4):
+          cronline: 0 0 * * * America/New_York
+          message: Daily Scout metadata update
+          branch: '9.4'
         Daily (9.3):
           cronline: 0 0 * * * America/New_York
           message: Daily Scout metadata update

--- a/.buildkite/pipeline-resource-definitions/kibana-scout-update-metadata.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-scout-update-metadata.yml
@@ -23,7 +23,7 @@ spec:
         KIBANA_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
       # Schedules set BUILDKITE_BRANCH; the step uses it as the PR base. Add a schedule per target branch.
-      branch_configuration: main 9.3 9.2 8.19
+      branch_configuration: main 9.3 8.19
       cancel_intermediate_builds: true
       default_branch: main
       repository: elastic/kibana
@@ -53,10 +53,6 @@ spec:
           cronline: 0 0 * * * America/New_York
           message: Daily Scout metadata update
           branch: '9.3'
-        Daily (9.2):
-          cronline: 0 0 * * * America/New_York
-          message: Daily Scout metadata update
-          branch: '9.2'
         Daily (8.19):
           cronline: 0 0 * * * America/New_York
           message: Daily Scout metadata update

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -24,7 +24,7 @@ spec:
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-deploy-cloud.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-deploy-project.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-entity-store-performance-from-pr.yml
-    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-2.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-3.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml

--- a/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
+++ b/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
@@ -46,11 +46,11 @@ spec:
         everyone:
           access_level: BUILD_AND_READ
       schedules:
-        Trigger ES forward compatibility tests 9.2:
+        Trigger ES forward compatibility tests 9.3:
           cronline: 0 5 * * *
-          message: Trigger ES forward compatibility tests 9.2
+          message: Trigger ES forward compatibility tests 9.3
           env:
-            TRIGGER_PIPELINE_SET: es-forward-9-dot-2
+            TRIGGER_PIPELINE_SET: es-forward-9-dot-3
         Trigger artifact staging builds:
           cronline: 0 7 * * * America/New_York
           message: Trigger artifact staging builds

--- a/.buildkite/scripts/pipelines/trigger_version_dependent_jobs/pipeline.ts
+++ b/.buildkite/scripts/pipelines/trigger_version_dependent_jobs/pipeline.ts
@@ -12,7 +12,7 @@ import type { BuildkiteTriggerStep } from '#pipeline-utils';
 import { getVersionsFile } from '#pipeline-utils';
 
 const pipelineSets = {
-  'es-forward-9-dot-2': 'kibana-es-forward-compatibility-testing-9-dot-2',
+  'es-forward-9-dot-3': 'kibana-es-forward-compatibility-testing-9-dot-3',
   'artifacts-snapshot': 'kibana-artifacts-snapshot',
   'artifacts-staging': 'kibana-artifacts-staging',
   'artifacts-trigger': 'kibana-artifacts-trigger',
@@ -37,8 +37,8 @@ async function main() {
   }
 
   switch (pipelineSetName) {
-    case 'es-forward-9-dot-2': {
-      pipelineSteps.push(...getESForward9Dot2PipelineTriggers());
+    case 'es-forward-9-dot-3': {
+      pipelineSteps.push(...getESForward9Dot3PipelineTriggers());
       break;
     }
     case 'artifacts-snapshot': {
@@ -62,25 +62,28 @@ async function main() {
 }
 
 /**
- * This pipeline is testing the forward compatibility of Kibana with different versions of Elasticsearch for 9.2.
+ * This pipeline is testing the forward compatibility of Kibana with different versions of Elasticsearch for 9.3.
  * Should be triggered for combinations of (Kibana@8.19 + ES@9.x {current open branches on the same major})
  */
-export function getESForward9Dot2PipelineTriggers(): BuildkiteTriggerStep[] {
+export function getESForward9Dot3PipelineTriggers(): BuildkiteTriggerStep[] {
   const versions = getVersionsFile();
   const KIBANA_8_19 = versions.versions.find((v) => v.branch === '8.19');
   if (!KIBANA_8_19) {
-    throw new Error('Update ES forward compatibility 9.2 pipeline to 8.19');
+    throw new Error('Update ES forward compatibility 9.3 pipeline to 8.19');
   }
   const targetESVersions = versions.versions.filter(
     (v) =>
-      // 9.2+, 8.19 => 9.0 is not supported
-      (v.branch.startsWith('9.') && v.branch !== '9.0' && v.branch !== '9.1') ||
+      // 9.3+, 8.19 => 9.0 is not supported
+      (v.branch.startsWith('9.') &&
+        v.branch !== '9.0' &&
+        v.branch !== '9.1' &&
+        v.branch !== '9.2') ||
       v.branch.includes('main')
   );
 
   return targetESVersions.map(({ version }) => {
     return {
-      trigger: pipelineSets['es-forward-9-dot-2'],
+      trigger: pipelineSets['es-forward-9-dot-3'],
       async: true,
       label: `Triggering Kibana ${KIBANA_8_19.version} + ES ${version} forward compatibility`,
       build: {

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   ],
   "ignorePaths": ["**/__fixtures__/**", "**/fixtures/**"],
   "enabledManagers": ["npm", "github-actions", "custom.regex", "devcontainer"],
-  "baseBranches": ["main", "9.4", "9.3", "9.2", "8.19"],
+  "baseBranches": ["main", "9.4", "9.3", "8.19"],
   "labels": ["release_note:skip", "backport:all-open"],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,

--- a/versions.json
+++ b/versions.json
@@ -17,11 +17,6 @@
       "branchType": "release"
     },
     {
-      "version": "9.2.9",
-      "branch": "9.2",
-      "branchType": "release"
-    },
-    {
       "version": "8.19.16",
       "branch": "8.19",
       "branchType": "release"


### PR DESCRIPTION
Removes 9.2 from CI. Also adds a missing 9.4 schedule to `kibana-scout-update-metadata.yml`.