### PR TITLE
Use word boundary for formatMessage in i18n pre-filter regex !!

### DIFF
--- a/src/dev/i18n_tools/constants.test.ts
+++ b/src/dev/i18n_tools/constants.test.ts
@@ -16,6 +16,7 @@ describe('I18N_CALL_PATTERN', () => {
     ["i18n.translate('id', { defaultMessage: 'msg' })"],
     ["I18n.translate('id', { defaultMessage: 'msg' })"],
     ["intl.formatMessage({ id: 'id', defaultMessage: 'msg' })"],
+    ["const { formatMessage } = intl;\nformatMessage({ id: 'id', defaultMessage: 'msg' })"],
     ['defineMessages({ id: { defaultMessage: "msg" } })'],
     ["<FormattedMessage id='id' defaultMessage='msg' />"],
     ["const { translate } = i18n;\ntranslate('id', { defaultMessage: 'msg' })"],

--- a/src/dev/i18n_tools/constants.ts
+++ b/src/dev/i18n_tools/constants.ts
@@ -17,4 +17,4 @@ export const I18N_RC = '.i18nrc.json';
  * early, plus usage-pattern fallbacks for edge cases like re-exported i18n helpers.
  */
 export const I18N_CALL_PATTERN =
-  /@kbn\/i18n|\btranslate\(|FormattedMessage|defineMessages|\.formatMessage\(/;
+  /@kbn\/i18n|\btranslate\(|FormattedMessage|defineMessages|\bformatMessage\(/;


### PR DESCRIPTION
## Summary

Follow-up to #265954 ([review comment](https://github.com/elastic/kibana/pull/265954#discussion_r3199244017)).

Changes `.formatMessage(` to `\bformatMessage(` in the `I18N_CALL_PATTERN` regex so the pre-filter also catches destructured standalone `formatMessage()` calls (e.g. `const { formatMessage } = intl; formatMessage(...)`), matching the same word-boundary pattern already used for `\btranslate(`.

The dot-prefix worked today because no code in the repo destructures `formatMessage`, but `\b` is strictly more defensive — false positives (extra files processed) are harmless, while false negatives (missing translations) are not.

Adds a unit test for the destructured `formatMessage` pattern.

## Test plan

- `node scripts/jest src/dev/i18n_tools/constants.test.ts` — all 12 tests pass
- CI passes (i18n check step)


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->