### PR TITLE
[9.3.4-1] Rollback chainguard-base-fips

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -63,7 +63,7 @@ export async function runDockerGenerator(
   if (flags.fips) {
     imageFlavor += '-fips';
     baseImageName =
-      'docker.elastic.co/wolfi/chainguard-base-fips:latest@sha256:ba331dd68f8e08ec1ea29f78869aea9e256df7adea4a329c82b5a6e7764fba6e';
+      'docker.elastic.co/wolfi/chainguard-base-fips:latest@sha256:e4cb92038b58c8c881962a17ec0b9970857a801c0a52f75550258f92f1e93ca1';
   }
 
   // General docker var config


### PR DESCRIPTION
More details on the issue at https://github.com/elastic/kibana/pull/268045.

See https://github.com/elastic/kibana/pull/268055 for the CI run.  The v9.3.4 tag is missing a required infrastructure backport to run the pull request pipeline. 