### PR TITLE
feat(user-activity): Add ECS event.outcome and error to activity logs

### DIFF
--- a/docs/reference/user-activity.md
+++ b/docs/reference/user-activity.md
@@ -34,7 +34,7 @@ user_activity:
 - `user_activity.appenders`: Logging appenders used by the service. This uses the same appender schema as Kibana logging. For more details, refer to [Logging settings](/reference/configuration-reference/logging-settings.md). By default, it uses a JSON console appender.
 - `user_activity.filters`: Optional list of filter rules applied to `event.action`.
 
-When enabled, events are logged under the logger context `user_activity.event` and include the fields `{ message, event, object, metadata, user, session, ...}`.
+When enabled, events are logged under the logger context `user_activity.event` and include the fields `{ message, event, object, metadata, error, user, session, ...}`.
 
 ### Filters
 
@@ -71,6 +71,7 @@ User activity events are written as JSON log entries. When using the JSON loggin
 | --- | --- |
 | `event.action` | Human readable standardized description of the action performed. Refer to [Available actions](#available-actions) for a list of possible values. |
 | `event.type` | Human readable standardized categorization of actions performed. |
+| `event.outcome` | (Optional) Denotes whether the event represents a success or a failure from the perspective of the entity that produced the event: `success`, `failure`, or `unknown`. |
 | `event.start` | (Optional) ISO8601 timestamp of the event start time. |
 | `event.end` | (Optional) ISO8601 timestamp of the event end time. |
 | `event.duration` | (Optional) Duration (in ns) between the event start and end timestamps. |
@@ -128,6 +129,15 @@ Some actions, such as `log_in_user` and `log_out_user`, are recorded on unauthen
 | **Field** | **Description** |
 | --- | --- |
 | `metadata` | (Optional) Additional bucket of non-standard metadata specific to the Kibana usage log. |
+
+### Error fields
+
+| **Field** | **Description** |
+| --- | --- |
+| `error.type` | (Optional) The type of the error, for example the class name of the exception. |
+| `error.message` | (Optional) Error message. |
+| `error.stack_trace` | (Optional) The stack trace of this error in plain text. |
+| `error.code` | (Optional) Error code describing the error. |
 
 ### Service fields
 

--- a/docs/reference/user-activity.md
+++ b/docs/reference/user-activity.md
@@ -71,7 +71,7 @@ User activity events are written as JSON log entries. When using the JSON loggin
 | --- | --- |
 | `event.action` | Human readable standardized description of the action performed. Refer to [Available actions](#available-actions) for a list of possible values. |
 | `event.type` | Human readable standardized categorization of actions performed. |
-| `event.outcome` | (Optional) Denotes whether the event represents a success or a failure from the perspective of the entity that produced the event: `success`, `failure`, or `unknown`. |
+| `event.outcome` {applies_to}`stack: ga 9.5+` | (Optional) Denotes whether the event represents a success or a failure from the perspective of the entity that produced the event: `success`, `failure`, or `unknown`. |
 | `event.start` | (Optional) ISO8601 timestamp of the event start time. |
 | `event.end` | (Optional) ISO8601 timestamp of the event end time. |
 | `event.duration` | (Optional) Duration (in ns) between the event start and end timestamps. |
@@ -134,10 +134,10 @@ Some actions, such as `log_in_user` and `log_out_user`, are recorded on unauthen
 
 | **Field** | **Description** |
 | --- | --- |
-| `error.type` | (Optional) The type of the error, for example the class name of the exception. |
-| `error.message` | (Optional) Error message. |
-| `error.stack_trace` | (Optional) The stack trace of this error in plain text. |
-| `error.code` | (Optional) Error code describing the error. |
+| `error.type` {applies_to}`stack: ga 9.5+` | (Optional) The type of the error, for example the class name of the exception. |
+| `error.message` {applies_to}`stack: ga 9.5+` | (Optional) Error message. |
+| `error.stack_trace` {applies_to}`stack: ga 9.5+` | (Optional) The stack trace of this error in plain text. |
+| `error.code` {applies_to}`stack: ga 9.5+` | (Optional) Error code describing the error. |
 
 ### Service fields
 

--- a/src/core/packages/user-activity/server-internal/src/user_activity_service.test.ts
+++ b/src/core/packages/user-activity/server-internal/src/user_activity_service.test.ts
@@ -109,6 +109,62 @@ describe('UserActivityService', () => {
       });
     });
 
+    it('logs optional event.outcome on the event object', () => {
+      service.trackUserAction({
+        message: 'Failed action',
+        event: { action: TEST_ACTION, type: 'error', outcome: 'failure' },
+        object: { id: 'obj-e', name: 'Object', type: 'rule', tags: [] },
+      });
+
+      expect(loggingSystemMock.collect(core.logger).info[0][1]).toMatchObject({
+        event: { action: TEST_ACTION, type: 'error', outcome: 'failure' },
+      });
+    });
+
+    it('logs optional top-level ECS error fields', () => {
+      service.trackUserAction({
+        message: 'User failed to create a rule.',
+        event: { action: TEST_ACTION, type: 'creation', outcome: 'failure' },
+        object: { id: 'obj-err', name: 'Rule', type: 'rule', tags: [] },
+        error: {
+          type: 'ResponseError',
+          message: 'index_not_found_exception',
+          code: '404',
+          stack_trace: 'Error: index_not_found_exception\n    at handler',
+        },
+      });
+
+      expect(loggingSystemMock.collect(core.logger).info[0][1]).toMatchObject({
+        event: { outcome: 'failure' },
+        error: {
+          type: 'ResponseError',
+          message: 'index_not_found_exception',
+          code: '404',
+          stack_trace: 'Error: index_not_found_exception\n    at handler',
+        },
+      });
+    });
+
+    it('merges outcome, error, and metadata into the log meta object', () => {
+      const params: TrackUserActionParams = {
+        message: 'Merged payload',
+        event: { action: TEST_ACTION, type: 'change', outcome: 'success' },
+        object: { id: 'obj-m', name: 'Obj', type: 'dashboard', tags: ['t1'] },
+        metadata: { attempt: 1 },
+        error: { message: 'ignored downstream' },
+      };
+
+      service.trackUserAction(params);
+
+      expect(loggingSystemMock.collect(core.logger).info[0][1]).toMatchObject({
+        message: 'Merged payload',
+        event: { action: TEST_ACTION, type: 'change', outcome: 'success' },
+        object: { id: 'obj-m', name: 'Obj', type: 'dashboard', tags: ['t1'] },
+        metadata: { attempt: 1 },
+        error: { message: 'ignored downstream' },
+      });
+    });
+
     it('generates default message when not provided', () => {
       service.setInjectedContext({
         user: { name: 'test_user' },

--- a/src/core/packages/user-activity/server-internal/src/user_activity_service.ts
+++ b/src/core/packages/user-activity/server-internal/src/user_activity_service.ts
@@ -91,7 +91,13 @@ export class UserActivityService
     this.enabled = false;
   }
 
-  private trackUserAction = ({ message, event, object, metadata }: TrackUserActionParams) => {
+  private trackUserAction = ({
+    message,
+    event,
+    object,
+    metadata,
+    error,
+  }: TrackUserActionParams) => {
     if (!this.enabled || !shouldLog(event.action, this.filters)) return;
 
     const injectedContext = this.getInjectedContext();
@@ -105,6 +111,7 @@ export class UserActivityService
       event,
       object,
       ...(metadata ? { metadata } : {}),
+      ...(error ? { error } : {}),
       ...injectedContext,
     });
   };

--- a/src/core/packages/user-activity/server/README.md
+++ b/src/core/packages/user-activity/server/README.md
@@ -24,12 +24,12 @@ core.userActivity.trackUserAction({
 });
 ```
 
-You can optionally provide a custom message and metadata:
+You can optionally provide a custom message, ECS `event.outcome`, top-level ECS `error.*` fields, and metadata:
 
 ```ts
 core.userActivity.trackUserAction({
   message: 'User snoozed an alerting rule',
-  event: { action: 'snooze_alerting_rule', type: 'change' },
+  event: { action: 'snooze_alerting_rule', type: 'change', outcome: 'success' },
   object: { id: 'rule-456', name: 'CPU usage threshold', type: 'rule', tags: ['production'] },
   metadata: {
     ui_surface: 'rules_table',
@@ -37,6 +37,8 @@ core.userActivity.trackUserAction({
   },
 });
 ```
+
+For failed actions, set `event.outcome` to `failure` and populate `error` with ECS fields (`type`, `message`, `stack_trace`, `code`) instead of stuffing failure detail only into `metadata`.
 
 ## Registering new actions
 

--- a/src/core/packages/user-activity/server/index.ts
+++ b/src/core/packages/user-activity/server/index.ts
@@ -10,6 +10,8 @@
 export type {
   UserActivityObject,
   UserActivityEventType,
+  UserActivityEventOutcome,
+  UserActivityError,
   UserActivityEvent,
   TrackUserActionParams,
   UserActivityServiceSetup,

--- a/src/core/packages/user-activity/server/src/types.ts
+++ b/src/core/packages/user-activity/server/src/types.ts
@@ -49,6 +49,29 @@ export type UserActivityEventType =
   | 'user';
 
 /**
+ * ECS `event.outcome` allowed values for user activity events.
+ * @see https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-outcome
+ * @public
+ */
+export type UserActivityEventOutcome = 'success' | 'failure' | 'unknown';
+
+/**
+ * ECS `error.*` fields supported on user activity log entries (subset).
+ * @see https://www.elastic.co/guide/en/ecs/current/ecs-error.html
+ * @public
+ */
+export interface UserActivityError {
+  /** The kind of error (for example, exception class name). */
+  type?: string;
+  /** Error message. */
+  message?: string;
+  /** Stack trace as a string. */
+  stack_trace?: string;
+  /** Optional error code. */
+  code?: string;
+}
+
+/**
  * Information about the event being performed by the user.
  * @public
  */
@@ -57,6 +80,8 @@ export interface UserActivityEvent {
   action: UserActivityActionId;
   /** Event type {@link UserActivityEventType}. */
   type: UserActivityEventType;
+  /** ECS event outcome; use with {@link UserActivityEventOutcome}. */
+  outcome?: UserActivityEventOutcome;
   /** ISO8601 timestamp of the event start time. */
   start?: string;
   /** ISO8601 timestamp of the event end time. */
@@ -79,6 +104,8 @@ export interface TrackUserActionParams {
   event: UserActivityEvent;
   /** Object attributes written to the log entry. */
   object: UserActivityObject;
+  /** ECS error fields written at the top level of the log entry when provided. */
+  error?: UserActivityError;
   /** Additional bucket of non-standard metadata. */
   metadata?: UserActivityMetadata;
 }


### PR DESCRIPTION
## Summary

Extends the User Activity Log API so structured events can include ECS-compliant **`event.outcome`** (`success`, `failure`, `unknown`) and an optional top-level **`error`** object (`type`, `message`, `stack_trace`, `code`), emitted by `UserActivityService.trackUserAction` alongside existing fields.

## Changes

- **Types:** `UserActivityEventOutcome`, `UserActivityError`, optional `UserActivityEvent.outcome`, optional `TrackUserActionParams.error`
- **Implementation:** merge `error` into log meta when present (same pattern as `metadata`)
- **Tests:** serialization / merging for outcome and error
- **Docs:** `docs/reference/user-activity.md` schema + server README usage note

Resolves #267741

---

**Review note:** This PR was drafted with assistance from an AI coding assistant (Cursor / Composer). Please review carefully.

Made with [Cursor](https://cursor.com)