### PR TITLE
[Lens] Make applyButtonDisabledTooltip accessible

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
@@ -219,6 +219,7 @@ export const FlyoutWrapper = ({
                     onClick={onApply}
                     fill
                     disabled={!isSaveable}
+                    hasAriaDisabled
                     iconType="check"
                     data-test-subj="applyFlyoutButton"
                   >

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.test.tsx
@@ -149,6 +149,12 @@ const startDependencies = {
 const datasourceMap = mockDatasourceMap();
 const visualizationMap = mockVisualizationMap();
 
+const expectToBeEUIAriaDisabledButton = (element: HTMLElement) => {
+  expect(element).toHaveClass('euiButton');
+  expect(element).toHaveAttribute('type', 'button');
+  expect(element).toHaveAttribute('aria-disabled', 'true');
+};
+
 describe('LensEditConfigurationFlyout', () => {
   async function renderConfigFlyout(
     propsOverrides: Partial<EditConfigPanelProps> = {},
@@ -364,7 +370,7 @@ describe('LensEditConfigurationFlyout', () => {
     // Set formBased to match the preloaded Redux state so no changes are detected
     newProps.attributes.state.datasourceStates.formBased = mockFormBasedState;
     await renderConfigFlyout(newProps);
-    expect(screen.getByRole('button', { name: /apply and close/i })).toBeDisabled();
+    expectToBeEUIAriaDisabledButton(screen.getByRole('button', { name: /apply and close/i }));
   });
 
   it('save button should be disabled if expression cannot be generated', async () => {
@@ -385,7 +391,7 @@ describe('LensEditConfigurationFlyout', () => {
     };
 
     await renderConfigFlyout(newProps);
-    expect(screen.getByRole('button', { name: /apply and close/i })).toBeDisabled();
+    expectToBeEUIAriaDisabledButton(screen.getByRole('button', { name: /apply and close/i }));
   });
 
   it('should use correct activeVisualization', async () => {


### PR DESCRIPTION
## Summary

Adds [hasAriaDisabled](https://eui.elastic.co/docs/components/navigation/buttons/button/#disabled-and-focusable-) to the Save button in the visualization flyout.

Without this, when the button is disabled and displaying an `applyButtonDisabledTooltip`, the user can only reveal this tooltip on mouse hover, not using the keyboard. `hasAriaDisabled` makes the disabled button keyboard-focusable for the purpose of showing the tooltip.
