### PR TITLE
test(apm): stabilize RedirectWithDefaultEnvironment Jest (#261857)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_default_environment/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_default_environment/index.test.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import { RouterProvider } from '@kbn/typed-react-router-config';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import type { Location, MemoryHistory } from 'history';
 import { createMemoryHistory } from 'history';
 import qs from 'query-string';
@@ -14,12 +14,19 @@ import { RedirectWithDefaultEnvironment } from '.';
 import { apmRouter } from '../../apm_route_config';
 import * as useApmPluginContextExports from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
+import { fromQuery } from '../../../shared/links/url_helpers';
 
 describe('RedirectWithDefaultEnvironment', () => {
   let history: MemoryHistory;
 
+  const noQuery = '';
+
   beforeEach(() => {
     history = createMemoryHistory();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   function renderUrl(location: Pick<Location, 'pathname' | 'search'>, defaultSetting: string) {
@@ -43,25 +50,23 @@ describe('RedirectWithDefaultEnvironment', () => {
   }
 
   it('eventually renders the child element', async () => {
-    const element = renderUrl(
+    const view = renderUrl(
       {
         pathname: '/services',
-        search: location.search,
+        search: noQuery,
       },
       ''
     );
 
-    await expect(element.findByText('Foo')).resolves.not.toBeUndefined();
-
-    // assertion to make sure our element test actually works
-    await expect(element.findByText('Bar')).rejects.not.toBeUndefined();
+    expect(await view.findByText('Foo')).toBeInTheDocument();
+    expect(view.queryByText('Bar')).not.toBeInTheDocument();
   });
 
   it('redirects to ENVIRONMENT_ALL if not set', async () => {
     renderUrl(
       {
         pathname: '/services',
-        search: location.search,
+        search: noQuery,
       },
       ''
     );
@@ -69,11 +74,31 @@ describe('RedirectWithDefaultEnvironment', () => {
     expect(qs.parse(history.entries[0].search).environment).toEqual(ENVIRONMENT_ALL.value);
   });
 
+  it('preserves existing query when adding default environment', async () => {
+    renderUrl(
+      {
+        pathname: '/services',
+        search: fromQuery({
+          rangeFrom: 'now-15m',
+          rangeTo: 'now',
+        }),
+      },
+      ''
+    );
+
+    await waitFor(() => {
+      const parsed = qs.parse(history.location.search);
+      expect(parsed.environment).toEqual(ENVIRONMENT_ALL.value);
+      expect(parsed.rangeFrom).toEqual('now-15m');
+      expect(parsed.rangeTo).toEqual('now');
+    });
+  });
+
   it('redirects to the default environment if set', () => {
     renderUrl(
       {
         pathname: '/services',
-        search: location.search,
+        search: noQuery,
       },
       'production'
     );
@@ -99,7 +124,7 @@ describe('RedirectWithDefaultEnvironment', () => {
     renderUrl(
       {
         pathname: '/services/opbeans-java',
-        search: location.search,
+        search: noQuery,
       },
       ''
     );


### PR DESCRIPTION
## Summary

Fixes unstable and slow behavior in `RedirectWithDefaultEnvironment` Jest tests ([CI hit the default 5000ms test timeout on main](https://github.com/elastic/kibana/issues/261857)).

- **Explicit `search`** — Use a fixed empty query (`noQuery`) instead of `window.location.search` so the scenario does not depend on JSDOM/global URL or test order.
- **Mock isolation** — `jest.restoreAllMocks()` in `afterEach` so `useApmPluginContext` spies do not leak across cases.
- **No `findBy*` for missing content** — Kibana sets RTL `asyncUtilTimeout: 4500` (`@kbn/test`). The old `findByText('Bar')` waited the full interval on every run because `Bar` never appears; that stacked on top of waiting for `Foo` and could exceed Jest’s **5000ms** per-test limit on CI. Replaced with synchronous `queryByText('Bar')` after `Foo` is found.
- **Query merge coverage** — New test using `fromQuery({ rangeFrom, rangeTo })` and `waitFor` on `history.location` to assert existing params are preserved when `environment` is injected.

Extra Jest timeout is no longer required once the negative assertion is fixed.

## Local run (single file)

Using the APM Jest config (`node scripts/jest … --config …/apm/jest.config.js`):

| Line | Meaning |
|------|--------|
| **~20s** | Full file / worker time (transform + loading `apm_router` and its dependency graph). |
| **~1–35 ms** per `✓` | Actual per-`it` execution after the above. Example: `eventually renders the child element` ~**35 ms** (author machine); **~202 ms** observed on another cold run—both far below 5s. |

So slow **file** wall time is dominated by **imports / bundling**, not the redirect assertions.

## References

Closes https://github.com/elastic/kibana/issues/261857
Closes https://github.com/elastic/kibana/issues/256015

## Flaky test runner

**Catch flakiness early (recommended):** run the flaky test runner against this PR before merging. This PR fixes a Jest test that previously exceeded the default **5000ms** per-test timeout on merge.

Trigger via the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment (repo member/owner):

```
/flaky config:x-pack/solutions/observability/plugins/apm/jest.config.js:30
```

Made with [Cursor](https://cursor.com)


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->