### PR TITLE
[Discover Enhanced] Set `discover.isEsqlDefault` to `false` in global setup hook

### DIFF
--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/global.setup.ts
@@ -9,8 +9,7 @@ import { globalSetupHook } from '@kbn/scout';
 import { testData } from '../fixtures';
 
 globalSetupHook('Ingest data to Elasticsearch', async ({ apiServices, esArchiver, log }) => {
-  // Turn "isEsqlDefault" off by default for all tests
-  log.debug('[setup] turning off isEsqlDefault for all tests');
+  log.debug('[setup] set isEsqlDefault feature flag to false');
   await apiServices.core.settings({
     'feature_flags.overrides': {
       'discover.isEsqlDefault': false,

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/global.setup.ts
@@ -8,7 +8,15 @@
 import { globalSetupHook } from '@kbn/scout';
 import { testData } from '../fixtures';
 
-globalSetupHook('Ingest data to Elasticsearch', async ({ esArchiver, log }) => {
+globalSetupHook('Ingest data to Elasticsearch', async ({ apiServices, esArchiver, log }) => {
+  // Turn "isEsqlDefault" off by default for all tests
+  log.debug('[setup] turning off isEsqlDefault for all tests');
+  await apiServices.core.settings({
+    'feature_flags.overrides': {
+      'discover.isEsqlDefault': false,
+    },
+  });
+
   // add archives to load, if needed
   const archives = [
     testData.ES_ARCHIVES.LOGSTASH,


### PR DESCRIPTION
Similar work to https://github.com/elastic/kibana/pull/267910 - set `discover.isEsqlDefault` to `false` to unblock Scout serverless pipeline.