### PR TITLE
[Entity Analytics] Enable CPS project picker on Entity Analytics Explore pages

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -44,7 +44,17 @@ import type {
 } from './types';
 import { ASSISTANT_MANAGEMENT_TITLE, SOLUTION_NAME } from './common/translations';
 
-import { APP_ICON_SOLUTION, APP_ID, APP_PATH, APP_UI_ID } from '../common/constants';
+import {
+  APP_ICON_SOLUTION,
+  APP_ID,
+  APP_PATH,
+  APP_UI_ID,
+  DASHBOARDS_PATH,
+  EXPLORE_PATH,
+  HOSTS_PATH,
+  NETWORK_PATH,
+  USERS_PATH,
+} from '../common/constants';
 
 import type { AppLinkItems } from './common/links';
 import {
@@ -82,6 +92,19 @@ import {
 } from './agent_builder/attachment_types';
 import type { SecurityCanvasEmbeddedBundle } from './agent_builder/components/security_redux_embedded_provider';
 import { registerWorkflowSteps } from './workflows/step_types';
+
+/**
+ * Builds a CPS access resolver that returns EDITABLE for any route whose path segment matches
+ * one of the provided route prefixes, and DISABLED for all other routes.
+ */
+export const createCpsAccessResolver =
+  (editableRoutes: string[]) =>
+  (location: string): ProjectRoutingAccess => {
+    const pattern = new RegExp(
+      `security/(${editableRoutes.map((p) => p.replace(/^\//, '')).join('|')})`
+    );
+    return pattern.test(location) ? ProjectRoutingAccess.EDITABLE : ProjectRoutingAccess.DISABLED;
+  };
 
 export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, StartPlugins> {
   private config: SecuritySolutionUiConfigType;
@@ -328,12 +351,9 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       });
     }
 
-    // Enable CPS picker only for individual dashboard views (not the listing page).
-    // TODO: Remove this restriction once CPS is enabled across all Security Solution pages.
-    plugins.cps?.cpsManager?.registerAppAccess(APP_UI_ID, (location: string) =>
-      /security\/dashboards\/[^?]+/.test(location)
-        ? ProjectRoutingAccess.EDITABLE
-        : ProjectRoutingAccess.DISABLED
+    plugins.cps?.cpsManager?.registerAppAccess(
+      APP_UI_ID,
+      createCpsAccessResolver([HOSTS_PATH, USERS_PATH, NETWORK_PATH, EXPLORE_PATH, DASHBOARDS_PATH])
     );
 
     return this.contract.getStartContract(core);

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin_cps_access_resolver.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin_cps_access_resolver.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ProjectRoutingAccess } from '@kbn/cps-utils';
+import {
+  DASHBOARDS_PATH,
+  EXPLORE_PATH,
+  HOSTS_PATH,
+  NETWORK_PATH,
+  USERS_PATH,
+} from '../common/constants';
+import { createCpsAccessResolver } from './plugin';
+
+const EDITABLE_ROUTES = [HOSTS_PATH, USERS_PATH, NETWORK_PATH, EXPLORE_PATH, DASHBOARDS_PATH];
+
+describe('createCpsAccessResolver', () => {
+  const resolver = createCpsAccessResolver(EDITABLE_ROUTES);
+
+  describe('EDITABLE routes', () => {
+    it.each([
+      ['hosts listing', '/app/security/hosts'],
+      ['hosts detail', '/app/security/hosts/web-01'],
+      ['users listing', '/app/security/users'],
+      ['users detail', '/app/security/users/alice'],
+      ['network listing', '/app/security/network'],
+      ['explore landing', '/app/security/explore'],
+      ['dashboards individual view', '/app/security/dashboards/some-id'],
+    ])('returns EDITABLE for %s (%s)', (_label, location) => {
+      expect(resolver(location)).toBe(ProjectRoutingAccess.EDITABLE);
+    });
+  });
+
+  describe('DISABLED routes', () => {
+    it.each([
+      ['rules', '/app/security/rules'],
+      ['cases', '/app/security/cases'],
+      ['attack discovery', '/app/security/attack_discovery'],
+      ['alerts', '/app/security/alerts'],
+      ['exceptions', '/app/security/exceptions'],
+      ['app root', '/app/security'],
+      ['unrelated path', '/app/kibana/dashboard'],
+    ])('returns DISABLED for %s (%s)', (_label, location) => {
+      expect(resolver(location)).toBe(ProjectRoutingAccess.DISABLED);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Enables the CPS (Cross-Project Search) project picker on all Entity Analytics Explore pages by expanding the `registerAppAccess` resolver in `plugin.tsx`.

**Before:** CPS picker was only EDITABLE on individual dashboard views (`/security/dashboards/[^?]+`). All Explore pages (Hosts, Users, Network) were DISABLED.

**After:** CPS picker is EDITABLE on `HOSTS_PATH`, `USERS_PATH`, `NETWORK_PATH`, `EXPLORE_PATH`, and `DASHBOARDS_PATH` — including sub-routes (entity detail views like `/hosts/web-01`).

## Changes

- **`plugin.tsx`**: Replaces hardcoded dashboard regex with `createCpsAccessResolver(...)` built from canonical route constants. Adds `HOSTS_PATH`, `USERS_PATH`, `NETWORK_PATH`, `EXPLORE_PATH` to the import.
- **`createCpsAccessResolver`**: New exported helper that builds the route-matching pattern from an array of path prefixes, making it independently testable.
- **`plugin_cps_access_resolver.test.ts`**: 14 unit tests — 7 EDITABLE cases (each Explore route + sub-paths), 7 DISABLED cases (rules, cases, attack_discovery, alerts, etc.).

## How CPS routing works for Explore pages

Two data categories on Explore pages have different routing behaviour:

| Query type | Routing behaviour | How |
|---|---|---|
| Raw event queries (hosts table, network events) | Follows CPS picker | Auto-injected by `data_views` plugin (`DataViewsApiClient` reads `cpsManager.getProjectRouting()`) |
| Entity store (`fetchEntitiesListV2`) | Origin-only | API route has no CPS awareness — effectively origin-only already |
| Risk scores (`useSearchStrategy`) | Origin-only | Security solution search strategy has no CPS awareness |
| Asset criticality / watchlists | Origin-only | Same as entity store |

Enabling the picker is the entire client-side deliverable. No per-query `project_routing` overrides are needed.

## Dependency

Full end-to-end testing of entity store origin pinning requires server-side `project_routing` support in the `entity_store` plugin CRUD GET route. This is tracked in https://github.com/elastic/kibana/issues/260198

Relates: elastic/security-team#16464