### PR TITLE
test(infra): stabilize inventory no-data onboarding Scout test

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -128,6 +128,15 @@ export class InventoryPage {
       .waitFor({ state: 'hidden', timeout: EXTENDED_TIMEOUT });
   }
 
+  /**
+   * Waits for the snapshot "Loading data" panel (`infraNodesOverviewLoadingPanel`) to finish,
+   * then for the onboarding empty state (`kbnNoDataPage`).
+   */
+  public async waitForOnboardingNoDataPage() {
+    await this.waitForNodesToLoad();
+    await this.noDataPage.waitFor({ state: 'visible', timeout: EXTENDED_TIMEOUT });
+  }
+
   private async waitForPageToLoad() {
     await this.page.getByTestId('infraMetricsPage').waitFor({ timeout: EXTENDED_TIMEOUT });
     await this.waitForNodesToLoad();

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/no_data_inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/no_data_inventory.spec.ts
@@ -15,7 +15,7 @@ test.describe(
   () => {
     test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
       await browserAuth.loginAsViewer();
-      // Skip load wait as there is no data to load in empty data test cases
+      // Skip full page load assertion; onboarding replaces inventory content after `/api/metrics/source/hasData`.
       await inventoryPage.goToPage({ skipLoadWait: true });
     });
 
@@ -24,6 +24,7 @@ test.describe(
       pageObjects: { inventoryPage },
     }) => {
       await test.step('display empty state', async () => {
+        await inventoryPage.waitForOnboardingNoDataPage();
         await expect(inventoryPage.noDataPage).toBeVisible();
         await expect(inventoryPage.noDataPageActionButton).toBeVisible();
       });


### PR DESCRIPTION
## Summary

- **Wait for the snapshot loading UI to finish** before asserting `kbnNoDataPage` in `no_data_inventory.spec.ts`, using a new `inventoryPage.waitForOnboardingNoDataPage()` helper that chains `waitForNodesToLoad()` (hides `infraNodesOverviewLoadingPanel`) and a visible wait for the onboarding no-data page (`EXTENDED_TIMEOUT` / 45s each).
- **Clarify `beforeEach`** so it matches real behavior: `noDataConfig` is only wired after `/api/metrics/source/hasData`, so onboarding content replaces the snapshot only when that settles—not “no loading” upfront.

### CI screenshot / failure context

The failing build screenshot for [#263863](https://github.com/elastic/kibana/issues/263863) showed **Infrastructure inventory** still in the **“Loading data”** state (`infraNodesOverviewLoadingPanel`) while Playwright waited for `kbnNoDataPage` and hit the default **10s** timeout. Those two states are sequential: metrics has-data onboarding mounts the shared no-data template only after loading completes, so asserting immediately raced the snapshot loader.

## References

Closes #263863

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->