### PR TITLE
[Lens] Align APM error tracking label names with kibana_meta_* convention

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -337,11 +337,12 @@ export function loadEmbeddableData(
         const transaction = apm.getCurrentTransaction();
         if (transaction) {
           const span = transaction.startSpan('lens-chart-error', 'lens-embeddable');
+
           if (span) {
             span.addLabels({
-              kibana_meta_lens_metric_type: currentState.attributes?.visualizationType ?? 'unknown',
-              kibana_meta_lens_profile_id: meta?.profile_id ?? 'unknown',
-              kibana_meta_lens_metric_id: meta?.metric_id ?? 'unknown',
+              kibana_meta_metric_type: currentState.attributes?.visualizationType ?? 'unknown',
+              kibana_meta_profile_id: meta?.profile_id ?? 'unknown',
+              kibana_meta_metric_id: meta?.metric_id ?? 'unknown',
             });
             apm.captureError(error);
             // @ts-expect-error RUM types don't include outcome


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/elastic/kibana/pull/265354.

Renames the APM span labels added for Lens chart render error tracking to align with the `kibana_meta_*` naming convention used across the codebase, matching the `meta` field names set in `use_lens_props.ts`:

- `kibana_meta_lens_metric_type` → `kibana_meta_metric_type`
- `kibana_meta_lens_profile_id` → `kibana_meta_profile_id`
- `kibana_meta_lens_metric_id` → `kibana_meta_metric_id`


<img width="1462" height="824" alt="Screenshot 2026-05-06 at 18 58 13" src="https://github.com/user-attachments/assets/11b1c841-fb15-4bbe-8598-d3ec852cf649" />


### How to test

Trigger a Lens chart render failure (e.g. open Discover in traces ES|QL mode and introduce a `verification_exception` by querying a non-existent field). In the APM UI, open the resulting transaction and confirm the `lens-chart-error` span carries labels named `kibana_meta_metric_type`, `kibana_meta_profile_id`, and `kibana_meta_metric_id`.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->