### PR TITLE
[Security Solution][Agent Builder] Clean up PR #256060 follow-ups (symlinks, broken eval JSON, PCI flag)

### DIFF
--- a/.buildkite/pipelines/evals/evals.suites.json
+++ b/.buildkite/pipelines/evals/evals.suites.json
@@ -178,6 +178,8 @@
       "tags": ["security", "pci-compliance"],
       "ciLabels": ["evals:pci-compliance"],
       "serverConfigSet": "evals_pci_compliance"
+    },
+    {
       "id": "security-automatic-migrations",
       "name": "Security Automatic Migrations",
       "slackChannel": "#security-generative-ai-evals",

--- a/elastic-llm-benchmarker
+++ b/elastic-llm-benchmarker
@@ -1,1 +1,0 @@
-/Users/patrykkopycinski/Projects/automaker/elastic-llm-benchmarker

--- a/openspec/specs
+++ b/openspec/specs
@@ -1,1 +1,0 @@
-/Users/patrykkopycinski/Projects/kibana/openspec/specs

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -228,7 +228,7 @@ export const allowedExperimentalValues = Object.freeze({
    * Enables the PCI DSS v4.0.1 Compliance Agent Builder skill and its backing tools.
    * Gates skill + tool registration so the feature can ship dark and be enabled per environment.
    */
-  pciComplianceAgentBuilder: false,
+  pciComplianceAgentBuilder: true,
 
   /**
    * Enables the new flyout using the EUI flyout system


### PR DESCRIPTION
## Summary

Follow-up cleanup for #256060 (Add PCI compliance skill and tools for Agent Builder). That PR accidentally committed two personal-machine symlinks and merged the new eval-suite entry in a way that produced invalid JSON. This PR fixes those regressions and enables the PCI compliance skill by default.

## What this PR does

1. **Removes `elastic-llm-benchmarker` symlink.** Pointed at `/Users/patrykkopycinski/Projects/automaker/elastic-llm-benchmarker` — an absolute path that only exists on a single contributor's machine, and a directory that is not part of this repo. Nothing tracked in the tree references it (`git grep elastic-llm-benchmarker` is empty).

2. **Removes `openspec/specs` symlink.** Pointed at `/Users/patrykkopycinski/Projects/kibana/openspec/specs` — a self-referential absolute path (the symlink itself). Same story: no tracked file references it.

3. **Fixes invalid JSON in `.buildkite/pipelines/evals/evals.suites.json`.** The new `pci-compliance` suite entry from #256060 is missing the closing `},` before the next entry, so the file is not valid JSON as merged. Reproducible with `python3 -m json.tool < .buildkite/pipelines/evals/evals.suites.json`. After this PR the file parses and contains 15 well-formed suites.

4. **Flips `pciComplianceAgentBuilder` from `false` to `true`** in `x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts`. The flag is still respected by `register_skills.ts` (gates `pciComplianceSkill`) and `register_tools.ts` (gates the four PCI tools), so any environment can still opt out by setting it back to `false` via `xpack.securitySolution.enableExperimental`.

## Test plan

- [ ] `node scripts/check_changes.ts`
- [ ] CI loads `.buildkite/pipelines/evals/evals.suites.json` without parse error.
- [ ] PCI compliance skill and tools register at startup with default config (no `enableExperimental` overrides).
- [ ] Existing PCI-compliance Jest tests continue to pass:
  - `x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/pci_compliance/pci_compliance_skill.test.ts`
  - `x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/pci_*_tool.test.ts`

## Notes for reviewers

- The two deleted symlinks were committed as gitlinks of mode `120000` and contained absolute paths from a single developer's laptop. They are dead weight in every other clone and should never have been tracked.
- I confirmed neither `tsconfig.base.json`, `package.json`, `.github/CODEOWNERS`, nor any other tracked file references either symlink path, so removing them is risk-free.
