### PR TITLE
[Obs AI] add anomaly test to get_services tool

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_services.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_services.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { timerange } from '@kbn/synthtrace-client';
+import moment from 'moment';
+import { apm, timerange } from '@kbn/synthtrace-client';
 import {
   type ApmSynthtraceEsClient,
   type LogsSynthtraceEsClient,
@@ -19,6 +20,7 @@ import type { OtherResult } from '@kbn/agent-builder-common';
 import { OBSERVABILITY_GET_SERVICES_TOOL_ID } from '@kbn/observability-agent-builder-plugin/server/tools';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { createAgentBuilderApiClient } from '../utils/agent_builder_client';
+import { createAndRunApmMlJobs } from '../utils/create_and_run_apm_ml_jobs';
 
 // APM-only services
 const APM_SERVICE_1 = 'apm-only-service';
@@ -322,6 +324,143 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
         expect(serviceNames).to.contain(APM_SERVICE_1);
         expect(serviceNames).to.not.contain(LOG_SERVICE_1);
+      });
+    });
+
+    describe('filtering by anomalySeverities with anomaly data', function () {
+      // ML lookback job + cleanup is slow
+      this.timeout(300_000);
+
+      const ANOMALOUS_SERVICE = 'anomalous-checkout';
+      const HEALTHY_SERVICE = 'healthy-cart';
+      const ML_TEST_ENVIRONMENT = 'production-anomaly-test';
+
+      const rangeStart = moment().subtract(2, 'days').valueOf();
+      const rangeEnd = moment().valueOf();
+      const spikeStart = moment().subtract(2, 'hours').valueOf();
+      const spikeEnd = moment().subtract(1, 'hour').valueOf();
+      const TEST_START_ISO = new Date(rangeStart).toISOString();
+      const TEST_END_ISO = new Date(rangeEnd).toISOString();
+
+      let anomalousServiceSeverity: string;
+
+      before(async () => {
+        const ml = getService('ml');
+        const es = getService('es');
+        const log = getService('log');
+
+        apmSynthtraceEsClient = await synthtrace.createApmSynthtraceEsClient();
+        await Promise.all([apmSynthtraceEsClient.clean(), ml.api.cleanMlIndices()]);
+        await ml.api.deleteAllAnomalyDetectionJobs();
+
+        const anomalousService = apm
+          .service({
+            name: ANOMALOUS_SERVICE,
+            environment: ML_TEST_ENVIRONMENT,
+            agentName: 'java',
+          })
+          .instance('a');
+        const healthyService = apm
+          .service({
+            name: HEALTHY_SERVICE,
+            environment: ML_TEST_ENVIRONMENT,
+            agentName: 'nodejs',
+          })
+          .instance('b');
+
+        const events = timerange(rangeStart, rangeEnd)
+          .interval('1m')
+          .rate(1)
+          .generator((timestamp) => {
+            const isInSpike = timestamp >= spikeStart && timestamp < spikeEnd;
+            return [
+              anomalousService
+                .transaction({ transactionName: 'GET /checkout' })
+                .timestamp(timestamp)
+                .duration(isInSpike ? 5000 : 100)
+                .outcome(isInSpike ? 'failure' : 'success'),
+              healthyService
+                .transaction({ transactionName: 'GET /cart' })
+                .timestamp(timestamp)
+                .duration(100)
+                .outcome('success'),
+            ];
+          });
+
+        await apmSynthtraceEsClient.index(events);
+
+        await createAndRunApmMlJobs({
+          es,
+          ml: ml.api,
+          environments: [ML_TEST_ENVIRONMENT],
+          logger: log,
+        });
+
+        // Capture ML's assigned severity for the anomalous service so the filter
+        // assertions don't hard-code a band (ML scoring varies run-to-run).
+        const results = await agentBuilderApiClient.executeTool<GetServicesToolResult>({
+          id: OBSERVABILITY_GET_SERVICES_TOOL_ID,
+          params: { start: TEST_START_ISO, end: TEST_END_ISO },
+        });
+        const anomalousResult = results[0].data.services.find(
+          (s) => s.serviceName === ANOMALOUS_SERVICE
+        );
+        anomalousServiceSeverity = anomalousResult?.anomalySeverity ?? 'unknown';
+      });
+
+      after(async () => {
+        const ml = getService('ml');
+        await Promise.all([apmSynthtraceEsClient.clean(), ml.api.cleanMlIndices()]);
+        await ml.api.deleteAllAnomalyDetectionJobs();
+      });
+
+      it('returns anomalyScore and anomalySeverity on the anomalous APM service', async () => {
+        const results = await agentBuilderApiClient.executeTool<GetServicesToolResult>({
+          id: OBSERVABILITY_GET_SERVICES_TOOL_ID,
+          params: { start: TEST_START_ISO, end: TEST_END_ISO },
+        });
+        const anomalousService = results[0].data.services.find(
+          (s) => s.serviceName === ANOMALOUS_SERVICE
+        );
+
+        expect(anomalousService).to.be.ok();
+        expect(anomalousService).to.have.property('anomalyScore');
+        expect(anomalousService).to.have.property('anomalySeverity');
+      });
+
+      it('assigns a non-low severity to the anomalous service', () => {
+        expect(['warning', 'minor', 'major', 'critical']).to.contain(anomalousServiceSeverity);
+      });
+
+      it('filters services by anomalySeverity', async () => {
+        const results = await agentBuilderApiClient.executeTool<GetServicesToolResult>({
+          id: OBSERVABILITY_GET_SERVICES_TOOL_ID,
+          params: {
+            start: TEST_START_ISO,
+            end: TEST_END_ISO,
+            anomalySeverities: [anomalousServiceSeverity],
+          },
+        });
+        const serviceNames = results[0].data.services.map((s) => s.serviceName);
+
+        expect(serviceNames).to.contain(ANOMALOUS_SERVICE);
+        expect(serviceNames).to.not.contain(HEALTHY_SERVICE);
+      });
+
+      it('emits anomalySeverity on every APM service (no field absence)', async () => {
+        const results = await agentBuilderApiClient.executeTool<GetServicesToolResult>({
+          id: OBSERVABILITY_GET_SERVICES_TOOL_ID,
+          params: { start: TEST_START_ISO, end: TEST_END_ISO },
+        });
+        const apmServices = results[0].data.services.filter((s) => s.latency !== undefined);
+
+        expect(apmServices.length).to.be.greaterThan(0);
+        for (const service of apmServices) {
+          expect(service).to.have.property('anomalySeverity');
+          expect(['critical', 'major', 'minor', 'warning', 'low', 'unknown']).to.contain(
+            service.anomalySeverity
+          );
+        }
       });
     });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/utils/create_and_run_apm_ml_jobs.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/utils/create_and_run_apm_ml_jobs.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import job from '@kbn/ml-plugin/server/models/data_recognizer/modules/apm_transaction/ml/apm_tx_metrics.json';
+import datafeed from '@kbn/ml-plugin/server/models/data_recognizer/modules/apm_transaction/ml/datafeed_apm_tx_metrics.json';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { MlApi } from '@kbn/test-suites-xpack-platform/api_integration/services/ml/api';
+
+export async function createAndRunApmMlJobs({
+  es,
+  ml,
+  environments,
+  logger,
+}: {
+  es: Client;
+  ml: MlApi;
+  environments: string[];
+  logger: ToolingLog;
+}) {
+  // Creating multiple ml jobs in parallel is causing this tests to be flaky
+  // https://github.com/elastic/elasticsearch/issues/36271
+  for (const environment of environments) {
+    await createAndRunApmMlJob({ es, environment, ml, logger });
+  }
+}
+
+async function createAndRunApmMlJob({
+  es,
+  ml,
+  environment,
+  logger,
+}: {
+  es: Client;
+  ml: MlApi;
+  environment: string;
+  logger: ToolingLog;
+}) {
+  const jobId = `apm-tx-metrics-${environment}`;
+  await ml.createAndRunAnomalyDetectionLookbackJob(
+    // @ts-expect-error not entire job config
+    {
+      ...job,
+      job_id: jobId,
+      allow_lazy_open: false,
+      custom_settings: {
+        job_tags: {
+          apm_ml_version: '3',
+          environment,
+        },
+      },
+    },
+    {
+      ...datafeed,
+      indices_options: { allow_no_indices: true },
+      job_id: jobId,
+      indices: ['metrics-apm*', 'apm-*'],
+      datafeed_id: `apm-tx-metrics-${environment}-datafeed`,
+      query: {
+        bool: {
+          filter: [...datafeed.query.bool.filter, { term: { 'service.environment': environment } }],
+        },
+      },
+    }
+  );
+
+  logger.info(`Created ml job ${jobId}`);
+
+  await es.cluster.health({ index: '.ml-*', wait_for_status: 'yellow' });
+
+  logger.info(`Finished waiting for cluster to be healthy`);
+}


### PR DESCRIPTION
## Summary

Added integration tests for the `observability.get_services` agent-builder tool in `get_services.spec.ts`:

- **Response structure** — verifies the tool returns the expected shape (`services`, `maxCountExceeded`, `serviceOverflowCount`) and that each service has a `serviceName`.
- **Multiple data sources** — APM-only, log-only, and shared services all surface; APM services include `latency`/`throughput`/`transactionErrorRate`; log-only services don't.
- **Filtering by `anomalySeverities` (no ML data)** — log-only services are excluded when an anomaly-severity filter is applied.
- **Filtering by `anomalySeverities` (with ML data)** — runs an APM transaction-metrics ML lookback job over synthetic data containing a 1h latency/error spike, then asserts:
  - the anomalous service has `anomalyScore` and `anomalySeverity`
  - the assigned severity is non-low (`warning|minor|major|critical`)
  - filtering by that severity returns the anomalous service and excludes the healthy one
  - every APM service emits `anomalySeverity` (no missing field)
- **Filtering by environment** — `kqlFilter` on `service.environment` filters APM and log services consistently across sources.
- **Filtering by `kqlFilter`** — works on `service.name`, `agent.name`, and `host.name`.

Added `utils/create_and_run_apm_ml_jobs.ts` (copied from `apm_api_integration`) to support the ML-based test.

Closes elastic/obs-ai-team#574