### PR TITLE
[Scout] Log a warning on empty lanes distribution multi-track summary

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
@@ -328,7 +328,8 @@ function displayMultiTrackSummary(
   log: ToolingLog
 ) {
   if (tracks.length === 0) {
-    throw createFlagError('Multi-track summary requested, but the provided track list is empty');
+    log.warning('Multi-track summary requested, but the provided track list is empty');
+    return;
   }
 
   const panel = new CliTable3();


### PR DESCRIPTION
This PR updates the `displayMultiTrackSummary` method in our Scout "lanes" test distribution logic to log a warning instead of throwing an error when it is called with an empty track list (which happened in https://github.com/elastic/kibana/pull/267792 due to Scout selective testing not selecting any configs to run).

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->