### PR TITLE
test: Fix flaky service map Scout accessibility test

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/service_map.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/service_map.ts
@@ -29,6 +29,11 @@ export class ServiceMapPage {
   public serviceMapEdgeExploreTracesButton: Locator;
   public serviceMapOptionsPanel: Locator;
   public serviceMapFindInPageInput: Locator;
+  /**
+   * Native search `<input>` (`SERVICE_MAP_FIND_INPUT_ID`). Prefer this for fill/focus so React
+   * `onFocus` runs and find highlights sync (`service_map_find_in_page` gates on `isFocused`).
+   */
+  public serviceMapFindInPageNativeInput: Locator;
   public serviceMapFindMatchSummary: Locator;
 
   constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
@@ -57,6 +62,7 @@ export class ServiceMapPage {
     );
     this.serviceMapOptionsPanel = page.testSubj.locator('serviceMapOptionsPanel');
     this.serviceMapFindInPageInput = page.testSubj.locator('serviceMapControlsSearch');
+    this.serviceMapFindInPageNativeInput = page.locator('#serviceMapFindInPageInput');
     this.serviceMapFindMatchSummary = page.testSubj.locator('serviceMapFindMatchSummary');
   }
 
@@ -204,6 +210,15 @@ export class ServiceMapPage {
   /** Wrapper for a service node (icon, badges row, label). `data.id` on the map matches the service name in tests. */
   getServiceNodeRoot(serviceName: string) {
     return this.serviceMapGraph.getByTestId(`serviceMapNode-service-${serviceName}`);
+  }
+
+  /**
+   * Highlight frame around the active find-in-page match (`HighlightWrapper` when `isActiveSearchMatch`).
+   */
+  getActiveFindMatchHighlightFrame(serviceName: string) {
+    return this.getServiceNodeRoot(serviceName).locator(
+      'xpath=ancestor::*[@data-test-subj="serviceMapNodeSearchHighlightFrame"][1]'
+    );
   }
 
   /**

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_a11y.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_a11y.spec.ts
@@ -44,12 +44,29 @@ test.describe(
     }) => {
       await test.step('nodes have visible focus indicators when focused', async () => {
         await serviceMapPage.waitForServiceNodeToLoad(SERVICE_OPBEANS_JAVA);
-        await serviceMapPage.openFindInPageWithKeyboardShortcut();
-        await serviceMapPage.serviceMapFindInPageInput.fill(SERVICE_OPBEANS_JAVA);
-        await expect(serviceMapPage.serviceMapFindMatchSummary).toHaveText(/[1-9]/);
         const node = serviceMapPage.getServiceNode(SERVICE_OPBEANS_JAVA);
         await node.focus();
         await expect(node).toBeFocused();
+      });
+
+      await test.step('find-in-page: highlight frame while focused, Enter centers match', async () => {
+        await serviceMapPage.focusBodyForMapShortcuts();
+        await serviceMapPage.openFindInPageWithKeyboardShortcut();
+        // Fill the real input (#serviceMapFindInPageInput) so EuiFieldSearch onFocus runs and
+        // highlight context updates (filling by layout test-subj alone can leave isFocused false).
+        await serviceMapPage.serviceMapFindInPageNativeInput.fill(SERVICE_OPBEANS_JAVA);
+        await expect(serviceMapPage.serviceMapFindMatchSummary).toHaveText(/[1-9]/);
+
+        // Highlights are driven only while the find field is focused; centering the map after Enter
+        // can move focus and clear highlights, so assert the frame before Enter.
+        const highlightFrame =
+          serviceMapPage.getActiveFindMatchHighlightFrame(SERVICE_OPBEANS_JAVA);
+        await expect(highlightFrame).toBeVisible();
+        await expect(highlightFrame).toHaveAttribute('data-search-active-match');
+
+        await serviceMapPage.serviceMapFindInPageNativeInput.press('Enter');
+        await serviceMapPage.settleServiceMapLayout();
+        await expect(serviceMapPage.serviceMapFindMatchSummary).toHaveText(/[1-9]/);
       });
 
       await test.step('zoom controls are keyboard accessible', async () => {


### PR DESCRIPTION
## Summary

- Fixes the Scout failure tracked in [#262609](https://github.com/elastic/kibana/issues/262609): `service_map_a11y.spec.ts` expected `toBeFocused()` on the service circle **after** typing in find-in-page. Focusing the node blurs the find field; search highlights are intentionally cleared when the find input loses focus (`isFocused`), which led to unstable focus/DOM during the assertion.
- Separates **node focus + focus ring** from **find-in-page**: focus the circle without opening find first; cover find in its own step (`focusBodyForMapShortcuts`, ⌃K, fill, match summary, Enter to center, settle).
- **`expect(locator).toBeVisible()` on `serviceMapNodeSearchHighlightFrame` failed** even when the counter showed `1/1` because highlight context only updates when React treats the field as focused. `fill()` on `data-test-subj="serviceMapControlsSearch"` targets the **layout wrapper**; the native input may receive keystrokes without reliably firing `EuiFieldSearch` `onFocus`, so `isFocused` stayed false and **`serviceMapNodeSearchHighlightFrame` never rendered**. The test now fills and sends Enter via **`#serviceMapFindInPageInput`** (same element as `focusServiceMapFindInput()`).
- Resolves the highlight frame from the service node root with an XPath ancestor to `[data-test-subj="serviceMapNodeSearchHighlightFrame"]`.
- Asserts the highlight **before** Enter where possible: map centering can steal focus and clear highlights per existing product behavior.

## References

Closes elastic/kibana#262609

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->