### PR TITLE
chore(eslint): enforce `@elastic/eui/badge-accessibility-rules` rule at the `error` level

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -399,6 +399,7 @@ module.exports = {
      */
     '@elastic/eui/prefer-eui-icon-tip': 'error',
     '@elastic/eui/sr-output-disabled-tooltip': 'error',
+    '@elastic/eui/badge-accessibility-rules': 'error',
   },
 
   overrides: [


### PR DESCRIPTION
## Summary

This PR enforces `@elastic/eui/badge-accessibility-rules` rule at the `error` level in the shared `@kbn/eslint-config` configuration:

- **`@elastic/eui/badge-accessibility-rules`** — Ensure the `EuiBadge` includes appropriate accessibility attributes.
  
All pre-existing violations of these rules have been fixed prior to this change. Setting them to `error` (instead of `warn` or off) prevents future regressions.

### Changes

- `packages/kbn-eslint-config/.eslintrc.js`