### PR TITLE
Temporarily disabled send_to_self telemetry due to error

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/config.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/config.ts
@@ -23,7 +23,7 @@ export const configSchema = schema.object({
     numWords: schema.number({ defaultValue: 750, min: 1, max: 5000 }),
   }),
   tracing: schema.object({
-    send_to_self: schema.boolean({ defaultValue: true }),
+    send_to_self: schema.boolean({ defaultValue: false }),
     exporters: schema.arrayOf(
       schema.object({
         url: schema.uri({ scheme: ['http', 'https'] }),


### PR DESCRIPTION
## Summary
Error:
```
RangeError: Maximum call stack size exceeded

Exception in PromiseRejectCallback:
/Users/stratoula/Documents/Forks/kibana/src/core/packages/saved-objects/api-server-internal/src/lib/repository.ts:310
      return await (0, _apis.performGet)({
                                        ^

RangeError: Maximum call stack size exceeded

Exception in PromiseRejectCallback:
/Users/stratoula/Documents/Forks/kibana/node_modules/rxjs/dist/cjs/internal/Observable.js:86
            _this.subscribe(function (x) { return (value = x); }, function (err) { return reject(err); }, function () { return resolve(value); });
                                                                                          ^

RangeError: Maximum call stack size exceeded

Exception in PromiseRejectCallback:
/Users/stratoula/Documents/Forks/kibana/node_modules/rxjs/dist/cjs/internal/Observable.js:84
        return new promiseCtor(function (resolve, reject) {
               ^

RangeError: Maximum call stack size exceeded

Exception in PromiseRejectCallback:
/Users/stratoula/Documents/Forks/kibana/src/core/packages/saved-objects/api-server-internal/src/lib/repository_es_client.ts:24
          return await (0, _coreElasticsearchServerInternal.retryCallCluster)(() => client[key](params, options !== null && options !== void 0 ? options : {}));
                                                                             ^

RangeError: Maximum call stack size exceeded
```
Diagnose:
```
This is a recursion bug in Agent Builder tracing, not an Elasticsearch/LRU cache data issue.
agent_builder registers a span processor on startup. For every span start, AgentBuilderSpanProcessor.onStart() calls isEnabled(). That isEnabled() comes from register_tracing.ts and does:
cache.fetch('enabled') -> reads the Agent Builder UI setting via saved objects/Elasticsearch.
Because lru-cache emits diagnostics tracing from fetch(), that creates another span. The span processor sees that new span, calls isEnabled() again, which calls cache.fetch() again, and so on until Node throws:
RangeError: Maximum call stack size exceeded
The key loop is:
AgentBuilderSpanProcessor.onStart() -> isEnabled() -> LRUCache.fetch() -> tracing diagnostics span -> AgentBuilderSpanProcessor.onStart() -> ...
The noisy frames from @elastic/transport, saved objects, and the giant minified lru-cache line are symptoms of that recursive tracing loop.
Immediate workaround: disable Agent Builder tracing/export-to-self for your local run, e.g. set xpack.agentBuilder.tracing.send_to_self: false so no Agent Builder tracing processor is registered.
Likely code fix: avoid calling traced LRUCache.fetch() from the span processor hot path. A robust fix would use a non-instrumented/manual cached boolean or suppress tracing around the refresh; just reordering checks may reduce the issue but may not fully protect inference-context spans.
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



