### PR TITLE
[Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test

### DIFF
--- a/src/platform/plugins/shared/console/moon.yml
+++ b/src/platform/plugins/shared/console/moon.yml
@@ -18,6 +18,7 @@ project:
   sourceRoot: src/platform/plugins/shared/console
 dependsOn:
   - '@kbn/scout'
+  - '@kbn/test-es-server'
   - '@kbn/core'
   - '@kbn/dev-tools-plugin'
   - '@kbn/es-ui-shared-plugin'

--- a/src/platform/plugins/shared/console/test/scout/api/tests/autocomplete_entities_stateful.spec.ts
+++ b/src/platform/plugins/shared/console/test/scout/api/tests/autocomplete_entities_stateful.spec.ts
@@ -7,13 +7,24 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { RoleApiCredentials } from '@kbn/scout';
+import { UndiciConnection } from '@elastic/elasticsearch';
+import type { EsClient, RoleApiCredentials } from '@kbn/scout';
 import { apiTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
+import { createEsClientForTesting } from '@kbn/test-es-server';
 import { COMMON_HEADERS } from '../fixtures/constants';
 
 const LEGACY_TEMPLATE_NAME = 'test-legacy-template-1';
 const AUTOCOMPLETE_API = 'api/console/autocomplete_entities';
+// `PUT _template` against a wildcard pattern emits one `Warning:` deprecation
+// header per overlapping composable template; on a populated cluster this can
+// exceed Node's default 16 KB `maxHeaderSize` and trip `HPE_HEADER_OVERFLOW`.
+// Use a dedicated client (Undici-backed, since `maxHeaderSize` is only
+// configurable on Undici's agent — Node's `http.Agent` does not accept it)
+// for the legacy-template setup; the assertion against the production route
+// still runs through the shared `apiClient` fixture.
+// See https://github.com/elastic/kibana/issues/268028
+const LEGACY_TEMPLATE_CLIENT_MAX_HEADER_SIZE = 64 * 1024;
 
 apiTest.describe(
   'GET /api/console/autocomplete_entities — legacy templates',
@@ -21,22 +32,35 @@ apiTest.describe(
   () => {
     let credentials: RoleApiCredentials;
     let requestOptions: { headers: Record<string, string>; responseType: 'json' };
+    let legacyTemplateClient: EsClient;
 
-    apiTest.beforeAll(async ({ esClient, requestAuth }) => {
+    apiTest.beforeAll(async ({ config, requestAuth }) => {
       credentials = await requestAuth.getApiKey('admin');
       requestOptions = {
         headers: { ...COMMON_HEADERS, ...credentials.apiKeyHeader },
         responseType: 'json',
       };
 
-      await esClient.indices.putTemplate({
+      legacyTemplateClient = createEsClientForTesting({
+        esUrl: config.hosts.elasticsearch,
+        isCloud: config.isCloud,
+        authOverride: config.auth,
+        Connection: UndiciConnection,
+        agent: { maxHeaderSize: LEGACY_TEMPLATE_CLIENT_MAX_HEADER_SIZE },
+      });
+
+      await legacyTemplateClient.indices.putTemplate({
         name: LEGACY_TEMPLATE_NAME,
         index_patterns: ['*'],
       });
     });
 
-    apiTest.afterAll(async ({ esClient }) => {
-      await esClient.indices.deleteTemplate({ name: LEGACY_TEMPLATE_NAME }, { ignore: [404] });
+    apiTest.afterAll(async () => {
+      await legacyTemplateClient.indices.deleteTemplate(
+        { name: LEGACY_TEMPLATE_NAME },
+        { ignore: [404] }
+      );
+      await legacyTemplateClient.close();
     });
 
     apiTest('returns legacy templates when templates setting is enabled', async ({ apiClient }) => {

--- a/src/platform/plugins/shared/console/tsconfig.json
+++ b/src/platform/plugins/shared/console/tsconfig.json
@@ -6,6 +6,7 @@
   "include": ["common/**/*", "public/**/*", "server/**/*", "packaging/**/*", "test/**/*"],
   "kbn_references": [
     "@kbn/scout",
+    "@kbn/test-es-server",
     "@kbn/core",
     "@kbn/dev-tools-plugin",
     "@kbn/es-ui-shared-plugin",


### PR DESCRIPTION
Closes #268028

## Summary

The Scout API test [`autocomplete_entities_stateful.spec.ts`](https://github.com/elastic/kibana/blob/2c4863f3d050e2c530389da1692f0ac720994398/src/platform/plugins/shared/console/test/scout/api/tests/autocomplete_entities_stateful.spec.ts) is failing in `beforeAll` with `ConnectionError: Parse Error: Header overflow` (`HPE_HEADER_OVERFLOW`). The setup calls `PUT _template` with `index_patterns: ['*']`; on a populated cluster ES emits a single `Warning:` deprecation header listing every overlapping composable template ([`MetadataIndexTemplateService.java#L1341-L1352`](https://github.com/elastic/elasticsearch/blob/f4096de27a8ad47955c15230d18db123dae7d013/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java#L1341-L1352)), and that single header alone exceeds Node's default 16 KB `maxHeaderSize`.

Test-only failure — the [`/api/console/autocomplete_entities`](https://github.com/elastic/kibana/blob/2c4863f3d050e2c530389da1692f0ac720994398/src/platform/plugins/shared/console/server/routes/api/console/autocomplete_entities/index.ts#L56-L63) production route only does `GET _template`.

## Fix

In the spec only, build a private ES `Client` for the legacy-template setup using `UndiciConnection` with `agent: { maxHeaderSize: 64 * 1024 }`. `UndiciConnection` is the only `@elastic/transport` connection that surfaces `maxHeaderSize`. The route assertion still runs through the shared `apiClient` fixture.

`tsconfig.json` adds `@kbn/test-es-server` as a `kbn_reference` for `createEsClientForTesting`.

## Test plan

- [x] `node scripts/type_check --project src/platform/plugins/shared/console/tsconfig.json`
- [x] `node scripts/eslint --fix` on the spec
- [x] `node scripts/check_changes.ts`
- [x] Local Scout on stateful classic (`node scripts/scout.js run-tests --arch stateful --domain classic --testFiles …/autocomplete_entities_stateful.spec.ts`) — `1 passed (5.6s)`; ES emitted the same multi-KB `legacy template […] matching patterns from existing composable templates […]` warning (~120 entries) that overflows in CI
- [ ] CI on this PR

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->