### PR TITLE
Fix fleet browse integrations scout tests

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
@@ -25,7 +25,7 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
       return;
     }
 
-    // await apiServices.fleet.internal.setup();
+    await apiServices.fleet.internal.setup();
 
     await apiServices.core.settings({
       'xpack.fleet.experimentalFeatures': { newBrowseIntegrationUx: true },
@@ -62,7 +62,7 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
     const { browseIntegrations } = pageObjects;
 
     await browseIntegrations.navigateTo();
-    await expect(browseIntegrations.getMainColumn()).toBeVisible();
+    await expect(browseIntegrations.getMainColumn()).toBeVisible({ timeout: 20_000 });
 
     await browseIntegrations.sortIntegrations('z-a');
 

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
@@ -25,7 +25,7 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
       return;
     }
 
-    await apiServices.fleet.internal.setup();
+    // await apiServices.fleet.internal.setup();
 
     await apiServices.core.settings({
       'xpack.fleet.experimentalFeatures': { newBrowseIntegrationUx: true },

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
@@ -51,7 +51,7 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
 
     await browseIntegrations.navigateTo();
 
-    await expect(browseIntegrations.getMainColumn()).toBeVisible();
+    await expect(browseIntegrations.getMainColumn()).toBeVisible({ timeout: 20_000 });
 
     await browseIntegrations.scrollToIntegration('nginx');
   });
@@ -75,7 +75,7 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
     const { browseIntegrations } = pageObjects;
 
     await browseIntegrations.navigateTo();
-    await expect(browseIntegrations.getMainColumn()).toBeVisible();
+    await expect(browseIntegrations.getMainColumn()).toBeVisible({ timeout: 20_000 });
 
     await browseIntegrations.searchForIntegration('nginx');
 

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/browse_integration.spec.ts
@@ -24,10 +24,14 @@ test.describe('Browse integration', { tag: tags.stateful.classic }, () => {
     if (config.isCloud) {
       return;
     }
+
+    await apiServices.fleet.internal.setup();
+
     await apiServices.core.settings({
       'xpack.fleet.experimentalFeatures': { newBrowseIntegrationUx: true },
     });
   });
+
   test.afterAll(async ({ apiServices, config }) => {
     if (config.isCloud) {
       return;


### PR DESCRIPTION
## Summary

Addresses:
- https://github.com/elastic/kibana/issues/268024
- https://github.com/elastic/kibana/issues/268026
- https://github.com/elastic/kibana/issues/268027

Attempts to resolve failing scout playwright tests for loading the browse integrations page. It appears this is correlated to the change to use Scout test lanes which groups playwright configs into shared test nodes (IIUC):

* https://github.com/elastic/kibana/pull/264506

I couldn't reproduce this failure locally, or in this PR's CI runs to validate the fix but there is a key difference in the CI runs here and the runs reported as failed in the issues above:

* In this PR the Fleet playwright test config was just ran with one other test config on a shared node
* In the failed runs in the issues above, it is in most cases in situations where the Fleet config is ran with ~5-8 configs (spot checking) on the same test node.
     *  Once the Fleet config fails, and that scout test lane job runs again, the ones that already succeeded don't run again but the Fleet config, or sometimes with one other are allowed to run on their own and succeed.

This is signaling to me a resource contention issue on the test node that is causing longer load times and this test to fail, although it does look like configs are ran in sequence. With that, this PR adds:

* A call to await Fleet setup in beforeAll to ensure this is in place, and not a factor in the page load readiness
* Doubled the timeout for awaiting the browse integrations main column (10s default -> 20s)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->