### PR TITLE
[8.19] [Hook Form Lib] Deprecate hook_form_lib (#266730)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -355,6 +355,19 @@ const AXIOS_LEGACY_CONSUMERS = [
   'x-pack/solutions/security/test/security_solution_playwright/api_utils/api_key.ts',
 ];
 
+/**
+ * Imports that are deprecated and should be phased out
+ * They are not restricted until fully removed,
+ * but will log a warning
+ **/
+const DEPRECATED_IMPORTS = [
+  {
+    name: '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib',
+    message:
+      '`hook_form_lib` is deprecated and will no longer be supported. Consider using `react-hook-form` for new and existing forms.',
+  },
+];
+
 module.exports = {
   root: true,
 
@@ -886,6 +899,19 @@ module.exports = {
       rules: {
         '@kbn/eslint/no_unsafe_dynamic_http_path': 'warn',
         'no-restricted-imports': ['error', ...RESTRICTED_IMPORTS],
+        '@kbn/eslint/no_deprecated_imports': [
+          'warn',
+          {
+            paths: DEPRECATED_IMPORTS,
+            patterns: [
+              {
+                group: ['@kbn/es-ui-shared-plugin/static/forms/hook_form_lib/**'],
+                message:
+                  '`hook_form_lib` is deprecated and will no longer be supported. Consider using `react-hook-form` for new and existing forms.',
+              },
+            ],
+          },
+        ],
         'no-restricted-modules': [
           'error',
           {

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/docs/welcome.mdx
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/docs/welcome.mdx
@@ -11,6 +11,8 @@ date: 2021-04-14
 
 The form library helps us build forms efficiently by providing a system whose main task is (1) to abstract away the state management of fields values and validity and (2) running validations on the fields when their values change.  
 
+**Deprecation notice:** `hook_form_lib` is deprecated and will no longer be supported. Consider using `react-hook-form` for new and existing forms.
+
 The system is composed of **three parts**:
 
 * <DocLink id="formLibCoreFundamentals" text="The core"/>

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/form.tsx
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/form.tsx
@@ -21,6 +21,10 @@ export interface Props {
   [key: string]: any;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export const Form = ({ form, FormWrapper = EuiForm, ...rest }: Props) => {
   const { getFormData, __getFormData$ } = form;
 

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/use_array.ts
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/use_array.ts
@@ -14,6 +14,10 @@ import { getFieldValidityAndErrorMessage } from '../helpers';
 import { useFormContext } from '../form_context';
 import { useField, InternalFieldConfig } from '../hooks';
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface Props {
   path: string;
   initialNumberOfItems?: number;
@@ -22,12 +26,20 @@ export interface Props {
   children: (formFieldArray: FormArrayField) => JSX.Element;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface ArrayItem {
   id: number;
   path: string;
   isNew: boolean;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FormArrayField {
   items: ArrayItem[];
   error: string | null;
@@ -39,6 +51,10 @@ export interface FormArrayField {
 
 let uniqueId = 0;
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export const createArrayItem = (path: string, index: number, isNew = true): ArrayItem => ({
   id: uniqueId++,
   path: `${path}[${index}]`,
@@ -53,11 +69,17 @@ export const createArrayItem = (path: string, index: number, isNew = true): Arra
  *
  * @param path The array path in the form data
  * @returns The internal array field path
+ *
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
  */
 export const getInternalArrayFieldPath = (path: string): string => `${path}__array__`;
 
 /**
  * Use UseArray to dynamically add fields to your form.
+ *
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
  *
  * example:
  * If your form data looks like this:

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/use_field.tsx
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/use_field.tsx
@@ -12,6 +12,10 @@ import React, { FunctionComponent } from 'react';
 import { FieldHook, FieldConfig, FormData } from '../types';
 import { useFieldFromProps } from '../hooks';
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface Props<T, FormType = FormData, I = T> {
   path: string;
   // @ts-expect-error upgrade typescript v4.9.5
@@ -73,10 +77,17 @@ function UseFieldComp<T = unknown, FormType = FormData, I = T>(props: Props<T, F
   return <ComponentToRender {...{ field, ...propsToForward }} />;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export const UseField = React.memo(UseFieldComp) as typeof UseFieldComp;
 
 /**
  * Get a <UseField /> component providing some common props for all instances.
+ *
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
  * @param partialProps Partial props to apply to all <UseField /> instances
  *
  * @example

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/use_multi_fields.tsx
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/use_multi_fields.tsx
@@ -20,7 +20,10 @@ interface Props<T> {
 
 /**
  * Use this component to avoid nesting multiple <UseField />
-  @example
+ *
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ * @example
 ```
 // before
 <UseField path="maxValue">

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/constants.ts
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/constants.ts
@@ -7,6 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 // Field types
 export const FIELD_TYPES = {
   TEXT: 'text',
@@ -28,6 +32,10 @@ export const FIELD_TYPES = {
   HIDDEN: 'hidden',
 };
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 // Validation types
 export const VALIDATION_TYPES = {
   /** Default validation error (on the field value) */

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/form_context.tsx
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/form_context.tsx
@@ -18,6 +18,10 @@ interface Props {
   children: React.ReactNode;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export const FormProvider = ({ children, form }: Props) => (
   <FormContext.Provider value={form}>{children}</FormContext.Provider>
 );
@@ -26,6 +30,10 @@ interface Options {
   throwIfNotFound?: boolean;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export const useFormContext = function <T extends FormData = FormData>({
   throwIfNotFound = true,
 }: Options = {}) {

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/form_data_context.tsx
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/form_data_context.tsx
@@ -12,6 +12,10 @@ import React, { createContext, useContext, useMemo } from 'react';
 import { FormData, FormHook } from './types';
 import { Subject } from './lib';
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface Context<T extends FormData = FormData, I extends FormData = T> {
   getFormData$: () => Subject<FormData>;
   getFormData: FormHook<T, I>['getFormData'];
@@ -29,6 +33,9 @@ interface Props extends Context {
 
 /**
  * This provider wraps the whole form and is consumed by the <Form /> component
+ *
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
  */
 export const FormDataContextProvider = ({ children, getFormData$, getFormData }: Props) => {
   const value = useMemo<Context>(
@@ -42,6 +49,10 @@ export const FormDataContextProvider = ({ children, getFormData$, getFormData }:
   return <FormDataContext.Provider value={value}>{children}</FormDataContext.Provider>;
 };
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export function useFormDataContext<T extends FormData = FormData, I extends FormData = T>() {
   return useContext<Context<T, I> | undefined>(FormDataContext);
 }

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/helpers.ts
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/helpers.ts
@@ -9,6 +9,10 @@
 
 import { FieldHook } from './types';
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export const getFieldValidityAndErrorMessage = (field: {
   isChangingValue: FieldHook['isChangingValue'];
   errors: FieldHook['errors'];

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
@@ -28,10 +28,18 @@ const DEFAULT_OPTIONS = {
   stripUnsetFields: false,
 };
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface UseFormReturn<T extends FormData, I extends FormData> {
   form: FormHook<T, I>;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export function useForm<T extends FormData = FormData, I extends FormData = T>(
   formConfig?: FormConfig<T, I>
 ): UseFormReturn<T, I> {

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/hooks/use_form_data.ts
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/hooks/use_form_data.ts
@@ -23,8 +23,16 @@ interface Options<I> {
   onChange?: (formData: I) => void;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export type HookReturn<I extends object = FormData, T extends object = I> = [I, () => T, boolean];
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export const useFormData = <I extends object = FormData, T extends object = I>(
   options: Options<I> = {}
 ): HookReturn<I, T> => {

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/hooks/use_form_is_modified.ts
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/hooks/use_form_is_modified.ts
@@ -31,6 +31,9 @@ interface Options {
  * This is useful to detect if a form has changed and we need to display a confirm modal
  * to the user before they navigate away and lose their changes.
  *
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ *
  * @param options - Optional options object
  * @returns flag to indicate if the form has been modified
  */

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/hooks/utils/use_behavior_subject.ts
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/hooks/utils/use_behavior_subject.ts
@@ -69,6 +69,10 @@ import { BehaviorSubject, Observable } from 'rxjs';
     );
   }
  */
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export const useBehaviorSubject = <T = any>(initialState: T) => {
   const subjectRef = useRef<BehaviorSubject<T>>();
 

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/types.ts
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/types.ts
@@ -14,6 +14,10 @@ import { Subject, Subscription } from './lib';
 // Comes from https://github.com/microsoft/TypeScript/issues/15012#issuecomment-365453623
 type Required<T> = T extends FormData ? { [P in keyof T]-?: NonNullable<T[P]> } : T;
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FormHook<T extends FormData = FormData, I extends FormData = T> {
   /**  Flag that indicates if the form has been submitted at least once. It is set to `true` when we call `submit()`. */
   readonly isSubmitted: boolean;
@@ -108,10 +112,18 @@ export interface FormHook<T extends FormData = FormData, I extends FormData = T>
   __getFieldsRemoved: () => FieldsMap;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export type FormSchema<T extends FormData = FormData> = {
   [K in keyof T]?: FieldConfig<T[K], T, any> | FormSchema<T[K]>;
 };
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FormConfig<T extends FormData = FormData, I extends FormData = T> {
   onSubmit?: FormSubmitHandler<T>;
   schema?: FormSchema<I>;
@@ -122,6 +134,10 @@ export interface FormConfig<T extends FormData = FormData, I extends FormData = 
   id?: string;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface OnFormUpdateArg<T extends FormData, I extends FormData = T> {
   data: {
     internal: I;
@@ -131,10 +147,18 @@ export interface OnFormUpdateArg<T extends FormData, I extends FormData = T> {
   isValid?: boolean;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export type OnUpdateHandler<T extends FormData = FormData, I extends FormData = T> = (
   arg: OnFormUpdateArg<T, I>
 ) => void;
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FormOptions {
   valueChangeDebounceTime?: number;
   /**
@@ -147,6 +171,10 @@ export interface FormOptions {
   stripUnsetFields?: boolean;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FieldHook<T = unknown, I = T> {
   readonly path: string;
   readonly label?: string;
@@ -213,6 +241,10 @@ export interface FieldHook<T = unknown, I = T> {
   __serializeValue: (internalValue?: I) => T;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FieldConfig<T = unknown, FormType extends FormData = FormData, I = T> {
   readonly label?: string;
   readonly labelAppend?: string | ReactNode;
@@ -227,20 +259,36 @@ export interface FieldConfig<T = unknown, FormType extends FormData = FormData, 
   readonly valueChangeDebounceTime?: number;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FieldValidationData {
   validationData?: unknown;
   validationDataProvider?: () => Promise<unknown>;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FieldsMap {
   [key: string]: FieldHook;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export type FormSubmitHandler<T extends FormData = FormData> = (
   formData: T,
   isValid: boolean
 ) => Promise<void>;
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface ValidationError<T = string> {
   message: string;
   code?: T;
@@ -249,6 +297,10 @@ export interface ValidationError<T = string> {
   [key: string]: any;
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface ValidationFuncArg<I extends FormData, V = unknown> {
   path: string;
   value: V;
@@ -265,6 +317,10 @@ export interface ValidationFuncArg<I extends FormData, V = unknown> {
   };
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export type ValidationFunc<
   I extends FormData = FormData,
   E extends string = string,
@@ -273,20 +329,40 @@ export type ValidationFunc<
   data: ValidationFuncArg<I, V>
 ) => ValidationError<E> | void | undefined | ValidationCancelablePromise<E>;
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export type ValidationResponsePromise<E extends string = string> = Promise<
   ValidationError<E> | void | undefined
 >;
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export type ValidationCancelablePromise<E extends string = string> =
   ValidationResponsePromise<E> & { cancel?(): void };
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FieldValidateResponse {
   isValid: boolean;
   errors: ValidationError[];
 }
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export type SerializerFunc<O = unknown, I = any> = (value: I) => O;
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface FormData {
   [key: string]: any;
 }
@@ -297,6 +373,10 @@ type FormatterFunc<I = unknown> = (value: any, formData: FormData) => I;
 // string | number | boolean | string[] ...
 type FieldValue = unknown;
 
+/**
+ * @deprecated `hook_form_lib` is deprecated and will no longer be supported. Consider using
+ * `react-hook-form` for new and existing forms.
+ */
 export interface ValidationConfig<
   I extends FormData = FormData,
   E extends string = string,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Hook Form Lib] Deprecate hook_form_lib (#266730)](https://github.com/elastic/kibana/pull/266730)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-05T10:36:06Z","message":"[Hook Form Lib] Deprecate hook_form_lib (#266730)\n\n## Summary\n\nThis PR:\n- Added an eslint deprecation warning when importing\n`@kbn/es-ui-shared-plugin/static/forms/hook_form_lib`.\n- Updated the form-lib docs landing page with a deprecation notice for\n`hook_form_lib`.\n- Updated `hook_form_lib` public APIs to be marked `@deprecated`,\nprompting IDE warnings and guiding contributors to consider\n`react-hook-form` for new and existing forms.","sha":"2915168e40c1b2e272d7e862a460247dfdf4a230","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:all-open","v9.4.0","v9.5.0","v9.2.9","v9.3.5"],"title":"[Hook Form Lib] Deprecate hook_form_lib","number":266730,"url":"https://github.com/elastic/kibana/pull/266730","mergeCommit":{"message":"[Hook Form Lib] Deprecate hook_form_lib (#266730)\n\n## Summary\n\nThis PR:\n- Added an eslint deprecation warning when importing\n`@kbn/es-ui-shared-plugin/static/forms/hook_form_lib`.\n- Updated the form-lib docs landing page with a deprecation notice for\n`hook_form_lib`.\n- Updated `hook_form_lib` public APIs to be marked `@deprecated`,\nprompting IDE warnings and guiding contributors to consider\n`react-hook-form` for new and existing forms.","sha":"2915168e40c1b2e272d7e862a460247dfdf4a230"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/267693","number":267693,"state":"MERGED","mergeCommit":{"sha":"076f0ad2a3fc3ae0b3c972ca3b9d328652d4a84e","message":"[9.4] [Hook Form Lib] Deprecate hook_form_lib (#266730) (#267693)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Hook Form Lib] Deprecate hook_form_lib\n(#266730)](https://github.com/elastic/kibana/pull/266730)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266730","number":266730,"mergeCommit":{"message":"[Hook Form Lib] Deprecate hook_form_lib (#266730)\n\n## Summary\n\nThis PR:\n- Added an eslint deprecation warning when importing\n`@kbn/es-ui-shared-plugin/static/forms/hook_form_lib`.\n- Updated the form-lib docs landing page with a deprecation notice for\n`hook_form_lib`.\n- Updated `hook_form_lib` public APIs to be marked `@deprecated`,\nprompting IDE warnings and guiding contributors to consider\n`react-hook-form` for new and existing forms.","sha":"2915168e40c1b2e272d7e862a460247dfdf4a230"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/267690","number":267690,"state":"MERGED","mergeCommit":{"sha":"f8c5702fc7d4c654021a87aa66c2cb5a71324b6c","message":"[9.2] [Hook Form Lib] Deprecate hook_form_lib (#266730) (#267690)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Hook Form Lib] Deprecate hook_form_lib\n(#266730)](https://github.com/elastic/kibana/pull/266730)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/267692","number":267692,"state":"MERGED","mergeCommit":{"sha":"f3bc2e3356f967a41f386c011a70dd45c3c0ef13","message":"[9.3] [Hook Form Lib] Deprecate hook_form_lib (#266730) (#267692)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Hook Form Lib] Deprecate hook_form_lib\n(#266730)](https://github.com/elastic/kibana/pull/266730)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}}]}] BACKPORT-->