### PR TITLE
[Synthetics] Register monitors as SML type and attachment in Agent Builder

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -136,6 +136,9 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'observability.investigation',
   'observability.service-map',
 
+  // O11Y – Synthetics
+  'monitor-management',
+
   // Search
   `${internalNamespaces.search}.keyword-search`,
   `${internalNamespaces.search}.catalog-ecommerce`,

--- a/x-pack/solutions/observability/plugins/synthetics/README.md
+++ b/x-pack/solutions/observability/plugins/synthetics/README.md
@@ -36,6 +36,10 @@ responses.
 
 There's also a `rest_api` folder that defines the structure of the RESTful API endpoints.
 
+### Agent Builder integration
+
+The plugin contributes a `monitor-management` skill, an inline tool, an attachment type, and an SML type to the [Agent Builder](../../../../platform/plugins/shared/agent_builder/README.md) framework. See [`server/agent_builder/README.md`](./server/agent_builder/README.md) for the architecture, the `operations[]` surface, the auth model, and local dev setup.
+
 ## Testing
 
 ### Unit tests

--- a/x-pack/solutions/observability/plugins/synthetics/common/agent_builder/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/agent_builder/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  MONITOR_SML_TYPE,
+} from './monitor_management_constants';
+export {
+  monitorAttachmentDataSchema,
+  monitorDraftSchema,
+} from './monitor_management_attachment_schema';
+export type { MonitorAttachmentData, MonitorDraft } from './monitor_management_attachment_schema';

--- a/x-pack/solutions/observability/plugins/synthetics/common/agent_builder/monitor_management_attachment_schema.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/agent_builder/monitor_management_attachment_schema.test.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ConfigKey } from '../constants/monitor_management';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../runtime_types/monitor_management/monitor_configs';
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  MONITOR_SML_TYPE,
+} from './monitor_management_constants';
+import {
+  monitorAttachmentDataSchema,
+  monitorDraftSchema,
+  type MonitorAttachmentData,
+  type MonitorDraft,
+} from './monitor_management_attachment_schema';
+
+const buildBaseRequiredFields = (): MonitorAttachmentData => ({
+  [ConfigKey.NAME]: 'Elastic API health',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [
+    { id: 'us_central', label: 'North America - US Central', isServiceManaged: true },
+  ],
+  [ConfigKey.URLS]: 'https://api.elastic.co',
+});
+
+const baseRequiredFields = buildBaseRequiredFields();
+
+describe('monitor_management_constants', () => {
+  it('exposes the agreed attachment type id', () => {
+    expect(MONITOR_MANAGEMENT_ATTACHMENT_TYPE).toBe('synthetics.monitor_management');
+  });
+
+  it('exposes the agreed SML type id', () => {
+    expect(MONITOR_SML_TYPE).toBe('synthetics_monitor');
+  });
+
+  it('does not collide with the observability_agent_builder preset attachment id', () => {
+    // The preset-context attachment registered by observability_agent_builder
+    // is `'observability.synthetics_monitor'`. Authoring/management is a
+    // distinct integration with a different lifecycle and id.
+    expect(MONITOR_MANAGEMENT_ATTACHMENT_TYPE).not.toBe('observability.synthetics_monitor');
+  });
+});
+
+describe('monitorAttachmentDataSchema', () => {
+  it('accepts a proposed monitor (no config_id, no monitor query id, no SO meta)', () => {
+    const proposed = { ...baseRequiredFields };
+
+    const result = monitorAttachmentDataSchema.safeParse(proposed);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[ConfigKey.CONFIG_ID]).toBeUndefined();
+      expect(result.data[ConfigKey.MONITOR_QUERY_ID]).toBeUndefined();
+      expect(result.data.created_at).toBeUndefined();
+      expect(result.data.updated_at).toBeUndefined();
+    }
+  });
+
+  it('accepts a saved monitor with config_id and SO meta populated', () => {
+    const saved = {
+      ...baseRequiredFields,
+      [ConfigKey.CONFIG_ID]: '6d7a8d8b-0e1f-4d97-a8d6-1f2a3b4c5d6e',
+      [ConfigKey.MONITOR_QUERY_ID]: '6d7a8d8b-0e1f-4d97-a8d6-1f2a3b4c5d6e',
+      [ConfigKey.REVISION]: 3,
+      [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+      created_at: '2026-04-15T10:00:00.000Z',
+      updated_at: '2026-04-30T17:00:00.000Z',
+    };
+
+    const result = monitorAttachmentDataSchema.safeParse(saved);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[ConfigKey.CONFIG_ID]).toBe(saved[ConfigKey.CONFIG_ID]);
+      expect(result.data[ConfigKey.REVISION]).toBe(3);
+      expect(result.data[ConfigKey.MONITOR_SOURCE_TYPE]).toBe(SourceType.UI);
+    }
+  });
+
+  it('accepts a project-origin monitor (origin: project)', () => {
+    const projectMonitor = {
+      ...baseRequiredFields,
+      [ConfigKey.CONFIG_ID]: 'project-cli-managed-id',
+      [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.PROJECT,
+    };
+
+    const result = monitorAttachmentDataSchema.safeParse(projectMonitor);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a private location with agentPolicyId', () => {
+    const withPrivateLocation = {
+      ...baseRequiredFields,
+      [ConfigKey.LOCATIONS]: [
+        {
+          id: 'pl-london',
+          label: 'London',
+          agentPolicyId: 'fleet-agent-policy-id',
+          isServiceManaged: false,
+        },
+      ],
+    };
+
+    const result = monitorAttachmentDataSchema.safeParse(withPrivateLocation);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const [location] = result.data[ConfigKey.LOCATIONS];
+      expect(location).toMatchObject({
+        id: 'pl-london',
+        agentPolicyId: 'fleet-agent-policy-id',
+      });
+    }
+  });
+
+  it('accepts HTTP-specific options used by set_http_check (T4 op)', () => {
+    const withHttpDetails = {
+      ...baseRequiredFields,
+      [ConfigKey.MAX_REDIRECTS]: 5,
+      [ConfigKey.REQUEST_METHOD_CHECK]: 'GET',
+      [ConfigKey.PORT]: 443,
+      [ConfigKey.IGNORE_HTTPS_ERRORS]: false,
+    };
+
+    const result = monitorAttachmentDataSchema.safeParse(withHttpDetails);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts string max_redirects (yaml-style)', () => {
+    // `MAX_REDIRECTS` mirrors the io-ts union of string | number — the
+    // string variant is what the yaml-config path produces and what we
+    // can receive from a GET response in some legacy fixtures.
+    const result = monitorAttachmentDataSchema.safeParse({
+      ...baseRequiredFields,
+      [ConfigKey.MAX_REDIRECTS]: '0',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts null url.port', () => {
+    const result = monitorAttachmentDataSchema.safeParse({
+      ...baseRequiredFields,
+      [ConfigKey.PORT]: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty name', () => {
+    const result = monitorAttachmentDataSchema.safeParse({
+      ...baseRequiredFields,
+      [ConfigKey.NAME]: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-HTTP type (v1 scope is HTTP only)', () => {
+    const result = monitorAttachmentDataSchema.safeParse({
+      ...baseRequiredFields,
+      [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.TCP,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty locations array', () => {
+    const result = monitorAttachmentDataSchema.safeParse({
+      ...baseRequiredFields,
+      [ConfigKey.LOCATIONS]: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a location without an id', () => {
+    const result = monitorAttachmentDataSchema.safeParse({
+      ...baseRequiredFields,
+      [ConfigKey.LOCATIONS]: [{ label: 'orphan' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty urls string', () => {
+    const result = monitorAttachmentDataSchema.safeParse({
+      ...baseRequiredFields,
+      [ConfigKey.URLS]: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a malformed schedule unit', () => {
+    const result = monitorAttachmentDataSchema.safeParse({
+      ...baseRequiredFields,
+      [ConfigKey.SCHEDULE]: { number: '5', unit: 'h' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('uses ConfigKey-aligned key names (parity rule)', () => {
+    const parsed = monitorAttachmentDataSchema.parse(baseRequiredFields);
+
+    // The shape must use ConfigKey *values* (e.g. `'name'`, `'urls'`,
+    // `'url.port'`) not arbitrary aliases — this is the contract with the
+    // CRUD response codec.
+    expect(parsed).toHaveProperty(ConfigKey.NAME);
+    expect(parsed).toHaveProperty(ConfigKey.URLS);
+    expect(parsed).toHaveProperty(ConfigKey.SCHEDULE);
+    expect(parsed).toHaveProperty(ConfigKey.LOCATIONS);
+    expect(parsed).toHaveProperty(ConfigKey.MONITOR_TYPE);
+    expect(parsed).toHaveProperty(ConfigKey.ENABLED);
+  });
+});
+
+describe('monitorDraftSchema (permissive, for in-memory operations[])', () => {
+  it('accepts an empty draft (no operations applied yet)', () => {
+    const result = monitorDraftSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a draft after only set_metadata (no schedule/locations/urls yet)', () => {
+    const result = monitorDraftSchema.safeParse({
+      [ConfigKey.NAME]: 'WIP - Elastic API',
+      [ConfigKey.TAGS]: ['poc'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a partial draft with only schedule set', () => {
+    const result = monitorDraftSchema.safeParse({
+      [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects malformed values when present (parity with attachment schema)', () => {
+    const result = monitorDraftSchema.safeParse({
+      [ConfigKey.SCHEDULE]: { number: '5', unit: 'invalid' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('a fully-populated draft round-trips into the attachment schema', () => {
+    // The draft schema is a strict superset (key-wise) of the attachment
+    // schema — once all required keys are present, the boundary validator
+    // can promote it without any key renaming or shape massaging.
+    const draft: MonitorDraft = { ...baseRequiredFields };
+
+    const promoted = monitorAttachmentDataSchema.safeParse(draft);
+    expect(promoted.success).toBe(true);
+  });
+});
+
+describe('static type parity (does not run at runtime)', () => {
+  it('MonitorAttachmentData carries the required keys as non-optional', () => {
+    // This block intentionally fails type-check if the Zod inference for
+    // required keys regresses. It does not assert anything at runtime.
+    const data: MonitorAttachmentData = { ...baseRequiredFields };
+    expect(data[ConfigKey.NAME]).toBeDefined();
+    expect(data[ConfigKey.URLS]).toBeDefined();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/common/agent_builder/monitor_management_attachment_schema.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/agent_builder/monitor_management_attachment_schema.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ConfigKey } from '../constants/monitor_management';
+import {
+  FormMonitorType,
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../runtime_types/monitor_management/monitor_configs';
+
+/**
+ * Zod schemas for the Agent Builder × Synthetics monitor management
+ * attachment. These mirror a **strict subset** of the response shape produced
+ * by `HTTPSimpleFieldsCodec` + `CommonFieldsCodec`
+ * (see `common/runtime_types/monitor_management/monitor_types.ts`).
+ *
+ * Parity rule (do not break):
+ *   Every key declared here MUST be a member of the response codec for HTTP
+ *   monitors, with a value type that is a Zod equivalent of the io-ts shape.
+ *   Server-generated fields (`config_id`, monitor query `id`, `created_at`,
+ *   `updated_at`, `revision`) are optional so the same schema accepts both
+ *   "proposed" (no `config_id`) and "saved" (with `config_id`) attachments.
+ *
+ * v1 scope: HTTP monitors with `origin: 'ui'`. TCP / ICMP / Browser come
+ * later via additional discriminators on `ConfigKey.MONITOR_TYPE`.
+ */
+
+// ---------------------------------------------------------------------------
+// Building blocks
+// ---------------------------------------------------------------------------
+
+/**
+ * Schedule shape from `ScheduleCodec` in `monitor_types.ts`.
+ * Allow-list enforcement (`ALLOWED_SCHEDULES_IN_MINUTES`,
+ * `ALLOWED_SCHEDULES_IN_SECONDS`) lives in the per-batch cross-field
+ * validation inside the `manage_synthetics_monitor` tool, not here.
+ */
+const scheduleSchema = z.object({
+  number: z.string().min(1),
+  unit: z.enum([ScheduleUnit.MINUTES, ScheduleUnit.SECONDS]),
+});
+
+/**
+ * Location shape — accepts both public/Elastic-managed locations
+ * (`MonitorServiceLocationCodec`) and private locations
+ * (`PrivateLocationCodec`). Extra keys are preserved via `.passthrough()`
+ * so private-location-only fields (e.g. `agentPolicyId`, `tags`,
+ * `namespace`) survive a round-trip without the schema needing to know
+ * about every variant.
+ */
+const locationSchema = z
+  .object({
+    id: z.string().min(1),
+    label: z.string().optional(),
+    isServiceManaged: z.boolean().optional(),
+    isInvalid: z.boolean().optional(),
+    url: z.string().optional(),
+    status: z.string().optional(),
+    geo: z
+      .object({
+        lat: z.union([z.string(), z.number(), z.null()]).optional(),
+        lon: z.union([z.string(), z.number(), z.null()]).optional(),
+      })
+      .passthrough()
+      .optional(),
+    agentPolicyId: z.string().optional(),
+  })
+  .passthrough();
+
+/**
+ * `__ui` metadata — `MetadataCodec` from
+ * `common/runtime_types/monitor_management/monitor_meta_data.ts`.
+ */
+const metadataSchema = z.object({
+  is_tls_enabled: z.boolean().optional(),
+  script_source: z
+    .object({
+      is_generated_script: z.boolean(),
+      file_name: z.string(),
+    })
+    .optional(),
+});
+
+/**
+ * `alert` config — `AlertConfigsCodec` (TLS + status alert toggles).
+ * Encrypted-secret subfields are deliberately not represented; only the
+ * non-secret toggles round-trip in attachments.
+ */
+const alertConfigSchema = z.object({
+  enabled: z.boolean(),
+  groupBy: z.string().optional(),
+});
+const alertConfigsSchema = z.object({
+  tls: alertConfigSchema.optional(),
+  status: alertConfigSchema.optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Attachment data schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Attachment data for `MONITOR_MANAGEMENT_ATTACHMENT_TYPE`.
+ *
+ * Required keys are those a user must supply for a monitor to be saveable
+ * (`name`, `type`, `enabled`, `schedule`, `locations`, `urls`). Everything
+ * else is optional, including all server-generated identifiers, so the same
+ * shape covers both proposed-but-not-yet-saved monitors and saved ones.
+ *
+ * Renderers branch on `data[ConfigKey.CONFIG_ID]` (and `data[ConfigKey.MONITOR_SOURCE_TYPE]`)
+ * to decide between `proposed` / `enabled` / `disabled` / `cli-managed`
+ * status badges.
+ */
+export const monitorAttachmentDataSchema = z.object({
+  // --- user-editable, required for a saveable monitor ------------------
+  [ConfigKey.NAME]: z.string().min(1),
+  [ConfigKey.MONITOR_TYPE]: z.literal(MonitorTypeEnum.HTTP),
+  [ConfigKey.ENABLED]: z.boolean(),
+  [ConfigKey.SCHEDULE]: scheduleSchema,
+  [ConfigKey.LOCATIONS]: z.array(locationSchema).min(1),
+  [ConfigKey.URLS]: z.string().min(1),
+
+  // --- user-editable, optional ----------------------------------------
+  [ConfigKey.TAGS]: z.array(z.string()).optional(),
+  [ConfigKey.LABELS]: z.record(z.string(), z.string()).optional(),
+  [ConfigKey.NAMESPACE]: z.string().optional(),
+  [ConfigKey.APM_SERVICE_NAME]: z.string().optional(),
+  [ConfigKey.MAX_REDIRECTS]: z.union([z.string(), z.number()]).optional(),
+  [ConfigKey.PORT]: z.union([z.number(), z.null()]).optional(),
+  [ConfigKey.REQUEST_METHOD_CHECK]: z.string().optional(),
+  [ConfigKey.IGNORE_HTTPS_ERRORS]: z.boolean().optional(),
+  [ConfigKey.METADATA]: metadataSchema.optional(),
+  [ConfigKey.ALERT_CONFIG]: alertConfigsSchema.optional(),
+  [ConfigKey.MAX_ATTEMPTS]: z.number().optional(),
+  [ConfigKey.KIBANA_SPACES]: z.array(z.string()).optional(),
+  [ConfigKey.FORM_MONITOR_TYPE]: z
+    .enum([
+      FormMonitorType.SINGLE,
+      FormMonitorType.MULTISTEP,
+      FormMonitorType.HTTP,
+      FormMonitorType.TCP,
+      FormMonitorType.ICMP,
+    ])
+    .optional(),
+
+  // --- server-generated / read-only after save ------------------------
+  [ConfigKey.MONITOR_SOURCE_TYPE]: z.enum([SourceType.UI, SourceType.PROJECT]).optional(),
+  [ConfigKey.CONFIG_ID]: z.string().optional(),
+  [ConfigKey.MONITOR_QUERY_ID]: z.string().optional(),
+  [ConfigKey.REVISION]: z.number().optional(),
+  [ConfigKey.CONFIG_HASH]: z.string().optional(),
+
+  // SO meta from the GET response shape
+  // (see `EncryptedSyntheticsSavedMonitorCodec`).
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export type MonitorAttachmentData = z.infer<typeof monitorAttachmentDataSchema>;
+
+// ---------------------------------------------------------------------------
+// Draft schema — permissive in-memory state for `operations[]`
+// ---------------------------------------------------------------------------
+
+/**
+ * Permissive draft used by `manage_synthetics_monitor` to merge
+ * `operations[]` mutations across a single tool batch. Every field is
+ * optional because the LLM may produce a partial draft mid-conversation
+ * (e.g. only `set_metadata` so far). Strict validation
+ * (`normalizeAPIConfig` → `validateMonitor`) runs at the **batch boundary**
+ * before the attachment is added/updated, not after every op.
+ *
+ * The set of keys is intentionally a strict superset of
+ * `monitorAttachmentDataSchema`: anything that can appear in the saved
+ * attachment can appear in a draft, plus nothing else, so a draft can be
+ * promoted to attachment data via the boundary validator without key
+ * renaming.
+ */
+export const monitorDraftSchema = monitorAttachmentDataSchema.partial();
+
+export type MonitorDraft = z.infer<typeof monitorDraftSchema>;

--- a/x-pack/solutions/observability/plugins/synthetics/common/agent_builder/monitor_management_constants.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/agent_builder/monitor_management_constants.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Attachment type identifier for the Agent Builder × Synthetics monitor
+ * authoring/management integration.
+ *
+ * Distinct from `OBSERVABILITY_MONITOR_ATTACHMENT_TYPE_ID`
+ * (`'observability.synthetics_monitor'`) which is the **preset-context**
+ * attachment surfaced by the `observability_agent_builder` plugin when the
+ * user is on a monitor details page. The two coexist with different
+ * lifecycles and responsibilities.
+ */
+export const MONITOR_MANAGEMENT_ATTACHMENT_TYPE = 'synthetics.monitor_management' as const;
+
+/**
+ * SML (Searchable Machine-readable Library) type identifier for the
+ * Synthetics monitor crawler. Used by the Agent Builder SML pipeline to
+ * key chunks and attachments produced from monitor saved objects.
+ */
+export const MONITOR_SML_TYPE = 'synthetics_monitor' as const;

--- a/x-pack/solutions/observability/plugins/synthetics/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/synthetics/kibana.jsonc
@@ -54,6 +54,7 @@
       "licenseManagement",
       "observabilityAIAssistant",
       "agentBuilder",
+      "agentContextLayer",
       "observabilityAgentBuilder",
       "maintenanceWindows"
     ],

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  buildMonitorManagementAttachmentUIDefinition,
+  registerMonitorManagementAttachmentUIDefinition,
+  type RegisterMonitorManagementAttachmentParams,
+} from './monitor_management_attachment_definition';

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_actions.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_actions.test.ts
@@ -74,14 +74,67 @@ describe('createMonitor', () => {
     });
   });
 
+  // The server's `normalizeAPIConfig` (in `monitor_validation.ts`) builds
+  // its allow-list from `Object.keys(DEFAULT_FIELDS[type])` and rejects
+  // any key not on the list with `Invalid monitor key(s) for {type}
+  // type: …`. Three keys arrive on the in-memory attachment data after
+  // a Save (`mapSavedObjectToMonitor` adds them and our Zod schema
+  // permits them so the same shape covers both proposed + saved
+  // monitors) but are *not* in `DEFAULT_FIELDS` and therefore need to
+  // be stripped before we echo the payload back: `created_at`,
+  // `updated_at`, and `revision`. See followup F15.
+  it('strips read-only SO metadata keys (created_at, updated_at, revision) before sending', async () => {
+    const http = buildHttp({ id: 'config-uuid' });
+    const monitor = buildMonitor({
+      created_at: '2026-05-02T00:00:00Z',
+      updated_at: '2026-05-02T01:00:00Z',
+      [ConfigKey.REVISION]: 7,
+    });
+
+    await createMonitor(http, monitor);
+
+    const sentBody = JSON.parse((http.post as jest.Mock).mock.calls[0][1].body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(sentBody).not.toHaveProperty('created_at');
+    expect(sentBody).not.toHaveProperty('updated_at');
+    expect(sentBody).not.toHaveProperty(ConfigKey.REVISION);
+    // Sanity: the user-editable fields are still on the wire.
+    expect(sentBody[ConfigKey.NAME]).toBe('Test');
+    expect(sentBody[ConfigKey.URLS]).toBe('https://example.com');
+  });
+
+  it('does not mutate the caller-supplied monitor object', async () => {
+    // The hook callers reuse the same `MonitorAttachmentData` reference
+    // across re-renders; an in-place delete here would silently change
+    // what the inline card / canvas display.
+    const http = buildHttp({ id: 'config-uuid' });
+    const monitor = buildMonitor({
+      created_at: '2026-05-02T00:00:00Z',
+      updated_at: '2026-05-02T01:00:00Z',
+      [ConfigKey.REVISION]: 7,
+    });
+
+    await createMonitor(http, monitor);
+
+    expect(monitor).toHaveProperty('created_at', '2026-05-02T00:00:00Z');
+    expect(monitor).toHaveProperty('updated_at', '2026-05-02T01:00:00Z');
+    expect(monitor).toHaveProperty(ConfigKey.REVISION, 7);
+  });
+
   it('treats partial-failure responses (id present + errors) as a save with location warnings', async () => {
+    // Mirrors the actual server response shape from `add_monitor.ts`:
+    // top-level `id` and `message`, errors nested under `attributes.errors`,
+    // and per-entry `error` is `{ reason, status }` (NOT `{ message }`).
     const http = buildHttp({
+      message: 'error pushing monitor to the service',
+      id: 'config-uuid',
       attributes: {
-        message: 'Some locations failed',
-        id: 'config-uuid',
         errors: [
-          { locationId: 'us_central', error: { message: 'Fleet agent offline' } },
-          { locationId: 'eu_west', error: undefined },
+          { locationId: 'us_central', error: { reason: 'Fleet agent offline', status: 503 } },
+          { locationId: 'eu_west', error: { reason: 'Connection timeout' } },
+          { locationId: 'us_east', error: undefined },
         ],
       },
     });
@@ -90,22 +143,36 @@ describe('createMonitor', () => {
 
     expect(outcome.id).toBe('config-uuid');
     expect(outcome.locationWarnings).toEqual([
-      { locationId: 'us_central', message: 'Fleet agent offline' },
-      { locationId: 'eu_west', message: 'Unknown location error' },
+      { locationId: 'us_central', message: '503 — Fleet agent offline' },
+      { locationId: 'eu_west', message: 'Connection timeout' },
+      {
+        locationId: 'us_east',
+        message: 'Could not reach this location (no response from the synthetics service).',
+      },
     ]);
   });
 
   it('throws MonitorSaveError when the response is an error without an id', async () => {
     const http = buildHttp({
-      attributes: {
-        message: 'Validation failed: name is required',
-        errors: [],
-      },
+      message: 'Validation failed: name is required',
+      attributes: { errors: [] },
     });
 
     await expect(createMonitor(http, buildMonitor())).rejects.toBeInstanceOf(MonitorSaveError);
     await expect(createMonitor(http, buildMonitor())).rejects.toMatchObject({
       message: 'Validation failed: name is required',
+    });
+  });
+
+  it('falls back to a generic error when the partial-failure shape carries no message and no id', async () => {
+    // Defensive: if the server ever drops both id and message we must
+    // still produce a non-empty MonitorSaveError so the callout body
+    // isn't blank (the "Save failed" empty-body bug we saw in manual
+    // smoke).
+    const http = buildHttp({ attributes: { errors: [] } });
+
+    await expect(createMonitor(http, buildMonitor())).rejects.toMatchObject({
+      message: 'Save failed',
     });
   });
 
@@ -207,6 +274,55 @@ describe('updateMonitor', () => {
     await updateMonitor(http, 'a/b%c', buildMonitor());
     const url = (http.put as jest.Mock).mock.calls[0][0];
     expect(url).toBe(`${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/a%2Fb%25c`);
+  });
+
+  it('falls back to the configId for partial-failure responses that omit the top-level id (edit shape)', async () => {
+    // `edit_monitor.ts` returns the partial-failure shape WITHOUT a
+    // top-level id (the caller already has the configId in the URL).
+    // Make sure we recover that id from the function argument so the
+    // user still sees the location warnings instead of an empty
+    // "Save failed" callout.
+    const http = buildHttp({
+      message: 'error pushing monitor to the service',
+      attributes: {
+        errors: [{ locationId: 'us_central', error: { reason: 'Push failed', status: 500 } }],
+      },
+    });
+
+    const outcome = await updateMonitor(http, 'config-uuid', buildMonitor());
+
+    expect(outcome).toEqual({
+      id: 'config-uuid',
+      locationWarnings: [{ locationId: 'us_central', message: '500 — Push failed' }],
+    });
+  });
+
+  // Mirrors the create-side strip test. Update is the *primary* path
+  // affected by F15 because the canvas-side overlay hands the canvas
+  // an attachment whose data was just refreshed off the SO (and the
+  // SO carries `created_at`/`updated_at`); without the strip every
+  // post-Create Update would 400.
+  it('strips read-only SO metadata keys before PUTing to the edit route', async () => {
+    const http = buildHttp({ id: 'config-uuid' });
+    const monitor = buildMonitor({
+      [ConfigKey.CONFIG_ID]: 'config-uuid',
+      created_at: '2026-05-02T00:00:00Z',
+      updated_at: '2026-05-02T01:00:00Z',
+      [ConfigKey.REVISION]: 12,
+    });
+
+    await updateMonitor(http, 'config-uuid', monitor);
+
+    const sentBody = JSON.parse((http.put as jest.Mock).mock.calls[0][1].body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(sentBody).not.toHaveProperty('created_at');
+    expect(sentBody).not.toHaveProperty('updated_at');
+    expect(sentBody).not.toHaveProperty(ConfigKey.REVISION);
+    // `config_id` *is* in DEFAULT_FIELDS so it stays on the wire.
+    expect(sentBody[ConfigKey.CONFIG_ID]).toBe('config-uuid');
+    expect(sentBody[ConfigKey.NAME]).toBe('Test');
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_actions.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_actions.test.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpStart } from '@kbn/core-http-browser';
+import { ConfigKey } from '../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+import { SYNTHETICS_API_URLS } from '../../../common/constants/synthetics/rest_api';
+import { INITIAL_REST_VERSION } from '../../../common/constants/ui';
+import {
+  MonitorSaveError,
+  createMonitor,
+  getMonitorDetailsUrl,
+  updateMonitor,
+} from './monitor_management_actions';
+
+const buildMonitor = (overrides: Partial<MonitorAttachmentData> = {}): MonitorAttachmentData => ({
+  [ConfigKey.NAME]: 'Test',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [{ id: 'us_central', isServiceManaged: true }],
+  [ConfigKey.URLS]: 'https://example.com',
+  [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+  ...overrides,
+});
+
+const buildHttp = (response: unknown): HttpStart => {
+  const post = jest.fn(async () => response);
+  const put = jest.fn(async () => response);
+  return { post, put } as unknown as HttpStart;
+};
+
+const buildHttpThatThrows = (error: unknown): HttpStart => {
+  const post = jest.fn(async () => {
+    throw error;
+  });
+  const put = jest.fn(async () => {
+    throw error;
+  });
+  return { post, put } as unknown as HttpStart;
+};
+
+/**
+ * Mirrors the shape of `IHttpFetchError` from `@kbn/core-http-browser`:
+ * `.message` is the HTTP status text, `.body` is the parsed server
+ * response. Synthetics's failed POSTs currently surface the validation
+ * detail under `body.message`; some error paths nest it deeper under
+ * `body.attributes.message`.
+ */
+const buildFetchError = (overrides: { message: string; body?: unknown }): Error =>
+  Object.assign(new Error(overrides.message), { body: overrides.body });
+
+describe('createMonitor', () => {
+  it('POSTs the monitor body to /api/synthetics/monitors with the v1 API version', async () => {
+    const http = buildHttp({ id: 'config-uuid' });
+    const monitor = buildMonitor();
+
+    const outcome = await createMonitor(http, monitor);
+
+    expect(outcome).toEqual({ id: 'config-uuid', locationWarnings: [] });
+    expect(http.post).toHaveBeenCalledWith(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS, {
+      body: JSON.stringify(monitor),
+      version: INITIAL_REST_VERSION,
+      query: { internal: true },
+    });
+  });
+
+  it('treats partial-failure responses (id present + errors) as a save with location warnings', async () => {
+    const http = buildHttp({
+      attributes: {
+        message: 'Some locations failed',
+        id: 'config-uuid',
+        errors: [
+          { locationId: 'us_central', error: { message: 'Fleet agent offline' } },
+          { locationId: 'eu_west', error: undefined },
+        ],
+      },
+    });
+
+    const outcome = await createMonitor(http, buildMonitor());
+
+    expect(outcome.id).toBe('config-uuid');
+    expect(outcome.locationWarnings).toEqual([
+      { locationId: 'us_central', message: 'Fleet agent offline' },
+      { locationId: 'eu_west', message: 'Unknown location error' },
+    ]);
+  });
+
+  it('throws MonitorSaveError when the response is an error without an id', async () => {
+    const http = buildHttp({
+      attributes: {
+        message: 'Validation failed: name is required',
+        errors: [],
+      },
+    });
+
+    await expect(createMonitor(http, buildMonitor())).rejects.toBeInstanceOf(MonitorSaveError);
+    await expect(createMonitor(http, buildMonitor())).rejects.toMatchObject({
+      message: 'Validation failed: name is required',
+    });
+  });
+
+  describe('error extraction (T7 hot-fix #3)', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('surfaces body.message from an IHttpFetchError instead of the generic status text', async () => {
+      const http = buildHttpThatThrows(
+        buildFetchError({
+          message: 'Bad Request',
+          body: {
+            statusCode: 400,
+            error: 'Bad Request',
+            message: 'request body.urls: Invalid URL format',
+          },
+        })
+      );
+
+      await expect(createMonitor(http, buildMonitor())).rejects.toMatchObject({
+        message: 'request body.urls: Invalid URL format',
+      });
+    });
+
+    it('prefers body.attributes.message when present (synthetics partial-failure shape on throw)', async () => {
+      const http = buildHttpThatThrows(
+        buildFetchError({
+          message: 'Bad Request',
+          body: {
+            attributes: {
+              message: 'Monitor is not valid: locations must contain at least 1 entry',
+              errors: [],
+            },
+          },
+        })
+      );
+
+      await expect(createMonitor(http, buildMonitor())).rejects.toMatchObject({
+        message: 'Monitor is not valid: locations must contain at least 1 entry',
+      });
+    });
+
+    it('falls back to error.message when body has no usable message', async () => {
+      const http = buildHttpThatThrows(buildFetchError({ message: 'Forbidden', body: {} }));
+      await expect(createMonitor(http, buildMonitor())).rejects.toMatchObject({
+        message: 'Forbidden',
+      });
+    });
+
+    it('falls back to error.message when there is no body at all', async () => {
+      const http = buildHttpThatThrows(new Error('Network error'));
+      await expect(createMonitor(http, buildMonitor())).rejects.toMatchObject({
+        message: 'Network error',
+      });
+    });
+
+    it('logs the full error + body to console.error so the dev can grab the raw payload', async () => {
+      const errorBody = { message: 'request body.schedule: Invalid schedule' };
+      const error = buildFetchError({ message: 'Bad Request', body: errorBody });
+      const http = buildHttpThatThrows(error);
+      await expect(createMonitor(http, buildMonitor())).rejects.toBeInstanceOf(MonitorSaveError);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[synthetics × agent_builder] create failed:',
+        error,
+        'body:',
+        errorBody
+      );
+    });
+  });
+});
+
+describe('updateMonitor', () => {
+  it('PUTs to /api/synthetics/monitors/{configId} with the v1 API version', async () => {
+    const http = buildHttp({ id: 'config-uuid' });
+    const monitor = buildMonitor({ [ConfigKey.CONFIG_ID]: 'config-uuid' });
+
+    const outcome = await updateMonitor(http, 'config-uuid', monitor);
+
+    expect(outcome).toEqual({ id: 'config-uuid', locationWarnings: [] });
+    expect(http.put).toHaveBeenCalledWith(
+      `${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/config-uuid`,
+      {
+        body: JSON.stringify(monitor),
+        version: INITIAL_REST_VERSION,
+        query: { internal: true },
+      }
+    );
+  });
+
+  it('URL-encodes config ids that contain unsafe path characters', async () => {
+    const http = buildHttp({ id: 'a/b%c' });
+    await updateMonitor(http, 'a/b%c', buildMonitor());
+    const url = (http.put as jest.Mock).mock.calls[0][0];
+    expect(url).toBe(`${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/a%2Fb%25c`);
+  });
+});
+
+describe('getMonitorDetailsUrl', () => {
+  it('joins the appPath with the monitor route, encoding the configId', () => {
+    expect(getMonitorDetailsUrl('config-1', '/app/synthetics')).toBe(
+      '/app/synthetics/monitor/config-1'
+    );
+    expect(getMonitorDetailsUrl('a/b', '/spc/dev/app/synthetics')).toBe(
+      '/spc/dev/app/synthetics/monitor/a%2Fb'
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_actions.ts
@@ -8,6 +8,7 @@
 import type { HttpStart } from '@kbn/core-http-browser';
 import { SYNTHETICS_API_URLS } from '../../../common/constants/synthetics/rest_api';
 import { INITIAL_REST_VERSION } from '../../../common/constants/ui';
+import { ConfigKey } from '../../../common/runtime_types';
 import type { MonitorAttachmentData } from '../../../common/agent_builder';
 
 /**
@@ -15,34 +16,50 @@ import type { MonitorAttachmentData } from '../../../common/agent_builder';
  *
  * 1. **Clean success** — a `SyntheticsMonitorWithId` (the saved monitor
  *    fields, plus top-level `id`, `created_at`, `updated_at`).
- * 2. **Partial-failure** — `ServiceLocationErrorsResponse`: the monitor
- *    saved-object **was** created, but one or more locations failed to
- *    start. The shape is `{ attributes: { message, errors, id? } }`. The
- *    `attributes.id` is set when the SO landed; absent only when the
- *    request never made it past pre-write validation, in which case
- *    `http.post` throws before this code runs.
+ * 2. **Partial-failure** — the SO **was** created/updated, but the push
+ *    to the global Synthetics service failed for one or more
+ *    Elastic-managed locations. The actual server shape is
+ *    `{ message, attributes: { errors }, id? }` — `message` and `id`
+ *    are at the **top level** (not nested under `attributes`), and
+ *    `id` is present on create (the new SO id) but omitted on update
+ *    (the caller already has the configId). Each entry of
+ *    `attributes.errors` is `{ locationId, error?: { reason, status, … } }`.
  *
- * We deliberately keep these types narrow / local instead of importing
- * the runtime-types codec — the SPA's exported codec brings several
- * megabytes of decoder graph along with it, and the two fields we care
- * about (`id` for `updateOrigin`, location warnings for the UI callout)
- * are stable across versions.
+ * NOTE: The runtime-types codec
+ * (`ServiceLocationErrorsResponse` in
+ * `common/runtime_types/monitor_management/locations.ts`) declares the
+ * shape as `{ attributes: { message, errors, id? } }` — but the actual
+ * server in `add_monitor.ts` / `edit_monitor.ts` returns `message` and
+ * `id` at the top level. The existing Synthetics SPA reads the actual
+ * shape (see `apps/synthetics/components/getting_started/use_simple_monitor.ts`
+ * for the precedent). We mirror that here, deliberately ignoring the
+ * codec to avoid importing several megabytes of decoder graph for two
+ * fields.
+ *
+ * `error?` is genuinely optional per entry: low-level network
+ * failures (TLS cert expiry, DNS, connection refused) reach the
+ * server-side `axios` `catchError` *before* `err.response` exists, so
+ * the entry is `{ locationId, error: undefined }`. We surface the
+ * location id with a generic message in that case.
  */
 interface UpsertMonitorSuccessResponse {
   id: string;
 }
 
-interface ServiceLocationErrorEntry {
+interface ServiceLocationSyncErrorBody {
+  reason?: string;
+  status?: number;
+}
+
+interface ServiceLocationSyncError {
   locationId: string;
-  error?: { message: string };
+  error?: ServiceLocationSyncErrorBody;
 }
 
 interface ServiceLocationErrorsResponse {
-  attributes: {
-    message: string;
-    errors: ServiceLocationErrorEntry[];
-    id?: string;
-  };
+  message?: string;
+  attributes: { errors: ServiceLocationSyncError[] };
+  id?: string;
 }
 
 type UpsertMonitorResponse = UpsertMonitorSuccessResponse | ServiceLocationErrorsResponse;
@@ -71,16 +88,48 @@ export class MonitorSaveError extends Error {
   }
 }
 
-const narrowSaveResponse = (response: UpsertMonitorResponse): MonitorSaveOutcome => {
+/**
+ * Format a per-location push error into a single human-readable string
+ * for the warnings callout. Mirrors the shape of
+ * `apps/synthetics/components/monitors_page/management/show_sync_errors.tsx`
+ * but flattened to one line — the callout already provides the
+ * `locationId` heading.
+ */
+const formatLocationErrorMessage = (error: ServiceLocationSyncError['error']): string => {
+  if (error == null) {
+    return 'Could not reach this location (no response from the synthetics service).';
+  }
+  const status = typeof error.status === 'number' ? `${error.status}` : null;
+  const reason = typeof error.reason === 'string' && error.reason.length > 0 ? error.reason : null;
+  if (status && reason) return `${status} — ${reason}`;
+  if (reason) return reason;
+  if (status) return `Status ${status}`;
+  return 'Unknown location error';
+};
+
+/**
+ * Narrow the upsert response into a `MonitorSaveOutcome`.
+ *
+ * `fallbackId` is used by `updateMonitor` to recover when the partial-
+ * failure response omits the `id` (edits don't echo it back; the
+ * caller already passed it in the URL path).
+ */
+const narrowSaveResponse = (
+  response: UpsertMonitorResponse,
+  fallbackId?: string
+): MonitorSaveOutcome => {
   if (isPartialFailureResponse(response)) {
-    if (!response.attributes.id) {
-      throw new MonitorSaveError(response.attributes.message);
+    const resolvedId = response.id ?? fallbackId;
+    if (!resolvedId) {
+      // No id anywhere — the SO write itself failed (validation,
+      // permissions). Surface the top-level message verbatim.
+      throw new MonitorSaveError(response.message ?? 'Save failed');
     }
     return {
-      id: response.attributes.id,
+      id: resolvedId,
       locationWarnings: response.attributes.errors.map((entry) => ({
         locationId: entry.locationId,
-        message: entry.error?.message ?? 'Unknown location error',
+        message: formatLocationErrorMessage(entry.error),
       })),
     };
   }
@@ -129,9 +178,49 @@ const extractServerErrorMessage = (error: unknown, op: 'create' | 'update'): str
 };
 
 /**
+ * Strip Saved-Object metadata / storage-only keys before sending the
+ * attachment to the monitor CRUD endpoints. The server's
+ * `normalizeAPIConfig` builds its allow-list from
+ * `Object.keys(DEFAULT_FIELDS[type])` and rejects anything not on it
+ * with `Invalid monitor key(s) for {type} type: …`.
+ *
+ * Three keys are present on attachment data after a Save (because
+ * `mapSavedObjectToMonitor` copies them off the SO and our Zod schema
+ * permits them so the same shape covers both proposed + saved
+ * monitors), but **none** of them appear in `DEFAULT_FIELDS`:
+ *
+ * - `created_at`, `updated_at` — SO meta added by
+ *   `mapSavedObjectToMonitor`. Pure read-only.
+ * - `revision` — stored on the SO attributes (see
+ *   `synthetics_monitor_config.ts`), bumped server-side on every
+ *   write. Echoing it back as part of the request body trips the
+ *   same validator.
+ *
+ * Echoing any of them produces a 400 from the route — observed in
+ * manual smoke as a "Save failed — Invalid monitor key(s) for http
+ * type: created_at | updated_at" callout right after a successful
+ * Create followed by an Update via the canvas. Bug write-up: F15 in
+ * `notes/01-monitor-management/followups.md`.
+ *
+ * Other server-managed keys (`config_id`, `monitor_query_id`,
+ * `config_hash`) **are** in `DEFAULT_FIELDS` and the server is
+ * idempotent on them, so they don't need stripping.
+ */
+const stripReadOnlyMonitorKeys = (monitor: MonitorAttachmentData): MonitorAttachmentData => {
+  const {
+    created_at: _createdAt,
+    updated_at: _updatedAt,
+    [ConfigKey.REVISION]: _revision,
+    ...rest
+  } = monitor;
+  return rest as MonitorAttachmentData;
+};
+
+/**
  * POST `/api/synthetics/monitors` with the user's session.
  *
- * The body is the current `MonitorAttachmentData`. The server runs
+ * The body is the current `MonitorAttachmentData` minus read-only
+ * keys (see {@link stripReadOnlyMonitorKeys}). The server runs
  * `normalizeAPIConfig` → `validateMonitor`, which fills in `DEFAULT_FIELDS`
  * and rejects malformed payloads — so the client doesn't need to mirror
  * those defaults.
@@ -149,7 +238,7 @@ export const createMonitor = async (
     const response = await http.post<UpsertMonitorResponse>(
       SYNTHETICS_API_URLS.SYNTHETICS_MONITORS,
       {
-        body: JSON.stringify(monitor),
+        body: JSON.stringify(stripReadOnlyMonitorKeys(monitor)),
         version: INITIAL_REST_VERSION,
         query: { internal: true },
       }
@@ -163,9 +252,10 @@ export const createMonitor = async (
 /**
  * PUT `/api/synthetics/monitors/{configId}` with the user's session.
  *
- * Same body / versioning rules as `createMonitor`. The full attachment
- * payload is sent — the server's normalizer is idempotent for unchanged
- * fields, so re-saving without modifications is a no-op write.
+ * Same body / versioning rules as `createMonitor`, including the
+ * read-only-key strip. The full attachment payload is sent — the
+ * server's normalizer is idempotent for unchanged fields, so
+ * re-saving without modifications is a no-op write.
  */
 export const updateMonitor = async (
   http: HttpStart,
@@ -176,12 +266,12 @@ export const updateMonitor = async (
     const response = await http.put<UpsertMonitorResponse>(
       `${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/${encodeURIComponent(configId)}`,
       {
-        body: JSON.stringify(monitor),
+        body: JSON.stringify(stripReadOnlyMonitorKeys(monitor)),
         version: INITIAL_REST_VERSION,
         query: { internal: true },
       }
     );
-    return narrowSaveResponse(response);
+    return narrowSaveResponse(response, configId);
   } catch (error) {
     throw new MonitorSaveError(extractServerErrorMessage(error, 'update'));
   }

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_actions.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpStart } from '@kbn/core-http-browser';
+import { SYNTHETICS_API_URLS } from '../../../common/constants/synthetics/rest_api';
+import { INITIAL_REST_VERSION } from '../../../common/constants/ui';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+
+/**
+ * The synthetics monitor CRUD route returns one of two shapes:
+ *
+ * 1. **Clean success** — a `SyntheticsMonitorWithId` (the saved monitor
+ *    fields, plus top-level `id`, `created_at`, `updated_at`).
+ * 2. **Partial-failure** — `ServiceLocationErrorsResponse`: the monitor
+ *    saved-object **was** created, but one or more locations failed to
+ *    start. The shape is `{ attributes: { message, errors, id? } }`. The
+ *    `attributes.id` is set when the SO landed; absent only when the
+ *    request never made it past pre-write validation, in which case
+ *    `http.post` throws before this code runs.
+ *
+ * We deliberately keep these types narrow / local instead of importing
+ * the runtime-types codec — the SPA's exported codec brings several
+ * megabytes of decoder graph along with it, and the two fields we care
+ * about (`id` for `updateOrigin`, location warnings for the UI callout)
+ * are stable across versions.
+ */
+interface UpsertMonitorSuccessResponse {
+  id: string;
+}
+
+interface ServiceLocationErrorEntry {
+  locationId: string;
+  error?: { message: string };
+}
+
+interface ServiceLocationErrorsResponse {
+  attributes: {
+    message: string;
+    errors: ServiceLocationErrorEntry[];
+    id?: string;
+  };
+}
+
+type UpsertMonitorResponse = UpsertMonitorSuccessResponse | ServiceLocationErrorsResponse;
+
+const isPartialFailureResponse = (
+  response: UpsertMonitorResponse
+): response is ServiceLocationErrorsResponse =>
+  typeof response === 'object' && response !== null && 'attributes' in response;
+
+export interface MonitorLocationWarning {
+  locationId: string;
+  message: string;
+}
+
+export interface MonitorSaveOutcome {
+  /** Saved-object id of the created / updated monitor. Used for `updateOrigin`. */
+  id: string;
+  /** Per-location warnings. Empty when the save was fully clean. */
+  locationWarnings: MonitorLocationWarning[];
+}
+
+export class MonitorSaveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MonitorSaveError';
+  }
+}
+
+const narrowSaveResponse = (response: UpsertMonitorResponse): MonitorSaveOutcome => {
+  if (isPartialFailureResponse(response)) {
+    if (!response.attributes.id) {
+      throw new MonitorSaveError(response.attributes.message);
+    }
+    return {
+      id: response.attributes.id,
+      locationWarnings: response.attributes.errors.map((entry) => ({
+        locationId: entry.locationId,
+        message: entry.error?.message ?? 'Unknown location error',
+      })),
+    };
+  }
+  return { id: response.id, locationWarnings: [] };
+};
+
+/**
+ * Pulls the most specific error message available out of an
+ * `IHttpFetchError`. Kibana's browser HTTP client throws errors whose
+ * `.message` is just the HTTP status text (e.g. `Bad Request`) — the
+ * actual server-side validation reason lives on `error.body.message`
+ * with structured details under `error.body.attributes` for the
+ * synthetics monitor route. Without this extraction the user sees a
+ * useless `Bad Request` callout when, e.g., a required field is
+ * missing or a location id doesn't exist.
+ *
+ * Defensive: never throws on unexpected shapes; falls back to the
+ * generic `error.message`. Always emits the full error to the console
+ * (single line, structured) so a developer doing manual smoke can grab
+ * the raw validation payload without opening DevTools' network tab.
+ */
+const extractServerErrorMessage = (error: unknown, op: 'create' | 'update'): string => {
+  if (error == null || typeof error !== 'object') {
+    return String(error);
+  }
+  const fallbackMessage = error instanceof Error ? error.message : 'Unknown error';
+  const body = (error as { body?: unknown }).body;
+  if (body == null || typeof body !== 'object') {
+    return fallbackMessage;
+  }
+  // eslint-disable-next-line no-console
+  console.error(`[synthetics × agent_builder] ${op} failed:`, error, 'body:', body);
+  const bodyMessage = (body as { message?: unknown }).message;
+  const attributes = (body as { attributes?: unknown }).attributes;
+  const attributesMessage =
+    attributes && typeof attributes === 'object'
+      ? (attributes as { message?: unknown }).message
+      : undefined;
+  if (typeof attributesMessage === 'string' && attributesMessage.length > 0) {
+    return attributesMessage;
+  }
+  if (typeof bodyMessage === 'string' && bodyMessage.length > 0) {
+    return bodyMessage;
+  }
+  return fallbackMessage;
+};
+
+/**
+ * POST `/api/synthetics/monitors` with the user's session.
+ *
+ * The body is the current `MonitorAttachmentData`. The server runs
+ * `normalizeAPIConfig` → `validateMonitor`, which fills in `DEFAULT_FIELDS`
+ * and rejects malformed payloads — so the client doesn't need to mirror
+ * those defaults.
+ *
+ * Secrets are sent **plaintext** in the JSON body, mirroring the
+ * monitor form's existing behaviour. The server's `formatSecrets`
+ * picks the secret keys (`PASSWORD`, `PARAMS`, `PROXY_HEADERS`, …),
+ * encrypts them, and stores them in the `secrets` blob.
+ */
+export const createMonitor = async (
+  http: HttpStart,
+  monitor: MonitorAttachmentData
+): Promise<MonitorSaveOutcome> => {
+  try {
+    const response = await http.post<UpsertMonitorResponse>(
+      SYNTHETICS_API_URLS.SYNTHETICS_MONITORS,
+      {
+        body: JSON.stringify(monitor),
+        version: INITIAL_REST_VERSION,
+        query: { internal: true },
+      }
+    );
+    return narrowSaveResponse(response);
+  } catch (error) {
+    throw new MonitorSaveError(extractServerErrorMessage(error, 'create'));
+  }
+};
+
+/**
+ * PUT `/api/synthetics/monitors/{configId}` with the user's session.
+ *
+ * Same body / versioning rules as `createMonitor`. The full attachment
+ * payload is sent — the server's normalizer is idempotent for unchanged
+ * fields, so re-saving without modifications is a no-op write.
+ */
+export const updateMonitor = async (
+  http: HttpStart,
+  configId: string,
+  monitor: MonitorAttachmentData
+): Promise<MonitorSaveOutcome> => {
+  try {
+    const response = await http.put<UpsertMonitorResponse>(
+      `${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/${encodeURIComponent(configId)}`,
+      {
+        body: JSON.stringify(monitor),
+        version: INITIAL_REST_VERSION,
+        query: { internal: true },
+      }
+    );
+    return narrowSaveResponse(response);
+  } catch (error) {
+    throw new MonitorSaveError(extractServerErrorMessage(error, 'update'));
+  }
+};
+
+/**
+ * Builds the in-app URL to a saved monitor's details page. The caller
+ * is responsible for `application.navigateToUrl(...)`-ing the result.
+ *
+ * `appPath` should come from `application.getUrlForApp('synthetics')`,
+ * which already includes the basePath.
+ */
+export const getMonitorDetailsUrl = (configId: string, appPath: string): string =>
+  `${appPath}/monitor/${encodeURIComponent(configId)}`;

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_attachment_definition.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_attachment_definition.test.tsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type {
+  AttachmentRenderProps,
+  AttachmentServiceStartContract,
+  AttachmentUIDefinition,
+  CanvasRenderCallbacks,
+  GetActionButtonsParams,
+} from '@kbn/agent-builder-browser/attachments';
+import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { ApplicationStart, HttpStart } from '@kbn/core/public';
+import { ConfigKey } from '../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  type MonitorAttachmentData,
+} from '../../../common/agent_builder';
+import {
+  buildMonitorManagementAttachmentUIDefinition,
+  registerMonitorManagementAttachmentUIDefinition,
+} from './monitor_management_attachment_definition';
+
+const stubHttp = {} as HttpStart;
+const stubApplication = {
+  capabilities: { uptime: { save: true, elasticManagedLocationsEnabled: true } },
+  getUrlForApp: jest.fn(() => '/app/synthetics'),
+  navigateToUrl: jest.fn(),
+} as unknown as ApplicationStart;
+
+const buildDefinition = () =>
+  buildMonitorManagementAttachmentUIDefinition({
+    http: stubHttp,
+    application: stubApplication,
+  });
+
+const buildAttachment = (overrides: Partial<MonitorAttachmentData> = {}) => ({
+  id: 'attachment-1',
+  type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  data: {
+    [ConfigKey.NAME]: 'Existing monitor',
+    [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+    [ConfigKey.ENABLED]: true,
+    [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+    [ConfigKey.LOCATIONS]: [{ id: 'us_central', isServiceManaged: true }],
+    [ConfigKey.URLS]: 'https://example.com',
+    [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+    ...overrides,
+  } as MonitorAttachmentData,
+});
+
+const renderProps = (
+  attachment: ReturnType<typeof buildAttachment>
+): AttachmentRenderProps<typeof attachment> => ({
+  attachment,
+  isSidebar: false,
+});
+
+const buildCallbacks = (): CanvasRenderCallbacks => ({
+  registerActionButtons: jest.fn(),
+  updateOrigin: jest.fn(async () => undefined),
+  closeCanvas: jest.fn(),
+});
+
+describe('buildMonitorManagementAttachmentUIDefinition', () => {
+  describe('getLabel', () => {
+    it('returns the monitor name when present', () => {
+      const definition = buildDefinition();
+      expect(definition.getLabel(buildAttachment({ name: 'My monitor' }))).toBe('My monitor');
+    });
+
+    it('falls back to a default i18n label when name is empty', () => {
+      const definition = buildDefinition();
+      const attachment = buildAttachment();
+      const label = definition.getLabel({
+        ...attachment,
+        data: { ...attachment.data, [ConfigKey.NAME]: '' as unknown as string },
+      });
+      expect(label).toBe('New Synthetics monitor');
+    });
+  });
+
+  describe('getIcon', () => {
+    it('returns an EUI icon name', () => {
+      const definition = buildDefinition();
+      expect(definition.getIcon?.()).toBe('uptimeApp');
+    });
+  });
+
+  describe('canvasWidth', () => {
+    it('exposes a 40vw canvas width override', () => {
+      const definition = buildDefinition();
+      expect(definition.canvasWidth).toBe('40vw');
+    });
+  });
+
+  describe('renderInlineContent', () => {
+    it('lazy-loads the inline content body and renders it under suspense', async () => {
+      const definition = buildDefinition();
+      const props = renderProps(buildAttachment());
+      const node = definition.renderInlineContent?.(props);
+      render(<>{node}</>);
+      await waitFor(() => {
+        expect(screen.getByTestId('syntheticsMonitorAttachmentInline')).toBeInTheDocument();
+      });
+    });
+
+    it('returns null when attachment.data is missing (defensive)', () => {
+      const definition = buildDefinition();
+      const partial = {
+        id: 'a',
+        type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+        data: undefined,
+      } as unknown as ReturnType<typeof buildAttachment>;
+      const props = renderProps(partial);
+      const node = definition.renderInlineContent?.(props);
+      expect(node).toBeNull();
+    });
+  });
+
+  describe('renderCanvasContent', () => {
+    it('lazy-loads the canvas content body and renders it under suspense', async () => {
+      const definition = buildDefinition();
+      const props = renderProps(buildAttachment());
+      const callbacks = buildCallbacks();
+      const node = definition.renderCanvasContent?.(props, callbacks);
+      render(<>{node}</>);
+      await waitFor(() => {
+        expect(screen.getByTestId('syntheticsMonitorAttachmentCanvas')).toBeInTheDocument();
+      });
+    });
+
+    it('returns null when attachment.data is missing', () => {
+      const definition = buildDefinition();
+      const partial = {
+        id: 'a',
+        type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+        data: undefined,
+      } as unknown as ReturnType<typeof buildAttachment>;
+      const props = renderProps(partial);
+      const callbacks = buildCallbacks();
+      const node = definition.renderCanvasContent?.(props, callbacks);
+      expect(node).toBeNull();
+    });
+  });
+
+  describe('getActionButtons', () => {
+    const buildActionButtonParams = (
+      overrides: Partial<GetActionButtonsParams<ReturnType<typeof buildAttachment>>> = {}
+    ): GetActionButtonsParams<ReturnType<typeof buildAttachment>> => ({
+      attachment: buildAttachment(),
+      isSidebar: false,
+      isCanvas: false,
+      updateOrigin: jest.fn(async () => undefined),
+      openCanvas: jest.fn(),
+      ...overrides,
+    });
+
+    it('returns a single Preview button when rendered inline outside the canvas', () => {
+      const definition = buildDefinition();
+      const params = buildActionButtonParams();
+      const buttons = definition.getActionButtons?.(params) ?? [];
+      expect(buttons).toHaveLength(1);
+      const [preview] = buttons;
+      expect(preview.label).toBe('Preview');
+      expect(preview.icon).toBe('eye');
+      expect(preview.type).toBe(ActionButtonType.SECONDARY);
+    });
+
+    it('Preview button delegates to the framework-provided openCanvas callback', () => {
+      const definition = buildDefinition();
+      const openCanvas = jest.fn();
+      const params = buildActionButtonParams({ openCanvas });
+      const [preview] = definition.getActionButtons?.(params) ?? [];
+      preview.handler();
+      expect(openCanvas).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns no buttons when already in canvas mode (avoids double registration)', () => {
+      const definition = buildDefinition();
+      const params = buildActionButtonParams({ isCanvas: true, openCanvas: undefined });
+      expect(definition.getActionButtons?.(params)).toEqual([]);
+    });
+
+    it('returns no buttons when openCanvas is unavailable (defensive)', () => {
+      const definition = buildDefinition();
+      const params = buildActionButtonParams({ isCanvas: false, openCanvas: undefined });
+      expect(definition.getActionButtons?.(params)).toEqual([]);
+    });
+  });
+});
+
+describe('registerMonitorManagementAttachmentUIDefinition', () => {
+  const createAttachmentService = () => {
+    const addAttachmentType = jest.fn();
+    const getAttachmentUiDefinition = jest.fn();
+    return {
+      service: {
+        addAttachmentType,
+        getAttachmentUiDefinition,
+      } as unknown as AttachmentServiceStartContract,
+      addAttachmentType,
+    };
+  };
+
+  it('registers a UI definition for MONITOR_MANAGEMENT_ATTACHMENT_TYPE with both renderers and inline action buttons', () => {
+    const { service, addAttachmentType } = createAttachmentService();
+    registerMonitorManagementAttachmentUIDefinition({
+      attachmentService: service,
+      http: stubHttp,
+      application: stubApplication,
+    });
+    expect(addAttachmentType).toHaveBeenCalledTimes(1);
+    expect(addAttachmentType).toHaveBeenCalledWith(
+      MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+      expect.objectContaining<Partial<AttachmentUIDefinition>>({
+        getLabel: expect.any(Function),
+        getIcon: expect.any(Function),
+        renderInlineContent: expect.any(Function),
+        renderCanvasContent: expect.any(Function),
+        getActionButtons: expect.any(Function),
+        canvasWidth: '40vw',
+      })
+    );
+  });
+
+  it('is the only side-effect on the attachment service (no other addAttachmentType calls)', () => {
+    const { service, addAttachmentType } = createAttachmentService();
+    registerMonitorManagementAttachmentUIDefinition({
+      attachmentService: service,
+      http: stubHttp,
+      application: stubApplication,
+    });
+    expect(addAttachmentType).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_attachment_definition.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_attachment_definition.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Suspense } from 'react';
+import { i18n } from '@kbn/i18n';
+import type {
+  ActionButton,
+  AttachmentRenderProps,
+  AttachmentServiceStartContract,
+  AttachmentUIDefinition,
+  CanvasRenderCallbacks,
+  GetActionButtonsParams,
+} from '@kbn/agent-builder-browser/attachments';
+import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { ApplicationStart, HttpStart } from '@kbn/core/public';
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  type MonitorAttachmentData,
+} from '../../../common/agent_builder';
+
+type MonitorAttachment = Attachment<
+  typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  MonitorAttachmentData
+>;
+
+/**
+ * Lazy import for the inline content body. Keeps the attachment-type
+ * registration itself a small, side-effect-free module so registering
+ * doesn't pull EUI components into the agent_builder bootstrap chunk.
+ *
+ * The dynamic `import()` resolves to a webpack chunk named after the
+ * file path; the chunk only loads when an attachment of this type is
+ * actually rendered.
+ */
+const LazyMonitorManagementInlineContent = React.lazy(async () => {
+  const { MonitorManagementInlineContent } = await import('./monitor_management_inline_content');
+  return { default: MonitorManagementInlineContent };
+});
+
+/**
+ * Lazy import for the canvas content body. Same chunk-isolation
+ * rationale as the inline content — but stricter: the canvas pulls in
+ * `EuiDescriptionList`, save / update HTTP wrappers, the canvas-action
+ * registration hook, and the @kbn/core ApplicationStart contract. We
+ * only want all of that in the bundle when the user actually opens
+ * the canvas flyout.
+ */
+const LazyMonitorManagementCanvasContent = React.lazy(async () => {
+  const { MonitorManagementCanvasContent } = await import('./monitor_management_canvas_content');
+  return { default: MonitorManagementCanvasContent };
+});
+
+const getAttachmentLabel = (attachment: MonitorAttachment): string => {
+  const name = attachment.data?.name;
+  if (name && name.length > 0) {
+    return name;
+  }
+  return i18n.translate('xpack.synthetics.agentBuilder.monitor.defaultLabel', {
+    defaultMessage: 'New Synthetics monitor',
+  });
+};
+
+const renderInlineContent = (props: AttachmentRenderProps<MonitorAttachment>): React.ReactNode => {
+  const { attachment } = props;
+  if (!attachment.data) {
+    return null;
+  }
+  return (
+    <Suspense fallback={null}>
+      <LazyMonitorManagementInlineContent data={attachment.data} />
+    </Suspense>
+  );
+};
+
+/**
+ * Inline action buttons. Returns a single "Preview" button whose
+ * handler is the framework-provided `openCanvas` callback.
+ *
+ * Without this, the inline card has no affordance to open the canvas
+ * flyout — and the canvas is where the status-specific Create / Update /
+ * View buttons live (see `use_monitor_canvas_actions.ts`). Caught
+ * during T9 manual testing: an inline-only render leaves users with no path
+ * to persist the proposed monitor.
+ *
+ * Mirrors the `dashboard_agent` precedent
+ * (`x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx`).
+ * When already inside the canvas (`isCanvas: true`, `openCanvas: undefined`),
+ * returns an empty array so the button doesn't double up.
+ */
+const getActionButtons = ({
+  isCanvas,
+  openCanvas,
+}: GetActionButtonsParams<MonitorAttachment>): ActionButton[] => {
+  if (isCanvas || !openCanvas) {
+    return [];
+  }
+  return [
+    {
+      label: i18n.translate('xpack.synthetics.agentBuilder.monitor.previewActionLabel', {
+        defaultMessage: 'Preview',
+      }),
+      icon: 'eye',
+      type: ActionButtonType.SECONDARY,
+      handler: () => {
+        openCanvas();
+      },
+    },
+  ];
+};
+
+interface BuildMonitorManagementUIDefinitionParams {
+  http: HttpStart;
+  application: ApplicationStart;
+}
+
+/**
+ * Builds the `AttachmentUIDefinition` for the monitor-management
+ * attachment, capturing the platform services it needs in a closure.
+ *
+ * Mirrors the dashboard_agent pattern (see `dashboard_agent/public/
+ * attachment_types/index.tsx`): inline + canvas renderers are built
+ * inside `addAttachmentType<T>(...)` so that core services (`http`,
+ * `application.capabilities`, `application.getUrlForApp`,
+ * `application.navigateToUrl`) are available to the canvas's Create /
+ * Update / View buttons without prop-drilling through the framework.
+ *
+ * The registration of *the type* itself is small and synchronous —
+ * the heavy modules (inline content, canvas content + actions) are
+ * loaded lazily when an attachment of this type renders.
+ */
+export const buildMonitorManagementAttachmentUIDefinition = ({
+  http,
+  application,
+}: BuildMonitorManagementUIDefinitionParams): AttachmentUIDefinition<MonitorAttachment> => {
+  const renderCanvasContent = (
+    props: AttachmentRenderProps<MonitorAttachment>,
+    callbacks: CanvasRenderCallbacks
+  ): React.ReactNode => {
+    const { attachment } = props;
+    if (!attachment.data) {
+      return null;
+    }
+    return (
+      <Suspense fallback={null}>
+        <LazyMonitorManagementCanvasContent
+          data={attachment.data}
+          http={http}
+          application={application}
+          registerActionButtons={callbacks.registerActionButtons}
+          updateOrigin={callbacks.updateOrigin}
+          closeCanvas={callbacks.closeCanvas}
+        />
+      </Suspense>
+    );
+  };
+
+  return {
+    getLabel: getAttachmentLabel,
+    getIcon: () => 'uptimeApp',
+    renderInlineContent,
+    renderCanvasContent,
+    getActionButtons,
+    canvasWidth: '40vw',
+  };
+};
+
+export interface RegisterMonitorManagementAttachmentParams {
+  attachmentService: AttachmentServiceStartContract;
+  http: HttpStart;
+  application: ApplicationStart;
+}
+
+/**
+ * Register the attachment UI definition with the agent_builder browser
+ * attachment service.
+ *
+ * Idempotent at the framework level — the service keeps the most
+ * recent registration. Caller is `bindAgentBuilderOnStart`, which is
+ * itself called from `public/plugin.ts`'s `start()` once `coreStart`
+ * + `pluginsStart` are available.
+ */
+export const registerMonitorManagementAttachmentUIDefinition = ({
+  attachmentService,
+  http,
+  application,
+}: RegisterMonitorManagementAttachmentParams): void => {
+  attachmentService.addAttachmentType<MonitorAttachment>(
+    MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+    buildMonitorManagementAttachmentUIDefinition({ http, application })
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.test.tsx
@@ -1,0 +1,326 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ApplicationStart, HttpStart } from '@kbn/core/public';
+import { ConfigKey } from '../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+import { SYNTHETICS_API_URLS } from '../../../common/constants/synthetics/rest_api';
+import { MonitorManagementCanvasContent } from './monitor_management_canvas_content';
+
+const buildMonitor = (overrides: Partial<MonitorAttachmentData> = {}): MonitorAttachmentData => ({
+  [ConfigKey.NAME]: 'Smoke check',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [{ id: 'us_central', label: 'US Central', isServiceManaged: true }],
+  [ConfigKey.URLS]: 'https://example.com',
+  [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+  [ConfigKey.TAGS]: ['smoke', 'prod'],
+  ...overrides,
+});
+
+interface MountResult {
+  registerActionButtons: jest.Mock;
+  updateOrigin: jest.Mock;
+  closeCanvas: jest.Mock;
+  http: HttpStart;
+  application: ApplicationStart;
+}
+
+const buildHttp = (overrides?: { post?: jest.Mock; put?: jest.Mock }): HttpStart => {
+  return {
+    post: overrides?.post ?? jest.fn(async () => ({ id: 'created-id' })),
+    put: overrides?.put ?? jest.fn(async () => ({ id: 'updated-id' })),
+  } as unknown as HttpStart;
+};
+
+interface ApplicationOverrides {
+  capabilities?: { uptime?: { save?: boolean; elasticManagedLocationsEnabled?: boolean } };
+  getUrlForApp?: ApplicationStart['getUrlForApp'];
+  navigateToUrl?: ApplicationStart['navigateToUrl'];
+}
+
+const buildApplication = (overrides?: ApplicationOverrides): ApplicationStart => {
+  return {
+    capabilities: overrides?.capabilities ?? {
+      uptime: { save: true, elasticManagedLocationsEnabled: true },
+    },
+    getUrlForApp: overrides?.getUrlForApp ?? jest.fn(() => '/app/synthetics'),
+    navigateToUrl: overrides?.navigateToUrl ?? jest.fn(),
+  } as unknown as ApplicationStart;
+};
+
+const mount = (
+  data: MonitorAttachmentData,
+  options: {
+    http?: HttpStart;
+    application?: ApplicationStart;
+    registerActionButtons?: jest.Mock;
+    updateOrigin?: jest.Mock;
+    closeCanvas?: jest.Mock;
+  } = {}
+): MountResult => {
+  const registerActionButtons = options.registerActionButtons ?? jest.fn();
+  const updateOrigin = options.updateOrigin ?? jest.fn(async () => undefined);
+  const closeCanvas = options.closeCanvas ?? jest.fn();
+  const http = options.http ?? buildHttp();
+  const application = options.application ?? buildApplication();
+
+  render(
+    <MonitorManagementCanvasContent
+      data={data}
+      http={http}
+      application={application}
+      registerActionButtons={registerActionButtons}
+      updateOrigin={updateOrigin}
+      closeCanvas={closeCanvas}
+    />
+  );
+
+  return { registerActionButtons, updateOrigin, closeCanvas, http, application };
+};
+
+const getActionFooter = (): HTMLElement =>
+  screen.getByTestId('syntheticsMonitorAttachmentCanvasActions');
+
+const getActionLabels = (): string[] =>
+  within(getActionFooter())
+    .getAllByRole('button')
+    .map((button) => button.textContent?.trim() ?? '');
+
+describe('MonitorManagementCanvasContent — header + details panel', () => {
+  it('renders title, status, type chip, caption, and the description list', () => {
+    mount(buildMonitor());
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvas')).toHaveAttribute(
+      'data-test-status',
+      'proposed'
+    );
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasTitle')).toHaveTextContent(
+      'Smoke check'
+    );
+    expect(
+      screen.getByTestId('syntheticsMonitorAttachmentCanvasStatus-proposed')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('syntheticsMonitorAttachmentType')).toHaveTextContent('HTTP');
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasCaption')).toHaveTextContent(
+      'Draft monitor — not yet saved to Synthetics.'
+    );
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasDetails')).toHaveTextContent(
+      'https://example.com'
+    );
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasDetails')).toHaveTextContent(
+      'Every 5 m'
+    );
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasDetails')).toHaveTextContent(
+      'US Central (Elastic-managed)'
+    );
+  });
+
+  it('renders the CLI-managed callout for project-origin monitors and only a "View" action', () => {
+    mount(
+      buildMonitor({
+        [ConfigKey.CONFIG_ID]: 'cli-id',
+        [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.PROJECT,
+      })
+    );
+    expect(
+      screen.getByTestId('syntheticsMonitorAttachmentCanvasCliManagedCallout')
+    ).toBeInTheDocument();
+    expect(getActionLabels()).toEqual(['View in Synthetics']);
+  });
+
+  it('falls back to a placeholder title when the monitor has no name', () => {
+    mount(buildMonitor({ [ConfigKey.NAME]: '' as unknown as string }));
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasTitle')).toHaveTextContent(
+      'Untitled monitor'
+    );
+  });
+});
+
+describe('MonitorManagementCanvasContent — proposed monitor (Create)', () => {
+  it('renders a single Create button (primary, save icon) when capabilities allow it', () => {
+    mount(buildMonitor());
+    expect(getActionLabels()).toEqual(['Create']);
+    const createButton = screen.getByTestId('syntheticsMonitorAttachmentCanvasAction-save');
+    expect(createButton).toBeEnabled();
+    expect(createButton).toHaveTextContent('Create');
+  });
+
+  it('disables Create with a missing-privilege tooltip when uptime.save is false', () => {
+    mount(buildMonitor(), {
+      application: buildApplication({
+        capabilities: { uptime: { save: false, elasticManagedLocationsEnabled: true } },
+      }),
+    });
+    const createButton = screen.getByTestId('syntheticsMonitorAttachmentCanvasAction-save');
+    expect(createButton).toBeDisabled();
+    // Disabled-reason text is rendered by the wrapping EuiToolTip on
+    // hover; we deliberately don't drive that interaction here because
+    // EuiToolTip lazy-mounts the visible bubble in a portal and the
+    // assertion is then fragile. The disabled state is what matters
+    // for behaviour; the tooltip wiring is unit-tested upstream in EUI.
+  });
+
+  it('disables Create when Elastic-managed locations are disabled and the draft uses one', () => {
+    mount(buildMonitor(), {
+      application: buildApplication({
+        capabilities: { uptime: { save: true, elasticManagedLocationsEnabled: false } },
+      }),
+    });
+    const createButton = screen.getByTestId('syntheticsMonitorAttachmentCanvasAction-save');
+    expect(createButton).toBeDisabled();
+  });
+
+  it('on click, POSTs the monitor, calls updateOrigin with the new id, and closes the canvas', async () => {
+    const post = jest.fn(async () => ({ id: 'new-config-id' }));
+    const updateOrigin = jest.fn(async () => undefined);
+    const closeCanvas = jest.fn();
+
+    mount(buildMonitor(), {
+      http: buildHttp({ post }),
+      updateOrigin,
+      closeCanvas,
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('syntheticsMonitorAttachmentCanvasAction-save'));
+    });
+
+    expect(post).toHaveBeenCalledWith(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS, expect.any(Object));
+    expect(updateOrigin).toHaveBeenCalledWith('new-config-id');
+    expect(closeCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a "Save failed" callout when the POST throws', async () => {
+    const post = jest.fn(async () => {
+      throw new Error('Network down');
+    });
+    const closeCanvas = jest.fn();
+    mount(buildMonitor(), {
+      http: buildHttp({ post }),
+      closeCanvas,
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('syntheticsMonitorAttachmentCanvasAction-save'));
+    });
+
+    expect(closeCanvas).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasSaveError')).toHaveTextContent(
+        'Network down'
+      );
+    });
+  });
+
+  it('renders the location-warnings callout on partial-failure save and keeps canvas open', async () => {
+    const post = jest.fn(async () => ({
+      attributes: {
+        message: 'Some locations failed',
+        id: 'partial-id',
+        errors: [{ locationId: 'us_east', error: { message: 'Fleet agent offline' } }],
+      },
+    }));
+    const updateOrigin = jest.fn(async () => undefined);
+    const closeCanvas = jest.fn();
+
+    mount(buildMonitor(), {
+      http: buildHttp({ post }),
+      updateOrigin,
+      closeCanvas,
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('syntheticsMonitorAttachmentCanvasAction-save'));
+    });
+
+    expect(updateOrigin).toHaveBeenCalledWith('partial-id');
+    expect(closeCanvas).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('syntheticsMonitorAttachmentCanvasLocationWarnings')
+      ).toHaveTextContent('Fleet agent offline');
+    });
+  });
+});
+
+describe('MonitorManagementCanvasContent — saved monitor (Update + View)', () => {
+  it('renders Update (primary) and View (secondary) for an enabled saved monitor', () => {
+    mount(buildMonitor({ [ConfigKey.CONFIG_ID]: 'saved-config-id' }));
+    expect(getActionLabels()).toEqual(['Update', 'View in Synthetics']);
+  });
+
+  it('on Update click, PUTs to /api/synthetics/monitors/{configId} and does NOT call updateOrigin', async () => {
+    const put = jest.fn(async () => ({ id: 'saved-config-id' }));
+    const updateOrigin = jest.fn(async () => undefined);
+    const closeCanvas = jest.fn();
+
+    mount(buildMonitor({ [ConfigKey.CONFIG_ID]: 'saved-config-id' }), {
+      http: buildHttp({ put }),
+      updateOrigin,
+      closeCanvas,
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('syntheticsMonitorAttachmentCanvasAction-save'));
+    });
+
+    expect(put).toHaveBeenCalledWith(
+      `${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/saved-config-id`,
+      expect.any(Object)
+    );
+    expect(updateOrigin).not.toHaveBeenCalled();
+    expect(closeCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it('on View click, navigates to the monitor details page in the synthetics app', async () => {
+    const navigateToUrl = jest.fn();
+    const closeCanvas = jest.fn();
+    mount(buildMonitor({ [ConfigKey.CONFIG_ID]: 'saved-config-id' }), {
+      application: buildApplication({
+        capabilities: { uptime: { save: true, elasticManagedLocationsEnabled: true } },
+        getUrlForApp: jest.fn(() => '/app/synthetics'),
+        navigateToUrl,
+      }),
+      closeCanvas,
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('syntheticsMonitorAttachmentCanvasAction-popout'));
+    });
+
+    expect(navigateToUrl).toHaveBeenCalledWith('/app/synthetics/monitor/saved-config-id');
+    expect(closeCanvas).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MonitorManagementCanvasContent — framework header (T7 hot-fix #4)', () => {
+  /**
+   * Earlier iterations registered Create/Update/View on the framework's
+   * flyout header. T7 hot-fix #4 moved them into the body footer (see
+   * `useMonitorCanvasActions`). The framework may have leftover dynamic
+   * buttons from a previous attachment, so we still call
+   * `registerActionButtons` — but exactly once with `[]` to clear them.
+   */
+  it('clears the framework header by registering an empty button array on mount', async () => {
+    const registerActionButtons = jest.fn();
+    mount(buildMonitor(), { registerActionButtons });
+
+    await waitFor(() => {
+      expect(registerActionButtons).toHaveBeenCalledTimes(1);
+    });
+    expect(registerActionButtons).toHaveBeenCalledWith([]);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.test.tsx
@@ -101,31 +101,37 @@ const getActionLabels = (): string[] =>
     .map((button) => button.textContent?.trim() ?? '');
 
 describe('MonitorManagementCanvasContent — header + details panel', () => {
-  it('renders title, status, type chip, caption, and the description list', () => {
+  it('renders the tile wrapper, status dot, title, URL link, caption, and chip-row details', () => {
     mount(buildMonitor());
     expect(screen.getByTestId('syntheticsMonitorAttachmentCanvas')).toHaveAttribute(
       'data-test-status',
       'proposed'
     );
+    // Fixed-height tile wrapper that hosts the status-tinted card.
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasTile')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('syntheticsMonitorAttachmentStatusDot-proposed')
+    ).toBeInTheDocument();
     expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasTitle')).toHaveTextContent(
       'Smoke check'
     );
-    expect(
-      screen.getByTestId('syntheticsMonitorAttachmentCanvasStatus-proposed')
-    ).toBeInTheDocument();
-    expect(screen.getByTestId('syntheticsMonitorAttachmentType')).toHaveTextContent('HTTP');
+    // URL is rendered as a real link in the subtitle line; the `href`
+    // attribute is the source of truth for navigation.
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasUrl')).toHaveAttribute(
+      'href',
+      'https://example.com'
+    );
     expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasCaption')).toHaveTextContent(
       'Draft monitor — not yet saved to Synthetics.'
     );
-    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasDetails')).toHaveTextContent(
-      'https://example.com'
+    // The chip row lives in the tile's details block (single render, no
+    // hidden duplicates now that we no longer go through `<Metric>`).
+    const details = screen.getByTestId('syntheticsMonitorAttachmentCanvasDetails');
+    expect(within(details).getByTestId('syntheticsMonitorAttachmentType')).toHaveTextContent(
+      'HTTP'
     );
-    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasDetails')).toHaveTextContent(
-      'Every 5 m'
-    );
-    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasDetails')).toHaveTextContent(
-      'US Central (Elastic-managed)'
-    );
+    expect(details).toHaveTextContent('Every 5 m');
+    expect(details).toHaveTextContent('US Central (Elastic-managed)');
   });
 
   it('renders the CLI-managed callout for project-origin monitors and only a "View" action', () => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.test.tsx
@@ -109,9 +109,7 @@ describe('MonitorManagementCanvasContent — header + details panel', () => {
     );
     // Fixed-height tile wrapper that hosts the status-tinted card.
     expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasTile')).toBeInTheDocument();
-    expect(
-      screen.getByTestId('syntheticsMonitorAttachmentStatusDot-proposed')
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('syntheticsMonitorAttachmentStatusDot-proposed')).toBeInTheDocument();
     expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasTitle')).toHaveTextContent(
       'Smoke check'
     );
@@ -232,11 +230,14 @@ describe('MonitorManagementCanvasContent — proposed monitor (Create)', () => {
   });
 
   it('renders the location-warnings callout on partial-failure save and keeps canvas open', async () => {
+    // Mirrors the actual `add_monitor.ts` response shape: top-level
+    // `message` and `id`, errors nested under `attributes.errors`,
+    // per-entry `error: { reason, status }` (NOT `{ message }`).
     const post = jest.fn(async () => ({
+      message: 'error pushing monitor to the service',
+      id: 'partial-id',
       attributes: {
-        message: 'Some locations failed',
-        id: 'partial-id',
-        errors: [{ locationId: 'us_east', error: { message: 'Fleet agent offline' } }],
+        errors: [{ locationId: 'us_east', error: { reason: 'Fleet agent offline', status: 503 } }],
       },
     }));
     const updateOrigin = jest.fn(async () => undefined);
@@ -257,8 +258,33 @@ describe('MonitorManagementCanvasContent — proposed monitor (Create)', () => {
     await waitFor(() => {
       expect(
         screen.getByTestId('syntheticsMonitorAttachmentCanvasLocationWarnings')
-      ).toHaveTextContent('Fleet agent offline');
+      ).toHaveTextContent('503 — Fleet agent offline');
     });
+  });
+});
+
+describe('MonitorManagementCanvasContent — close button (F13 workaround)', () => {
+  /**
+   * The framework's `AttachmentHeader` bails out (`return null`) when
+   * `actionButtons.length === 0`, taking the close X with it. We
+   * register `[]` on the framework header to keep it clean
+   * (T7 hot-fix #4), so we render our own close button at the top of
+   * the canvas body to keep the affordance discoverable. Tracked as
+   * F13 in `followups.md` — the proper fix is in the platform's
+   * `attachment_header.tsx`.
+   */
+  it('renders a close button that invokes closeCanvas', async () => {
+    const closeCanvas = jest.fn();
+    mount(buildMonitor(), { closeCanvas });
+
+    const closeButton = screen.getByTestId('syntheticsMonitorAttachmentCanvasCloseButton');
+    expect(closeButton).toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(closeButton);
+    });
+
+    expect(closeCanvas).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -309,6 +335,106 @@ describe('MonitorManagementCanvasContent — saved monitor (Update + View)', () 
 
     expect(navigateToUrl).toHaveBeenCalledWith('/app/synthetics/monitor/saved-config-id');
     expect(closeCanvas).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MonitorManagementCanvasContent — post-Save state (no duplicate-name retries)', () => {
+  /**
+   * Pins the user-visible fix for the "click Save → canvas keeps
+   * showing Create" bug. The framework's `updateOrigin` only writes
+   * the origin onto the attachment record; it does not refresh
+   * `data` (followup F14). Without the local `lastSaved` overlay in
+   * the canvas, the next render would still infer `'proposed'` and
+   * the user would click **Create** again, hitting the server's
+   * duplicate-name error.
+   */
+  const buildPartialFailureHttp = (configId: string): HttpStart =>
+    buildHttp({
+      post: jest.fn(async () => ({
+        message: 'error pushing monitor to the service',
+        id: configId,
+        attributes: {
+          errors: [
+            { locationId: 'us_central', error: { reason: 'Fleet agent offline', status: 503 } },
+          ],
+        },
+      })),
+    });
+
+  const clickAction = async (testSubj: string) => {
+    await act(async () => {
+      await userEvent.click(screen.getByTestId(testSubj));
+    });
+  };
+
+  it("after a successful Create with partial-failure (canvas stays open), swaps Create for Update + View, flips status to 'enabled', and PUTs to the captured configId on Update click", async () => {
+    const put = jest.fn(async () => ({ id: 'persisted-config-id' }));
+    const http = {
+      ...buildPartialFailureHttp('persisted-config-id'),
+      put,
+    } as unknown as HttpStart;
+    const closeCanvas = jest.fn();
+
+    mount(buildMonitor(), { http, closeCanvas });
+
+    // Sanity: pre-Save state is the proposed draft.
+    expect(getActionLabels()).toEqual(['Create']);
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvas')).toHaveAttribute(
+      'data-test-status',
+      'proposed'
+    );
+
+    await clickAction('syntheticsMonitorAttachmentCanvasAction-save');
+
+    // Partial-failure path keeps the canvas open and the warning
+    // callout visible — the user needs to see the location error
+    // before deciding whether to retry.
+    expect(closeCanvas).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('syntheticsMonitorAttachmentCanvasLocationWarnings')
+      ).toBeInTheDocument();
+    });
+
+    // Buttons must swap. If they don't, the next click round-trips
+    // to a duplicate-name `POST` against Synthetics.
+    expect(getActionLabels()).toEqual(['Update', 'View in Synthetics']);
+    // And the visual treatment must flip — same heuristic the
+    // status dot / caption / tile background all key off.
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvas')).toHaveAttribute(
+      'data-test-status',
+      'enabled'
+    );
+    expect(screen.getByTestId('syntheticsMonitorAttachmentStatusDot-enabled')).toBeInTheDocument();
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvasCaption')).toHaveTextContent(
+      'Saved monitor — currently running on its schedule.'
+    );
+
+    // Now Update — must `PUT` to the captured configId, not `POST`
+    // again. The `POST` mock was already exhausted by the Create
+    // click; the `put` mock is the one that should fire.
+    await clickAction('syntheticsMonitorAttachmentCanvasAction-save');
+
+    expect(put).toHaveBeenCalledWith(
+      `${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/persisted-config-id`,
+      expect.any(Object)
+    );
+  });
+
+  it('does NOT carry the lastSaved overlay across attachments — a different monitor (different name + url) still renders Create', () => {
+    // The overlay is keyed on the saved monitor's name + url so a
+    // different attachment that happens to share the canvas instance
+    // doesn't accidentally inherit a stale configId. We can't easily
+    // re-mount with a new prop in this canvas component (its data is
+    // injected by the framework), so instead we cover the projector
+    // contract directly via a render with mismatched data — same as
+    // what the canvas would render after a prop swap.
+    mount(buildMonitor({ [ConfigKey.NAME]: 'A different monitor' }));
+    expect(getActionLabels()).toEqual(['Create']);
+    expect(screen.getByTestId('syntheticsMonitorAttachmentCanvas')).toHaveAttribute(
+      'data-test-status',
+      'proposed'
+    );
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.tsx
@@ -7,14 +7,11 @@
 
 import React, { useEffect, useState } from 'react';
 import {
-  EuiBadge,
-  EuiBadgeGroup,
   EuiButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHorizontalRule,
   EuiIcon,
   EuiLink,
   EuiPanel,
@@ -29,20 +26,25 @@ import { i18n } from '@kbn/i18n';
 import { type ActionButton, ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import type { ApplicationStart, HttpStart } from '@kbn/core/public';
 import { ConfigKey } from '../../../common/runtime_types';
-import type { ScheduleUnit } from '../../../common/runtime_types/monitor_management/monitor_configs';
 import type { MonitorAttachmentData } from '../../../common/agent_builder';
 import {
-  MonitorTypeChip,
-  STATUS_BADGE_COLORS,
+  MonitorChipRow,
+  MonitorStatusDot,
+  getStatusAccentColor,
   getStatusBackgroundColor,
   getStatusCaption,
-  getStatusLabel,
   inferMonitorStatus,
 } from './monitor_management_status';
 import {
   useMonitorCanvasActions,
   type MonitorCanvasSaveState,
 } from './use_monitor_canvas_actions';
+
+/**
+ * Fixed height of the tile area, mirroring `METRIC_ITEM_HEIGHT` from
+ * the Synthetics Overview tile. Keeps the visual rhyme exact.
+ */
+const METRIC_TILE_HEIGHT = 180;
 
 export interface MonitorManagementCanvasContentProps {
   /** The current attachment payload. */
@@ -63,38 +65,6 @@ export interface MonitorManagementCanvasContentProps {
   /** Framework canvas callback — closes the flyout. */
   closeCanvas: () => void;
 }
-
-const formatScheduleLabel = (
-  schedule: { number: string; unit: ScheduleUnit } | undefined
-): string => {
-  if (!schedule) {
-    return i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.scheduleUnset', {
-      defaultMessage: 'Schedule not set',
-    });
-  }
-  return i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.scheduleValue', {
-    defaultMessage: 'Every {number} {unit}',
-    values: { number: schedule.number, unit: schedule.unit },
-  });
-};
-
-const formatLocationLabel = (location: {
-  id: string;
-  label?: string;
-  isServiceManaged?: boolean;
-}): string => {
-  const labelText = location.label ?? location.id;
-  if (location.isServiceManaged) {
-    return i18n.translate(
-      'xpack.synthetics.agentBuilder.monitor.canvas.locations.elasticManagedLabel',
-      {
-        defaultMessage: '{label} (Elastic-managed)',
-        values: { label: labelText },
-      }
-    );
-  }
-  return labelText;
-};
 
 interface ActionFooterProps {
   buttons: ActionButton[];
@@ -169,39 +139,37 @@ const ActionFooter: React.FC<ActionFooterProps> = ({ buttons, isSaving }) => {
 /**
  * Canvas body for the `MONITOR_MANAGEMENT_ATTACHMENT_TYPE` attachment.
  *
- * Visual treatment intentionally mirrors the Synthetics Overview tile
- * (`MetricItem`): the panel itself is washed with a status-tinted
- * background, the title sits prominent at the top, and the type chip
- * + tags ride in a dedicated chip row. We deliberately do **not**
- * inherit the heavy bits of `MetricItem` — sparkline trend chart,
- * latency metric, errors popover, actions popover — because:
+ * Visual treatment is hand-built to mirror the Synthetics Overview
+ * tile (`MetricItem`) without going through `@elastic/charts`'s
+ * `<Metric>` component. We tried `<Chart><Metric/></Chart>` first
+ * because it's how the Overview itself draws the tile, but Metric's
+ * "no value, no trend" rendering branch falls back to a text-only
+ * mode that drops the status-tinted card background and the
+ * fixed-height layout — exactly the visual treatment we wanted to
+ * inherit. Without heartbeat data (which we don't fetch in v1; see
+ * F11 in `followups.md`), Metric has nothing to draw and gracefully
+ * degrades into something that doesn't read as a tile at all. So we
+ * rebuild the tile directly from EUI primitives:
  *
- * - Those depend on heartbeat data + Redux selectors that have no
- *   meaning for a `proposed` (unsaved) monitor.
- * - The flyout context is detail-oriented; cramming a sparkline into
- *   it duplicates the Synthetics Overview without adding new info.
+ * | Tile slot       | Implementation                                    |
+ * | --------------- | ------------------------------------------------- |
+ * | Card            | Fixed-height `EuiPanel`, status-tinted bg         |
+ * | Status accent   | `MonitorStatusDot` (top-left)                     |
+ * | Title           | `EuiTitle size="m"` (monitor name)                |
+ * | Subtitle        | `EuiText size="s" color="subdued"` (caption + URL)|
+ * | Chip row        | `MonitorChipRow` (type / schedule / locations…)   |
+ * | Sparkline       | Deferred to F12 (heartbeat fetch).                |
  *
- * Read-only by design: the user mutates the attachment via chat
- * (re-running `manage_synthetics_monitor` operations), then commits
- * the result via the action footer. Editing inline here would
- * require duplicating the synthetics monitor form and its validation
- * surface, which is out of scope for v1.
+ * Below the tile we keep our own structure: optional callouts (CLI-
+ * managed banner, save-error, location warnings) followed by the
+ * action footer with Create / Update / View buttons.
  *
- * Action placement (T7 hot-fix #4): the Create / Update / View
- * buttons live **inside the panel footer**, not in the framework's
- * flyout header. That decision is rationalised in the
- * `useMonitorCanvasActions` doc comment. We still call
- * `registerActionButtons([])` once per mount to clear any header
- * buttons the framework may have carried over from a previous
- * canvas attachment.
- *
- * Tree-shake hygiene: like the inline content body, this file only
- * imports `@elastic/eui`, `@emotion/react`, `@kbn/i18n`,
- * `@kbn/agent-builder-browser`, `@kbn/core/public`, types from
- * `common/`, and the shared `monitor_management_status` /
- * `monitor_management_actions` / `use_monitor_canvas_actions`
- * helpers in this folder. **Do not** pull in monitor-form or anything
- * from `apps/synthetics/components/`.
+ * Tree-shake hygiene: imports `@elastic/eui`, `@emotion/react`,
+ * `@kbn/i18n`, `@kbn/agent-builder-browser`, `@kbn/core/public`,
+ * types from `common/`, and the shared
+ * `monitor_management_status` / `use_monitor_canvas_actions` helpers
+ * in this folder. **Do not** pull in monitor-form, anything from
+ * `apps/synthetics/components/`, or `@elastic/charts`.
  */
 export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasContentProps> = ({
   data,
@@ -214,6 +182,7 @@ export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasCon
   const { euiTheme } = useEuiTheme();
   const status = inferMonitorStatus(data);
   const tileBg = getStatusBackgroundColor(status, euiTheme);
+  const accentColor = getStatusAccentColor(status, euiTheme);
 
   const capabilities = application.capabilities;
   const canEdit = capabilities.uptime?.save === true;
@@ -247,212 +216,193 @@ export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasCon
 
   const monitorName = data[ConfigKey.NAME];
   const url = data[ConfigKey.URLS];
+  const placeholderName = i18n.translate(
+    'xpack.synthetics.agentBuilder.monitor.canvas.placeholderName',
+    { defaultMessage: 'Untitled monitor' }
+  );
+  const tileTitle = monitorName && monitorName.length > 0 ? monitorName : placeholderName;
+  const caption = getStatusCaption(status);
 
   return (
-    <div data-test-subj="syntheticsMonitorAttachmentCanvas" data-test-status={status}>
-      <EuiPanel
-        paddingSize="l"
-        hasBorder
-        hasShadow={false}
-        css={css`
-          background-color: ${tileBg};
-        `}
+    <div
+      data-test-subj="syntheticsMonitorAttachmentCanvas"
+      data-test-status={status}
+      // The agent_builder flyout body only sets `padding-top: m` (see
+      // `canvas_flyout.tsx`'s `flyoutBodyStyles`), so without our own
+      // wrapper the tile + action footer would sit flush against the
+      // flyout edges. Pad uniformly so the tile reads as a card with
+      // breathing room and the footer doesn't kiss the right edge.
+      css={css`
+        padding: 0 ${euiTheme.size.m} ${euiTheme.size.m};
+      `}
+    >
+      {/*
+        Outer fixed-height shell mirrors the Overview tile (`MetricItem`):
+        180px tall panel, the status-tinted background fills the entire
+        card surface so the status reads at a glance.
+
+        We add a thicker left accent strip (`MonitorStatusDot` plus a
+        `border-left` on the panel) so the status colour reads even when
+        the background tint is subtle (proposed → backgroundBasePrimary
+        is very light in light mode).
+      */}
+      <div
+        data-test-subj="syntheticsMonitorAttachmentCanvasTile"
+        style={{ height: METRIC_TILE_HEIGHT }}
       >
-        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
-          <EuiFlexItem grow={false}>
-            <EuiBadge
-              color={STATUS_BADGE_COLORS[status]}
-              data-test-subj={`syntheticsMonitorAttachmentCanvasStatus-${status}`}
-            >
-              {getStatusLabel(status)}
-            </EuiBadge>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <MonitorTypeChip type={data[ConfigKey.MONITOR_TYPE]} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size="s" />
-
-        <EuiTitle size="m">
-          <h2 data-test-subj="syntheticsMonitorAttachmentCanvasTitle">
-            {monitorName && monitorName.length > 0
-              ? monitorName
-              : i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.placeholderName', {
-                  defaultMessage: 'Untitled monitor',
-                })}
-          </h2>
-        </EuiTitle>
-
-        <EuiSpacer size="xs" />
-
-        <EuiText
-          size="s"
-          color="subdued"
-          data-test-subj="syntheticsMonitorAttachmentCanvasCaption"
+        <EuiPanel
+          paddingSize="l"
+          hasBorder
+          hasShadow={false}
+          css={css`
+            height: 100%;
+            overflow: hidden;
+            position: relative;
+            background-color: ${tileBg};
+            border-left: ${euiTheme.border.width.thick} solid ${accentColor};
+          `}
         >
-          {getStatusCaption(status)}
-        </EuiText>
-
-        {status === 'cli-managed' ? (
-          <>
-            <EuiSpacer size="m" />
-            <EuiCallOut
-              size="s"
-              color="warning"
-              iconType="warning"
-              announceOnMount
-              data-test-subj="syntheticsMonitorAttachmentCanvasCliManagedCallout"
-              title={i18n.translate(
-                'xpack.synthetics.agentBuilder.monitor.canvas.cliManagedTitle',
-                { defaultMessage: 'CLI-managed monitor' }
-              )}
-            >
-              <p>
-                {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.cliManagedBody', {
-                  defaultMessage:
-                    'This monitor was created via the synthetics CLI and is read-only here. To edit it, update the project source and re-push with `@elastic/synthetics push`.',
-                })}
-              </p>
-            </EuiCallOut>
-          </>
-        ) : null}
-
-        {saveState.saveError ? (
-          <>
-            <EuiSpacer size="m" />
-            <EuiCallOut
-              size="s"
-              color="danger"
-              iconType="error"
-              announceOnMount
-              data-test-subj="syntheticsMonitorAttachmentCanvasSaveError"
-              title={i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.saveErrorTitle', {
-                defaultMessage: 'Save failed',
-              })}
-            >
-              <p>{saveState.saveError.message}</p>
-            </EuiCallOut>
-          </>
-        ) : null}
-
-        {saveState.locationWarnings.length > 0 ? (
-          <>
-            <EuiSpacer size="m" />
-            <EuiCallOut
-              size="s"
-              color="warning"
-              iconType="warning"
-              announceOnMount
-              data-test-subj="syntheticsMonitorAttachmentCanvasLocationWarnings"
-              title={i18n.translate(
-                'xpack.synthetics.agentBuilder.monitor.canvas.locationWarningsTitle',
-                {
-                  defaultMessage:
-                    'Saved, but {count, plural, one {# location} other {# locations}} reported errors.',
-                  values: { count: saveState.locationWarnings.length },
-                }
-              )}
-            >
-              <ul>
-                {saveState.locationWarnings.map((warning) => (
-                  <li key={warning.locationId}>
-                    <strong>{warning.locationId}</strong>: {warning.message}
-                  </li>
-                ))}
-              </ul>
-            </EuiCallOut>
-          </>
-        ) : null}
-
-        <EuiSpacer size="m" />
-
-        {/*
-         * Body layout intentionally mirrors `MetricItemBody` from the
-         * Synthetics Overview tile: prominent target (URL), then a
-         * single chip row that aggregates schedule + locations + tags
-         * + paused-state. Avoids the visual weight of a description
-         * list while still surfacing every field the user needs to
-         * sanity-check before clicking Create.
-         */}
-        <div data-test-subj="syntheticsMonitorAttachmentCanvasDetails">
-          <EuiFlexGroup
-            gutterSize="s"
-            alignItems="center"
-            responsive={false}
-            data-test-subj="syntheticsMonitorAttachmentCanvasUrl"
-          >
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="link" size="s" color="subdued" aria-hidden={true} />
+              <MonitorStatusDot status={status} />
             </EuiFlexItem>
-            <EuiFlexItem>
-              {url ? (
-                <EuiLink
-                  href={url}
-                  external
-                  target="_blank"
-                  data-test-subj="syntheticsMonitorAttachmentCanvasUrlLink"
+            <EuiFlexItem
+              css={css`
+                min-width: 0;
+              `}
+            >
+              <EuiTitle size="m">
+                <h2
+                  data-test-subj="syntheticsMonitorAttachmentCanvasTitle"
+                  css={css`
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  `}
                 >
-                  {url}
-                </EuiLink>
-              ) : (
-                <EuiText size="s" color="subdued">
-                  {i18n.translate(
-                    'xpack.synthetics.agentBuilder.monitor.canvas.fields.urlUnset',
-                    { defaultMessage: 'No URL set' }
-                  )}
-                </EuiText>
-              )}
+                  {tileTitle}
+                </h2>
+              </EuiTitle>
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          <EuiSpacer size="s" />
+          <EuiSpacer size="xs" />
 
-          <EuiBadgeGroup
-            gutterSize="xs"
-            data-test-subj="syntheticsMonitorAttachmentCanvasMeta"
+          <EuiText
+            size="s"
+            color="subdued"
+            data-test-subj="syntheticsMonitorAttachmentCanvasCaption"
           >
-            <EuiBadge color="hollow" iconType="clock">
-              {formatScheduleLabel(data[ConfigKey.SCHEDULE])}
-            </EuiBadge>
-            {(data[ConfigKey.LOCATIONS] ?? []).map((location) => (
-              <EuiBadge key={location.id} color="hollow" iconType="visMapCoordinate">
-                {formatLocationLabel(location)}
-              </EuiBadge>
-            ))}
-            {(data[ConfigKey.LOCATIONS] ?? []).length === 0 ? (
-              <EuiBadge color="hollow" iconType="visMapCoordinate">
-                {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.locationsUnset', {
-                  defaultMessage: 'No locations selected',
-                })}
-              </EuiBadge>
-            ) : null}
-            {(data[ConfigKey.TAGS] ?? []).map((tag) => (
-              <EuiBadge key={tag} color="hollow">
-                {tag}
-              </EuiBadge>
-            ))}
-            {!data[ConfigKey.ENABLED] && status !== 'cli-managed' ? (
-              <EuiBadge
-                color="default"
-                iconType="pause"
-                data-test-subj="syntheticsMonitorAttachmentCanvasPausedBadge"
-              >
-                {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.pausedBadge', {
-                  defaultMessage: 'Paused',
-                })}
-              </EuiBadge>
-            ) : null}
-          </EuiBadgeGroup>
-        </div>
+            <p
+              css={css`
+                margin: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              `}
+            >
+              {caption}
+              {url ? (
+                <>
+                  {' · '}
+                  <EuiLink
+                    href={url}
+                    external
+                    target="_blank"
+                    data-test-subj="syntheticsMonitorAttachmentCanvasUrl"
+                  >
+                    <EuiIcon type="link" size="s" aria-hidden={true} /> {url}
+                  </EuiLink>
+                </>
+              ) : null}
+            </p>
+          </EuiText>
 
-        {actionButtons.length > 0 ? (
-          <>
-            <EuiHorizontalRule margin="m" />
-            <ActionFooter buttons={actionButtons} isSaving={saveState.isSaving} />
-          </>
-        ) : null}
-      </EuiPanel>
+          <EuiSpacer size="m" />
+
+          <div data-test-subj="syntheticsMonitorAttachmentCanvasDetails">
+            <MonitorChipRow data={data} />
+          </div>
+        </EuiPanel>
+      </div>
+
+      {status === 'cli-managed' ? (
+        <>
+          <EuiSpacer size="m" />
+          <EuiCallOut
+            size="s"
+            color="warning"
+            iconType="warning"
+            announceOnMount
+            data-test-subj="syntheticsMonitorAttachmentCanvasCliManagedCallout"
+            title={i18n.translate(
+              'xpack.synthetics.agentBuilder.monitor.canvas.cliManagedTitle',
+              { defaultMessage: 'CLI-managed monitor' }
+            )}
+          >
+            <p>
+              {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.cliManagedBody', {
+                defaultMessage:
+                  'This monitor was created via the synthetics CLI and is read-only here. To edit it, update the project source and re-push with `@elastic/synthetics push`.',
+              })}
+            </p>
+          </EuiCallOut>
+        </>
+      ) : null}
+
+      {saveState.saveError ? (
+        <>
+          <EuiSpacer size="m" />
+          <EuiCallOut
+            size="s"
+            color="danger"
+            iconType="error"
+            announceOnMount
+            data-test-subj="syntheticsMonitorAttachmentCanvasSaveError"
+            title={i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.saveErrorTitle', {
+              defaultMessage: 'Save failed',
+            })}
+          >
+            <p>{saveState.saveError.message}</p>
+          </EuiCallOut>
+        </>
+      ) : null}
+
+      {saveState.locationWarnings.length > 0 ? (
+        <>
+          <EuiSpacer size="m" />
+          <EuiCallOut
+            size="s"
+            color="warning"
+            iconType="warning"
+            announceOnMount
+            data-test-subj="syntheticsMonitorAttachmentCanvasLocationWarnings"
+            title={i18n.translate(
+              'xpack.synthetics.agentBuilder.monitor.canvas.locationWarningsTitle',
+              {
+                defaultMessage:
+                  'Saved, but {count, plural, one {# location} other {# locations}} reported errors.',
+                values: { count: saveState.locationWarnings.length },
+              }
+            )}
+          >
+            <ul>
+              {saveState.locationWarnings.map((warning) => (
+                <li key={warning.locationId}>
+                  <strong>{warning.locationId}</strong>: {warning.message}
+                </li>
+              ))}
+            </ul>
+          </EuiCallOut>
+        </>
+      ) : null}
+
+      {actionButtons.length > 0 ? (
+        <>
+          <EuiSpacer size="m" />
+          <ActionFooter buttons={actionButtons} isSaving={saveState.isSaving} />
+        </>
+      ) : null}
     </div>
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -36,6 +37,7 @@ import {
   inferMonitorStatus,
 } from './monitor_management_status';
 import {
+  projectMonitorWithLastSaved,
   useMonitorCanvasActions,
   type MonitorCanvasSaveState,
 } from './use_monitor_canvas_actions';
@@ -180,9 +182,6 @@ export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasCon
   closeCanvas,
 }) => {
   const { euiTheme } = useEuiTheme();
-  const status = inferMonitorStatus(data);
-  const tileBg = getStatusBackgroundColor(status, euiTheme);
-  const accentColor = getStatusAccentColor(status, euiTheme);
 
   const capabilities = application.capabilities;
   const canEdit = capabilities.uptime?.save === true;
@@ -195,8 +194,26 @@ export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasCon
     locationWarnings: [],
   });
 
+  // After a successful Create the framework's `updateOrigin` writes
+  // the new origin onto the attachment record but **does not refresh
+  // the data snapshot** (see followup F14). Without this projection
+  // the canvas would keep inferring `'proposed'` from the stale data
+  // and the user would see **Create** even though Synthetics already
+  // owns the monitor — a second click would round-trip to the
+  // duplicate-name error. `projectMonitorWithLastSaved` overlays the
+  // captured `config_id` only when the name + url still match the
+  // saved monitor, so the override doesn't bleed across attachments.
+  const effectiveData = useMemo(
+    () => projectMonitorWithLastSaved(data, saveState.lastSaved),
+    [data, saveState.lastSaved]
+  );
+
+  const status = inferMonitorStatus(effectiveData);
+  const tileBg = getStatusBackgroundColor(status, euiTheme);
+  const accentColor = getStatusAccentColor(status, euiTheme);
+
   const actionButtons = useMonitorCanvasActions({
-    monitor: data,
+    monitor: effectiveData,
     canEdit,
     canUseElasticManaged,
     http,
@@ -214,8 +231,8 @@ export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasCon
     registerActionButtons([]);
   }, [registerActionButtons]);
 
-  const monitorName = data[ConfigKey.NAME];
-  const url = data[ConfigKey.URLS];
+  const monitorName = effectiveData[ConfigKey.NAME];
+  const url = effectiveData[ConfigKey.URLS];
   const placeholderName = i18n.translate(
     'xpack.synthetics.agentBuilder.monitor.canvas.placeholderName',
     { defaultMessage: 'Untitled monitor' }
@@ -236,6 +253,38 @@ export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasCon
         padding: 0 ${euiTheme.size.m} ${euiTheme.size.m};
       `}
     >
+      {/*
+        Local close affordance.
+
+        The framework's `AttachmentHeader` (which normally renders the
+        flyout title + close X) bails out with `return null` when
+        `actionButtons.length === 0` — and we register an empty array so
+        the framework header stays clean while we render the
+        Create / Update / View buttons in our own body footer
+        (T7 hot-fix #4 in `tasks.md`). Side effect: no framework
+        header → no framework close X → users can only escape via
+        outside-click / Escape, which isn't discoverable. Add a small
+        close button at the top of the body so the affordance is
+        always visible. Tracked as F13 in `followups.md` — the proper
+        fix is in the platform's `attachment_header.tsx` to always
+        render the close X.
+      */}
+      <EuiFlexGroup justifyContent="flexEnd" gutterSize="none" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            data-test-subj="syntheticsMonitorAttachmentCanvasCloseButton"
+            aria-label={i18n.translate(
+              'xpack.synthetics.agentBuilder.monitor.canvas.closeAriaLabel',
+              { defaultMessage: 'Close monitor preview' }
+            )}
+            iconType="cross"
+            color="text"
+            size="xs"
+            onClick={closeCanvas}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
       {/*
         Outer fixed-height shell mirrors the Overview tile (`MetricItem`):
         180px tall panel, the status-tinted background fills the entire
@@ -321,7 +370,7 @@ export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasCon
           <EuiSpacer size="m" />
 
           <div data-test-subj="syntheticsMonitorAttachmentCanvasDetails">
-            <MonitorChipRow data={data} />
+            <MonitorChipRow data={effectiveData} />
           </div>
         </EuiPanel>
       </div>
@@ -335,10 +384,9 @@ export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasCon
             iconType="warning"
             announceOnMount
             data-test-subj="syntheticsMonitorAttachmentCanvasCliManagedCallout"
-            title={i18n.translate(
-              'xpack.synthetics.agentBuilder.monitor.canvas.cliManagedTitle',
-              { defaultMessage: 'CLI-managed monitor' }
-            )}
+            title={i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.cliManagedTitle', {
+              defaultMessage: 'CLI-managed monitor',
+            })}
           >
             <p>
               {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.cliManagedBody', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_canvas_content.tsx
@@ -1,0 +1,458 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  EuiBadge,
+  EuiBadgeGroup,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiLink,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { type ActionButton, ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { ApplicationStart, HttpStart } from '@kbn/core/public';
+import { ConfigKey } from '../../../common/runtime_types';
+import type { ScheduleUnit } from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+import {
+  MonitorTypeChip,
+  STATUS_BADGE_COLORS,
+  getStatusBackgroundColor,
+  getStatusCaption,
+  getStatusLabel,
+  inferMonitorStatus,
+} from './monitor_management_status';
+import {
+  useMonitorCanvasActions,
+  type MonitorCanvasSaveState,
+} from './use_monitor_canvas_actions';
+
+export interface MonitorManagementCanvasContentProps {
+  /** The current attachment payload. */
+  data: MonitorAttachmentData;
+  /** Browser HTTP client (forwarded to actions). */
+  http: HttpStart;
+  /** Application contract for capability lookup + navigation. */
+  application: ApplicationStart;
+  /**
+   * Framework canvas callback — registers buttons in the flyout header.
+   * We deliberately register an empty array to keep the header clean and
+   * render Create/Update/View as proper `EuiButton`s in the body footer
+   * instead. See `useMonitorCanvasActions` for the rationale.
+   */
+  registerActionButtons: (buttons: ActionButton[]) => void;
+  /** Framework canvas callback — invoked after a clean Create. */
+  updateOrigin: (origin: string) => Promise<unknown>;
+  /** Framework canvas callback — closes the flyout. */
+  closeCanvas: () => void;
+}
+
+const formatScheduleLabel = (
+  schedule: { number: string; unit: ScheduleUnit } | undefined
+): string => {
+  if (!schedule) {
+    return i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.scheduleUnset', {
+      defaultMessage: 'Schedule not set',
+    });
+  }
+  return i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.scheduleValue', {
+    defaultMessage: 'Every {number} {unit}',
+    values: { number: schedule.number, unit: schedule.unit },
+  });
+};
+
+const formatLocationLabel = (location: {
+  id: string;
+  label?: string;
+  isServiceManaged?: boolean;
+}): string => {
+  const labelText = location.label ?? location.id;
+  if (location.isServiceManaged) {
+    return i18n.translate(
+      'xpack.synthetics.agentBuilder.monitor.canvas.locations.elasticManagedLabel',
+      {
+        defaultMessage: '{label} (Elastic-managed)',
+        values: { label: labelText },
+      }
+    );
+  }
+  return labelText;
+};
+
+interface ActionFooterProps {
+  buttons: ActionButton[];
+  isSaving: boolean;
+}
+
+/**
+ * Renders the Create / Update / View buttons returned by
+ * `useMonitorCanvasActions` as proper EUI buttons in the canvas body
+ * footer. PRIMARY → `EuiButton fill`, SECONDARY → `EuiButtonEmpty`.
+ *
+ * `disabledReason` is wrapped in an `EuiToolTip` so we don't lose the
+ * affordance the framework's `ActionButton` shape promises.
+ */
+const ActionFooter: React.FC<ActionFooterProps> = ({ buttons, isSaving }) => {
+  if (buttons.length === 0) {
+    return null;
+  }
+  return (
+    <EuiFlexGroup
+      gutterSize="s"
+      justifyContent="flexEnd"
+      responsive={false}
+      data-test-subj="syntheticsMonitorAttachmentCanvasActions"
+    >
+      {buttons.map((button) => {
+        const isPrimary = button.type === ActionButtonType.PRIMARY;
+        const onClick = () => {
+          void button.handler();
+        };
+        const button$ = isPrimary ? (
+          <EuiButton
+            fill
+            color="primary"
+            size="m"
+            iconType={button.icon}
+            isLoading={isSaving && button.icon === 'save'}
+            disabled={Boolean(button.disabled)}
+            onClick={onClick}
+            data-test-subj={`syntheticsMonitorAttachmentCanvasAction-${button.icon}`}
+          >
+            {button.label}
+          </EuiButton>
+        ) : (
+          <EuiButtonEmpty
+            color="primary"
+            size="m"
+            iconType={button.icon}
+            disabled={Boolean(button.disabled)}
+            onClick={onClick}
+            data-test-subj={`syntheticsMonitorAttachmentCanvasAction-${button.icon}`}
+          >
+            {button.label}
+          </EuiButtonEmpty>
+        );
+        return (
+          <EuiFlexItem grow={false} key={button.label}>
+            {button.disabled && button.disabledReason ? (
+              <EuiToolTip content={button.disabledReason}>
+                <span>{button$}</span>
+              </EuiToolTip>
+            ) : (
+              button$
+            )}
+          </EuiFlexItem>
+        );
+      })}
+    </EuiFlexGroup>
+  );
+};
+
+/**
+ * Canvas body for the `MONITOR_MANAGEMENT_ATTACHMENT_TYPE` attachment.
+ *
+ * Visual treatment intentionally mirrors the Synthetics Overview tile
+ * (`MetricItem`): the panel itself is washed with a status-tinted
+ * background, the title sits prominent at the top, and the type chip
+ * + tags ride in a dedicated chip row. We deliberately do **not**
+ * inherit the heavy bits of `MetricItem` — sparkline trend chart,
+ * latency metric, errors popover, actions popover — because:
+ *
+ * - Those depend on heartbeat data + Redux selectors that have no
+ *   meaning for a `proposed` (unsaved) monitor.
+ * - The flyout context is detail-oriented; cramming a sparkline into
+ *   it duplicates the Synthetics Overview without adding new info.
+ *
+ * Read-only by design: the user mutates the attachment via chat
+ * (re-running `manage_synthetics_monitor` operations), then commits
+ * the result via the action footer. Editing inline here would
+ * require duplicating the synthetics monitor form and its validation
+ * surface, which is out of scope for v1.
+ *
+ * Action placement (T7 hot-fix #4): the Create / Update / View
+ * buttons live **inside the panel footer**, not in the framework's
+ * flyout header. That decision is rationalised in the
+ * `useMonitorCanvasActions` doc comment. We still call
+ * `registerActionButtons([])` once per mount to clear any header
+ * buttons the framework may have carried over from a previous
+ * canvas attachment.
+ *
+ * Tree-shake hygiene: like the inline content body, this file only
+ * imports `@elastic/eui`, `@emotion/react`, `@kbn/i18n`,
+ * `@kbn/agent-builder-browser`, `@kbn/core/public`, types from
+ * `common/`, and the shared `monitor_management_status` /
+ * `monitor_management_actions` / `use_monitor_canvas_actions`
+ * helpers in this folder. **Do not** pull in monitor-form or anything
+ * from `apps/synthetics/components/`.
+ */
+export const MonitorManagementCanvasContent: React.FC<MonitorManagementCanvasContentProps> = ({
+  data,
+  http,
+  application,
+  registerActionButtons,
+  updateOrigin,
+  closeCanvas,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const status = inferMonitorStatus(data);
+  const tileBg = getStatusBackgroundColor(status, euiTheme);
+
+  const capabilities = application.capabilities;
+  const canEdit = capabilities.uptime?.save === true;
+  const canUseElasticManaged = (capabilities.uptime?.elasticManagedLocationsEnabled ??
+    true) as boolean;
+
+  const [saveState, setSaveState] = useState<MonitorCanvasSaveState>({
+    isSaving: false,
+    saveError: null,
+    locationWarnings: [],
+  });
+
+  const actionButtons = useMonitorCanvasActions({
+    monitor: data,
+    canEdit,
+    canUseElasticManaged,
+    http,
+    application,
+    updateOrigin,
+    closeCanvas,
+    setSaveState,
+  });
+
+  // Keep the framework header buttons clear — the action footer below
+  // owns the Create / Update / View affordance now. We still need to
+  // call `registerActionButtons` (rather than no-op) because the
+  // framework may have leftover buttons from a previous attachment.
+  useEffect(() => {
+    registerActionButtons([]);
+  }, [registerActionButtons]);
+
+  const monitorName = data[ConfigKey.NAME];
+  const url = data[ConfigKey.URLS];
+
+  return (
+    <div data-test-subj="syntheticsMonitorAttachmentCanvas" data-test-status={status}>
+      <EuiPanel
+        paddingSize="l"
+        hasBorder
+        hasShadow={false}
+        css={css`
+          background-color: ${tileBg};
+        `}
+      >
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+          <EuiFlexItem grow={false}>
+            <EuiBadge
+              color={STATUS_BADGE_COLORS[status]}
+              data-test-subj={`syntheticsMonitorAttachmentCanvasStatus-${status}`}
+            >
+              {getStatusLabel(status)}
+            </EuiBadge>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <MonitorTypeChip type={data[ConfigKey.MONITOR_TYPE]} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer size="s" />
+
+        <EuiTitle size="m">
+          <h2 data-test-subj="syntheticsMonitorAttachmentCanvasTitle">
+            {monitorName && monitorName.length > 0
+              ? monitorName
+              : i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.placeholderName', {
+                  defaultMessage: 'Untitled monitor',
+                })}
+          </h2>
+        </EuiTitle>
+
+        <EuiSpacer size="xs" />
+
+        <EuiText
+          size="s"
+          color="subdued"
+          data-test-subj="syntheticsMonitorAttachmentCanvasCaption"
+        >
+          {getStatusCaption(status)}
+        </EuiText>
+
+        {status === 'cli-managed' ? (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              size="s"
+              color="warning"
+              iconType="warning"
+              announceOnMount
+              data-test-subj="syntheticsMonitorAttachmentCanvasCliManagedCallout"
+              title={i18n.translate(
+                'xpack.synthetics.agentBuilder.monitor.canvas.cliManagedTitle',
+                { defaultMessage: 'CLI-managed monitor' }
+              )}
+            >
+              <p>
+                {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.cliManagedBody', {
+                  defaultMessage:
+                    'This monitor was created via the synthetics CLI and is read-only here. To edit it, update the project source and re-push with `@elastic/synthetics push`.',
+                })}
+              </p>
+            </EuiCallOut>
+          </>
+        ) : null}
+
+        {saveState.saveError ? (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              size="s"
+              color="danger"
+              iconType="error"
+              announceOnMount
+              data-test-subj="syntheticsMonitorAttachmentCanvasSaveError"
+              title={i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.saveErrorTitle', {
+                defaultMessage: 'Save failed',
+              })}
+            >
+              <p>{saveState.saveError.message}</p>
+            </EuiCallOut>
+          </>
+        ) : null}
+
+        {saveState.locationWarnings.length > 0 ? (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              size="s"
+              color="warning"
+              iconType="warning"
+              announceOnMount
+              data-test-subj="syntheticsMonitorAttachmentCanvasLocationWarnings"
+              title={i18n.translate(
+                'xpack.synthetics.agentBuilder.monitor.canvas.locationWarningsTitle',
+                {
+                  defaultMessage:
+                    'Saved, but {count, plural, one {# location} other {# locations}} reported errors.',
+                  values: { count: saveState.locationWarnings.length },
+                }
+              )}
+            >
+              <ul>
+                {saveState.locationWarnings.map((warning) => (
+                  <li key={warning.locationId}>
+                    <strong>{warning.locationId}</strong>: {warning.message}
+                  </li>
+                ))}
+              </ul>
+            </EuiCallOut>
+          </>
+        ) : null}
+
+        <EuiSpacer size="m" />
+
+        {/*
+         * Body layout intentionally mirrors `MetricItemBody` from the
+         * Synthetics Overview tile: prominent target (URL), then a
+         * single chip row that aggregates schedule + locations + tags
+         * + paused-state. Avoids the visual weight of a description
+         * list while still surfacing every field the user needs to
+         * sanity-check before clicking Create.
+         */}
+        <div data-test-subj="syntheticsMonitorAttachmentCanvasDetails">
+          <EuiFlexGroup
+            gutterSize="s"
+            alignItems="center"
+            responsive={false}
+            data-test-subj="syntheticsMonitorAttachmentCanvasUrl"
+          >
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="link" size="s" color="subdued" aria-hidden={true} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              {url ? (
+                <EuiLink
+                  href={url}
+                  external
+                  target="_blank"
+                  data-test-subj="syntheticsMonitorAttachmentCanvasUrlLink"
+                >
+                  {url}
+                </EuiLink>
+              ) : (
+                <EuiText size="s" color="subdued">
+                  {i18n.translate(
+                    'xpack.synthetics.agentBuilder.monitor.canvas.fields.urlUnset',
+                    { defaultMessage: 'No URL set' }
+                  )}
+                </EuiText>
+              )}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+
+          <EuiSpacer size="s" />
+
+          <EuiBadgeGroup
+            gutterSize="xs"
+            data-test-subj="syntheticsMonitorAttachmentCanvasMeta"
+          >
+            <EuiBadge color="hollow" iconType="clock">
+              {formatScheduleLabel(data[ConfigKey.SCHEDULE])}
+            </EuiBadge>
+            {(data[ConfigKey.LOCATIONS] ?? []).map((location) => (
+              <EuiBadge key={location.id} color="hollow" iconType="visMapCoordinate">
+                {formatLocationLabel(location)}
+              </EuiBadge>
+            ))}
+            {(data[ConfigKey.LOCATIONS] ?? []).length === 0 ? (
+              <EuiBadge color="hollow" iconType="visMapCoordinate">
+                {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.locationsUnset', {
+                  defaultMessage: 'No locations selected',
+                })}
+              </EuiBadge>
+            ) : null}
+            {(data[ConfigKey.TAGS] ?? []).map((tag) => (
+              <EuiBadge key={tag} color="hollow">
+                {tag}
+              </EuiBadge>
+            ))}
+            {!data[ConfigKey.ENABLED] && status !== 'cli-managed' ? (
+              <EuiBadge
+                color="default"
+                iconType="pause"
+                data-test-subj="syntheticsMonitorAttachmentCanvasPausedBadge"
+              >
+                {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.pausedBadge', {
+                  defaultMessage: 'Paused',
+                })}
+              </EuiBadge>
+            ) : null}
+          </EuiBadgeGroup>
+        </div>
+
+        {actionButtons.length > 0 ? (
+          <>
+            <EuiHorizontalRule margin="m" />
+            <ActionFooter buttons={actionButtons} isSaving={saveState.isSaving} />
+          </>
+        ) : null}
+      </EuiPanel>
+    </div>
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_inline_content.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_inline_content.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { ConfigKey } from '../../../common/runtime_types';
 import {
   MonitorTypeEnum,
@@ -28,13 +28,15 @@ const buildData = (overrides: Partial<MonitorAttachmentData> = {}): MonitorAttac
 });
 
 describe('MonitorManagementInlineContent', () => {
-  describe('status badge', () => {
-    it('renders a "Proposed" badge when there is no config_id', () => {
+  describe('header (status dot + title)', () => {
+    it('renders the status dot for proposed monitors', () => {
       render(<MonitorManagementInlineContent data={buildData()} />);
-      expect(screen.getByTestId('syntheticsMonitorAttachmentStatus-proposed')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('syntheticsMonitorAttachmentStatusDot-proposed')
+      ).toBeInTheDocument();
     });
 
-    it('renders an "Enabled" badge when saved + enabled', () => {
+    it('renders the status dot for saved+enabled monitors', () => {
       render(
         <MonitorManagementInlineContent
           data={buildData({
@@ -43,10 +45,12 @@ describe('MonitorManagementInlineContent', () => {
           })}
         />
       );
-      expect(screen.getByTestId('syntheticsMonitorAttachmentStatus-enabled')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('syntheticsMonitorAttachmentStatusDot-enabled')
+      ).toBeInTheDocument();
     });
 
-    it('renders a "Disabled" badge when saved + disabled', () => {
+    it('renders the status dot for saved+disabled monitors', () => {
       render(
         <MonitorManagementInlineContent
           data={buildData({
@@ -55,10 +59,12 @@ describe('MonitorManagementInlineContent', () => {
           })}
         />
       );
-      expect(screen.getByTestId('syntheticsMonitorAttachmentStatus-disabled')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('syntheticsMonitorAttachmentStatusDot-disabled')
+      ).toBeInTheDocument();
     });
 
-    it('renders a "CLI-managed" badge for project-origin monitors regardless of enabled flag', () => {
+    it('renders the status dot for CLI-managed monitors regardless of enabled flag', () => {
       render(
         <MonitorManagementInlineContent
           data={buildData({
@@ -69,16 +75,57 @@ describe('MonitorManagementInlineContent', () => {
         />
       );
       expect(
-        screen.getByTestId('syntheticsMonitorAttachmentStatus-cli-managed')
+        screen.getByTestId('syntheticsMonitorAttachmentStatusDot-cli-managed')
       ).toBeInTheDocument();
+    });
+
+    it('shows the monitor name in the title', () => {
+      render(<MonitorManagementInlineContent data={buildData()} />);
+      expect(screen.getByTestId('syntheticsMonitorAttachmentInlineTitle')).toHaveTextContent(
+        'Test monitor'
+      );
+    });
+
+    it('falls back to a placeholder title when name is empty', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({ [ConfigKey.NAME]: '' as unknown as string })}
+        />
+      );
+      expect(screen.getByTestId('syntheticsMonitorAttachmentInlineTitle')).toHaveTextContent(
+        'Untitled monitor'
+      );
     });
   });
 
-  describe('type chip', () => {
-    it('renders an HTTP chip for HTTP monitors', () => {
+  describe('subtitle row', () => {
+    it('shows the URL when present', () => {
       render(<MonitorManagementInlineContent data={buildData()} />);
-      const chip = screen.getByTestId('syntheticsMonitorAttachmentType');
-      expect(chip).toHaveTextContent('HTTP');
+      expect(screen.getByTestId('syntheticsMonitorAttachmentInlineUrl')).toHaveTextContent(
+        'https://example.com'
+      );
+    });
+
+    it('falls back to the lifecycle caption when URL is missing', () => {
+      const partial = { ...buildData() } as MonitorAttachmentData;
+      delete (partial as Partial<MonitorAttachmentData>)[ConfigKey.URLS];
+      render(<MonitorManagementInlineContent data={partial} />);
+      expect(screen.queryByTestId('syntheticsMonitorAttachmentInlineUrl')).not.toBeInTheDocument();
+      expect(screen.getByTestId('syntheticsMonitorAttachmentInlineSubtitle')).toHaveTextContent(
+        'Draft monitor — not yet saved to Synthetics.'
+      );
+    });
+  });
+
+  describe('chip row (MonitorChipRow)', () => {
+    it('renders the type chip, schedule, and location badges', () => {
+      render(<MonitorManagementInlineContent data={buildData()} />);
+      const chipRow = screen.getByTestId('syntheticsMonitorAttachmentCanvasMeta');
+      expect(within(chipRow).getByTestId('syntheticsMonitorAttachmentType')).toHaveTextContent(
+        'HTTP'
+      );
+      expect(chipRow).toHaveTextContent('Every 5 m');
+      expect(chipRow).toHaveTextContent('US Central (Elastic-managed)');
     });
 
     // v1's `MonitorAttachmentData` schema is HTTP-only
@@ -102,11 +149,37 @@ describe('MonitorManagementInlineContent', () => {
       );
     });
 
-    it('falls back to a generic "Monitor" label when the type is missing', () => {
+    it('falls back to a generic "Monitor" type chip when the type is missing', () => {
       const partial = { ...buildData() } as MonitorAttachmentData;
       delete (partial as Partial<MonitorAttachmentData>)[ConfigKey.MONITOR_TYPE];
       render(<MonitorManagementInlineContent data={partial} />);
       expect(screen.getByTestId('syntheticsMonitorAttachmentType')).toHaveTextContent('Monitor');
+    });
+
+    it('renders one chip per tag', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({ [ConfigKey.TAGS]: ['team-a', 'prod', 'staging'] })}
+        />
+      );
+      const chipRow = screen.getByTestId('syntheticsMonitorAttachmentCanvasMeta');
+      expect(chipRow).toHaveTextContent('team-a');
+      expect(chipRow).toHaveTextContent('prod');
+      expect(chipRow).toHaveTextContent('staging');
+    });
+
+    it('renders a "Paused" badge for saved+disabled monitors', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({
+            [ConfigKey.CONFIG_ID]: 'config-uuid',
+            [ConfigKey.ENABLED]: false,
+          })}
+        />
+      );
+      expect(
+        screen.getByTestId('syntheticsMonitorAttachmentCanvasPausedBadge')
+      ).toBeInTheDocument();
     });
   });
 
@@ -132,77 +205,6 @@ describe('MonitorManagementInlineContent', () => {
         'data-test-status',
         'disabled'
       );
-    });
-  });
-
-  describe('meta block', () => {
-    it('renders schedule, locations, and url', () => {
-      render(<MonitorManagementInlineContent data={buildData()} />);
-
-      expect(screen.getByTestId('syntheticsMonitorAttachmentSchedule')).toHaveTextContent(
-        'every 5m'
-      );
-      expect(screen.getByTestId('syntheticsMonitorAttachmentLocations')).toHaveTextContent(
-        '1 location'
-      );
-      expect(screen.getByTestId('syntheticsMonitorAttachmentUrl')).toHaveTextContent(
-        'https://example.com'
-      );
-    });
-
-    it('pluralizes locations correctly', () => {
-      render(
-        <MonitorManagementInlineContent
-          data={buildData({
-            [ConfigKey.LOCATIONS]: [
-              { id: 'us_central', isServiceManaged: true },
-              { id: 'eu_west', isServiceManaged: true },
-            ],
-          })}
-        />
-      );
-      expect(screen.getByTestId('syntheticsMonitorAttachmentLocations')).toHaveTextContent(
-        '2 locations'
-      );
-    });
-
-    it('renders "not set" when schedule is missing', () => {
-      const partial = {
-        ...buildData(),
-      } as MonitorAttachmentData;
-      // simulate an in-flight draft promoted to attachment-shape: schedule missing
-      delete (partial as Partial<MonitorAttachmentData>)[ConfigKey.SCHEDULE];
-      render(<MonitorManagementInlineContent data={partial} />);
-      expect(screen.getByTestId('syntheticsMonitorAttachmentSchedule')).toHaveTextContent(
-        'not set'
-      );
-    });
-
-    it('omits the URL row when urls is empty', () => {
-      const partial = { ...buildData() } as MonitorAttachmentData;
-      delete (partial as Partial<MonitorAttachmentData>)[ConfigKey.URLS];
-      render(<MonitorManagementInlineContent data={partial} />);
-      expect(screen.queryByTestId('syntheticsMonitorAttachmentUrl')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('tags', () => {
-    it('does not render the tag row when tags is empty', () => {
-      render(<MonitorManagementInlineContent data={buildData()} />);
-      expect(screen.queryByTestId('syntheticsMonitorAttachmentTags')).not.toBeInTheDocument();
-    });
-
-    it('renders one badge per tag', () => {
-      render(
-        <MonitorManagementInlineContent
-          data={buildData({ [ConfigKey.TAGS]: ['team-a', 'prod', 'staging'] })}
-        />
-      );
-      const tagsContainer = screen.getByTestId('syntheticsMonitorAttachmentTags');
-      expect(tagsContainer).toBeInTheDocument();
-      expect(tagsContainer).toHaveTextContent('team-a');
-      expect(tagsContainer).toHaveTextContent('prod');
-      expect(tagsContainer).toHaveTextContent('staging');
     });
   });
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_inline_content.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_inline_content.test.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ConfigKey } from '../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+import { MonitorManagementInlineContent } from './monitor_management_inline_content';
+
+const buildData = (overrides: Partial<MonitorAttachmentData> = {}): MonitorAttachmentData => ({
+  [ConfigKey.NAME]: 'Test monitor',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [{ id: 'us_central', label: 'US Central', isServiceManaged: true }],
+  [ConfigKey.URLS]: 'https://example.com',
+  [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+  ...overrides,
+});
+
+describe('MonitorManagementInlineContent', () => {
+  describe('status badge', () => {
+    it('renders a "Proposed" badge when there is no config_id', () => {
+      render(<MonitorManagementInlineContent data={buildData()} />);
+      expect(screen.getByTestId('syntheticsMonitorAttachmentStatus-proposed')).toBeInTheDocument();
+    });
+
+    it('renders an "Enabled" badge when saved + enabled', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({
+            [ConfigKey.CONFIG_ID]: 'config-uuid',
+            [ConfigKey.ENABLED]: true,
+          })}
+        />
+      );
+      expect(screen.getByTestId('syntheticsMonitorAttachmentStatus-enabled')).toBeInTheDocument();
+    });
+
+    it('renders a "Disabled" badge when saved + disabled', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({
+            [ConfigKey.CONFIG_ID]: 'config-uuid',
+            [ConfigKey.ENABLED]: false,
+          })}
+        />
+      );
+      expect(screen.getByTestId('syntheticsMonitorAttachmentStatus-disabled')).toBeInTheDocument();
+    });
+
+    it('renders a "CLI-managed" badge for project-origin monitors regardless of enabled flag', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({
+            [ConfigKey.CONFIG_ID]: 'config-uuid',
+            [ConfigKey.ENABLED]: true,
+            [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.PROJECT,
+          })}
+        />
+      );
+      expect(
+        screen.getByTestId('syntheticsMonitorAttachmentStatus-cli-managed')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('type chip', () => {
+    it('renders an HTTP chip for HTTP monitors', () => {
+      render(<MonitorManagementInlineContent data={buildData()} />);
+      const chip = screen.getByTestId('syntheticsMonitorAttachmentType');
+      expect(chip).toHaveTextContent('HTTP');
+    });
+
+    // v1's `MonitorAttachmentData` schema is HTTP-only
+    // (`z.literal(MonitorTypeEnum.HTTP)`), so passing TCP/ICMP/BROWSER
+    // through `buildData(overrides)` would fail the static type check.
+    // We still want to exercise the chip's defensive rendering branches
+    // because T2's SML path can surface saved monitors of any type —
+    // once the schema widens to accept non-HTTP, these casts can drop.
+    it.each([
+      [MonitorTypeEnum.TCP, 'TCP'],
+      [MonitorTypeEnum.ICMP, 'ICMP'],
+      [MonitorTypeEnum.BROWSER, 'Journey'],
+    ])('renders %s monitors with label "%s"', (type, expectedLabel) => {
+      const data = {
+        ...buildData(),
+        [ConfigKey.MONITOR_TYPE]: type,
+      } as unknown as MonitorAttachmentData;
+      render(<MonitorManagementInlineContent data={data} />);
+      expect(screen.getByTestId('syntheticsMonitorAttachmentType')).toHaveTextContent(
+        expectedLabel
+      );
+    });
+
+    it('falls back to a generic "Monitor" label when the type is missing', () => {
+      const partial = { ...buildData() } as MonitorAttachmentData;
+      delete (partial as Partial<MonitorAttachmentData>)[ConfigKey.MONITOR_TYPE];
+      render(<MonitorManagementInlineContent data={partial} />);
+      expect(screen.getByTestId('syntheticsMonitorAttachmentType')).toHaveTextContent('Monitor');
+    });
+  });
+
+  describe('status accent', () => {
+    it('exposes the inferred status as a data attribute on the root', () => {
+      render(<MonitorManagementInlineContent data={buildData()} />);
+      expect(screen.getByTestId('syntheticsMonitorAttachmentInline')).toHaveAttribute(
+        'data-test-status',
+        'proposed'
+      );
+    });
+
+    it('reflects the saved-disabled status on the root', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({
+            [ConfigKey.CONFIG_ID]: 'config-uuid',
+            [ConfigKey.ENABLED]: false,
+          })}
+        />
+      );
+      expect(screen.getByTestId('syntheticsMonitorAttachmentInline')).toHaveAttribute(
+        'data-test-status',
+        'disabled'
+      );
+    });
+  });
+
+  describe('meta block', () => {
+    it('renders schedule, locations, and url', () => {
+      render(<MonitorManagementInlineContent data={buildData()} />);
+
+      expect(screen.getByTestId('syntheticsMonitorAttachmentSchedule')).toHaveTextContent(
+        'every 5m'
+      );
+      expect(screen.getByTestId('syntheticsMonitorAttachmentLocations')).toHaveTextContent(
+        '1 location'
+      );
+      expect(screen.getByTestId('syntheticsMonitorAttachmentUrl')).toHaveTextContent(
+        'https://example.com'
+      );
+    });
+
+    it('pluralizes locations correctly', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({
+            [ConfigKey.LOCATIONS]: [
+              { id: 'us_central', isServiceManaged: true },
+              { id: 'eu_west', isServiceManaged: true },
+            ],
+          })}
+        />
+      );
+      expect(screen.getByTestId('syntheticsMonitorAttachmentLocations')).toHaveTextContent(
+        '2 locations'
+      );
+    });
+
+    it('renders "not set" when schedule is missing', () => {
+      const partial = {
+        ...buildData(),
+      } as MonitorAttachmentData;
+      // simulate an in-flight draft promoted to attachment-shape: schedule missing
+      delete (partial as Partial<MonitorAttachmentData>)[ConfigKey.SCHEDULE];
+      render(<MonitorManagementInlineContent data={partial} />);
+      expect(screen.getByTestId('syntheticsMonitorAttachmentSchedule')).toHaveTextContent(
+        'not set'
+      );
+    });
+
+    it('omits the URL row when urls is empty', () => {
+      const partial = { ...buildData() } as MonitorAttachmentData;
+      delete (partial as Partial<MonitorAttachmentData>)[ConfigKey.URLS];
+      render(<MonitorManagementInlineContent data={partial} />);
+      expect(screen.queryByTestId('syntheticsMonitorAttachmentUrl')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('tags', () => {
+    it('does not render the tag row when tags is empty', () => {
+      render(<MonitorManagementInlineContent data={buildData()} />);
+      expect(screen.queryByTestId('syntheticsMonitorAttachmentTags')).not.toBeInTheDocument();
+    });
+
+    it('renders one badge per tag', () => {
+      render(
+        <MonitorManagementInlineContent
+          data={buildData({ [ConfigKey.TAGS]: ['team-a', 'prod', 'staging'] })}
+        />
+      );
+      const tagsContainer = screen.getByTestId('syntheticsMonitorAttachmentTags');
+      expect(tagsContainer).toBeInTheDocument();
+      expect(tagsContainer).toHaveTextContent('team-a');
+      expect(tagsContainer).toHaveTextContent('prod');
+      expect(tagsContainer).toHaveTextContent('staging');
+    });
+  });
+
+  it('does not crash on a minimal proposed draft (only required schema keys)', () => {
+    const minimal = buildData();
+    render(<MonitorManagementInlineContent data={minimal} />);
+    expect(screen.getByTestId('syntheticsMonitorAttachmentInline')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_inline_content.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_inline_content.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiBadgeGroup,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiSpacer,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { ConfigKey } from '../../../common/runtime_types';
+import type { ScheduleUnit } from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+import {
+  MonitorTypeChip,
+  STATUS_BADGE_COLORS,
+  getStatusAccentColor,
+  getStatusLabel,
+  inferMonitorStatus,
+} from './monitor_management_status';
+
+interface MetaItemProps {
+  iconType: string;
+  label: string;
+  value: string;
+  testSubj: string;
+}
+
+const MetaItem = ({ iconType, label, value, testSubj }: MetaItemProps) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <EuiFlexItem grow={false} data-test-subj={testSubj}>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiIcon
+            type={iconType}
+            size="s"
+            color={euiTheme.colors.subduedText}
+            aria-hidden={true}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            <strong>{label}</strong> {value}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+};
+
+const formatSchedule = (schedule: { number: string; unit: ScheduleUnit } | undefined): string => {
+  if (!schedule) {
+    return i18n.translate('xpack.synthetics.agentBuilder.monitor.scheduleNotSet', {
+      defaultMessage: 'not set',
+    });
+  }
+  return i18n.translate('xpack.synthetics.agentBuilder.monitor.scheduleValue', {
+    defaultMessage: 'every {number}{unit}',
+    values: { number: schedule.number, unit: schedule.unit },
+  });
+};
+
+export interface MonitorManagementInlineContentProps {
+  data: MonitorAttachmentData;
+}
+
+/**
+ * Inline card body for the `MONITOR_MANAGEMENT_ATTACHMENT_TYPE` attachment.
+ *
+ * Visual conventions intentionally borrow from the Synthetics Overview
+ * tile (`MetricItem`) without inheriting its data dependencies:
+ *
+ * - The left accent strip mirrors the Overview tile's status-coloured
+ *   panel background, but mapped onto our agent-side statuses
+ *   (`proposed` / `enabled` / `disabled` / `cli-managed`) which don't
+ *   correspond 1:1 to up/down heartbeat states.
+ * - `MonitorTypeChip` reproduces the Overview's `MonitorTypeBadge`
+ *   visual without dragging in router / Redux.
+ *
+ * What we deliberately **don't** render here (kept for the canvas, T7):
+ * sparkline trend, last-status icon, latency metric, error popover,
+ * actions popover, location flags. All of those depend on heartbeat
+ * data that doesn't exist for proposed monitors and would require
+ * pulling in `@elastic/charts` + the synthetics Redux store.
+ *
+ * No heading is rendered — the agent_builder framework already renders
+ * the attachment label/icon above the inline content slot, so a heading
+ * here would double up.
+ *
+ * Tree-shake hygiene: this file imports only `@elastic/eui`,
+ * `@emotion/react`, `@kbn/i18n`, types from `common/`, and the shared
+ * `monitor_management_status` helpers in the same folder. **Do not**
+ * pull in monitor-form or anything from `apps/synthetics/components/` —
+ * those would balloon the inline chunk.
+ */
+export const MonitorManagementInlineContent: React.FC<MonitorManagementInlineContentProps> = ({
+  data,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const status = inferMonitorStatus(data);
+  const accentColor = getStatusAccentColor(status, euiTheme);
+  const locations = data[ConfigKey.LOCATIONS] ?? [];
+  const tags = data[ConfigKey.TAGS] ?? [];
+  const url = data[ConfigKey.URLS];
+  const schedule = data[ConfigKey.SCHEDULE];
+  const monitorType = data[ConfigKey.MONITOR_TYPE];
+
+  const locationsLabel = i18n.translate('xpack.synthetics.agentBuilder.monitor.locationsCount', {
+    defaultMessage: '{count, plural, one {# location} other {# locations}}',
+    values: { count: locations.length },
+  });
+
+  return (
+    <div
+      data-test-subj="syntheticsMonitorAttachmentInline"
+      data-test-status={status}
+      css={css`
+        border-left: ${euiTheme.border.width.thick} solid ${accentColor};
+        padding: ${euiTheme.size.s} ${euiTheme.size.m};
+      `}
+    >
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+        <EuiFlexItem grow={false}>
+          <EuiBadge
+            color={STATUS_BADGE_COLORS[status]}
+            data-test-subj={`syntheticsMonitorAttachmentStatus-${status}`}
+          >
+            {getStatusLabel(status)}
+          </EuiBadge>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <MonitorTypeChip type={monitorType} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup gutterSize="m" wrap responsive={false}>
+        <MetaItem
+          iconType="clock"
+          testSubj="syntheticsMonitorAttachmentSchedule"
+          label={i18n.translate('xpack.synthetics.agentBuilder.monitor.scheduleLabel', {
+            defaultMessage: 'Schedule:',
+          })}
+          value={formatSchedule(schedule)}
+        />
+        <MetaItem
+          iconType="visMapCoordinate"
+          testSubj="syntheticsMonitorAttachmentLocations"
+          label={i18n.translate('xpack.synthetics.agentBuilder.monitor.locationsLabel', {
+            defaultMessage: 'Locations:',
+          })}
+          value={locationsLabel}
+        />
+        {url ? (
+          <MetaItem
+            iconType="link"
+            testSubj="syntheticsMonitorAttachmentUrl"
+            label={i18n.translate('xpack.synthetics.agentBuilder.monitor.urlLabel', {
+              defaultMessage: 'URL:',
+            })}
+            value={url}
+          />
+        ) : null}
+      </EuiFlexGroup>
+
+      {tags.length > 0 ? (
+        <>
+          <EuiSpacer size="s" />
+          <EuiBadgeGroup data-test-subj="syntheticsMonitorAttachmentTags">
+            {tags.map((tag) => (
+              <EuiBadge key={tag} color="hollow">
+                {tag}
+              </EuiBadge>
+            ))}
+          </EuiBadgeGroup>
+        </>
+      ) : null}
+    </div>
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_inline_content.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_inline_content.tsx
@@ -7,69 +7,25 @@
 
 import React from 'react';
 import {
-  EuiBadge,
-  EuiBadgeGroup,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiSpacer,
   EuiText,
+  EuiTitle,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { ConfigKey } from '../../../common/runtime_types';
-import type { ScheduleUnit } from '../../../common/runtime_types/monitor_management/monitor_configs';
 import type { MonitorAttachmentData } from '../../../common/agent_builder';
 import {
-  MonitorTypeChip,
-  STATUS_BADGE_COLORS,
+  MonitorChipRow,
+  MonitorStatusDot,
   getStatusAccentColor,
-  getStatusLabel,
+  getStatusBackgroundColor,
+  getStatusCaption,
   inferMonitorStatus,
 } from './monitor_management_status';
-
-interface MetaItemProps {
-  iconType: string;
-  label: string;
-  value: string;
-  testSubj: string;
-}
-
-const MetaItem = ({ iconType, label, value, testSubj }: MetaItemProps) => {
-  const { euiTheme } = useEuiTheme();
-  return (
-    <EuiFlexItem grow={false} data-test-subj={testSubj}>
-      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-        <EuiFlexItem grow={false}>
-          <EuiIcon
-            type={iconType}
-            size="s"
-            color={euiTheme.colors.subduedText}
-            aria-hidden={true}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued">
-            <strong>{label}</strong> {value}
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiFlexItem>
-  );
-};
-
-const formatSchedule = (schedule: { number: string; unit: ScheduleUnit } | undefined): string => {
-  if (!schedule) {
-    return i18n.translate('xpack.synthetics.agentBuilder.monitor.scheduleNotSet', {
-      defaultMessage: 'not set',
-    });
-  }
-  return i18n.translate('xpack.synthetics.agentBuilder.monitor.scheduleValue', {
-    defaultMessage: 'every {number}{unit}',
-    values: { number: schedule.number, unit: schedule.unit },
-  });
-};
 
 export interface MonitorManagementInlineContentProps {
   data: MonitorAttachmentData;
@@ -78,31 +34,29 @@ export interface MonitorManagementInlineContentProps {
 /**
  * Inline card body for the `MONITOR_MANAGEMENT_ATTACHMENT_TYPE` attachment.
  *
- * Visual conventions intentionally borrow from the Synthetics Overview
- * tile (`MetricItem`) without inheriting its data dependencies:
+ * This is the compact card the agent_builder framework renders inside
+ * the chat message body. Visual conventions are kept deliberately
+ * close to the canvas tile (`MonitorManagementCanvasContent`) so that
+ * the inline preview and the canvas preview read as the same object:
  *
- * - The left accent strip mirrors the Overview tile's status-coloured
- *   panel background, but mapped onto our agent-side statuses
- *   (`proposed` / `enabled` / `disabled` / `cli-managed`) which don't
- *   correspond 1:1 to up/down heartbeat states.
- * - `MonitorTypeChip` reproduces the Overview's `MonitorTypeBadge`
- *   visual without dragging in router / Redux.
+ * - Status accent strip on the left (`getStatusAccentColor`).
+ * - Status-tinted background (`getStatusBackgroundColor`).
+ * - Status dot + monitor name as a compact header.
+ * - Optional URL on a single subtitle line.
+ * - `MonitorChipRow` (type / schedule / locations / tags / paused) as
+ *   the body — the *same* component the canvas uses, so the two stay
+ *   in lockstep when fields are added or renamed.
  *
- * What we deliberately **don't** render here (kept for the canvas, T7):
- * sparkline trend, last-status icon, latency metric, error popover,
- * actions popover, location flags. All of those depend on heartbeat
- * data that doesn't exist for proposed monitors and would require
- * pulling in `@elastic/charts` + the synthetics Redux store.
+ * Heading: we render the monitor name ourselves rather than relying
+ * on the framework's attachment label slot, because the framework
+ * label uses `getLabel()` which falls back to "New Synthetics monitor"
+ * for unnamed drafts — fine in the menu, but reads oddly on the
+ * inline card. Showing the actual draft name directly is clearer.
  *
- * No heading is rendered — the agent_builder framework already renders
- * the attachment label/icon above the inline content slot, so a heading
- * here would double up.
- *
- * Tree-shake hygiene: this file imports only `@elastic/eui`,
- * `@emotion/react`, `@kbn/i18n`, types from `common/`, and the shared
- * `monitor_management_status` helpers in the same folder. **Do not**
- * pull in monitor-form or anything from `apps/synthetics/components/` —
- * those would balloon the inline chunk.
+ * Tree-shake hygiene: imports only `@elastic/eui`, `@emotion/react`,
+ * `@kbn/i18n`, types from `common/`, and the shared
+ * `monitor_management_status` helpers in this folder. Stays out of
+ * `apps/synthetics/components/` to keep the inline chunk small.
  */
 export const MonitorManagementInlineContent: React.FC<MonitorManagementInlineContentProps> = ({
   data,
@@ -110,16 +64,14 @@ export const MonitorManagementInlineContent: React.FC<MonitorManagementInlineCon
   const { euiTheme } = useEuiTheme();
   const status = inferMonitorStatus(data);
   const accentColor = getStatusAccentColor(status, euiTheme);
-  const locations = data[ConfigKey.LOCATIONS] ?? [];
-  const tags = data[ConfigKey.TAGS] ?? [];
+  const tileBg = getStatusBackgroundColor(status, euiTheme);
+  const monitorName = data[ConfigKey.NAME];
   const url = data[ConfigKey.URLS];
-  const schedule = data[ConfigKey.SCHEDULE];
-  const monitorType = data[ConfigKey.MONITOR_TYPE];
-
-  const locationsLabel = i18n.translate('xpack.synthetics.agentBuilder.monitor.locationsCount', {
-    defaultMessage: '{count, plural, one {# location} other {# locations}}',
-    values: { count: locations.length },
-  });
+  const caption = getStatusCaption(status);
+  const placeholderName = i18n.translate(
+    'xpack.synthetics.agentBuilder.monitor.canvas.placeholderName',
+    { defaultMessage: 'Untitled monitor' }
+  );
 
   return (
     <div
@@ -127,66 +79,59 @@ export const MonitorManagementInlineContent: React.FC<MonitorManagementInlineCon
       data-test-status={status}
       css={css`
         border-left: ${euiTheme.border.width.thick} solid ${accentColor};
+        background-color: ${tileBg};
+        border-radius: ${euiTheme.border.radius.medium};
         padding: ${euiTheme.size.s} ${euiTheme.size.m};
       `}
     >
-      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiBadge
-            color={STATUS_BADGE_COLORS[status]}
-            data-test-subj={`syntheticsMonitorAttachmentStatus-${status}`}
-          >
-            {getStatusLabel(status)}
-          </EuiBadge>
+          <MonitorStatusDot status={status} />
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <MonitorTypeChip type={monitorType} />
+        <EuiFlexItem>
+          <EuiTitle size="xxs">
+            <h4 data-test-subj="syntheticsMonitorAttachmentInlineTitle">
+              {monitorName && monitorName.length > 0 ? monitorName : placeholderName}
+            </h4>
+          </EuiTitle>
         </EuiFlexItem>
       </EuiFlexGroup>
 
-      <EuiSpacer size="s" />
-
-      <EuiFlexGroup gutterSize="m" wrap responsive={false}>
-        <MetaItem
-          iconType="clock"
-          testSubj="syntheticsMonitorAttachmentSchedule"
-          label={i18n.translate('xpack.synthetics.agentBuilder.monitor.scheduleLabel', {
-            defaultMessage: 'Schedule:',
-          })}
-          value={formatSchedule(schedule)}
-        />
-        <MetaItem
-          iconType="visMapCoordinate"
-          testSubj="syntheticsMonitorAttachmentLocations"
-          label={i18n.translate('xpack.synthetics.agentBuilder.monitor.locationsLabel', {
-            defaultMessage: 'Locations:',
-          })}
-          value={locationsLabel}
-        />
+      <EuiText
+        size="xs"
+        color="subdued"
+        data-test-subj="syntheticsMonitorAttachmentInlineSubtitle"
+        css={css`
+          margin-top: ${euiTheme.size.xs};
+        `}
+      >
         {url ? (
-          <MetaItem
-            iconType="link"
-            testSubj="syntheticsMonitorAttachmentUrl"
-            label={i18n.translate('xpack.synthetics.agentBuilder.monitor.urlLabel', {
-              defaultMessage: 'URL:',
-            })}
-            value={url}
-          />
-        ) : null}
-      </EuiFlexGroup>
+          <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} wrap={false}>
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="link" size="s" color="subdued" aria-hidden={true} />
+            </EuiFlexItem>
+            <EuiFlexItem
+              css={css`
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              `}
+            >
+              <span data-test-subj="syntheticsMonitorAttachmentInlineUrl">{url}</span>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ) : (
+          <span>{caption}</span>
+        )}
+      </EuiText>
 
-      {tags.length > 0 ? (
-        <>
-          <EuiSpacer size="s" />
-          <EuiBadgeGroup data-test-subj="syntheticsMonitorAttachmentTags">
-            {tags.map((tag) => (
-              <EuiBadge key={tag} color="hollow">
-                {tag}
-              </EuiBadge>
-            ))}
-          </EuiBadgeGroup>
-        </>
-      ) : null}
+      <div
+        css={css`
+          margin-top: ${euiTheme.size.s};
+        `}
+      >
+        <MonitorChipRow data={data} />
+      </div>
     </div>
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_status.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_status.tsx
@@ -6,9 +6,16 @@
  */
 
 import React from 'react';
-import { EuiBadge, type EuiThemeComputed } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiBadgeGroup,
+  useEuiTheme,
+  type EuiThemeComputed,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { ConfigKey } from '../../../common/runtime_types';
+import type { ScheduleUnit } from '../../../common/runtime_types/monitor_management/monitor_configs';
 import {
   MonitorTypeEnum,
   SourceType,
@@ -211,5 +218,131 @@ export const MonitorTypeChip: React.FC<MonitorTypeChipProps> = ({ type }) => {
     >
       {label}
     </EuiBadge>
+  );
+};
+
+interface MonitorStatusDotProps {
+  status: MonitorAgentStatus;
+}
+
+/**
+ * Small filled circle in the status accent color, intended to sit
+ * immediately before the canvas title — mirrors the role of
+ * `MetricItemIcon` on the Synthetics Overview tile (status signal in
+ * the upper-left), but without the popover / animation / heartbeat-
+ * dependent variants. The dot is purely decorative; the textual
+ * status caption underneath the title remains the source of truth for
+ * screen readers, hence `aria-hidden`.
+ */
+export const MonitorStatusDot: React.FC<MonitorStatusDotProps> = ({ status }) => {
+  const { euiTheme } = useEuiTheme();
+  const color = getStatusAccentColor(status, euiTheme);
+  return (
+    <span
+      role="presentation"
+      aria-hidden={true}
+      data-test-subj={`syntheticsMonitorAttachmentStatusDot-${status}`}
+      css={css`
+        display: inline-block;
+        width: ${euiTheme.size.s};
+        height: ${euiTheme.size.s};
+        border-radius: 50%;
+        background-color: ${color};
+        flex-shrink: 0;
+      `}
+    />
+  );
+};
+
+const formatScheduleLabel = (
+  schedule: { number: string; unit: ScheduleUnit } | undefined
+): string => {
+  if (!schedule) {
+    return i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.scheduleUnset', {
+      defaultMessage: 'Schedule not set',
+    });
+  }
+  return i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.scheduleValue', {
+    defaultMessage: 'Every {number} {unit}',
+    values: { number: schedule.number, unit: schedule.unit },
+  });
+};
+
+const formatLocationLabel = (location: {
+  id: string;
+  label?: string;
+  isServiceManaged?: boolean;
+}): string => {
+  const labelText = location.label ?? location.id;
+  if (location.isServiceManaged) {
+    return i18n.translate(
+      'xpack.synthetics.agentBuilder.monitor.canvas.locations.elasticManagedLabel',
+      {
+        defaultMessage: '{label} (Elastic-managed)',
+        values: { label: labelText },
+      }
+    );
+  }
+  return labelText;
+};
+
+interface MonitorChipRowProps {
+  data: MonitorAttachmentData;
+}
+
+/**
+ * Compact "what's in this monitor" chip row. Mirrors `MetricItemBody`
+ * on the Synthetics Overview tile (type chip + tags + location badges),
+ * with two agent-side additions: a schedule chip and a "Paused" badge
+ * for explicitly disabled saved monitors. The Overview tile gets these
+ * implicitly from heartbeat data; we have to communicate them
+ * explicitly because we don't have heartbeat status to lean on.
+ *
+ * Deliberately stateless and router-free, so this component can render
+ * inside the canvas `<Metric>` `body` slot without dragging
+ * `react-router-dom` / Redux into the agent_builder canvas chunk.
+ */
+export const MonitorChipRow: React.FC<MonitorChipRowProps> = ({ data }) => {
+  const status = inferMonitorStatus(data);
+  const locations = data[ConfigKey.LOCATIONS] ?? [];
+  const tags = data[ConfigKey.TAGS] ?? [];
+  return (
+    <EuiBadgeGroup
+      gutterSize="xs"
+      data-test-subj="syntheticsMonitorAttachmentCanvasMeta"
+    >
+      <MonitorTypeChip type={data[ConfigKey.MONITOR_TYPE]} />
+      <EuiBadge color="hollow" iconType="clock">
+        {formatScheduleLabel(data[ConfigKey.SCHEDULE])}
+      </EuiBadge>
+      {locations.map((location) => (
+        <EuiBadge key={location.id} color="hollow" iconType="visMapCoordinate">
+          {formatLocationLabel(location)}
+        </EuiBadge>
+      ))}
+      {locations.length === 0 ? (
+        <EuiBadge color="hollow" iconType="visMapCoordinate">
+          {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.locationsUnset', {
+            defaultMessage: 'No locations selected',
+          })}
+        </EuiBadge>
+      ) : null}
+      {tags.map((tag) => (
+        <EuiBadge key={tag} color="hollow">
+          {tag}
+        </EuiBadge>
+      ))}
+      {!data[ConfigKey.ENABLED] && status !== 'cli-managed' ? (
+        <EuiBadge
+          color="default"
+          iconType="pause"
+          data-test-subj="syntheticsMonitorAttachmentCanvasPausedBadge"
+        >
+          {i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.pausedBadge', {
+            defaultMessage: 'Paused',
+          })}
+        </EuiBadge>
+      ) : null}
+    </EuiBadgeGroup>
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_status.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/monitor_management_status.tsx
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiBadge, type EuiThemeComputed } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { ConfigKey } from '../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  SourceType,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+
+/**
+ * Status the agent_builder UI surfaces for a monitor attachment.
+ * Derived from the attachment payload — never from request state.
+ *
+ * - `proposed`     — no `config_id` yet; user can Save to create it.
+ * - `enabled`      — saved + `enabled: true`.
+ * - `disabled`     — saved + `enabled: false`.
+ * - `cli-managed`  — `origin: project`. Read-only via the agent.
+ *
+ * Shared between `monitor_management_inline_content.tsx` and
+ * `monitor_management_canvas_content.tsx` so both surfaces classify
+ * the attachment identically.
+ */
+export type MonitorAgentStatus = 'proposed' | 'enabled' | 'disabled' | 'cli-managed';
+
+export const inferMonitorStatus = (data: MonitorAttachmentData): MonitorAgentStatus => {
+  if (data[ConfigKey.MONITOR_SOURCE_TYPE] === SourceType.PROJECT) {
+    return 'cli-managed';
+  }
+  if (!data[ConfigKey.CONFIG_ID]) {
+    return 'proposed';
+  }
+  return data[ConfigKey.ENABLED] ? 'enabled' : 'disabled';
+};
+
+export const STATUS_BADGE_COLORS: Record<
+  MonitorAgentStatus,
+  'hollow' | 'default' | 'success' | 'warning'
+> = {
+  proposed: 'hollow',
+  enabled: 'success',
+  disabled: 'default',
+  'cli-managed': 'warning',
+};
+
+/**
+ * Maps each agent status to an EUI semantic color token used for the
+ * left accent strip / canvas heading bar. Mirrors the **intent** of
+ * the Synthetics Overview tile (`MetricItem`'s `getColor`) without
+ * inheriting its runtime up/down assumptions — proposed monitors
+ * have no heartbeat data, so we lean on `primary` / `success` /
+ * `warning` / `subduedText` rather than the Overview's
+ * danger/success palette.
+ */
+export const getStatusAccentColor = (
+  status: MonitorAgentStatus,
+  euiTheme: EuiThemeComputed
+): string => {
+  switch (status) {
+    case 'proposed':
+      return euiTheme.colors.primary;
+    case 'enabled':
+      return euiTheme.colors.success;
+    case 'disabled':
+      return euiTheme.colors.subduedText;
+    case 'cli-managed':
+      return euiTheme.colors.warning;
+  }
+};
+
+/**
+ * Tile-background color for the canvas card. Mirrors the **intent** of
+ * the Synthetics Overview tile (`MetricItem`'s `getColor`): the panel
+ * itself is washed with a status-tinted base, not just bordered with
+ * an accent strip. Up/down semantics don't apply (no heartbeat data
+ * for proposed monitors), so we map the agent lifecycle states onto
+ * `backgroundBase*` tokens that EUI guarantees are AA-contrast against
+ * `text` on both themes:
+ *
+ * - `proposed`    — `backgroundBasePrimary` (light blue: actionable draft)
+ * - `enabled`     — `backgroundBaseSuccess` (light green: saved & running)
+ * - `disabled`    — `backgroundBaseDisabled` (grey: saved but paused)
+ * - `cli-managed` — `backgroundBaseWarning` (light yellow: read-only via CLI)
+ */
+export const getStatusBackgroundColor = (
+  status: MonitorAgentStatus,
+  euiTheme: EuiThemeComputed
+): string => {
+  switch (status) {
+    case 'proposed':
+      return euiTheme.colors.backgroundBasePrimary;
+    case 'enabled':
+      return euiTheme.colors.backgroundBaseSuccess;
+    case 'disabled':
+      return euiTheme.colors.backgroundBaseDisabled;
+    case 'cli-managed':
+      return euiTheme.colors.backgroundBaseWarning;
+  }
+};
+
+/**
+ * One-line status caption rendered immediately under the canvas title.
+ * Stands in for the Overview tile's *"Up in {location}"* subtitle —
+ * we don't have heartbeat data, but we can still tell the user what
+ * lifecycle state the attachment is in and whether it's actionable.
+ */
+export const getStatusCaption = (status: MonitorAgentStatus): string => {
+  switch (status) {
+    case 'proposed':
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.status.proposedCaption', {
+        defaultMessage: 'Draft monitor — not yet saved to Synthetics.',
+      });
+    case 'enabled':
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.status.enabledCaption', {
+        defaultMessage: 'Saved monitor — currently running on its schedule.',
+      });
+    case 'disabled':
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.status.disabledCaption', {
+        defaultMessage: 'Saved monitor — currently paused.',
+      });
+    case 'cli-managed':
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.status.cliManagedCaption', {
+        defaultMessage: 'Managed by the synthetics CLI — read-only here.',
+      });
+  }
+};
+
+export const getStatusLabel = (status: MonitorAgentStatus): string => {
+  switch (status) {
+    case 'proposed':
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.status.proposed', {
+        defaultMessage: 'Proposed',
+      });
+    case 'enabled':
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.status.enabled', {
+        defaultMessage: 'Enabled',
+      });
+    case 'disabled':
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.status.disabled', {
+        defaultMessage: 'Disabled',
+      });
+    case 'cli-managed':
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.status.cliManaged', {
+        defaultMessage: 'CLI-managed',
+      });
+  }
+};
+
+/**
+ * Inline equivalent of `MonitorTypeBadge` from
+ * `apps/synthetics/components/common/components/monitor_type_badge.tsx`.
+ *
+ * We deliberately don't import that component: the agent_builder
+ * inline / canvas chunks must avoid `apps/synthetics/components/`
+ * imports for tree-shake hygiene, and the SPA component drags in
+ * `react-router-dom` (for its on-click filter navigation) which has
+ * no place inside an Agent Builder conversation. This re-implements
+ * just the visual — same icon, same label scheme — without the click
+ * handler.
+ */
+const getMonitorTypeIcon = (type: string | undefined): string =>
+  type === MonitorTypeEnum.BROWSER ? 'videoPlayer' : 'online';
+
+const getMonitorTypeLabel = (type: string | undefined): string => {
+  switch (type) {
+    case MonitorTypeEnum.HTTP:
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.type.http', {
+        defaultMessage: 'HTTP',
+      });
+    case MonitorTypeEnum.TCP:
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.type.tcp', {
+        defaultMessage: 'TCP',
+      });
+    case MonitorTypeEnum.ICMP:
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.type.icmp', {
+        defaultMessage: 'ICMP',
+      });
+    case MonitorTypeEnum.BROWSER:
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.type.journey', {
+        defaultMessage: 'Journey',
+      });
+    default:
+      return i18n.translate('xpack.synthetics.agentBuilder.monitor.type.unknown', {
+        defaultMessage: 'Monitor',
+      });
+  }
+};
+
+interface MonitorTypeChipProps {
+  type: string | undefined;
+}
+
+export const MonitorTypeChip: React.FC<MonitorTypeChipProps> = ({ type }) => {
+  const label = getMonitorTypeLabel(type);
+  return (
+    <EuiBadge
+      iconType={getMonitorTypeIcon(type)}
+      color="hollow"
+      data-test-subj="syntheticsMonitorAttachmentType"
+      aria-label={i18n.translate('xpack.synthetics.agentBuilder.monitor.type.ariaLabel', {
+        defaultMessage: 'Monitor type: {label}',
+        values: { label },
+      })}
+    >
+      {label}
+    </EuiBadge>
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/use_monitor_canvas_actions.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/use_monitor_canvas_actions.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ConfigKey } from '../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+import {
+  projectMonitorWithLastSaved,
+  type MonitorCanvasLastSavedSnapshot,
+} from './use_monitor_canvas_actions';
+
+const buildMonitor = (overrides: Partial<MonitorAttachmentData> = {}): MonitorAttachmentData => ({
+  [ConfigKey.NAME]: 'Smoke check',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [{ id: 'us_central', label: 'US Central', isServiceManaged: true }],
+  [ConfigKey.URLS]: 'https://example.com',
+  [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+  ...overrides,
+});
+
+const lastSaved = (
+  overrides: Partial<MonitorCanvasLastSavedSnapshot> = {}
+): MonitorCanvasLastSavedSnapshot => ({
+  configId: 'persisted-config-id',
+  name: 'Smoke check',
+  url: 'https://example.com',
+  ...overrides,
+});
+
+describe('projectMonitorWithLastSaved', () => {
+  // Why this exists at all: the framework's `updateOrigin` does not
+  // refresh the attachment data after a successful Create (followup
+  // F14). The canvas overlays the just-assigned `config_id` via this
+  // projector so the next render flips to **Update** + **View**
+  // instead of staying on **Create** and round-tripping a
+  // duplicate-name `POST` to Synthetics. The tests below pin the
+  // exact branches that decide whether the overlay applies.
+
+  it('returns the original data unchanged when no `lastSaved` snapshot is present (steady state)', () => {
+    const data = buildMonitor();
+    expect(projectMonitorWithLastSaved(data, undefined)).toBe(data);
+  });
+
+  it('returns the original data unchanged when the data already carries `config_id` (post-refresh state)', () => {
+    // Once the framework or the agent's tool refreshes the data, the
+    // overlay must defer to the real value — otherwise we would mask
+    // an already-saved monitor whose configId differs from a stale
+    // snapshot.
+    const data = buildMonitor({ [ConfigKey.CONFIG_ID]: 'real-config-id' });
+    const projected = projectMonitorWithLastSaved(data, lastSaved({ configId: 'stale-id' }));
+    expect(projected).toBe(data);
+    expect(projected[ConfigKey.CONFIG_ID]).toBe('real-config-id');
+  });
+
+  it('overlays `config_id` when `lastSaved.name` + `lastSaved.url` match the in-memory data (post-Create flip)', () => {
+    const data = buildMonitor();
+    const projected = projectMonitorWithLastSaved(data, lastSaved());
+    expect(projected).not.toBe(data);
+    expect(projected[ConfigKey.CONFIG_ID]).toBe('persisted-config-id');
+    // The rest of the data is preserved — only `config_id` is added.
+    expect(projected[ConfigKey.NAME]).toBe(data[ConfigKey.NAME]);
+    expect(projected[ConfigKey.URLS]).toBe(data[ConfigKey.URLS]);
+    expect(projected[ConfigKey.LOCATIONS]).toEqual(data[ConfigKey.LOCATIONS]);
+  });
+
+  it('does NOT overlay when `lastSaved.name` does not match the current data (different attachment in canvas)', () => {
+    // Canvas component instances may be reused across attachments
+    // without remount. Overlaying `lastSaved.configId` onto the
+    // wrong monitor would cause an Update click to `PUT` the new
+    // monitor's data over the previous monitor's saved object —
+    // silent data loss. The name guard is the cheapest stable
+    // identity we have without dragging the framework attachment
+    // id into the body component.
+    const data = buildMonitor({ [ConfigKey.NAME]: 'Other monitor' });
+    const projected = projectMonitorWithLastSaved(data, lastSaved({ name: 'Smoke check' }));
+    expect(projected).toBe(data);
+    expect(projected[ConfigKey.CONFIG_ID]).toBeUndefined();
+  });
+
+  it('does NOT overlay when `lastSaved.url` does not match the current data (different attachment in canvas)', () => {
+    const data = buildMonitor({ [ConfigKey.URLS]: 'https://other.example.com' });
+    const projected = projectMonitorWithLastSaved(data, lastSaved({ url: 'https://example.com' }));
+    expect(projected).toBe(data);
+    expect(projected[ConfigKey.CONFIG_ID]).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/use_monitor_canvas_actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/use_monitor_canvas_actions.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { type ActionButton, ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { ApplicationStart, HttpStart } from '@kbn/core/public';
+import { ConfigKey } from '../../../common/runtime_types';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+import {
+  createMonitor,
+  getMonitorDetailsUrl,
+  updateMonitor,
+  type MonitorLocationWarning,
+} from './monitor_management_actions';
+import { inferMonitorStatus, type MonitorAgentStatus } from './monitor_management_status';
+
+export interface MonitorCanvasSaveState {
+  /** True while a Create / Update is in flight. */
+  isSaving: boolean;
+  /** Last persistence error. Cleared when a new save attempt starts. */
+  saveError: Error | null;
+  /** Per-location warnings from the most recent save (partial-failure path). */
+  locationWarnings: MonitorLocationWarning[];
+}
+
+export interface UseMonitorCanvasActionsParams {
+  /** Current attachment data. Reactive — re-running ops update this. */
+  monitor: MonitorAttachmentData;
+  /** Synthetics save capability flag (`capabilities.uptime.save`). */
+  canEdit: boolean;
+  /**
+   * `capabilities.uptime.elasticManagedLocationsEnabled` — relevant only
+   * when the draft uses Elastic-managed locations. Default `true` when
+   * the capability is undefined (matches `useCanUsePublicLocations`).
+   */
+  canUseElasticManaged: boolean;
+  /** Browser HTTP client. */
+  http: HttpStart;
+  /** Application contract for navigation + capability lookup. */
+  application: ApplicationStart;
+  /**
+   * Framework-provided callback. After a successful create, we call this
+   * with the new saved-object id so the attachment transitions from
+   * by-value (proposed) to by-reference (saved).
+   */
+  updateOrigin: (origin: string) => Promise<unknown>;
+  /** Framework-provided callback. Closes the canvas flyout. */
+  closeCanvas: () => void;
+  /**
+   * State setter passed by the canvas body. The hook drives the body's
+   * spinner / error callout via this single state object.
+   */
+  setSaveState: (next: MonitorCanvasSaveState) => void;
+}
+
+const writeDisabledReason = (
+  canEdit: boolean,
+  canUseElasticManaged: boolean
+): string | undefined => {
+  if (!canEdit) {
+    return i18n.translate(
+      'xpack.synthetics.agentBuilder.monitor.canvas.disabledReason.missingPrivilege',
+      {
+        defaultMessage:
+          'You don\u2019t have permission to save synthetics monitors. Contact your administrator to grant the Uptime "Save" privilege.',
+      }
+    );
+  }
+  if (!canUseElasticManaged) {
+    return i18n.translate(
+      'xpack.synthetics.agentBuilder.monitor.canvas.disabledReason.elasticManagedDisabled',
+      {
+        defaultMessage:
+          'Elastic-managed locations are disabled for your role. Re-create the monitor on a private location, or ask an administrator to enable Elastic-managed locations.',
+      }
+    );
+  }
+  return undefined;
+};
+
+/**
+ * Returns the Create / Update / View action buttons for the current
+ * monitor attachment, based on its lifecycle status and the user's
+ * Synthetics capabilities.
+ *
+ * Status-based wiring:
+ *
+ * | Status        | Buttons                                  |
+ * | ------------- | ---------------------------------------- |
+ * | `proposed`    | **Create** (primary)                     |
+ * | `enabled`     | **Update** (primary), **View** (secondary) |
+ * | `disabled`    | **Update** (primary), **View** (secondary) |
+ * | `cli-managed` | **View** (primary, navigates to the synthetics monitor details page) |
+ *
+ * ---
+ *
+ * **In-body rendering, not framework-header (T7 hot-fix #4):** earlier
+ * iterations registered these buttons on the canvas flyout's header
+ * via the framework's `registerActionButtons` callback (mirroring
+ * `dashboard_agent`'s `useRegisterCanvasActionButtons`). Manual
+ * testing surfaced two issues with that placement:
+ *
+ * - The framework header packs Create + close + the by-reference
+ *   "Preview Only" lock badge into a thin strip; primary CTAs are
+ *   visually crowded and hard to discover.
+ * - The framework's `CanvasFlyout` clears `dynamicButtons` on attachment
+ *   change in a parent `useEffect`, racing our child registration. We
+ *   worked around it once with a `queueMicrotask` defer, but that's
+ *   fragile and the platform-level race itself is still tracked as
+ *   followup F10.
+ *
+ * Returning the button descriptors and rendering them as proper
+ * `EuiButton`s in the canvas body footer side-steps both problems and
+ * matches the "card with a primary CTA at the bottom" pattern users
+ * already know from the Synthetics SPA save flow. The button shape
+ * (label / icon / type / disabled / disabledReason / handler) is the
+ * same `ActionButton` contract the framework uses, so we don't pay a
+ * naming or refactor cost if a future iteration moves them back.
+ *
+ * The returned reference is stable per render — `useMemo`'d on the
+ * inputs the buttons close over. Handlers internally drive the
+ * `setSaveState` callback so the body can render the spinner / error
+ * callout / location-warnings callout.
+ */
+export const useMonitorCanvasActions = ({
+  monitor,
+  canEdit,
+  canUseElasticManaged,
+  http,
+  application,
+  updateOrigin,
+  closeCanvas,
+  setSaveState,
+}: UseMonitorCanvasActionsParams): ActionButton[] => {
+  return useMemo<ActionButton[]>(() => {
+    const status: MonitorAgentStatus = inferMonitorStatus(monitor);
+    const configId = monitor[ConfigKey.CONFIG_ID];
+    const disabledReason = writeDisabledReason(canEdit, canUseElasticManaged);
+    const writeDisabled = disabledReason !== undefined;
+
+    const navigateToMonitor = async () => {
+      if (!configId) return;
+      const appPath = application.getUrlForApp('synthetics');
+      await application.navigateToUrl(getMonitorDetailsUrl(configId, appPath));
+      closeCanvas();
+    };
+
+    const runSave = async (mode: 'create' | 'update') => {
+      setSaveState({ isSaving: true, saveError: null, locationWarnings: [] });
+      try {
+        const outcome =
+          mode === 'create'
+            ? await createMonitor(http, monitor)
+            : await updateMonitor(http, configId!, monitor);
+
+        if (mode === 'create') {
+          await updateOrigin(outcome.id);
+        }
+
+        setSaveState({
+          isSaving: false,
+          saveError: null,
+          locationWarnings: outcome.locationWarnings,
+        });
+
+        // Only auto-close on a fully clean save. Partial-failure
+        // (location warnings present) keeps the canvas open so the
+        // user can read the callout.
+        if (outcome.locationWarnings.length === 0) {
+          closeCanvas();
+        }
+      } catch (error) {
+        setSaveState({
+          isSaving: false,
+          saveError: error instanceof Error ? error : new Error(String(error)),
+          locationWarnings: [],
+        });
+      }
+    };
+
+    const buttons: ActionButton[] = [];
+
+    if (status === 'cli-managed') {
+      buttons.push({
+        label: i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.actions.viewLabel', {
+          defaultMessage: 'View in Synthetics',
+        }),
+        icon: 'popout',
+        type: ActionButtonType.PRIMARY,
+        disabled: !configId,
+        handler: navigateToMonitor,
+      });
+    } else if (status === 'proposed') {
+      buttons.push({
+        label: i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.actions.createLabel', {
+          defaultMessage: 'Create',
+        }),
+        icon: 'save',
+        type: ActionButtonType.PRIMARY,
+        disabled: writeDisabled,
+        disabledReason,
+        handler: () => runSave('create'),
+      });
+    } else {
+      buttons.push({
+        label: i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.actions.updateLabel', {
+          defaultMessage: 'Update',
+        }),
+        icon: 'save',
+        type: ActionButtonType.PRIMARY,
+        disabled: writeDisabled || !configId,
+        disabledReason,
+        handler: () => runSave('update'),
+      });
+      buttons.push({
+        label: i18n.translate('xpack.synthetics.agentBuilder.monitor.canvas.actions.viewLabel', {
+          defaultMessage: 'View in Synthetics',
+        }),
+        icon: 'popout',
+        type: ActionButtonType.SECONDARY,
+        disabled: !configId,
+        handler: navigateToMonitor,
+      });
+    }
+
+    return buttons;
+  }, [
+    monitor,
+    canEdit,
+    canUseElasticManaged,
+    http,
+    application,
+    updateOrigin,
+    closeCanvas,
+    setSaveState,
+  ]);
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/use_monitor_canvas_actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/attachments/use_monitor_canvas_actions.ts
@@ -19,6 +19,38 @@ import {
 } from './monitor_management_actions';
 import { inferMonitorStatus, type MonitorAgentStatus } from './monitor_management_status';
 
+/**
+ * Snapshot captured immediately after a successful Create. Lets the
+ * canvas overlay the freshly-assigned `config_id` onto the in-memory
+ * attachment data so the next render flips to **Update** + **View**
+ * instead of staying on **Create**.
+ *
+ * Why we need this at all: the framework's `updateOrigin` writes the
+ * `origin` onto the conversation attachment record but does **not**
+ * refresh the data snapshot through the type's `resolve` hook (see
+ * followup F14). Without this overlay the canvas would keep showing
+ * **Create** even after a successful Save — and clicking Create
+ * again would re-POST the same monitor and fail with the server's
+ * duplicate-name error. The overlay also keeps the status dot,
+ * caption, and tile background in sync with reality (saved → green +
+ * "Saved monitor — currently running on its schedule").
+ *
+ * Why we tie it to `name` + `url` rather than blindly applying the
+ * `configId`: a single canvas component instance may be re-used for a
+ * different attachment if the framework opens the flyout on a fresh
+ * monitor without remounting. Without an identity guard, the previous
+ * monitor's `configId` would leak onto the new attachment and a Save
+ * click would `PUT` the new monitor's data over the old monitor's
+ * saved object. Matching on `name` + `url` is the cheapest stable
+ * identity we have without dragging the framework attachment id into
+ * the body component (it isn't passed in props today).
+ */
+export interface MonitorCanvasLastSavedSnapshot {
+  configId: string;
+  name?: string;
+  url?: string;
+}
+
 export interface MonitorCanvasSaveState {
   /** True while a Create / Update is in flight. */
   isSaving: boolean;
@@ -26,6 +58,13 @@ export interface MonitorCanvasSaveState {
   saveError: Error | null;
   /** Per-location warnings from the most recent save (partial-failure path). */
   locationWarnings: MonitorLocationWarning[];
+  /**
+   * Set after a clean OR partial-failure **Create** call. See
+   * {@link MonitorCanvasLastSavedSnapshot} for the rationale.
+   * Update calls leave this untouched (the configId already lives
+   * in the in-memory data on that path).
+   */
+  lastSaved?: MonitorCanvasLastSavedSnapshot;
 }
 
 export interface UseMonitorCanvasActionsParams {
@@ -57,6 +96,37 @@ export interface UseMonitorCanvasActionsParams {
    */
   setSaveState: (next: MonitorCanvasSaveState) => void;
 }
+
+/**
+ * Project the in-memory attachment data through the most-recent
+ * Create snapshot, if any. Returns the original `data` when no
+ * overlay applies — either because the data already carries
+ * `config_id` (the framework refreshed it, or the agent's tool
+ * server-side refresh did) or because `lastSaved` doesn't match the
+ * current monitor's `name` + `url` (different attachment, drop the
+ * stale snapshot).
+ *
+ * Exported because the canvas body needs to drive `inferMonitorStatus`
+ * + the chip row + the action buttons off of the **same** projection,
+ * so the visual treatment stays in lockstep with the available
+ * actions.
+ */
+export const projectMonitorWithLastSaved = (
+  data: MonitorAttachmentData,
+  lastSaved: MonitorCanvasLastSavedSnapshot | undefined
+): MonitorAttachmentData => {
+  if (data[ConfigKey.CONFIG_ID]) {
+    return data;
+  }
+  if (
+    !lastSaved ||
+    lastSaved.name !== data[ConfigKey.NAME] ||
+    lastSaved.url !== data[ConfigKey.URLS]
+  ) {
+    return data;
+  }
+  return { ...data, [ConfigKey.CONFIG_ID]: lastSaved.configId };
+};
 
 const writeDisabledReason = (
   canEdit: boolean,
@@ -166,6 +236,21 @@ export const useMonitorCanvasActions = ({
           isSaving: false,
           saveError: null,
           locationWarnings: outcome.locationWarnings,
+          // On `create` we capture the just-assigned configId (plus
+          // the identifying name/url tuple — see
+          // `MonitorCanvasLastSavedSnapshot` for why). On `update` the
+          // configId already lives in the in-memory data so there is
+          // nothing to overlay; leave `lastSaved` undefined so we
+          // don't accidentally pin the canvas to a stale snapshot
+          // from a previous create.
+          lastSaved:
+            mode === 'create'
+              ? {
+                  configId: outcome.id,
+                  name: monitor[ConfigKey.NAME],
+                  url: monitor[ConfigKey.URLS],
+                }
+              : undefined,
         });
 
         // Only auto-close on a fully clean save. Partial-failure

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/bind_on_start.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/bind_on_start.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ApplicationStart, HttpStart } from '@kbn/core/public';
+import { MONITOR_MANAGEMENT_ATTACHMENT_TYPE } from '../../common/agent_builder';
+import { bindAgentBuilderOnStart } from './bind_on_start';
+
+const buildAgentBuilderStart = () => {
+  const addAttachmentType = jest.fn();
+  return {
+    mock: {
+      attachments: { addAttachmentType },
+    } as unknown as AgentBuilderPluginStart,
+    addAttachmentType,
+  };
+};
+
+const stubHttp = {} as HttpStart;
+const stubApplication = {
+  capabilities: {},
+  getUrlForApp: jest.fn(),
+  navigateToUrl: jest.fn(),
+} as unknown as ApplicationStart;
+
+describe('bindAgentBuilderOnStart', () => {
+  it('returns plugin_missing without touching anything when agentBuilder is undefined', () => {
+    const result = bindAgentBuilderOnStart({
+      agentBuilder: undefined,
+      http: stubHttp,
+      application: stubApplication,
+    });
+    expect(result).toEqual({ registered: false, reason: 'plugin_missing' });
+  });
+
+  it('registers the attachment UI definition when the agentBuilder plugin is present', () => {
+    const { mock, addAttachmentType } = buildAgentBuilderStart();
+    const result = bindAgentBuilderOnStart({
+      agentBuilder: mock,
+      http: stubHttp,
+      application: stubApplication,
+    });
+    expect(result).toEqual({ registered: true });
+    expect(addAttachmentType).toHaveBeenCalledTimes(1);
+    expect(addAttachmentType.mock.calls[0][0]).toBe(MONITOR_MANAGEMENT_ATTACHMENT_TYPE);
+  });
+
+  it('passes a UI definition with both inline and canvas renderers wired', () => {
+    const { mock, addAttachmentType } = buildAgentBuilderStart();
+    bindAgentBuilderOnStart({
+      agentBuilder: mock,
+      http: stubHttp,
+      application: stubApplication,
+    });
+    const uiDefinition = addAttachmentType.mock.calls[0][1];
+    expect(typeof uiDefinition.renderInlineContent).toBe('function');
+    expect(typeof uiDefinition.renderCanvasContent).toBe('function');
+    expect(typeof uiDefinition.getActionButtons).toBe('function');
+    expect(uiDefinition.canvasWidth).toBe('40vw');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/bind_on_start.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/agent_builder/bind_on_start.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ApplicationStart, HttpStart } from '@kbn/core/public';
+import { registerMonitorManagementAttachmentUIDefinition } from './attachments';
+
+interface BindAgentBuilderOnStartOptions {
+  /** Optional plugin contract — `undefined` when `agentBuilder` is not loaded. */
+  agentBuilder: AgentBuilderPluginStart | undefined;
+  /** Browser HTTP client, used by canvas Create / Update buttons. */
+  http: HttpStart;
+  /** Application contract, used for capability lookup + monitor-detail nav. */
+  application: ApplicationStart;
+}
+
+export interface BindAgentBuilderOnStartResult {
+  registered: boolean;
+  reason?: 'plugin_missing';
+}
+
+/**
+ * Browser-side counterpart to `bindAgentBuilder` (server). Registers the
+ * Synthetics monitor-management attachment UI definition with the
+ * `agentBuilder` plugin's attachment service.
+ *
+ * Same single gate as the server bind: `agentBuilder` plugin presence.
+ * No additional FF — the Agent Builder UX itself is the gate.
+ *
+ * Calling without registration is **not an error**: many Kibana flavours
+ * omit `agentBuilder` and we want the no-op path silent.
+ */
+export const bindAgentBuilderOnStart = ({
+  agentBuilder,
+  http,
+  application,
+}: BindAgentBuilderOnStartOptions): BindAgentBuilderOnStartResult => {
+  if (!agentBuilder) {
+    return { registered: false, reason: 'plugin_missing' };
+  }
+
+  registerMonitorManagementAttachmentUIDefinition({
+    attachmentService: agentBuilder.attachments,
+    http,
+    application,
+  });
+  return { registered: true };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/plugin.ts
@@ -70,6 +70,7 @@ import type { KqlPluginStart } from '@kbn/kql/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import { registerSyntheticsEmbeddables } from './apps/embeddables/register_embeddables';
+import { bindAgentBuilderOnStart } from './agent_builder/bind_on_start';
 import { kibanaService } from './utils/kibana_service';
 import { PLUGIN } from '../common/constants/plugin';
 import { OVERVIEW_ROUTE } from '../common/constants/ui';
@@ -264,6 +265,12 @@ export class SyntheticsPlugin
       if (!triggersActionsUi.ruleTypeRegistry.has(alertInitializer.id)) {
         observabilityRuleTypeRegistry.register(alertInitializer);
       }
+    });
+
+    bindAgentBuilderOnStart({
+      agentBuilder: pluginsStart.agentBuilder,
+      http: coreStart.http,
+      application: coreStart.application,
     });
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/scripts/agent_builder_monitor_smoke.js
+++ b/x-pack/solutions/observability/plugins/synthetics/scripts/agent_builder_monitor_smoke.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+require('@kbn/babel-register').install();
+require('./tasks/agent_builder_monitor_smoke').runAgentBuilderMonitorSmoke();

--- a/x-pack/solutions/observability/plugins/synthetics/scripts/tasks/agent_builder_monitor_smoke.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/scripts/tasks/agent_builder_monitor_smoke.ts
@@ -1,0 +1,490 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Synthetics × Agent Builder smoke verification script.
+ *
+ * This is the **scriptable companion** to the manual smoke-test doc at
+ * `~/.agents/synthetics-agent-builder/notes/01-monitor-management/smoke-tests.md`.
+ * It bypasses the LLM and the chat UI entirely and verifies the two
+ * pieces that matter for shipping confidence:
+ *
+ * 1. **Bind / discovery** — the `monitor-management` skill is registered
+ *    with Agent Builder and discoverable via the public skills API.
+ *    Failures here usually mean the bind on setup never ran (FF was
+ *    silently off, plugin missing, allow_lists.ts didn't pick up the
+ *    skill id).
+ *
+ * 2. **Canvas-Save persistence round-trip** — a complete
+ *    `MonitorAttachmentData` payload, identical in shape to what the
+ *    canvas Save button POSTs, lands a real synthetics monitor and is
+ *    cleanly readable back, then deletable. This proves the
+ *    monitor-form codec parity (T1 vs `SyntheticsMonitorCodec`) and
+ *    the role-derived auth behaviour without manual chrome.
+ *
+ * What this script does **NOT** verify (intentionally):
+ *
+ * - The actual UI rendering. Manual smoke covers that. A future Scout
+ *   UI test would as well — see `notes/01-monitor-management/scout-outline.md`.
+ * - The tool execution path under conversation context. The tool's
+ *   `attachments.add` / `getAttachmentRecord` calls require a live
+ *   conversation; calling the public `/_execute` endpoint without one
+ *   would fail in a misleading way. The tool is exhaustively covered
+ *   by Jest unit tests (`manage_synthetics_monitor.test.ts`).
+ * - Attachment `resolve` / `isStale`. Same conversation-context limit;
+ *   covered by Jest in `monitor_management_attachment_type.test.ts`.
+ *
+ * Usage:
+ *
+ *     node x-pack/solutions/observability/plugins/synthetics/scripts/agent_builder_monitor_smoke.js
+ *
+ * Auto-detects Kibana credentials from `kibana.yml` / `kibana.dev.yml`
+ * (same logic as `generate_monitors.ts`), falling back to
+ * `elastic:changeme` on `http://127.0.0.1:5601`.
+ *
+ * Configuration (env vars, all optional):
+ *
+ *     KIBANA_URL          base URL (default http://127.0.0.1:5601)
+ *     KIBANA_USERNAME     (default from kibana.yml or 'elastic')
+ *     KIBANA_PASSWORD     (default from kibana.yml or 'changeme')
+ *     SMOKE_LOCATION_ID   private-location id to use; falls back to
+ *                         the first available location (Elastic-managed
+ *                         preferred over private)
+ *     SMOKE_MONITOR_NAME  monitor name (default 'Agent Builder smoke
+ *                         test'); the script always cleans it up at the
+ *                         end of a successful run.
+ *     SMOKE_VERBOSE       'true' to log each request/response
+ *
+ * Exit codes:
+ *
+ *     0  all stages passed
+ *     1  at least one stage failed (details printed)
+ *     2  setup error (no location found, auth failed before stage 1, …)
+ */
+
+import axios, { type AxiosInstance } from 'axios';
+import { readKibanaConfig } from '@kbn/observability-synthetics-test-data';
+
+// ---------------------------------------------------------------------------
+// Pretty-printing helpers
+// ---------------------------------------------------------------------------
+
+const COLOR = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  gray: '\x1b[90m',
+};
+
+const tag = {
+  pass: `${COLOR.green}PASS${COLOR.reset}`,
+  fail: `${COLOR.red}FAIL${COLOR.reset}`,
+  skip: `${COLOR.yellow}SKIP${COLOR.reset}`,
+  info: `${COLOR.cyan}INFO${COLOR.reset}`,
+  step: `${COLOR.bold}>>${COLOR.reset}`,
+};
+
+const verbose = process.env.SMOKE_VERBOSE === 'true';
+
+const log = (line: string) => {
+  // eslint-disable-next-line no-console
+  console.log(line);
+};
+
+const logVerbose = (line: string) => {
+  if (verbose) {
+    log(`${COLOR.gray}${line}${COLOR.reset}`);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Config + auth resolution
+// ---------------------------------------------------------------------------
+
+interface ResolvedConfig {
+  baseUrl: string;
+  username: string;
+  password: string;
+  locationIdHint: string | undefined;
+  monitorName: string;
+}
+
+const resolveConfig = (): ResolvedConfig => {
+  const baseUrl = process.env.KIBANA_URL ?? 'http://127.0.0.1:5601';
+  let username = process.env.KIBANA_USERNAME;
+  let password = process.env.KIBANA_PASSWORD;
+
+  if (!username || !password) {
+    try {
+      const config = readKibanaConfig();
+      const yamlUser = config.elasticsearch?.username;
+      // `kibana_system_user` can't write monitors; the dev usually wants
+      // the superuser path here. Same pivot `generate_monitors.ts` does.
+      username = username ?? (yamlUser === 'kibana_system_user' ? 'elastic' : yamlUser);
+      password = password ?? config.elasticsearch?.password;
+    } catch {
+      // fall through
+    }
+  }
+
+  return {
+    baseUrl,
+    username: username ?? 'elastic',
+    password: password ?? 'changeme',
+    locationIdHint: process.env.SMOKE_LOCATION_ID,
+    monitorName: process.env.SMOKE_MONITOR_NAME ?? 'Agent Builder smoke test',
+  };
+};
+
+const buildHttp = (config: ResolvedConfig): AxiosInstance =>
+  axios.create({
+    baseURL: config.baseUrl,
+    auth: { username: config.username, password: config.password },
+    headers: {
+      'kbn-xsrf': 'true',
+      'elastic-api-version': '2023-10-31',
+    },
+    // We assert non-2xx ourselves so we can render a clean failure line
+    // instead of a mid-stack axios throw.
+    validateStatus: () => true,
+  });
+
+// ---------------------------------------------------------------------------
+// Stage results
+// ---------------------------------------------------------------------------
+
+interface StageResult {
+  name: string;
+  status: 'pass' | 'fail' | 'skip';
+  detail?: string;
+}
+
+const printStage = (result: StageResult) => {
+  const symbol =
+    result.status === 'pass' ? tag.pass : result.status === 'fail' ? tag.fail : tag.skip;
+  log(
+    `  ${symbol}  ${result.name}${
+      result.detail ? `  ${COLOR.dim}—${COLOR.reset} ${result.detail}` : ''
+    }`
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Stage 1 — Bind / discovery
+// ---------------------------------------------------------------------------
+
+interface SkillSummary {
+  id: string;
+  name?: string;
+}
+
+const stageDiscoverSkill = async (http: AxiosInstance): Promise<StageResult[]> => {
+  const results: StageResult[] = [];
+
+  log(`\n${tag.step} Stage 1 — Skill registration & discovery\n`);
+
+  const listResp = await http.get('/api/agent_builder/skills', {
+    params: { include_plugins: true },
+  });
+  logVerbose(`GET /api/agent_builder/skills?include_plugins=true → ${listResp.status}`);
+
+  if (listResp.status !== 200) {
+    results.push({
+      name: 'List skills returns 200',
+      status: 'fail',
+      detail: `got ${listResp.status} (${
+        typeof listResp.data === 'object' ? JSON.stringify(listResp.data).slice(0, 200) : 'no body'
+      })`,
+    });
+    return results;
+  }
+  results.push({ name: 'List skills returns 200', status: 'pass' });
+
+  const skills: SkillSummary[] = Array.isArray(listResp.data?.results) ? listResp.data.results : [];
+  const found = skills.find((s) => s.id === 'monitor-management');
+  results.push({
+    name: 'monitor-management skill is listed',
+    status: found ? 'pass' : 'fail',
+    detail: found ? undefined : `not in ${skills.length} returned skills`,
+  });
+  if (!found) {
+    return results;
+  }
+
+  const skillResp = await http.get('/api/agent_builder/skills/monitor-management');
+  logVerbose(`GET /api/agent_builder/skills/monitor-management → ${skillResp.status}`);
+  if (skillResp.status !== 200) {
+    results.push({
+      name: 'Get monitor-management skill returns 200',
+      status: 'fail',
+      detail: `got ${skillResp.status}`,
+    });
+    return results;
+  }
+  results.push({ name: 'Get monitor-management skill returns 200', status: 'pass' });
+
+  const skill = skillResp.data;
+  const content: string = typeof skill?.content === 'string' ? skill.content : '';
+
+  results.push({
+    name: 'Skill content references manage_synthetics_monitor tool',
+    status: content.includes('manage_synthetics_monitor') ? 'pass' : 'fail',
+    detail: content.length === 0 ? 'empty content' : undefined,
+  });
+
+  results.push({
+    name: 'Skill content explains the operations[] surface',
+    status:
+      content.includes('set_metadata') &&
+      content.includes('set_schedule') &&
+      content.includes('set_locations') &&
+      content.includes('set_http_check')
+        ? 'pass'
+        : 'fail',
+  });
+
+  return results;
+};
+
+// ---------------------------------------------------------------------------
+// Stage 2 — Persistence round-trip
+// ---------------------------------------------------------------------------
+
+interface ResolvedLocation {
+  id: string;
+  label?: string;
+  isServiceManaged: boolean;
+}
+
+const resolveLocation = async (
+  http: AxiosInstance,
+  hint: string | undefined
+): Promise<ResolvedLocation | undefined> => {
+  // Prefer the public service-locations endpoint (returns Elastic-managed
+  // locations + private locations). When a hint id is provided, find by id
+  // exactly; otherwise prefer the first Elastic-managed entry, then the
+  // first private one.
+  const resp = await http.get('/internal/uptime/service/locations');
+  logVerbose(`GET /internal/uptime/service/locations → ${resp.status}`);
+  if (resp.status !== 200) {
+    return undefined;
+  }
+  const locations: ResolvedLocation[] = Array.isArray(resp.data?.locations)
+    ? resp.data.locations
+    : [];
+  if (locations.length === 0) {
+    return undefined;
+  }
+  if (hint) {
+    return locations.find((l) => l.id === hint);
+  }
+  return locations.find((l) => l.isServiceManaged) ?? locations[0];
+};
+
+const buildMonitorPayload = (location: ResolvedLocation, monitorName: string) => ({
+  // Field-name parity with `MonitorAttachmentData` (T1) and the canvas
+  // Save body (T7). The server's `normalizeAPIConfig` fills in
+  // `DEFAULT_FIELDS[http]` for everything we don't pass.
+  type: 'http',
+  enabled: true,
+  alert: { status: { enabled: true }, tls: { enabled: true } },
+  schedule: { number: '5', unit: 'm' },
+  locations: [
+    {
+      id: location.id,
+      label: location.label ?? location.id,
+      isServiceManaged: location.isServiceManaged,
+    },
+  ],
+  name: monitorName,
+  urls: 'https://example.com',
+  tags: ['agent-builder-smoke'],
+  namespace: 'default',
+  origin: 'ui',
+});
+
+const stagePersistenceRoundTrip = async (
+  http: AxiosInstance,
+  monitorName: string,
+  locationHint: string | undefined
+): Promise<{ results: StageResult[]; createdConfigId?: string }> => {
+  const results: StageResult[] = [];
+
+  log(`\n${tag.step} Stage 2 — Canvas-Save persistence round-trip\n`);
+
+  const location = await resolveLocation(http, locationHint);
+  if (!location) {
+    results.push({
+      name: 'Resolved a synthetics location',
+      status: 'skip',
+      detail: locationHint
+        ? `no location with id "${locationHint}"`
+        : 'no Elastic-managed or private locations configured',
+    });
+    return { results };
+  }
+  results.push({
+    name: 'Resolved a synthetics location',
+    status: 'pass',
+    detail: `${location.id} (${location.isServiceManaged ? 'managed' : 'private'})`,
+  });
+
+  // POST — what the canvas's Create button does
+  const monitorBody = buildMonitorPayload(location, monitorName);
+  const createResp = await http.post('/api/synthetics/monitors', monitorBody, {
+    params: { internal: true },
+  });
+  logVerbose(`POST /api/synthetics/monitors → ${createResp.status}`);
+
+  if (createResp.status !== 200) {
+    results.push({
+      name: 'POST /api/synthetics/monitors creates the monitor',
+      status: 'fail',
+      detail: `got ${createResp.status} (${
+        typeof createResp.data === 'object'
+          ? JSON.stringify(createResp.data).slice(0, 200)
+          : 'no body'
+      })`,
+    });
+    return { results };
+  }
+
+  const created = createResp.data;
+  // Successful body has a top-level `id`. Partial-failure bodies put it
+  // at `attributes.id` — that's still a save success for our purposes.
+  const configId: string | undefined =
+    typeof created?.id === 'string' ? created.id : created?.attributes?.id;
+
+  if (!configId) {
+    results.push({
+      name: 'Create response includes a config id',
+      status: 'fail',
+      detail: 'neither response.id nor response.attributes.id was present',
+    });
+    return { results };
+  }
+  results.push({
+    name: 'POST /api/synthetics/monitors creates the monitor',
+    status: 'pass',
+    detail: `id=${configId}`,
+  });
+
+  // GET — confirm round-trip readability
+  const getResp = await http.get(`/api/synthetics/monitors/${encodeURIComponent(configId)}`);
+  logVerbose(`GET /api/synthetics/monitors/${configId} → ${getResp.status}`);
+
+  if (getResp.status !== 200) {
+    results.push({
+      name: 'GET round-trip returns the saved monitor',
+      status: 'fail',
+      detail: `got ${getResp.status}`,
+    });
+    return { results, createdConfigId: configId };
+  }
+
+  const fetched = getResp.data;
+  const matchesName = fetched?.name === monitorName;
+  const matchesUrl = fetched?.urls === 'https://example.com';
+  const matchesSchedule = fetched?.schedule?.number === '5' && fetched?.schedule?.unit === 'm';
+
+  results.push({
+    name: 'GET round-trip returns the saved monitor',
+    status: matchesName && matchesUrl && matchesSchedule ? 'pass' : 'fail',
+    detail:
+      matchesName && matchesUrl && matchesSchedule
+        ? `name + url + schedule match`
+        : `mismatch — name: ${fetched?.name}, url: ${fetched?.urls}, schedule: ${JSON.stringify(
+            fetched?.schedule
+          )}`,
+  });
+
+  return { results, createdConfigId: configId };
+};
+
+const cleanupMonitor = async (http: AxiosInstance, configId: string): Promise<StageResult> => {
+  const resp = await http.delete(`/api/synthetics/monitors/${encodeURIComponent(configId)}`);
+  logVerbose(`DELETE /api/synthetics/monitors/${configId} → ${resp.status}`);
+  return {
+    name: 'Cleanup: DELETE the smoke-test monitor',
+    status: resp.status === 200 ? 'pass' : 'fail',
+    detail:
+      resp.status === 200
+        ? undefined
+        : `got ${resp.status}; manually run "DELETE /api/synthetics/monitors/${configId}"`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Entrypoint
+// ---------------------------------------------------------------------------
+
+export const runAgentBuilderMonitorSmoke = async (): Promise<void> => {
+  const config = resolveConfig();
+  const http = buildHttp(config);
+
+  log(`${COLOR.bold}Synthetics × Agent Builder smoke${COLOR.reset}`);
+  log(`  ${COLOR.dim}base url:${COLOR.reset} ${config.baseUrl}`);
+  log(`  ${COLOR.dim}user:    ${COLOR.reset} ${config.username}`);
+  log(`  ${COLOR.dim}monitor: ${COLOR.reset} "${config.monitorName}"`);
+
+  const allResults: StageResult[] = [];
+  let configIdToCleanup: string | undefined;
+  let setupFailed = false;
+
+  try {
+    const stage1 = await stageDiscoverSkill(http);
+    allResults.push(...stage1);
+    stage1.forEach(printStage);
+
+    if (stage1.some((r) => r.status === 'fail')) {
+      log(
+        `\n${tag.info} Stage 1 found bind issues — Stage 2 still runs (it tests a different surface).`
+      );
+    }
+
+    const stage2 = await stagePersistenceRoundTrip(http, config.monitorName, config.locationIdHint);
+    allResults.push(...stage2.results);
+    stage2.results.forEach(printStage);
+    configIdToCleanup = stage2.createdConfigId;
+  } catch (error) {
+    setupFailed = true;
+    log(
+      `\n${tag.fail}  Setup error before all stages completed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  if (configIdToCleanup) {
+    log(`\n${tag.step} Cleanup\n`);
+    const cleanup = await cleanupMonitor(http, configIdToCleanup);
+    allResults.push(cleanup);
+    printStage(cleanup);
+  }
+
+  // Summary
+  const passed = allResults.filter((r) => r.status === 'pass').length;
+  const failed = allResults.filter((r) => r.status === 'fail').length;
+  const skipped = allResults.filter((r) => r.status === 'skip').length;
+
+  log('');
+  log(
+    `${COLOR.bold}Summary:${COLOR.reset} ${COLOR.green}${passed} passed${COLOR.reset}, ${
+      failed > 0 ? COLOR.red : COLOR.dim
+    }${failed} failed${COLOR.reset}, ${COLOR.yellow}${skipped} skipped${COLOR.reset}`
+  );
+
+  if (setupFailed) {
+    process.exitCode = 2;
+    return;
+  }
+  process.exitCode = failed > 0 ? 1 : 0;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/README.md
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/README.md
@@ -1,0 +1,225 @@
+# Synthetics × Agent Builder
+
+The Synthetics plugin contributes a `monitor-management` skill, a
+`manage_synthetics_monitor` inline tool, a
+`synthetics.monitor_management` attachment type, and a
+`synthetics_monitor` SML type to the
+[Agent Builder](../../../../../../platform/plugins/shared/agent_builder/README.md)
+framework. This README is the entry point for engineers extending the
+integration. The bulk of the design rationale, spike findings, and
+acceptance criteria live in the longer notes folder at
+`~/.agents/synthetics-agent-builder/notes/`; this doc is the in-repo
+TL;DR.
+
+## What does it do
+
+In a chat conversation:
+
+1. The user asks for a monitor (*"create an HTTP monitor for
+   `https://example.com` every 5 minutes from `us_central`"*).
+2. The agent loads the `monitor-management` skill, which scopes its
+   tool surface to `manage_synthetics_monitor` plus the platform's
+   SML helpers.
+3. `manage_synthetics_monitor` builds an in-memory **draft** by
+   applying the LLM's `operations[]` (set_metadata, set_schedule,
+   set_locations, set_http_check, set_enabled). Each op runs a Zod
+   refine; cross-field saveability is checked at batch boundary.
+4. The draft becomes a `synthetics.monitor_management` attachment
+   with `status: 'proposed'`. The chat UI renders the inline card
+   (browser-side, lazy-loaded).
+5. The user clicks the inline card → canvas flyout opens → clicks
+   **Create**. The browser POSTs to `/api/synthetics/monitors`
+   exactly as the existing monitor form does. On success, the
+   attachment's `origin` flips from by-value to by-reference (the
+   saved-object id) via the framework's `updateOrigin` callback.
+6. Future turns in the same conversation can mutate the saved
+   monitor via the same tool — `Update` button on the canvas issues
+   a PUT.
+
+The tool **never persists**. Only the Create / Update buttons in the
+canvas write to Synthetics, and they do so under the user's session
+with the existing `uptime-write` privilege check.
+
+## Architectural pieces
+
+| Piece | Files | Layer |
+|---|---|---|
+| Skill | `skills/monitor_management_skill.ts` | server |
+| Inline tool (`manage_synthetics_monitor`) | `tools/manage_synthetics_monitor/` | server |
+| Attachment type (`synthetics.monitor_management`) | `attachments/monitor_management_attachment_type.ts` | server |
+| SML type (`synthetics_monitor`) | `sml/monitor_sml_type.ts` | server |
+| Server-side bind | `bind_on_setup.ts` | server |
+| Browser-side bind | `../../public/agent_builder/bind_on_start.ts` | client |
+| Inline content (chat card) | `../../public/agent_builder/attachments/monitor_management_inline_content.tsx` | client |
+| Canvas content (flyout) | `../../public/agent_builder/attachments/monitor_management_canvas_content.tsx` | client |
+| Canvas action wiring | `../../public/agent_builder/attachments/use_monitor_canvas_actions.ts` | client |
+| Canvas Create/Update HTTP wrappers | `../../public/agent_builder/attachments/monitor_management_actions.ts` | client |
+| Shared Zod schemas + types | `../../common/agent_builder/` | common |
+
+This is the "5+3 piece" pattern referenced across Agent Builder
+integrations (5 server pieces, 3 client pieces). The exact same shape
+is used by `dashboard_agent` and the alerting v2 rule attachment.
+
+## The `operations[]` surface
+
+`manage_synthetics_monitor` accepts a discriminated-union array of
+mutations applied in order to a single in-memory draft. Each op is a
+Zod schema with its own `.refine` checks; per-op invariants fail at
+parse time, cross-field invariants are caught when
+`assertMonitorDraftSaveable` runs at batch boundary.
+
+| Op | Mutates | Per-op checks |
+|---|---|---|
+| `set_metadata` | name, tags, apm_service_name, namespace | name length, tag count |
+| `set_schedule` | schedule.number + schedule.unit | allow-listed values (1, 3, 5, 10, 15, 30, 60, 120, 240 minutes) |
+| `set_http_check` | urls, request_method, max_redirects, ignore_https_errors | URL must parse as `http`/`https` |
+| `set_locations` | locations[] (replaces — not merges) | non-empty, ids must look like ids |
+| `set_enabled` | enabled boolean | — |
+
+v1 is HTTP-only (`MONITOR_TYPE: z.literal(MonitorTypeEnum.HTTP)`). TCP
+/ ICMP / Browser would extend the schema to a discriminated union.
+
+## Auth + persistence model
+
+- **Tool never persists.** Mutations live in the per-conversation
+  attachment store. There is no synthetics CRUD path through
+  `manage_synthetics_monitor`.
+- **Canvas Create / Update buttons** call the existing public
+  synthetics REST endpoints (`POST` / `PUT
+  /api/synthetics/monitors[/{configId}]`) under the user's session.
+  Authorization rides on `uptime-read` + `uptime-write` (already
+  required by the route). The canvas mirrors the SPA's monitor form
+  in this regard — secrets ride plaintext in the JSON body, server
+  encrypts via `formatSecrets` before persisting.
+- **Capabilities:** the canvas reads
+  `application.capabilities.uptime.save` (disables Create / Update
+  with a "missing privilege" tooltip if false) and
+  `application.capabilities.uptime.elasticManagedLocationsEnabled`
+  (disables only when the draft uses Elastic-managed locations).
+- **Project-origin (CLI-managed) monitors** are read-only. The tool
+  refuses to mutate; the canvas surfaces a callout explaining the
+  CLI workflow and shows only a "View in Synthetics" button.
+
+## Registration gate
+
+There is **one** gate: the optional `agentBuilder` plugin's presence.
+Both `bind_on_setup.ts` (server) and `bind_on_start.ts` (browser)
+short-circuit silently when the plugin isn't loaded. There is **no
+synthetics-side feature flag** — the Agent Builder UX itself is the
+gate, and an extra micro-FF would be dead config surface.
+
+The `monitor-management` skill id must also be present in
+[`@kbn/agent-builder-server/allow_lists.ts`](../../../../../../platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts).
+That file is hand-curated by the Agent Builder team as a cross-team
+review trigger — adding new built-in skills/tools/agents will pull
+their reviewers in.
+
+## Local dev setup
+
+Minimum config in `config/kibana.dev.yml`:
+
+```yaml
+xpack.agentBuilder.enabled: true
+
+# An LLM connector reachable from your machine.
+xpack.actions.preconfigured:
+  smoke-test-llm:
+    name: 'Smoke-test LLM'
+    actionTypeId: .gen-ai
+    config:
+      apiUrl: https://api.openai.com/v1/chat/completions
+      apiProvider: 'OpenAI'
+      defaultModel: 'gpt-4o'
+    secrets:
+      apiKey: '<your key>'
+```
+
+Start ES + Kibana, then verify the bind ran:
+
+```bash
+node x-pack/solutions/observability/plugins/synthetics/scripts/agent_builder_monitor_smoke.js
+```
+
+This is non-LLM, ~30s, and tests both that the skill registered and
+that the canvas Save payload round-trips through the synthetics REST
+API. See its docstring for env-var overrides.
+
+For end-to-end manual verification with a real chat surface, follow
+the tiered scenario doc at
+`~/.agents/synthetics-agent-builder/notes/01-monitor-management/smoke-tests.md`.
+
+## File map
+
+```
+server/agent_builder/
+├── README.md                           (this file)
+├── bind_on_setup.ts                    main entry — registers all 4 pieces
+├── bind_on_setup.test.ts
+├── skills/
+│   └── monitor_management_skill.ts     skill content (LLM system prompt)
+├── tools/
+│   └── manage_synthetics_monitor/
+│       ├── manage_synthetics_monitor.ts    tool handler (operations dispatch)
+│       ├── operations.ts                   Zod discriminated union of ops
+│       └── monitor_draft.ts                executeMonitorOperations + saveability checks
+├── attachments/
+│   └── monitor_management_attachment_type.ts   resolve / isStale / format
+├── sml/
+│   └── monitor_sml_type.ts             SML chunking strategy (per-monitor chunks)
+├── internal/
+│   └── monitor_attachment_data.ts      shared bulkGet → schema-projection helper
+└── register_data_provider.ts           (existing — observability data providers)
+
+public/agent_builder/
+├── bind_on_start.ts                    browser-side bind entry
+└── attachments/
+    ├── monitor_management_attachment_definition.tsx   AttachmentUIDefinition factory
+    ├── monitor_management_inline_content.tsx          chat card
+    ├── monitor_management_canvas_content.tsx          flyout body
+    ├── monitor_management_status.tsx                  shared status helpers
+    ├── monitor_management_actions.ts                  Create/Update HTTP wrappers
+    └── use_monitor_canvas_actions.ts                   Canvas action button wiring (returns ActionButton[])
+
+common/agent_builder/
+├── monitor_management_constants.ts                    type ids
+└── monitor_management_attachment_schema.ts            Zod (MonitorAttachmentData + MonitorDraft)
+```
+
+## Followups
+
+Tracked in `~/.agents/synthetics-agent-builder/notes/01-monitor-management/followups.md`.
+Selected highlights:
+
+- **TCP / ICMP / Browser monitor types** — extend the v1 HTTP-only
+  schema to a discriminated union (with new ops e.g.
+  `set_tcp_check`).
+- **`params` / inline parameter editor** — currently treated as
+  opaque secret-key. Users will eventually want to author params via
+  chat.
+- **Diagnosis merge** — connect the in-flight Synthetics diagnosis
+  skill (separate POC) so the agent can explain a saved monitor's
+  failure modes from the same canvas.
+- **Multi-space edge cases** — `synthetics-monitor-multi-space` SO
+  type vs legacy `synthetics-monitor`. SML chunking already handles
+  this defensively, but the attachment `resolve` path could still
+  mishandle a cross-space edit.
+- **`isStale` UI banner** — server hook fires today; the canvas
+  doesn't visually surface it. Captured in `smoke-tests.md` as
+  "currently NOT smoke-testable".
+- **Rich Overview tile in the canvas** — sparkline trend, last-status
+  icon, latency, errors. Requires plumbing
+  `OverviewStatusMetaData` outside the synthetics SPA.
+- **Scout UI E2E suite** — outline at
+  `~/.agents/synthetics-agent-builder/notes/01-monitor-management/scout-outline.md`,
+  blocked on Agent Builder shipping a stub LLM connector or stable
+  conversation-seed API.
+
+## Where to go next
+
+| Question | Answer |
+|---|---|
+| How does Agent Builder route attachments to inline / canvas renderers? | `dashboard_agent` is the canonical precedent; see `x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/` |
+| What's the AttachmentUIDefinition contract? | `x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts` |
+| Where does the Agent Builder plugin live? | `x-pack/platform/plugins/shared/agent_builder/` (read its README first) |
+| Why is there no feature flag? | See the design discussion captured in `~/.agents/synthetics-agent-builder/notes/00-cross-cutting-decisions.md` |
+| How do I plan a new Synthetics × Agent Builder use case? | The `kibana-agent-builder-expert` subagent + the structured loop in `~/.agents/synthetics-agent-builder/notes/README.md` |

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/attachments/monitor_management_attachment_type.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/attachments/monitor_management_attachment_type.test.ts
@@ -1,0 +1,562 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type {
+  AttachmentResolveContext,
+  AttachmentTypeDefinition,
+} from '@kbn/agent-builder-server/attachments';
+import type {
+  Attachment,
+  VersionedAttachmentWithOrigin,
+} from '@kbn/agent-builder-common/attachments';
+import {
+  legacySyntheticsMonitorTypeSingle,
+  syntheticsMonitorSavedObjectType,
+} from '../../../common/types/saved_objects';
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  type MonitorAttachmentData,
+} from '../../../common/agent_builder';
+import { ConfigKey } from '../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+import { createMonitorManagementAttachmentType } from './monitor_management_attachment_type';
+
+const createLogger = (): jest.Mocked<Logger> =>
+  ({
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+    fatal: jest.fn(),
+    log: jest.fn(),
+    isLevelEnabled: jest.fn(() => false),
+    get: jest.fn(),
+  } as unknown as jest.Mocked<Logger>);
+
+const buildHttpMonitorAttributes = (overrides: Record<string, unknown> = {}) => ({
+  [ConfigKey.NAME]: 'Elastic API health',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [
+    { id: 'us_central', label: 'North America - US Central', isServiceManaged: true },
+  ],
+  [ConfigKey.URLS]: 'https://api.elastic.co',
+  [ConfigKey.TAGS]: ['poc', 'public-api'],
+  [ConfigKey.NAMESPACE]: 'default',
+  [ConfigKey.MAX_ATTEMPTS]: 1,
+  [ConfigKey.APM_SERVICE_NAME]: '',
+  [ConfigKey.CONFIG_ID]: 'config-1',
+  [ConfigKey.MONITOR_QUERY_ID]: 'config-1',
+  ...overrides,
+});
+
+const buildSavedObjectFound = ({
+  id,
+  type,
+  attributes = buildHttpMonitorAttributes(),
+  updatedAt = '2026-04-30T17:00:00.000Z',
+}: {
+  id: string;
+  type: string;
+  attributes?: Record<string, unknown>;
+  updatedAt?: string;
+}) => ({
+  id,
+  type,
+  attributes,
+  namespaces: ['default'],
+  updated_at: updatedAt,
+  created_at: '2026-04-15T10:00:00.000Z',
+  references: [],
+});
+
+const buildSavedObjectMissing = ({ id, type }: { id: string; type: string }) => ({
+  id,
+  type,
+  error: {
+    statusCode: 404,
+    error: 'Not Found',
+    message: 'Saved object [type/id] not found',
+  },
+  attributes: undefined as unknown as Record<string, unknown>,
+});
+
+const buildAttachmentData = (
+  overrides: Partial<MonitorAttachmentData> = {}
+): MonitorAttachmentData => ({
+  [ConfigKey.NAME]: 'Elastic API health',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [
+    { id: 'us_central', label: 'North America - US Central', isServiceManaged: true },
+  ],
+  [ConfigKey.URLS]: 'https://api.elastic.co',
+  ...overrides,
+});
+
+const buildResolveContext = ({
+  savedObjectsClient,
+  spaceId = 'default',
+}: {
+  savedObjectsClient?: unknown;
+  spaceId?: string;
+} = {}): AttachmentResolveContext => ({
+  request: {} as never,
+  spaceId,
+  savedObjectsClient: savedObjectsClient as never,
+});
+
+describe('createMonitorManagementAttachmentType', () => {
+  const buildAttachmentType = (): AttachmentTypeDefinition<
+    typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+    MonitorAttachmentData
+  > => createMonitorManagementAttachmentType({ logger: createLogger() });
+
+  it('exposes the agreed attachment type id and is not read-only', () => {
+    const def = buildAttachmentType();
+    expect(def.id).toBe(MONITOR_MANAGEMENT_ATTACHMENT_TYPE);
+    expect(def.isReadonly).toBe(false);
+  });
+
+  describe('validate', () => {
+    it('accepts a valid HTTP monitor (proposed)', async () => {
+      const def = buildAttachmentType();
+      const result = await Promise.resolve(def.validate(buildAttachmentData()));
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.data[ConfigKey.NAME]).toBe('Elastic API health');
+      }
+    });
+
+    it('rejects malformed input with an error message', async () => {
+      const def = buildAttachmentType();
+      const result = await Promise.resolve(def.validate({ junk: true }));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(typeof result.error).toBe('string');
+        expect(result.error.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('resolve', () => {
+    it('returns projected attachment data for an HTTP monitor scoped to the user', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-1',
+              type: syntheticsMonitorSavedObjectType,
+            }),
+            buildSavedObjectMissing({
+              id: 'config-1',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const def = buildAttachmentType();
+      const data = await def.resolve!('config-1', buildResolveContext({ savedObjectsClient }));
+
+      expect(savedObjectsClient.bulkGet).toHaveBeenCalledWith([
+        { type: syntheticsMonitorSavedObjectType, id: 'config-1' },
+        { type: legacySyntheticsMonitorTypeSingle, id: 'config-1' },
+      ]);
+      expect(data?.[ConfigKey.NAME]).toBe('Elastic API health');
+      expect(data?.[ConfigKey.URLS]).toBe('https://api.elastic.co');
+      expect(data?.[ConfigKey.CONFIG_ID]).toBe('config-1');
+    });
+
+    it('resolves a project-origin (CLI-managed) monitor without throwing', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'project-config-1',
+              type: syntheticsMonitorSavedObjectType,
+              attributes: buildHttpMonitorAttributes({
+                [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.PROJECT,
+                [ConfigKey.PROJECT_ID]: 'my-project',
+              }),
+            }),
+            buildSavedObjectMissing({
+              id: 'project-config-1',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const def = buildAttachmentType();
+      const data = await def.resolve!(
+        'project-config-1',
+        buildResolveContext({ savedObjectsClient })
+      );
+
+      // Project-origin monitors must still resolve — the canvas needs the
+      // data to render the "Edit via CLI" read-only state. Save buttons are
+      // gated client-side, not by resolve refusal.
+      expect(data?.[ConfigKey.MONITOR_SOURCE_TYPE]).toBe(SourceType.PROJECT);
+    });
+
+    it('logs warn and returns undefined when no SO matches the origin', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectMissing({
+              id: 'gone',
+              type: syntheticsMonitorSavedObjectType,
+            }),
+            buildSavedObjectMissing({
+              id: 'gone',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+      const logger = createLogger();
+      const def = createMonitorManagementAttachmentType({ logger });
+
+      const data = await def.resolve!('gone', buildResolveContext({ savedObjectsClient }));
+
+      expect(data).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "monitor_management attachment.resolve: no monitor found for config_id='gone'"
+        )
+      );
+    });
+
+    it('logs warn and returns undefined for non-HTTP monitors (v1 scope)', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-tcp',
+              type: syntheticsMonitorSavedObjectType,
+              attributes: buildHttpMonitorAttributes({
+                [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.TCP,
+              }),
+            }),
+            buildSavedObjectMissing({
+              id: 'config-tcp',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+      const def = buildAttachmentType();
+      const data = await def.resolve!('config-tcp', buildResolveContext({ savedObjectsClient }));
+      expect(data).toBeUndefined();
+    });
+
+    it('logs warn and returns undefined when savedObjectsClient is missing from the context', async () => {
+      const logger = createLogger();
+      const def = createMonitorManagementAttachmentType({ logger });
+
+      const data = await def.resolve!(
+        'config-1',
+        buildResolveContext({ savedObjectsClient: undefined })
+      );
+
+      expect(data).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "monitor_management attachment.resolve: missing savedObjectsClient on context for origin 'config-1'"
+        )
+      );
+    });
+  });
+
+  describe('isStale', () => {
+    const buildVersionedAttachment = ({
+      origin = 'config-1',
+      origin_snapshot_at = '2026-04-30T16:00:00.000Z',
+    }: {
+      origin?: string;
+      origin_snapshot_at?: string;
+    } = {}): VersionedAttachmentWithOrigin<
+      typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+      MonitorAttachmentData
+    > => ({
+      id: 'attachment-1',
+      type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+      versions: [
+        {
+          version: 1,
+          data: buildAttachmentData(),
+          created_at: origin_snapshot_at,
+          content_hash: 'abc',
+        },
+      ],
+      current_version: 1,
+      origin,
+      origin_snapshot_at,
+    });
+
+    it('returns true when the live monitor is newer than the snapshot', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-1',
+              type: syntheticsMonitorSavedObjectType,
+              updatedAt: '2026-04-30T18:00:00.000Z',
+            }),
+            buildSavedObjectMissing({
+              id: 'config-1',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const def = buildAttachmentType();
+      const stale = await def.isStale!(
+        buildVersionedAttachment({ origin_snapshot_at: '2026-04-30T16:00:00.000Z' }),
+        buildResolveContext({ savedObjectsClient })
+      );
+
+      expect(stale).toBe(true);
+    });
+
+    it('returns false when the live monitor is the same age or older than the snapshot', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-1',
+              type: syntheticsMonitorSavedObjectType,
+              updatedAt: '2026-04-30T16:00:00.000Z',
+            }),
+            buildSavedObjectMissing({
+              id: 'config-1',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const def = buildAttachmentType();
+      const stale = await def.isStale!(
+        buildVersionedAttachment({ origin_snapshot_at: '2026-04-30T16:00:00.000Z' }),
+        buildResolveContext({ savedObjectsClient })
+      );
+
+      expect(stale).toBe(false);
+    });
+
+    it('returns false when origin_snapshot_at is missing (no anchor)', async () => {
+      const def = buildAttachmentType();
+      const stale = await def.isStale!(
+        {
+          ...buildVersionedAttachment(),
+          origin_snapshot_at: undefined,
+        } as never,
+        buildResolveContext({ savedObjectsClient: { bulkGet: jest.fn() } })
+      );
+      expect(stale).toBe(false);
+    });
+
+    it('warns and returns false when the live monitor has no updated_at', async () => {
+      // Build a SO **without** an `updated_at` field (mirrors a partially
+      // migrated fixture). JS destructure defaults coalesce an explicit
+      // `undefined`, so we drop the key entirely instead.
+      const savedObjectWithoutUpdatedAt = {
+        ...buildSavedObjectFound({
+          id: 'config-1',
+          type: syntheticsMonitorSavedObjectType,
+        }),
+      };
+      delete (savedObjectWithoutUpdatedAt as { updated_at?: string }).updated_at;
+
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            savedObjectWithoutUpdatedAt,
+            buildSavedObjectMissing({
+              id: 'config-1',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+      const logger = createLogger();
+      const def = createMonitorManagementAttachmentType({ logger });
+
+      const stale = await def.isStale!(
+        buildVersionedAttachment(),
+        buildResolveContext({ savedObjectsClient })
+      );
+
+      expect(stale).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'monitor_management attachment.isStale: no updated_at on live monitor'
+        )
+      );
+    });
+
+    it('warns and returns false when bulkGet throws', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockRejectedValue(new Error('ES connection refused')),
+      };
+      const logger = createLogger();
+      const def = createMonitorManagementAttachmentType({ logger });
+
+      const stale = await def.isStale!(
+        buildVersionedAttachment(),
+        buildResolveContext({ savedObjectsClient })
+      );
+
+      expect(stale).toBe(false);
+      // Either the inner fetch helper warning OR the outer try/catch
+      // warning satisfies this — both are "warn, not error" by design.
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('warns and returns false when savedObjectsClient is missing from the context', async () => {
+      const logger = createLogger();
+      const def = createMonitorManagementAttachmentType({ logger });
+
+      const stale = await def.isStale!(
+        buildVersionedAttachment(),
+        buildResolveContext({ savedObjectsClient: undefined })
+      );
+
+      expect(stale).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'monitor_management attachment.isStale: missing savedObjectsClient on context'
+        )
+      );
+    });
+  });
+
+  describe('format.getRepresentation', () => {
+    const buildAttachment = (
+      data: MonitorAttachmentData
+    ): Attachment<typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE, MonitorAttachmentData> => ({
+      id: 'attachment-1',
+      type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+      data,
+    });
+
+    // `format()` returns `MaybePromise<AgentFormattedAttachment>`. We
+    // unwrap once per test via `Promise.resolve` so each block stays
+    // async and the assertions read top-down.
+    const renderText = async (
+      def: AttachmentTypeDefinition<
+        typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+        MonitorAttachmentData
+      >,
+      data: MonitorAttachmentData
+    ): Promise<string> => {
+      const formatted = await Promise.resolve(
+        def.format(buildAttachment(data), { request: {} as never, spaceId: 'default' })
+      );
+      const rep = await Promise.resolve(formatted.getRepresentation!());
+      if (rep.type !== 'text') {
+        throw new Error(`Expected text representation, got ${rep.type}`);
+      }
+      return rep.value;
+    };
+
+    it('renders status="proposed" when there is no config_id', async () => {
+      const value = await renderText(buildAttachmentType(), buildAttachmentData());
+      expect(value).toContain('status: proposed');
+      expect(value).toContain('Elastic API health');
+      expect(value).toContain('attachment-1');
+    });
+
+    it('renders status="enabled" for a saved enabled monitor', async () => {
+      const value = await renderText(
+        buildAttachmentType(),
+        buildAttachmentData({
+          [ConfigKey.CONFIG_ID]: 'config-1',
+          [ConfigKey.ENABLED]: true,
+        })
+      );
+      expect(value).toContain('status: enabled');
+    });
+
+    it('renders status="disabled" for a saved disabled monitor', async () => {
+      const value = await renderText(
+        buildAttachmentType(),
+        buildAttachmentData({
+          [ConfigKey.CONFIG_ID]: 'config-1',
+          [ConfigKey.ENABLED]: false,
+        })
+      );
+      expect(value).toContain('status: disabled');
+    });
+
+    it('renders status="cli-managed" for a project-origin monitor (regardless of enabled)', async () => {
+      const value = await renderText(
+        buildAttachmentType(),
+        buildAttachmentData({
+          [ConfigKey.CONFIG_ID]: 'project-config-1',
+          [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.PROJECT,
+          [ConfigKey.ENABLED]: true,
+        })
+      );
+      expect(value).toContain('status: cli-managed');
+    });
+
+    it('does not leak any value that looks like a secret (defense check)', async () => {
+      // Pretend the data carries fields that snuck through. The
+      // representation only references the schema-known keys, so neither
+      // value nor any structure-leaking key must appear.
+      const dataWithLeakedSecret = {
+        ...buildAttachmentData(),
+        password: 'super-secret-pa$$w0rd',
+        params: '{"hidden":true}',
+      } as unknown as MonitorAttachmentData;
+      const value = await renderText(buildAttachmentType(), dataWithLeakedSecret);
+      expect(value).not.toContain('super-secret-pa$$w0rd');
+      expect(value).not.toContain('hidden');
+    });
+
+    it('renders schedule, locations count, and tags', async () => {
+      const value = await renderText(
+        buildAttachmentType(),
+        buildAttachmentData({
+          [ConfigKey.SCHEDULE]: { number: '10', unit: ScheduleUnit.MINUTES },
+          [ConfigKey.LOCATIONS]: [
+            { id: 'a', label: 'A', isServiceManaged: true },
+            { id: 'b', label: 'B', isServiceManaged: false, agentPolicyId: 'fleet-1' },
+          ],
+          [ConfigKey.TAGS]: ['poc', 'prod'],
+        })
+      );
+      expect(value).toContain('Schedule: every 10m');
+      expect(value).toContain('Locations: 2');
+      expect(value).toContain('Tags: poc, prod');
+    });
+  });
+
+  describe('getAgentDescription', () => {
+    it('points to the real skill and tool — no fictitious tool names', () => {
+      const def = buildAttachmentType();
+      const description = def.getAgentDescription!();
+      expect(description).toContain('monitor-management');
+      expect(description).toContain('manage_synthetics_monitor');
+      // Sanity check: no obviously fake names from prior drafts of the doc
+      expect(description).not.toContain('manage_monitor');
+      expect(description).not.toContain('synthetics_monitor_tool');
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/attachments/monitor_management_attachment_type.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/attachments/monitor_management_attachment_type.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type { Logger } from '@kbn/logging';
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  monitorAttachmentDataSchema,
+  type MonitorAttachmentData,
+} from '../../../common/agent_builder';
+import { ConfigKey } from '../../../common/runtime_types';
+import { SourceType } from '../../../common/runtime_types/monitor_management/monitor_configs';
+import { fetchMonitorAttachmentData } from '../internal/monitor_attachment_data';
+
+interface CreateMonitorManagementAttachmentTypeOptions {
+  logger: Logger;
+}
+
+/**
+ * Status badge values surfaced in the inline card and the LLM
+ * representation. Mirrors the four states the UI inline card renders
+ * (`proposed` / `enabled` / `disabled` / `cli-managed`) — see brief §B and
+ * `00-architecture.md`.
+ */
+type MonitorAttachmentStatus = 'proposed' | 'enabled' | 'disabled' | 'cli-managed';
+
+const getMonitorStatus = (data: MonitorAttachmentData): MonitorAttachmentStatus => {
+  // Project-origin monitors are CLI-managed — UI/agent edits are forbidden,
+  // and the canvas Save button is replaced with a "Edit via CLI" link.
+  if (data[ConfigKey.MONITOR_SOURCE_TYPE] === SourceType.PROJECT) {
+    return 'cli-managed';
+  }
+  // No `config_id` ⇒ this is a draft the agent has composed via
+  // `manage_synthetics_monitor` but the user has not yet saved.
+  if (!data[ConfigKey.CONFIG_ID]) {
+    return 'proposed';
+  }
+  return data[ConfigKey.ENABLED] ? 'enabled' : 'disabled';
+};
+
+/**
+ * Render a plain-text summary of the monitor for the LLM prompt. We
+ * deliberately avoid leaking encrypted secrets — the schema has already
+ * stripped them on parse, but we keep the projection list explicit so
+ * future fields default to "not exposed unless added here".
+ */
+const formatMonitorRepresentation = (attachmentId: string, data: MonitorAttachmentData): string => {
+  const status = getMonitorStatus(data);
+  const schedule = data[ConfigKey.SCHEDULE];
+  const locationsCount = data[ConfigKey.LOCATIONS]?.length ?? 0;
+  const tags = data[ConfigKey.TAGS] ?? [];
+
+  const lines: string[] = [
+    `Synthetics monitor "${
+      data[ConfigKey.NAME]
+    }" (monitorAttachment.id: "${attachmentId}", status: ${status}, type: ${
+      data[ConfigKey.MONITOR_TYPE]
+    })`,
+    `URL: ${data[ConfigKey.URLS]}`,
+    `Schedule: every ${schedule.number}${schedule.unit}`,
+    `Locations: ${locationsCount}`,
+  ];
+
+  if (tags.length > 0) {
+    lines.push(`Tags: ${tags.join(', ')}`);
+  }
+
+  if (data[ConfigKey.CONFIG_ID]) {
+    lines.push(`config_id: ${data[ConfigKey.CONFIG_ID]}`);
+  }
+
+  return lines.join('\n');
+};
+
+/**
+ * Attachment type definition for `MONITOR_MANAGEMENT_ATTACHMENT_TYPE`.
+ *
+ * Behaviour mirrors the dashboard_agent attachment type:
+ * - `validate` runs `monitorAttachmentDataSchema` (Zod) — keys are
+ *   `ConfigKey`-aligned, so a successful validation is also a structural
+ *   guarantee that the data round-trips through the GET response shape
+ *   for HTTP monitors.
+ * - `resolve` is invoked once at attachment-add time for by-reference
+ *   attachments — fetches the live monitor scoped to the user's request,
+ *   logs at `warn` (not `error`) on failure, returns `undefined`.
+ * - `isStale` compares the live monitor's SO `updated_at` against the
+ *   attachment's `origin_snapshot_at`. Returns `false` (and warns) when
+ *   either timestamp is missing — a conservative default that avoids
+ *   spurious "outdated" banners.
+ * - `format` exposes a plain-text representation built from the schema
+ *   data — never from the raw SO — so secrets never leak into prompts.
+ *
+ * Persistence is the **user's** click; this attachment type never writes.
+ */
+export const createMonitorManagementAttachmentType = ({
+  logger,
+}: CreateMonitorManagementAttachmentTypeOptions): AttachmentTypeDefinition<
+  typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  MonitorAttachmentData
+> => {
+  return {
+    id: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+
+    validate: (input) => {
+      const parsed = monitorAttachmentDataSchema.safeParse(input);
+      if (parsed.success) {
+        return { valid: true, data: parsed.data };
+      }
+      return { valid: false, error: parsed.error.message };
+    },
+
+    resolve: async (origin, context) => {
+      if (!context.savedObjectsClient) {
+        // Same posture as dashboard_agent: bail loudly when the runtime
+        // didn't pass us the request-scoped client. Without it we cannot
+        // honour the auth-boundary contract (user is the actor).
+        logger.warn(
+          `monitor_management attachment.resolve: missing savedObjectsClient on context for origin '${origin}'`
+        );
+        return undefined;
+      }
+
+      const fetched = await fetchMonitorAttachmentData({
+        soClient: context.savedObjectsClient,
+        configId: origin,
+        logger,
+        context: 'attachment.resolve',
+      });
+
+      return fetched?.data;
+    },
+
+    isStale: async (attachment, context) => {
+      // `isStale` is only invoked for attachments with a populated
+      // `origin` per the framework contract, but the framework also
+      // requires `origin_snapshot_at` to make a meaningful comparison —
+      // without it we have no "last seen" anchor. Be conservative.
+      if (!attachment.origin_snapshot_at) {
+        return false;
+      }
+      if (!context.savedObjectsClient) {
+        logger.warn(
+          `monitor_management attachment.isStale: missing savedObjectsClient on context for origin '${attachment.origin}'`
+        );
+        return false;
+      }
+
+      try {
+        const fetched = await fetchMonitorAttachmentData({
+          soClient: context.savedObjectsClient,
+          configId: attachment.origin,
+          logger,
+          context: 'attachment.isStale',
+        });
+
+        const liveUpdatedAt = fetched?.updatedAt;
+        if (!liveUpdatedAt) {
+          // Fallback when the SO has no `updated_at` (e.g. legacy fixture)
+          // — avoid showing a spurious "outdated" banner.
+          logger.warn(
+            `monitor_management attachment.isStale: no updated_at on live monitor for origin '${attachment.origin}' — treating as fresh`
+          );
+          return false;
+        }
+
+        return Date.parse(liveUpdatedAt) > Date.parse(attachment.origin_snapshot_at);
+      } catch (error) {
+        logger.warn(
+          `monitor_management attachment.isStale: failed for origin '${attachment.origin}': ${
+            (error as Error).message
+          }`
+        );
+        return false;
+      }
+    },
+
+    format: (attachment) => ({
+      getRepresentation: () => ({
+        type: 'text',
+        value: formatMonitorRepresentation(attachment.id, attachment.data),
+      }),
+    }),
+
+    getAgentDescription: () =>
+      // Aligns with the cross-cutting decision: agent description points to
+      // the **real** skill (registered in T5 as `monitor-management`) and
+      // the **real** tool (`manage_synthetics_monitor` from T4). No
+      // fictitious tools.
+      `A Synthetics monitor attachment. Rendering it inline shows a card with the monitor's name, status (proposed / enabled / disabled / cli-managed), schedule, location count, and tags. To compose or modify a draft monitor, load the \`monitor-management\` skill and use the \`manage_synthetics_monitor\` tool — the tool never persists; the user's click on Create / Update in the canvas flyout is what writes to Synthetics. CLI-managed (project-origin) monitors are read-only via this attachment.`,
+
+    isReadonly: false,
+  };
+};
+
+export { MONITOR_MANAGEMENT_ATTACHMENT_TYPE };
+export type { MonitorAttachmentData };

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/bind_on_setup.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/bind_on_setup.test.ts
@@ -7,20 +7,23 @@
 
 import { loggerMock } from '@kbn/logging-mocks';
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import type { AgentContextLayerPluginSetup } from '@kbn/agent-context-layer-plugin/server';
 import { MONITOR_MANAGEMENT_ATTACHMENT_TYPE, MONITOR_SML_TYPE } from '../../common/agent_builder';
 import { bindAgentBuilder } from './bind_on_setup';
 import { monitorManagementSkill } from './skills';
 
-const buildAgentBuilderMock = () => {
+const buildMocks = () => {
   const registerType = jest.fn();
   const registerSmlType = jest.fn();
   const registerSkill = jest.fn();
   return {
-    mock: {
+    agentBuilder: {
       attachments: { registerType },
-      sml: { registerType: registerSmlType },
       skills: { register: registerSkill },
     } as unknown as AgentBuilderPluginSetup,
+    agentContextLayer: {
+      registerType: registerSmlType,
+    } as unknown as AgentContextLayerPluginSetup,
     registerType,
     registerSmlType,
     registerSkill,
@@ -28,21 +31,34 @@ const buildAgentBuilderMock = () => {
 };
 
 describe('bindAgentBuilder', () => {
-  it('returns plugin_missing without touching anything when agentBuilder is undefined', () => {
-    const logger = loggerMock.create();
+  it('returns plugin_missing when agentBuilder is undefined', () => {
+    const { agentContextLayer } = buildMocks();
     const result = bindAgentBuilder({
       agentBuilder: undefined,
-      logger,
+      agentContextLayer,
+      logger: loggerMock.create(),
     });
     expect(result).toEqual({ registered: false, reason: 'plugin_missing' });
   });
 
-  it('registers attachment + SML + skill when the agentBuilder plugin is present', () => {
-    const { mock, registerType, registerSmlType, registerSkill } = buildAgentBuilderMock();
+  it('returns plugin_missing when agentContextLayer is undefined', () => {
+    const { agentBuilder } = buildMocks();
+    const result = bindAgentBuilder({
+      agentBuilder,
+      agentContextLayer: undefined,
+      logger: loggerMock.create(),
+    });
+    expect(result).toEqual({ registered: false, reason: 'plugin_missing' });
+  });
+
+  it('registers attachment + SML + skill when both plugins are present', () => {
+    const { agentBuilder, agentContextLayer, registerType, registerSmlType, registerSkill } =
+      buildMocks();
     const logger = loggerMock.create();
 
     const result = bindAgentBuilder({
-      agentBuilder: mock,
+      agentBuilder,
+      agentContextLayer,
       logger,
     });
 
@@ -53,24 +69,24 @@ describe('bindAgentBuilder', () => {
   });
 
   it('registers the attachment type with the correct id', () => {
-    const { mock, registerType } = buildAgentBuilderMock();
-    bindAgentBuilder({ agentBuilder: mock, logger: loggerMock.create() });
+    const { agentBuilder, agentContextLayer, registerType } = buildMocks();
+    bindAgentBuilder({ agentBuilder, agentContextLayer, logger: loggerMock.create() });
     expect(registerType.mock.calls[0][0]).toEqual(
       expect.objectContaining({ id: MONITOR_MANAGEMENT_ATTACHMENT_TYPE })
     );
   });
 
   it('registers the SML type with the correct id', () => {
-    const { mock, registerSmlType } = buildAgentBuilderMock();
-    bindAgentBuilder({ agentBuilder: mock, logger: loggerMock.create() });
+    const { agentBuilder, agentContextLayer, registerSmlType } = buildMocks();
+    bindAgentBuilder({ agentBuilder, agentContextLayer, logger: loggerMock.create() });
     expect(registerSmlType.mock.calls[0][0]).toEqual(
       expect.objectContaining({ id: MONITOR_SML_TYPE })
     );
   });
 
   it('registers the monitor-management skill exactly as defined', () => {
-    const { mock, registerSkill } = buildAgentBuilderMock();
-    bindAgentBuilder({ agentBuilder: mock, logger: loggerMock.create() });
+    const { agentBuilder, agentContextLayer, registerSkill } = buildMocks();
+    bindAgentBuilder({ agentBuilder, agentContextLayer, logger: loggerMock.create() });
     expect(registerSkill).toHaveBeenCalledWith(monitorManagementSkill);
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/bind_on_setup.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/bind_on_setup.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import { MONITOR_MANAGEMENT_ATTACHMENT_TYPE, MONITOR_SML_TYPE } from '../../common/agent_builder';
+import { bindAgentBuilder } from './bind_on_setup';
+import { monitorManagementSkill } from './skills';
+
+const buildAgentBuilderMock = () => {
+  const registerType = jest.fn();
+  const registerSmlType = jest.fn();
+  const registerSkill = jest.fn();
+  return {
+    mock: {
+      attachments: { registerType },
+      sml: { registerType: registerSmlType },
+      skills: { register: registerSkill },
+    } as unknown as AgentBuilderPluginSetup,
+    registerType,
+    registerSmlType,
+    registerSkill,
+  };
+};
+
+describe('bindAgentBuilder', () => {
+  it('returns plugin_missing without touching anything when agentBuilder is undefined', () => {
+    const logger = loggerMock.create();
+    const result = bindAgentBuilder({
+      agentBuilder: undefined,
+      logger,
+    });
+    expect(result).toEqual({ registered: false, reason: 'plugin_missing' });
+  });
+
+  it('registers attachment + SML + skill when the agentBuilder plugin is present', () => {
+    const { mock, registerType, registerSmlType, registerSkill } = buildAgentBuilderMock();
+    const logger = loggerMock.create();
+
+    const result = bindAgentBuilder({
+      agentBuilder: mock,
+      logger,
+    });
+
+    expect(result).toEqual({ registered: true });
+    expect(registerType).toHaveBeenCalledTimes(1);
+    expect(registerSmlType).toHaveBeenCalledTimes(1);
+    expect(registerSkill).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers the attachment type with the correct id', () => {
+    const { mock, registerType } = buildAgentBuilderMock();
+    bindAgentBuilder({ agentBuilder: mock, logger: loggerMock.create() });
+    expect(registerType.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: MONITOR_MANAGEMENT_ATTACHMENT_TYPE })
+    );
+  });
+
+  it('registers the SML type with the correct id', () => {
+    const { mock, registerSmlType } = buildAgentBuilderMock();
+    bindAgentBuilder({ agentBuilder: mock, logger: loggerMock.create() });
+    expect(registerSmlType.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: MONITOR_SML_TYPE })
+    );
+  });
+
+  it('registers the monitor-management skill exactly as defined', () => {
+    const { mock, registerSkill } = buildAgentBuilderMock();
+    bindAgentBuilder({ agentBuilder: mock, logger: loggerMock.create() });
+    expect(registerSkill).toHaveBeenCalledWith(monitorManagementSkill);
+  });
+});
+
+describe('monitorManagementSkill', () => {
+  it('declares the expected id and name', () => {
+    expect(monitorManagementSkill.id).toBe('monitor-management');
+    expect(monitorManagementSkill.name).toBe('monitor-management');
+    expect(monitorManagementSkill.basePath).toBe('skills/observability');
+  });
+
+  it('exposes the manage_synthetics_monitor tool inline', async () => {
+    const tools = await monitorManagementSkill.getInlineTools?.();
+    expect(tools).toBeDefined();
+    expect(tools).toHaveLength(1);
+    expect(tools?.[0]?.id).toBe('manage_synthetics_monitor');
+  });
+
+  it('mentions SML helpers, attachment type, and the v1 HTTP-only restriction in the prompt', () => {
+    expect(monitorManagementSkill.content).toContain('platform.core.sml_search');
+    expect(monitorManagementSkill.content).toContain('platform.core.sml_attach');
+    expect(monitorManagementSkill.content).toContain(MONITOR_MANAGEMENT_ATTACHMENT_TYPE);
+    expect(monitorManagementSkill.content).toContain('HTTP only');
+  });
+
+  it('warns the LLM about CLI-managed (project-origin) monitors', () => {
+    expect(monitorManagementSkill.content.toLowerCase()).toContain('cli-managed');
+    expect(monitorManagementSkill.content).toContain('project');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/bind_on_setup.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/bind_on_setup.ts
@@ -7,6 +7,7 @@
 
 import type { Logger } from '@kbn/logging';
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import type { AgentContextLayerPluginSetup } from '@kbn/agent-context-layer-plugin/server';
 import { createMonitorManagementAttachmentType } from './attachments/monitor_management_attachment_type';
 import { createMonitorSmlType } from './sml/monitor_sml_type';
 import { monitorManagementSkill } from './skills';
@@ -14,6 +15,12 @@ import { monitorManagementSkill } from './skills';
 interface BindAgentBuilderOptions {
   /** May be `undefined` when the optional `agentBuilder` plugin is missing. */
   agentBuilder: AgentBuilderPluginSetup | undefined;
+  /**
+   * SML registration moved from `agentBuilder` to the `agentContextLayer`
+   * plugin. Optional for the same reason as `agentBuilder` — deployments
+   * that don't include Agent Builder must still boot.
+   */
+  agentContextLayer: AgentContextLayerPluginSetup | undefined;
   logger: Logger;
 }
 
@@ -25,12 +32,13 @@ export interface BindAgentBuilderResult {
 
 /**
  * Conditionally registers the Synthetics × Agent Builder integration
- * with the `agentBuilder` plugin during `setup()`.
+ * with the `agentBuilder` and `agentContextLayer` plugins during `setup()`.
  *
- * Single gate: the `agentBuilder` plugin is actually present. It's
- * declared optional in `kibana.jsonc` (deployments without Agent Builder
- * — e.g. some on-prem / classic stack flavours — still need to boot),
- * so we have to guard.
+ * Single gate: both plugins are actually present. They're declared
+ * optional in `kibana.jsonc` (deployments without Agent Builder — e.g.
+ * some on-prem / classic stack flavours — still need to boot), so we
+ * have to guard. `agentBuilder` itself depends on `agentContextLayer`,
+ * so in practice they appear or disappear together.
  *
  * No additional Synthetics-side feature flag: the broader Agent Builder
  * UX is itself the gate. When `agentBuilder` is enabled in a Kibana
@@ -44,11 +52,12 @@ export interface BindAgentBuilderResult {
  */
 export const bindAgentBuilder = ({
   agentBuilder,
+  agentContextLayer,
   logger,
 }: BindAgentBuilderOptions): BindAgentBuilderResult => {
-  if (!agentBuilder) {
+  if (!agentBuilder || !agentContextLayer) {
     logger.debug(
-      'Synthetics × Agent Builder integration: agentBuilder plugin not present; skipping.'
+      'Synthetics × Agent Builder integration: agentBuilder or agentContextLayer plugin not present; skipping.'
     );
     return { registered: false, reason: 'plugin_missing' };
   }
@@ -62,9 +71,7 @@ export const bindAgentBuilder = ({
     }) as Parameters<typeof agentBuilder.attachments.registerType>[0]
   );
 
-  agentBuilder.sml.registerType(
-    createMonitorSmlType({ logger }) as Parameters<typeof agentBuilder.sml.registerType>[0]
-  );
+  agentContextLayer.registerType(createMonitorSmlType({ logger }));
 
   agentBuilder.skills.register(monitorManagementSkill);
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/bind_on_setup.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/bind_on_setup.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import { createMonitorManagementAttachmentType } from './attachments/monitor_management_attachment_type';
+import { createMonitorSmlType } from './sml/monitor_sml_type';
+import { monitorManagementSkill } from './skills';
+
+interface BindAgentBuilderOptions {
+  /** May be `undefined` when the optional `agentBuilder` plugin is missing. */
+  agentBuilder: AgentBuilderPluginSetup | undefined;
+  logger: Logger;
+}
+
+export interface BindAgentBuilderResult {
+  registered: boolean;
+  /** Reason the binding was a no-op (only set when registered=false). */
+  reason?: 'plugin_missing';
+}
+
+/**
+ * Conditionally registers the Synthetics × Agent Builder integration
+ * with the `agentBuilder` plugin during `setup()`.
+ *
+ * Single gate: the `agentBuilder` plugin is actually present. It's
+ * declared optional in `kibana.jsonc` (deployments without Agent Builder
+ * — e.g. some on-prem / classic stack flavours — still need to boot),
+ * so we have to guard.
+ *
+ * No additional Synthetics-side feature flag: the broader Agent Builder
+ * UX is itself the gate. When `agentBuilder` is enabled in a Kibana
+ * deployment, registering one more skill / attachment type / SML type
+ * is cheap (no UI footprint until an LLM produces a matching attachment)
+ * and keeping the integration unconditional avoids dead config surface.
+ *
+ * Returns `{ registered: true }` on success — useful for tests and for
+ * future diagnostic / observability hooks that want to mirror the same
+ * predicate without re-implementing it.
+ */
+export const bindAgentBuilder = ({
+  agentBuilder,
+  logger,
+}: BindAgentBuilderOptions): BindAgentBuilderResult => {
+  if (!agentBuilder) {
+    logger.debug(
+      'Synthetics × Agent Builder integration: agentBuilder plugin not present; skipping.'
+    );
+    return { registered: false, reason: 'plugin_missing' };
+  }
+
+  // Cast: `registerType` is generic over the attachment type's data
+  // shape, but the agentBuilder plugin's contract narrows to a single
+  // unknown-data definition. Same pattern used by `dashboard_agent`.
+  agentBuilder.attachments.registerType(
+    createMonitorManagementAttachmentType({
+      logger,
+    }) as Parameters<typeof agentBuilder.attachments.registerType>[0]
+  );
+
+  agentBuilder.sml.registerType(
+    createMonitorSmlType({ logger }) as Parameters<typeof agentBuilder.sml.registerType>[0]
+  );
+
+  agentBuilder.skills.register(monitorManagementSkill);
+
+  logger.info(
+    'Synthetics × Agent Builder integration: registered attachment type, SML type, and monitor-management skill.'
+  );
+
+  return { registered: true };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/internal/monitor_attachment_data.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/internal/monitor_attachment_data.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObject, SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { Logger } from '@kbn/logging';
+import type { MonitorAttachmentData } from '../../../common/agent_builder';
+import { monitorAttachmentDataSchema } from '../../../common/agent_builder';
+import {
+  legacySyntheticsMonitorTypeSingle,
+  syntheticsMonitorSavedObjectType,
+} from '../../../common/types/saved_objects';
+import { MonitorTypeEnum } from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { EncryptedSyntheticsMonitorAttributes } from '../../../common/runtime_types';
+import { ConfigKey } from '../../../common/runtime_types';
+import { mapSavedObjectToMonitor } from '../../routes/monitor_cruds/formatters/saved_object_to_monitor';
+
+/**
+ * Either of the two saved object types that can back a Synthetics monitor.
+ *
+ * - `synthetics-monitor-multi-space` — current type
+ * - `synthetics-monitor` — legacy single-namespace type
+ *
+ * Surfacing the resolved type lets callers attach the right SML chunk
+ * permission string (`saved_object:<so-type>/get`) without coupling them to
+ * the constants directly.
+ */
+export type ResolvedMonitorSavedObjectType =
+  | typeof syntheticsMonitorSavedObjectType
+  | typeof legacySyntheticsMonitorTypeSingle;
+
+/**
+ * Outcome of {@link fetchMonitorAttachmentData}. `undefined` is returned when
+ * either no SO matched the id, or the SO matched but is **not** an HTTP
+ * monitor (v1 scope).
+ */
+export interface FetchedMonitorAttachmentData {
+  /** Schema-projected attachment data ready to feed to the attachment type. */
+  data: MonitorAttachmentData;
+  /** SO type the monitor was resolved from — drives chunk permission string. */
+  soType: ResolvedMonitorSavedObjectType;
+  /** SO meta `updated_at`, mirrored at the data level too — exposed here so callers don't re-bulkGet for `isStale`. */
+  updatedAt?: string;
+  /** Raw SO meta — useful for tests and for richer formatters that don't want to round-trip through Zod. */
+  savedObject: SavedObject<EncryptedSyntheticsMonitorAttributes>;
+}
+
+/**
+ * Look up a Synthetics monitor by `config_id` using the request-scoped
+ * saved objects client and project it into the attachment-data shape used by
+ * `MONITOR_MANAGEMENT_ATTACHMENT_TYPE`.
+ *
+ * Behaviour:
+ * - Issues a `bulkGet` over both the current and legacy SO types (mirrors
+ *   `MonitorConfigRepository.get`) so a single helper covers both reads.
+ * - Filters out non-HTTP monitors — v1 of monitor management is HTTP only;
+ *   TCP/ICMP/Browser come later via discriminated-union widening of the
+ *   attachment schema.
+ * - Strips secrets and any non-attachment-schema keys via
+ *   `monitorAttachmentDataSchema.safeParse`. This is the only path through
+ *   which monitor attribute data reaches the conversation index, so the
+ *   parse step doubles as a defense-in-depth check that no encrypted
+ *   field accidentally leaks.
+ *
+ * Errors are logged at `warn` (expected: not found, schema mismatch from a
+ * legacy/partially-migrated monitor) — not thrown — and surface as
+ * `undefined`. This mirrors the dashboard_agent attachment type's
+ * `resolve()` policy.
+ */
+export const fetchMonitorAttachmentData = async ({
+  soClient,
+  configId,
+  logger,
+  context,
+}: {
+  soClient: SavedObjectsClientContract;
+  configId: string;
+  logger: Logger;
+  /** Free-form context label used in warn logs (e.g. `'sml.toAttachment'`, `'attachment.resolve'`). */
+  context: string;
+}): Promise<FetchedMonitorAttachmentData | undefined> => {
+  const { saved_objects: savedObjects } =
+    await soClient.bulkGet<EncryptedSyntheticsMonitorAttributes>([
+      { type: syntheticsMonitorSavedObjectType, id: configId },
+      { type: legacySyntheticsMonitorTypeSingle, id: configId },
+    ]);
+
+  const resolved = savedObjects.find((obj) => Boolean(obj?.attributes));
+  if (!resolved) {
+    logger.warn(
+      `monitor_management ${context}: no monitor found for config_id='${configId}' in either current or legacy SO type`
+    );
+    return undefined;
+  }
+
+  if (resolved.attributes[ConfigKey.MONITOR_TYPE] !== MonitorTypeEnum.HTTP) {
+    // v1 scope: HTTP monitors only. Other types (tcp/icmp/browser) cannot
+    // currently round-trip through `monitorAttachmentDataSchema` — bail
+    // silently rather than warn so non-HTTP indexings stay quiet.
+    return undefined;
+  }
+
+  const formatted = mapSavedObjectToMonitor({
+    monitor: resolved,
+    internal: true,
+  }) as Record<string, unknown>;
+
+  const parsed = monitorAttachmentDataSchema.safeParse(formatted);
+  if (!parsed.success) {
+    logger.warn(
+      `monitor_management ${context}: monitor '${configId}' (type=${resolved.type}) failed attachment-schema parse — ${parsed.error.message}`
+    );
+    return undefined;
+  }
+
+  return {
+    data: parsed.data,
+    soType: resolved.type as ResolvedMonitorSavedObjectType,
+    updatedAt: resolved.updated_at,
+    savedObject: resolved,
+  };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/skills/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/skills/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { monitorManagementSkill } from './monitor_management_skill';

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/skills/monitor_management_skill.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/skills/monitor_management_skill.ts
@@ -85,13 +85,44 @@ When the user just wants to **list** monitors matching a keyword, summarize the 
 ## After a Successful Tool Call
 
 The tool returns a structured result with:
-- \`status\`: one of \`proposed\` (new), \`updated\` (existing), \`incomplete\` (still missing required fields), \`cli_managed\` (rejected — project-origin).
-- \`attachment_id\`: reuse this on follow-up calls to update the same draft.
+- \`status\`: what the **tool** just did to the conversation attachment record. One of \`proposed\` (created a new draft), \`updated\` (mutated an existing record — note: this can be either a draft OR a saved monitor), \`incomplete\` (still missing required fields), \`cli_managed\` (rejected — project-origin).
+- \`lifecycle\`: what the **monitor itself** is right now. One of \`draft\` (no \`config_id\` — not yet in Synthetics) or \`saved\` (has \`config_id\` — already persisted). **This is what controls the Create-vs-Update wording you give the user**, not \`status\`.
+- \`attachment_id\`: reuse this on follow-up calls to update the same record.
 - \`saveable\`: \`true\` when the draft has all of name + url + schedule + locations.
 - \`missing_fields\`: present when \`saveable: false\` — list the LLM should address with further \`operations[]\` calls or by asking the user.
-- \`monitor\`: a small summary (name, type, schedule, url, locations_count, enabled, origin) — use this in the natural-language reply, not the full attachment.
+- \`monitor\`: a small summary (name, type, schedule, url, locations_count, enabled, origin, config_id) — use this in the natural-language reply, not the full attachment.
 
-Render the monitor attachment inline in the final assistant turn so the user sees the proposed state with Create/Update buttons. Do **not** render the same attachment multiple times in one turn.
+Render the monitor attachment in the final assistant turn so the user can review it. Do **not** render the same attachment multiple times in one turn.
+
+### Choose Create vs Update strictly from \`lifecycle\` (not \`status\`)
+
+\`status: 'updated'\` only means "the tool mutated an existing attachment record". That record can still be a draft (no \`config_id\`) — for example, a draft the agent composed in a previous turn that the user has never clicked **Create** on. Telling the user to "click Update" in that case is wrong: the canvas will show **Create**, the user will be confused, and the action will create a duplicate row.
+
+The correct mapping is:
+
+- \`lifecycle: 'draft'\` → tell the user to click **Create**. Examples: "Click **Create** in the canvas to save the monitor to Synthetics." / "Open the preview and click **Create** when you're ready."
+- \`lifecycle: 'saved'\` → tell the user to click **Update**. Examples: "Click **Update** in the canvas to push your changes." / "Open the preview and click **Update** to apply."
+- \`status: 'incomplete'\` (regardless of lifecycle) → do **not** point the user at Create/Update at all. List the \`missing_fields\` and either call \`manage_synthetics_monitor\` again with the missing operations or ask the user for the missing input.
+- \`status: 'cli_managed'\` → the monitor is read-only; explain it's CLI-managed and do not offer Create/Update.
+
+### Where the Create / Update buttons live (do not get this wrong)
+
+The chat shows a **read-only inline preview card** for the attachment. The **Create** / **Update** button lives in the **canvas flyout** that opens when the user clicks the inline preview (or that is already open from a previous turn). The flyout's position depends on the user's layout: it may dock to the right of the chat, appear as a sidebar, or open full-screen on narrow viewports — so its **direction relative to the chat is not guaranteed**.
+
+Phrase the call-to-action in a layout-agnostic way:
+
+- **Good:** "Click **Create** in the canvas to save the monitor to Synthetics."
+- **Good:** "Click **Update** in the preview panel to push your changes."
+- **Good:** "Open the monitor preview and click **Create** to save it."
+- **Bad:** "Click Create in the card above" — the canvas may be to the side or below.
+- **Bad:** "Click Create in the card below" — same problem.
+- **Bad:** "Click Create in the inline card" — the inline card has no buttons.
+
+### Avoid creating duplicate drafts
+
+Before calling \`manage_synthetics_monitor\` **without** \`monitor_attachment_id\`, check whether the conversation already carries a \`${MONITOR_MANAGEMENT_ATTACHMENT_TYPE}\` attachment that matches the user's reference (by name, URL, or \`config_id\`). If yes, reuse that attachment's id — creating a fresh draft when an existing attachment is in scope leaves the user with two cards (one saved, one draft) and the canvas will open on the new draft, hiding the saved monitor's **Update** button.
+
+When the user references an existing monitor by name (e.g. "update Last monitor"), prefer the attachment whose \`monitor.config_id\` is set — that is the persisted monitor; an attachment without \`config_id\` is a never-saved draft and would be the wrong target for an "update" request.
 
 ## Edge Cases
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/skills/monitor_management_skill.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/skills/monitor_management_skill.ts
@@ -35,14 +35,16 @@ export const monitorManagementSkill = defineSkillType({
   name: 'monitor-management',
   basePath: 'skills/observability',
   description:
-    'Compose, modify, and discover Elastic Synthetics HTTP monitors. Use when the user asks to create, edit, enable/disable, or look up uptime/availability monitors. v1 supports HTTP-only monitors with origin: ui; TCP, ICMP, and Browser monitors are out of scope.',
+    'Compose, modify, and discover Elastic Synthetics HTTP monitors. Use when the user asks to create, edit, enable/disable, or look up uptime/availability monitors against any URL, with any schedule, and from any location (Elastic-managed region or private location, regardless of the specific id or label the user mentions). v1 supports HTTP-only monitors with origin: ui; TCP, ICMP, and Browser monitors are out of scope.',
   content: `## When to Use This Skill
 
 Use this skill when:
-- A user asks to **create** a Synthetics HTTP monitor for a URL ("monitor https://example.com every 5 minutes from us_central").
+- A user asks to **create** a Synthetics HTTP monitor for any URL, optionally with a schedule and one or more locations. The location can be named anything — a public Elastic-managed region id (e.g. \`us_central\`, \`us_east_qa\`, \`japan\`), a region label ("US Central", "Frankfurt"), or a private-location name the user has set up. The skill is responsible for resolving the user's location wording into a real id; do not skip this skill just because the location name is unfamiliar.
 - A user asks to **modify** an existing monitor's name, schedule, locations, tags, or enabled state.
 - A user asks to **find** existing monitors by name, URL, or tag.
 - A user asks to enable / disable / pause an existing monitor.
+
+Phrasings like "create an HTTP monitor for https://X every N minutes from <anything>", "add a synthetic check for X", "monitor X", "watch X every 5m from <anything>" all trigger this skill. The presence of an HTTP/HTTPS URL plus an availability verb is enough — the location name does not need to match a specific known id.
 
 Do **not** use this skill when:
 - The user asks about a non-HTTP monitor type (Browser, TCP, ICMP). v1 supports HTTP only — politely say so and offer to help once the corresponding monitor type is added.

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/skills/monitor_management_skill.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/skills/monitor_management_skill.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { manageSyntheticsMonitorTool } from '../tools/manage_synthetics_monitor';
+import { MONITOR_MANAGEMENT_ATTACHMENT_TYPE } from '../../../common/agent_builder';
+
+/**
+ * Skill definition for the Agent Builder × Synthetics monitor-management
+ * integration.
+ *
+ * The skill content below is the **system prompt** the LLM sees when
+ * `monitor-management` is bound to the conversation. Keep it tight — every
+ * line is in the agent's context budget. Conventions cribbed from
+ * `dashboard_agent`'s `dashboardManagementSkill` so that LLMs that have
+ * been tuned for that skill carry over consistently:
+ *
+ * - Use `## When to Use This Skill` / `## Core Instructions` / `## Edge
+ *   Cases` headings.
+ * - Reference SML helpers as `platform.core.sml_search` / `platform.core.sml_attach`.
+ * - Quote the **real** tool name (`manage_synthetics_monitor`) and
+ *   attachment type (`synthetics.monitor_management`) so the LLM doesn't
+ *   confabulate them.
+ *
+ * v1 scope (HTTP / `origin: ui`) is intentionally restated multiple times
+ * in the prompt — LLMs are otherwise prone to suggesting Browser/TCP/ICMP
+ * monitors even when the tool schema makes them impossible.
+ */
+export const monitorManagementSkill = defineSkillType({
+  id: 'monitor-management',
+  name: 'monitor-management',
+  basePath: 'skills/observability',
+  description:
+    'Compose, modify, and discover Elastic Synthetics HTTP monitors. Use when the user asks to create, edit, enable/disable, or look up uptime/availability monitors. v1 supports HTTP-only monitors with origin: ui; TCP, ICMP, and Browser monitors are out of scope.',
+  content: `## When to Use This Skill
+
+Use this skill when:
+- A user asks to **create** a Synthetics HTTP monitor for a URL ("monitor https://example.com every 5 minutes from us_central").
+- A user asks to **modify** an existing monitor's name, schedule, locations, tags, or enabled state.
+- A user asks to **find** existing monitors by name, URL, or tag.
+- A user asks to enable / disable / pause an existing monitor.
+
+Do **not** use this skill when:
+- The user asks about a non-HTTP monitor type (Browser, TCP, ICMP). v1 supports HTTP only — politely say so and offer to help once the corresponding monitor type is added.
+- The user asks to interpret monitor **results** (status, ping data, screenshots). That belongs to the observability data-exploration skills, not this one.
+- The user asks to reconfigure private locations or Fleet agent policies — those have their own management surfaces.
+
+## Core Instructions
+
+You are working with **draft attachments** of type \`${MONITOR_MANAGEMENT_ATTACHMENT_TYPE}\`. The \`manage_synthetics_monitor\` tool mutates the **conversation-scoped draft**. It does **NOT** persist the monitor to Synthetics — the user persists by clicking **Create** or **Update** in the canvas, which calls the existing \`POST/PUT /api/synthetics/monitors\` API on their behalf.
+
+Build the request for \`manage_synthetics_monitor\` as an ordered \`operations\` array:
+- \`set_metadata\` — name (required for save), tags, apm_service_name, namespace.
+- \`set_schedule\` — \`number\` + \`unit\`. When \`unit: "m"\`, \`number\` MUST be one of: \`1, 2, 3, 5, 10, 15, 20, 30, 60, 120, 240\`. Other minute values are rejected.
+- \`set_http_check\` — \`url\` (required, must start with \`http://\` or \`https://\`). Optional: \`method\`, \`max_redirects\`, \`ignore_https_errors\`.
+- \`set_locations\` — full replacement list. Each entry needs an \`id\`. For Elastic-managed locations use the standard region id (\`us_central\`, \`us_east\`, etc.). For private locations, use the saved-object id of the private location and set \`isServiceManaged: false\` plus \`agentPolicyId\`.
+- \`set_enabled\` — toggle whether the monitor runs once saved.
+
+Operations run in order. Earlier ops should set up state that later ops depend on. For a brand-new monitor you typically need at least \`set_metadata\` (with \`name\`), \`set_http_check\` (with \`url\`), \`set_schedule\`, and \`set_locations\` before the user can save — the tool result's \`saveable\` flag and \`missing_fields\` array tell you whether anything is still missing.
+
+For an **existing** monitor:
+- Reuse \`monitor_attachment_id\` from the latest tool result so subsequent calls update the same draft.
+- Use a single \`manage_synthetics_monitor\` call per user request unless intermediate state must be observed.
+
+Do **not** invent location \`id\`s. Discover real ones by:
+1. Calling \`platform.core.sml_search\` with the user's location keywords (e.g. \`["us central"]\`) against the \`synthetics_monitor\` SML type.
+2. Or, when location lookup is wider than what SML returns, fall back to asking the user for the location id explicitly.
+
+## Discovery via SML
+
+Synthetics monitors are crawled into the SML index. Use \`platform.core.sml_search\` to find monitors by name, URL, tags, or location. Use \`platform.core.sml_attach\` with the exact \`chunk_id\` from the search result to bring an existing monitor into the conversation as a draft attachment, then mutate it via \`manage_synthetics_monitor\`.
+
+When the user just wants to **list** monitors matching a keyword, summarize the search results in plain language by name + URL + status. Do **not** attach every match — only attach the one(s) the user explicitly wants to inspect or modify.
+
+## Persistence and Authorization
+
+- The agent **never** writes to Synthetics directly. The user clicks Create/Update in the canvas; the canvas calls the existing CRUD API with the user's session.
+- If the user lacks the \`uptime.save\` capability, the canvas Save button is disabled — the agent has no way to override this. Surface the limitation to the user clearly when relevant.
+- **CLI-managed monitors** (\`origin: project\`) are **read-only via the agent**. If the user attaches a project-origin monitor and asks to edit it, refuse with a short explanation: those monitors are managed via \`synthetics-cli\` and editing them through the agent would be overwritten on the next CLI sync.
+
+## After a Successful Tool Call
+
+The tool returns a structured result with:
+- \`status\`: one of \`proposed\` (new), \`updated\` (existing), \`incomplete\` (still missing required fields), \`cli_managed\` (rejected — project-origin).
+- \`attachment_id\`: reuse this on follow-up calls to update the same draft.
+- \`saveable\`: \`true\` when the draft has all of name + url + schedule + locations.
+- \`missing_fields\`: present when \`saveable: false\` — list the LLM should address with further \`operations[]\` calls or by asking the user.
+- \`monitor\`: a small summary (name, type, schedule, url, locations_count, enabled, origin) — use this in the natural-language reply, not the full attachment.
+
+Render the monitor attachment inline in the final assistant turn so the user sees the proposed state with Create/Update buttons. Do **not** render the same attachment multiple times in one turn.
+
+## Edge Cases
+
+- **Schedule out of allow-list**: if the user asks for an interval like "every 7 minutes" that isn't in the allowed list, propose the closest allowed interval (e.g. 5 or 10 minutes) and ask for confirmation.
+- **Empty URL**: do not call \`set_http_check\` with an empty URL — ask the user for the target URL first.
+- **No locations**: if the user hasn't specified where to run the monitor and SML search returns no obvious match, ask. Don't default to a region without confirming — the user may have private locations set up that should be preferred.
+- **Project-origin attachment**: if \`monitor.origin\` is \`project\`, do not attempt mutations. Report the read-only state and offer to discuss the CLI workflow if relevant.
+- **Tool returns an error result**: if the result type is \`error\`, surface the \`message\` to the user and do not retry blindly — most error codes (e.g. \`duplicate_location\`, \`invalid_schedule\`) call for asking the user for a corrected input.
+`,
+  getInlineTools: () => [manageSyntheticsMonitorTool()],
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/sml/monitor_sml_type.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/sml/monitor_sml_type.test.ts
@@ -1,0 +1,616 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import {
+  legacySyntheticsMonitorTypeSingle,
+  syntheticsMonitorSavedObjectType,
+} from '../../../common/types/saved_objects';
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  MONITOR_SML_TYPE,
+} from '../../../common/agent_builder';
+import { ConfigKey } from '../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+} from '../../../common/runtime_types/monitor_management/monitor_configs';
+import { createMonitorSmlType } from './monitor_sml_type';
+
+const createLogger = (): jest.Mocked<Logger> =>
+  ({
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+    fatal: jest.fn(),
+    log: jest.fn(),
+    isLevelEnabled: jest.fn(() => false),
+    get: jest.fn(),
+  } as unknown as jest.Mocked<Logger>);
+
+const buildHttpMonitorAttributes = (overrides: Record<string, unknown> = {}) => ({
+  [ConfigKey.NAME]: 'Elastic API health',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [
+    { id: 'us_central', label: 'North America - US Central', isServiceManaged: true },
+  ],
+  [ConfigKey.URLS]: 'https://api.elastic.co',
+  [ConfigKey.TAGS]: ['poc'],
+  [ConfigKey.NAMESPACE]: 'default',
+  [ConfigKey.MAX_ATTEMPTS]: 1,
+  [ConfigKey.APM_SERVICE_NAME]: '',
+  ...overrides,
+});
+
+const buildSavedObjectFound = ({
+  id,
+  type,
+  attributes = buildHttpMonitorAttributes(),
+}: {
+  id: string;
+  type: string;
+  attributes?: Record<string, unknown>;
+}) => ({
+  id,
+  type,
+  attributes,
+  namespaces: ['default'],
+  updated_at: '2026-04-30T17:00:00.000Z',
+  created_at: '2026-04-15T10:00:00.000Z',
+  references: [],
+});
+
+const buildSavedObjectMissing = ({ id, type }: { id: string; type: string }) => ({
+  id,
+  type,
+  error: {
+    statusCode: 404,
+    error: 'Not Found',
+    message: 'Saved object [type/id] not found',
+  },
+  attributes: undefined as unknown as Record<string, unknown>,
+});
+
+describe('createMonitorSmlType', () => {
+  it('exposes the agreed SML type id and 5m fetch frequency', () => {
+    const sml = createMonitorSmlType({ logger: createLogger() });
+    expect(sml.id).toBe(MONITOR_SML_TYPE);
+    expect(sml.fetchFrequency?.()).toBe('5m');
+  });
+
+  describe('list', () => {
+    it('yields one page per non-empty SO type and closes both finders', async () => {
+      const multiSpaceFinder = {
+        find: jest.fn().mockReturnValue(
+          (async function* () {
+            yield {
+              saved_objects: [
+                {
+                  id: 'config-1',
+                  type: syntheticsMonitorSavedObjectType,
+                  attributes: { type: MonitorTypeEnum.HTTP },
+                  updated_at: '2026-04-30T17:00:00.000Z',
+                  namespaces: ['default', 'team-a'],
+                },
+              ],
+            };
+          })()
+        ),
+        close: jest.fn().mockResolvedValue(undefined),
+      };
+      const legacyFinder = {
+        find: jest.fn().mockReturnValue(
+          (async function* () {
+            yield {
+              saved_objects: [
+                {
+                  id: 'config-2',
+                  type: legacySyntheticsMonitorTypeSingle,
+                  attributes: { type: MonitorTypeEnum.HTTP },
+                  updated_at: '2026-04-30T18:00:00.000Z',
+                  namespaces: ['default'],
+                },
+              ],
+            };
+          })()
+        ),
+        close: jest.fn().mockResolvedValue(undefined),
+      };
+      const finderQueue = [multiSpaceFinder, legacyFinder];
+      const savedObjectsClient = {
+        createPointInTimeFinder: jest.fn(() => finderQueue.shift()),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const pages = [];
+      for await (const page of sml.list({
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger: createLogger(),
+      })) {
+        pages.push(page);
+      }
+
+      expect(savedObjectsClient.createPointInTimeFinder).toHaveBeenNthCalledWith(1, {
+        type: syntheticsMonitorSavedObjectType,
+        perPage: 1000,
+        namespaces: ['*'],
+        fields: [ConfigKey.MONITOR_TYPE],
+      });
+      expect(savedObjectsClient.createPointInTimeFinder).toHaveBeenNthCalledWith(2, {
+        type: legacySyntheticsMonitorTypeSingle,
+        perPage: 1000,
+        namespaces: ['*'],
+        fields: [ConfigKey.MONITOR_TYPE],
+      });
+      expect(pages).toEqual([
+        [
+          {
+            id: 'config-1',
+            updatedAt: '2026-04-30T17:00:00.000Z',
+            spaces: ['default', 'team-a'],
+          },
+        ],
+        [
+          {
+            id: 'config-2',
+            updatedAt: '2026-04-30T18:00:00.000Z',
+            spaces: ['default'],
+          },
+        ],
+      ]);
+      expect(multiSpaceFinder.close).toHaveBeenCalledTimes(1);
+      expect(legacyFinder.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes the finder even when the consumer aborts mid-iteration', async () => {
+      const close = jest.fn().mockResolvedValue(undefined);
+      const finder = {
+        find: jest.fn().mockReturnValue(
+          (async function* () {
+            yield {
+              saved_objects: [
+                {
+                  id: 'a',
+                  type: syntheticsMonitorSavedObjectType,
+                  attributes: {},
+                  namespaces: ['default'],
+                  updated_at: '2026-04-30T17:00:00.000Z',
+                },
+              ],
+            };
+            yield {
+              saved_objects: [
+                {
+                  id: 'b',
+                  type: syntheticsMonitorSavedObjectType,
+                  attributes: {},
+                  namespaces: ['default'],
+                  updated_at: '2026-04-30T17:01:00.000Z',
+                },
+              ],
+            };
+          })()
+        ),
+        close,
+      };
+      const finderQueue = [
+        finder,
+        { ...finder, find: jest.fn().mockReturnValue((async function* () {})()), close: jest.fn() },
+      ];
+      const savedObjectsClient = {
+        createPointInTimeFinder: jest.fn(() => finderQueue.shift()),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+      const iter = sml.list({
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger: createLogger(),
+      });
+      const first = await iter[Symbol.asyncIterator]().next();
+      expect(first.value).toEqual([
+        { id: 'a', updatedAt: '2026-04-30T17:00:00.000Z', spaces: ['default'] },
+      ]);
+      // Force consumer abort — `for await` would normally call return() to
+      // wind down the generator; mimic that here.
+      await iter[Symbol.asyncIterator]().return?.(undefined as never);
+
+      // Allow the `try/finally` to flush. close() is fire-and-forget but
+      // synchronous in our finder mock.
+      expect(close).toHaveBeenCalled();
+    });
+
+    it('yields nothing (no SO) without crashing', async () => {
+      const emptyFinder = () => ({
+        find: jest.fn().mockReturnValue((async function* () {})()),
+        close: jest.fn().mockResolvedValue(undefined),
+      });
+      const finderQueue = [emptyFinder(), emptyFinder()];
+      const savedObjectsClient = {
+        createPointInTimeFinder: jest.fn(() => finderQueue.shift()),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const pages = [];
+      for await (const page of sml.list({
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger: createLogger(),
+      })) {
+        pages.push(page);
+      }
+
+      expect(pages).toEqual([]);
+    });
+  });
+
+  describe('getSmlData', () => {
+    it('emits a chunk with the multi-space permission for current-type HTTP monitors', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-1',
+              type: syntheticsMonitorSavedObjectType,
+            }),
+            buildSavedObjectMissing({
+              id: 'config-1',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.getSmlData('config-1', {
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger: createLogger(),
+      });
+
+      expect(savedObjectsClient.bulkGet).toHaveBeenCalledWith([
+        { type: syntheticsMonitorSavedObjectType, id: 'config-1' },
+        { type: legacySyntheticsMonitorTypeSingle, id: 'config-1' },
+      ]);
+      expect(result?.chunks).toHaveLength(1);
+      expect(result?.chunks[0]).toEqual({
+        type: MONITOR_SML_TYPE,
+        title: 'Elastic API health',
+        content: expect.stringContaining('Elastic API health'),
+        permissions: ['saved_object:synthetics-monitor-multi-space/get'],
+      });
+      expect(result?.chunks[0].content).toContain('https://api.elastic.co');
+      expect(result?.chunks[0].content).toContain('http');
+      expect(result?.chunks[0].content).toContain('North America - US Central');
+      expect(result?.chunks[0].content).toContain('poc');
+    });
+
+    it('emits a chunk with the legacy permission when the monitor lives in the legacy SO type', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectMissing({
+              id: 'config-2',
+              type: syntheticsMonitorSavedObjectType,
+            }),
+            buildSavedObjectFound({
+              id: 'config-2',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.getSmlData('config-2', {
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger: createLogger(),
+      });
+
+      expect(result?.chunks[0].permissions).toEqual(['saved_object:synthetics-monitor/get']);
+      // Critically: only ONE chunk — never both permissions on a single chunk
+      // (AND-semantics would silently hide it from most users).
+      expect(result?.chunks).toHaveLength(1);
+    });
+
+    it('returns undefined for non-HTTP monitor types (v1 scope)', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-3',
+              type: syntheticsMonitorSavedObjectType,
+              attributes: buildHttpMonitorAttributes({
+                [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.TCP,
+              }),
+            }),
+            buildSavedObjectMissing({
+              id: 'config-3',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.getSmlData('config-3', {
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger: createLogger(),
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when no SO exists for the id', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectMissing({
+              id: 'gone',
+              type: syntheticsMonitorSavedObjectType,
+            }),
+            buildSavedObjectMissing({
+              id: 'gone',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.getSmlData('gone', {
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger: createLogger(),
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("warns and returns undefined when bulkGet throws (so the indexer doesn't loop on transient errors)", async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockRejectedValue(new Error('ES connection refused')),
+      };
+      const logger = createLogger();
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.getSmlData('config-1', {
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger,
+      });
+
+      expect(result).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("monitor_management sml.getSmlData: failed for 'config-1'")
+      );
+    });
+
+    it('falls back to the origin id for the chunk title when the monitor has no name', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-untitled',
+              type: syntheticsMonitorSavedObjectType,
+              attributes: buildHttpMonitorAttributes({ [ConfigKey.NAME]: '' }),
+            }),
+            buildSavedObjectMissing({
+              id: 'config-untitled',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.getSmlData('config-untitled', {
+        savedObjectsClient: savedObjectsClient as never,
+        esClient: {} as never,
+        logger: createLogger(),
+      });
+
+      expect(result?.chunks[0].title).toBe('config-untitled');
+    });
+  });
+
+  describe('toAttachment', () => {
+    it('wraps a found HTTP monitor as a MONITOR_MANAGEMENT_ATTACHMENT_TYPE attachment with origin set to the SO id', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-1',
+              type: syntheticsMonitorSavedObjectType,
+              attributes: buildHttpMonitorAttributes({
+                [ConfigKey.CONFIG_ID]: 'config-1',
+              }),
+            }),
+            buildSavedObjectMissing({
+              id: 'config-1',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.toAttachment(
+        {
+          id: 'sml-chunk-1',
+          type: MONITOR_SML_TYPE,
+          title: 'Elastic API health',
+          origin_id: 'config-1',
+          content: 'irrelevant for this test',
+          created_at: '2026-04-30T17:00:00.000Z',
+          updated_at: '2026-04-30T17:00:00.000Z',
+          spaces: ['default'],
+          permissions: ['saved_object:synthetics-monitor-multi-space/get'],
+        },
+        {
+          request: {} as never,
+          spaceId: 'default',
+          savedObjectsClient: savedObjectsClient as never,
+        }
+      );
+
+      expect(result).toEqual({
+        type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+        origin: 'config-1',
+        data: expect.objectContaining({
+          [ConfigKey.NAME]: 'Elastic API health',
+          [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+          [ConfigKey.URLS]: 'https://api.elastic.co',
+          [ConfigKey.CONFIG_ID]: 'config-1',
+        }),
+      });
+    });
+
+    it('uses the **request-scoped** soClient (no internal repo) — drives the auth-boundary contract', async () => {
+      const requestScopedClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-1',
+              type: syntheticsMonitorSavedObjectType,
+            }),
+            buildSavedObjectMissing({
+              id: 'config-1',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      await sml.toAttachment(
+        {
+          id: 'sml-chunk-1',
+          type: MONITOR_SML_TYPE,
+          title: 'name',
+          origin_id: 'config-1',
+          content: '',
+          created_at: '2026-04-30T17:00:00.000Z',
+          updated_at: '2026-04-30T17:00:00.000Z',
+          spaces: ['default'],
+          permissions: ['saved_object:synthetics-monitor-multi-space/get'],
+        },
+        {
+          request: {} as never,
+          spaceId: 'default',
+          savedObjectsClient: requestScopedClient as never,
+        }
+      );
+
+      // The bulkGet must be invoked on the *passed* (request-scoped)
+      // client — not via any module-level / internal repo. If this test
+      // ever fails it usually means a refactor accidentally swapped to
+      // `asInternalUser`, which would break the auth boundary.
+      expect(requestScopedClient.bulkGet).toHaveBeenCalled();
+    });
+
+    it('returns undefined for non-HTTP monitors (v1 scope)', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectFound({
+              id: 'config-tcp',
+              type: syntheticsMonitorSavedObjectType,
+              attributes: buildHttpMonitorAttributes({
+                [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.TCP,
+              }),
+            }),
+            buildSavedObjectMissing({
+              id: 'config-tcp',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.toAttachment(
+        {
+          id: 'sml-chunk-tcp',
+          type: MONITOR_SML_TYPE,
+          title: 'TCP',
+          origin_id: 'config-tcp',
+          content: '',
+          created_at: '2026-04-30T17:00:00.000Z',
+          updated_at: '2026-04-30T17:00:00.000Z',
+          spaces: ['default'],
+          permissions: ['saved_object:synthetics-monitor-multi-space/get'],
+        },
+        {
+          request: {} as never,
+          spaceId: 'default',
+          savedObjectsClient: savedObjectsClient as never,
+        }
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the monitor has been deleted', async () => {
+      const savedObjectsClient = {
+        bulkGet: jest.fn().mockResolvedValue({
+          saved_objects: [
+            buildSavedObjectMissing({
+              id: 'gone',
+              type: syntheticsMonitorSavedObjectType,
+            }),
+            buildSavedObjectMissing({
+              id: 'gone',
+              type: legacySyntheticsMonitorTypeSingle,
+            }),
+          ],
+        }),
+      };
+
+      const sml = createMonitorSmlType({ logger: createLogger() });
+
+      const result = await sml.toAttachment(
+        {
+          id: 'sml-chunk-gone',
+          type: MONITOR_SML_TYPE,
+          title: 'gone',
+          origin_id: 'gone',
+          content: '',
+          created_at: '2026-04-30T17:00:00.000Z',
+          updated_at: '2026-04-30T17:00:00.000Z',
+          spaces: ['default'],
+          permissions: ['saved_object:synthetics-monitor-multi-space/get'],
+        },
+        {
+          request: {} as never,
+          spaceId: 'default',
+          savedObjectsClient: savedObjectsClient as never,
+        }
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/sml/monitor_sml_type.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/sml/monitor_sml_type.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SmlTypeDefinition } from '@kbn/agent-builder-plugin/server';
+import type { SmlTypeDefinition } from '@kbn/agent-context-layer-plugin/server';
 import type { SavedObject } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
 import {

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/sml/monitor_sml_type.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/sml/monitor_sml_type.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SmlTypeDefinition } from '@kbn/agent-builder-plugin/server';
+import type { SavedObject } from '@kbn/core-saved-objects-api-server';
+import type { Logger } from '@kbn/logging';
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  MONITOR_SML_TYPE,
+} from '../../../common/agent_builder';
+import {
+  legacySyntheticsMonitorTypeSingle,
+  syntheticsMonitorSavedObjectType,
+  syntheticsMonitorSOTypes,
+} from '../../../common/types/saved_objects';
+import { ConfigKey } from '../../../common/runtime_types';
+import { MonitorTypeEnum } from '../../../common/runtime_types/monitor_management/monitor_configs';
+import type { EncryptedSyntheticsMonitorAttributes } from '../../../common/runtime_types';
+import {
+  fetchMonitorAttachmentData,
+  type ResolvedMonitorSavedObjectType,
+} from '../internal/monitor_attachment_data';
+
+/**
+ * SML chunk permission strings keyed by saved object type.
+ *
+ * AND-semantics in `SmlService.search` mean each chunk must list **every**
+ * permission its viewer needs. Mixing the two SO type permissions on a
+ * single chunk would silently hide it from users who only have the
+ * appropriate one — see `00-cross-cutting-decisions.md`. Hence one chunk
+ * per SO type per monitor.
+ */
+const PERMISSIONS_BY_SO_TYPE: Record<ResolvedMonitorSavedObjectType, readonly string[]> = {
+  [syntheticsMonitorSavedObjectType]: [`saved_object:${syntheticsMonitorSavedObjectType}/get`],
+  [legacySyntheticsMonitorTypeSingle]: [`saved_object:${legacySyntheticsMonitorTypeSingle}/get`],
+};
+
+/**
+ * The fields we read off a monitor SO to build SML chunk content. Typed as
+ * a narrow record (rather than `EncryptedSyntheticsMonitorAttributes`,
+ * which is a **union** of HTTP/TCP/ICMP/Browser variants) because the
+ * variants don't share a common subtype that includes `URLS` — and by the
+ * time these helpers run the caller has already narrowed via the
+ * discriminator (`attributes[ConfigKey.MONITOR_TYPE] === 'http'`). The
+ * read-side projection keeps the helpers cheap and unit-testable.
+ */
+interface MonitorChunkFields {
+  [ConfigKey.NAME]?: string;
+  [ConfigKey.MONITOR_TYPE]?: string;
+  [ConfigKey.URLS]?: string;
+  [ConfigKey.TAGS]?: string[];
+  [ConfigKey.LOCATIONS]?: Array<{ id: string; label?: string }>;
+}
+
+/**
+ * Build the searchable text indexed for one monitor. Aimed at BM25 +
+ * semantic search relevance — keep it terse and free of secrets.
+ *
+ * Order: name first (highest BM25 weight via prefix), then identifying
+ * fields the user might mention in chat (URL, type, tags, location names).
+ */
+const toMonitorSearchContent = (attributes: MonitorChunkFields): string => {
+  const lines: Array<string | undefined> = [
+    attributes[ConfigKey.NAME],
+    attributes[ConfigKey.MONITOR_TYPE],
+    attributes[ConfigKey.URLS],
+  ];
+
+  for (const tag of attributes[ConfigKey.TAGS] ?? []) {
+    lines.push(tag);
+  }
+
+  for (const location of attributes[ConfigKey.LOCATIONS] ?? []) {
+    lines.push(location.label || location.id);
+  }
+
+  return lines.filter((line): line is string => Boolean(line && line.trim())).join('\n');
+};
+
+/** Fall-back chunk title when a monitor is somehow saved without a name. */
+const toMonitorChunkTitle = (attributes: MonitorChunkFields, fallbackId: string): string => {
+  const name = attributes[ConfigKey.NAME];
+  if (name && name.trim()) {
+    return name;
+  }
+  return fallbackId;
+};
+
+interface CreateMonitorSmlTypeOptions {
+  /**
+   * Plugin-level logger used by hooks that don't receive an `SmlContext`
+   * (notably `toAttachment`, whose context only carries the user's
+   * `request`, `savedObjectsClient`, and `spaceId`).
+   */
+  logger: Logger;
+}
+
+/**
+ * SML type definition for Synthetics monitors.
+ *
+ * Wiring expectations (T5):
+ * - Registered with Agent Builder behind both the experimental flag and
+ *   the optional-`agentBuilder` plugin guard from `bind_on_setup.ts`.
+ * - Indexed by the Agent Builder crawler at `fetchFrequency()` cadence.
+ * - Search hits are filtered at runtime by the chunk's `permissions[]`,
+ *   so users only see monitors they can read via the `<so-type>/get` SO
+ *   privilege.
+ *
+ * Notes vs. dashboard_agent reference:
+ * - We use `bulkGet` against both the current and legacy SO types instead
+ *   of a domain client (`MonitorConfigRepository.get` is constructor-bound
+ *   to an encrypted client we deliberately don't pass into the SML hooks).
+ * - We emit a single chunk per monitor; the chunk's `permissions[]` matches
+ *   the SO type the monitor was actually resolved from. Legacy
+ *   (`synthetics-monitor`) and current (`synthetics-monitor-multi-space`)
+ *   monitors never share a chunk — keeps the SML AND-semantics clean.
+ */
+export const createMonitorSmlType = ({
+  logger,
+}: CreateMonitorSmlTypeOptions): SmlTypeDefinition => ({
+  id: MONITOR_SML_TYPE,
+  fetchFrequency: () => '5m',
+
+  async *list(context) {
+    for (const soType of syntheticsMonitorSOTypes) {
+      const finder =
+        context.savedObjectsClient.createPointInTimeFinder<EncryptedSyntheticsMonitorAttributes>({
+          type: soType,
+          perPage: 1000,
+          namespaces: ['*'],
+          // Mirror `MonitorConfigRepository.getAll`'s pattern. We only need
+          // SO meta (`id`, `updated_at`, `namespaces`) to populate
+          // `SmlListItem`. `fields: [type]` keeps the page payload small
+          // and lets the indexer short-circuit if a future filter slips
+          // past us.
+          fields: [ConfigKey.MONITOR_TYPE],
+        });
+
+      try {
+        for await (const response of finder.find()) {
+          const items = response.saved_objects.map(
+            (savedObject: SavedObject<EncryptedSyntheticsMonitorAttributes>) => ({
+              id: savedObject.id,
+              updatedAt: savedObject.updated_at ?? new Date().toISOString(),
+              spaces: savedObject.namespaces ?? [],
+            })
+          );
+          if (items.length > 0) {
+            yield items;
+          }
+        }
+      } finally {
+        await finder.close();
+      }
+    }
+  },
+
+  getSmlData: async (originId, context) => {
+    try {
+      const { saved_objects: savedObjects } =
+        await context.savedObjectsClient.bulkGet<EncryptedSyntheticsMonitorAttributes>([
+          { type: syntheticsMonitorSavedObjectType, id: originId },
+          { type: legacySyntheticsMonitorTypeSingle, id: originId },
+        ]);
+
+      const resolved = savedObjects.find((obj) => Boolean(obj?.attributes));
+      if (!resolved) {
+        // Returning `undefined` tells the indexer to drop any prior chunks
+        // for this origin — same handling as a deleted monitor.
+        return undefined;
+      }
+
+      if (resolved.attributes[ConfigKey.MONITOR_TYPE] !== MonitorTypeEnum.HTTP) {
+        // v1 scope: HTTP monitors only.
+        return undefined;
+      }
+
+      const soType = resolved.type as ResolvedMonitorSavedObjectType;
+      // Discriminator-checked above (`MONITOR_TYPE === 'http'`), but the
+      // SO union doesn't carry `URLS` on every variant — narrow via the
+      // read-side projection.
+      const httpAttributes = resolved.attributes as MonitorChunkFields;
+      return {
+        chunks: [
+          {
+            type: MONITOR_SML_TYPE,
+            title: toMonitorChunkTitle(httpAttributes, originId),
+            content: toMonitorSearchContent(httpAttributes),
+            permissions: [...PERMISSIONS_BY_SO_TYPE[soType]],
+          },
+        ],
+      };
+    } catch (error) {
+      context.logger.warn(
+        `monitor_management sml.getSmlData: failed for '${originId}': ${(error as Error).message}`
+      );
+      return undefined;
+    }
+  },
+
+  toAttachment: async (item, context) => {
+    const fetched = await fetchMonitorAttachmentData({
+      soClient: context.savedObjectsClient,
+      configId: item.origin_id,
+      logger,
+      context: 'sml.toAttachment',
+    });
+
+    if (!fetched) {
+      return undefined;
+    }
+
+    return {
+      type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+      data: fetched.data,
+      origin: item.origin_id,
+    };
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  manageSyntheticsMonitorTool,
+  manageSyntheticsMonitorSchema,
+} from './manage_synthetics_monitor';
+export {
+  monitorOperationSchema,
+  setMetadataOperationSchema,
+  setScheduleOperationSchema,
+  setHttpCheckOperationSchema,
+  setLocationsOperationSchema,
+  setEnabledOperationSchema,
+  type MonitorOperation,
+} from './operations';
+export {
+  MonitorOperationValidationError,
+  assertMonitorDraftSaveable,
+  buildEmptyMonitorDraft,
+  executeMonitorOperations,
+} from './monitor_draft';

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/manage_synthetics_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/manage_synthetics_monitor.test.ts
@@ -1,0 +1,388 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type {
+  AttachmentStateManager,
+  AttachmentUpdateInput,
+} from '@kbn/agent-builder-server/attachments';
+import type { AttachmentInput, VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  type MonitorAttachmentData,
+} from '../../../../common/agent_builder';
+import { ConfigKey } from '../../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../../common/runtime_types/monitor_management/monitor_configs';
+import { manageSyntheticsMonitorTool } from './manage_synthetics_monitor';
+import type { MonitorOperation } from './operations';
+
+type MonitorAttachment = VersionedAttachment<
+  typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  MonitorAttachmentData
+>;
+
+const buildSavedAttachmentData = (
+  overrides: Partial<MonitorAttachmentData> = {}
+): MonitorAttachmentData => ({
+  [ConfigKey.NAME]: 'Existing monitor',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [{ id: 'us_central', label: 'US Central', isServiceManaged: true }],
+  [ConfigKey.URLS]: 'https://existing.example.com',
+  [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+  [ConfigKey.CONFIG_ID]: 'config-uuid',
+  ...overrides,
+});
+
+const buildAttachmentRecord = (
+  id: string,
+  data: MonitorAttachmentData,
+  origin?: string
+): MonitorAttachment => ({
+  id,
+  type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  current_version: 1,
+  versions: [
+    {
+      version: 1,
+      data,
+      created_at: new Date().toISOString(),
+      content_hash: 'hash-1',
+    },
+  ],
+  origin,
+});
+
+const createAttachmentsMock = (records: Map<string, MonitorAttachment>) => {
+  const addedInputs: AttachmentInput[] = [];
+  const updatedInputs: Array<{ id: string; input: AttachmentUpdateInput }> = [];
+
+  const mock = {
+    getAttachmentRecord: jest.fn((id: string) => records.get(id)),
+    add: jest.fn(async (input: AttachmentInput) => {
+      addedInputs.push(input);
+      const record: MonitorAttachment = {
+        id: input.id ?? 'generated-uuid',
+        type: input.type as typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+        current_version: 1,
+        versions: [
+          {
+            version: 1,
+            data: input.data as MonitorAttachmentData,
+            created_at: new Date().toISOString(),
+            content_hash: 'new-hash',
+          },
+        ],
+      };
+      records.set(record.id, record);
+      return record as VersionedAttachment;
+    }),
+    update: jest.fn(async (id: string, input: AttachmentUpdateInput) => {
+      updatedInputs.push({ id, input });
+      const existing = records.get(id);
+      if (!existing) return undefined;
+      const updated: MonitorAttachment = {
+        ...existing,
+        current_version: existing.current_version + 1,
+        versions: [
+          ...existing.versions,
+          {
+            version: existing.current_version + 1,
+            data: (input.data ??
+              existing.versions[existing.current_version - 1].data) as MonitorAttachmentData,
+            created_at: new Date().toISOString(),
+            content_hash: 'updated-hash',
+          },
+        ],
+      };
+      records.set(id, updated);
+      return updated as VersionedAttachment;
+    }),
+  } as unknown as AttachmentStateManager & {
+    add: jest.Mock;
+    update: jest.Mock;
+    getAttachmentRecord: jest.Mock;
+  };
+
+  return { mock, addedInputs, updatedInputs };
+};
+
+const buildContext = (attachmentsMock: AttachmentStateManager) => {
+  const logger = loggerMock.create();
+  const ctx = {
+    logger,
+    attachments: attachmentsMock,
+    request: {} as never,
+    spaceId: 'default',
+    esClient: {} as never,
+    savedObjectsClient: {} as never,
+    modelProvider: {} as never,
+    toolProvider: {} as never,
+    runner: {} as never,
+    resultStore: {} as never,
+    events: {} as never,
+    prompts: {} as never,
+    stateManager: {} as never,
+    filestore: {} as never,
+    skills: {} as never,
+    toolManager: {} as never,
+    runContext: {} as never,
+  };
+  return { ctx, logger };
+};
+
+describe('manageSyntheticsMonitorTool', () => {
+  const tool = manageSyntheticsMonitorTool();
+
+  it('exposes the expected id and schema', () => {
+    expect(tool.id).toBe('manage_synthetics_monitor');
+    expect(tool.schema).toBeDefined();
+  });
+
+  describe('proposed (new) monitor', () => {
+    it('creates an attachment when monitor_attachment_id is omitted', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      const { mock: attachments, addedInputs, updatedInputs } = createAttachmentsMock(records);
+      const { ctx } = buildContext(attachments);
+
+      const operations: MonitorOperation[] = [
+        { operation: 'set_metadata', name: 'New monitor' },
+        { operation: 'set_http_check', url: 'https://example.com' },
+        { operation: 'set_schedule', number: '5', unit: ScheduleUnit.MINUTES },
+        {
+          operation: 'set_locations',
+          locations: [{ id: 'us_central', isServiceManaged: true }],
+        },
+      ];
+
+      const result = await tool.handler({ operations }, ctx);
+
+      expect(attachments.add).toHaveBeenCalledTimes(1);
+      expect(attachments.update).not.toHaveBeenCalled();
+      expect(addedInputs[0].type).toBe(MONITOR_MANAGEMENT_ATTACHMENT_TYPE);
+      expect(addedInputs[0].description).toContain('New monitor');
+      expect(updatedInputs).toHaveLength(0);
+
+      if (!('results' in result)) throw new Error('expected standard return');
+      const [first] = result.results;
+      expect(first.type).toBe(ToolResultType.other);
+      const data = first.data as Record<string, unknown>;
+      expect(data.status).toBe('proposed');
+      expect(data.saveable).toBe(true);
+      expect(data.missing_fields).toBeUndefined();
+    });
+
+    it('returns status=incomplete with missing fields when ops are insufficient', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      const { mock: attachments } = createAttachmentsMock(records);
+      const { ctx } = buildContext(attachments);
+
+      const result = await tool.handler(
+        { operations: [{ operation: 'set_metadata', name: 'Half-built' }] },
+        ctx
+      );
+
+      if (!('results' in result)) throw new Error('expected standard return');
+      const [first] = result.results;
+      const data = first.data as Record<string, unknown>;
+      expect(data.status).toBe('incomplete');
+      expect(data.saveable).toBe(false);
+      expect(data.missing_fields).toContain('url (set via set_http_check)');
+    });
+  });
+
+  describe('updating an existing attachment', () => {
+    it('updates instead of adding when monitor_attachment_id is provided', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      records.set('mon-1', buildAttachmentRecord('mon-1', buildSavedAttachmentData()));
+      const { mock: attachments, addedInputs, updatedInputs } = createAttachmentsMock(records);
+      const { ctx } = buildContext(attachments);
+
+      const result = await tool.handler(
+        {
+          monitor_attachment_id: 'mon-1',
+          operations: [{ operation: 'set_enabled', enabled: false }],
+        },
+        ctx
+      );
+
+      expect(attachments.add).not.toHaveBeenCalled();
+      expect(attachments.update).toHaveBeenCalledTimes(1);
+      expect(addedInputs).toHaveLength(0);
+      expect(updatedInputs[0].id).toBe('mon-1');
+
+      const newData = updatedInputs[0].input.data as MonitorAttachmentData;
+      expect(newData[ConfigKey.ENABLED]).toBe(false);
+
+      if (!('results' in result)) throw new Error('expected standard return');
+      const data = result.results[0].data as Record<string, unknown>;
+      expect(data.status).toBe('updated');
+      expect(data.saveable).toBe(true);
+    });
+
+    it('returns an error result when the referenced attachment is missing', async () => {
+      const { mock: attachments } = createAttachmentsMock(new Map());
+      const { ctx, logger } = buildContext(attachments);
+
+      const result = await tool.handler(
+        {
+          monitor_attachment_id: 'missing',
+          operations: [{ operation: 'set_enabled', enabled: true }],
+        },
+        ctx
+      );
+
+      if (!('results' in result)) throw new Error('expected standard return');
+      expect(result.results[0].type).toBe(ToolResultType.error);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('refuses to mutate a project-origin (CLI-managed) monitor', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      records.set(
+        'mon-cli',
+        buildAttachmentRecord(
+          'mon-cli',
+          buildSavedAttachmentData({ [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.PROJECT })
+        )
+      );
+      const { mock: attachments } = createAttachmentsMock(records);
+      const { ctx } = buildContext(attachments);
+
+      const result = await tool.handler(
+        {
+          monitor_attachment_id: 'mon-cli',
+          operations: [{ operation: 'set_enabled', enabled: false }],
+        },
+        ctx
+      );
+
+      expect(attachments.update).not.toHaveBeenCalled();
+      if (!('results' in result)) throw new Error('expected standard return');
+      const [first] = result.results;
+      expect(first.type).toBe(ToolResultType.other);
+      const data = first.data as Record<string, unknown>;
+      expect(data.error).toBe('cli_managed_monitor');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns a structured error result and warns on MonitorOperationValidationError', async () => {
+      const { mock: attachments } = createAttachmentsMock(new Map());
+      const { ctx, logger } = buildContext(attachments);
+
+      const result = await tool.handler(
+        {
+          operations: [
+            {
+              operation: 'set_locations',
+              locations: [
+                { id: 'dup', isServiceManaged: true },
+                { id: 'dup', isServiceManaged: true },
+              ],
+            },
+          ],
+        },
+        ctx
+      );
+
+      if (!('results' in result)) throw new Error('expected standard return');
+      const [first] = result.results;
+      expect(first.type).toBe(ToolResultType.error);
+      const data = first.data as { message: string; metadata?: Record<string, unknown> };
+      expect(data.metadata?.code).toBe('duplicate_location');
+      expect(logger.warn).toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(attachments.add).not.toHaveBeenCalled();
+    });
+
+    it('returns a structured error result and logs at error for unexpected failures', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      records.set('boom', buildAttachmentRecord('boom', buildSavedAttachmentData()));
+      const { mock: attachments } = createAttachmentsMock(records);
+      attachments.update = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('persist failed')) as typeof attachments.update;
+      const { ctx, logger } = buildContext(attachments);
+
+      const result = await tool.handler(
+        {
+          monitor_attachment_id: 'boom',
+          operations: [{ operation: 'set_enabled', enabled: false }],
+        },
+        ctx
+      );
+
+      if (!('results' in result)) throw new Error('expected standard return');
+      expect(result.results[0].type).toBe(ToolResultType.error);
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('proposed → saved transition', () => {
+    it("keeps origin: ui through ops; updateOrigin is the framework's job, not the tool's", async () => {
+      const records = new Map<string, MonitorAttachment>();
+      const { mock: attachments, addedInputs } = createAttachmentsMock(records);
+      const { ctx } = buildContext(attachments);
+
+      await tool.handler(
+        {
+          operations: [
+            { operation: 'set_metadata', name: 'New' },
+            { operation: 'set_http_check', url: 'https://example.com' },
+            { operation: 'set_schedule', number: '5', unit: ScheduleUnit.MINUTES },
+            {
+              operation: 'set_locations',
+              locations: [{ id: 'us_central', isServiceManaged: true }],
+            },
+          ],
+        },
+        ctx
+      );
+
+      const data = addedInputs[0].data as MonitorAttachmentData;
+      // Stub seeds origin: ui — the tool never marks anything `project`,
+      // and never assigns a config_id (that's the CRUD endpoint's job).
+      expect(data[ConfigKey.MONITOR_SOURCE_TYPE]).toBe(SourceType.UI);
+      expect(data[ConfigKey.CONFIG_ID]).toBeUndefined();
+    });
+  });
+
+  describe('no-persistence guarantee', () => {
+    it('never reaches a Synthetics service or saved-objects client', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      const { mock: attachments } = createAttachmentsMock(records);
+      const { ctx } = buildContext(attachments);
+
+      await tool.handler(
+        {
+          operations: [
+            { operation: 'set_metadata', name: 'New' },
+            { operation: 'set_http_check', url: 'https://example.com' },
+            { operation: 'set_schedule', number: '5', unit: ScheduleUnit.MINUTES },
+            {
+              operation: 'set_locations',
+              locations: [{ id: 'us_central', isServiceManaged: true }],
+            },
+          ],
+        },
+        ctx
+      );
+
+      // savedObjectsClient is the surface we'd use to write monitors —
+      // assert that nothing about it was touched.
+      expect(ctx.savedObjectsClient).toEqual({});
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/manage_synthetics_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/manage_synthetics_monitor.test.ts
@@ -118,15 +118,31 @@ const createAttachmentsMock = (records: Map<string, MonitorAttachment>) => {
   return { mock, addedInputs, updatedInputs };
 };
 
-const buildContext = (attachmentsMock: AttachmentStateManager) => {
+/**
+ * Stub `savedObjectsClient` whose `bulkGet` always returns a not-found
+ * response. Used by the bulk of the tests, which never trigger the
+ * post-Create refresh path (because `attachmentRecord.origin` is
+ * undefined or the in-memory data already has `config_id`). The Jest
+ * `not.toHaveBeenCalled()` checks below ensure we don't silently start
+ * relying on this stub returning anything meaningful.
+ */
+const buildSilentSavedObjectsClient = () => ({
+  bulkGet: jest.fn(async () => ({ saved_objects: [] })),
+});
+
+const buildContext = (
+  attachmentsMock: AttachmentStateManager,
+  options: { savedObjectsClient?: { bulkGet: jest.Mock } } = {}
+) => {
   const logger = loggerMock.create();
+  const savedObjectsClient = options.savedObjectsClient ?? buildSilentSavedObjectsClient();
   const ctx = {
     logger,
     attachments: attachmentsMock,
     request: {} as never,
     spaceId: 'default',
     esClient: {} as never,
-    savedObjectsClient: {} as never,
+    savedObjectsClient: savedObjectsClient as never,
     modelProvider: {} as never,
     toolProvider: {} as never,
     runner: {} as never,
@@ -139,7 +155,7 @@ const buildContext = (attachmentsMock: AttachmentStateManager) => {
     toolManager: {} as never,
     runContext: {} as never,
   };
-  return { ctx, logger };
+  return { ctx, logger, savedObjectsClient };
 };
 
 describe('manageSyntheticsMonitorTool', () => {
@@ -179,6 +195,9 @@ describe('manageSyntheticsMonitorTool', () => {
       expect(first.type).toBe(ToolResultType.other);
       const data = first.data as Record<string, unknown>;
       expect(data.status).toBe('proposed');
+      // Brand-new draft → no `config_id` → lifecycle must be 'draft'
+      // so the LLM picks the **Create** wording, not **Update**.
+      expect(data.lifecycle).toBe('draft');
       expect(data.saveable).toBe(true);
       expect(data.missing_fields).toBeUndefined();
     });
@@ -228,6 +247,10 @@ describe('manageSyntheticsMonitorTool', () => {
       if (!('results' in result)) throw new Error('expected standard return');
       const data = result.results[0].data as Record<string, unknown>;
       expect(data.status).toBe('updated');
+      // Existing attachment seeded with `config_id` (via
+      // `buildSavedAttachmentData`) → lifecycle stays 'saved'
+      // through the operation, so the LLM picks **Update**.
+      expect(data.lifecycle).toBe('saved');
       expect(data.saveable).toBe(true);
     });
 
@@ -360,10 +383,10 @@ describe('manageSyntheticsMonitorTool', () => {
   });
 
   describe('no-persistence guarantee', () => {
-    it('never reaches a Synthetics service or saved-objects client', async () => {
+    it('never reaches the saved-objects client when composing a fresh draft (no monitor_attachment_id)', async () => {
       const records = new Map<string, MonitorAttachment>();
       const { mock: attachments } = createAttachmentsMock(records);
-      const { ctx } = buildContext(attachments);
+      const { ctx, savedObjectsClient } = buildContext(attachments);
 
       await tool.handler(
         {
@@ -380,9 +403,220 @@ describe('manageSyntheticsMonitorTool', () => {
         ctx
       );
 
-      // savedObjectsClient is the surface we'd use to write monitors —
-      // assert that nothing about it was touched.
-      expect(ctx.savedObjectsClient).toEqual({});
+      // The "no SO refresh" guarantee for the new-draft path: we only
+      // touch the saved-objects client when re-resolving an attachment
+      // that already has an `origin` and lacks `config_id` (the
+      // post-Create refresh in `resolveMonitorAttachmentData`). For a
+      // fresh draft neither precondition holds, so `bulkGet` must
+      // remain untouched.
+      expect(savedObjectsClient.bulkGet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('refresh after Save (origin set, in-memory data missing config_id)', () => {
+    /**
+     * Reproduces the post-Create UX bug: the framework's `updateOrigin`
+     * sets `attachment.origin` after a successful Save, but never
+     * re-resolves the in-memory data. The next tool call would then
+     * read a snapshot with no `config_id` and the canvas would keep
+     * showing **Create** instead of **Update** for what is in fact a
+     * saved monitor. The fix re-fetches the live SO and overlays the
+     * fresh data before applying operations, so the round-tripped
+     * attachment again carries `config_id`.
+     */
+    const buildSavedMonitorSO = (
+      configId: string,
+      overrides: Partial<MonitorAttachmentData> = {}
+    ) => ({
+      type: 'synthetics-monitor-multi-space',
+      id: configId,
+      attributes: buildSavedAttachmentData({
+        [ConfigKey.CONFIG_ID]: configId,
+        ...overrides,
+      }),
+      updated_at: '2026-05-02T20:00:00.000Z',
+      created_at: '2026-05-02T19:00:00.000Z',
+    });
+
+    it("refreshes data from the SO when origin is set but the in-memory snapshot has no config_id, so the next save round-trips as 'updated'", async () => {
+      const records = new Map<string, MonitorAttachment>();
+      // Stale snapshot — what `attachmentStateManager` holds right
+      // after `updateOrigin('config-uuid')`: the data the agent
+      // composed pre-Save (no `config_id`), with the new origin
+      // grafted on by the framework.
+      const staleData = buildSavedAttachmentData({
+        [ConfigKey.NAME]: 'Last monitor',
+      });
+      delete staleData[ConfigKey.CONFIG_ID];
+      records.set('mon-1', buildAttachmentRecord('mon-1', staleData, 'config-uuid'));
+      const { mock: attachments, updatedInputs } = createAttachmentsMock(records);
+
+      // SO bulkGet returns the saved monitor with `config_id` populated
+      // — `fetchMonitorAttachmentData` returns the first SO that has
+      // attributes (the legacy SO type entry is null in this scenario).
+      const bulkGet = jest.fn(async () => ({
+        saved_objects: [
+          buildSavedMonitorSO('config-uuid', { [ConfigKey.NAME]: 'Last monitor' }),
+          null,
+        ],
+      }));
+      const { ctx } = buildContext(attachments, {
+        savedObjectsClient: { bulkGet } as { bulkGet: jest.Mock },
+      });
+
+      const result = await tool.handler(
+        {
+          monitor_attachment_id: 'mon-1',
+          operations: [
+            {
+              operation: 'set_locations',
+              locations: [{ id: 'eu_west', label: 'EU West', isServiceManaged: true }],
+            },
+          ],
+        },
+        ctx
+      );
+
+      // Refresh hit the SO once with both type variants — same call
+      // shape as the attachment type's `resolve` hook.
+      expect(bulkGet).toHaveBeenCalledTimes(1);
+
+      // The persisted attachment now carries `config_id`, so the
+      // canvas's `inferMonitorStatus` will resolve to `'enabled'`
+      // and render the **Update** button instead of **Create**.
+      const newData = updatedInputs[0].input.data as MonitorAttachmentData;
+      expect(newData[ConfigKey.CONFIG_ID]).toBe('config-uuid');
+      // Operation still applied on top of the refreshed snapshot.
+      expect(newData[ConfigKey.LOCATIONS]).toEqual([
+        { id: 'eu_west', label: 'EU West', isServiceManaged: true },
+      ]);
+
+      if (!('results' in result)) throw new Error('expected standard return');
+      const data = result.results[0].data as Record<string, unknown>;
+      expect(data.status).toBe('updated');
+      // Lifecycle reports the **monitor's** state, not the tool
+      // action's: refresh resolved a `config_id`, so the LLM should
+      // see `lifecycle: 'saved'` and tell the user to click
+      // **Update** (not **Create**) — this is the precise signal that
+      // was missing in the original "Update button still says Create"
+      // bug report.
+      expect(data.lifecycle).toBe('saved');
+      expect(data.monitor).toMatchObject({ config_id: 'config-uuid' });
+    });
+
+    it('does NOT refresh when origin is unset (proposed draft path stays SO-free)', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      const staleData = buildSavedAttachmentData();
+      delete staleData[ConfigKey.CONFIG_ID];
+      // No origin — this is the proposed-draft path.
+      records.set('mon-1', buildAttachmentRecord('mon-1', staleData));
+      const { mock: attachments } = createAttachmentsMock(records);
+      const { ctx, savedObjectsClient } = buildContext(attachments);
+
+      await tool.handler(
+        {
+          monitor_attachment_id: 'mon-1',
+          operations: [{ operation: 'set_enabled', enabled: false }],
+        },
+        ctx
+      );
+
+      expect(savedObjectsClient.bulkGet).not.toHaveBeenCalled();
+    });
+
+    it("reports lifecycle='draft' when updating a never-saved draft (status='updated' alone is NOT enough to claim 'Update' wording)", async () => {
+      // Reproduces the "Click Update — but the canvas still shows
+      // Create" symptom we hit in field testing. The agent passed
+      // `monitor_attachment_id` for an existing **draft** attachment
+      // (no origin, no config_id). The tool correctly returns
+      // `status: 'updated'` (we did mutate an existing record), but
+      // the canvas's `inferMonitorStatus` ignores `status` — it keys
+      // off `config_id`. The new `lifecycle` field collapses both
+      // signals into one for the LLM.
+      const records = new Map<string, MonitorAttachment>();
+      const draftData = buildSavedAttachmentData();
+      delete draftData[ConfigKey.CONFIG_ID];
+      records.set('mon-draft', buildAttachmentRecord('mon-draft', draftData));
+      const { mock: attachments, updatedInputs } = createAttachmentsMock(records);
+      const { ctx } = buildContext(attachments);
+
+      const result = await tool.handler(
+        {
+          monitor_attachment_id: 'mon-draft',
+          operations: [
+            {
+              operation: 'set_locations',
+              locations: [{ id: 'eu_west', label: 'EU West', isServiceManaged: true }],
+            },
+          ],
+        },
+        ctx
+      );
+
+      const newData = updatedInputs[0].input.data as MonitorAttachmentData;
+      expect(newData[ConfigKey.CONFIG_ID]).toBeUndefined();
+
+      if (!('results' in result)) throw new Error('expected standard return');
+      const data = result.results[0].data as Record<string, unknown>;
+      expect(data.status).toBe('updated');
+      // The contract that matters for the user: lifecycle === 'draft'
+      // tells the LLM to point at **Create** (matching what the
+      // canvas will actually render), not **Update**.
+      expect(data.lifecycle).toBe('draft');
+    });
+
+    it('does NOT refresh when the in-memory snapshot already has config_id (steady state)', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      // Already-fresh snapshot — buildSavedAttachmentData seeds CONFIG_ID.
+      records.set(
+        'mon-1',
+        buildAttachmentRecord('mon-1', buildSavedAttachmentData(), 'config-uuid')
+      );
+      const { mock: attachments } = createAttachmentsMock(records);
+      const { ctx, savedObjectsClient } = buildContext(attachments);
+
+      await tool.handler(
+        {
+          monitor_attachment_id: 'mon-1',
+          operations: [{ operation: 'set_enabled', enabled: false }],
+        },
+        ctx
+      );
+
+      expect(savedObjectsClient.bulkGet).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the in-memory snapshot and warns when the SO refresh returns nothing (deleted out-of-band)', async () => {
+      const records = new Map<string, MonitorAttachment>();
+      const staleData = buildSavedAttachmentData();
+      delete staleData[ConfigKey.CONFIG_ID];
+      records.set('mon-1', buildAttachmentRecord('mon-1', staleData, 'gone-uuid'));
+      const { mock: attachments, updatedInputs } = createAttachmentsMock(records);
+
+      // Both SO type variants come back as null — `fetchMonitorAttachmentData`
+      // logs a warn and returns `undefined`, which our resolver then
+      // also warns on before falling back to the in-memory data.
+      const bulkGet = jest.fn(async () => ({ saved_objects: [null, null] }));
+      const { ctx, logger } = buildContext(attachments, {
+        savedObjectsClient: { bulkGet } as { bulkGet: jest.Mock },
+      });
+
+      await tool.handler(
+        {
+          monitor_attachment_id: 'mon-1',
+          operations: [{ operation: 'set_enabled', enabled: false }],
+        },
+        ctx
+      );
+
+      expect(bulkGet).toHaveBeenCalledTimes(1);
+      const newData = updatedInputs[0].input.data as MonitorAttachmentData;
+      // Still no config_id — operations applied to the stale snapshot.
+      expect(newData[ConfigKey.CONFIG_ID]).toBeUndefined();
+      expect(newData[ConfigKey.ENABLED]).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/manage_synthetics_monitor\.refresh: miss attachment='mon-1'/)
+      );
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/manage_synthetics_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/manage_synthetics_monitor.ts
@@ -7,6 +7,8 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { z } from '@kbn/zod/v4';
+import type { Logger } from '@kbn/logging';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import { ToolType } from '@kbn/agent-builder-common';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
@@ -17,6 +19,7 @@ import {
   type MonitorAttachmentData,
 } from '../../../../common/agent_builder';
 import { ConfigKey } from '../../../../common/runtime_types';
+import { fetchMonitorAttachmentData } from '../../internal/monitor_attachment_data';
 import { monitorOperationSchema } from './operations';
 import {
   MonitorOperationValidationError,
@@ -71,8 +74,28 @@ Use \`operations[]\` (in order) to:
 
 Look up location ids via the \`monitor-management\` skill's SML search before calling \`set_locations\`. Project-origin (CLI-managed) monitors are read-only via this tool.`;
 
+/**
+ * Two orthogonal axes the LLM needs to keep separate when narrating
+ * results back to the user:
+ *
+ * - `status` — what the **tool** just did to the conversation
+ *   attachment record: created it (`proposed`), mutated an existing
+ *   one (`updated`), refused (`cli_managed`), or bailed because the
+ *   draft is missing required fields (`incomplete`).
+ * - `lifecycle` — what the **monitor** itself actually is right now:
+ *   `draft` (no `config_id` yet — the user must click **Create** to
+ *   write it to Synthetics) or `saved` (already persisted — the user
+ *   clicks **Update** to push the agent's changes).
+ *
+ * Without `lifecycle`, the LLM was conflating "tool action = updated"
+ * with "monitor is saved", and would tell the user "Click Update"
+ * even when the underlying attachment was still a draft (no
+ * `config_id`). Splitting the two lets the skill prompt wire the
+ * Create-vs-Update wording strictly to `lifecycle`.
+ */
 interface ToolResultPayload {
   status: 'proposed' | 'updated' | 'incomplete' | 'cli_managed';
+  lifecycle: 'draft' | 'saved';
   attachment_id: string;
   saveable: boolean;
   missing_fields?: string[];
@@ -96,6 +119,13 @@ const summarizeMonitor = (
   status: ToolResultPayload['status']
 ): ToolResultPayload => ({
   status,
+  // Lifecycle keys off `config_id` exclusively — same heuristic the
+  // canvas's `inferMonitorStatus` uses (sans the project/CLI branch
+  // which is already surfaced via `status: 'cli_managed'` and the
+  // `monitor.origin` field). Keeping the two in lockstep means the
+  // LLM and the canvas always agree on whether the user should see
+  // **Create** or **Update**.
+  lifecycle: data[ConfigKey.CONFIG_ID] ? 'saved' : 'draft',
   attachment_id: attachmentId,
   saveable,
   missing_fields: missingFields,
@@ -116,6 +146,15 @@ const summarizeMonitor = (
   },
 });
 
+/**
+ * Read the latest in-memory snapshot of an existing monitor attachment.
+ *
+ * Pure projection of `attachments.getAttachmentRecord(id)` — does not
+ * touch ES / SOs. The freshness layering (when to trust this snapshot
+ * vs. re-resolve from the saved object) lives in
+ * {@link resolveMonitorAttachmentData} so the snapshot reader stays
+ * cheap and synchronous.
+ */
 const retrieveExistingMonitorAttachment = (
   attachmentRecord: VersionedAttachment | undefined,
   attachmentId: string
@@ -137,6 +176,94 @@ const retrieveExistingMonitorAttachment = (
   return latest?.data;
 };
 
+/**
+ * Resolve the monitor data the agent should mutate.
+ *
+ * This is intentionally *not* the same as just reading the conversation
+ * attachment's latest version. Sequence we have to handle:
+ *
+ *   1. Tool composes a draft (no `config_id`, no `origin`).
+ *   2. User clicks Create in the canvas → `POST /api/synthetics/monitors`
+ *      returns the new SO id → canvas calls `updateOrigin(id)`. The
+ *      framework writes the origin onto the attachment record but
+ *      does **not** re-resolve the data — the in-memory snapshot
+ *      still has no `config_id`.
+ *   3. Agent calls this tool again to update something (e.g. swap a
+ *      location). If we trust the in-memory snapshot, we send back a
+ *      result with `status: 'updated'`, but the canvas's
+ *      `inferMonitorStatus` reads `config_id` to decide between
+ *      proposed / enabled / disabled — without it, the canvas keeps
+ *      showing **Create** instead of **Update**, and the action is
+ *      silently a no-op against the saved monitor.
+ *
+ * Heuristic: when the attachment has an `origin` set (i.e. it has
+ * been linked to a saved monitor) but the in-memory data is missing
+ * `config_id`, refresh from the saved object via
+ * `fetchMonitorAttachmentData`. The lookup is the same one the
+ * attachment type's `resolve` uses, scoped to the user's request via
+ * the tool context's `savedObjectsClient`.
+ *
+ * If the SO read fails (e.g. the monitor was deleted out-of-band),
+ * fall back to the in-memory snapshot and warn — the operation will
+ * still proceed and the eventual canvas Save will surface a
+ * structured error. This mirrors the attachment type's
+ * "warn-not-throw" posture for resolve failures.
+ */
+const resolveMonitorAttachmentData = async ({
+  attachmentRecord,
+  inMemoryData,
+  savedObjectsClient,
+  logger,
+  attachmentId,
+}: {
+  attachmentRecord: VersionedAttachment | undefined;
+  inMemoryData: MonitorAttachmentData | undefined;
+  savedObjectsClient: SavedObjectsClientContract;
+  logger: Logger;
+  attachmentId: string;
+}): Promise<MonitorAttachmentData | undefined> => {
+  // We log every branch — including the no-ops — at debug because the
+  // post-Create refresh is invisible from the UI side and field
+  // debugging hinges on knowing *why* it did or didn't fire.
+  // Production logs typically run at info, so this stays quiet by
+  // default; flip the synthetics logger to debug to inspect.
+  if (!inMemoryData || !attachmentRecord?.origin) {
+    logger.debug(
+      `manage_synthetics_monitor.refresh: skip attachment='${attachmentId}' reason='no-origin-or-no-data' hasOrigin=${Boolean(
+        attachmentRecord?.origin
+      )} hasInMemoryData=${Boolean(inMemoryData)}`
+    );
+    return inMemoryData;
+  }
+  if (inMemoryData[ConfigKey.CONFIG_ID]) {
+    logger.debug(
+      `manage_synthetics_monitor.refresh: skip attachment='${attachmentId}' reason='already-has-config-id' origin='${attachmentRecord.origin}'`
+    );
+    return inMemoryData;
+  }
+  logger.info(
+    `manage_synthetics_monitor.refresh: fetch attachment='${attachmentId}' origin='${attachmentRecord.origin}' (in-memory snapshot has no config_id; refreshing from saved object)`
+  );
+  const fetched = await fetchMonitorAttachmentData({
+    soClient: savedObjectsClient,
+    configId: attachmentRecord.origin,
+    logger,
+    context: 'manage_synthetics_monitor.refreshAfterSave',
+  });
+  if (!fetched) {
+    logger.warn(
+      `manage_synthetics_monitor.refresh: miss attachment='${attachmentId}' origin='${attachmentRecord.origin}' — falling back to in-memory snapshot (canvas will still render as a draft until the SO is reachable)`
+    );
+    return inMemoryData;
+  }
+  logger.info(
+    `manage_synthetics_monitor.refresh: hit attachment='${attachmentId}' origin='${
+      attachmentRecord.origin
+    }' resolvedConfigId='${fetched.data[ConfigKey.CONFIG_ID] ?? 'none'}'`
+  );
+  return fetched.data;
+};
+
 export const manageSyntheticsMonitorTool = (): BuiltinSkillBoundedTool<
   typeof manageSyntheticsMonitorSchema
 > => ({
@@ -146,14 +273,23 @@ export const manageSyntheticsMonitorTool = (): BuiltinSkillBoundedTool<
   schema: manageSyntheticsMonitorSchema,
   handler: async (
     { monitor_attachment_id: previousAttachmentId, operations },
-    { logger, attachments }
+    { logger, attachments, savedObjectsClient }
   ) => {
     try {
       const attachmentRecord = previousAttachmentId
         ? attachments.getAttachmentRecord(previousAttachmentId)
         : undefined;
-      const previousData = previousAttachmentId
+      const inMemoryData = previousAttachmentId
         ? retrieveExistingMonitorAttachment(attachmentRecord, previousAttachmentId)
+        : undefined;
+      const previousData = previousAttachmentId
+        ? await resolveMonitorAttachmentData({
+            attachmentRecord,
+            inMemoryData,
+            savedObjectsClient,
+            logger,
+            attachmentId: previousAttachmentId,
+          })
         : undefined;
 
       // Project-origin (CLI-managed) monitors are read-only via this
@@ -221,8 +357,11 @@ export const manageSyntheticsMonitorTool = (): BuiltinSkillBoundedTool<
 
       const missingFields = saveability.saveable ? undefined : saveability.missing;
 
+      const lifecycle = draft[ConfigKey.CONFIG_ID] ? 'saved' : 'draft';
       logger.info(
-        `${TOOL_ID}: ${status} attachment '${attachmentId}' (saveable=${saveability.saveable}, ops=${operations.length})`
+        `${TOOL_ID}: ${status} attachment '${attachmentId}' lifecycle=${lifecycle} configId='${
+          draft[ConfigKey.CONFIG_ID] ?? 'none'
+        }' (saveable=${saveability.saveable}, ops=${operations.length})`
       );
 
       return {

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/manage_synthetics_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/manage_synthetics_monitor.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
+import { getLatestVersion, type VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+
+import {
+  MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+  type MonitorAttachmentData,
+} from '../../../../common/agent_builder';
+import { ConfigKey } from '../../../../common/runtime_types';
+import { monitorOperationSchema } from './operations';
+import {
+  MonitorOperationValidationError,
+  assertMonitorDraftSaveable,
+  executeMonitorOperations,
+} from './monitor_draft';
+
+/**
+ * Tool input schema. Two top-level inputs:
+ *
+ * - `monitor_attachment_id` (optional): when present, mutate the
+ *   attachment in place; when absent, propose a new monitor.
+ * - `operations[]`: ordered list of mutations applied to the in-memory
+ *   draft. Discriminated union — invalid combinations are rejected by
+ *   Zod before the handler runs.
+ *
+ * Field names are snake_case to match the LLM-facing tool JSON convention
+ * used by the rest of agent_builder.
+ */
+const manageSyntheticsMonitorSchema = z.object({
+  monitor_attachment_id: z
+    .string()
+    .optional()
+    .describe(
+      '(optional) Existing monitor attachment id to update. If omitted, a new monitor draft is proposed.'
+    ),
+  operations: z
+    .array(monitorOperationSchema)
+    .min(1)
+    .describe(
+      'Ordered list of mutations to apply to the draft. At minimum a new monitor needs `set_metadata` (name), `set_http_check` (url), `set_schedule`, and `set_locations` before the user can save.'
+    ),
+});
+
+const TOOL_ID = 'manage_synthetics_monitor';
+
+/**
+ * Description shown to the LLM. Keep terse — every line spends context
+ * tokens. Cross-link to the skill (T5) so the agent loads the broader
+ * authoring guidance when this tool is bound.
+ */
+const TOOL_DESCRIPTION = `Compose or modify a draft Synthetics monitor in conversation context.
+
+This tool mutates an in-memory **draft attachment** of type \`${MONITOR_MANAGEMENT_ATTACHMENT_TYPE}\`. It NEVER persists to Synthetics — the user clicks Create or Update in the canvas to write the monitor via the existing CRUD HTTP API. v1 supports HTTP monitors with origin: ui only.
+
+Use \`operations[]\` (in order) to:
+1. set_metadata    — name, tags, apm_service_name, namespace
+2. set_schedule    — schedule.number + schedule.unit (allow-listed)
+3. set_http_check  — url, method, max_redirects, ignore_https_errors
+4. set_locations   — replace the location list (provide the full set)
+5. set_enabled     — toggle whether the monitor runs once saved
+
+Look up location ids via the \`monitor-management\` skill's SML search before calling \`set_locations\`. Project-origin (CLI-managed) monitors are read-only via this tool.`;
+
+interface ToolResultPayload {
+  status: 'proposed' | 'updated' | 'incomplete' | 'cli_managed';
+  attachment_id: string;
+  saveable: boolean;
+  missing_fields?: string[];
+  monitor: {
+    name?: string;
+    type: string;
+    enabled?: boolean;
+    schedule?: { number: string; unit: string };
+    locations_count: number;
+    url?: string;
+    config_id?: string;
+    origin?: string;
+  };
+}
+
+const summarizeMonitor = (
+  attachmentId: string,
+  data: ReturnType<typeof executeMonitorOperations>,
+  saveable: boolean,
+  missingFields: string[] | undefined,
+  status: ToolResultPayload['status']
+): ToolResultPayload => ({
+  status,
+  attachment_id: attachmentId,
+  saveable,
+  missing_fields: missingFields,
+  monitor: {
+    name: data[ConfigKey.NAME],
+    type: data[ConfigKey.MONITOR_TYPE] ?? 'http',
+    enabled: data[ConfigKey.ENABLED],
+    schedule: data[ConfigKey.SCHEDULE]
+      ? {
+          number: data[ConfigKey.SCHEDULE].number,
+          unit: data[ConfigKey.SCHEDULE].unit,
+        }
+      : undefined,
+    locations_count: data[ConfigKey.LOCATIONS]?.length ?? 0,
+    url: data[ConfigKey.URLS],
+    config_id: data[ConfigKey.CONFIG_ID],
+    origin: data[ConfigKey.MONITOR_SOURCE_TYPE],
+  },
+});
+
+const retrieveExistingMonitorAttachment = (
+  attachmentRecord: VersionedAttachment | undefined,
+  attachmentId: string
+): MonitorAttachmentData | undefined => {
+  if (!attachmentRecord) {
+    throw new Error(`Monitor attachment "${attachmentId}" not found in conversation.`);
+  }
+  if (attachmentRecord.type !== MONITOR_MANAGEMENT_ATTACHMENT_TYPE) {
+    throw new Error(
+      `Attachment "${attachmentId}" is type "${attachmentRecord.type}", expected "${MONITOR_MANAGEMENT_ATTACHMENT_TYPE}".`
+    );
+  }
+  const latest = getLatestVersion<MonitorAttachmentData>(
+    attachmentRecord as VersionedAttachment<
+      typeof MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+      MonitorAttachmentData
+    >
+  );
+  return latest?.data;
+};
+
+export const manageSyntheticsMonitorTool = (): BuiltinSkillBoundedTool<
+  typeof manageSyntheticsMonitorSchema
+> => ({
+  id: TOOL_ID,
+  type: ToolType.builtin,
+  description: TOOL_DESCRIPTION,
+  schema: manageSyntheticsMonitorSchema,
+  handler: async (
+    { monitor_attachment_id: previousAttachmentId, operations },
+    { logger, attachments }
+  ) => {
+    try {
+      const attachmentRecord = previousAttachmentId
+        ? attachments.getAttachmentRecord(previousAttachmentId)
+        : undefined;
+      const previousData = previousAttachmentId
+        ? retrieveExistingMonitorAttachment(attachmentRecord, previousAttachmentId)
+        : undefined;
+
+      // Project-origin (CLI-managed) monitors are read-only via this
+      // tool — the brief makes this explicit. Refuse early with a
+      // structured error so the LLM doesn't silently mutate something
+      // the user can't save.
+      if (previousData?.[ConfigKey.MONITOR_SOURCE_TYPE] === 'project') {
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                error: 'cli_managed_monitor',
+                message: `Monitor "${previousAttachmentId}" is CLI-managed (origin: project) and cannot be edited via the agent. Use the synthetics-cli to update it.`,
+                attachment_id: previousAttachmentId,
+              },
+            },
+          ],
+        };
+      }
+
+      // Apply ops to the in-memory draft. Per-op `.refine` checks ran
+      // during Zod parse before the handler started, so this only
+      // raises on **cross-field** failures.
+      const draft = executeMonitorOperations({
+        currentDraft: previousData,
+        operations,
+        logger,
+      });
+
+      const saveability = assertMonitorDraftSaveable(draft);
+
+      const isNewMonitor = !previousAttachmentId;
+      const attachmentId = previousAttachmentId ?? uuidv4();
+
+      // Persist into the **conversation-level** attachment store —
+      // distinct from any Synthetics persistence, which only happens
+      // when the user clicks Save in the canvas.
+      const attachmentInput = {
+        id: attachmentId,
+        type: MONITOR_MANAGEMENT_ATTACHMENT_TYPE,
+        description:
+          draft[ConfigKey.NAME] !== undefined
+            ? `Synthetics monitor: ${draft[ConfigKey.NAME]}`
+            : 'Synthetics monitor (proposed)',
+        data: draft,
+      };
+
+      const attachment = isNewMonitor
+        ? await attachments.add(attachmentInput)
+        : await attachments.update(attachmentId, {
+            data: draft,
+            description: attachmentInput.description,
+          });
+
+      if (!attachment) {
+        throw new Error(`Failed to persist monitor attachment "${attachmentId}".`);
+      }
+
+      const status: ToolResultPayload['status'] = !saveability.saveable
+        ? 'incomplete'
+        : isNewMonitor
+        ? 'proposed'
+        : 'updated';
+
+      const missingFields = saveability.saveable ? undefined : saveability.missing;
+
+      logger.info(
+        `${TOOL_ID}: ${status} attachment '${attachmentId}' (saveable=${saveability.saveable}, ops=${operations.length})`
+      );
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: summarizeMonitor(
+              attachment.id,
+              draft,
+              saveability.saveable,
+              missingFields,
+              status
+            ),
+          },
+        ],
+      };
+    } catch (error) {
+      // Per the brief: validation errors → warn, everything else →
+      // error. Both surface a structured error result to the LLM.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof MonitorOperationValidationError) {
+        logger.warn(`${TOOL_ID}: validation error (${error.code}) — ${message}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message,
+                metadata: {
+                  code: error.code,
+                  monitor_attachment_id: previousAttachmentId,
+                  operations,
+                },
+              },
+            },
+          ],
+        };
+      }
+      logger.error(`${TOOL_ID}: ${message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to manage Synthetics monitor: ${message}`,
+              metadata: {
+                monitor_attachment_id: previousAttachmentId,
+                operations,
+              },
+            },
+          },
+        ],
+      };
+    }
+  },
+});
+
+export { manageSyntheticsMonitorSchema };

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/monitor_draft.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/monitor_draft.test.ts
@@ -1,0 +1,270 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import { ConfigKey } from '../../../../common/runtime_types';
+import {
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../../common/runtime_types/monitor_management/monitor_configs';
+import type { MonitorAttachmentData } from '../../../../common/agent_builder';
+import {
+  MonitorOperationValidationError,
+  assertMonitorDraftSaveable,
+  buildEmptyMonitorDraft,
+  executeMonitorOperations,
+} from './monitor_draft';
+import type { MonitorOperation } from './operations';
+
+const buildSavedDraft = (
+  overrides: Partial<MonitorAttachmentData> = {}
+): MonitorAttachmentData => ({
+  [ConfigKey.NAME]: 'Saved monitor',
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.ENABLED]: true,
+  [ConfigKey.SCHEDULE]: { number: '5', unit: ScheduleUnit.MINUTES },
+  [ConfigKey.LOCATIONS]: [{ id: 'us_central', label: 'US Central', isServiceManaged: true }],
+  [ConfigKey.URLS]: 'https://example.com',
+  [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+  ...overrides,
+});
+
+describe('buildEmptyMonitorDraft', () => {
+  it('seeds only structural keys; required user-supplied fields are absent', () => {
+    const draft = buildEmptyMonitorDraft();
+    expect(draft[ConfigKey.MONITOR_TYPE]).toBe(MonitorTypeEnum.HTTP);
+    expect(draft[ConfigKey.MONITOR_SOURCE_TYPE]).toBe(SourceType.UI);
+    expect(draft[ConfigKey.ENABLED]).toBe(true);
+    expect(draft[ConfigKey.NAME]).toBeUndefined();
+    expect(draft[ConfigKey.URLS]).toBeUndefined();
+    expect(draft[ConfigKey.SCHEDULE]).toBeUndefined();
+    expect(draft[ConfigKey.LOCATIONS]).toBeUndefined();
+  });
+});
+
+describe('executeMonitorOperations', () => {
+  const logger = loggerMock.create();
+
+  beforeEach(() => {
+    loggerMock.clear(logger);
+  });
+
+  describe('set_metadata', () => {
+    it('writes name, tags, apm_service_name, namespace into the draft', () => {
+      const draft = executeMonitorOperations({
+        currentDraft: undefined,
+        operations: [
+          {
+            operation: 'set_metadata',
+            name: 'My monitor',
+            tags: ['prod'],
+            apm_service_name: 'svc',
+            namespace: 'foo',
+          },
+        ],
+        logger,
+      });
+      expect(draft[ConfigKey.NAME]).toBe('My monitor');
+      expect(draft[ConfigKey.TAGS]).toEqual(['prod']);
+      expect(draft[ConfigKey.APM_SERVICE_NAME]).toBe('svc');
+      expect(draft[ConfigKey.NAMESPACE]).toBe('foo');
+    });
+
+    it('skips an empty set_metadata op (debug-logs and no-ops)', () => {
+      const draft = executeMonitorOperations({
+        currentDraft: undefined,
+        operations: [{ operation: 'set_metadata' }],
+        logger,
+      });
+      expect(draft[ConfigKey.NAME]).toBeUndefined();
+      expect(logger.debug).toHaveBeenCalledWith('Skipping empty set_metadata operation');
+    });
+  });
+
+  describe('set_schedule', () => {
+    it('writes schedule', () => {
+      const draft = executeMonitorOperations({
+        currentDraft: undefined,
+        operations: [{ operation: 'set_schedule', number: '5', unit: ScheduleUnit.MINUTES }],
+        logger,
+      });
+      expect(draft[ConfigKey.SCHEDULE]).toEqual({ number: '5', unit: ScheduleUnit.MINUTES });
+    });
+  });
+
+  describe('set_http_check', () => {
+    it('writes url and optional advanced fields', () => {
+      const draft = executeMonitorOperations({
+        currentDraft: undefined,
+        operations: [
+          {
+            operation: 'set_http_check',
+            url: 'https://example.com',
+            method: 'POST',
+            max_redirects: 3,
+            ignore_https_errors: true,
+          },
+        ],
+        logger,
+      });
+      expect(draft[ConfigKey.URLS]).toBe('https://example.com');
+      expect(draft[ConfigKey.REQUEST_METHOD_CHECK]).toBe('POST');
+      expect(draft[ConfigKey.MAX_REDIRECTS]).toBe(3);
+      expect(draft[ConfigKey.IGNORE_HTTPS_ERRORS]).toBe(true);
+    });
+
+    it('does not overwrite advanced fields with undefined', () => {
+      const draft = executeMonitorOperations({
+        currentDraft: buildSavedDraft({
+          [ConfigKey.REQUEST_METHOD_CHECK]: 'GET',
+        }),
+        operations: [{ operation: 'set_http_check', url: 'https://example.com/v2' }],
+        logger,
+      });
+      expect(draft[ConfigKey.URLS]).toBe('https://example.com/v2');
+      expect(draft[ConfigKey.REQUEST_METHOD_CHECK]).toBe('GET');
+    });
+  });
+
+  describe('set_locations', () => {
+    it('replaces locations and preserves agentPolicyId for private locations', () => {
+      const draft = executeMonitorOperations({
+        currentDraft: undefined,
+        operations: [
+          {
+            operation: 'set_locations',
+            locations: [
+              { id: 'us_central', isServiceManaged: true },
+              {
+                id: 'pl-uuid',
+                isServiceManaged: false,
+                agentPolicyId: 'agent-policy-uuid',
+              },
+            ],
+          },
+        ],
+        logger,
+      });
+      expect(draft[ConfigKey.LOCATIONS]).toHaveLength(2);
+      expect(draft[ConfigKey.LOCATIONS]?.[0]).toEqual({
+        id: 'us_central',
+        isServiceManaged: true,
+      });
+      expect(draft[ConfigKey.LOCATIONS]?.[1]).toEqual({
+        id: 'pl-uuid',
+        isServiceManaged: false,
+        agentPolicyId: 'agent-policy-uuid',
+      });
+    });
+
+    it('throws MonitorOperationValidationError on duplicate location ids', () => {
+      expect(() =>
+        executeMonitorOperations({
+          currentDraft: undefined,
+          operations: [
+            {
+              operation: 'set_locations',
+              locations: [
+                { id: 'us_central', isServiceManaged: true },
+                { id: 'us_central', isServiceManaged: true },
+              ],
+            },
+          ],
+          logger,
+        })
+      ).toThrow(MonitorOperationValidationError);
+    });
+  });
+
+  describe('set_enabled', () => {
+    it('toggles enabled', () => {
+      const draft = executeMonitorOperations({
+        currentDraft: buildSavedDraft({ [ConfigKey.ENABLED]: true }),
+        operations: [{ operation: 'set_enabled', enabled: false }],
+        logger,
+      });
+      expect(draft[ConfigKey.ENABLED]).toBe(false);
+    });
+  });
+
+  it('applies multiple operations in order', () => {
+    const operations: MonitorOperation[] = [
+      { operation: 'set_metadata', name: 'New monitor' },
+      { operation: 'set_http_check', url: 'https://example.com' },
+      { operation: 'set_schedule', number: '3', unit: ScheduleUnit.MINUTES },
+      {
+        operation: 'set_locations',
+        locations: [{ id: 'us_central', isServiceManaged: true }],
+      },
+    ];
+    const draft = executeMonitorOperations({ currentDraft: undefined, operations, logger });
+    expect(draft[ConfigKey.NAME]).toBe('New monitor');
+    expect(draft[ConfigKey.URLS]).toBe('https://example.com');
+    expect(draft[ConfigKey.SCHEDULE]).toEqual({ number: '3', unit: ScheduleUnit.MINUTES });
+    expect(draft[ConfigKey.LOCATIONS]).toHaveLength(1);
+  });
+
+  it('does not mutate the input currentDraft', () => {
+    const original = buildSavedDraft();
+    const snapshotName = original[ConfigKey.NAME];
+    executeMonitorOperations({
+      currentDraft: original,
+      operations: [{ operation: 'set_metadata', name: 'Renamed' }],
+      logger,
+    });
+    expect(original[ConfigKey.NAME]).toBe(snapshotName);
+  });
+});
+
+describe('assertMonitorDraftSaveable', () => {
+  it('returns saveable=true with attachment data when all required keys are present', () => {
+    const result = assertMonitorDraftSaveable(buildSavedDraft());
+    expect(result.saveable).toBe(true);
+    if (result.saveable) {
+      expect(result.data[ConfigKey.NAME]).toBe('Saved monitor');
+    }
+  });
+
+  it('lists missing fields in the deterministic order: name, url, schedule, locations', () => {
+    const result = assertMonitorDraftSaveable(buildEmptyMonitorDraft());
+    expect(result.saveable).toBe(false);
+    if (!result.saveable) {
+      expect(result.missing).toEqual([
+        'name',
+        'url (set via set_http_check)',
+        'schedule (set via set_schedule)',
+        'locations (set via set_locations)',
+      ]);
+    }
+  });
+
+  it('rejects an off-allow-list minutes schedule', () => {
+    const result = assertMonitorDraftSaveable(
+      buildSavedDraft({ [ConfigKey.SCHEDULE]: { number: '7', unit: ScheduleUnit.MINUTES } })
+    );
+    expect(result.saveable).toBe(false);
+    if (!result.saveable) {
+      expect(result.missing).toEqual(['schedule']);
+    }
+  });
+
+  it('accepts a seconds-unit schedule without enforcing the minute allow-list', () => {
+    const result = assertMonitorDraftSaveable(
+      buildSavedDraft({ [ConfigKey.SCHEDULE]: { number: '30', unit: ScheduleUnit.SECONDS } })
+    );
+    expect(result.saveable).toBe(true);
+  });
+
+  it('rejects an empty locations array', () => {
+    const result = assertMonitorDraftSaveable(buildSavedDraft({ [ConfigKey.LOCATIONS]: [] }));
+    expect(result.saveable).toBe(false);
+    if (!result.saveable) {
+      expect(result.missing).toContain('locations (set via set_locations)');
+    }
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/monitor_draft.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/monitor_draft.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import { ConfigKey } from '../../../../common/runtime_types';
+import {
+  FormMonitorType,
+  MonitorTypeEnum,
+  ScheduleUnit,
+  SourceType,
+} from '../../../../common/runtime_types/monitor_management/monitor_configs';
+import { ALLOWED_SCHEDULES_IN_MINUTES } from '../../../../common/constants/monitor_defaults';
+import type { MonitorAttachmentData, MonitorDraft } from '../../../../common/agent_builder';
+import type { MonitorOperation } from './operations';
+
+/**
+ * Validation error thrown by `executeMonitorOperations` when an operation
+ * is structurally fine (`monitorOperationSchema` passed) but breaks a
+ * cross-field invariant — e.g. duplicate location ids, empty locations,
+ * an out-of-allow-list schedule that snuck past the per-op `.refine`.
+ *
+ * Logger guidance from the brief:
+ *   - `MonitorOperationValidationError` → `logger.warn`
+ *   - any other error               → `logger.error`
+ *
+ * Distinct error class so `manage_synthetics_monitor.ts` can catch+log
+ * appropriately and the LLM gets a structured error result back.
+ */
+export class MonitorOperationValidationError extends Error {
+  /** Stable code for the LLM to branch on without parsing the message. */
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'MonitorOperationValidationError';
+    this.code = code;
+  }
+}
+
+/**
+ * Stub of the **agent-only** default fields needed before the user edits
+ * the proposed monitor in the canvas. Mirrors a minimal subset of
+ * `DEFAULT_HTTP_SIMPLE_FIELDS` from
+ * `common/constants/monitor_defaults.ts` — keeps Tools out of the io-ts
+ * runtime path.
+ *
+ * Per the brief: the proposed attachment is **not** a fully formed
+ * `HTTPSimpleFields` object. It only carries fields the user can edit
+ * via `operations[]`. The Save button (T7) is what calls
+ * `POST /api/synthetics/monitors`; that endpoint runs `normalizeAPIConfig`
+ * (which fills in **all** missing default fields) before persistence.
+ *
+ * So the stub here only needs to satisfy `monitorAttachmentDataSchema`'s
+ * required keys (T1) — not `HTTPSimpleFieldsCodec`'s full surface.
+ */
+export const buildEmptyMonitorDraft = (): MonitorDraft => ({
+  [ConfigKey.MONITOR_TYPE]: MonitorTypeEnum.HTTP,
+  [ConfigKey.FORM_MONITOR_TYPE]: FormMonitorType.HTTP,
+  [ConfigKey.MONITOR_SOURCE_TYPE]: SourceType.UI,
+  [ConfigKey.ENABLED]: true,
+  // Schedule + locations + urls + name are deliberately **not** seeded —
+  // requiring the LLM to set them via `operations[]` keeps the proposed
+  // attachment honest about what's been agreed with the user.
+});
+
+/**
+ * Apply each operation in order, mutating an in-memory draft. Returns
+ * the new draft (does not mutate the input). Per-op `.refine(...)` checks
+ * have already run via `monitorOperationSchema.parse` before we get here,
+ * so this loop only handles **cross-op** state transitions and deeper
+ * cross-field rules that don't fit a single op.
+ */
+export const executeMonitorOperations = ({
+  currentDraft,
+  operations,
+  logger,
+}: {
+  /** The previous attachment data (when updating) or `undefined` (when proposing). */
+  currentDraft: MonitorAttachmentData | undefined;
+  operations: MonitorOperation[];
+  logger: Logger;
+}): MonitorDraft => {
+  let draft: MonitorDraft = currentDraft
+    ? // Clone so callers don't observe partial mutations on errors.
+      structuredClone(currentDraft as MonitorDraft)
+    : buildEmptyMonitorDraft();
+
+  for (const op of operations) {
+    switch (op.operation) {
+      case 'set_metadata': {
+        if (
+          op.name === undefined &&
+          op.tags === undefined &&
+          op.apm_service_name === undefined &&
+          op.namespace === undefined
+        ) {
+          logger.debug('Skipping empty set_metadata operation');
+          break;
+        }
+        draft = {
+          ...draft,
+          ...(op.name !== undefined ? { [ConfigKey.NAME]: op.name } : {}),
+          ...(op.tags !== undefined ? { [ConfigKey.TAGS]: op.tags } : {}),
+          ...(op.apm_service_name !== undefined
+            ? { [ConfigKey.APM_SERVICE_NAME]: op.apm_service_name }
+            : {}),
+          ...(op.namespace !== undefined ? { [ConfigKey.NAMESPACE]: op.namespace } : {}),
+        };
+        break;
+      }
+
+      case 'set_schedule': {
+        if (op.unit === ScheduleUnit.MINUTES && !ALLOWED_SCHEDULES_IN_MINUTES.includes(op.number)) {
+          // Defensive: the per-op `.refine` should have rejected this
+          // already. If it didn't, the codec layer downstream will, but a
+          // structured error here is friendlier to the LLM.
+          throw new MonitorOperationValidationError(
+            'invalid_schedule',
+            `Schedule "${op.number}${
+              op.unit
+            }" is not in the allow-list. Use one of: ${ALLOWED_SCHEDULES_IN_MINUTES.join(
+              ', '
+            )} (minutes).`
+          );
+        }
+        draft = {
+          ...draft,
+          [ConfigKey.SCHEDULE]: { number: op.number, unit: op.unit },
+        };
+        break;
+      }
+
+      case 'set_http_check': {
+        draft = {
+          ...draft,
+          [ConfigKey.URLS]: op.url,
+          ...(op.method !== undefined ? { [ConfigKey.REQUEST_METHOD_CHECK]: op.method } : {}),
+          ...(op.max_redirects !== undefined
+            ? { [ConfigKey.MAX_REDIRECTS]: op.max_redirects }
+            : {}),
+          ...(op.ignore_https_errors !== undefined
+            ? { [ConfigKey.IGNORE_HTTPS_ERRORS]: op.ignore_https_errors }
+            : {}),
+        };
+        break;
+      }
+
+      case 'set_locations': {
+        const ids = new Set<string>();
+        for (const location of op.locations) {
+          if (ids.has(location.id)) {
+            throw new MonitorOperationValidationError(
+              'duplicate_location',
+              `Duplicate location id "${location.id}" in set_locations.`
+            );
+          }
+          ids.add(location.id);
+        }
+        draft = {
+          ...draft,
+          [ConfigKey.LOCATIONS]: op.locations.map((location) => ({
+            id: location.id,
+            ...(location.label !== undefined ? { label: location.label } : {}),
+            ...(location.isServiceManaged !== undefined
+              ? { isServiceManaged: location.isServiceManaged }
+              : {}),
+            ...(location.agentPolicyId !== undefined
+              ? { agentPolicyId: location.agentPolicyId }
+              : {}),
+          })),
+        };
+        break;
+      }
+
+      case 'set_enabled': {
+        draft = {
+          ...draft,
+          [ConfigKey.ENABLED]: op.enabled,
+        };
+        break;
+      }
+    }
+  }
+
+  return draft;
+};
+
+/**
+ * Result of {@link assertMonitorDraftSaveable} — used by the tool handler
+ * to decide whether the canvas Save button should be enabled and what
+ * (if anything) is still missing.
+ */
+export type MonitorDraftSaveability =
+  | { saveable: true; data: MonitorAttachmentData }
+  | { saveable: false; missing: string[]; reason: string };
+
+/**
+ * Batch-boundary check: the draft is structurally a complete
+ * `MonitorAttachmentData` (all required keys present, schedule still in
+ * the allow-list).
+ *
+ * This is **not** a substitute for `validateMonitor` — that runs server-
+ * side at POST time when the user clicks Save and applies the full io-ts
+ * codec including default fields. Here we just gate the Save button.
+ */
+export const assertMonitorDraftSaveable = (draft: MonitorDraft): MonitorDraftSaveability => {
+  const missing: string[] = [];
+
+  if (!draft[ConfigKey.NAME]) missing.push('name');
+  if (!draft[ConfigKey.URLS]) missing.push('url (set via set_http_check)');
+
+  const schedule = draft[ConfigKey.SCHEDULE];
+  if (!schedule) {
+    missing.push('schedule (set via set_schedule)');
+  } else if (
+    schedule.unit === ScheduleUnit.MINUTES &&
+    !ALLOWED_SCHEDULES_IN_MINUTES.includes(schedule.number)
+  ) {
+    return {
+      saveable: false,
+      missing: ['schedule'],
+      reason: `Schedule "${schedule.number}${
+        schedule.unit
+      }" is not in the allow-list (${ALLOWED_SCHEDULES_IN_MINUTES.join(', ')} minutes).`,
+    };
+  }
+
+  const locations = draft[ConfigKey.LOCATIONS];
+  if (!locations || locations.length === 0) {
+    missing.push('locations (set via set_locations)');
+  }
+
+  if (missing.length > 0) {
+    return {
+      saveable: false,
+      missing,
+      reason: `Draft is missing required fields: ${missing.join(', ')}.`,
+    };
+  }
+
+  // At this point all required keys are present and the schedule is in
+  // the allow-list. Promote to attachment-data shape — the cast is safe
+  // because `monitorDraftSchema = monitorAttachmentDataSchema.partial()`
+  // (T1) and we just checked that no required key is missing.
+  return {
+    saveable: true,
+    data: draft as MonitorAttachmentData,
+  };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/operations.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/operations.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { monitorOperationSchema } from './operations';
+
+describe('monitorOperationSchema', () => {
+  describe('set_metadata', () => {
+    it('accepts a valid set_metadata op', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_metadata',
+        name: 'My monitor',
+        tags: ['team-a', 'prod'],
+        apm_service_name: 'my-service',
+        namespace: 'default',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects empty name (.min(1))', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_metadata',
+        name: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty tag entries', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_metadata',
+        tags: ['', 'prod'],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('set_schedule', () => {
+    it('accepts an allow-listed minutes schedule', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_schedule',
+        number: '5',
+        unit: 'm',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an off-allow-list minutes schedule via .refine', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_schedule',
+        number: '7',
+        unit: 'm',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts seconds without enforcing the minute allow-list', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_schedule',
+        number: '30',
+        unit: 's',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('set_http_check', () => {
+    it('accepts a https url with no extras', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_http_check',
+        url: 'https://example.com',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts http (not just https)', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_http_check',
+        url: 'http://example.com',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a non-http(s) url via .refine', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_http_check',
+        url: 'ftp://example.com',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an empty url', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_http_check',
+        url: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts advanced fields (method, max_redirects, ignore_https_errors)', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_http_check',
+        url: 'https://example.com',
+        method: 'POST',
+        max_redirects: 5,
+        ignore_https_errors: true,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an unsupported HTTP method', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_http_check',
+        url: 'https://example.com',
+        method: 'TRACE',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('set_locations', () => {
+    it('accepts a single Elastic-managed location', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_locations',
+        locations: [
+          {
+            id: 'us_central',
+            label: 'US Central',
+            isServiceManaged: true,
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a private location with agentPolicyId', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_locations',
+        locations: [
+          {
+            id: 'pl-uuid',
+            label: 'On-prem',
+            isServiceManaged: false,
+            agentPolicyId: 'agent-policy-uuid',
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty locations array', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_locations',
+        locations: [],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('set_enabled', () => {
+    it('accepts true', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_enabled',
+        enabled: true,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts false', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_enabled',
+        enabled: false,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing enabled flag', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'set_enabled',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('discriminator', () => {
+    it('rejects unknown operation names', () => {
+      const result = monitorOperationSchema.safeParse({
+        operation: 'unknown_op',
+        url: 'https://example.com',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/operations.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/agent_builder/tools/manage_synthetics_monitor/operations.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ScheduleUnit } from '../../../../common/runtime_types/monitor_management/monitor_configs';
+
+/**
+ * Discriminated-union of in-memory mutations applied to a `MonitorDraft`
+ * during a single `manage_synthetics_monitor` tool batch.
+ *
+ * Design rules:
+ * - Every operation maps to one or more `ConfigKey`s. The "promoted" draft
+ *   (after `executeMonitorOperations`) must round-trip through
+ *   `monitorAttachmentDataSchema` if it's complete.
+ * - HTTP-only in v1. TCP / ICMP / Browser come later via additional
+ *   operations (`set_tcp_check`, `set_icmp_check`, `set_browser_script`)
+ *   discriminated on a `monitor_type` field added at that point.
+ * - Per-op cross-field checks (e.g. schedule allow-list, urls non-empty)
+ *   live here in `set_*` op `.refine(...)` blocks; **batch-boundary**
+ *   checks (locations resolved against private-location SOs, name+urls+
+ *   schedule+locations all present together) live in
+ *   `manage_synthetics_monitor.ts`.
+ *
+ * Keep the descriptions terse — they show up verbatim in the LLM tool
+ * prompt and contribute to context size.
+ */
+
+import { ALLOWED_SCHEDULES_IN_MINUTES } from '../../../../common/constants/monitor_defaults';
+
+const allowedScheduleNumbersInMinutes = ALLOWED_SCHEDULES_IN_MINUTES as ReadonlyArray<string>;
+
+export const setMetadataOperationSchema = z.object({
+  operation: z.literal('set_metadata'),
+  name: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Human-readable monitor name. Required before the user can save (the canvas Save button is disabled without it).'
+    ),
+  tags: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Free-form tags. Use to group related monitors (e.g. team, environment).'),
+  apm_service_name: z
+    .string()
+    .optional()
+    .describe(
+      'Optional. APM service name to correlate this monitor with an existing service in APM.'
+    ),
+  namespace: z
+    .string()
+    .optional()
+    .describe('Heartbeat data stream namespace. Defaults to the current Kibana space if omitted.'),
+});
+
+export const setScheduleOperationSchema = z
+  .object({
+    operation: z.literal('set_schedule'),
+    number: z
+      .string()
+      .min(1)
+      .describe(
+        `Schedule interval as a string. Allowed values when unit is minutes: ${allowedScheduleNumbersInMinutes.join(
+          ', '
+        )}. Other values are rejected at the per-op check.`
+      ),
+    unit: z
+      .enum([ScheduleUnit.MINUTES, ScheduleUnit.SECONDS])
+      .describe('Schedule unit. Use minutes for production monitors; seconds is rare.'),
+  })
+  .refine(
+    (op) => op.unit !== ScheduleUnit.MINUTES || allowedScheduleNumbersInMinutes.includes(op.number),
+    {
+      message: `When unit is minutes, schedule.number must be one of: ${allowedScheduleNumbersInMinutes.join(
+        ', '
+      )}`,
+      path: ['number'],
+    }
+  );
+
+const httpMethodSchema = z.enum(['GET', 'HEAD', 'POST', 'OPTIONS', 'PUT', 'PATCH', 'DELETE']);
+
+export const setHttpCheckOperationSchema = z
+  .object({
+    operation: z.literal('set_http_check'),
+    url: z
+      .string()
+      .min(1)
+      .describe(
+        'Full URL to monitor (e.g. `https://example.com/health`). Required for HTTP monitors.'
+      ),
+    method: httpMethodSchema.optional().describe('HTTP method. Defaults to GET when omitted.'),
+    max_redirects: z
+      .union([z.string(), z.number()])
+      .optional()
+      .describe('Maximum redirects to follow. Defaults to 0.'),
+    ignore_https_errors: z
+      .boolean()
+      .optional()
+      .describe('Skip TLS certificate validation. Use only for staging/testing.'),
+  })
+  .refine((op) => /^https?:\/\//i.test(op.url), {
+    message: 'url must start with http:// or https://',
+    path: ['url'],
+  });
+
+const locationInputSchema = z
+  .object({
+    id: z
+      .string()
+      .min(1)
+      .describe(
+        'Location id. For Elastic-managed locations use the standard region id (e.g. `us_central`). For private locations use the saved object id of the private location.'
+      ),
+    label: z.string().optional(),
+    isServiceManaged: z
+      .boolean()
+      .optional()
+      .describe(
+        '`true` for Elastic-managed (public) locations, `false` for private locations. Resolves to the proper structural shape at the batch boundary.'
+      ),
+    agentPolicyId: z
+      .string()
+      .optional()
+      .describe('Required for private locations. The Fleet agent policy id backing the location.'),
+  })
+  .passthrough();
+
+export const setLocationsOperationSchema = z.object({
+  operation: z.literal('set_locations'),
+  locations: z
+    .array(locationInputSchema)
+    .min(1)
+    .describe(
+      'Replace the monitor locations with this list. For v1 the tool does not append; provide the full desired set.'
+    ),
+});
+
+export const setEnabledOperationSchema = z.object({
+  operation: z.literal('set_enabled'),
+  enabled: z.boolean().describe('`true` to enable; `false` to keep the monitor saved but paused.'),
+});
+
+export const monitorOperationSchema = z.discriminatedUnion('operation', [
+  setMetadataOperationSchema,
+  setScheduleOperationSchema,
+  setHttpCheckOperationSchema,
+  setLocationsOperationSchema,
+  setEnabledOperationSchema,
+]);
+
+export type MonitorOperation = z.infer<typeof monitorOperationSchema>;

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -133,6 +133,7 @@ export class Plugin implements PluginType {
 
     bindAgentBuilder({
       agentBuilder: plugins.agentBuilder,
+      agentContextLayer: plugins.agentContextLayer,
       logger: this.logger,
     });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -39,6 +39,7 @@ import { getTransforms as getMonitorsTransforms } from '../common/embeddables/mo
 import { SYNTHETICS_MONITORS_EMBEDDABLE } from '../common/embeddables/monitors_overview/constants';
 import { getStatsOverviewEmbeddableSchema, syntheticsMonitorsEmbeddableSchema } from './schemas';
 import { registerDataProviders } from './agent_builder/register_data_provider';
+import { bindAgentBuilder } from './agent_builder/bind_on_setup';
 
 export class Plugin implements PluginType {
   private savedObjectsClient?: SavedObjectsClientContract;
@@ -129,6 +130,11 @@ export class Plugin implements PluginType {
     });
 
     registerDataProviders({ core, plugins });
+
+    bindAgentBuilder({
+      agentBuilder: plugins.agentBuilder,
+      logger: this.logger,
+    });
 
     return {};
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/types.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/types.ts
@@ -42,6 +42,7 @@ import type {
   MaintenanceWindowsServerStart,
 } from '@kbn/maintenance-windows-plugin/server';
 import type { ObservabilityAgentBuilderPluginSetup } from '@kbn/observability-agent-builder-plugin/server';
+import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
 import type { TelemetryEventsSender } from './telemetry/sender';
 import type { UptimeConfig } from './config';
 import type { SyntheticsEsClient } from './lib';
@@ -86,6 +87,7 @@ export interface SyntheticsPluginsSetupDependencies {
   share: SharePluginSetup;
   embeddable: EmbeddableSetup;
   observabilityAgentBuilder?: ObservabilityAgentBuilderPluginSetup;
+  agentBuilder?: AgentBuilderPluginSetup;
 }
 
 export interface SyntheticsPluginsStartDependencies {

--- a/x-pack/solutions/observability/plugins/synthetics/server/types.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/types.ts
@@ -43,6 +43,7 @@ import type {
 } from '@kbn/maintenance-windows-plugin/server';
 import type { ObservabilityAgentBuilderPluginSetup } from '@kbn/observability-agent-builder-plugin/server';
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import type { AgentContextLayerPluginSetup } from '@kbn/agent-context-layer-plugin/server';
 import type { TelemetryEventsSender } from './telemetry/sender';
 import type { UptimeConfig } from './config';
 import type { SyntheticsEsClient } from './lib';
@@ -88,6 +89,7 @@ export interface SyntheticsPluginsSetupDependencies {
   embeddable: EmbeddableSetup;
   observabilityAgentBuilder?: ObservabilityAgentBuilderPluginSetup;
   agentBuilder?: AgentBuilderPluginSetup;
+  agentContextLayer?: AgentContextLayerPluginSetup;
 }
 
 export interface SyntheticsPluginsStartDependencies {

--- a/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
@@ -128,6 +128,7 @@
     "@kbn/agent-builder-server",
     "@kbn/agent-builder-common",
     "@kbn/agent-builder-browser",
+    "@kbn/agent-context-layer-plugin",
     "@kbn/scout-oblt",
     "@kbn/core-saved-objects-utils-server",
     "@kbn/zod"

--- a/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/synthetics/tsconfig.json
@@ -124,9 +124,13 @@
     "@kbn/presentation-publishing-schemas",
     "@kbn/maintenance-windows-plugin",
     "@kbn/observability-agent-builder-plugin",
+    "@kbn/agent-builder-plugin",
+    "@kbn/agent-builder-server",
+    "@kbn/agent-builder-common",
     "@kbn/agent-builder-browser",
     "@kbn/scout-oblt",
-    "@kbn/core-saved-objects-utils-server"
+    "@kbn/core-saved-objects-utils-server",
+    "@kbn/zod"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Resolves #267923.

Registers Synthetics HTTP monitors as an SML type and attachment in the Agent Builder platform, enabling an end-to-end flow where the agent can discover, propose, create, and update monitors through conversation.

https://github.com/user-attachments/assets/21aae0aa-b543-4755-9754-8632d011c7f9



### Flow

1. **Discovery** — Monitors are registered as an SML type (current `synthetics-monitor-multi-space` + legacy `synthetics-monitor`). The agent can search for existing monitors and attach them to a conversation.
2. **Proposal** — The agent uses the `manage_synthetics_monitor` tool to propose a monitor via an ordered `operations` array (`set_metadata`, `set_schedule`, `set_http_check`, `set_locations`, `set_enabled`). This creates an inline attachment visible in the conversation — a status-tinted card mirroring the chip-row layout of the Synthetics Overview tile.
3. **Preview** — The user clicks the inline card to open the canvas flyout, which renders the full monitor tile (status accent strip, title, URL link, type/schedule/locations chip row, optional save- warnings callout) — visually consistent with the Synthetics Overview.
4. **Save / Update / View** — The canvas footer exposes:
   * **Create** (`lifecycle: 'draft'`): persists the proposal via `POST /api/synthetics/monitors`.
   * **Update** (`lifecycle: 'saved'`): pushes agent-revised data via `PUT /api/synthetics/monitors/{configId}`.
   * **View in Synthetics** (`lifecycle: 'saved'`): navigates to the monitor details page.

### Implementation

* **Server**: SML monitor type for discovery (covers both current and legacy SO types), monitor attachment type with validate / resolve / isStale / format, `manage_synthetics_monitor` tool with 5 ops over a `MonitorDraft`, and a `monitor-management` skill. Tool never persists — the result payload exposes `status` (tool action) and `lifecycle` (`draft` vs `saved`) so the LLM picks Create vs Update wording from monitor state, not from the tool action.
* **UI**: Inline attachment card and canvas tile, both built from EUI primitives so the look stays reliable across data states. Persistence reuses the existing CRUD routes — no new server endpoint. Read-only SO metadata (`created_at`, `updated_at`, `revision`) is stripped from the upsert body so the existing route's validator accepts the refreshed payload.
* **Post-Save reactivity**: After Create, the server tool re-fetches the live SO when the framework's `updateOrigin` leaves `config_id` missing, and the canvas overlays the new id locally so the button flips to **Update** in the same render cycle.

### Screenshot

https://github.com/user-attachments/assets/b9360651-2ea3-4dd0-9ffc-e4274c6e8e57

### Identify risks

* **Skill routing depends on prompt content**: whether the LLM picks `manage_synthetics_monitor` for a given user phrasing is driven by the skill description and "When to Use" prompt. Tested with multiple location-wording variants; future regressions are a prompt edit, not a code change.
* **Two platform-side workarounds shipped in this PR**: server-side re-resolve after `updateOrigin` (the framework doesn't refresh attachment data on origin change), and read-only-SO-metadata strip on the upsert body (the route validator rejects fields not in `DEFAULT_FIELDS`). 
* **v1 scope is HTTP / `origin: ui` only**. CLI-managed (`origin: project`) monitors are recognised and rendered as read-only in chat; TCP / ICMP / Browser are out of scope and will widen the schema as a discriminated union in a follow-up.