### PR TITLE
[Agent Builder] Add standing session background agents

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/namespaces.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/namespaces.ts
@@ -21,6 +21,8 @@ export const internalNamespaces = {
   security: 'security',
   streams: 'platform.streams',
   workflows: 'platform.workflows',
+  /** Reserved for built-in standing-session lifecycle tools (session.set_idle, session.terminate, etc.) */
+  session: 'session',
 } as const;
 
 /**
@@ -38,6 +40,7 @@ export const protectedNamespaces: string[] = [
   internalNamespaces.security,
   internalNamespaces.streams,
   internalNamespaces.workflows,
+  internalNamespaces.session,
 ];
 
 /**

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -18,6 +18,12 @@ import type {
 import type { PromptRequest, PromptResponse, PromptStorageState } from '../agents/prompts';
 import type { RuntimeAgentConfigurationOverrides } from '../agents/definition';
 import type { RoundState } from './round_state';
+import type {
+  SessionMode,
+  RoundInputSource,
+  TriggerContext,
+  StandingSessionState,
+} from './standing_session';
 
 /**
  * Represents the input that initiated a conversation round.
@@ -36,7 +42,19 @@ export interface RoundInput {
    * References to versioned conversation-level attachments.
    */
   attachment_refs?: AttachmentVersionRef[];
+  /**
+   * What initiated this round. Absent means 'human' for backwards compatibility.
+   * Only present on standing session rounds.
+   */
+  source?: RoundInputSource;
+  /**
+   * Trigger-specific context injected when source is not 'human'.
+   * Present whenever source is a trigger or session_message.
+   */
+  trigger_context?: TriggerContext;
 }
+
+export type { RoundInputSource, TriggerContext } from './standing_session';
 
 /**
  * Represents the input used to interact with an agent (new round, resume round)
@@ -60,6 +78,16 @@ export interface ConverseInput {
    * Response from the user to prompt requests.
    */
   prompts?: Record<string, PromptResponse>;
+  /**
+   * What initiated this round (for standing sessions).
+   * When set, the stored round will record source and trigger_context.
+   */
+  source?: RoundInputSource;
+  /**
+   * Trigger-specific context injected when source is not 'human'.
+   * Present whenever source is a trigger or session_message.
+   */
+  trigger_context?: TriggerContext;
 }
 
 /**
@@ -221,6 +249,11 @@ export enum ConversationRoundStatus {
   completed = 'completed',
   /** round has been interrupted and is awaiting user input */
   awaitingPrompt = 'awaiting_prompt',
+  /**
+   * Standing-session round completed with set_idle — session is dormant,
+   * waiting for the next trigger event to start a new round.
+   */
+  awaitingTrigger = 'awaiting_trigger',
 }
 
 /**
@@ -287,6 +320,11 @@ export interface Conversation {
   id: string;
   /** id of the agent this conversation is bound to */
   agent_id: string;
+  /**
+   * Whether this is a traditional interactive conversation or a long-lived standing session.
+   * Absent means 'interactive' for backwards compatibility.
+   */
+  session_mode?: SessionMode;
   /** info of the owner of the discussion */
   user: UserIdAndName;
   /** title of the conversation */
@@ -328,6 +366,10 @@ export interface ConversationInternalState {
   compaction_summary?: CompactionSummary;
   /** Background sub-agent executions keyed by execution ID. */
   background_executions?: Record<string, BackgroundExecutionState>;
+  /**
+   * Standing session lifecycle state. Only present when Conversation.session_mode === 'standing'.
+   */
+  standing_session?: StandingSessionState;
 }
 
 export interface BackgroundExecutionCompletedAt {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/index.ts
@@ -9,6 +9,8 @@ export {
   ConversationRoundStatus,
   type ConversationAction,
   type RoundInput,
+  type RoundInputSource,
+  type TriggerContext,
   type ConverseInput,
   type AssistantResponse,
   type ToolCallWithResult,
@@ -38,6 +40,23 @@ export {
   isReasoningStep,
   isCompactionStep,
 } from './conversation';
+export {
+  type SessionMode,
+  type StandingSessionStatus,
+  type StandingSessionState,
+  type TriggerSubscription,
+  type AlertTriggerSubscription,
+  type ScheduleTriggerSubscription,
+  type ReminderTriggerSubscription,
+  type WebhookTriggerSubscription,
+  type PendingTriggerEvent,
+  type AlertTriggerContext,
+  type ScheduleTriggerContext,
+  type ReminderTriggerContext,
+  type WebhookTriggerContext,
+  type SessionMessageTriggerContext,
+  type SessionListOptions,
+} from './standing_session';
 export {
   ChatEventType,
   type ChatEventBase,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/standing_session.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/standing_session.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UserIdAndName } from '../base/users';
+
+// ---------------------------------------------------------------------------
+// Session mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminates between a traditional interactive conversation (default) and
+ * a long-lived standing session that can be woken up by external triggers.
+ */
+export type SessionMode = 'interactive' | 'standing';
+
+// ---------------------------------------------------------------------------
+// Round input source
+// ---------------------------------------------------------------------------
+
+/**
+ * Describes what initiated a conversation round.
+ * Absent / undefined is treated as 'human' for backwards compatibility.
+ */
+export type RoundInputSource =
+  | 'human'
+  | 'alert_trigger'
+  | 'schedule_trigger'
+  | 'reminder_trigger'
+  | 'webhook_trigger'
+  | 'session_message';
+
+// ---------------------------------------------------------------------------
+// Trigger contexts — type-specific event payloads
+// ---------------------------------------------------------------------------
+
+export interface AlertTriggerContext {
+  type: 'alert_trigger';
+  subscription_id: string;
+  event: {
+    rule_id: string;
+    rule_name: string;
+    alert_ids: string[];
+    severity?: string;
+    tags?: string[];
+    context?: Record<string, unknown>;
+  };
+}
+
+export interface ScheduleTriggerContext {
+  type: 'schedule_trigger';
+  subscription_id: string;
+  event: {
+    fired_at: string;
+    /** Human-readable description of the schedule (e.g. "every 15 minutes"). */
+    schedule_description: string;
+  };
+}
+
+export interface ReminderTriggerContext {
+  type: 'reminder_trigger';
+  /** Same as the reminder subscription ID. */
+  subscription_id: string;
+  event: {
+    reminder_id: string;
+    note?: string;
+    fired_at: string;
+  };
+}
+
+export interface WebhookTriggerContext {
+  type: 'webhook_trigger';
+  subscription_id: string;
+  event: {
+    payload: Record<string, unknown>;
+    received_at: string;
+  };
+}
+
+export interface SessionMessageTriggerContext {
+  type: 'session_message';
+  /** Not tied to a subscription — subscription_id is absent. */
+  subscription_id: undefined;
+  event: {
+    from_session_id: string;
+    from_agent_id: string;
+    message: string;
+    message_id: string;
+    context?: Record<string, unknown>;
+  };
+}
+
+export type TriggerContext =
+  | AlertTriggerContext
+  | ScheduleTriggerContext
+  | ReminderTriggerContext
+  | WebhookTriggerContext
+  | SessionMessageTriggerContext;
+
+// ---------------------------------------------------------------------------
+// Trigger subscriptions — persisted on the session
+// ---------------------------------------------------------------------------
+
+interface TriggerSubscriptionBase {
+  /** Unique subscription ID within the session. */
+  id: string;
+  /** When this subscription was created. */
+  created_at: string;
+}
+
+export interface AlertTriggerSubscription extends TriggerSubscriptionBase {
+  type: 'alert_trigger';
+  config: {
+    rule_id: string;
+    rule_name?: string;
+  };
+  /** ID of the Kibana Actions action that was registered on the rule. */
+  alert_action_id: string;
+}
+
+export interface ScheduleTriggerSubscription extends TriggerSubscriptionBase {
+  type: 'schedule_trigger';
+  config: {
+    /** Simple interval string, e.g. "15m", "1h". */
+    interval: string;
+    /** Human-readable description stored for display in the UI. */
+    description: string;
+  };
+  /** Task Manager task ID. */
+  task_id: string;
+}
+
+export interface ReminderTriggerSubscription extends TriggerSubscriptionBase {
+  type: 'reminder_trigger';
+  /** Always true — reminders are one-shot and auto-remove on fire. */
+  one_shot: true;
+  config: {
+    fires_at: string;
+    note?: string;
+  };
+  /** Task Manager task ID. */
+  task_id: string;
+}
+
+export interface WebhookTriggerSubscription extends TriggerSubscriptionBase {
+  type: 'webhook_trigger';
+  config: {
+    /** HMAC-signed token embedded in the webhook URL. */
+    token: string;
+    /** Optional expiry; no expiry means the webhook lives until unsubscribed. */
+    expires_at?: string;
+  };
+}
+
+export type TriggerSubscription =
+  | AlertTriggerSubscription
+  | ScheduleTriggerSubscription
+  | ReminderTriggerSubscription
+  | WebhookTriggerSubscription;
+
+// ---------------------------------------------------------------------------
+// Pending trigger queue — events waiting while the session is active
+// ---------------------------------------------------------------------------
+
+export interface PendingTriggerEvent {
+  /** Unique event ID, used to deduplicate if needed. */
+  id: string;
+  /** When the event arrived and was appended to the queue. */
+  queued_at: string;
+  /** The full trigger context that will be injected as the next round's input. */
+  context: TriggerContext;
+}
+
+// ---------------------------------------------------------------------------
+// Standing session state — stored in ConversationInternalState
+// ---------------------------------------------------------------------------
+
+export type StandingSessionStatus = 'active' | 'idle' | 'terminated';
+
+export interface StandingSessionState {
+  status: StandingSessionStatus;
+  /** All active trigger subscriptions. Reminders auto-remove on fire. */
+  trigger_subscriptions: TriggerSubscription[];
+  /** Events that arrived while the session was active — drained one at a time after each round. */
+  pending_triggers: PendingTriggerEvent[];
+  /** ISO timestamp of the last round start (human or trigger). */
+  last_active_at: string;
+  /** Auto-terminate after this many seconds of idle time. Absent means no TTL. */
+  ttl_seconds?: number;
+  /** The user who created this session; their credentials are used for background execution. */
+  created_by: UserIdAndName;
+  /**
+   * The execution ID of the currently running round.
+   * Used by drainQueue for a race-condition safety check — ensures that only the
+   * execution that started a round can advance the queue when it completes.
+   */
+  active_execution_id?: string;
+  /** GenAI connector override applied to every round. Falls back to the agent's default when absent. */
+  connector_id?: string;
+  /** System prompt override injected as `instructions` into the agent configuration for every round. */
+  system_prompt_override?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Session list / filter types
+// ---------------------------------------------------------------------------
+
+export interface SessionListOptions {
+  agent_id?: string;
+  status?: StandingSessionStatus;
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
@@ -133,7 +133,26 @@ export {
   type AgentDeleteRequest,
 } from './agents';
 export {
+  type SessionMode,
+  type StandingSessionStatus,
+  type StandingSessionState,
+  type TriggerSubscription,
+  type AlertTriggerSubscription,
+  type ScheduleTriggerSubscription,
+  type ReminderTriggerSubscription,
+  type WebhookTriggerSubscription,
+  type PendingTriggerEvent,
+  type AlertTriggerContext,
+  type ScheduleTriggerContext,
+  type ReminderTriggerContext,
+  type WebhookTriggerContext,
+  type SessionMessageTriggerContext,
+  type SessionListOptions,
+} from './chat';
+export {
   type RoundInput,
+  type RoundInputSource,
+  type TriggerContext,
   type ConverseInput,
   type AssistantResponse,
   type ToolCallWithResult,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -72,6 +72,16 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.workflows}.workflow_delete_step`,
   `${internalNamespaces.workflows}.workflow_set_yaml`,
   `${internalNamespaces.workflows}.workflow_execute_step`,
+
+  // Standing session lifecycle tools
+  `${internalNamespaces.session}.set_idle`,
+  `${internalNamespaces.session}.terminate`,
+  `${internalNamespaces.session}.subscribe_to_alert`,
+  `${internalNamespaces.session}.subscribe_to_schedule`,
+  `${internalNamespaces.session}.set_reminder`,
+  `${internalNamespaces.session}.subscribe_to_webhook`,
+  `${internalNamespaces.session}.unsubscribe`,
+  `${internalNamespaces.session}.send_message`,
 ] as const;
 
 export type AgentBuilderBuiltinTool = (typeof AGENT_BUILDER_BUILTIN_TOOLS)[number];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -84,6 +84,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.session}.send_message`,
   `${internalNamespaces.session}.list_sessions`,
   `${internalNamespaces.session}.run_workflow`,
+  `${internalNamespaces.session}.list_workflows`,
 ] as const;
 
 export type AgentBuilderBuiltinTool = (typeof AGENT_BUILDER_BUILTIN_TOOLS)[number];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -82,6 +82,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.session}.subscribe_to_webhook`,
   `${internalNamespaces.session}.unsubscribe`,
   `${internalNamespaces.session}.send_message`,
+  `${internalNamespaces.session}.list_sessions`,
 ] as const;
 
 export type AgentBuilderBuiltinTool = (typeof AGENT_BUILDER_BUILTIN_TOOLS)[number];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -83,6 +83,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.session}.unsubscribe`,
   `${internalNamespaces.session}.send_message`,
   `${internalNamespaces.session}.list_sessions`,
+  `${internalNamespaces.session}.run_workflow`,
 ] as const;
 
 export type AgentBuilderBuiltinTool = (typeof AGENT_BUILDER_BUILTIN_TOOLS)[number];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/index.ts
@@ -138,4 +138,12 @@ export type {
   ReadOnlyConversationClient,
   ConversationsStart,
 } from './plugin_contract';
+export type {
+  CreateSessionParams,
+  EnqueueTriggerResult,
+  SendMessageResult,
+  SessionClient,
+  SessionsStart,
+} from './sessions';
+export { createSessionTools } from './tools/session_tools';
 export { describeZodSchema, formatSchemaForLlm } from './tools';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/index.ts
@@ -145,5 +145,5 @@ export type {
   SessionClient,
   SessionsStart,
 } from './sessions';
-export { createSessionTools } from './tools/session_tools';
+export { createSessionTools, SESSION_TOOL_IDS } from './tools/session_tools';
 export { describeZodSchema, formatSchemaForLlm } from './tools';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/plugin_contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/plugin_contract.ts
@@ -27,6 +27,7 @@ import type {
   AgentExecution,
   FindExecutionsOptions,
 } from './execution';
+import type { SessionsStart } from './sessions';
 
 /**
  * AgentBuilder tool service's setup contract.
@@ -257,4 +258,8 @@ export interface AgentBuilderPluginStart {
    * Conversations service (read-only), to list and retrieve conversations.
    */
   conversations: ConversationsStart;
+  /**
+   * Sessions service, to create and manage long-lived standing sessions.
+   */
+  sessions: SessionsStart;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/sessions/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/sessions/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type {
+  CreateSessionParams,
+  EnqueueTriggerResult,
+  SendMessageResult,
+  SessionClient,
+  SessionsStart,
+} from './session_service';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/sessions/session_service.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/sessions/session_service.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type {
+  Conversation,
+  ConversationWithoutRounds,
+  TriggerContext,
+  TriggerSubscription,
+  SessionListOptions,
+  StandingSessionStatus,
+} from '@kbn/agent-builder-common';
+
+// ---------------------------------------------------------------------------
+// Session creation
+// ---------------------------------------------------------------------------
+
+export interface CreateSessionParams {
+  /** ID of the agent to bind this session to. */
+  agent_id: string;
+  /** Human-readable name shown in the sessions list. */
+  name: string;
+  /**
+   * Optional initial system prompt override for this session.
+   * When absent the agent's default system prompt is used.
+   */
+  system_prompt_override?: string;
+  /** Optional auto-termination TTL in seconds. Absent means no TTL. */
+  ttl_seconds?: number;
+  /** Optional GenAI connector override. Falls back to the agent's default. */
+  connector_id?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Enqueue result
+// ---------------------------------------------------------------------------
+
+export interface EnqueueTriggerResult {
+  /**
+   * 'injected' — session was idle; a new round has been started immediately.
+   * 'queued'   — session was active; event is in pending_triggers and will be
+   *              processed when the current round completes.
+   */
+  status: 'injected' | 'queued';
+}
+
+// ---------------------------------------------------------------------------
+// Send-message result
+// ---------------------------------------------------------------------------
+
+export interface SendMessageResult {
+  message_id: string;
+  status: 'injected' | 'queued';
+}
+
+// ---------------------------------------------------------------------------
+// Session client — scoped to a request (user + space)
+// ---------------------------------------------------------------------------
+
+export interface SessionClient {
+  /**
+   * Create a new standing session. The session starts in 'idle' status.
+   * The creator's credentials (from the scoped request) are stored and reused
+   * for all background (trigger-fired) executions.
+   */
+  create(params: CreateSessionParams): Promise<Conversation>;
+
+  /**
+   * Retrieve a standing session by its conversation ID, including all rounds.
+   */
+  get(conversationId: string): Promise<Conversation>;
+
+  /**
+   * List standing sessions for the current user's space.
+   */
+  list(options?: SessionListOptions): Promise<ConversationWithoutRounds[]>;
+
+  /**
+   * Terminate a session: cleans up all trigger subscriptions (Task Manager tasks,
+   * alert actions, webhook tokens) and sets status to 'terminated'.
+   * Subsequent enqueue calls on a terminated session throw.
+   */
+  terminate(conversationId: string): Promise<void>;
+
+  /**
+   * Enqueue an external trigger event into a session's queue.
+   *
+   * - If the session is 'idle': starts a new round immediately and returns { status: 'injected' }.
+   * - If the session is 'active': appends to pending_triggers and returns { status: 'queued' }.
+   * - If the session is 'terminated': throws.
+   *
+   * Called by: Task Manager trigger tasks, alert action handlers, webhook endpoint, session.send_message tool.
+   */
+  enqueueTrigger(conversationId: string, context: TriggerContext): Promise<EnqueueTriggerResult>;
+
+  /**
+   * Called by the execution service after each standing-session round completes.
+   * Checks pending_triggers: if any events are queued, starts the next round immediately.
+   * If the queue is empty, transitions the session to 'idle'.
+   *
+   * @param forExecutionId - When provided, drain is skipped if this is no longer the active
+   *   execution ID (race-condition guard).
+   */
+  drainQueue(conversationId: string, forExecutionId?: string): Promise<void>;
+
+  /**
+   * Add a trigger subscription to the session (called by session.subscribe_* tools).
+   * The subscription is appended to standing_session.trigger_subscriptions.
+   */
+  addSubscription(conversationId: string, subscription: TriggerSubscription): Promise<void>;
+
+  /**
+   * Remove a trigger subscription by ID (called by session.unsubscribe tool).
+   * Returns the removed subscription so the caller can clean up external resources
+   * (e.g., cancel the TM task or alert action).
+   * Throws if the subscription ID is not found.
+   */
+  removeSubscription(conversationId: string, subscriptionId: string): Promise<TriggerSubscription>;
+
+  /**
+   * Update the session's lifecycle status.
+   * Used internally by the execution service when a round starts (→ active)
+   * and by drainQueue (→ idle when queue is empty).
+   */
+  setStatus(conversationId: string, status: StandingSessionStatus): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Sessions start contract — exposed on AgentBuilderPluginStart
+// ---------------------------------------------------------------------------
+
+export interface SessionsStart {
+  /**
+   * Returns a session client scoped to the given request's user and space.
+   * The client uses the request's credentials for all Saved Objects access
+   * and stores them as the creator credentials for background executions.
+   */
+  getScopedClient(opts: { request: KibanaRequest }): SessionClient;
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
@@ -21,6 +21,21 @@ import type { SessionsStart } from '../sessions';
 import { createOtherResult, createErrorResult } from './utils';
 
 // ---------------------------------------------------------------------------
+// Constant — all session tool IDs, used to inject them into standing session runs
+// ---------------------------------------------------------------------------
+
+export const SESSION_TOOL_IDS = [
+  'session.set_idle',
+  'session.terminate',
+  'session.subscribe_to_alert',
+  'session.subscribe_to_schedule',
+  'session.set_reminder',
+  'session.subscribe_to_webhook',
+  'session.unsubscribe',
+  'session.send_message',
+] as const;
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
@@ -1,0 +1,404 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { v4 as uuidv4 } from 'uuid';
+import { ToolType } from '@kbn/agent-builder-common';
+import type {
+  AlertTriggerSubscription,
+  ScheduleTriggerSubscription,
+  ReminderTriggerSubscription,
+  WebhookTriggerSubscription,
+} from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition } from './builtin';
+import type { RunContext } from '../runner';
+import { getAgentFromRunContext } from '../runner';
+import type { SessionsStart } from '../sessions';
+import { createOtherResult, createErrorResult } from './utils';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const otherResult = (content: string) => ({
+  results: [createOtherResult({ content })],
+});
+
+const errResult = (message: string) => ({
+  results: [createErrorResult(`Error: ${message}`)],
+});
+
+/** Resolve conversationId from run context — throws if not in a conversation. */
+const requireConversationId = (runContext: RunContext): string => {
+  const agentEntry = getAgentFromRunContext(runContext);
+  const id = agentEntry?.conversationId;
+  if (!id) {
+    throw new Error('session tools are only available inside a standing session conversation');
+  }
+  return id;
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the set of built-in session lifecycle tools.
+ * The session service is injected via closure so tools can call back into it.
+ *
+ * These tools are only registered for conversations with session_mode === 'standing'.
+ * The `session` namespace is protected, so no user-registered tool can shadow them.
+ */
+export const createSessionTools = (sessions: SessionsStart): BuiltinToolDefinition[] => {
+  // -------------------------------------------------------------------------
+  // session.set_idle
+  // -------------------------------------------------------------------------
+  const setIdle: BuiltinToolDefinition = {
+    id: 'session.set_idle',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      'Signal that you have finished your current work and the session should go idle ' +
+      'until the next trigger event or human message arrives. Call this when you have ' +
+      'completed all tasks for this round and do not need to take any further action right now.',
+    schema: z.object({}),
+    handler: async (_params, context) => {
+      const conversationId = requireConversationId(context.runContext);
+      const agentEntry = getAgentFromRunContext(context.runContext);
+      const executionId = agentEntry?.executionId;
+      const client = sessions.getScopedClient({ request: context.request });
+      await client.drainQueue(conversationId, executionId);
+      return otherResult(
+        'Round complete. Session will process the next queued trigger or return to idle.'
+      );
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // session.terminate
+  // -------------------------------------------------------------------------
+  const terminate: BuiltinToolDefinition = {
+    id: 'session.terminate',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      'Permanently end this standing session. All trigger subscriptions will be removed and ' +
+      'no further trigger events or human messages will be processed. This action cannot be undone.',
+    schema: z.object({
+      reason: z.string().optional().describe('Optional reason for termination, stored for audit.'),
+    }),
+    handler: async (_params, context) => {
+      const conversationId = requireConversationId(context.runContext);
+      const client = sessions.getScopedClient({ request: context.request });
+      await client.terminate(conversationId);
+      return otherResult('Session has been terminated. All subscriptions removed.');
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // session.subscribe_to_alert
+  // -------------------------------------------------------------------------
+  const subscribeToAlertSchema = z.object({
+    rule_id: z.string().describe('ID of the Kibana alert rule to subscribe to.'),
+    rule_name: z
+      .string()
+      .optional()
+      .describe('Human-readable name of the rule, stored for display purposes.'),
+  });
+
+  const subscribeToAlert: BuiltinToolDefinition<typeof subscribeToAlertSchema> = {
+    id: 'session.subscribe_to_alert',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      'Subscribe to a Kibana alert rule. When the rule fires, a new round will be started ' +
+      'in this session with the alert details injected as the input. ' +
+      'Returns a subscription ID you can use to unsubscribe later.',
+    schema: subscribeToAlertSchema,
+    handler: async (params, context) => {
+      const conversationId = requireConversationId(context.runContext);
+      const client = sessions.getScopedClient({ request: context.request });
+
+      const subscriptionId = uuidv4();
+      const subscription: AlertTriggerSubscription = {
+        id: subscriptionId,
+        type: 'alert_trigger',
+        config: { rule_id: params.rule_id, rule_name: params.rule_name },
+        alert_action_id: '',
+        created_at: new Date().toISOString(),
+      };
+
+      await client.addSubscription(conversationId, subscription);
+      return otherResult(
+        JSON.stringify({ subscription_id: subscriptionId, rule_id: params.rule_id })
+      );
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // session.subscribe_to_schedule
+  // -------------------------------------------------------------------------
+  const subscribeToScheduleSchema = z.object({
+    interval: z.string().describe('Simple interval string, e.g. "15m", "1h", "30s".'),
+    description: z
+      .string()
+      .optional()
+      .describe('Human-readable description of the schedule, e.g. "every 15 minutes".'),
+  });
+
+  const subscribeToSchedule: BuiltinToolDefinition<typeof subscribeToScheduleSchema> = {
+    id: 'session.subscribe_to_schedule',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      'Subscribe to a recurring time-based schedule. A new session round will be started ' +
+      'on each tick. Use "interval" (e.g. "15m", "1h") to specify the schedule frequency. ' +
+      'Returns a subscription ID you can use to unsubscribe later.',
+    schema: subscribeToScheduleSchema,
+    handler: async (params, context) => {
+      if (!params.interval) {
+        return errResult('"interval" must be provided.');
+      }
+
+      const conversationId = requireConversationId(context.runContext);
+      const client = sessions.getScopedClient({ request: context.request });
+
+      const subscriptionId = uuidv4();
+      const scheduleDescription = params.description ?? `every ${params.interval}`;
+
+      const subscription: ScheduleTriggerSubscription = {
+        id: subscriptionId,
+        type: 'schedule_trigger',
+        config: {
+          interval: params.interval,
+          description: scheduleDescription,
+        },
+        task_id: '',
+        created_at: new Date().toISOString(),
+      };
+
+      await client.addSubscription(conversationId, subscription);
+      return otherResult(
+        JSON.stringify({ subscription_id: subscriptionId, description: scheduleDescription })
+      );
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // session.set_reminder
+  // -------------------------------------------------------------------------
+  const setReminderSchema = z.object({
+    in_seconds: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe('Delay in seconds from now. Mutually exclusive with "at".'),
+    at: z
+      .string()
+      .optional()
+      .describe(
+        'Absolute datetime to fire the reminder, in ISO 8601 format. Mutually exclusive with "in_seconds".'
+      ),
+    note: z
+      .string()
+      .optional()
+      .describe('Optional label echoed back when the reminder fires so you can identify it.'),
+  });
+
+  const setReminder: BuiltinToolDefinition<typeof setReminderSchema> = {
+    id: 'session.set_reminder',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      'Schedule a one-time reminder that wakes this session after a delay or at a specific time. ' +
+      'Unlike a recurring schedule, reminders fire exactly once and then auto-remove. ' +
+      'Provide either "in_seconds" (relative delay) or "at" (absolute ISO 8601 datetime).',
+    schema: setReminderSchema,
+    handler: async (params, context) => {
+      if (!params.in_seconds && !params.at) {
+        return errResult('Either "in_seconds" or "at" must be provided.');
+      }
+      if (params.in_seconds && params.at) {
+        return errResult('"in_seconds" and "at" are mutually exclusive.');
+      }
+
+      const conversationId = requireConversationId(context.runContext);
+      const client = sessions.getScopedClient({ request: context.request });
+
+      const delayMs = params.in_seconds ? params.in_seconds * 1000 : 0;
+      const firesAt = params.at
+        ? new Date(params.at).toISOString()
+        : new Date(Date.now() + delayMs).toISOString();
+
+      const subscriptionId = uuidv4();
+      const subscription: ReminderTriggerSubscription = {
+        id: subscriptionId,
+        type: 'reminder_trigger',
+        one_shot: true,
+        config: { fires_at: firesAt, note: params.note },
+        task_id: '',
+        created_at: new Date().toISOString(),
+      };
+
+      await client.addSubscription(conversationId, subscription);
+      return otherResult(JSON.stringify({ reminder_id: subscriptionId, fires_at: firesAt }));
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // session.subscribe_to_webhook
+  // -------------------------------------------------------------------------
+  const subscribeToWebhookSchema = z.object({
+    expires_at: z
+      .string()
+      .optional()
+      .describe(
+        'Optional expiry datetime in ISO 8601 format. After this time the webhook rejects requests.'
+      ),
+  });
+
+  const subscribeToWebhook: BuiltinToolDefinition<typeof subscribeToWebhookSchema> = {
+    id: 'session.subscribe_to_webhook',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      'Generate a signed webhook URL. Any HTTP POST to this URL will start a new session round ' +
+      'with the request body as the trigger payload. ' +
+      'Returns the webhook URL and a subscription ID you can use to unsubscribe.',
+    schema: subscribeToWebhookSchema,
+    handler: async (params, context) => {
+      const conversationId = requireConversationId(context.runContext);
+      const client = sessions.getScopedClient({ request: context.request });
+
+      const subscriptionId = uuidv4();
+      const subscription: WebhookTriggerSubscription = {
+        id: subscriptionId,
+        type: 'webhook_trigger',
+        config: { token: '', expires_at: params.expires_at },
+        created_at: new Date().toISOString(),
+      };
+
+      await client.addSubscription(conversationId, subscription);
+
+      // Re-read so the session service can write back the real token.
+      const session = await client.get(conversationId);
+      const saved = session.state?.standing_session?.trigger_subscriptions.find(
+        (s) => s.id === subscriptionId
+      ) as WebhookTriggerSubscription | undefined;
+
+      const token = saved?.config.token ?? '(pending — check session state)';
+      return otherResult(
+        JSON.stringify({
+          subscription_id: subscriptionId,
+          webhook_url: `/internal/agent_builder/sessions/webhook/${token}`,
+          expires_at: params.expires_at ?? null,
+        })
+      );
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // session.unsubscribe
+  // -------------------------------------------------------------------------
+  const unsubscribeSchema = z.object({
+    subscription_id: z.string().describe('ID of the subscription to remove.'),
+  });
+
+  const unsubscribe: BuiltinToolDefinition<typeof unsubscribeSchema> = {
+    id: 'session.unsubscribe',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      'Remove a trigger subscription by its ID. ' +
+      'The associated Task Manager task, alert action, or webhook token will be cleaned up.',
+    schema: unsubscribeSchema,
+    handler: async (params, context) => {
+      const conversationId = requireConversationId(context.runContext);
+      const client = sessions.getScopedClient({ request: context.request });
+
+      try {
+        const removed = await client.removeSubscription(conversationId, params.subscription_id);
+        return otherResult(
+          JSON.stringify({ removed_subscription_id: removed.id, type: removed.type })
+        );
+      } catch (err) {
+        return errResult(`Subscription "${params.subscription_id}" not found.`);
+      }
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // session.send_message
+  // -------------------------------------------------------------------------
+  const sendMessageSchema = z.object({
+    target_session_id: z.string().describe('Conversation ID of the target standing session.'),
+    message: z.string().describe('Free-text message to send to the target session.'),
+    context: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('Optional structured metadata attached to the message.'),
+  });
+
+  const sendMessage: BuiltinToolDefinition<typeof sendMessageSchema> = {
+    id: 'session.send_message',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      "Inject a message into another standing session's trigger queue. " +
+      'The message arrives as a new round input with source "session_message". ' +
+      'This is fire-and-forget: the tool returns once the message is queued or injected. ' +
+      'The target session must exist in the same space and must not be terminated.',
+    schema: sendMessageSchema,
+    handler: async (params, context) => {
+      const fromConversationId = requireConversationId(context.runContext);
+      const client = sessions.getScopedClient({ request: context.request });
+
+      let fromAgentId: string;
+      try {
+        const fromSession = await client.get(fromConversationId);
+        fromAgentId = fromSession.agent_id;
+      } catch {
+        return errResult('Could not resolve the current session.');
+      }
+
+      const messageId = uuidv4();
+      const triggerContext = {
+        type: 'session_message' as const,
+        subscription_id: undefined,
+        event: {
+          from_session_id: fromConversationId,
+          from_agent_id: fromAgentId,
+          message: params.message,
+          message_id: messageId,
+          context: params.context,
+        },
+      };
+
+      try {
+        const result = await client.enqueueTrigger(params.target_session_id, triggerContext);
+        return otherResult(JSON.stringify({ message_id: messageId, status: result.status }));
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errResult(
+          `Could not deliver message to session "${params.target_session_id}": ${msg}`
+        );
+      }
+    },
+  };
+
+  return [
+    setIdle,
+    terminate,
+    subscribeToAlert,
+    subscribeToSchedule,
+    setReminder,
+    subscribeToWebhook,
+    unsubscribe,
+    sendMessage,
+  ];
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
@@ -34,6 +34,7 @@ export const SESSION_TOOL_IDS = [
   'session.unsubscribe',
   'session.send_message',
   'session.list_sessions',
+  'session.run_workflow',
 ] as const;
 
 // ---------------------------------------------------------------------------

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
@@ -33,6 +33,7 @@ export const SESSION_TOOL_IDS = [
   'session.subscribe_to_webhook',
   'session.unsubscribe',
   'session.send_message',
+  'session.list_sessions',
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -406,6 +407,45 @@ export const createSessionTools = (sessions: SessionsStart): BuiltinToolDefiniti
     },
   };
 
+  // -------------------------------------------------------------------------
+  // session.list_sessions
+  // -------------------------------------------------------------------------
+  const listSessionsSchema = z.object({
+    agent_id: z
+      .string()
+      .optional()
+      .describe('Filter sessions to a specific agent ID. Omit to list all sessions in the space.'),
+  });
+
+  const listSessions: BuiltinToolDefinition<typeof listSessionsSchema> = {
+    id: 'session.list_sessions',
+    type: ToolType.builtin,
+    tags: [],
+    description:
+      'List standing sessions visible to the current user in this space. ' +
+      'Returns session IDs, names, statuses, and subscription counts. ' +
+      'Use the returned session_id values with session.send_message to communicate with other sessions.',
+    schema: listSessionsSchema,
+    handler: async (params, context) => {
+      const client = sessions.getScopedClient({ request: context.request });
+      try {
+        const sessionList = await client.list({ agent_id: params.agent_id });
+        const summary = sessionList.map((s) => ({
+          session_id: s.id,
+          name: s.title,
+          agent_id: s.agent_id,
+          status: s.state?.standing_session?.status ?? 'unknown',
+          subscriptions: s.state?.standing_session?.trigger_subscriptions?.length ?? 0,
+          last_active_at: s.state?.standing_session?.last_active_at,
+        }));
+        return otherResult(JSON.stringify(summary));
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errResult(`Could not list sessions: ${msg}`);
+      }
+    },
+  };
+
   return [
     setIdle,
     terminate,
@@ -415,5 +455,6 @@ export const createSessionTools = (sessions: SessionsStart): BuiltinToolDefiniti
     subscribeToWebhook,
     unsubscribe,
     sendMessage,
+    listSessions,
   ];
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/session_tools.ts
@@ -35,6 +35,7 @@ export const SESSION_TOOL_IDS = [
   'session.send_message',
   'session.list_sessions',
   'session.run_workflow',
+  'session.list_workflows',
 ] as const;
 
 // ---------------------------------------------------------------------------

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/send_session_message_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/send_session_message_step.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
+import { i18n } from '@kbn/i18n';
+
+export const SendSessionMessageStepTypeId = 'ai.send_session_message';
+
+export const InputSchema = z.object({
+  session_id: z.string().describe('ID of the standing session to send the message to.'),
+  message: z.string().describe('Message to inject into the session as a new round.'),
+});
+
+export const OutputSchema = z.object({
+  status: z
+    .enum(['injected', 'queued'])
+    .describe('Whether the message started a new round immediately or was queued.'),
+  message_id: z.string().describe('Unique ID assigned to this message.'),
+});
+
+export type SendSessionMessageStepInputSchema = typeof InputSchema;
+export type SendSessionMessageStepOutputSchema = typeof OutputSchema;
+
+export const sendSessionMessageStepCommonDefinition: CommonStepDefinition<
+  typeof InputSchema,
+  typeof OutputSchema
+> = {
+  id: SendSessionMessageStepTypeId,
+  category: StepCategory.Ai,
+  label: i18n.translate('xpack.agentBuilder.stepTypes.sendSessionMessage.label', {
+    defaultMessage: 'Send message to standing session',
+  }),
+  description: i18n.translate('xpack.agentBuilder.stepTypes.sendSessionMessage.description', {
+    defaultMessage: 'Inject a message into a standing session, starting a new agent round.',
+  }),
+  documentation: {
+    details: i18n.translate(
+      'xpack.agentBuilder.stepTypes.sendSessionMessage.documentation.details',
+      {
+        defaultMessage:
+          'Injects a text message into a standing session. If the session is idle, a new round starts immediately. If active, the message is queued.',
+      }
+    ),
+    examples: [],
+  },
+  inputSchema: InputSchema,
+  outputSchema: OutputSchema,
+};

--- a/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
@@ -41,6 +41,7 @@
       "usageCollection"
     ],
     "optionalPlugins": [
+      "alerting",
       "cloud",
       "evals",
       "licenseManagement",

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/agent_builder_view_ids.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/agent_builder_view_ids.ts
@@ -30,4 +30,6 @@ export const agentBuilderViewIds = {
   manageToolCreate: 'agent_builder_manage_tools_create',
   manageToolBulkImportMcp: 'agent_builder_manage_tools_bulk_import_mcp',
   manageToolDetails: 'agent_builder_manage_tools_detail',
+  agentSessions: 'agent_builder_agent_sessions',
+  agentSession: 'agent_builder_agent_session',
 } as const;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/index.tsx
@@ -71,7 +71,7 @@ const conversationListScrollRegionLabel = i18n.translate(
 );
 
 const sessionsLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.sessions', {
-  defaultMessage: 'Sessions',
+  defaultMessage: 'Bots',
 });
 
 const newSessionLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.newSession', {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/index.tsx
@@ -27,6 +27,7 @@ import {
   getAgentIdFromPath,
   getAgentSettingsNavItems,
   getConversationIdFromPath,
+  getSessionIdFromPath,
 } from '../../../../../route_config';
 import { useFeatureFlags } from '../../../../../hooks/use_feature_flags';
 import { useNavigation } from '../../../../../hooks/use_navigation';
@@ -39,6 +40,7 @@ import { SidebarNavList } from '../../shared/sidebar_nav_list';
 
 import { ConversationFooter } from './conversation_footer';
 import { ConversationList } from './conversation_list';
+import { SessionList } from './session_list';
 import { ConversationSearchModal } from '../../../../conversations/conversation_search_modal';
 
 const customizeLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.customize', {
@@ -68,10 +70,19 @@ const conversationListScrollRegionLabel = i18n.translate(
   }
 );
 
+const sessionsLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.sessions', {
+  defaultMessage: 'Sessions',
+});
+
+const newSessionLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.newSession', {
+  defaultMessage: 'New',
+});
+
 export const ConversationSidebarView: React.FC = () => {
   const { pathname } = useLocation();
   const agentId = getAgentIdFromPath(pathname) ?? agentBuilderDefaultAgentId;
   const conversationId = getConversationIdFromPath(pathname);
+  const sessionId = getSessionIdFromPath(pathname);
   const { euiTheme } = useEuiTheme();
   const { navigateToAgentBuilderUrl } = useNavigation();
   const validateAgentId = useValidateAgentId();
@@ -244,6 +255,35 @@ export const ConversationSidebarView: React.FC = () => {
                       />
                     </EuiFlexItem>
                   </EuiFlexGroup>
+                </EuiFlexItem>
+
+                <EuiFlexItem grow={false}>
+                  <EuiSpacer size="m" />
+                </EuiFlexItem>
+
+                <EuiFlexItem grow={false}>
+                  <EuiFlexGroup gutterSize="none" responsive={false} alignItems="center">
+                    <EuiFlexItem grow>
+                      <EuiText size="xs" color="subdued" css={sectionLabelCss}>
+                        {sessionsLabel}
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiButton
+                        iconType="plus"
+                        size="s"
+                        color="text"
+                        onClick={() =>
+                          navigateToAgentBuilderUrl(appPaths.agent.sessions.list({ agentId }))
+                        }
+                        data-test-subj="agentBuilderSidebarNewSessionButton"
+                      >
+                        {newSessionLabel}
+                      </EuiButton>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                  <EuiSpacer size="s" />
+                  <SessionList agentId={agentId} currentSessionId={sessionId} />
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPanel>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/session_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/session_list.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../../conversations/conversation_list_item_styles';
 
 const noSessionsLabel = i18n.translate('xpack.agentBuilder.sidebar.sessionList.noSessions', {
-  defaultMessage: 'No sessions',
+  defaultMessage: 'No bots',
 });
 
 const statusDotColors: Record<StandingSessionStatus, string> = {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/session_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/session_list.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom-v5-compat';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiText, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
+import type { StandingSessionStatus } from '@kbn/agent-builder-common';
+import { useSessionList } from '../../../../../hooks/use_session_list';
+import { appPaths } from '../../../../../utils/app_paths';
+import {
+  createConversationListItemStyles,
+  createActiveConversationListItemStyles,
+} from '../../../../conversations/conversation_list_item_styles';
+
+const noSessionsLabel = i18n.translate('xpack.agentBuilder.sidebar.sessionList.noSessions', {
+  defaultMessage: 'No sessions',
+});
+
+const statusDotColors: Record<StandingSessionStatus, string> = {
+  active: '#00bfb3',
+  idle: '#c2c2c2',
+  terminated: '#bd271e',
+};
+
+interface SessionListProps {
+  agentId: string;
+  currentSessionId: string | undefined;
+}
+
+export const SessionList: React.FC<SessionListProps> = ({ agentId, currentSessionId }) => {
+  const { euiTheme } = useEuiTheme();
+  const { sessions = [], isLoading } = useSessionList({ agentId });
+
+  const sortedSessions = useMemo(
+    () =>
+      [...sessions].sort(
+        (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      ),
+    [sessions]
+  );
+
+  const linkStyles = createConversationListItemStyles(euiTheme);
+  const activeLinkStyles = createActiveConversationListItemStyles(euiTheme);
+
+  if (isLoading) {
+    return (
+      <EuiFlexGroup direction="column" gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="s" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  if (sortedSessions.length === 0) {
+    return (
+      <EuiText size="xs" color="subdued">
+        {noSessionsLabel}
+      </EuiText>
+    );
+  }
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      {sortedSessions.map((session) => {
+        const isActive = currentSessionId === session.id;
+        const status = session.state?.standing_session?.status as StandingSessionStatus | undefined;
+        const dotColor = status ? statusDotColors[status] : statusDotColors.idle;
+
+        const rowStyles = css`
+          display: flex;
+          align-items: center;
+          gap: ${euiTheme.size.xs};
+        `;
+
+        const dotStyles = css`
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          background-color: ${dotColor};
+          flex-shrink: 0;
+        `;
+
+        const linkStyle = css([
+          isActive ? activeLinkStyles : linkStyles,
+          css`
+            flex: 1 1 0;
+            min-width: 0;
+          `,
+        ]);
+
+        return (
+          <EuiFlexItem grow={false} key={session.id}>
+            <div css={rowStyles}>
+              <Link
+                to={appPaths.agent.sessions.byId({ agentId, sessionId: session.id })}
+                css={linkStyle}
+                data-test-subj={`agentBuilderSidebarSession-${session.id}`}
+              >
+                {session.title || session.id}
+              </Link>
+              <div css={dotStyles} />
+            </div>
+          </EuiFlexItem>
+        );
+      })}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_detail_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_detail_view.tsx
@@ -7,7 +7,14 @@
 
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiText,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useQueryClient } from '@kbn/react-query';
 import { useSession } from '../../hooks/use_session';
@@ -16,20 +23,22 @@ import { SessionStatusBadge } from './session_status_badge';
 import { useAgentBuilderServices } from '../../hooks/use_agent_builder_service';
 import { queryKeys } from '../../query_keys';
 
-const standingSessionLabel = i18n.translate(
-  'xpack.agentBuilder.sessionDetail.standingSessionLabel',
-  { defaultMessage: 'Bot' }
-);
-
-const subscriptionsLabel = (count: number) =>
-  i18n.translate('xpack.agentBuilder.sessionDetail.subscriptionsLabel', {
-    defaultMessage: '{count} subscription(s)',
-    values: { count },
-  });
-
-const terminateLabel = i18n.translate('xpack.agentBuilder.sessionDetail.terminateLabel', {
-  defaultMessage: 'Terminate',
-});
+const labels = {
+  bot: i18n.translate('xpack.agentBuilder.sessionDetail.standingSessionLabel', {
+    defaultMessage: 'Bot',
+  }),
+  subscriptions: (count: number) =>
+    i18n.translate('xpack.agentBuilder.sessionDetail.subscriptionsLabel', {
+      defaultMessage: '{count} subscription(s)',
+      values: { count },
+    }),
+  terminate: i18n.translate('xpack.agentBuilder.sessionDetail.terminateLabel', {
+    defaultMessage: 'Terminate',
+  }),
+  processing: i18n.translate('xpack.agentBuilder.sessionDetail.processingLabel', {
+    defaultMessage: 'Processing — messages you send now will be queued',
+  }),
+};
 
 export const AgentBuilderSessionDetailView: React.FC = () => {
   const { conversationId, agentId } = useParams<{ conversationId: string; agentId: string }>();
@@ -37,6 +46,7 @@ export const AgentBuilderSessionDetailView: React.FC = () => {
   const { sessionsService } = useAgentBuilderServices();
   const queryClient = useQueryClient();
   const standingSession = session?.state?.standing_session;
+  const isActive = standingSession?.status === 'active';
 
   const handleTerminate = async () => {
     if (!conversationId) return;
@@ -46,11 +56,7 @@ export const AgentBuilderSessionDetailView: React.FC = () => {
   };
 
   const calloutColor =
-    standingSession?.status === 'terminated'
-      ? 'danger'
-      : standingSession?.status === 'active'
-      ? 'success'
-      : 'primary';
+    standingSession?.status === 'terminated' ? 'danger' : isActive ? 'success' : 'primary';
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -58,26 +64,42 @@ export const AgentBuilderSessionDetailView: React.FC = () => {
         <EuiCallOut
           size="s"
           color={calloutColor}
-          iconType="clock"
+          iconType={isActive ? 'empty' : 'clock'}
           title={
             <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
               <EuiFlexItem grow={false}>
                 <EuiText size="s">
-                  <strong>{standingSessionLabel}</strong>
+                  <strong>{labels.bot}</strong>
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <SessionStatusBadge status={standingSession.status} />
               </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText size="s" color="subdued">
-                  {subscriptionsLabel(standingSession.trigger_subscriptions.length)}
-                </EuiText>
-              </EuiFlexItem>
+              {isActive && (
+                <EuiFlexItem grow={false}>
+                  <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiLoadingSpinner size="s" />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s" color="subdued">
+                        {labels.processing}
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              )}
+              {!isActive && (
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s" color="subdued">
+                    {labels.subscriptions(standingSession.trigger_subscriptions.length)}
+                  </EuiText>
+                </EuiFlexItem>
+              )}
               {standingSession.status !== 'terminated' && (
                 <EuiFlexItem grow={false}>
                   <EuiButton size="s" color="danger" onClick={handleTerminate}>
-                    {terminateLabel}
+                    {labels.terminate}
                   </EuiButton>
                 </EuiFlexItem>
               )}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_detail_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_detail_view.tsx
@@ -10,14 +10,22 @@ import { useParams } from 'react-router-dom';
 import {
   EuiButton,
   EuiCallOut,
+  EuiCode,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
+  EuiPanel,
+  EuiSpacer,
   EuiText,
+  EuiTitle,
+  useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { useQueryClient } from '@kbn/react-query';
+import { ConversationRoundStepType } from '@kbn/agent-builder-common';
 import { useSession } from '../../hooks/use_session';
+import { useFollowExecution } from '../../hooks/use_follow_execution';
 import { AgentBuilderConversationsView } from '../conversations/conversations_view';
 import { SessionStatusBadge } from './session_status_badge';
 import { useAgentBuilderServices } from '../../hooks/use_agent_builder_service';
@@ -38,7 +46,82 @@ const labels = {
   processing: i18n.translate('xpack.agentBuilder.sessionDetail.processingLabel', {
     defaultMessage: 'Processing — messages you send now will be queued',
   }),
+  liveTitle: i18n.translate('xpack.agentBuilder.sessionDetail.liveTitle', {
+    defaultMessage: 'Live activity',
+  }),
+  thinking: i18n.translate('xpack.agentBuilder.sessionDetail.thinking', {
+    defaultMessage: 'Thinking…',
+  }),
 };
+
+// ---------------------------------------------------------------------------
+// Live activity panel — attaches to the running round via useFollowExecution
+// ---------------------------------------------------------------------------
+
+const LiveActivityPanel: React.FC<{ executionId: string }> = ({ executionId }) => {
+  const { euiTheme } = useEuiTheme();
+  const { steps, streamingMessage, isLoading } = useFollowExecution(executionId);
+
+  const panelCss = css`
+    border-left: 3px solid ${euiTheme.colors.success};
+    background: ${euiTheme.colors.backgroundBaseSuccess};
+    padding: ${euiTheme.size.m};
+    overflow-y: auto;
+    max-height: 280px;
+  `;
+
+  const toolCallSteps = steps.filter((s) => s.type === ConversationRoundStepType.toolCall);
+
+  return (
+    <div css={panelCss}>
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="s" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xxxs">
+            <span>{labels.liveTitle}</span>
+          </EuiTitle>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      {toolCallSteps.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+            {toolCallSteps.map((step, i) => {
+              if (step.type !== ConversationRoundStepType.toolCall) return null;
+              return (
+                <EuiFlexItem grow={false} key={i}>
+                  <EuiText size="xs" color="subdued">
+                    <EuiCode>{step.tool_id}</EuiCode>
+                  </EuiText>
+                </EuiFlexItem>
+              );
+            })}
+          </EuiFlexGroup>
+        </>
+      )}
+
+      {(streamingMessage || (isLoading && toolCallSteps.length === 0)) && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiText size="s">
+            {streamingMessage || (
+              <span style={{ color: euiTheme.colors.textSubdued, fontStyle: 'italic' }}>
+                {labels.thinking}
+              </span>
+            )}
+          </EuiText>
+        </>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main view
+// ---------------------------------------------------------------------------
 
 export const AgentBuilderSessionDetailView: React.FC = () => {
   const { conversationId, agentId } = useParams<{ conversationId: string; agentId: string }>();
@@ -47,6 +130,7 @@ export const AgentBuilderSessionDetailView: React.FC = () => {
   const queryClient = useQueryClient();
   const standingSession = session?.state?.standing_session;
   const isActive = standingSession?.status === 'active';
+  const activeExecutionId = standingSession?.active_execution_id ?? null;
 
   const handleTerminate = async () => {
     if (!conversationId) return;
@@ -107,6 +191,13 @@ export const AgentBuilderSessionDetailView: React.FC = () => {
           }
         />
       )}
+
+      {isActive && activeExecutionId && (
+        <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none">
+          <LiveActivityPanel executionId={activeExecutionId} />
+        </EuiPanel>
+      )}
+
       <div style={{ flex: 1, minHeight: 0 }}>
         <AgentBuilderConversationsView />
       </div>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_detail_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_detail_view.tsx
@@ -18,7 +18,7 @@ import { queryKeys } from '../../query_keys';
 
 const standingSessionLabel = i18n.translate(
   'xpack.agentBuilder.sessionDetail.standingSessionLabel',
-  { defaultMessage: 'Standing Session' }
+  { defaultMessage: 'Bot' }
 );
 
 const subscriptionsLabel = (count: number) =>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_detail_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_detail_view.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useQueryClient } from '@kbn/react-query';
+import { useSession } from '../../hooks/use_session';
+import { AgentBuilderConversationsView } from '../conversations/conversations_view';
+import { SessionStatusBadge } from './session_status_badge';
+import { useAgentBuilderServices } from '../../hooks/use_agent_builder_service';
+import { queryKeys } from '../../query_keys';
+
+const standingSessionLabel = i18n.translate(
+  'xpack.agentBuilder.sessionDetail.standingSessionLabel',
+  { defaultMessage: 'Standing Session' }
+);
+
+const subscriptionsLabel = (count: number) =>
+  i18n.translate('xpack.agentBuilder.sessionDetail.subscriptionsLabel', {
+    defaultMessage: '{count} subscription(s)',
+    values: { count },
+  });
+
+const terminateLabel = i18n.translate('xpack.agentBuilder.sessionDetail.terminateLabel', {
+  defaultMessage: 'Terminate',
+});
+
+export const AgentBuilderSessionDetailView: React.FC = () => {
+  const { conversationId, agentId } = useParams<{ conversationId: string; agentId: string }>();
+  const { session } = useSession(conversationId);
+  const { sessionsService } = useAgentBuilderServices();
+  const queryClient = useQueryClient();
+  const standingSession = session?.state?.standing_session;
+
+  const handleTerminate = async () => {
+    if (!conversationId) return;
+    await sessionsService.terminate(conversationId);
+    queryClient.invalidateQueries({ queryKey: queryKeys.sessions.byAgent(agentId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.sessions.byId(conversationId) });
+  };
+
+  const calloutColor =
+    standingSession?.status === 'terminated'
+      ? 'danger'
+      : standingSession?.status === 'active'
+      ? 'success'
+      : 'primary';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {standingSession && (
+        <EuiCallOut
+          size="s"
+          color={calloutColor}
+          iconType="clock"
+          title={
+            <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s">
+                  <strong>{standingSessionLabel}</strong>
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <SessionStatusBadge status={standingSession.status} />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s" color="subdued">
+                  {subscriptionsLabel(standingSession.trigger_subscriptions.length)}
+                </EuiText>
+              </EuiFlexItem>
+              {standingSession.status !== 'terminated' && (
+                <EuiFlexItem grow={false}>
+                  <EuiButton size="s" color="danger" onClick={handleTerminate}>
+                    {terminateLabel}
+                  </EuiButton>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+          }
+        />
+      )}
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <AgentBuilderConversationsView />
+      </div>
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_status_badge.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/session_status_badge.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiBadge } from '@elastic/eui';
+import type { StandingSessionStatus } from '@kbn/agent-builder-common';
+
+interface Props {
+  status: StandingSessionStatus;
+}
+
+const colorMap: Record<StandingSessionStatus, string> = {
+  idle: 'default',
+  active: 'success',
+  terminated: 'danger',
+};
+
+export const SessionStatusBadge: React.FC<Props> = ({ status }) => {
+  return <EuiBadge color={colorMap[status]}>{status}</EuiBadge>;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/sessions_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/sessions_view.tsx
@@ -37,10 +37,10 @@ import { SessionStatusBadge } from './session_status_badge';
 
 const labels = {
   title: i18n.translate('xpack.agentBuilder.sessions.view.title', {
-    defaultMessage: 'Sessions',
+    defaultMessage: 'Bots',
   }),
   newSession: i18n.translate('xpack.agentBuilder.sessions.view.newSession', {
-    defaultMessage: 'New session',
+    defaultMessage: 'New bot',
   }),
   columnName: i18n.translate('xpack.agentBuilder.sessions.view.column.name', {
     defaultMessage: 'Name',
@@ -64,10 +64,10 @@ const labels = {
     defaultMessage: 'Terminate',
   }),
   emptyState: i18n.translate('xpack.agentBuilder.sessions.view.emptyState', {
-    defaultMessage: 'No sessions yet. Create one to get started.',
+    defaultMessage: 'No bots yet. Create one to get started.',
   }),
   modalTitle: i18n.translate('xpack.agentBuilder.sessions.view.modal.title', {
-    defaultMessage: 'New session',
+    defaultMessage: 'New bot',
   }),
   modalNameLabel: i18n.translate('xpack.agentBuilder.sessions.view.modal.nameLabel', {
     defaultMessage: 'Name',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/sessions_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/sessions/sessions_view.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  EuiBasicTable,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiForm,
+  EuiFormRow,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiPageHeader,
+  EuiSpacer,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import type { ConversationWithoutRounds, StandingSessionStatus } from '@kbn/agent-builder-common';
+import { useQueryClient } from '@kbn/react-query';
+import { useSessionList } from '../../hooks/use_session_list';
+import { useAgentBuilderServices } from '../../hooks/use_agent_builder_service';
+import { useNavigation } from '../../hooks/use_navigation';
+import { queryKeys } from '../../query_keys';
+import { appPaths } from '../../utils/app_paths';
+import { SessionStatusBadge } from './session_status_badge';
+
+const labels = {
+  title: i18n.translate('xpack.agentBuilder.sessions.view.title', {
+    defaultMessage: 'Sessions',
+  }),
+  newSession: i18n.translate('xpack.agentBuilder.sessions.view.newSession', {
+    defaultMessage: 'New session',
+  }),
+  columnName: i18n.translate('xpack.agentBuilder.sessions.view.column.name', {
+    defaultMessage: 'Name',
+  }),
+  columnStatus: i18n.translate('xpack.agentBuilder.sessions.view.column.status', {
+    defaultMessage: 'Status',
+  }),
+  columnSubscriptions: i18n.translate('xpack.agentBuilder.sessions.view.column.subscriptions', {
+    defaultMessage: 'Subscriptions',
+  }),
+  columnLastActive: i18n.translate('xpack.agentBuilder.sessions.view.column.lastActive', {
+    defaultMessage: 'Last active',
+  }),
+  columnActions: i18n.translate('xpack.agentBuilder.sessions.view.column.actions', {
+    defaultMessage: 'Actions',
+  }),
+  openAction: i18n.translate('xpack.agentBuilder.sessions.view.action.open', {
+    defaultMessage: 'Open',
+  }),
+  terminateAction: i18n.translate('xpack.agentBuilder.sessions.view.action.terminate', {
+    defaultMessage: 'Terminate',
+  }),
+  emptyState: i18n.translate('xpack.agentBuilder.sessions.view.emptyState', {
+    defaultMessage: 'No sessions yet. Create one to get started.',
+  }),
+  modalTitle: i18n.translate('xpack.agentBuilder.sessions.view.modal.title', {
+    defaultMessage: 'New session',
+  }),
+  modalNameLabel: i18n.translate('xpack.agentBuilder.sessions.view.modal.nameLabel', {
+    defaultMessage: 'Name',
+  }),
+  modalCancelButton: i18n.translate('xpack.agentBuilder.sessions.view.modal.cancel', {
+    defaultMessage: 'Cancel',
+  }),
+  modalCreateButton: i18n.translate('xpack.agentBuilder.sessions.view.modal.create', {
+    defaultMessage: 'Create',
+  }),
+};
+
+export const AgentBuilderSessionsView: React.FC = () => {
+  const { agentId } = useParams<{ agentId: string }>();
+  const { sessions = [], isLoading } = useSessionList({ agentId });
+  const { sessionsService } = useAgentBuilderServices();
+  const { navigateToAgentBuilderUrl } = useNavigation();
+  const queryClient = useQueryClient();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newSessionName, setNewSessionName] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+
+  const modalTitleId = useGeneratedHtmlId({ prefix: 'newSessionModal' });
+
+  const handleTerminate = useCallback(
+    async (sessionId: string) => {
+      await sessionsService.terminate(sessionId);
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessions.byAgent(agentId) });
+    },
+    [sessionsService, queryClient, agentId]
+  );
+
+  const handleCreate = useCallback(async () => {
+    if (!newSessionName.trim()) return;
+    setIsCreating(true);
+    try {
+      await sessionsService.create({ agent_id: agentId, name: newSessionName.trim() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessions.byAgent(agentId) });
+      setIsModalOpen(false);
+      setNewSessionName('');
+    } finally {
+      setIsCreating(false);
+    }
+  }, [sessionsService, queryClient, agentId, newSessionName]);
+
+  const columns: Array<EuiBasicTableColumn<ConversationWithoutRounds>> = [
+    {
+      field: 'title',
+      name: labels.columnName,
+      truncateText: true,
+    },
+    {
+      name: labels.columnStatus,
+      render: (session: ConversationWithoutRounds) => {
+        const status = session.state?.standing_session?.status as StandingSessionStatus | undefined;
+        return status ? <SessionStatusBadge status={status} /> : null;
+      },
+    },
+    {
+      name: labels.columnSubscriptions,
+      render: (session: ConversationWithoutRounds) => {
+        const count = session.state?.standing_session?.trigger_subscriptions?.length ?? 0;
+        return <EuiText size="s">{count}</EuiText>;
+      },
+    },
+    {
+      name: labels.columnLastActive,
+      render: (session: ConversationWithoutRounds) => {
+        const lastActiveAt = session.state?.standing_session?.last_active_at;
+        return (
+          <EuiText size="s">{lastActiveAt ? new Date(lastActiveAt).toLocaleString() : '—'}</EuiText>
+        );
+      },
+    },
+    {
+      name: labels.columnActions,
+      actions: [
+        {
+          name: labels.openAction,
+          description: labels.openAction,
+          type: 'button',
+          onClick: (session: ConversationWithoutRounds) => {
+            navigateToAgentBuilderUrl(
+              appPaths.agent.sessions.byId({ agentId, sessionId: session.id })
+            );
+          },
+        },
+        {
+          name: labels.terminateAction,
+          description: labels.terminateAction,
+          type: 'button',
+          color: 'danger',
+          available: (session: ConversationWithoutRounds) =>
+            session.state?.standing_session?.status !== 'terminated',
+          onClick: (session: ConversationWithoutRounds) => {
+            handleTerminate(session.id);
+          },
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={labels.title}
+        rightSideItems={[
+          <EuiButton
+            key="new-session"
+            iconType="plus"
+            onClick={() => setIsModalOpen(true)}
+            data-test-subj="agentBuilderSessionsNewButton"
+          >
+            {labels.newSession}
+          </EuiButton>,
+        ]}
+      />
+      <EuiSpacer size="m" />
+      <EuiBasicTable
+        items={sessions}
+        columns={columns}
+        loading={isLoading}
+        noItemsMessage={labels.emptyState}
+        data-test-subj="agentBuilderSessionsTable"
+      />
+
+      {isModalOpen && (
+        <EuiModal onClose={() => setIsModalOpen(false)} aria-labelledby={modalTitleId}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle id={modalTitleId}>{labels.modalTitle}</EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <EuiForm>
+              <EuiFormRow label={labels.modalNameLabel}>
+                <EuiFieldText
+                  value={newSessionName}
+                  onChange={(e) => setNewSessionName(e.target.value)}
+                  data-test-subj="agentBuilderSessionsModalNameInput"
+                  autoFocus
+                />
+              </EuiFormRow>
+            </EuiForm>
+          </EuiModalBody>
+          <EuiModalFooter>
+            <EuiButtonEmpty onClick={() => setIsModalOpen(false)}>
+              {labels.modalCancelButton}
+            </EuiButtonEmpty>
+            <EuiButton
+              fill
+              onClick={handleCreate}
+              isLoading={isCreating}
+              isDisabled={!newSessionName.trim()}
+              data-test-subj="agentBuilderSessionsModalCreateButton"
+            >
+              {labels.modalCreateButton}
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_session.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_session.ts
@@ -23,7 +23,11 @@ export const useSession = (sessionId: string | undefined) => {
     enabled: !!sessionId,
     refetchInterval: (data) => {
       const status = (data as Conversation | undefined)?.state?.standing_session?.status;
-      return status === 'active' ? 3000 : false;
+      // Poll aggressively when active so live-status transitions are near-instant.
+      // Poll gently when idle so we notice when a new round starts.
+      if (status === 'active') return 1000;
+      if (status === 'idle') return 2000;
+      return false; // terminated — no need to keep polling
     },
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_session.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_session.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import type { Conversation } from '@kbn/agent-builder-common';
+import { queryKeys } from '../query_keys';
+import { useAgentBuilderServices } from './use_agent_builder_service';
+
+export const useSession = (sessionId: string | undefined) => {
+  const { sessionsService } = useAgentBuilderServices();
+
+  const {
+    data: session,
+    isLoading,
+    refetch,
+  } = useQuery<Conversation>({
+    queryKey: queryKeys.sessions.byId(sessionId ?? ''),
+    queryFn: () => sessionsService.get(sessionId!),
+    enabled: !!sessionId,
+    refetchInterval: (data) => {
+      const status = (data as Conversation | undefined)?.state?.standing_session?.status;
+      return status === 'active' ? 3000 : false;
+    },
+  });
+
+  return { session, isLoading, refetch };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_session_list.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_session_list.ts
@@ -21,6 +21,12 @@ export const useSessionList = ({ agentId }: { agentId?: string } = {}) => {
     queryFn: () => {
       return sessionsService.list({ agentId });
     },
+    // Poll every 2s so sidebar status dots and the list page update promptly.
+    refetchInterval: (data) => {
+      const list = data as typeof sessions;
+      const hasActive = list?.some((s) => s.state?.standing_session?.status === 'active');
+      return hasActive ? 1000 : 2000;
+    },
   });
 
   return {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_session_list.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_session_list.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { queryKeys } from '../query_keys';
+import { useAgentBuilderServices } from './use_agent_builder_service';
+
+export const useSessionList = ({ agentId }: { agentId?: string } = {}) => {
+  const { sessionsService } = useAgentBuilderServices();
+
+  const {
+    data: sessions,
+    isLoading,
+    refetch: refresh,
+  } = useQuery({
+    queryKey: agentId ? queryKeys.sessions.byAgent(agentId) : queryKeys.sessions.all,
+    queryFn: () => {
+      return sessionsService.list({ agentId });
+    },
+  });
+
+  return {
+    sessions,
+    isLoading,
+    refresh,
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/session_detail.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/session_detail.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { useBreadcrumb } from '../hooks/use_breadcrumbs';
+import { AgentBuilderSessionDetailView } from '../components/sessions/session_detail_view';
+
+const sessionTitle = i18n.translate('xpack.agentBuilder.session.title', {
+  defaultMessage: 'Session',
+});
+
+export const AgentBuilderSessionDetailPage: React.FC = () => {
+  useBreadcrumb([{ text: sessionTitle, path: '/' }]);
+  return <AgentBuilderSessionDetailView />;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/sessions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/sessions.tsx
@@ -12,7 +12,7 @@ import { appPaths } from '../utils/app_paths';
 import { AgentBuilderSessionsView } from '../components/sessions/sessions_view';
 
 const sessionsTitle = i18n.translate('xpack.agentBuilder.sessions.title', {
-  defaultMessage: 'Sessions',
+  defaultMessage: 'Bots',
 });
 
 export const AgentBuilderSessionsPage: React.FC = () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/sessions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/sessions.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { useBreadcrumb } from '../hooks/use_breadcrumbs';
+import { appPaths } from '../utils/app_paths';
+import { AgentBuilderSessionsView } from '../components/sessions/sessions_view';
+
+const sessionsTitle = i18n.translate('xpack.agentBuilder.sessions.title', {
+  defaultMessage: 'Sessions',
+});
+
+export const AgentBuilderSessionsPage: React.FC = () => {
+  useBreadcrumb([{ text: sessionsTitle, path: appPaths.root }]);
+  return <AgentBuilderSessionsView />;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
@@ -61,4 +61,9 @@ export const queryKeys = {
   connectors: {
     all: ['connectors'] as const,
   },
+  sessions: {
+    all: ['sessions'] as const,
+    byAgent: (agentId: string) => ['sessions', 'list', { agentId }],
+    byId: (sessionId: string) => ['sessions', sessionId],
+  },
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -68,7 +68,7 @@ const navLabels = {
     defaultMessage: 'Agents',
   }),
   sessions: i18n.translate('xpack.agentBuilder.routeConfig.sessions', {
-    defaultMessage: 'Sessions',
+    defaultMessage: 'Bots',
   }),
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -10,6 +10,8 @@ import { matchPath } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 
 import { AgentBuilderConversationsPage } from './pages/conversations';
+import { AgentBuilderSessionsPage } from './pages/sessions';
+import { AgentBuilderSessionDetailPage } from './pages/session_detail';
 import { AgentBuilderAgentsPage } from './pages/agents';
 import { AgentBuilderAgentsCreate } from './pages/agent_create';
 import { AgentBuilderAgentsEdit } from './pages/agent_edit';
@@ -65,10 +67,26 @@ const navLabels = {
   agents: i18n.translate('xpack.agentBuilder.routeConfig.agents', {
     defaultMessage: 'Agents',
   }),
+  sessions: i18n.translate('xpack.agentBuilder.routeConfig.sessions', {
+    defaultMessage: 'Sessions',
+  }),
 };
 
 // Routes ordered from most specific to least specific for correct matching
 export const agentRoutes: RouteDefinition[] = [
+  {
+    path: '/agents/:agentId/sessions/:conversationId',
+    viewId: agentBuilderViewIds.agentSession,
+    sidebarView: 'conversation',
+    element: <AgentBuilderSessionDetailPage />,
+  },
+  {
+    path: '/agents/:agentId/sessions',
+    viewId: agentBuilderViewIds.agentSessions,
+    sidebarView: 'conversation',
+    navLabel: navLabels.sessions,
+    element: <AgentBuilderSessionsPage />,
+  },
   {
     path: '/agents/:agentId/conversations/:conversationId',
     viewId: agentBuilderViewIds.agentConversation,
@@ -226,6 +244,11 @@ export const getAgentIdFromPath = (pathname: string): string | undefined => {
 
 export const getConversationIdFromPath = (pathname: string): string | undefined => {
   const match = pathname.match(/^\/agents\/[^/]+\/conversations\/([^/]+)/);
+  return match ? match[1] : undefined;
+};
+
+export const getSessionIdFromPath = (pathname: string): string | undefined => {
+  const match = pathname.match(/^\/agents\/[^/]+\/sessions\/([^/]+)/);
   return match ? match[1] : undefined;
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
@@ -16,6 +16,11 @@ export const appPaths = {
       byId: ({ agentId, conversationId }: { agentId: string; conversationId: string }) =>
         `/agents/${agentId}/conversations/${conversationId}`,
     },
+    sessions: {
+      list: ({ agentId }: { agentId: string }) => `/agents/${agentId}/sessions`,
+      byId: ({ agentId, sessionId }: { agentId: string; sessionId: string }) =>
+        `/agents/${agentId}/sessions/${sessionId}`,
+    },
     skills: ({ agentId }: { agentId: string }) => `/agents/${agentId}/skills`,
     plugins: ({ agentId }: { agentId: string }) => `/agents/${agentId}/plugins`,
     tools: ({ agentId }: { agentId: string }) => `/agents/${agentId}/tools`,

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -42,6 +42,7 @@ import {
   SmlService,
   PluginsService,
   EventsService,
+  SessionsService,
   type AgentBuilderInternalService,
 } from './services';
 import { createPublicAttachmentContract } from './services/attachments';
@@ -158,6 +159,7 @@ export class AgentBuilderPlugin
     const skillsService = new SkillsService({ http });
     const smlService = new SmlService({ http });
     const pluginsService = new PluginsService({ http });
+    const sessionsService = new SessionsService({ http });
     const accessChecker = new AgentBuilderAccessChecker({ licensing, inference });
 
     if (!this.setupServices) {
@@ -221,6 +223,7 @@ export class AgentBuilderPlugin
       usageCollection,
       accessChecker,
       eventsService,
+      sessionsService,
       isEarsEnabled: this.isEarsEnabled,
       openSidebarConversation: (options?: OpenConversationSidebarOptions) => {
         return openSidebarInternal(options);

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/index.ts
@@ -17,4 +17,5 @@ export { SkillsService } from './skills/skills_service';
 export { SmlService } from './sml/sml_service';
 export { PluginsService } from './plugins/plugins_service';
 export { EventsService } from './events';
+export { SessionsService } from './sessions';
 export type { AgentBuilderInternalService } from './types';

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/sessions/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/sessions/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { SessionsService } from './sessions_service';

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/sessions/sessions_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/sessions/sessions_service.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpSetup } from '@kbn/core-http-browser';
+import type { Conversation, ConversationWithoutRounds } from '@kbn/agent-builder-common';
+import { internalApiPath } from '../../../common/constants';
+
+export class SessionsService {
+  private readonly http: HttpSetup;
+
+  constructor({ http }: { http: HttpSetup }) {
+    this.http = http;
+  }
+
+  async list({ agentId }: { agentId?: string }): Promise<ConversationWithoutRounds[]> {
+    const response = await this.http.get<{ sessions: ConversationWithoutRounds[] }>(
+      `${internalApiPath}/sessions`,
+      { query: { agent_id: agentId } }
+    );
+    return response.sessions;
+  }
+
+  async get(sessionId: string): Promise<Conversation> {
+    return this.http.get<Conversation>(`${internalApiPath}/sessions/${sessionId}`);
+  }
+
+  async create(params: {
+    agent_id: string;
+    name: string;
+    system_prompt_override?: string;
+    connector_id?: string;
+    ttl_seconds?: number;
+  }): Promise<Conversation> {
+    return this.http.post<Conversation>(`${internalApiPath}/sessions`, {
+      body: JSON.stringify(params),
+    });
+  }
+
+  async terminate(sessionId: string): Promise<void> {
+    await this.http.delete(`${internalApiPath}/sessions/${sessionId}`);
+  }
+
+  async sendMessage(sessionId: string, message: string): Promise<{ status: string }> {
+    return this.http.post<{ status: string }>(`${internalApiPath}/sessions/${sessionId}/messages`, {
+      body: JSON.stringify({ message }),
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
@@ -20,6 +20,7 @@ import type { SmlService } from './sml/sml_service';
 import type { PluginsService } from './plugins/plugins_service';
 import type { NavigationService } from './navigation';
 import type { EventsService } from './events';
+import type { SessionsService } from './sessions/sessions_service';
 
 export interface AgentBuilderInternalService {
   agentService: AgentService;
@@ -36,6 +37,7 @@ export interface AgentBuilderInternalService {
   usageCollection?: UsageCollectionSetup;
   accessChecker: AgentBuilderAccessChecker;
   eventsService: EventsService;
+  sessionsService: SessionsService;
   isEarsEnabled: boolean;
   openSidebarConversation: (
     options?: OpenConversationSidebarOptions

--- a/x-pack/platform/plugins/shared/agent_builder/server/config.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/config.ts
@@ -23,7 +23,7 @@ export const configSchema = schema.object({
     numWords: schema.number({ defaultValue: 750, min: 1, max: 5000 }),
   }),
   tracing: schema.object({
-    send_to_self: schema.boolean({ defaultValue: true }),
+    send_to_self: schema.boolean({ defaultValue: false }),
     exporters: schema.arrayOf(
       schema.object({
         url: schema.uri({ scheme: ['http', 'https'] }),

--- a/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
@@ -73,6 +73,19 @@ const createStartContractMock = (): AgentBuilderPluginStartMock => {
         list: jest.fn(),
       }),
     },
+    sessions: {
+      getScopedClient: jest.fn().mockReturnValue({
+        create: jest.fn(),
+        get: jest.fn(),
+        list: jest.fn(),
+        terminate: jest.fn(),
+        enqueueTrigger: jest.fn(),
+        drainQueue: jest.fn(),
+        addSubscription: jest.fn(),
+        removeSubscription: jest.fn(),
+        setStatus: jest.fn(),
+      }),
+    },
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -46,6 +46,7 @@ import {
   registerAgentSessionTriggerTasks,
   registerAgentSessionAlertConnectorType,
 } from './services/sessions';
+import { createWorkflowSessionTool } from './services/sessions/workflow_session_tool';
 
 export class AgentBuilderPlugin
   implements
@@ -231,6 +232,20 @@ export class AgentBuilderPlugin
     sessionTools.forEach((tool) => {
       serviceSetups.tools.register(tool);
     });
+
+    if (setupDeps.workflowsManagement) {
+      const workflowSessionTool = createWorkflowSessionTool(
+        {
+          getScopedClient: ({ request }) => {
+            const services = this.serviceManager.internalStart;
+            if (!services) throw new Error('Session service not yet initialized');
+            return services.sessions.getScopedClient({ request });
+          },
+        },
+        setupDeps.workflowsManagement.management
+      );
+      serviceSetups.tools.register(workflowSessionTool);
+    }
 
     return {
       tools: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -46,7 +46,7 @@ import {
   registerAgentSessionTriggerTasks,
   registerAgentSessionAlertConnectorType,
 } from './services/sessions';
-import { createWorkflowSessionTool } from './services/sessions/workflow_session_tool';
+import { createWorkflowSessionTools } from './services/sessions/workflow_session_tool';
 
 export class AgentBuilderPlugin
   implements
@@ -234,7 +234,7 @@ export class AgentBuilderPlugin
     });
 
     if (setupDeps.workflowsManagement) {
-      const workflowSessionTool = createWorkflowSessionTool(
+      const workflowSessionTools = createWorkflowSessionTools(
         {
           getScopedClient: ({ request }) => {
             const services = this.serviceManager.internalStart;
@@ -244,7 +244,7 @@ export class AgentBuilderPlugin
         },
         setupDeps.workflowsManagement.management
       );
-      serviceSetups.tools.register(workflowSessionTool);
+      workflowSessionTools.forEach((tool) => serviceSetups.tools.register(tool));
     }
 
     return {

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -9,6 +9,7 @@ import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kb
 import type { Logger } from '@kbn/logging';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { HomeServerPluginSetup } from '@kbn/home-plugin/server';
+import { createSessionTools } from '@kbn/agent-builder-server';
 import type { AgentBuilderConfig } from './config';
 import { registerTracingExporter } from './tracing/register_tracing';
 import { ServiceManager } from './services';
@@ -21,7 +22,11 @@ import type {
 import { registerFeatures } from './features';
 import { registerRoutes } from './routes';
 import { registerUISettings } from './ui_settings';
-import { getRunAgentStepDefinition, rerankStepDefinition } from './step_types';
+import {
+  getRunAgentStepDefinition,
+  rerankStepDefinition,
+  getSendSessionMessageStepDefinition,
+} from './step_types';
 import type { AgentBuilderHandlerContext } from './request_handler_context';
 import { registerAgentBuilderHandlerContext } from './request_handler_context';
 import { createAgentBuilderUsageCounter } from './telemetry/usage_counters';
@@ -37,6 +42,10 @@ import { createSmlTools } from './services/tools/builtin/sml';
 import { createConnectorTools } from './services/tools/builtin/connectors';
 import { createAdminPrivilegeSwitcher } from './capabilities/admin_privilege_switcher';
 import { registerInferenceFeatures } from './inference_features';
+import {
+  registerAgentSessionTriggerTasks,
+  registerAgentSessionAlertConnectorType,
+} from './services/sessions';
 
 export class AgentBuilderPlugin
   implements
@@ -108,6 +117,29 @@ export class AgentBuilderPlugin
       },
     });
 
+    registerAgentSessionTriggerTasks({
+      taskManager: setupDeps.taskManager,
+      logger: this.logger.get('sessions'),
+      getSessionsStart: () => {
+        const services = this.serviceManager.internalStart;
+        if (!services) {
+          throw new Error('getSessionsStart called before service init');
+        }
+        return services.sessions;
+      },
+    });
+
+    registerAgentSessionAlertConnectorType(setupDeps.actions, {
+      logger: this.logger.get('sessions'),
+      getSessionsStart: () => {
+        const services = this.serviceManager.internalStart;
+        if (!services) {
+          throw new Error('getSessionsStart called before service init');
+        }
+        return services.sessions;
+      },
+    });
+
     registerFeatures({ features: setupDeps.features });
 
     // Phantom capability: not a registered feature privilege. Used as an admin check
@@ -129,6 +161,9 @@ export class AgentBuilderPlugin
       getRunAgentStepDefinition(this.serviceManager)
     );
     setupDeps.workflowsExtensions.registerStepDefinition(rerankStepDefinition);
+    setupDeps.workflowsExtensions.registerStepDefinition(
+      getSendSessionMessageStepDefinition(this.serviceManager)
+    );
 
     registerAgentBuilderHandlerContext({ coreSetup });
 
@@ -184,6 +219,19 @@ export class AgentBuilderPlugin
       serviceSetups.tools.register(tool);
     });
 
+    const sessionTools = createSessionTools({
+      getScopedClient: ({ request }) => {
+        const services = this.serviceManager.internalStart;
+        if (!services) {
+          throw new Error('Session service not yet initialized');
+        }
+        return services.sessions.getScopedClient({ request });
+      },
+    });
+    sessionTools.forEach((tool) => {
+      serviceSetups.tools.register(tool);
+    });
+
     return {
       tools: {
         register: serviceSetups.tools.register.bind(serviceSetups.tools),
@@ -216,7 +264,8 @@ export class AgentBuilderPlugin
     }).then((teardownTracing) => {
       this.teardownTracing = teardownTracing;
     });
-    const { inference, spaces, actions, taskManager, searchInferenceEndpoints } = startDeps;
+    const { inference, spaces, actions, taskManager, searchInferenceEndpoints, alerting } =
+      startDeps;
     const { elasticsearch, security, uiSettings, savedObjects, dataStreams, featureFlags } =
       coreStart;
 
@@ -239,9 +288,10 @@ export class AgentBuilderPlugin
       trackingService: this.trackingService,
       analyticsService: this.analyticsService,
       searchInferenceEndpoints,
+      alerting,
     });
 
-    const { tools, agents, skills, runnerFactory, execution, plugins, conversations } =
+    const { tools, agents, skills, runnerFactory, execution, plugins, conversations, sessions } =
       startServices;
     const runner = runnerFactory.getRunner();
 
@@ -290,6 +340,9 @@ export class AgentBuilderPlugin
             list: client.list.bind(client),
           };
         },
+      },
+      sessions: {
+        getScopedClient: ({ request }) => sessions.getScopedClient({ request }),
       },
     };
   }

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/index.ts
@@ -23,6 +23,7 @@ import { registerA2ARoutes } from './a2a';
 import { registerSkillsRoutes } from './skills';
 import { registerPluginsRoutes } from './plugins';
 import { registerInternalExecutionRoutes } from './internal/executions';
+import { registerInternalSessionRoutes } from './internal/sessions';
 
 export const registerRoutes = (dependencies: RouteDependencies) => {
   registerToolsRoutes(dependencies);
@@ -42,4 +43,5 @@ export const registerRoutes = (dependencies: RouteDependencies) => {
   registerSkillsRoutes(dependencies);
   registerPluginsRoutes(dependencies);
   registerInternalExecutionRoutes(dependencies);
+  registerInternalSessionRoutes(dependencies);
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/sessions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/sessions.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { schema } from '@kbn/config-schema';
+import type { RouteDependencies } from '../types';
+import { getHandlerWrapper } from '../wrap_handler';
+import { apiPrivileges } from '../../../common/features';
+import { internalApiPath } from '../../../common/constants';
+
+export function registerInternalSessionRoutes({
+  router,
+  getInternalServices,
+  logger,
+}: RouteDependencies) {
+  const wrapHandler = getHandlerWrapper({ logger });
+
+  // ---------------------------------------------------------------------------
+  // POST /internal/agent_builder/sessions — create a standing session
+  // ---------------------------------------------------------------------------
+  router.post(
+    {
+      path: `${internalApiPath}/sessions`,
+      validate: {
+        body: schema.object({
+          agent_id: schema.string(),
+          name: schema.string(),
+          system_prompt_override: schema.maybe(schema.string()),
+          ttl_seconds: schema.maybe(schema.number()),
+          connector_id: schema.maybe(schema.string()),
+        }),
+      },
+      options: { access: 'internal' },
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.writeAgentBuilder] },
+      },
+    },
+    wrapHandler(async (_ctx, request, response) => {
+      const { sessions } = getInternalServices();
+      const client = sessions.getScopedClient({ request });
+
+      const session = await client.create({
+        agent_id: request.body.agent_id,
+        name: request.body.name,
+        system_prompt_override: request.body.system_prompt_override,
+        ttl_seconds: request.body.ttl_seconds,
+        connector_id: request.body.connector_id,
+      });
+
+      return response.ok({ body: session });
+    })
+  );
+
+  // ---------------------------------------------------------------------------
+  // GET /internal/agent_builder/sessions — list standing sessions
+  // ---------------------------------------------------------------------------
+  router.get(
+    {
+      path: `${internalApiPath}/sessions`,
+      validate: {
+        query: schema.object({
+          agent_id: schema.maybe(schema.string()),
+        }),
+      },
+      options: { access: 'internal' },
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.readAgentBuilder] },
+      },
+    },
+    wrapHandler(async (_ctx, request, response) => {
+      const { sessions } = getInternalServices();
+      const client = sessions.getScopedClient({ request });
+
+      const list = await client.list({
+        agent_id: request.query.agent_id,
+      });
+
+      return response.ok({ body: { sessions: list } });
+    })
+  );
+
+  // ---------------------------------------------------------------------------
+  // GET /internal/agent_builder/sessions/{id} — get a single session
+  // ---------------------------------------------------------------------------
+  router.get(
+    {
+      path: `${internalApiPath}/sessions/{id}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+      options: { access: 'internal' },
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.readAgentBuilder] },
+      },
+    },
+    wrapHandler(async (_ctx, request, response) => {
+      const { sessions } = getInternalServices();
+      const client = sessions.getScopedClient({ request });
+
+      const session = await client.get(request.params.id);
+      return response.ok({ body: session });
+    })
+  );
+
+  // ---------------------------------------------------------------------------
+  // DELETE /internal/agent_builder/sessions/{id} — terminate a session
+  // ---------------------------------------------------------------------------
+  router.delete(
+    {
+      path: `${internalApiPath}/sessions/{id}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+      options: { access: 'internal' },
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.writeAgentBuilder] },
+      },
+    },
+    wrapHandler(async (_ctx, request, response) => {
+      const { sessions } = getInternalServices();
+      const client = sessions.getScopedClient({ request });
+
+      await client.terminate(request.params.id);
+      return response.ok({ body: { terminated: true } });
+    })
+  );
+
+  // ---------------------------------------------------------------------------
+  // POST /internal/agent_builder/sessions/{id}/messages — inject a message
+  // ---------------------------------------------------------------------------
+  router.post(
+    {
+      path: `${internalApiPath}/sessions/{id}/messages`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+        body: schema.object({
+          message: schema.string(),
+        }),
+      },
+      options: { access: 'internal' },
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.writeAgentBuilder] },
+      },
+    },
+    wrapHandler(async (_ctx, request, response) => {
+      const { sessions } = getInternalServices();
+      const client = sessions.getScopedClient({ request });
+
+      // Resolve the session's agent_id for attribution before injecting.
+      const session = await client.get(request.params.id);
+      const result = await client.enqueueTrigger(request.params.id, {
+        type: 'session_message',
+        subscription_id: undefined,
+        event: {
+          from_session_id: request.params.id,
+          from_agent_id: session.agent_id,
+          message: request.body.message,
+          message_id: uuidv4(),
+        },
+      });
+
+      return response.ok({ body: result });
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -167,34 +167,58 @@ class ConversationClientImpl implements ConversationClient {
 
   async update(conversationUpdate: ConversationUpdateRequest): Promise<Conversation> {
     const { id: conversationId } = conversationUpdate;
-    const now = new Date();
-    const document = await this._get(conversationUpdate.id);
-    if (!document) {
-      throw createConversationNotFoundError({ conversationId });
+    const MAX_RETRIES = 3;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      const now = new Date();
+      const document = await this._get(conversationUpdate.id);
+      if (!document) {
+        throw createConversationNotFoundError({ conversationId });
+      }
+
+      if (!hasAccess({ conversation: document, user: this.user })) {
+        throw createConversationNotFoundError({ conversationId });
+      }
+
+      const storedConversation = fromEs(document);
+
+      // On retry: merge only the rounds that aren't already stored so that
+      // rounds written by a concurrent execution are preserved.
+      const effectiveUpdate =
+        attempt === 0 || !conversationUpdate.rounds
+          ? conversationUpdate
+          : mergeRoundsForRetry(storedConversation, conversationUpdate);
+
+      const updatedConversation = updateConversation({
+        conversation: storedConversation,
+        update: effectiveUpdate,
+        updateDate: now,
+        space: this.space,
+      });
+      const attributes = toEs(updatedConversation, this.space);
+
+      try {
+        await this.storage.getClient().index({
+          id: conversationUpdate.id,
+          document: attributes,
+          // use optimistic concurrency control to prevent concurrent update conflicts
+          if_seq_no: document._seq_no,
+          if_primary_term: document._primary_term,
+        });
+        return this.get(conversationUpdate.id);
+      } catch (err) {
+        const statusCode =
+          (err as { meta?: { statusCode?: number }; statusCode?: number })?.meta?.statusCode ??
+          (err as { statusCode?: number })?.statusCode;
+
+        if (statusCode === 409 && attempt < MAX_RETRIES - 1) {
+          continue;
+        }
+        throw err;
+      }
     }
 
-    if (!hasAccess({ conversation: document, user: this.user })) {
-      throw createConversationNotFoundError({ conversationId });
-    }
-
-    const storedConversation = fromEs(document);
-    const updatedConversation = updateConversation({
-      conversation: storedConversation,
-      update: conversationUpdate,
-      updateDate: now,
-      space: this.space,
-    });
-    const attributes = toEs(updatedConversation, this.space);
-
-    await this.storage.getClient().index({
-      id: conversationUpdate.id,
-      document: attributes,
-      // use optimistic concurrency control to prevent concurrent update conflicts
-      if_seq_no: document._seq_no,
-      if_primary_term: document._primary_term,
-    });
-
-    return this.get(conversationUpdate.id);
+    throw createConversationNotFoundError({ conversationId });
   }
 
   async delete(conversationId: string): Promise<boolean> {
@@ -229,6 +253,23 @@ class ConversationClientImpl implements ConversationClient {
     }
   }
 }
+
+/**
+ * On a 409 OCC retry, merge the update's rounds with the freshly-read stored
+ * conversation so that rounds written by a concurrent execution are preserved.
+ * Only rounds whose IDs are absent from the stored conversation are appended.
+ */
+const mergeRoundsForRetry = (
+  stored: { rounds: Array<{ id: string }> },
+  update: ConversationUpdateRequest
+): ConversationUpdateRequest => {
+  const storedIds = new Set(stored.rounds.map((r) => r.id));
+  const newRounds = (update.rounds ?? []).filter((r) => !storedIds.has(r.id));
+  return {
+    ...update,
+    rounds: [...stored.rounds, ...newRounds] as ConversationUpdateRequest['rounds'],
+  };
+};
 
 const hasAccess = ({
   conversation,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -106,6 +106,7 @@ class ConversationClientImpl implements ConversationClient {
         'created_at',
         'updated_at',
         'session_mode',
+        'state',
       ],
       query: {
         bool: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -74,12 +74,39 @@ class ConversationClientImpl implements ConversationClient {
   }
 
   async list(options: ConversationListOptions = {}): Promise<ConversationWithoutRounds[]> {
-    const { agentId } = options;
+    const { agentId, sessionMode } = options;
+
+    const sessionModeFilter = (() => {
+      if (sessionMode === 'standing') {
+        return [{ term: { session_mode: 'standing' } }];
+      }
+      if (sessionMode === 'interactive') {
+        return [
+          {
+            bool: {
+              should: [
+                { term: { session_mode: 'interactive' } },
+                { bool: { must_not: { exists: { field: 'session_mode' } } } },
+              ],
+            },
+          },
+        ];
+      }
+      return [];
+    })();
 
     const response = await this.storage.getClient().search({
       track_total_hits: false,
       size: 1000,
-      _source: ['agent_id', 'user_id', 'user_name', 'title', 'created_at', 'updated_at'],
+      _source: [
+        'agent_id',
+        'user_id',
+        'user_name',
+        'title',
+        'created_at',
+        'updated_at',
+        'session_mode',
+      ],
       query: {
         bool: {
           filter: [createSpaceDslFilter(this.space)],
@@ -88,6 +115,7 @@ class ConversationClientImpl implements ConversationClient {
               term: { user_name: this.user.username },
             },
             ...(agentId ? [{ term: { agent_id: agentId } }] : []),
+            ...sessionModeFilter,
           ],
         },
       },

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -218,7 +218,11 @@ export const fromEs = (document: Document): Conversation => {
 };
 
 export const fromEsWithoutRounds = (document: Document): ConversationWithoutRounds => {
-  return convertBaseFromEs(document);
+  const base = convertBaseFromEs(document);
+  return {
+    ...base,
+    ...(document._source!.state && { state: document._source!.state }),
+  };
 };
 
 export const toEs = (conversation: Conversation, space: string): ConversationProperties => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -13,6 +13,7 @@ import type {
   ConversationWithoutRounds,
   ToolResult,
   UserIdAndName,
+  SessionMode,
 } from '@kbn/agent-builder-common';
 import type { AttachmentVersionRef } from '@kbn/agent-builder-common/attachments';
 import type { RoundState } from '@kbn/agent-builder-common/chat/round_state';
@@ -59,6 +60,9 @@ const convertBaseFromEs = (document: Document) => {
     title: document._source.title,
     created_at: document._source.created_at,
     updated_at: document._source.updated_at,
+    ...(document._source.session_mode && {
+      session_mode: document._source.session_mode as SessionMode,
+    }),
   };
 };
 
@@ -223,6 +227,7 @@ export const toEs = (conversation: Conversation, space: string): ConversationPro
     user_id: conversation.user.id,
     user_name: conversation.user.username,
     space,
+    session_mode: conversation.session_mode,
     title: conversation.title,
     created_at: conversation.created_at,
     updated_at: conversation.updated_at,
@@ -271,6 +276,7 @@ export const createRequestToEs = ({
     user_id: currentUser.id,
     user_name: currentUser.username,
     space,
+    session_mode: conversation.session_mode,
     title: conversation.title,
     created_at: creationDate.toISOString(),
     updated_at: creationDate.toISOString(),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
@@ -23,6 +23,7 @@ const storageSettings = {
       user_name: types.keyword({}),
       agent_id: types.keyword({}),
       space: types.keyword({}),
+      session_mode: types.keyword({}),
       title: types.text({}),
       created_at: types.date({}),
       updated_at: types.date({}),
@@ -38,6 +39,7 @@ export interface ConversationProperties {
   user_name: string;
   agent_id: string;
   space: string;
+  session_mode?: string;
   title: string;
   created_at: string;
   updated_at: string;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/types.ts
@@ -30,6 +30,7 @@ export type ConversationUpdateRequest = Pick<Conversation, 'id'> &
 
 export interface ConversationListOptions {
   agentId?: string;
+  sessionMode?: string;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -30,6 +30,7 @@ import {
   type ConsumptionService,
 } from './metering';
 import { type PluginsService, createPluginsService } from './plugins';
+import { SessionServiceImpl } from './sessions';
 
 interface ServiceInstances {
   tools: ToolsService;
@@ -103,6 +104,7 @@ export class ServiceManager {
     trackingService,
     analyticsService,
     searchInferenceEndpoints,
+    alerting,
   }: ServicesStartDeps): InternalStartServices {
     if (!this.services) {
       throw new Error('#startServices called before #setupServices');
@@ -199,6 +201,18 @@ export class ServiceManager {
       spaces,
     });
 
+    const sessions = new SessionServiceImpl({
+      logger: logger.get('sessions'),
+      esClient: elasticsearch.client.asInternalUser,
+      taskManager,
+      security,
+      spaces,
+      conversationService: conversations,
+      getExecutionService,
+      getActionsStart: () => actions,
+      getAlertingStart: alerting ? () => alerting : undefined,
+    });
+
     const auditLogService = new AuditLogService({
       security,
       logger: logger.get('audit'),
@@ -218,6 +232,7 @@ export class ServiceManager {
       analyticsService,
       meteringService: this.services.metering,
       searchInferenceEndpoints,
+      sessionsService: sessions,
     });
 
     executionService = createAgentExecutionService({
@@ -236,6 +251,7 @@ export class ServiceManager {
       analyticsService,
       meteringService: this.services.metering,
       searchInferenceEndpoints,
+      sessionsService: sessions,
     });
 
     const consumption = this.services.consumption.start({ elasticsearch, spaces });
@@ -246,6 +262,7 @@ export class ServiceManager {
       attachments,
       skills: skillsServiceStart,
       conversations,
+      sessions,
       runnerFactory,
       auditLogService,
       execution: executionService,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -7,7 +7,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { Observable } from 'rxjs';
-import { EMPTY, shareReplay } from 'rxjs';
+import { of, shareReplay } from 'rxjs';
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchServiceStart } from '@kbn/core-elasticsearch-server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
@@ -18,6 +18,7 @@ import {
   agentBuilderDefaultAgentId,
   createBadRequestError,
   AgentExecutionMode,
+  ChatEventType,
 } from '@kbn/agent-builder-common';
 import type { Attachment, AttachmentInput } from '@kbn/agent-builder-common/attachments';
 import type {
@@ -414,7 +415,21 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
         `[session] ${conversationId} is active; queued human message as pending trigger`
       );
 
-      return { executionId: uuidv4(), events$: EMPTY as Observable<never> };
+      // Emit a message_complete event so the chat UI shows immediate feedback.
+      // No round is created in the conversation — the actual round arrives when
+      // the queued trigger fires after the current round finishes.
+      const queuedEvent = {
+        type: ChatEventType.messageComplete,
+        data: {
+          message_id: uuidv4(),
+          message_content:
+            '✓ Message queued — the bot will process it when it finishes its current task.',
+        },
+      };
+      return {
+        executionId: uuidv4(),
+        events$: of(queuedEvent) as unknown as Observable<ChatEvent>,
+      };
     } catch (err) {
       this.logger.debug(
         `[session] queue check failed for ${conversationId}, proceeding normally: ${err}`

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -7,7 +7,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { Observable } from 'rxjs';
-import { shareReplay } from 'rxjs';
+import { EMPTY, shareReplay } from 'rxjs';
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchServiceStart } from '@kbn/core-elasticsearch-server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
@@ -78,6 +78,22 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
     abortSignal,
     metadata,
   }: ExecuteAgentParams): Promise<ExecuteAgentResult> {
+    // For standing sessions that are currently active: queue the incoming message
+    // instead of starting a concurrent round. Skip this check when the execution is
+    // itself session-managed (source already set by startRound) to avoid recursion.
+    if (
+      mode === AgentExecutionMode.conversation &&
+      !params.nextInput.source &&
+      this.deps.sessionsService
+    ) {
+      const conversationId = (params as ConversationExecutionParams).conversationId;
+      const message = params.nextInput.message;
+      if (conversationId && message) {
+        const queued = await this.tryQueueForActiveSession(conversationId, message, request);
+        if (queued) return queued;
+      }
+    }
+
     const executionId = providedExecutionId ?? uuidv4();
     const agentId = params.agentId ?? agentBuilderDefaultAgentId;
     const spaceId = getCurrentSpaceId({ request, spaces: this.deps.spaces });
@@ -361,6 +377,50 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
       ...options,
       spaceId: options?.spaceId || defaultSpaceId,
     });
+  }
+
+  /**
+   * If the conversation is a standing session currently running a round (status=active),
+   * queue the incoming human message as a pending trigger instead of starting a concurrent
+   * round. Returns a synthetic ExecuteAgentResult with an empty events$ on success, or
+   * null to proceed with normal execution.
+   */
+  private async tryQueueForActiveSession(
+    conversationId: string,
+    message: string,
+    request: KibanaRequest
+  ): Promise<ExecuteAgentResult | null> {
+    try {
+      const client = this.deps.sessionsService!.getScopedClient({ request });
+      const conversation = await client.get(conversationId).catch(() => null);
+
+      if (conversation?.session_mode !== 'standing') return null;
+
+      const ss = conversation.state?.standing_session;
+      if (!ss || ss.status !== 'active') return null;
+
+      await client.enqueueTrigger(conversationId, {
+        type: 'session_message',
+        subscription_id: undefined,
+        event: {
+          from_session_id: conversationId,
+          from_agent_id: conversation.agent_id,
+          message,
+          message_id: uuidv4(),
+        },
+      });
+
+      this.logger.debug(
+        `[session] ${conversationId} is active; queued human message as pending trigger`
+      );
+
+      return { executionId: uuidv4(), events$: EMPTY as Observable<never> };
+    } catch (err) {
+      this.logger.debug(
+        `[session] queue check failed for ${conversationId}, proceeding normally: ${err}`
+      );
+      return null;
+    }
   }
 
   private createExecutionClient(): AgentExecutionClient {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -14,7 +14,11 @@ import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ChatEvent } from '@kbn/agent-builder-common';
-import { agentBuilderDefaultAgentId, createBadRequestError } from '@kbn/agent-builder-common';
+import {
+  agentBuilderDefaultAgentId,
+  createBadRequestError,
+  AgentExecutionMode,
+} from '@kbn/agent-builder-common';
 import type { Attachment, AttachmentInput } from '@kbn/agent-builder-common/attachments';
 import type {
   AgentExecutionService,
@@ -23,8 +27,10 @@ import type {
   ExecuteAgentResult,
   FollowExecutionOptions,
   FindExecutionsOptions,
+  ConversationExecutionParams,
 } from '@kbn/agent-builder-server/execution';
 import { ExecutionStatus } from '@kbn/agent-builder-common';
+import type { SessionsStart } from '@kbn/agent-builder-server';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import type { AttachmentServiceStart } from '../attachments';
 import { taskTypes } from './task';
@@ -43,6 +49,7 @@ export interface AgentExecutionServiceDeps extends AgentExecutionDeps {
   taskManager: TaskManagerStartContract;
   spaces?: SpacesPluginStart;
   attachmentsService: AttachmentServiceStart;
+  sessionsService?: SessionsStart;
 }
 
 export const createAgentExecutionService = (
@@ -230,6 +237,7 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
         execution,
         executionClient,
         abortMonitor,
+        request,
       });
 
       this.logger.debug(
@@ -255,11 +263,13 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
     execution,
     executionClient,
     abortMonitor,
+    request,
   }: {
     events$: Observable<ChatEvent>;
     execution: AgentExecution;
     executionClient: AgentExecutionClient;
     abortMonitor: AbortMonitor;
+    request: KibanaRequest;
   }): void {
     const { executionId } = execution;
 
@@ -272,6 +282,8 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
       .then(async () => {
         await executionClient.updateStatus(executionId, ExecutionStatus.completed);
         this.logger.debug(`Local execution ${executionId} completed`);
+        // Post-round: drain the standing session queue if applicable
+        await this.drainStandingSessionQueue(execution, request);
       })
       .catch(async (error) => {
         this.logger.error(`Local execution ${executionId} failed: ${error.message}`);
@@ -291,6 +303,28 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
       .finally(() => {
         abortMonitor.stop();
       });
+  }
+
+  /**
+   * After a conversation round completes, check if it belongs to a standing session
+   * and drain the pending trigger queue if so.
+   */
+  private async drainStandingSessionQueue(
+    execution: AgentExecution,
+    request: KibanaRequest
+  ): Promise<void> {
+    const { sessionsService } = this.deps;
+    if (!sessionsService) return;
+    if (execution.executionMode !== AgentExecutionMode.conversation) return;
+    const conversationId = (execution.agentParams as ConversationExecutionParams).conversationId;
+    if (!conversationId) return;
+
+    try {
+      const client = sessionsService.getScopedClient({ request });
+      await client.drainQueue(conversationId, execution.executionId);
+    } catch (err) {
+      this.logger.debug(`[session] post-round drainQueue failed for ${conversationId}: ${err}`);
+    }
   }
 
   /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -21,7 +21,7 @@ import {
   AgentExecutionMode,
 } from '@kbn/agent-builder-common';
 import type { AgentEventEmitterFn, AgentHandlerContext } from '@kbn/agent-builder-server';
-import { HookLifecycle } from '@kbn/agent-builder-server';
+import { HookLifecycle, SESSION_TOOL_IDS } from '@kbn/agent-builder-server';
 import type { ConversationInternalState, CompactionSummary } from '@kbn/agent-builder-common/chat';
 import type { ToolManager } from '@kbn/agent-builder-server/runner';
 import { ToolManagerToolType, type PromptManager } from '@kbn/agent-builder-server/runner';
@@ -165,13 +165,22 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
   });
   processedConversation.nextInput = beforeHookResult.nextInput ?? processedConversation.nextInput;
 
+  // For standing sessions, inject the session lifecycle tools regardless of agent config.
+  const effectiveAgentConfiguration =
+    conversation?.session_mode === 'standing'
+      ? {
+          ...agentConfiguration,
+          tools: [...agentConfiguration.tools, { tool_ids: [...SESSION_TOOL_IDS] }],
+        }
+      : agentConfiguration;
+
   const { staticTools, dynamicTools } = await selectTools({
     conversation: processedConversation,
     previousDynamicToolIds: conversation?.state?.dynamic_tool_ids ?? [],
     filteredSkills,
     skills,
     toolProvider,
-    agentConfiguration,
+    agentConfiguration: effectiveAgentConfiguration,
     attachmentsService: attachments,
     filestore,
     request,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -331,6 +331,9 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
   const processedInput: RoundInput = {
     message: processedConversation.nextInput.message,
     attachments: processedConversation.nextInput.attachments.map((a) => a.attachment),
+    // Pass through trigger metadata for standing session rounds
+    ...(nextInput.source && { source: nextInput.source }),
+    ...(nextInput.trigger_context && { trigger_context: nextInput.trigger_context }),
   };
 
   // Use provided overrides, or fall back to pending round's overrides (for HITL resume)

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -357,6 +357,7 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
           toolManager,
           compactionSummary: compactionResult.summary,
           backgroundExecutionService,
+          standing_session: conversation?.state?.standing_session,
         }),
       pendingRound,
       startTime,
@@ -389,11 +390,13 @@ const getConversationState = ({
   toolManager,
   backgroundExecutionService,
   compactionSummary,
+  standing_session,
 }: {
   promptManager: PromptManager;
   toolManager: ToolManager;
   backgroundExecutionService: BackgroundExecutionService;
   compactionSummary?: CompactionSummary;
+  standing_session?: ConversationInternalState['standing_session'];
 }): ConversationInternalState => {
   const bgState = backgroundExecutionService.getPendingState();
   return {
@@ -401,6 +404,7 @@ const getConversationState = ({
     dynamic_tool_ids: toolManager.getDynamicToolIds(),
     ...(compactionSummary ? { compaction_summary: compactionSummary } : {}),
     ...(Object.keys(bgState).length > 0 ? { background_executions: bgState } : {}),
+    ...(standing_session ? { standing_session } : {}),
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/task/task_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/task/task_handler.ts
@@ -108,6 +108,9 @@ class TaskHandlerImpl implements TaskHandler {
           `Failed to update status for execution ${executionId}: ${statusError.message}`
         );
       }
+
+      // Even on failure the session must not stay stuck in active — reset it to idle.
+      await this.drainStandingSessionQueue(execution, executionId, fakeRequest);
     } finally {
       abortMonitor.stop();
     }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/task/task_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/task/task_handler.ts
@@ -8,7 +8,9 @@
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ElasticsearchServiceStart } from '@kbn/core-elasticsearch-server';
-import { ExecutionStatus } from '@kbn/agent-builder-common';
+import { AgentExecutionMode, ExecutionStatus } from '@kbn/agent-builder-common';
+import type { SessionsStart } from '@kbn/agent-builder-server';
+import type { ConversationExecutionParams } from '@kbn/agent-builder-server/execution';
 import { createAgentExecutionClient, type AgentExecutionClient } from '../persistence';
 import {
   handleAgentExecution,
@@ -20,6 +22,7 @@ import { AbortMonitor } from './abort_monitor';
 
 export interface TaskHandlerDeps extends AgentExecutionDeps {
   elasticsearch: ElasticsearchServiceStart;
+  sessionsService?: SessionsStart;
 }
 
 /**
@@ -88,6 +91,9 @@ class TaskHandlerImpl implements TaskHandler {
 
       // 6. Mark as completed
       await executionClient.updateStatus(executionId, ExecutionStatus.completed);
+
+      // 7. Post-round: drain the standing session queue if applicable.
+      await this.drainStandingSessionQueue(execution, executionId, fakeRequest);
     } catch (error) {
       this.logger.error(`Execution ${executionId} failed: ${error.message}`);
 
@@ -117,5 +123,24 @@ class TaskHandlerImpl implements TaskHandler {
       logger: this.logger.get('execution-client'),
       esClient: this.deps.elasticsearch.client.asInternalUser,
     });
+  }
+
+  private async drainStandingSessionQueue(
+    execution: Awaited<ReturnType<AgentExecutionClient['get']>>,
+    executionId: string,
+    request: KibanaRequest
+  ): Promise<void> {
+    const { sessionsService } = this.deps;
+    if (!sessionsService || !execution) return;
+    if (execution.executionMode !== AgentExecutionMode.conversation) return;
+    const conversationId = (execution.agentParams as ConversationExecutionParams).conversationId;
+    if (!conversationId) return;
+
+    try {
+      const client = sessionsService.getScopedClient({ request });
+      await client.drainQueue(conversationId, executionId);
+    } catch (err) {
+      this.logger.debug(`[session] TM post-round drainQueue failed for ${conversationId}: ${err}`);
+    }
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/alert_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/alert_handler.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { AlertingConnectorFeatureId } from '@kbn/actions-plugin/common';
+import type {
+  ActionType as ConnectorType,
+  ActionTypeExecutorOptions,
+  ActionTypeExecutorResult,
+} from '@kbn/actions-plugin/server/types';
+import type { PluginSetupContract as ActionsPluginSetupContract } from '@kbn/actions-plugin/server';
+import type { Logger } from '@kbn/logging';
+import type { AlertTriggerContext } from '@kbn/agent-builder-common';
+import type { SessionsStart } from '@kbn/agent-builder-server';
+
+// ---------------------------------------------------------------------------
+// Connector type ID
+// ---------------------------------------------------------------------------
+
+/**
+ * System action type ID for the agent session alert handler.
+ * Used when creating/attaching actions to Kibana alert rules.
+ */
+export const AGENT_SESSION_ALERT_CONNECTOR_TYPE_ID = '.agent-session-alert';
+
+// ---------------------------------------------------------------------------
+// Executor params schema — the config stored on the rule action
+// ---------------------------------------------------------------------------
+
+const ExecutorParamsSchema = z.object({
+  /** The standing session conversation ID to notify when this alert fires. */
+  conversation_id: z.string(),
+  /** The subscription ID (from TriggerSubscription.id) for correlation. */
+  subscription_id: z.string(),
+});
+
+type ExecutorParams = z.infer<typeof ExecutorParamsSchema>;
+
+// ---------------------------------------------------------------------------
+// Alert event shape coming from the alerting framework
+// ---------------------------------------------------------------------------
+
+interface AlertActionContext {
+  alerts?: Array<{
+    id?: string;
+    status?: string;
+    severity?: string;
+    [key: string]: unknown;
+  }>;
+  rule?: {
+    id?: string;
+    name?: string;
+    tags?: string[];
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Connector type factory
+// ---------------------------------------------------------------------------
+
+interface CreateAlertConnectorTypeDeps {
+  logger: Logger;
+  getSessionsStart: () => SessionsStart;
+}
+
+/**
+ * Returns the connector type definition for the agent session alert action.
+ * Register this with `actions.registerType()` during plugin setup.
+ *
+ * When an alert rule fires and this action is attached:
+ * 1. The alerting framework calls the executor with the alert context.
+ * 2. The executor looks up the standing session via conversation_id.
+ * 3. It enqueues an alert_trigger event into the session queue.
+ */
+export const createAgentSessionAlertConnectorType = ({
+  logger,
+  getSessionsStart,
+}: CreateAlertConnectorTypeDeps): ConnectorType<
+  Record<string, unknown>,
+  Record<string, unknown>,
+  ExecutorParams,
+  void
+> => ({
+  id: AGENT_SESSION_ALERT_CONNECTOR_TYPE_ID,
+  name: 'Notify Agent Session',
+  minimumLicenseRequired: 'enterprise',
+  supportedFeatureIds: [AlertingConnectorFeatureId],
+  validate: {
+    params: { schema: ExecutorParamsSchema },
+    config: { schema: z.object({}).passthrough() },
+    secrets: { schema: z.object({}).passthrough() },
+  },
+  executor: async (
+    options: ActionTypeExecutorOptions<
+      Record<string, unknown>,
+      Record<string, unknown>,
+      ExecutorParams
+    >
+  ): Promise<ActionTypeExecutorResult<void>> => {
+    const { params, request: maybeRequest, actionId } = options;
+    const { conversation_id: conversationId, subscription_id: subscriptionId } = params;
+
+    if (!maybeRequest) {
+      logger.error(
+        `[${AGENT_SESSION_ALERT_CONNECTOR_TYPE_ID}] No request context — cannot enqueue trigger for session ${conversationId}`
+      );
+      return { actionId, status: 'error', message: 'No request context available', retry: false };
+    }
+
+    const request = maybeRequest;
+
+    // The alerting framework passes the alert context via the execution context.
+    // Extract what we can from the available data.
+    const alertContext = (options as unknown as { alertsFilter?: AlertActionContext })
+      .alertsFilter as AlertActionContext | undefined;
+
+    const triggerContext: AlertTriggerContext = {
+      type: 'alert_trigger',
+      subscription_id: subscriptionId,
+      event: {
+        rule_id: alertContext?.rule?.id ?? 'unknown',
+        rule_name: alertContext?.rule?.name ?? 'unknown',
+        alert_ids: (alertContext?.alerts ?? []).map((a) => a.id ?? '').filter(Boolean),
+        severity: alertContext?.alerts?.[0]?.severity,
+        tags: alertContext?.rule?.tags,
+        context: alertContext,
+      },
+    };
+
+    try {
+      const sessions = getSessionsStart();
+      // Alert actions receive a `request` scoped to the rule creator's API key.
+      // This matches the "creator credentials" model.
+      const client = sessions.getScopedClient({ request });
+      await client.enqueueTrigger(conversationId, triggerContext);
+
+      logger.debug(
+        `[${AGENT_SESSION_ALERT_CONNECTOR_TYPE_ID}] Alert enqueued for session ${conversationId}, ` +
+          `subscription ${subscriptionId}, action ${actionId}`
+      );
+
+      return { actionId, status: 'ok' };
+    } catch (err) {
+      logger.error(
+        `[${AGENT_SESSION_ALERT_CONNECTOR_TYPE_ID}] Failed to enqueue alert for session ${conversationId}: ${err}`
+      );
+      return {
+        actionId,
+        status: 'error',
+        message: `Failed to notify agent session: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        retry: true,
+      };
+    }
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Registration helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the agent session alert connector type during plugin setup.
+ */
+export const registerAgentSessionAlertConnectorType = (
+  actions: ActionsPluginSetupContract,
+  deps: CreateAlertConnectorTypeDeps
+): void => {
+  actions.registerType(createAgentSessionAlertConnectorType(deps));
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { SessionServiceImpl } from './session_service';
+export type { SessionServiceDeps } from './session_service';
+export {
+  registerAgentSessionTriggerTasks,
+  scheduleSessionScheduledTask,
+  scheduleSessionReminderTask,
+  cancelSessionTriggerTask,
+  scheduledTaskId,
+  reminderTaskId,
+  AGENT_SESSION_SCHEDULED_TASK_TYPE,
+  AGENT_SESSION_REMINDER_TASK_TYPE,
+} from './trigger_tasks';
+export type {
+  AgentSessionScheduledTaskParams,
+  AgentSessionReminderTaskParams,
+} from './trigger_tasks';
+export {
+  AGENT_SESSION_ALERT_CONNECTOR_TYPE_ID,
+  registerAgentSessionAlertConnectorType,
+} from './alert_handler';

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
@@ -28,7 +28,7 @@ import type {
   WebhookTriggerSubscription,
   StandingSessionState,
 } from '@kbn/agent-builder-common';
-import { AgentExecutionMode } from '@kbn/agent-builder-common';
+import { AgentExecutionMode, ExecutionStatus } from '@kbn/agent-builder-common';
 import type { AgentExecutionService } from '@kbn/agent-builder-server/execution';
 import type {
   SessionClient,
@@ -208,6 +208,11 @@ export class SessionClientImpl implements SessionClient {
     conversationId: string,
     context: TriggerContext
   ): Promise<EnqueueTriggerResult> {
+    // Pre-flight: if the session appears active but the execution that "owns" that
+    // active status is already done, reset to idle so the trigger starts immediately
+    // instead of being queued behind a ghost execution.
+    await this.resetIfDeadActive(conversationId);
+
     let resultStatus: 'injected' | 'queued' = 'queued';
     let triggerToStart: TriggerContext | undefined;
     let agentId: string | undefined;
@@ -747,6 +752,50 @@ export class SessionClientImpl implements SessionClient {
   // ---------------------------------------------------------------------------
   // Private — round execution
   // ---------------------------------------------------------------------------
+
+  /**
+   * If the session is `active` but the execution that set that status is no longer
+   * running (completed, failed, or gone), reset the session to `idle`.
+   * This recovers sessions that got stuck when the post-round drainQueue hook
+   * wasn't reached (e.g. server restart, hook not yet deployed).
+   */
+  private async resetIfDeadActive(conversationId: string): Promise<void> {
+    const doc = await this.esClient
+      .get<ConversationProperties>({
+        index: conversationIndexName,
+        id: conversationId,
+      })
+      .catch(() => null);
+
+    const ss = doc?._source?.state?.standing_session;
+    if (!ss || ss.status !== 'active' || !ss.active_execution_id) return;
+
+    const execution = await this.getExecutionService()
+      .getExecution(ss.active_execution_id)
+      .catch(() => undefined);
+
+    const isAlive =
+      execution?.status === ExecutionStatus.running ||
+      execution?.status === ExecutionStatus.scheduled;
+
+    if (!isAlive) {
+      this.logger.debug(
+        `[session] ${conversationId} stuck active (execution ${ss.active_execution_id} is ${
+          execution?.status ?? 'not found'
+        }); resetting to idle`
+      );
+      await this.withOCC(conversationId, (source) => {
+        const standingSession = source.state?.standing_session;
+        if (!standingSession || standingSession.status !== 'active') return source;
+        if (standingSession.active_execution_id !== ss.active_execution_id) return source;
+        return updateStandingSession(source, {
+          ...standingSession,
+          status: 'idle',
+          active_execution_id: undefined,
+        });
+      });
+    }
+  }
 
   private async startRound(
     conversationId: string,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
@@ -325,16 +325,36 @@ export class SessionClientImpl implements SessionClient {
     });
 
     if (triggerToStart && agentId) {
+      const capturedTrigger = triggerToStart;
       this.startRound(
         conversationId,
         agentId,
-        triggerToStart,
+        capturedTrigger,
         connectorId,
         systemPromptOverride
-      ).catch((err) => {
+      ).catch(async (err) => {
         this.logger.error(
           `Failed to start round from drain queue for session ${conversationId}: ${err}`
         );
+        // Re-queue the trigger so it isn't silently dropped.
+        await this.withOCC(conversationId, (source) => {
+          const ss = source.state?.standing_session;
+          if (!ss) return source;
+          const requeued: PendingTriggerEvent = {
+            id: uuidv4(),
+            queued_at: new Date().toISOString(),
+            context: capturedTrigger,
+          };
+          return updateStandingSession(source, {
+            ...ss,
+            status: 'idle',
+            pending_triggers: [requeued, ...ss.pending_triggers],
+          });
+        }).catch((requeueErr) => {
+          this.logger.error(
+            `Failed to re-queue trigger for session ${conversationId}: ${requeueErr}`
+          );
+        });
       });
     }
   }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
@@ -1,0 +1,794 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import crypto from 'node:crypto';
+import { v4 as uuidv4 } from 'uuid';
+import type { Logger } from '@kbn/logging';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { SecurityServiceStart } from '@kbn/core-security-server';
+import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { AlertingServerStart } from '@kbn/alerting-plugin/server';
+import type {
+  AlertTriggerSubscription,
+  Conversation,
+  ConversationWithoutRounds,
+  TriggerContext,
+  TriggerSubscription,
+  StandingSessionStatus,
+  SessionListOptions,
+  PendingTriggerEvent,
+  ScheduleTriggerSubscription,
+  ReminderTriggerSubscription,
+  WebhookTriggerSubscription,
+  StandingSessionState,
+} from '@kbn/agent-builder-common';
+import { AgentExecutionMode } from '@kbn/agent-builder-common';
+import type { AgentExecutionService } from '@kbn/agent-builder-server/execution';
+import type {
+  SessionClient,
+  CreateSessionParams,
+  EnqueueTriggerResult,
+} from '@kbn/agent-builder-server';
+import {
+  scheduleSessionScheduledTask,
+  scheduleSessionReminderTask,
+  cancelSessionTriggerTask,
+  scheduledTaskId,
+  reminderTaskId,
+} from './trigger_tasks';
+import { AGENT_SESSION_ALERT_CONNECTOR_TYPE_ID } from './alert_handler';
+import type { ConversationService } from '../conversation';
+import type { ConversationProperties } from '../conversation/client/storage';
+import { conversationIndexName } from '../conversation/client/storage';
+
+const MAX_RETRIES = 3;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatTriggerMessage = (context: TriggerContext): string => {
+  switch (context.type) {
+    case 'alert_trigger':
+      return `Alert rule "${
+        context.event.rule_name
+      }" fired. Alert IDs: [${context.event.alert_ids.join(', ')}].`;
+    case 'schedule_trigger':
+      return `Scheduled trigger fired (${context.event.schedule_description}) at ${context.event.fired_at}.`;
+    case 'reminder_trigger':
+      return `Reminder fired at ${context.event.fired_at}${
+        context.event.note ? `: ${context.event.note}` : ''
+      }.`;
+    case 'webhook_trigger':
+      return `Webhook trigger received at ${context.event.received_at}. Payload: ${JSON.stringify(
+        context.event.payload
+      )}`;
+    case 'session_message':
+      return context.event.message;
+  }
+};
+
+const getStandingSession = (source: ConversationProperties): StandingSessionState => {
+  const standing = source.state?.standing_session;
+  if (!standing) {
+    throw new Error('Document is not a standing session (missing state.standing_session)');
+  }
+  return standing;
+};
+
+const updateStandingSession = (
+  source: ConversationProperties,
+  updated: StandingSessionState
+): ConversationProperties => ({
+  ...source,
+  state: { ...source.state, standing_session: updated },
+});
+
+// ---------------------------------------------------------------------------
+// Deps
+// ---------------------------------------------------------------------------
+
+export interface SessionClientImplDeps {
+  esClient: ElasticsearchClient;
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+  request: KibanaRequest;
+  space: string;
+  security: SecurityServiceStart;
+  conversationService: ConversationService;
+  getExecutionService: () => AgentExecutionService;
+  getActionsStart: () => ActionsPluginStart;
+  getAlertingStart: (() => AlertingServerStart) | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Session client implementation
+// ---------------------------------------------------------------------------
+
+export class SessionClientImpl implements SessionClient {
+  private readonly esClient: ElasticsearchClient;
+  private readonly taskManager: TaskManagerStartContract;
+  private readonly logger: Logger;
+  private readonly request: KibanaRequest;
+  private readonly space: string;
+  private readonly security: SecurityServiceStart;
+  private readonly conversationService: ConversationService;
+  private readonly getExecutionService: () => AgentExecutionService;
+  private readonly getActionsStart: () => ActionsPluginStart;
+  private readonly getAlertingStart: (() => AlertingServerStart) | undefined;
+
+  constructor(deps: SessionClientImplDeps) {
+    this.esClient = deps.esClient;
+    this.taskManager = deps.taskManager;
+    this.logger = deps.logger;
+    this.request = deps.request;
+    this.space = deps.space;
+    this.security = deps.security;
+    this.conversationService = deps.conversationService;
+    this.getExecutionService = deps.getExecutionService;
+    this.getActionsStart = deps.getActionsStart;
+    this.getAlertingStart = deps.getAlertingStart;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  async create(params: CreateSessionParams): Promise<Conversation> {
+    const { security, request } = this;
+    const conversationClient = await this.conversationService.getScopedClient({ request });
+
+    const authUser = security.authc.getCurrentUser(request);
+    const user = authUser
+      ? { id: authUser.profile_uid, username: authUser.username }
+      : { username: 'system' };
+
+    const now = new Date().toISOString();
+    return conversationClient.create({
+      agent_id: params.agent_id,
+      session_mode: 'standing',
+      title: params.name,
+      rounds: [],
+      state: {
+        standing_session: {
+          status: 'idle',
+          trigger_subscriptions: [],
+          pending_triggers: [],
+          last_active_at: now,
+          created_by: user,
+          ...(params.ttl_seconds !== undefined && { ttl_seconds: params.ttl_seconds }),
+          ...(params.connector_id !== undefined && { connector_id: params.connector_id }),
+          ...(params.system_prompt_override !== undefined && {
+            system_prompt_override: params.system_prompt_override,
+          }),
+        },
+      },
+    });
+  }
+
+  async get(conversationId: string): Promise<Conversation> {
+    const conversationClient = await this.conversationService.getScopedClient({
+      request: this.request,
+    });
+    return conversationClient.get(conversationId);
+  }
+
+  async list(options?: SessionListOptions): Promise<ConversationWithoutRounds[]> {
+    const conversationClient = await this.conversationService.getScopedClient({
+      request: this.request,
+    });
+    return conversationClient.list({ agentId: options?.agent_id, sessionMode: 'standing' });
+  }
+
+  async terminate(conversationId: string): Promise<void> {
+    let subscriptionsToCleanup: TriggerSubscription[] = [];
+
+    await this.withOCC(conversationId, (source) => {
+      const standingSession = getStandingSession(source);
+      subscriptionsToCleanup = [...standingSession.trigger_subscriptions];
+      return updateStandingSession(source, {
+        ...standingSession,
+        status: 'terminated',
+        trigger_subscriptions: [],
+        pending_triggers: [],
+      });
+    });
+
+    // Cleanup runs after the OCC write succeeds — retries can't multiply side effects.
+    await this.cleanupSubscriptions(conversationId, subscriptionsToCleanup);
+  }
+
+  async enqueueTrigger(
+    conversationId: string,
+    context: TriggerContext
+  ): Promise<EnqueueTriggerResult> {
+    let resultStatus: 'injected' | 'queued' = 'queued';
+    let triggerToStart: TriggerContext | undefined;
+    let agentId: string | undefined;
+    let connectorId: string | undefined;
+    let systemPromptOverride: string | undefined;
+
+    await this.withOCC(conversationId, (source) => {
+      const standingSession = getStandingSession(source);
+
+      if (standingSession.status === 'terminated') {
+        throw new Error(`Session ${conversationId} is terminated`);
+      }
+
+      if (standingSession.status === 'active') {
+        const pendingEvent: PendingTriggerEvent = {
+          id: uuidv4(),
+          queued_at: new Date().toISOString(),
+          context,
+        };
+        resultStatus = 'queued';
+        return updateStandingSession(source, {
+          ...standingSession,
+          pending_triggers: [...standingSession.pending_triggers, pendingEvent],
+        });
+      }
+
+      // Status is 'idle' — start immediately.
+      resultStatus = 'injected';
+      triggerToStart = context;
+      agentId = source.agent_id;
+      connectorId = standingSession.connector_id;
+      systemPromptOverride = standingSession.system_prompt_override;
+
+      return updateStandingSession(source, {
+        ...standingSession,
+        status: 'active',
+        last_active_at: new Date().toISOString(),
+      });
+    });
+
+    if (triggerToStart && agentId) {
+      this.startRound(
+        conversationId,
+        agentId,
+        triggerToStart,
+        connectorId,
+        systemPromptOverride
+      ).catch((err) => {
+        this.logger.error(`Failed to start round for session ${conversationId}: ${err}`);
+      });
+    }
+
+    return { status: resultStatus };
+  }
+
+  async drainQueue(conversationId: string, forExecutionId?: string): Promise<void> {
+    let triggerToStart: TriggerContext | undefined;
+    let agentId: string | undefined;
+    let connectorId: string | undefined;
+    let systemPromptOverride: string | undefined;
+
+    await this.withOCC(conversationId, (source) => {
+      const standingSession = source.state?.standing_session;
+      if (!standingSession) return source; // not a standing session, no-op
+
+      // Safety guard: only skip when active_execution_id is set AND mismatches.
+      // If active_execution_id is null (e.g. due to a transient write failure in startRound),
+      // proceed rather than deadlocking the session in active state forever.
+      if (
+        forExecutionId &&
+        standingSession.active_execution_id &&
+        standingSession.active_execution_id !== forExecutionId
+      ) {
+        return source; // another round is already running
+      }
+
+      if (standingSession.status === 'terminated') return source; // no-op
+
+      if (standingSession.pending_triggers.length === 0) {
+        // Already idle with nothing pending — skip the write.
+        if (standingSession.status === 'idle' && standingSession.active_execution_id == null) {
+          return source;
+        }
+        return updateStandingSession(source, {
+          ...standingSession,
+          status: 'idle',
+          last_active_at: new Date().toISOString(),
+          active_execution_id: undefined,
+        });
+      }
+
+      const [next, ...remaining] = standingSession.pending_triggers;
+      triggerToStart = next.context;
+      agentId = source.agent_id;
+      connectorId = standingSession.connector_id;
+      systemPromptOverride = standingSession.system_prompt_override;
+
+      return updateStandingSession(source, {
+        ...standingSession,
+        status: 'active',
+        last_active_at: new Date().toISOString(),
+        active_execution_id: undefined, // will be set by startRound
+        pending_triggers: remaining,
+      });
+    });
+
+    if (triggerToStart && agentId) {
+      this.startRound(
+        conversationId,
+        agentId,
+        triggerToStart,
+        connectorId,
+        systemPromptOverride
+      ).catch((err) => {
+        this.logger.error(
+          `Failed to start round from drain queue for session ${conversationId}: ${err}`
+        );
+      });
+    }
+  }
+
+  async addSubscription(conversationId: string, subscription: TriggerSubscription): Promise<void> {
+    if (subscription.type === 'schedule_trigger') {
+      await this.addScheduleSubscription(
+        conversationId,
+        subscription as ScheduleTriggerSubscription
+      );
+      return;
+    }
+    if (subscription.type === 'reminder_trigger') {
+      await this.addReminderSubscription(
+        conversationId,
+        subscription as ReminderTriggerSubscription
+      );
+      return;
+    }
+    if (subscription.type === 'webhook_trigger') {
+      await this.addWebhookSubscription(conversationId, subscription as WebhookTriggerSubscription);
+      return;
+    }
+    if (subscription.type === 'alert_trigger') {
+      await this.addAlertSubscription(conversationId, subscription as AlertTriggerSubscription);
+    }
+  }
+
+  async removeSubscription(
+    conversationId: string,
+    subscriptionId: string
+  ): Promise<TriggerSubscription> {
+    let removed: TriggerSubscription | undefined;
+
+    await this.withOCC(conversationId, (source) => {
+      const ss = getStandingSession(source);
+      const index = ss.trigger_subscriptions.findIndex((s) => s.id === subscriptionId);
+      if (index === -1) {
+        throw new Error(`Subscription "${subscriptionId}" not found on session ${conversationId}`);
+      }
+      removed = ss.trigger_subscriptions[index];
+      const remaining = [
+        ...ss.trigger_subscriptions.slice(0, index),
+        ...ss.trigger_subscriptions.slice(index + 1),
+      ];
+      return updateStandingSession(source, { ...ss, trigger_subscriptions: remaining });
+    });
+
+    if (!removed) {
+      throw new Error(`Subscription "${subscriptionId}" not found on session ${conversationId}`);
+    }
+
+    // Cleanup external resources after the state write succeeds.
+    await this.cleanupSubscriptions(conversationId, [removed]);
+    return removed;
+  }
+
+  async setStatus(conversationId: string, status: StandingSessionStatus): Promise<void> {
+    await this.withOCC(conversationId, (source) => {
+      const ss = getStandingSession(source);
+      return updateStandingSession(source, { ...ss, status });
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private — subscription helpers (two-phase: write placeholder → provision → update)
+  // ---------------------------------------------------------------------------
+
+  private async addScheduleSubscription(
+    conversationId: string,
+    sub: ScheduleTriggerSubscription
+  ): Promise<void> {
+    if (!sub.config.interval) {
+      throw new Error('Cron-based schedules are not yet supported; use "interval" instead.');
+    }
+
+    // Phase 1: Write placeholder (task_id: '') so the subscription is tracked.
+    await this.writeNewSubscription(conversationId, sub);
+
+    // Phase 2: Schedule the TM task.
+    let taskId: string;
+    try {
+      taskId = await scheduleSessionScheduledTask(
+        {
+          conversationId,
+          subscriptionId: sub.id,
+          spaceId: this.space,
+          scheduleDescription: sub.config.description,
+        },
+        { interval: sub.config.interval },
+        { taskManager: this.taskManager, request: this.request, logger: this.logger }
+      );
+    } catch (err) {
+      await this.removeSubscriptionFromState(conversationId, sub.id);
+      throw err;
+    }
+
+    // Phase 3: Stamp the real task_id onto the stored subscription.
+    try {
+      await this.updateSubscriptionInState(conversationId, { ...sub, task_id: taskId });
+    } catch (err) {
+      await cancelSessionTriggerTask(scheduledTaskId(conversationId, sub.id), {
+        taskManager: this.taskManager,
+        logger: this.logger,
+      }).catch(() => {});
+      await this.removeSubscriptionFromState(conversationId, sub.id).catch(() => {});
+      throw err;
+    }
+  }
+
+  private async addReminderSubscription(
+    conversationId: string,
+    sub: ReminderTriggerSubscription
+  ): Promise<void> {
+    // Phase 1: Write placeholder.
+    await this.writeNewSubscription(conversationId, sub);
+
+    // Phase 2: Schedule the one-shot TM task.
+    let taskId: string;
+    try {
+      taskId = await scheduleSessionReminderTask(
+        { conversationId, subscriptionId: sub.id, spaceId: this.space, note: sub.config.note },
+        new Date(sub.config.fires_at),
+        { taskManager: this.taskManager, request: this.request, logger: this.logger }
+      );
+    } catch (err) {
+      await this.removeSubscriptionFromState(conversationId, sub.id);
+      throw err;
+    }
+
+    // Phase 3: Stamp the real task_id.
+    try {
+      await this.updateSubscriptionInState(conversationId, { ...sub, task_id: taskId });
+    } catch (err) {
+      await cancelSessionTriggerTask(reminderTaskId(conversationId, sub.id), {
+        taskManager: this.taskManager,
+        logger: this.logger,
+      }).catch(() => {});
+      await this.removeSubscriptionFromState(conversationId, sub.id).catch(() => {});
+      throw err;
+    }
+  }
+
+  private async addWebhookSubscription(
+    conversationId: string,
+    sub: WebhookTriggerSubscription
+  ): Promise<void> {
+    const tokenRaw = `${conversationId}:${sub.id}:${crypto.randomBytes(16).toString('hex')}`;
+    const token = Buffer.from(tokenRaw).toString('base64url');
+    // Token generation is pure — no external resource to provision, so no two-phase needed.
+    await this.writeNewSubscription(conversationId, {
+      ...sub,
+      config: { ...sub.config, token },
+    });
+  }
+
+  private async addAlertSubscription(
+    conversationId: string,
+    sub: AlertTriggerSubscription
+  ): Promise<void> {
+    const alertingStart = this.getAlertingStart?.();
+    if (!alertingStart) {
+      this.logger.warn(
+        `Alerting plugin not available; storing alert subscription without wiring rule.`
+      );
+      await this.writeNewSubscription(conversationId, sub);
+      return;
+    }
+
+    // Phase 1: Write placeholder (alert_action_id: '') so the subscription is tracked.
+    await this.writeNewSubscription(conversationId, sub);
+
+    // Phase 2: Create connector and wire it to the alert rule.
+    let connectorId: string;
+    try {
+      const actionsClient = await this.getActionsStart().getActionsClientWithRequest(this.request);
+      const connector = await actionsClient.create({
+        action: {
+          name: `Agent session trigger - ${sub.id}`,
+          actionTypeId: AGENT_SESSION_ALERT_CONNECTOR_TYPE_ID,
+          config: {},
+          secrets: {},
+        },
+      });
+      connectorId = connector.id;
+
+      try {
+        const rulesClient = await alertingStart.getRulesClientWithRequest(this.request);
+        const rule = await rulesClient.get({ id: sub.config.rule_id });
+        const currentActions = rule.actions.map((a) => ({
+          id: a.id,
+          group: a.group,
+          params: a.params,
+          frequency: a.frequency,
+          uuid: a.uuid,
+          alertsFilter: a.alertsFilter,
+        }));
+        await rulesClient.bulkEdit({
+          ids: [sub.config.rule_id],
+          operations: [
+            {
+              field: 'actions',
+              operation: 'set',
+              value: [
+                ...currentActions,
+                {
+                  id: connectorId,
+                  group: 'default',
+                  params: { conversation_id: conversationId, subscription_id: sub.id },
+                  frequency: {
+                    notifyWhen: 'onActiveAlert' as const,
+                    summary: false,
+                    throttle: null,
+                  },
+                },
+              ],
+            },
+          ],
+        });
+      } catch (ruleErr) {
+        // Rule update failed — delete the orphaned connector.
+        await actionsClient.delete({ id: connectorId }).catch(() => {});
+        throw ruleErr;
+      }
+    } catch (err) {
+      // Phase 2 failed entirely — remove the placeholder from state.
+      await this.removeSubscriptionFromState(conversationId, sub.id).catch(() => {});
+      throw err;
+    }
+
+    // Phase 3: Stamp the real connector ID onto the stored subscription.
+    try {
+      await this.updateSubscriptionInState(conversationId, {
+        ...sub,
+        alert_action_id: connectorId,
+      });
+    } catch (err) {
+      // Phase 3 failed — clean up the external resource and the placeholder.
+      await this.cleanupAlertSubscription({ ...sub, alert_action_id: connectorId }).catch(() => {});
+      await this.removeSubscriptionFromState(conversationId, sub.id).catch(() => {});
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private — cleanup helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Clean up all external resources for the given subscriptions (TM tasks, alert connectors).
+   * Called after the OCC write completes so retries can't multiply side effects.
+   * Individual errors are logged but do not propagate — partial cleanup is acceptable.
+   */
+  private async cleanupSubscriptions(
+    conversationId: string,
+    subscriptions: TriggerSubscription[]
+  ): Promise<void> {
+    await Promise.all(
+      subscriptions.map(async (sub) => {
+        try {
+          if (sub.type === 'schedule_trigger') {
+            await cancelSessionTriggerTask(scheduledTaskId(conversationId, sub.id), {
+              taskManager: this.taskManager,
+              logger: this.logger,
+            });
+          } else if (sub.type === 'reminder_trigger') {
+            await cancelSessionTriggerTask(reminderTaskId(conversationId, sub.id), {
+              taskManager: this.taskManager,
+              logger: this.logger,
+            });
+          } else if (sub.type === 'alert_trigger') {
+            await this.cleanupAlertSubscription(sub as AlertTriggerSubscription);
+          }
+        } catch (err) {
+          this.logger.warn(
+            `Failed to clean up subscription ${sub.id} (${sub.type}) for session ${conversationId}: ${err}`
+          );
+        }
+      })
+    );
+  }
+
+  /**
+   * Remove the connector instance and rule action for an alert subscription.
+   * Splits rule and connector cleanup so that a deleted rule doesn't prevent
+   * the connector from being removed.
+   */
+  private async cleanupAlertSubscription(sub: AlertTriggerSubscription): Promise<void> {
+    const alertingStart = this.getAlertingStart?.();
+    if (!alertingStart || !sub.alert_action_id) return;
+
+    // Remove from the rule — non-fatal if the rule was already deleted.
+    try {
+      const rulesClient = await alertingStart.getRulesClientWithRequest(this.request);
+      const rule = await rulesClient.get({ id: sub.config.rule_id });
+      const filteredActions = rule.actions
+        .filter((a) => a.id !== sub.alert_action_id)
+        .map((a) => ({
+          id: a.id,
+          group: a.group,
+          params: a.params,
+          frequency: a.frequency,
+          uuid: a.uuid,
+        }));
+      await rulesClient.bulkEdit({
+        ids: [sub.config.rule_id],
+        operations: [{ field: 'actions', operation: 'set', value: filteredActions }],
+      });
+    } catch (ruleErr) {
+      // Rule may have been deleted — log and proceed to delete the connector.
+      this.logger.debug(
+        `Could not remove action from rule ${sub.config.rule_id} (may be deleted): ${ruleErr}`
+      );
+    }
+
+    // Always attempt to delete the connector regardless of rule cleanup outcome.
+    const actionsClient = await this.getActionsStart().getActionsClientWithRequest(this.request);
+    await actionsClient.delete({ id: sub.alert_action_id });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private — OCC state mutation helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Optimistic concurrency control wrapper.
+   * The operation callback MUST be pure (no side effects) since it may run
+   * multiple times on 409 conflicts. Returns the same reference to skip the write.
+   * Retries up to MAX_RETRIES total attempts.
+   */
+  private async withOCC(
+    conversationId: string,
+    operation: (source: ConversationProperties) => ConversationProperties
+  ): Promise<void> {
+    let attempts = 0;
+
+    while (attempts < MAX_RETRIES) {
+      const doc = await this.esClient.get<ConversationProperties>({
+        index: conversationIndexName,
+        id: conversationId,
+      });
+
+      if (!doc._source) {
+        throw new Error(`Session document ${conversationId} not found`);
+      }
+
+      const updated = operation(doc._source);
+
+      // Skip the write if the operation produced no change (avoids pointless seq_no bumps).
+      if (updated === doc._source) return;
+
+      try {
+        await this.esClient.index({
+          index: conversationIndexName,
+          id: conversationId,
+          document: updated,
+          if_seq_no: doc._seq_no,
+          if_primary_term: doc._primary_term,
+        });
+        return;
+      } catch (err) {
+        const statusCode =
+          (err as { statusCode?: number })?.statusCode ??
+          (err as { meta?: { statusCode?: number } })?.meta?.statusCode;
+
+        if (statusCode === 409 && attempts < MAX_RETRIES - 1) {
+          attempts++;
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
+  /** Append a new subscription to the session's trigger_subscriptions list. */
+  private async writeNewSubscription(
+    conversationId: string,
+    subscription: TriggerSubscription
+  ): Promise<void> {
+    await this.withOCC(conversationId, (source) => {
+      const ss = getStandingSession(source);
+      if (ss.status === 'terminated') {
+        throw new Error(`Session ${conversationId} is terminated`);
+      }
+      return updateStandingSession(source, {
+        ...ss,
+        trigger_subscriptions: [...ss.trigger_subscriptions, subscription],
+      });
+    });
+  }
+
+  /** Update a specific subscription in-place, identified by `updatedSub.id`. */
+  private async updateSubscriptionInState(
+    conversationId: string,
+    updatedSub: TriggerSubscription
+  ): Promise<void> {
+    await this.withOCC(conversationId, (source) => {
+      const ss = getStandingSession(source);
+      const subscriptions = ss.trigger_subscriptions.map((s) =>
+        s.id === updatedSub.id ? updatedSub : s
+      );
+      return updateStandingSession(source, { ...ss, trigger_subscriptions: subscriptions });
+    });
+  }
+
+  /** Remove a subscription from state without cleaning up any external resources. */
+  private async removeSubscriptionFromState(
+    conversationId: string,
+    subscriptionId: string
+  ): Promise<void> {
+    await this.withOCC(conversationId, (source) => {
+      const ss = source.state?.standing_session;
+      if (!ss) return source;
+      const remaining = ss.trigger_subscriptions.filter((s) => s.id !== subscriptionId);
+      if (remaining.length === ss.trigger_subscriptions.length) return source; // not found, no-op
+      return updateStandingSession(source, { ...ss, trigger_subscriptions: remaining });
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private — round execution
+  // ---------------------------------------------------------------------------
+
+  private async startRound(
+    conversationId: string,
+    agentId: string,
+    triggerContext: TriggerContext,
+    connectorId?: string,
+    systemPromptOverride?: string
+  ): Promise<void> {
+    const executionService = this.getExecutionService();
+    try {
+      const { executionId } = await executionService.executeAgent({
+        request: this.request,
+        mode: AgentExecutionMode.conversation,
+        params: {
+          conversationId,
+          agentId,
+          ...(connectorId && { connectorId }),
+          ...(systemPromptOverride && {
+            configurationOverrides: { instructions: systemPromptOverride },
+          }),
+          nextInput: {
+            message: formatTriggerMessage(triggerContext),
+            source: triggerContext.type,
+            trigger_context: triggerContext,
+          },
+        },
+      });
+
+      // Store the executionId so the post-round hook can perform the safety check.
+      await this.withOCC(conversationId, (source) => {
+        const ss = source.state?.standing_session;
+        if (!ss) return source;
+        return updateStandingSession(source, { ...ss, active_execution_id: executionId });
+      });
+    } catch (err) {
+      // Roll back to idle so the session doesn't get permanently stuck in active.
+      await this.setStatus(conversationId, 'idle').catch((setErr) => {
+        this.logger.error(
+          `Failed to reset session ${conversationId} to idle after execution start failure: ${setErr}`
+        );
+      });
+      throw err;
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
@@ -183,7 +183,12 @@ export class SessionClientImpl implements SessionClient {
     const conversationClient = await this.conversationService.getScopedClient({
       request: this.request,
     });
-    return conversationClient.list({ agentId: options?.agent_id, sessionMode: 'standing' });
+    const results = await conversationClient.list({
+      agentId: options?.agent_id,
+      sessionMode: 'standing',
+    });
+    // Exclude terminated sessions by default — they are not actionable and clutter the list.
+    return results.filter((s) => s.state?.standing_session?.status !== 'terminated');
   }
 
   async terminate(conversationId: string): Promise<void> {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_client.ts
@@ -808,6 +808,11 @@ export class SessionClientImpl implements SessionClient {
     try {
       const { executionId } = await executionService.executeAgent({
         request: this.request,
+        // Always schedule on Task Manager so the round runs with a fakeRequest
+        // that is not tied to any HTTP connection lifecycle. Without this, rounds
+        // triggered from live HTTP requests (e.g. the messages endpoint) are aborted
+        // the moment the HTTP response is sent and the connection is closed.
+        useTaskManager: true,
         mode: AgentExecutionMode.conversation,
         params: {
           conversationId,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/session_service.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SecurityServiceStart } from '@kbn/core-security-server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { AlertingServerStart } from '@kbn/alerting-plugin/server';
+import type { SessionsStart, SessionClient } from '@kbn/agent-builder-server';
+import type { AgentExecutionService } from '@kbn/agent-builder-server/execution';
+import type { ConversationService } from '../conversation';
+import { getCurrentSpaceId } from '../../utils/spaces';
+import { SessionClientImpl } from './session_client';
+
+export interface SessionServiceDeps {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  taskManager: TaskManagerStartContract;
+  security: SecurityServiceStart;
+  spaces?: SpacesPluginStart;
+  conversationService: ConversationService;
+  getExecutionService: () => AgentExecutionService;
+  getActionsStart: () => ActionsPluginStart;
+  getAlertingStart: (() => AlertingServerStart) | undefined;
+}
+
+export class SessionServiceImpl implements SessionsStart {
+  private readonly deps: SessionServiceDeps;
+
+  constructor(deps: SessionServiceDeps) {
+    this.deps = deps;
+  }
+
+  getScopedClient({ request }: { request: KibanaRequest }): SessionClient {
+    const {
+      logger,
+      esClient,
+      taskManager,
+      security,
+      spaces,
+      conversationService,
+      getExecutionService,
+      getActionsStart,
+      getAlertingStart,
+    } = this.deps;
+    const space = getCurrentSpaceId({ request, spaces });
+
+    return new SessionClientImpl({
+      esClient,
+      taskManager,
+      logger,
+      request,
+      space,
+      security,
+      conversationService,
+      getExecutionService,
+      getActionsStart,
+      getAlertingStart,
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/trigger_tasks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/trigger_tasks.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+  IntervalSchedule,
+} from '@kbn/task-manager-plugin/server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { ScheduleTriggerContext, ReminderTriggerContext } from '@kbn/agent-builder-common';
+import type { SessionsStart } from '@kbn/agent-builder-server';
+
+// ---------------------------------------------------------------------------
+// Task type constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Task type for recurring scheduled triggers.
+ * One task per ScheduleTriggerSubscription, runs on its configured interval/cron.
+ */
+export const AGENT_SESSION_SCHEDULED_TASK_TYPE = 'agent_session:scheduled';
+
+/**
+ * Task type for one-shot reminder triggers.
+ * Runs once at the configured time then self-removes.
+ */
+export const AGENT_SESSION_REMINDER_TASK_TYPE = 'agent_session:reminder';
+
+// ---------------------------------------------------------------------------
+// Task params — stored in the Task Manager document
+// ---------------------------------------------------------------------------
+
+export interface AgentSessionScheduledTaskParams {
+  conversationId: string;
+  subscriptionId: string;
+  spaceId: string;
+  /** Human-readable schedule description echoed into the trigger context. */
+  scheduleDescription: string;
+}
+
+export interface AgentSessionReminderTaskParams {
+  conversationId: string;
+  subscriptionId: string;
+  spaceId: string;
+  note?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Task ID helpers
+// ---------------------------------------------------------------------------
+
+export const scheduledTaskId = (conversationId: string, subscriptionId: string) =>
+  `agent_session:scheduled:${conversationId}:${subscriptionId}`;
+
+export const reminderTaskId = (conversationId: string, subscriptionId: string) =>
+  `agent_session:reminder:${conversationId}:${subscriptionId}`;
+
+// ---------------------------------------------------------------------------
+// Task definition factory
+// ---------------------------------------------------------------------------
+
+interface RegisterDeps {
+  taskManager: TaskManagerSetupContract;
+  logger: Logger;
+  /** Resolved lazily at run time via getStartServices to avoid circular init order. */
+  getSessionsStart: () => SessionsStart;
+}
+
+/**
+ * Register both session trigger task types with Task Manager.
+ * Call this during plugin setup (when taskManager.registerTaskDefinitions is available).
+ */
+export const registerAgentSessionTriggerTasks = ({
+  taskManager,
+  logger,
+  getSessionsStart,
+}: RegisterDeps): void => {
+  // -------------------------------------------------------------------------
+  // Recurring scheduled trigger
+  // -------------------------------------------------------------------------
+  taskManager.registerTaskDefinitions({
+    [AGENT_SESSION_SCHEDULED_TASK_TYPE]: {
+      title: 'Agent Session: Scheduled Trigger',
+      description: 'Wakes a standing agent session on a recurring schedule.',
+      timeout: '1m',
+      maxAttempts: 3,
+      createTaskRunner: ({ taskInstance, fakeRequest }) => {
+        return {
+          run: async () => {
+            if (!fakeRequest) {
+              logger.error(
+                `[${AGENT_SESSION_SCHEDULED_TASK_TYPE}] No fakeRequest — task was scheduled without a user context.`
+              );
+              return { state: taskInstance.state };
+            }
+
+            const { conversationId, subscriptionId, scheduleDescription } =
+              taskInstance.params as AgentSessionScheduledTaskParams;
+
+            const firedAt = new Date().toISOString();
+            const context: ScheduleTriggerContext = {
+              type: 'schedule_trigger',
+              subscription_id: subscriptionId,
+              event: { fired_at: firedAt, schedule_description: scheduleDescription },
+            };
+
+            try {
+              const sessions = getSessionsStart();
+              const client = sessions.getScopedClient({ request: fakeRequest as KibanaRequest });
+              await client.enqueueTrigger(conversationId, context);
+              logger.debug(
+                `[${AGENT_SESSION_SCHEDULED_TASK_TYPE}] Enqueued trigger for session ${conversationId}, subscription ${subscriptionId}`
+              );
+            } catch (err) {
+              logger.error(
+                `[${AGENT_SESSION_SCHEDULED_TASK_TYPE}] Failed to enqueue trigger for session ${conversationId}: ${err}`
+              );
+              throw err;
+            }
+
+            return { state: taskInstance.state };
+          },
+        };
+      },
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // One-shot reminder trigger
+  // -------------------------------------------------------------------------
+  taskManager.registerTaskDefinitions({
+    [AGENT_SESSION_REMINDER_TASK_TYPE]: {
+      title: 'Agent Session: Reminder Trigger',
+      description: 'Wakes a standing agent session once at a configured time.',
+      timeout: '1m',
+      maxAttempts: 3,
+      createTaskRunner: ({ taskInstance, fakeRequest }) => {
+        return {
+          run: async () => {
+            if (!fakeRequest) {
+              logger.error(
+                `[${AGENT_SESSION_REMINDER_TASK_TYPE}] No fakeRequest — task was scheduled without a user context.`
+              );
+              return { state: taskInstance.state };
+            }
+
+            const { conversationId, subscriptionId, note } =
+              taskInstance.params as AgentSessionReminderTaskParams;
+
+            const firedAt = new Date().toISOString();
+            const context: ReminderTriggerContext = {
+              type: 'reminder_trigger',
+              subscription_id: subscriptionId,
+              event: { reminder_id: subscriptionId, note, fired_at: firedAt },
+            };
+
+            try {
+              const sessions = getSessionsStart();
+              const client = sessions.getScopedClient({ request: fakeRequest as KibanaRequest });
+
+              await client.enqueueTrigger(conversationId, context);
+
+              // Auto-remove the reminder subscription — it's one-shot.
+              try {
+                await client.removeSubscription(conversationId, subscriptionId);
+              } catch (removeErr) {
+                // Non-fatal: subscription may have already been removed manually.
+                logger.debug(
+                  `[${AGENT_SESSION_REMINDER_TASK_TYPE}] Could not remove subscription ${subscriptionId} after firing: ${removeErr}`
+                );
+              }
+
+              logger.debug(
+                `[${AGENT_SESSION_REMINDER_TASK_TYPE}] Reminder fired for session ${conversationId}, subscription ${subscriptionId}`
+              );
+            } catch (err) {
+              logger.error(
+                `[${AGENT_SESSION_REMINDER_TASK_TYPE}] Failed to fire reminder for session ${conversationId}: ${err}`
+              );
+              throw err;
+            }
+
+            // Return deleteTaskAfterRun to prevent TM from rescheduling.
+            return { state: taskInstance.state, deleteTaskAfterRun: true };
+          },
+        };
+      },
+    },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Task scheduler helpers — called by SessionService when tools subscribe
+// ---------------------------------------------------------------------------
+
+interface ScheduleSessionTaskDeps {
+  taskManager: TaskManagerStartContract;
+  request: KibanaRequest;
+  logger: Logger;
+}
+
+/**
+ * Schedule (or update) a Task Manager task for a recurring session schedule subscription.
+ * Idempotent: 409 conflicts update the existing task's schedule in place.
+ */
+export const scheduleSessionScheduledTask = async (
+  params: AgentSessionScheduledTaskParams,
+  schedule: IntervalSchedule,
+  deps: ScheduleSessionTaskDeps
+): Promise<string> => {
+  const taskId = scheduledTaskId(params.conversationId, params.subscriptionId);
+
+  try {
+    const task = await deps.taskManager.schedule(
+      {
+        id: taskId,
+        taskType: AGENT_SESSION_SCHEDULED_TASK_TYPE,
+        schedule,
+        params,
+        state: {},
+        scope: ['agent_sessions'],
+        enabled: true,
+      },
+      { request: deps.request }
+    );
+    return task.id;
+  } catch (err) {
+    if ((err as { statusCode?: number }).statusCode === 409) {
+      await deps.taskManager.bulkUpdateSchedules([taskId], schedule, { request: deps.request });
+      return taskId;
+    }
+    throw err;
+  }
+};
+
+/**
+ * Schedule a one-shot Task Manager task for a reminder subscription.
+ * Uses `runAt` to fire exactly once at the configured time.
+ */
+export const scheduleSessionReminderTask = async (
+  params: AgentSessionReminderTaskParams,
+  firesAt: Date,
+  deps: ScheduleSessionTaskDeps
+): Promise<string> => {
+  const taskId = reminderTaskId(params.conversationId, params.subscriptionId);
+
+  const task = await deps.taskManager.schedule(
+    {
+      id: taskId,
+      taskType: AGENT_SESSION_REMINDER_TASK_TYPE,
+      runAt: firesAt,
+      params,
+      state: {},
+      scope: ['agent_sessions'],
+      enabled: true,
+    },
+    { request: deps.request }
+  );
+  return task.id;
+};
+
+/**
+ * Cancel a Task Manager task for a session trigger subscription.
+ * Non-fatal if the task no longer exists.
+ */
+export const cancelSessionTriggerTask = async (
+  taskId: string,
+  deps: { taskManager: TaskManagerStartContract; logger: Logger }
+): Promise<void> => {
+  try {
+    await deps.taskManager.removeIfExists(taskId);
+  } catch (err) {
+    deps.logger.debug(`Could not remove task ${taskId}: ${err}`);
+  }
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/workflow_session_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/workflow_session_tool.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import type { ReminderTriggerSubscription } from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import {
+  getAgentFromRunContext,
+  createOtherResult,
+  createErrorResult,
+} from '@kbn/agent-builder-server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import { executeWorkflow } from '../workflow/execute_workflow';
+import type { SessionsStart } from './session_service';
+
+type WorkflowApi = WorkflowsServerPluginSetup['management'];
+
+const otherResult = (content: string) => ({ results: [createOtherResult({ content })] });
+const errResult = (message: string) => ({ results: [createErrorResult(`Error: ${message}`)] });
+
+const requireConversationId = (
+  runContext: Parameters<typeof getAgentFromRunContext>[0]
+): string => {
+  const id = getAgentFromRunContext(runContext)?.conversationId;
+  if (!id)
+    throw new Error('session tools are only available inside a standing session conversation');
+  return id;
+};
+
+const runWorkflowSchema = z.object({
+  workflow_id: z.string().describe('ID of the workflow to run.'),
+  params: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Input parameters to pass to the workflow.'),
+  check_interval_seconds: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      'How often (in seconds) to wake this session to check the workflow status. Default: 60. ' +
+        'When the reminder fires, use the workflow status tool to check progress; ' +
+        'if still running, set another reminder. Cancel the check subscription when done.'
+    ),
+});
+
+/**
+ * Creates the session.run_workflow built-in tool.
+ * Kept separate from createSessionTools because it requires workflowApi
+ * from the plugin setup contract (not available in the shared package).
+ */
+export const createWorkflowSessionTool = (
+  sessions: SessionsStart,
+  workflowApi: WorkflowApi
+): BuiltinToolDefinition<typeof runWorkflowSchema> => ({
+  id: 'session.run_workflow',
+  type: ToolType.builtin,
+  tags: [],
+  description:
+    'Start a Kibana workflow and subscribe this session to be notified when it completes. ' +
+    'The workflow receives the current session ID as `__session_id__` so any ' +
+    '`ai.send_session_message` step in the workflow can notify the session immediately. ' +
+    'A reminder is also set automatically to poll for completion in case the workflow ' +
+    'does not include a callback step. ' +
+    'Returns the workflow execution ID and the check-subscription ID.',
+  schema: runWorkflowSchema,
+  handler: async (params, context) => {
+    const conversationId = requireConversationId(context.runContext);
+    const client = sessions.getScopedClient({ request: context.request });
+
+    const workflowParams: Record<string, unknown> = {
+      ...(params.params ?? {}),
+      __session_id__: conversationId,
+    };
+
+    const result = await executeWorkflow({
+      workflowId: params.workflow_id,
+      workflowParams,
+      request: context.request,
+      spaceId: context.spaceId,
+      workflowApi,
+      waitForCompletion: false,
+    });
+
+    if (!result.success) {
+      return errResult(result.error ?? 'Failed to start workflow');
+    }
+
+    const executionId = result.execution.executionId;
+    const intervalSeconds = params.check_interval_seconds ?? 60;
+    const firesAt = new Date(Date.now() + intervalSeconds * 1000).toISOString();
+    const subscriptionId = uuidv4();
+
+    const subscription: ReminderTriggerSubscription = {
+      id: subscriptionId,
+      type: 'reminder_trigger',
+      one_shot: true,
+      config: {
+        fires_at: firesAt,
+        note: `workflow_check:${executionId}`,
+      },
+      task_id: '',
+      created_at: new Date().toISOString(),
+    };
+
+    try {
+      await client.addSubscription(conversationId, subscription);
+    } catch (err) {
+      // Non-fatal — the workflow still started; warn the agent it must poll manually.
+      return otherResult(
+        JSON.stringify({
+          execution_id: executionId,
+          check_subscription_id: null,
+          warning:
+            `Workflow started but could not set automatic check reminder: ${err}. ` +
+            'Use session.set_reminder manually to poll for completion.',
+        })
+      );
+    }
+
+    return otherResult(
+      JSON.stringify({
+        execution_id: executionId,
+        check_subscription_id: subscriptionId,
+        check_at: firesAt,
+        instructions:
+          `Workflow started. A reminder fires in ${intervalSeconds}s. ` +
+          'When the reminder note is "workflow_check:<id>", call the workflow status tool with that execution ID. ' +
+          'If not yet complete, set another reminder via session.set_reminder. ' +
+          'Once complete, call session.unsubscribe with the check_subscription_id (if it has not yet fired) ' +
+          'and process the workflow result.',
+      })
+    );
+  },
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/workflow_session_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/workflow_session_tool.ts
@@ -155,7 +155,7 @@ const createRunWorkflowTool = (
       return errResult(result.error ?? 'Failed to start workflow');
     }
 
-    const executionId = result.execution.executionId;
+    const executionId = result.execution.execution_id;
     const intervalSeconds = params.check_interval_seconds ?? 60;
     const firesAt = new Date(Date.now() + intervalSeconds * 1000).toISOString();
     const subscriptionId = uuidv4();

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/workflow_session_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sessions/workflow_session_tool.ts
@@ -51,12 +51,74 @@ const runWorkflowSchema = z.object({
     ),
 });
 
+// ---------------------------------------------------------------------------
+// session.list_workflows
+// ---------------------------------------------------------------------------
+
+const listWorkflowsSchema = z.object({
+  query: z.string().optional().describe('Free-text search to filter workflows by name.'),
+  enabled_only: z
+    .boolean()
+    .optional()
+    .describe('When true (default), only return enabled workflows.'),
+});
+
+const createListWorkflowsTool = (
+  workflowApi: WorkflowApi
+): BuiltinToolDefinition<typeof listWorkflowsSchema> => ({
+  id: 'session.list_workflows',
+  type: ToolType.builtin,
+  tags: [],
+  description:
+    'List Kibana workflows available in the current space. ' +
+    'Returns workflow IDs, names, descriptions, and enabled status. ' +
+    'Use the returned id with session.run_workflow to start a workflow.',
+  schema: listWorkflowsSchema,
+  handler: async (params, context) => {
+    try {
+      const result = await workflowApi.getWorkflows(
+        {
+          size: 100,
+          page: 1,
+          enabled: params.enabled_only !== false ? [true] : undefined,
+          query: params.query,
+        },
+        context.spaceId
+      );
+      const summary = result.results.map((w) => ({
+        id: w.id,
+        name: w.name,
+        description: w.description ?? null,
+        enabled: w.enabled,
+        valid: w.valid,
+        tags: w.tags ?? [],
+      }));
+      return otherResult(JSON.stringify({ total: result.total, workflows: summary }));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return errResult(`Could not list workflows: ${msg}`);
+    }
+  },
+});
+
+// ---------------------------------------------------------------------------
+// session.run_workflow
+// ---------------------------------------------------------------------------
+
 /**
- * Creates the session.run_workflow built-in tool.
- * Kept separate from createSessionTools because it requires workflowApi
+ * Creates both workflow-related session tools.
+ * Kept separate from createSessionTools because they require workflowApi
  * from the plugin setup contract (not available in the shared package).
  */
-export const createWorkflowSessionTool = (
+export const createWorkflowSessionTools = (
+  sessions: SessionsStart,
+  workflowApi: WorkflowApi
+): BuiltinToolDefinition[] => [
+  createListWorkflowsTool(workflowApi),
+  createRunWorkflowTool(sessions, workflowApi),
+];
+
+const createRunWorkflowTool = (
   sessions: SessionsStart,
   workflowApi: WorkflowApi
 ): BuiltinToolDefinition<typeof runWorkflowSchema> => ({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
@@ -18,8 +18,13 @@ import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { AlertingServerStart } from '@kbn/alerting-plugin/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
-import type { HooksServiceSetup, HooksServiceStart } from '@kbn/agent-builder-server';
+import type {
+  HooksServiceSetup,
+  HooksServiceStart,
+  SessionsStart,
+} from '@kbn/agent-builder-server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { UsageApiSetup } from '@kbn/usage-api-plugin/server';
 import type { AgentExecutionService } from '@kbn/agent-builder-server/execution';
@@ -52,6 +57,7 @@ export interface InternalStartServices {
   attachments: AttachmentServiceStart;
   skills: SkillServiceStart;
   conversations: ConversationService;
+  sessions: SessionsStart;
   runnerFactory: RunnerFactory;
   hooks: HooksServiceStart;
   auditLogService: AuditLogService;
@@ -91,4 +97,5 @@ export interface ServicesStartDeps {
   trackingService?: TrackingService;
   analyticsService?: AnalyticsService;
   searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
+  alerting?: AlertingServerStart;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/index.ts
@@ -9,3 +9,4 @@ import { getRunAgentStepDefinition } from './run_agent_step';
 import { rerankStepDefinition } from './rerank_step';
 
 export { getRunAgentStepDefinition, rerankStepDefinition };
+export { getSendSessionMessageStepDefinition } from './send_session_message_step';

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/send_session_message_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/send_session_message_step.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import type { ServiceManager } from '../services';
+import { sendSessionMessageStepCommonDefinition } from '../../common/step_types/send_session_message_step';
+
+/**
+ * Server step definition for the "ai.send_session_message" step.
+ * Injects a text message into a standing session trigger queue.
+ */
+export const getSendSessionMessageStepDefinition = (serviceManager: ServiceManager) => {
+  return createServerStepDefinition({
+    ...sendSessionMessageStepCommonDefinition,
+    handler: async (context) => {
+      try {
+        const { session_id: sessionId, message } = context.input;
+        const request = context.contextManager.getFakeRequest();
+        if (!request) {
+          throw new Error('No request available in workflow context');
+        }
+
+        const sessionsService = serviceManager.internalStart?.sessions;
+        if (!sessionsService) {
+          throw new Error('Sessions service is not available');
+        }
+
+        const client = sessionsService.getScopedClient({ request });
+        const messageId = uuidv4();
+        const result = await client.enqueueTrigger(sessionId, {
+          type: 'session_message',
+          subscription_id: undefined,
+          event: {
+            from_session_id: 'workflow',
+            from_agent_id: 'workflow',
+            message,
+            message_id: messageId,
+          },
+        });
+
+        return {
+          output: {
+            status: result.status,
+            message_id: messageId,
+          },
+        };
+      } catch (error) {
+        context.logger.error(
+          'ai.send_session_message step failed',
+          error instanceof Error ? error : new Error(String(error))
+        );
+        return { error: error instanceof Error ? error : new Error(String(error)) };
+      }
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -32,6 +32,7 @@ import type {
   AgentContextLayerPluginSetup,
   AgentContextLayerPluginStart,
 } from '@kbn/agent-context-layer-plugin/server';
+import type { AlertingServerStart } from '@kbn/alerting-plugin/server';
 
 export type {
   AgentBuilderPluginSetup,
@@ -79,4 +80,5 @@ export interface AgentBuilderStartDependencies {
   security?: SecurityPluginStart;
   searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
   agentContextLayer: AgentContextLayerPluginStart;
+  alerting?: AlertingServerStart;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
@@ -108,6 +108,7 @@
     "@kbn/core-saved-objects-api-server",
     "@kbn/security-plugin-types-server",
     "@kbn/agent-context-layer-plugin",
+    "@kbn/alerting-plugin",
     "@kbn/shared-ux-ai-components",
     "@kbn/fs",
     "@kbn/react-hooks",


### PR DESCRIPTION
## Summary

Introduces **standing sessions**: long-lived agents that run in the background, independent of active UI sessions. They wake on external triggers, process events sequentially, and sleep when idle.

### What's in this PR

**Data model**
- `SessionMode` discriminator on `Conversation` (`'interactive' | 'standing'`)
- `StandingSessionState` stored in `ConversationInternalState`: status, trigger subscriptions, pending trigger queue, `active_execution_id` for post-round safety
- `TriggerContext` discriminated union for 5 trigger types; `source` / `trigger_context` fields piped through `ConverseInput` → `RoundInput`

**Session lifecycle (server)**
- `SessionClient` / `SessionsStart` contract (agent-builder-server package)
- `SessionClientImpl` with OCC-based state mutations; three-phase subscription provisioning prevents orphaned TM tasks and connectors on partial failure
- Task Manager task definitions for recurring interval schedules and one-shot reminders
- Alert connector type (`.agent-session-alert`) registered with Kibana Actions
- Post-round `drainQueue` hook in both local and TM execution paths, with `active_execution_id` safety guard to prevent double-drain races
- `alerting` added as optional plugin dependency for rule action management

**Session tools (agent-controlled)**
- `session.set_idle`, `session.terminate`, `session.subscribe_to_alert/schedule/webhook`, `session.set_reminder`, `session.unsubscribe`, `session.send_message`

**HTTP routes (internal)**
- `POST/GET /internal/agent_builder/sessions` — create / list
- `GET/DELETE /internal/agent_builder/sessions/{id}` — get / terminate
- `POST /internal/agent_builder/sessions/{id}/messages` — inject message

**Workflow step**
- `ai.send_session_message` step for Kibana Workflows

## Known limitations / follow-ups
- Webhook receive endpoint not yet implemented
- TTL enforcement (periodic cleanup) not yet implemented
- Creator-credential pinning requires storing API key at session creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)