### PR TITLE
[Chrome Next] Show text with back button

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/back_button.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/back_button.tsx
@@ -11,6 +11,8 @@ import {
   EuiButtonIcon,
   EuiContextMenuItem,
   EuiContextMenuPanel,
+  EuiIcon,
+  EuiLink,
   EuiPopover,
   EuiToolTip,
   useEuiTheme,
@@ -38,15 +40,22 @@ const useBackButtonStyles = () => {
       color: ${euiTheme.colors.textSubdued};
     `;
 
-    return { button };
+    const link = css`
+      display: inline-flex;
+      align-items: center;
+      gap: ${euiTheme.size.xs};
+    `;
+
+    return { button, link };
   }, [euiTheme]);
 };
 
 export interface BackButtonProps {
   targets: BackNavigation[];
+  showLabel?: boolean;
 }
 
-export const BackButton = React.memo<BackButtonProps>(({ targets }) => {
+export const BackButton = React.memo<BackButtonProps>(({ targets, showLabel }) => {
   const styles = useBackButtonStyles();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
@@ -54,7 +63,7 @@ export const BackButton = React.memo<BackButtonProps>(({ targets }) => {
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
   const primary = targets[0];
-  const tooltip = primary?.backDestinationLabel
+  const label = primary?.backDestinationLabel
     ? getBackToLabel(primary.backDestinationLabel)
     : backLabel;
 
@@ -62,30 +71,42 @@ export const BackButton = React.memo<BackButtonProps>(({ targets }) => {
     return null;
   }
 
-  const buttonIcon = (
-    <EuiButtonIcon
-      iconType="sortLeft"
+  const hasMultipleTargets = targets.length > 1;
+
+  const trigger = showLabel ? (
+    <EuiLink
       color="text"
-      display="empty"
-      size="xs"
-      css={styles.button}
-      aria-label={tooltip}
-      data-test-subj="appHeaderBack"
-      {...(targets.length > 1
+      css={styles.link}
+      {...(hasMultipleTargets
         ? { onClick: togglePopover }
         : { href: primary.backHref, onClick: primary.backOnClick })}
-    />
+      data-test-subj="appHeaderBack"
+    >
+      <EuiIcon type="sortLeft" aria-hidden />
+      {label}
+    </EuiLink>
+  ) : (
+    <EuiToolTip content={label} delay="long" disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="sortLeft"
+        color="text"
+        display="empty"
+        size="xs"
+        css={styles.button}
+        aria-label={label}
+        data-test-subj="appHeaderBack"
+        {...(hasMultipleTargets
+          ? { onClick: togglePopover }
+          : { href: primary.backHref, onClick: primary.backOnClick })}
+      />
+    </EuiToolTip>
   );
 
-  if (targets.length > 1) {
+  if (hasMultipleTargets) {
     return (
       <EuiPopover
-        aria-label={tooltip}
-        button={
-          <EuiToolTip content={tooltip} delay="long">
-            {buttonIcon}
-          </EuiToolTip>
-        }
+        aria-label={label}
+        button={trigger}
         isOpen={isPopoverOpen}
         closePopover={closePopover}
         panelPaddingSize="none"
@@ -108,11 +129,7 @@ export const BackButton = React.memo<BackButtonProps>(({ targets }) => {
     );
   }
 
-  return (
-    <EuiToolTip content={tooltip} delay="long">
-      {buttonIcon}
-    </EuiToolTip>
-  );
+  return trigger;
 });
 
 BackButton.displayName = 'BackButton';

--- a/src/core/packages/chrome/app-header/src/app_header/title_area.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area.tsx
@@ -47,7 +47,7 @@ export const TitleArea = React.memo<TitleAreaProps>(({ title, back }) => {
 
   return (
     <div css={styles.wrapper}>
-      {hasBack && <BackButton targets={backTargets} />}
+      {hasBack && <BackButton targets={backTargets} showLabel={!title} />}
       {title && (
         <EuiTitle size="xs" css={!hasBack ? styles.titleOffset : undefined}>
           <h1 className="eui-textTruncate">{title}</h1>


### PR DESCRIPTION
## Summary

@ryankeairns, Here is an attempt. Maybe there is something to polish in the style, but I am not sure I like it anyway. This is mostly a change for the fallback use case for unmigrated pages. The back button is there as a replacement for breadcrumbs. With the text next to the button, the redundant header becomes much more noticeable and heavy. It is especially annoying for back buttons that lead nowhere and just reload the page.


Good migrated page with proper title and back button: 

<img width="1846" height="894" alt="Screenshot 2026-05-07 at 12 43 51" src="https://github.com/user-attachments/assets/942918bc-d4b0-4cba-840f-f544485f2114" />


Bad unmigrated pages with breadcrumbs fallbacks. Some correct, some broken and lead nowhere: 

<img width="1852" height="862" alt="Screenshot 2026-05-07 at 12 44 06" src="https://github.com/user-attachments/assets/2f8fa787-21f0-48c5-bd0d-c001c3efbc65" />

<img width="1847" height="780" alt="Screenshot 2026-05-07 at 12 44 12" src="https://github.com/user-attachments/assets/cbb849d3-6779-4322-ac55-6a3e4cdfe294" />

<img width="1850" height="1010" alt="Screenshot 2026-05-07 at 12 44 43" src="https://github.com/user-attachments/assets/fdb4a524-b09d-42d3-9c70-d8aca27edb17" />






