### PR TITLE
[Chrome Next][DoNotReview] Use app docs API for index management

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
@@ -31,10 +31,11 @@ export interface AppHeaderViewProps {
   favorite?: ReactNode;
   sticky?: boolean;
   padding?: AppHeaderPadding;
+  docLink?: string;
 }
 
 export const AppHeaderView = React.memo<AppHeaderViewProps>(
-  ({ title, back, tabs, badges, menu, onShare, favorite, sticky, padding }) => {
+  ({ title, back, tabs, badges, menu, onShare, favorite, sticky, padding, docLink }) => {
     const hasLegacyActionMenu = useHasLegacyActionMenu();
     const shareAction = useShareAction(menu, onShare);
     const show =
@@ -54,7 +55,7 @@ export const AppHeaderView = React.memo<AppHeaderViewProps>(
         title={<TitleArea title={title} back={back} />}
         badges={<AppBadges badges={badges} />}
         titleActions={<TitleActions shareAction={shareAction} favorite={favorite} />}
-        trailing={<AppMenu menu={menu} hasExplicitShare={!!onShare} />}
+        trailing={<AppMenu menu={menu} hasExplicitShare={!!onShare} docLink={docLink} />}
         tabs={<AppTabs tabs={tabs} />}
         sticky={sticky}
         padding={padding}

--- a/src/core/packages/chrome/app-header/src/app_header/app_menu.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_menu.tsx
@@ -21,10 +21,11 @@ const AppMenuComponent = lazy(async () => {
 export interface AppMenuProps {
   menu?: AppMenuConfig;
   hasExplicitShare?: boolean;
+  docLink?: string;
 }
 
-export const AppMenu = React.memo<AppMenuProps>(({ menu, hasExplicitShare }) => {
-  const { config, staticItems } = useAppHeaderMenu(menu, !!hasExplicitShare);
+export const AppMenu = React.memo<AppMenuProps>(({ menu, hasExplicitShare, docLink }) => {
+  const { config, staticItems } = useAppHeaderMenu(menu, !!hasExplicitShare, docLink);
   const hasLegacyActionMenu = useHasLegacyActionMenu();
 
   if (config || staticItems?.length) {

--- a/src/core/packages/chrome/app-header/src/app_header/app_menu.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_menu.tsx
@@ -27,7 +27,7 @@ export const AppMenu = React.memo<AppMenuProps>(({ menu, hasExplicitShare }) => 
   const { config, staticItems } = useAppHeaderMenu(menu, !!hasExplicitShare);
   const hasLegacyActionMenu = useHasLegacyActionMenu();
 
-  if (config) {
+  if (config || staticItems?.length) {
     return (
       <Suspense>
         <AppMenuComponent config={config} staticItems={staticItems} />

--- a/src/core/packages/chrome/app-header/src/app_header/hooks/use_app_header_menu.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/hooks/use_app_header_menu.ts
@@ -45,7 +45,7 @@ interface ResolvedAppMenu {
   shareItem: AppMenuItemType | undefined;
 }
 
-const useStaticItems = () => {
+const useStaticItems = (explicitDocLink?: string) => {
   const chrome = useChromeService();
   const feedbackHandler = useObservable(chrome.getFeedbackHandler$(), undefined);
   const documentationLink = useObservable(chrome.getAppDocumentationLink$(), undefined);
@@ -58,7 +58,11 @@ const useStaticItems = () => {
       staticItems.push(createFeedbackMenuItem(feedbackHandler));
     }
 
+    /**
+     * Precedence: <AppHeader/> docLink prop -> chrome.getAppDocumentationLink$() -> chrome.getHelpExtension$()
+     */
     const docLink =
+      explicitDocLink ??
       documentationLink ??
       helpExtension?.links?.find((link) => link.linkType === 'documentation')?.href;
 
@@ -67,7 +71,7 @@ const useStaticItems = () => {
     }
 
     return staticItems;
-  }, [feedbackHandler, documentationLink, helpExtension]);
+  }, [feedbackHandler, explicitDocLink, documentationLink, helpExtension]);
 };
 
 const useResolvedAppMenu = (
@@ -92,13 +96,14 @@ const useResolvedAppMenu = (
 
 export function useAppHeaderMenu(
   pageAppMenu: AppMenuConfig | undefined,
-  hasExplicitShare: boolean
+  hasExplicitShare: boolean,
+  docLink?: string
 ): {
   config: AppMenuConfig | undefined;
   staticItems: AppMenuStaticItem[];
 } {
   const { menu } = useResolvedAppMenu(pageAppMenu, hasExplicitShare);
-  const staticItems = useStaticItems();
+  const staticItems = useStaticItems(docLink);
 
   return {
     config: menu,

--- a/src/core/packages/chrome/app-header/src/app_header/hooks/use_app_header_menu.ts
+++ b/src/core/packages/chrome/app-header/src/app_header/hooks/use_app_header_menu.ts
@@ -8,13 +8,17 @@
  */
 
 import { useMemo } from 'react';
-import type { AppMenuConfig, AppMenuItemType } from '@kbn/core-chrome-app-menu-components';
+import type {
+  AppMenuConfig,
+  AppMenuItemType,
+  AppMenuStaticItem,
+} from '@kbn/core-chrome-app-menu-components';
 import { APP_MENU_SHARE_ID, getTooltip } from '@kbn/core-chrome-app-menu-components';
 import { useChromeService } from '@kbn/core-chrome-browser-context';
 import { useObservable } from '@kbn/use-observable';
 import { i18n } from '@kbn/i18n';
 
-const createFeedbackMenuItem = (feedbackHandler: () => void): AppMenuItemType => ({
+const createFeedbackMenuItem = (feedbackHandler: () => void): AppMenuStaticItem => ({
   label: i18n.translate('chrome.appHeader.feedbackMenuItemLabel', {
     defaultMessage: 'Feedback',
   }),
@@ -22,9 +26,10 @@ const createFeedbackMenuItem = (feedbackHandler: () => void): AppMenuItemType =>
   iconType: 'comment',
   order: 1,
   run: feedbackHandler,
+  global: true,
 });
 
-const createDocumentationMenuItem = (href: string): AppMenuItemType => ({
+const createDocumentationMenuItem = (href: string): AppMenuStaticItem => ({
   label: i18n.translate('chrome.appHeader.documentationMenuItemLabel', {
     defaultMessage: 'Documentation',
   }),
@@ -47,7 +52,7 @@ const useStaticItems = () => {
   const helpExtension = useObservable(chrome.getHelpExtension$(), undefined);
 
   return useMemo(() => {
-    const staticItems: AppMenuItemType[] = [];
+    const staticItems: AppMenuStaticItem[] = [];
 
     if (feedbackHandler) {
       staticItems.push(createFeedbackMenuItem(feedbackHandler));
@@ -90,7 +95,7 @@ export function useAppHeaderMenu(
   hasExplicitShare: boolean
 ): {
   config: AppMenuConfig | undefined;
-  staticItems: AppMenuItemType[];
+  staticItems: AppMenuStaticItem[];
 } {
   const { menu } = useResolvedAppMenu(pageAppMenu, hasExplicitShare);
   const staticItems = useStaticItems();

--- a/src/core/packages/chrome/app-header/src/app_header_with_fallback.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header_with_fallback.tsx
@@ -42,6 +42,7 @@ export const AppHeaderWithFallback: FC<AppHeaderWithFallbackProps> = ({
   fallback,
   sticky,
   padding,
+  docLink,
 }) => {
   const chrome = useChromeService();
 
@@ -72,6 +73,7 @@ export const AppHeaderWithFallback: FC<AppHeaderWithFallbackProps> = ({
       favorite={favorite}
       sticky={sticky}
       padding={padding}
+      docLink={docLink}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/enrich_policy_create/enrich_policy_create.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/enrich_policy_create/enrich_policy_create.tsx
@@ -12,25 +12,14 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
 import { documentationService } from '../../services/documentation';
 import { breadcrumbService, IndexManagementBreadcrumb } from '../../services/breadcrumbs';
-import { useAppContext } from '../../app_context';
 import { PageHeader } from '../../components/page_header';
-
 import { CreatePolicyWizard } from './create_policy_wizard';
 import { CreatePolicyContextProvider } from './create_policy_context';
 
 export const EnrichPolicyCreate: React.FunctionComponent<RouteComponentProps> = () => {
-  const {
-    core: { chrome },
-  } = useAppContext();
-
   useEffect(() => {
     breadcrumbService.setBreadcrumbs(IndexManagementBreadcrumb.enrichPoliciesCreate);
-    chrome.registerAppDocumentationLink(documentationService.getCreateEnrichPolicyLink());
-
-    return () => {
-      chrome.registerAppDocumentationLink('');
-    };
-  }, [chrome]);
+  }, []);
 
   return (
     <CreatePolicyContextProvider>
@@ -40,6 +29,7 @@ export const EnrichPolicyCreate: React.FunctionComponent<RouteComponentProps> = 
         })}
         back="/app/management/data/index_management/enrich_policies"
         padding={{ bleed: 'l' }}
+        docLink={documentationService.getCreateEnrichPolicyLink()}
         fallback={{
           'data-test-subj': 'createEnrichPolicyHeaderContent',
           description: (

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/enrich_policy_create/enrich_policy_create.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/enrich_policy_create/enrich_policy_create.tsx
@@ -5,43 +5,32 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import type { RouteComponentProps } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
-import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import { documentationService } from '../../services/documentation';
 import { breadcrumbService, IndexManagementBreadcrumb } from '../../services/breadcrumbs';
+import { useAppContext } from '../../app_context';
 import { PageHeader } from '../../components/page_header';
 
 import { CreatePolicyWizard } from './create_policy_wizard';
 import { CreatePolicyContextProvider } from './create_policy_context';
 
 export const EnrichPolicyCreate: React.FunctionComponent<RouteComponentProps> = () => {
+  const {
+    core: { chrome },
+  } = useAppContext();
+
   useEffect(() => {
     breadcrumbService.setBreadcrumbs(IndexManagementBreadcrumb.enrichPoliciesCreate);
-  }, []);
+    chrome.registerAppDocumentationLink(documentationService.getCreateEnrichPolicyLink());
 
-  const appMenu = useMemo<AppMenuConfig>(
-    () => ({
-      items: [
-        {
-          id: 'createEnrichPolicyDocumentationLink',
-          order: 0,
-          overflow: true,
-          label: i18n.translate('xpack.idxMgmt.enrichPolicyCreate.titleDocsLinkText', {
-            defaultMessage: 'Documentation',
-          }),
-          iconType: 'documentation',
-          href: documentationService.getCreateEnrichPolicyLink(),
-          target: '_blank',
-          testId: 'createEnrichPolicyDocumentationLink',
-        },
-      ],
-    }),
-    []
-  );
+    return () => {
+      chrome.registerAppDocumentationLink('');
+    };
+  }, [chrome]);
 
   return (
     <CreatePolicyContextProvider>
@@ -50,7 +39,6 @@ export const EnrichPolicyCreate: React.FunctionComponent<RouteComponentProps> = 
           defaultMessage: 'Create enrich policy',
         })}
         back="/app/management/data/index_management/enrich_policies"
-        menu={appMenu}
         padding={{ bleed: 'l' }}
         fallback={{
           'data-test-subj': 'createEnrichPolicyHeaderContent',

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/home.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/home.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useEffect } from 'react';
 import type { RouteComponentProps } from 'react-router-dom';
 import { Routes, Route } from '@kbn/shared-ux-router';
 import { i18n } from '@kbn/i18n';
@@ -13,7 +13,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
 
 import type { AppHeaderTab } from '@kbn/app-header';
-import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import { PageHeader } from '../../components/page_header';
 
 import { Section } from '../../../../common/constants';
@@ -45,9 +44,18 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
   history,
 }) => {
   const {
+    core: { chrome },
     plugins: { console: consolePlugin },
     privs,
   } = useAppContext();
+
+  useEffect(() => {
+    chrome.registerAppDocumentationLink(documentationService.getIdxMgmtDocumentationLink());
+
+    return () => {
+      chrome.registerAppDocumentationLink('');
+    };
+  }, [chrome]);
   const onSectionChange = (newSection: Section) => {
     history.push(`/${newSection}`);
   };
@@ -101,26 +109,6 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
     });
   }
 
-  const appMenu = useMemo<AppMenuConfig>(
-    () => ({
-      items: [
-        {
-          id: 'documentationLink',
-          order: 0,
-          overflow: true,
-          label: i18n.translate('xpack.idxMgmt.home.idxMgmtDocsLinkText', {
-            defaultMessage: 'Documentation',
-          }),
-          iconType: 'documentation',
-          href: documentationService.getIdxMgmtDocumentationLink(),
-          target: '_blank',
-          testId: 'documentationLink',
-        },
-      ],
-    }),
-    []
-  );
-
   const indexManagementTabs = (
     <>
       <PageHeader
@@ -128,7 +116,6 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
           defaultMessage: 'Index Management',
         })}
         tabs={tabs}
-        menu={appMenu}
         padding={{ bleed: 'l' }}
         fallback={{
           'data-test-subj': 'indexManagementHeaderContent',

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/home.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/home.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import type { RouteComponentProps } from 'react-router-dom';
 import { Routes, Route } from '@kbn/shared-ux-router';
 import { i18n } from '@kbn/i18n';
@@ -44,18 +44,10 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
   history,
 }) => {
   const {
-    core: { chrome },
     plugins: { console: consolePlugin },
     privs,
   } = useAppContext();
 
-  useEffect(() => {
-    chrome.registerAppDocumentationLink(documentationService.getIdxMgmtDocumentationLink());
-
-    return () => {
-      chrome.registerAppDocumentationLink('');
-    };
-  }, [chrome]);
   const onSectionChange = (newSection: Section) => {
     history.push(`/${newSection}`);
   };
@@ -117,6 +109,7 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
         })}
         tabs={tabs}
         padding={{ bleed: 'l' }}
+        docLink={documentationService.getIdxMgmtDocumentationLink()}
         fallback={{
           'data-test-subj': 'indexManagementHeaderContent',
           rightSideItems: [


### PR DESCRIPTION
## Summary

This PR changes index management to use app docs API instead of registering app menu config.

