### PR TITLE
[9.4] [AI Infra] Extend GenAI Settings Scout page navigation timeout (#265692)

### DIFF
--- a/x-pack/platform/plugins/private/gen_ai_settings/test/scout/ui/fixtures/page_objects/gen_ai_settings_page.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/test/scout/ui/fixtures/page_objects/gen_ai_settings_page.ts
@@ -24,8 +24,13 @@ export class GenAiSettingsPage {
    * Navigate to the GenAI Settings page in Stack Management
    */
   async navigateTo() {
-    await this.page.gotoApp('management/ai/genAiSettings');
-    await this.waitForPageToLoad();
+    await expect(async () => {
+      await this.page.gotoApp('management/ai/genAiSettings');
+      await this.page.testSubj.waitForSelector('genAiSettingsPage', {
+        state: 'visible',
+        timeout: 10_000,
+      });
+    }).toPass({ timeout: 35_000, intervals: [500, 1_000, 2_000] });
   }
 
   /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[AI Infra] Extend GenAI Settings Scout page navigation timeout (#265692)](https://github.com/elastic/kibana/pull/265692)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Krasocki","email":"104936644+KodeRad@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-28T11:24:53Z","message":"[AI Infra] Extend GenAI Settings Scout page navigation timeout (#265692)\n\n## Summary\n\nExtends the timeout values in the `GenAiSettingsPage.navigateTo()` page\nobject to give the page sufficient time to load.\n\nThe retry logic introduced in #260496 used a 3s inner `waitForSelector`\ntimeout, which was too short on slower VMs — the page could fail to\nappear within that window even though it would have loaded given more\ntime. This meant the retry loop was bailing out prematurely rather than\nwaiting long enough per attempt.\n\nChanges:\n- `waitForSelector` timeout: `3_000` → `10_000` ms\n- `.toPass` outer timeout: `30_000` → `35_000` ms (accommodates 3 full\nretry attempts of up to 10s each, with intervals of 500ms / 1s / 2s\nbetween them)\n\nRelates to #260496\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk — test-only change, no production code affected.","sha":"5462ceb8c6ccb0e582719b2dc432bcb09236b69f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":[":ml","release_note:skip","Team:ML","backport:version","reviewer:coderabbit","reviewer:macroscope","v9.5.0","v9.4.1"],"title":"[AI Infra] Extend GenAI Settings Scout page navigation timeout","number":265692,"url":"https://github.com/elastic/kibana/pull/265692","mergeCommit":{"message":"[AI Infra] Extend GenAI Settings Scout page navigation timeout (#265692)\n\n## Summary\n\nExtends the timeout values in the `GenAiSettingsPage.navigateTo()` page\nobject to give the page sufficient time to load.\n\nThe retry logic introduced in #260496 used a 3s inner `waitForSelector`\ntimeout, which was too short on slower VMs — the page could fail to\nappear within that window even though it would have loaded given more\ntime. This meant the retry loop was bailing out prematurely rather than\nwaiting long enough per attempt.\n\nChanges:\n- `waitForSelector` timeout: `3_000` → `10_000` ms\n- `.toPass` outer timeout: `30_000` → `35_000` ms (accommodates 3 full\nretry attempts of up to 10s each, with intervals of 500ms / 1s / 2s\nbetween them)\n\nRelates to #260496\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk — test-only change, no production code affected.","sha":"5462ceb8c6ccb0e582719b2dc432bcb09236b69f"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265692","number":265692,"mergeCommit":{"message":"[AI Infra] Extend GenAI Settings Scout page navigation timeout (#265692)\n\n## Summary\n\nExtends the timeout values in the `GenAiSettingsPage.navigateTo()` page\nobject to give the page sufficient time to load.\n\nThe retry logic introduced in #260496 used a 3s inner `waitForSelector`\ntimeout, which was too short on slower VMs — the page could fail to\nappear within that window even though it would have loaded given more\ntime. This meant the retry loop was bailing out prematurely rather than\nwaiting long enough per attempt.\n\nChanges:\n- `waitForSelector` timeout: `3_000` → `10_000` ms\n- `.toPass` outer timeout: `30_000` → `35_000` ms (accommodates 3 full\nretry attempts of up to 10s each, with intervals of 500ms / 1s / 2s\nbetween them)\n\nRelates to #260496\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk — test-only change, no production code affected.","sha":"5462ceb8c6ccb0e582719b2dc432bcb09236b69f"}},{"branch":"9.4","label":"v9.4.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->