### PR TITLE
[Entity Analytics] Add EA permission audit script and internal dev UI

### DIFF
--- a/openspec/changes/ea_permission_audit/proposal.md
+++ b/openspec/changes/ea_permission_audit/proposal.md
@@ -1,0 +1,218 @@
+## Why
+
+Entity Analytics exposes multiple feature surfaces — Home Page, Management Page, Explore pages
+(Hosts/Users Risk tabs), and the Entity Flyout — each gated by different combinations of
+Elasticsearch index privileges and cluster privileges. There is currently no single artifact
+that documents which privilege grants result in which UI states across all of these surfaces.
+
+This creates a blind spot when onboarding customers with restrictive RBAC setups, debugging
+permission-related support tickets, and verifying that new features properly degrade when
+privileges are reduced.
+
+A one-time, locally-executable audit script calls privilege-check API endpoints as a set of
+purpose-built test personas, checks key `data-test-subj` elements via a headless browser, and
+opens a seeded entity's flyout to verify what each persona can see inside it. The result is a
+compact three-section Markdown report: **API**, **UI**, and **Flyout**.
+
+## What Changes
+
+A standalone script at `scripts/entity_analytics_permission_audit/` orchestrates:
+
+1. **Setup** — creates 15 test roles + users via the Elasticsearch native security API (admin
+   credentials via `--es-url`).
+2. **Seed** — writes a synthetic user entity (`ea-audit-test-user`) with full data across
+   four surfaces: entity store record, risk score, asset criticality, and a watchlist. This
+   gives the flyout probe something real to check. Seeded data is tagged (`entity.source:
+   ea-audit-fixture`) for safe cleanup.
+3. **Browser Probe** — for each persona, launches headless Chromium (Playwright), logs in via
+   `/login`, and runs two sub-probes in the same browser session:
+   - **API sub-probe** — calls each privilege endpoint from within the browser's authenticated
+     session (`page.evaluate → fetch`), capturing `has_read_permissions` / `has_write_permissions`.
+   - **UI sub-probe** — navigates to each target page and asserts `data-test-subj` presence
+     or absence per the correlation map.
+4. **Flyout sub-probe** — for personas that have entity store read, navigates to the EA Home
+   Page, clicks the "Open entity details" expand button on the `ea-audit-test-user` row, and
+   checks each flyout panel against the flyout correlation map.
+5. **Correlate** — merges API + UI + flyout observations into `PASS / FAIL / SKIP` per
+   persona × feature.
+6. **Report** — renders a single Markdown file with **three trimmed tables** (5 columns each):
+   API section, UI section, Flyout section.
+7. **Cleanup** — deletes all test roles, users, and seeded entity data (runs in `finally`).
+
+## Capabilities
+
+### New Capabilities
+
+- `ea-permission-audit`: A runnable Node.js/Playwright script that produces a compact,
+  three-section Markdown permissions audit report for all Entity Analytics features.
+
+### Modified Capabilities
+
+- **Report format** — trimmed from a dense multi-column matrix to three focused 5-column
+  tables: `Endpoint / URL / Panel | Permissions | Persona | Access granted | Result`.
+
+## Privilege Surfaces Covered
+
+### Endpoints probed (5 total)
+
+| Privilege endpoint                                | Feature area                    |
+|---------------------------------------------------|---------------------------------|
+| `GET /internal/risk_score/engine/privileges`      | Risk Score / Risk Engine        |
+| `GET /internal/security/entity_store/check_privileges` | Entity Store (V2)          |
+| `GET /api/entity_analytics/watchlists/privileges` | Watchlists                      |
+| `GET /internal/entity_analytics/leads/privileges` | Lead Generation (Leads panel)   |
+| `GET /internal/asset_criticality/privileges`      | Asset Criticality               |
+
+### Index patterns and privilege types per feature
+
+| Feature            | Index pattern                               | Privilege types checked              |
+|--------------------|---------------------------------------------|--------------------------------------|
+| Leads              | `.internal.*entity-leads-*`                 | `read`, `write`                      |
+| Watchlists         | `.entity_analytics.watchlists.<namespace>`  | `read`, `write`                      |
+| Asset Criticality  | `.asset-criticality.asset-criticality-*`    | `read`, `write`                      |
+| Risk Score (index) | `risk-score.risk-score-*`                   | `read`, `write`                      |
+| Risk Engine        | (same + cluster)                            | `manage_transform`, `manage_index_templates`, `manage_ingest_pipelines` |
+| Entity Store       | `.entities.*`, `.entities.v1.updates.*`     | `read`, `manage`                     |
+| Entity Store (src) | all security data view source indices       | `read`, `view_index_metadata`        |
+| Entity Store       | (cluster)                                   | `manage_index_templates`, `manage_transform`, `manage_ingest_pipelines`, `manage_enrich` |
+
+## Test Personas (15 total)
+
+| ID  | Name                    | Privilege profile                                           |
+|-----|-------------------------|-------------------------------------------------------------|
+| P1  | `no_ea_access`          | Kibana feature only — no ES index/cluster grants            |
+| P2  | `read_all`              | `read` on all EA indices, no write, no cluster privs        |
+| P3  | `full_all`              | `read+write` on all EA indices + all required cluster privs |
+| P4  | `entity_store_no`       | `full_all` minus entity store indices                       |
+| P5  | `entity_store_read`     | `full_all`, entity store: `read+view_index_metadata` only   |
+| P6  | `risk_score_no`         | `full_all` minus `risk-score.risk-score-*`                  |
+| P7  | `risk_score_read`       | `full_all`, risk score: `read` only                         |
+| P8  | `watchlists_no`         | `full_all` minus watchlists index                           |
+| P9  | `watchlists_read`       | `full_all`, watchlists: `read` only                         |
+| P10 | `leads_no`              | `full_all` minus leads index                                |
+| P11 | `leads_read`            | `full_all`, leads: `read` only                              |
+| P12 | `asset_crit_no`         | `full_all` minus asset criticality index                    |
+| P13 | `asset_crit_read`       | `full_all`, asset criticality: `read` only                  |
+| P14 | `no_manage_transform`   | `full_all`, cluster: no `manage_transform`                  |
+| P15 | `no_enable_cluster`     | `full_all`, cluster: no `manage_index_templates` / `manage_ingest_pipelines` |
+
+All personas are granted the Kibana feature privilege `siem: all` as a precondition.
+
+## Report Format (3 sections, 5 columns each)
+
+### Section 1 — API
+
+| Endpoint | Permissions checked | Persona | Access granted | Result |
+|----------|---------------------|---------|----------------|--------|
+| `/internal/risk_score/engine/privileges` | `read`, `write` | `read_all` | `read` | PASS |
+
+### Section 2 — UI
+
+| URL | Permissions checked | Persona | Access granted | Result |
+|-----|---------------------|---------|----------------|--------|
+| `/app/security/entity_analytics_home_page` | `entity_store.read` | `no_ea_access` | denied | PASS |
+
+### Section 3 — Flyout
+
+| Panel | Permissions checked | Persona | Access granted | Result |
+|-------|---------------------|---------|----------------|--------|
+| `risk-summary-result-score` visible | `risk_engine.read` | `risk_score_no` | denied | PASS |
+| `asset-criticality-change-btn` present | `asset_crit.write` | `asset_crit_read` | read only | PASS |
+| `entityWatchlistsCell` visible | `watchlists.read` | `watchlists_no` | denied | PASS |
+
+**Result values**: `PASS` (observed matches expected), `FAIL` (mismatch), `SKIP` (flyout
+unreachable — entity store denied for this persona).
+
+## Feature → Expected UI Behavior Correlation Maps
+
+### UI Correlation Map
+
+| Feature | Permissions gate | Expected state | Element present | Element absent |
+|---------|-----------------|----------------|-----------------|----------------|
+| EA Home: full page blocked | `entity_store.has_read=false` | NoPrivileges page | `noPrivilegesPage` | `entityAnalyticsHomePage` |
+| EA Home: risk callout | `risk_engine` missing read | Callout shown | `callout-missing-risk-engine-privileges` | — |
+| EA Home: leads panel hidden | `leads.has_read=false` | Panel absent | — | `topThreatHuntingLeads` |
+| EA Mgmt: missing privs callout | `entity_store.has_all=false` | Callout shown | `callout-missing-privileges-callout` | — |
+| EA Mgmt: Engine Status tab | `entity_store.has_all=false` | Tab absent | — | `engineStatusTab` |
+| EA Mgmt: Clear Entity Data btn | `entity_store.has_all=false` | Button absent | — | `clear-entity-data-button` |
+| Watchlists: no read callout | `watchlists.has_read=false` | Callout shown | `callout-missing-privileges-callout` | — |
+| Watchlists: Create btn disabled | `watchlists.has_write=false` | Button disabled | `watchlistsTabCreateButton[disabled]` | — |
+| Asset Criticality: no write | `asset_crit.has_write=false` | Uploader hidden | `asset-criticality-insufficient-privileges` | — |
+| Explore → Hosts → Risk tab | `risk_engine` missing read | Tab replaced | `callout-missing-risk-engine-privileges` | — |
+| Explore → Users → Risk tab | `risk_engine` missing read | Tab replaced | `callout-missing-risk-engine-privileges` | — |
+
+### Flyout Correlation Map
+
+Flyout probe navigates to EA Home Page and clicks `button[aria-label="Open entity details"]`
+on the `ea-audit-test-user` row. Skipped for personas where entity store read is denied.
+
+| Panel / element | Permissions gate | Visible when | Element |
+|-----------------|-----------------|--------------|---------|
+| Flyout opened | `entity_store.read` | always (if reached) | `user-panel-header` |
+| Risk score value | `risk_engine.read` | granted | `risk-summary-result-score` |
+| Risk inputs section | `risk_engine.read` | granted | `riskInputs` |
+| Asset criticality selector | `asset_crit.read` | granted | `asset-criticality-selector` |
+| Asset criticality edit btn | `asset_crit.write` | granted | `asset-criticality-change-btn` |
+| Watchlists cell | `watchlists.read` | granted | `entityWatchlistsCell` |
+| Table tab (full doc) | `entity_store.read` | granted | `SecurityEntityPanelTableTab` |
+
+## Seed Entity (`ea-audit-test-user`)
+
+Created in the **seed phase** using admin credentials before personas are probed.
+Cleaned up in the **cleanup phase** after all probes complete.
+
+| Data surface | How seeded | Index / API |
+|--------------|------------|-------------|
+| Entity store record | ES `/_doc` direct write | `.entities.v2.latest.security_default` |
+| Risk score | ES `/_doc` direct write | `risk-score.risk-score-latest-default` |
+| Asset criticality | Kibana API | `PUT /api/asset_criticality/` |
+| Watchlist + membership | Kibana API | `POST /api/entity_analytics/watchlists/` |
+
+Entity store document includes: `entity.attributes.Privileged: true`, `asset.criticality:
+high_impact`, `entity.risk.calculated_score_norm: 85`, `entity.source: ea-audit-fixture`
+(tag used to scope deletion safely).
+
+## Known Gaps
+
+- `WatchlistFilter` on the EA Home Page header renders without a privilege pre-check. If the
+  user lacks `read` on the watchlist index, the dropdown call fails silently. No `data-test-subj`
+  to assert against — documented in report only.
+- The entity store transform may overwrite the seeded `ea-audit-test-user` document during its
+  scheduled run. The seed is written immediately before probing; the ~4 minute audit window
+  is short enough that this race is unlikely in practice.
+
+## Impact
+
+- New/updated files in `scripts/entity_analytics_permission_audit/`:
+  - `index.ts` — orchestration (setup → seed → probe → report → cleanup)
+  - `personas.ts` — 15 role + user definitions
+  - `endpoints.ts` — 5 privilege URLs + UI correlation map + flyout correlation map
+  - `api.ts` — fetch wrapper (admin + per-persona Basic auth)
+  - `browser.ts` — Playwright: login, API sub-probe, UI sub-probe, flyout sub-probe
+  - `seed.ts` — **new**: create/delete `ea-audit-test-user` across four data surfaces
+  - `correlate.ts` — merge API + UI + flyout results into unified status
+  - `report.ts` — **updated**: three 5-column tables (API / UI / Flyout)
+  - `cleanup.ts` — delete personas + seeded entity data
+- Requires running Kibana (`--kibana-url`) and Elasticsearch (`--es-url`, default `localhost:9200`).
+- Estimated run time: ~6–10 minutes (15 personas × page navigations + flyout per persona).
+
+## Run Command
+
+```bash
+node --require @kbn/babel-register/install \
+  scripts/entity_analytics_permission_audit/index.ts \
+  --kibana-url http://localhost:5601 \
+  --es-url http://localhost:9200 \
+  --user elastic \
+  --password changeme \
+  --space default \
+  --output entity_analytics_permissions_audit.md \
+  --headed   # optional: show browser windows
+```
+
+## Out of Scope
+
+- CI integration (one-time developer audit, not a recurring check)
+- Privilege monitoring, detection engine, or non-EA features
+- Testing Kibana feature privilege tier (`siem`, `securitySolution`) — treated as a precondition
+- Seeding real alert data for the Entity Insights / CSP section of the flyout

--- a/openspec/changes/ea_permission_audit/tasks.md
+++ b/openspec/changes/ea_permission_audit/tasks.md
@@ -1,0 +1,115 @@
+# Tasks
+
+## Status key
+- `[ ]` pending
+- `[x]` complete
+- `[-]` skipped / superseded
+
+---
+
+## Phase 1 — Core audit script (complete)
+
+- [x] **T1** Scaffold directory + CLI entry point (`index.ts`)
+  - CLI args: `--kibana-url`, `--es-url`, `--user`, `--password`, `--space`, `--output`, `--headed`
+  - Orchestration: setup → seed → probe → correlate → report → cleanup
+
+- [x] **T2** Define 15 personas (`personas.ts`)
+  - Each persona: `{ id, name, username, password, roleName, roleDefinition }`
+  - `createPersona`: POST role via Kibana API + PUT user via ES native `/_security/user`
+  - Covers: no access, read-only, full, per-feature read/no-read/no-write (see proposal matrix)
+
+- [x] **T3** Define endpoints + UI correlation map (`endpoints.ts`)
+  - 5 privilege endpoint paths + versions
+  - `CORRELATION_MAP`: feature → `{ page, url, presentWhenFalse, absentWhenFalse }` per entry
+
+- [x] **T4** HTTP fetch wrapper (`api.ts`)
+  - `adminFetch(url, adminAuth, opts)` — includes `x-elastic-internal-origin: Kibana`
+  - `personaFetch(url, username, password, version)` — Basic auth, same internal header
+
+- [x] **T5** Browser probe — API + UI sub-probes (`browser.ts`)
+  - Playwright launch (headless/headed)
+  - `loginAsPersona`: navigate to `/login`, fill credentials, wait for redirect
+  - `fetchAllPrivilegesInBrowser`: call all 5 privilege endpoints via `page.evaluate → fetch`
+    (inherits session cookies, satisfies `x-elastic-internal-origin` requirement)
+  - `checkCorrelationEntry`: navigate to page, assert present/absent selectors
+  - `probeBrowserForPersonas`: loop 15 personas, return `PersonaBrowserResult[]`
+
+- [x] **T6** Correlate results (`correlate.ts`)
+  - Input: `Persona[]`, `CorrelationEntry[]`, `PersonaBrowserResult[]`
+  - Output: `AuditResult[]` with `{ personaId, featureId, apiResult, uiResult, status }`
+
+- [x] **T7** Report renderer (`report.ts`)
+  - **Pending update** — currently dense matrix; see T11 for the trimmed 3-section format
+
+- [x] **T8** Cleanup (`cleanup.ts`)
+  - `deleteResource(url, adminAuth, label, needsKbnXsrf)`
+  - Deletes roles via Kibana API, users via ES `/_security/user`
+
+---
+
+## Phase 2 — Flyout section + report trim (new)
+
+- [ ] **T9** Seed entity (`seed.ts`)
+  - `seedTestEntity(kibanaUrl, esUrl, adminAuth, spaceId)` → creates `ea-audit-test-user`
+    1. Create watchlist via `POST /api/entity_analytics/watchlists/` → capture `watchlistId`
+    2. Set asset criticality via `PUT /api/asset_criticality/`
+       `{ id_field: "user.name", id_value: "ea-audit-test-user", criticality_level: "high_impact" }`
+    3. Write risk score doc via ES direct:
+       `PUT ${esUrl}/risk-score.risk-score-latest-default/_doc/ea-audit-test-user`
+       `{ user.name, user.risk.calculated_score_norm: 85, user.risk.calculated_level: "High", @timestamp }`
+    4. Write entity store record via ES direct:
+       `PUT ${esUrl}/.entities.v2.latest.security_default/_doc/ea-audit-test-user`
+       `{ user.name, entity.attributes.Privileged: true, entity.attributes.watchlists: [watchlistId],`
+       `  asset.criticality: "high_impact", entity.risk.calculated_score_norm: 85,`
+       `  entity.source: "ea-audit-fixture" }`
+  - `cleanupTestEntity(kibanaUrl, esUrl, adminAuth, spaceId, watchlistId)` → reverses all writes
+
+- [ ] **T10** Flyout sub-probe (`browser.ts` — extend existing)
+  - `probeFlyoutForPersona(page, kibanaUrl, space, flyoutCorrelationMap)`:
+    1. Navigate to EA Home Page
+    2. Wait for entity table to load
+    3. Find `button[aria-label="Open entity details"]` in the row containing `ea-audit-test-user`
+    4. Click it, wait for `[data-test-subj="user-panel-header"]` to appear
+    5. For each `FlyoutCorrelationEntry`: check `presentWhenGranted` / `absentWhenDenied` selector
+    6. Return `FlyoutCheckResult[]`
+  - Skip and record `{ status: "SKIP", reason: "entity store denied" }` for personas where
+    `entity_store.has_read_permissions === false`
+  - Add `flyoutResults: FlyoutCheckResult[]` to `PersonaBrowserResult`
+
+- [ ] **T11** Trim report to 3-section format (`report.ts` — rewrite)
+  - Replace current dense matrix with three separate `EuiBasicTable`-style Markdown tables,
+    each with exactly 5 columns:
+    - **API**: `Endpoint | Permissions checked | Persona | Access granted | Result`
+    - **UI**: `URL | Permissions checked | Persona | Access granted | Result`
+    - **Flyout**: `Panel | Permissions checked | Persona | Access granted | Result`
+  - Result values: `✅ PASS`, `❌ FAIL`, `⏭ SKIP`
+  - Known Gaps section: unchanged (append after the three tables)
+
+- [ ] **T12** Update `correlate.ts` for flyout results
+  - Extend `AuditResult` to include `flyoutChecks: FlyoutCheckResult[]`
+  - Derive flyout PASS/FAIL/SKIP per panel per persona
+
+- [ ] **T13** Update `cleanup.ts` for entity data
+  - Accept `watchlistId` from seed phase
+  - Delete entity store doc, risk score doc, asset criticality, watchlist
+  - All deletes scoped by `entity.source: ea-audit-fixture` or explicit IDs
+
+- [ ] **T14** Wire seed + flyout into `index.ts`
+  - After persona creation, call `seedTestEntity` → capture `watchlistId`
+  - Pass flyout correlation map into `probeBrowserForPersonas`
+  - Pass `watchlistId` into `cleanupPersonas` / `cleanupTestEntity`
+  - Update step labels: `[1/4] Personas`, `[2/4] Seed`, `[3/4] Probe`, `[4/4] Report + Cleanup`
+
+- [ ] **T15** Define flyout correlation map (`endpoints.ts` — extend)
+  - `FLYOUT_CORRELATION_MAP: FlyoutCorrelationEntry[]`
+  - Each entry: `{ panelLabel, permissionsGate, presentSelector?, absentSelector? }`
+  - Entries (verified `data-test-subj` values from source):
+    | Panel label | Selector | Present when |
+    |---|---|---|
+    | Flyout opened | `user-panel-header` | entity store read |
+    | Risk score value | `risk-summary-result-score` | risk engine read |
+    | Risk inputs | `riskInputs` | risk engine read |
+    | Criticality selector | `asset-criticality-selector` | asset crit read |
+    | Criticality edit btn | `asset-criticality-change-btn` | asset crit write |
+    | Watchlists cell | `entityWatchlistsCell` | watchlists read |
+    | Table tab | `SecurityEntityPanelTableTab` | entity store read |

--- a/scripts/entity_analytics_permission_audit/api.ts
+++ b/scripts/entity_analytics_permission_audit/api.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const toBase64 = (value: string): string => Buffer.from(value).toString('base64');
+
+const handleResponse = async (res: Response): Promise<unknown> => {
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${text.slice(0, 200)}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+export const adminFetch = async (
+  url: string,
+  adminAuth: string,
+  opts: RequestInit = {}
+): Promise<unknown> => {
+  const res = await fetch(url, {
+    ...opts,
+    headers: {
+      Authorization: `Basic ${adminAuth}`,
+      'Content-Type': 'application/json',
+      'kbn-xsrf': 'true',
+      'x-elastic-internal-origin': 'Kibana',
+      'elastic-api-version': '1',
+      ...(opts.headers as Record<string, string>),
+    },
+  });
+  return handleResponse(res);
+};
+
+export const personaFetch = async (
+  url: string,
+  username: string,
+  password: string,
+  version = '1'
+): Promise<unknown> => {
+  const auth = toBase64(`${username}:${password}`);
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'x-elastic-internal-origin': 'Kibana',
+      'elastic-api-version': version,
+    },
+  });
+  return handleResponse(res);
+};

--- a/scripts/entity_analytics_permission_audit/browser.ts
+++ b/scripts/entity_analytics_permission_audit/browser.ts
@@ -1,0 +1,591 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { chromium } from '@playwright/test';
+import type { Page, Browser, BrowserContext } from '@playwright/test';
+import type {
+  Persona,
+  CorrelationEntry,
+  FlyoutCorrelationEntry,
+  FlyoutCheckResult,
+  BrowserCheckResult,
+  ObservedState,
+  InBrowserApiResult,
+  PersonaBrowserResult,
+} from './types';
+import { PRIVILEGE_ENDPOINT_PATHS, buildSpacePath } from './endpoints';
+import type { EndpointId } from './types';
+import { TEST_ENTITY_NAME } from './seed';
+
+const PAGE_TIMEOUT_MS = 30_000;
+const LOGIN_TIMEOUT_MS = 15_000;
+
+/** API version per endpoint path (internal = '1' or '2', public = '2023-10-31') */
+const ENDPOINT_VERSIONS: Record<string, string> = {
+  '/internal/risk_score/engine/privileges': '1',
+  '/internal/security/entity_store/check_privileges': '2',
+  '/api/entity_store/privileges': '1',
+  '/api/entity_analytics/watchlists/privileges': '2023-10-31',
+  '/internal/entity_analytics/leads/privileges': '1',
+  '/internal/asset_criticality/privileges': '1',
+};
+
+const loginAsPersona = async (
+  page: Page,
+  kibanaUrl: string,
+  persona: Persona
+): Promise<boolean> => {
+  try {
+    await page.goto(`${kibanaUrl}/login`, { timeout: PAGE_TIMEOUT_MS });
+    await page.locator('[data-test-subj="loginUsername"]').fill(persona.username);
+    await page.locator('[data-test-subj="loginPassword"]').fill(persona.password);
+    await page.locator('[data-test-subj="loginSubmit"]').click();
+    await page.waitForURL(/\/app\//, { timeout: LOGIN_TIMEOUT_MS });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Call a privilege endpoint from within the browser's session context */
+const fetchPrivilegeInBrowser = async (
+  page: Page,
+  path: string,
+  version: string
+): Promise<InBrowserApiResult['response']> => {
+  const result = await page.evaluate(
+    async ({ apiPath, apiVersion }: { apiPath: string; apiVersion: string }) => {
+      try {
+        const res = await fetch(apiPath, {
+          headers: {
+            'elastic-api-version': apiVersion,
+            'x-elastic-internal-origin': 'Kibana',
+          },
+        });
+        const text = await res.text();
+        try {
+          return { ok: res.ok, status: res.status, data: JSON.parse(text) };
+        } catch {
+          return { ok: false, status: res.status, data: null, raw: text };
+        }
+      } catch (e) {
+        return { ok: false, status: 0, data: null, raw: String(e) };
+      }
+    },
+    { apiPath: path, apiVersion: version }
+  );
+
+  if (result.ok && result.data) {
+    return result.data as InBrowserApiResult['response'];
+  }
+  throw new Error(
+    `HTTP ${result.status}: ${
+      typeof result.raw === 'string'
+        ? result.raw.slice(0, 200)
+        : JSON.stringify(result.data).slice(0, 200)
+    }`
+  );
+};
+
+const fetchAllPrivilegesInBrowser = async (
+  page: Page,
+  spacePath: string
+): Promise<InBrowserApiResult[]> => {
+  const results: InBrowserApiResult[] = [];
+  for (const [endpointId, path] of Object.entries(PRIVILEGE_ENDPOINT_PATHS) as Array<
+    [EndpointId, string]
+  >) {
+    const fullPath = `${spacePath}${path}`;
+    const version = ENDPOINT_VERSIONS[path] ?? '1';
+    let response: InBrowserApiResult['response'] = null;
+    let error: string | undefined;
+    try {
+      response = await fetchPrivilegeInBrowser(page, fullPath, version);
+      if (!response) error = `No response (HTTP error) for ${path}`;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+    results.push({ endpointId, response, error });
+  }
+  return results;
+};
+
+const checkSelector = async (
+  page: Page,
+  selector: string
+): Promise<'present' | 'absent' | 'disabled'> => {
+  try {
+    const locator = page.locator(selector.replace(/\[disabled\]$/, ''));
+    const count = await locator.count();
+    if (count === 0) return 'absent';
+    if (selector.endsWith('[disabled]')) {
+      const isDisabled =
+        (await locator.first().getAttribute('disabled')) !== null ||
+        (await locator.first().getAttribute('aria-disabled')) === 'true';
+      return isDisabled ? 'disabled' : 'present';
+    }
+    return 'present';
+  } catch {
+    return 'absent';
+  }
+};
+
+const navigateTo = async (page: Page, url: string): Promise<boolean> => {
+  try {
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: PAGE_TIMEOUT_MS });
+    await page.waitForTimeout(2000);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Checks a single feature gate using:
+ *   1. Text visibility  — page.getByText() substring match
+ *   2. Button ARIA state — page.getByRole('button', { disabled }) for button state checks
+ *
+ * Assertions are inverted automatically depending on access level:
+ *   denied  → textWhenDenied visible, textWhenGranted absent, buttons disabled
+ *   granted → textWhenGranted visible, textWhenDenied absent, buttons enabled
+ */
+const checkCorrelationEntry = async (
+  page: Page,
+  entry: CorrelationEntry,
+  apiGranted: boolean
+): Promise<BrowserCheckResult> => {
+  const textShouldBeVisible = apiGranted ? entry.textWhenGranted ?? [] : entry.textWhenDenied ?? [];
+  const textShouldBeHidden = apiGranted ? entry.textWhenDenied ?? [] : entry.textWhenGranted ?? [];
+  const buttons = entry.buttonDisabledWhenDenied ?? [];
+
+  if (textShouldBeVisible.length === 0 && textShouldBeHidden.length === 0 && buttons.length === 0) {
+    return {
+      featureName: entry.featureName,
+      observed: 'skipped',
+      details: 'No text or button assertions defined for this feature gate',
+    };
+  }
+
+  const failures: string[] = [];
+
+  // Text that should be visible
+  for (const text of textShouldBeVisible) {
+    try {
+      const visible = await page.getByText(text, { exact: false }).first().isVisible();
+      if (!visible) failures.push(`Expected "${text}" to be visible`);
+    } catch {
+      failures.push(`Error checking visibility of "${text}"`);
+    }
+  }
+
+  // Text that should NOT be visible
+  for (const text of textShouldBeHidden) {
+    try {
+      const visible = await page.getByText(text, { exact: false }).first().isVisible();
+      if (visible) failures.push(`Expected "${text}" to NOT be visible`);
+    } catch {
+      // Element not found → it is hidden, which is what we want
+    }
+  }
+
+  // Button state (disabled when denied, enabled when granted)
+  for (const btnName of buttons) {
+    try {
+      const btn = page.getByRole('button', { name: btnName, exact: false }).first();
+      const count = await btn.count();
+      if (count === 0) {
+        if (!apiGranted) {
+          // Button absent when denied — treat same as disabled (access revoked entirely)
+        } else {
+          failures.push(`Expected button "${btnName}" to be visible and enabled`);
+        }
+      } else {
+        const isDisabled =
+          (await btn.getAttribute('disabled')) !== null ||
+          (await btn.getAttribute('aria-disabled')) === 'true';
+        if (!apiGranted && !isDisabled) {
+          failures.push(`Expected button "${btnName}" to be disabled but it is enabled`);
+        } else if (apiGranted && isDisabled) {
+          failures.push(`Expected button "${btnName}" to be enabled but it is disabled`);
+        }
+      }
+    } catch {
+      failures.push(`Error checking button state for "${btnName}"`);
+    }
+  }
+
+  if (failures.length > 0) {
+    return {
+      featureName: entry.featureName,
+      observed: 'error' as ObservedState,
+      details: failures.join('; '),
+    };
+  }
+
+  return { featureName: entry.featureName, observed: 'present' };
+};
+
+const FLYOUT_OPEN_TIMEOUT_MS = 20_000;
+
+/**
+ * Opens the entity flyout for TEST_ENTITY_NAME on the EA Home Page and checks
+ * each privilege-gated panel.  If the entity is not found in the table (e.g.
+ * entity store is empty or the persona lacks read access) every entry is SKIP.
+ */
+const probeFlyout = async (
+  page: Page,
+  kibanaUrl: string,
+  spacePath: string,
+  flyoutMap: FlyoutCorrelationEntry[],
+  apiValueLookup: Map<string, Record<string, boolean | null>>
+): Promise<{ checks: FlyoutCheckResult[]; skipReason?: string }> => {
+  const checks: FlyoutCheckResult[] = [];
+
+  // Navigate to EA home page
+  const homeUrl = `${kibanaUrl}${spacePath}/app/security/entity_analytics`;
+  const navigated = await navigateTo(page, homeUrl);
+  if (!navigated) {
+    const reason = `Failed to navigate to ${homeUrl}`;
+    return {
+      checks: flyoutMap.map((e) => ({
+        panelLabel: e.panelLabel,
+        endpoint: e.endpoint,
+        privilegeField: e.privilegeField,
+        apiValue: apiValueLookup.get(e.endpoint)?.[e.privilegeField] ?? null,
+        observed: 'error' as ObservedState,
+        status: 'ERROR',
+        details: reason,
+      })),
+      skipReason: reason,
+    };
+  }
+
+  // Wait a little extra for the entity table to render
+  await page.waitForTimeout(3000);
+
+  // Find the expand button next to ea-audit-test-user
+  // The table groups entities; the button has aria-label="Open entity details"
+  // and is rendered near the entity name text.
+  let flyoutOpened = false;
+  try {
+    // Find a row/cell containing the test entity name
+    const entityCell = page.locator(`text="${TEST_ENTITY_NAME}"`).first();
+    const count = await entityCell.count();
+
+    if (count === 0) {
+      const reason = `${TEST_ENTITY_NAME} not found in entity table (entity store may be empty or access denied)`;
+      return {
+        checks: flyoutMap.map((e) => ({
+          panelLabel: e.panelLabel,
+          endpoint: e.endpoint,
+          privilegeField: e.privilegeField,
+          apiValue: apiValueLookup.get(e.endpoint)?.[e.privilegeField] ?? null,
+          observed: 'skipped' as ObservedState,
+          status: 'SKIP',
+          details: reason,
+        })),
+        skipReason: reason,
+      };
+    }
+
+    // The expand button is the nearest EuiButtonIcon with iconType="expand"
+    // We look for it within the same ancestor group as the entity name cell.
+    const expandBtn = page.locator('[aria-label="Open entity details"]').first();
+    const btnCount = await expandBtn.count();
+    if (btnCount === 0) {
+      const reason = 'Expand button (aria-label="Open entity details") not found on page';
+      return {
+        checks: flyoutMap.map((e) => ({
+          panelLabel: e.panelLabel,
+          endpoint: e.endpoint,
+          privilegeField: e.privilegeField,
+          apiValue: apiValueLookup.get(e.endpoint)?.[e.privilegeField] ?? null,
+          observed: 'skipped' as ObservedState,
+          status: 'SKIP',
+          details: reason,
+        })),
+        skipReason: reason,
+      };
+    }
+
+    await expandBtn.click();
+
+    // Wait for the flyout header to appear
+    await page.waitForSelector('[data-test-subj="user-panel-header"]', {
+      timeout: FLYOUT_OPEN_TIMEOUT_MS,
+    });
+    flyoutOpened = true;
+  } catch (err) {
+    const reason = `Could not open flyout: ${err instanceof Error ? err.message : String(err)}`;
+    return {
+      checks: flyoutMap.map((e) => ({
+        panelLabel: e.panelLabel,
+        endpoint: e.endpoint,
+        privilegeField: e.privilegeField,
+        apiValue: apiValueLookup.get(e.endpoint)?.[e.privilegeField] ?? null,
+        observed: 'error' as ObservedState,
+        status: 'ERROR',
+        details: reason,
+      })),
+      skipReason: reason,
+    };
+  }
+
+  if (!flyoutOpened) {
+    const reason = 'Flyout did not open';
+    return {
+      checks: flyoutMap.map((e) => ({
+        panelLabel: e.panelLabel,
+        endpoint: e.endpoint,
+        privilegeField: e.privilegeField,
+        apiValue: apiValueLookup.get(e.endpoint)?.[e.privilegeField] ?? null,
+        observed: 'error' as ObservedState,
+        status: 'ERROR',
+        details: reason,
+      })),
+      skipReason: reason,
+    };
+  }
+
+  // Give the flyout panels time to load
+  await page.waitForTimeout(2000);
+
+  for (const entry of flyoutMap) {
+    const apiValue = apiValueLookup.get(entry.endpoint)?.[entry.privilegeField] ?? null;
+    const observed = await checkSelector(page, entry.selectorWhenGranted);
+
+    let status: FlyoutCheckResult['status'];
+    let details: string | undefined;
+
+    if (apiValue === true) {
+      // Permission granted → panel should be visible
+      status = observed === 'present' ? 'PASS' : 'FAIL';
+      if (status === 'FAIL') {
+        details = `Panel "${entry.panelLabel}" expected to be visible (API granted) but was ${observed}`;
+      }
+    } else if (apiValue === false) {
+      // Permission denied → panel should be absent
+      status = observed === 'absent' ? 'PASS' : 'FAIL';
+      if (status === 'FAIL') {
+        details = `Panel "${entry.panelLabel}" expected to be absent (API denied) but was ${observed}`;
+      }
+    } else {
+      // API error → can't determine expectation
+      status = 'ERROR';
+      details = 'API value unknown; cannot assert panel state';
+    }
+
+    checks.push({
+      panelLabel: entry.panelLabel,
+      endpoint: entry.endpoint,
+      privilegeField: entry.privilegeField,
+      apiValue,
+      observed,
+      status,
+      details,
+    });
+  }
+
+  return { checks };
+};
+
+export const probeBrowserForPersonas = async (
+  kibanaUrl: string,
+  space: string,
+  personas: Persona[],
+  correlationMap: CorrelationEntry[],
+  flyoutMap: FlyoutCorrelationEntry[],
+  headed: boolean
+): Promise<PersonaBrowserResult[]> => {
+  const spacePath = buildSpacePath(space);
+  const results: PersonaBrowserResult[] = [];
+
+  let browser: Browser | null = null;
+  try {
+    browser = await chromium.launch({ headless: !headed });
+
+    for (const persona of personas) {
+      process.stdout.write(`  [browser] ${persona.name}\n`);
+
+      let context: BrowserContext | null = null;
+      const personaResult: PersonaBrowserResult = {
+        personaId: persona.id,
+        apiResults: [],
+        browserChecks: [],
+        flyoutChecks: [],
+        interceptedNetworkCalls: {},
+      };
+
+      try {
+        context = await browser.newContext({ ignoreHTTPSErrors: true });
+        const page = await context.newPage();
+
+        // Intercept responses to privilege endpoints that the UI fires during render.
+        // This verifies the UI is actually wired to each expected privilege API.
+        page.on('response', async (res) => {
+          const url = res.url();
+          for (const [endpointId, path] of Object.entries(PRIVILEGE_ENDPOINT_PATHS) as Array<
+            [EndpointId, string]
+          >) {
+            if (url.includes(path) && res.ok()) {
+              try {
+                const body = (await res.json()) as unknown;
+                personaResult.interceptedNetworkCalls[endpointId] = body;
+              } catch {
+                // non-JSON or body already consumed
+              }
+            }
+          }
+        });
+
+        const loggedIn = await loginAsPersona(page, kibanaUrl, persona);
+        if (!loggedIn) {
+          const errMsg = 'Login failed';
+          personaResult.apiResults = Object.keys(PRIVILEGE_ENDPOINT_PATHS).map((id) => ({
+            endpointId: id as EndpointId,
+            response: null,
+            error: errMsg,
+          }));
+          personaResult.browserChecks = correlationMap.map((entry) => ({
+            featureName: entry.featureName,
+            observed: 'error' as ObservedState,
+            details: errMsg,
+          }));
+          personaResult.flyoutChecks = flyoutMap.map((entry) => ({
+            panelLabel: entry.panelLabel,
+            endpoint: entry.endpoint,
+            privilegeField: entry.privilegeField,
+            apiValue: null,
+            observed: 'error' as ObservedState,
+            status: 'ERROR' as const,
+            details: errMsg,
+          }));
+          personaResult.interceptedNetworkCalls = {};
+          results.push(personaResult);
+          continue;
+        }
+
+        // Call all privilege APIs from within the browser session
+        personaResult.apiResults = await fetchAllPrivilegesInBrowser(page, spacePath);
+
+        // Build a quick lookup: endpoint → privilege field → value
+        const apiValueLookup = new Map<string, Record<string, boolean | null>>();
+        for (const r of personaResult.apiResults) {
+          if (r.response) {
+            apiValueLookup.set(r.endpointId, {
+              has_all_required: r.response.has_all_required ?? null,
+              has_read_permissions: r.response.has_read_permissions ?? null,
+              has_write_permissions: r.response.has_write_permissions ?? null,
+            });
+          }
+        }
+
+        // Navigate to each unique page and check DOM elements
+        const pageGroups = new Map<string, CorrelationEntry[]>();
+        for (const entry of correlationMap) {
+          const pageUrl = `${kibanaUrl}${spacePath}${entry.page}`;
+          const existing = pageGroups.get(pageUrl) ?? [];
+          existing.push(entry);
+          pageGroups.set(pageUrl, existing);
+        }
+
+        for (const [pageUrl, entries] of pageGroups) {
+          const navigated = await navigateTo(page, pageUrl);
+          if (!navigated) {
+            for (const entry of entries) {
+              personaResult.browserChecks.push({
+                featureName: entry.featureName,
+                observed: 'error',
+                details: `Failed to navigate to ${pageUrl}`,
+              });
+            }
+            continue;
+          }
+
+          for (const entry of entries) {
+            const endpointValues = apiValueLookup.get(entry.endpoint) ?? {};
+            const apiValue = endpointValues[entry.privilegeField] ?? null;
+            if (apiValue === null) {
+              // API call errored — can't determine expected state, skip UI check
+              personaResult.browserChecks.push({
+                featureName: entry.featureName,
+                observed: 'skipped',
+                details: 'API call failed; cannot determine expected UI state',
+              });
+              continue;
+            }
+            const result = await checkCorrelationEntry(page, entry, apiValue === true);
+            personaResult.browserChecks.push(result);
+          }
+        }
+
+        // Flyout probe: only run if entity store read is granted
+        const entityStoreRead = apiValueLookup.get('entity_store')?.has_read_permissions ?? null;
+        if (entityStoreRead === false) {
+          personaResult.flyoutSkipReason =
+            'entity_store.has_read_permissions is false; flyout is inaccessible';
+          personaResult.flyoutChecks = flyoutMap.map((entry) => ({
+            panelLabel: entry.panelLabel,
+            endpoint: entry.endpoint,
+            privilegeField: entry.privilegeField,
+            apiValue: apiValueLookup.get(entry.endpoint)?.[entry.privilegeField] ?? null,
+            observed: 'skipped' as ObservedState,
+            status: 'SKIP' as const,
+            details: personaResult.flyoutSkipReason,
+          }));
+        } else {
+          process.stdout.write(`  [flyout] ${persona.name}\n`);
+          const flyoutResult = await probeFlyout(
+            page,
+            kibanaUrl,
+            spacePath,
+            flyoutMap,
+            apiValueLookup
+          );
+          personaResult.flyoutChecks = flyoutResult.checks;
+          if (flyoutResult.skipReason) {
+            personaResult.flyoutSkipReason = flyoutResult.skipReason;
+          }
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        for (const entry of correlationMap) {
+          if (!personaResult.browserChecks.some((r) => r.featureName === entry.featureName)) {
+            personaResult.browserChecks.push({
+              featureName: entry.featureName,
+              observed: 'error',
+              details: msg,
+            });
+          }
+        }
+        for (const entry of flyoutMap) {
+          if (!personaResult.flyoutChecks.some((r) => r.panelLabel === entry.panelLabel)) {
+            personaResult.flyoutChecks.push({
+              panelLabel: entry.panelLabel,
+              endpoint: entry.endpoint,
+              privilegeField: entry.privilegeField,
+              apiValue: null,
+              observed: 'error' as ObservedState,
+              status: 'ERROR',
+              details: msg,
+            });
+          }
+        }
+      } finally {
+        await context?.close();
+      }
+
+      results.push(personaResult);
+    }
+  } finally {
+    await browser?.close();
+  }
+
+  return results;
+};

--- a/scripts/entity_analytics_permission_audit/cleanup.ts
+++ b/scripts/entity_analytics_permission_audit/cleanup.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Persona, SeedContext } from './types';
+import { cleanupTestEntity } from './seed';
+
+const deleteResource = async (
+  url: string,
+  adminAuth: string,
+  label: string,
+  needsKbnXsrf: boolean
+): Promise<void> => {
+  try {
+    const headers: Record<string, string> = { Authorization: `Basic ${adminAuth}` };
+    if (needsKbnXsrf) headers['kbn-xsrf'] = 'true';
+    const res = await fetch(url, { method: 'DELETE', headers });
+    if (!res.ok && res.status !== 404) {
+      const body = await res.text();
+      process.stderr.write(
+        `  [cleanup] WARNING: could not delete ${label}: ${res.status} ${body.slice(0, 120)}\n`
+      );
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`  [cleanup] WARNING: request failed for ${label}: ${msg}\n`);
+  }
+};
+
+export const cleanupAll = async (
+  kibanaUrl: string,
+  esUrl: string,
+  adminAuth: string,
+  space: string,
+  personas: Persona[],
+  seedCtx: SeedContext | null
+): Promise<void> => {
+  if (seedCtx) {
+    process.stdout.write('\nCleaning up seeded test entity data...\n');
+    await cleanupTestEntity(kibanaUrl, esUrl, adminAuth, space, seedCtx);
+  }
+  await cleanupPersonas(kibanaUrl, esUrl, adminAuth, personas);
+};
+
+export const cleanupPersonas = async (
+  kibanaUrl: string,
+  esUrl: string,
+  adminAuth: string,
+  personas: Persona[]
+): Promise<void> => {
+  process.stdout.write('\nCleaning up test roles and users...\n');
+  for (const persona of personas) {
+    // Users are created via ES native API
+    await deleteResource(
+      `${esUrl}/_security/user/${persona.username}`,
+      adminAuth,
+      `user ${persona.username}`,
+      false
+    );
+    // Roles are created via Kibana API
+    await deleteResource(
+      `${kibanaUrl}/api/security/role/${persona.roleName}`,
+      adminAuth,
+      `role ${persona.roleName}`,
+      true
+    );
+  }
+  process.stdout.write('Cleanup complete.\n');
+};

--- a/scripts/entity_analytics_permission_audit/correlate.ts
+++ b/scripts/entity_analytics_permission_audit/correlate.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type {
+  Persona,
+  PersonaBrowserResult,
+  AuditResult,
+  AuditStatus,
+  CorrelationEntry,
+  ObservedState,
+  PrivilegeField,
+  FlyoutCheckResult,
+} from './types';
+
+const resolveApiValue = (
+  personaResult: PersonaBrowserResult,
+  endpoint: string,
+  field: PrivilegeField
+): boolean | null => {
+  const r = personaResult.apiResults.find((a) => a.endpointId === endpoint);
+  if (!r?.response) return null;
+  return r.response[field] ?? null;
+};
+
+const resolveApiError = (
+  personaResult: PersonaBrowserResult,
+  endpoint: string
+): string | undefined => {
+  return personaResult.apiResults.find((a) => a.endpointId === endpoint)?.error;
+};
+
+const computeStatus = (
+  apiValue: boolean | null,
+  browserObserved: ObservedState | null,
+  apiError: string | undefined
+): AuditStatus => {
+  if (apiError || apiValue === null) return 'ERROR';
+  // 'skipped' means no DOM selectors are defined for this feature gate
+  if (browserObserved === 'skipped' || browserObserved === null) return 'API_ONLY';
+  // 'error' means one or more DOM assertions failed
+  if (browserObserved === 'error') return 'FAIL';
+  return 'PASS';
+};
+
+/** Flatten flyout checks across all personas into a single array with persona attached. */
+export const collectFlyoutResults = (
+  personas: Persona[],
+  browserResults: PersonaBrowserResult[]
+): Array<{ persona: Persona; check: FlyoutCheckResult }> => {
+  const resultIndex = new Map(browserResults.map((r) => [r.personaId, r]));
+  const rows: Array<{ persona: Persona; check: FlyoutCheckResult }> = [];
+  for (const persona of personas) {
+    const pr = resultIndex.get(persona.id);
+    if (!pr) continue;
+    for (const check of pr.flyoutChecks) {
+      rows.push({ persona, check });
+    }
+  }
+  return rows;
+};
+
+export const correlate = (
+  personas: Persona[],
+  correlationMap: CorrelationEntry[],
+  browserResults: PersonaBrowserResult[]
+): AuditResult[] => {
+  const results: AuditResult[] = [];
+  const resultIndex = new Map(browserResults.map((r) => [r.personaId, r]));
+
+  for (const persona of personas) {
+    const personaResult = resultIndex.get(persona.id);
+    if (!personaResult) continue;
+
+    const browserCheckIndex = new Map(personaResult.browserChecks.map((c) => [c.featureName, c]));
+
+    for (const entry of correlationMap) {
+      const apiValue = resolveApiValue(personaResult, entry.endpoint, entry.privilegeField);
+      const apiError = resolveApiError(personaResult, entry.endpoint);
+      const browserCheck = browserCheckIndex.get(entry.featureName) ?? null;
+      const browserObserved: ObservedState | null = browserCheck?.observed ?? null;
+
+      results.push({
+        persona,
+        featureName: entry.featureName,
+        page: entry.page,
+        endpoint: entry.endpoint,
+        privilegeField: entry.privilegeField,
+        apiValue,
+        browserObserved,
+        expectedWhenDenied: entry.expectedWhenDenied,
+        status: computeStatus(apiValue, browserObserved, apiError),
+        details: apiError ?? browserCheck?.details,
+      });
+    }
+  }
+
+  return results;
+};

--- a/scripts/entity_analytics_permission_audit/endpoints.ts
+++ b/scripts/entity_analytics_permission_audit/endpoints.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CorrelationEntry, EndpointId, FlyoutCorrelationEntry } from './types';
+
+export const PRIVILEGE_ENDPOINT_PATHS: Record<EndpointId, string> = {
+  risk_engine: '/internal/risk_score/engine/privileges',
+  // Uses V2 entity store endpoint when FF_ENABLE_ENTITY_STORE_V2 is active
+  entity_store: '/internal/security/entity_store/check_privileges',
+  leads: '/internal/entity_analytics/leads/privileges',
+  watchlists: '/api/entity_analytics/watchlists/privileges',
+  asset_criticality: '/internal/asset_criticality/privileges',
+};
+
+export const buildEndpointUrl = (kibanaUrl: string, spacePath: string, path: string): string =>
+  `${kibanaUrl}${spacePath}${path}`;
+
+export const buildSpacePath = (space: string): string => (space === 'default' ? '' : `/s/${space}`);
+
+/**
+ * One entry per UI feature gate.
+ * privilegeField = the field in the API response that determines the gate.
+ * page = Kibana app path (no space prefix; caller prepends /s/{space} when needed).
+ * presentWhenDenied = data-test-subj selectors expected in the DOM when the privilege is denied.
+ * absentWhenDenied = data-test-subj selectors expected to be absent when the privilege is denied.
+ */
+export const CORRELATION_MAP: CorrelationEntry[] = [
+  // ── EA Home Page ────────────────────────────────────────────────────────────
+  {
+    featureName: 'EA Home: full page blocked',
+    endpoint: 'entity_store',
+    privilegeField: 'has_read_permissions',
+    expectedWhenDenied: 'NoPrivileges page shown — "Privileges required" heading visible',
+    page: '/app/security/entity_analytics',
+    // NoPrivileges component title (no_privileges/translations.ts → NO_PERMISSIONS_TITLE)
+    // Absence of this title is sufficient to confirm the full page loaded (no textWhenGranted
+    // needed: the NoPrivileges body itself contains "entity analytics" as the pageName).
+    textWhenDenied: ['Privileges required'],
+  },
+  {
+    featureName: 'EA Home: risk engine callout',
+    endpoint: 'risk_engine',
+    // The callout is driven by useMissingRiskEnginePrivileges({ readonly: true }) which only
+    // requires read access — not the full has_all_required set (read+write+cluster).
+    privilegeField: 'has_read_permissions',
+    expectedWhenDenied: '"Insufficient privileges" callout visible; page still loads',
+    page: '/app/security/entity_analytics',
+    // missing_privileges/translations.tsx → MISSING_PRIVILEGES_CALLOUT_TITLE
+    textWhenDenied: ['Insufficient privileges'],
+  },
+  {
+    featureName: 'EA Home: leads panel hidden',
+    endpoint: 'leads',
+    privilegeField: 'has_read_permissions',
+    expectedWhenDenied: 'Leads panel absent; panel heading not visible',
+    page: '/app/security/entity_analytics',
+    // top_threat_hunting_leads/translations.ts → TITLE
+    textWhenGranted: ['Top threat hunting leads'],
+  },
+  {
+    featureName: 'EA Home: leads generate button disabled',
+    endpoint: 'leads',
+    privilegeField: 'has_write_permissions',
+    expectedWhenDenied: 'Generate button is aria-disabled',
+    page: '/app/security/entity_analytics',
+    // top_threat_hunting_leads/translations.ts → GENERATE_BUTTON / REGENERATE_BUTTON
+    buttonDisabledWhenDenied: ['Generate', 'Regenerate'],
+  },
+
+  // ── EA Management Page ──────────────────────────────────────────────────────
+  {
+    featureName: 'EA Management: missing privileges callout',
+    endpoint: 'entity_store',
+    privilegeField: 'has_all_required',
+    expectedWhenDenied: '"Insufficient privileges" callout shown on management page',
+    page: '/app/security/entity_analytics_management',
+    textWhenDenied: ['Insufficient privileges'],
+  },
+  {
+    featureName: 'EA Management: Engine Status tab hidden',
+    endpoint: 'entity_store',
+    privilegeField: 'has_all_required',
+    expectedWhenDenied: '"Engine Status" tab not rendered',
+    page: '/app/security/entity_analytics_management',
+    // entity_analytics_management_page.tsx → "Engine Status" tab label
+    textWhenGranted: ['Engine Status'],
+  },
+  {
+    featureName: 'EA Management: Clear Entity Data button hidden',
+    endpoint: 'entity_store',
+    privilegeField: 'has_all_required',
+    expectedWhenDenied: '"Clear Entity Data" button not rendered',
+    page: '/app/security/entity_analytics_management',
+    // clear_entity_data_button.tsx → "Clear Entity Data"
+    textWhenGranted: ['Clear Entity Data'],
+  },
+
+  // ── EA Management → Watchlists Tab ─────────────────────────────────────────
+  {
+    featureName: 'EA Management → Watchlists: no read callout',
+    endpoint: 'watchlists',
+    privilegeField: 'has_read_permissions',
+    expectedWhenDenied: '"Insufficient privileges to view or manage Watchlists" callout',
+    page: '/app/security/entity_analytics_management/watchlists',
+    // watchlists/index.tsx → inline defaultMessage
+    textWhenDenied: ['Insufficient privileges to view or manage Watchlists'],
+  },
+  {
+    featureName: 'EA Management → Watchlists: Create button disabled',
+    endpoint: 'watchlists',
+    privilegeField: 'has_write_permissions',
+    expectedWhenDenied: '"Insufficient privileges to create or delete watchlists" callout',
+    page: '/app/security/entity_analytics_management/watchlists',
+    // watchlists/watchlists_tab.tsx → inline defaultMessage (write denied → callout shown)
+    textWhenDenied: ['Insufficient privileges to create or delete watchlists'],
+    // watchlists_tab.tsx → button always renders, isDisabled={!hasAllRequired}
+    buttonDisabledWhenDenied: ['Create watchlist'],
+  },
+
+  // ── EA Management → Asset Criticality Tab ──────────────────────────────────
+  {
+    featureName: 'EA Management → Asset Criticality: no write uploader hidden',
+    endpoint: 'asset_criticality',
+    privilegeField: 'has_write_permissions',
+    expectedWhenDenied:
+      '"Privileges to access the Asset Criticality feature are missing" callout shown',
+    page: '/app/security/entity_analytics_management/asset_criticality',
+    // asset_criticality_tab.tsx → InsufficientAssetCriticalityPrivilegesCallout text
+    textWhenDenied: ['Privileges to access the Asset Criticality feature are missing'],
+    // asset_criticality_tab.tsx → upload section visible when granted
+    textWhenGranted: ['Bulk assign asset criticality'],
+  },
+
+  // ── Explore → Hosts → Risk Tab ──────────────────────────────────────────────
+  {
+    featureName: 'Explore → Hosts → Risk tab callout',
+    endpoint: 'risk_engine',
+    // host_risk_score_tab_body.tsx uses useMissingRiskEnginePrivileges({ readonly: true })
+    privilegeField: 'has_read_permissions',
+    expectedWhenDenied: '"Insufficient privileges" callout replaces risk tab body',
+    page: '/app/security/hosts/risk',
+    textWhenDenied: ['Insufficient privileges'],
+  },
+
+  // ── Explore → Users → Risk Tab ──────────────────────────────────────────────
+  {
+    featureName: 'Explore → Users → Risk tab callout',
+    endpoint: 'risk_engine',
+    // user_risk_score_tab_body uses useMissingRiskEnginePrivileges({ readonly: true })
+    privilegeField: 'has_read_permissions',
+    expectedWhenDenied: '"Insufficient privileges" callout replaces risk tab body',
+    page: '/app/security/users/risk',
+    textWhenDenied: ['Insufficient privileges'],
+  },
+];
+
+/**
+ * Flyout panel correlation map.
+ * Each entry describes one privilege-gated panel inside the entity details flyout.
+ * selectorWhenGranted is the CSS selector that should be PRESENT in the DOM when
+ * the persona has the required permission; its absence is treated as a denial.
+ *
+ * The flyout is opened by navigating to the EA Home Page and clicking the
+ * "Open entity details" expand button on the ea-audit-test-user row.
+ * Probing is skipped for personas that lack entity_store read access.
+ */
+export const FLYOUT_CORRELATION_MAP: FlyoutCorrelationEntry[] = [
+  {
+    panelLabel: 'Risk Score Summary',
+    endpoint: 'risk_engine',
+    privilegeField: 'has_all_required',
+    selectorWhenGranted: '[data-test-subj="risk-summary-table"]',
+  },
+  {
+    panelLabel: 'Asset Criticality Selector',
+    endpoint: 'asset_criticality',
+    privilegeField: 'has_read_permissions',
+    selectorWhenGranted: '[data-test-subj="asset-criticality-selector"]',
+  },
+];
+
+export const KNOWN_GAPS: string[] = [
+  'WatchlistFilter on EA Home Page header: renders without a privilege pre-check. ' +
+    'If the user lacks read on the watchlist index, the dropdown call fails silently (empty) ' +
+    'or surfaces an unhandled error. No data-test-subj target exists for automated verification.',
+  'Flyout probe only runs for personas that have entity_store read access; ' +
+    'personas denied entity store access receive SKIP for all flyout panels.',
+  'Watchlist membership badge inside the flyout (EntityHighlightsAccordion) has no stable ' +
+    'data-test-subj that can be targeted per watchlist entry, so it is not covered in the ' +
+    'automated flyout probe.',
+];

--- a/scripts/entity_analytics_permission_audit/index.ts
+++ b/scripts/entity_analytics_permission_audit/index.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Entity Analytics Permission Audit Script
+ *
+ * Runs a set of purpose-built test personas against all EA privilege endpoints,
+ * seeds a test entity with risk score / asset criticality / watchlist data,
+ * verifies UI behaviour via Playwright, probes the entity flyout for each
+ * persona, and renders a compact three-section Markdown report.
+ *
+ * Usage:
+ *   node --require @kbn/babel-register/install \
+ *     scripts/entity_analytics_permission_audit/index.ts \
+ *     [--kibana-url http://localhost:5601] \
+ *     [--es-url http://localhost:9200] \
+ *     [--user elastic] \
+ *     [--password changeme] \
+ *     [--space default] \
+ *     [--output entity_analytics_permissions_audit.md] \
+ *     [--headed]
+ */
+
+import { parseArgs } from 'node:util';
+import type { CliArgs, SeedContext } from './types';
+import { PERSONAS, createPersona } from './personas';
+import { CORRELATION_MAP, FLYOUT_CORRELATION_MAP, KNOWN_GAPS } from './endpoints';
+import { probeBrowserForPersonas } from './browser';
+import { correlate } from './correlate';
+import { renderReport } from './report';
+import { cleanupAll, cleanupPersonas } from './cleanup';
+import { seedTestEntity } from './seed';
+import { toBase64 } from './api';
+
+const parseCliArgs = (): CliArgs => {
+  const { values } = parseArgs({
+    options: {
+      'kibana-url': { type: 'string', default: 'http://localhost:5601' },
+      'es-url': { type: 'string', default: 'http://localhost:9200' },
+      user: { type: 'string', default: 'elastic' },
+      password: { type: 'string', default: 'changeme' },
+      space: { type: 'string', default: 'default' },
+      output: { type: 'string', default: 'entity_analytics_permissions_audit.md' },
+      headed: { type: 'boolean', default: false },
+    },
+  });
+  return {
+    kibanaUrl: values['kibana-url'] as string,
+    esUrl: values['es-url'] as string,
+    user: values.user as string,
+    password: values.password as string,
+    space: values.space as string,
+    output: values.output as string,
+    headed: values.headed as boolean,
+  };
+};
+
+const main = async (): Promise<void> => {
+  const args = parseCliArgs();
+  const adminAuth = toBase64(`${args.user}:${args.password}`);
+
+  const log = (msg: string) => process.stdout.write(`${msg}\n`);
+  const err = (msg: string) => process.stderr.write(`${msg}\n`);
+
+  log(`\nEntity Analytics Permission Audit`);
+  log(`  Kibana:  ${args.kibanaUrl}`);
+  log(`  ES:      ${args.esUrl}`);
+  log(`  Space:   ${args.space}`);
+  log(`  Headed:  ${args.headed}`);
+  log(`  Output:  ${args.output}\n`);
+
+  // Step 1: Create test roles + users
+  log(`[1/4] Creating ${PERSONAS.length} test personas...`);
+  try {
+    for (const persona of PERSONAS) {
+      process.stdout.write(`  Creating ${persona.name}...`);
+      await createPersona(args.kibanaUrl, args.esUrl, adminAuth, persona);
+      process.stdout.write(' done\n');
+    }
+  } catch (setupErr) {
+    const msg = setupErr instanceof Error ? setupErr.message : String(setupErr);
+    err(`\nFailed during persona setup: ${msg}`);
+    err('Attempting cleanup before exit...');
+    await cleanupPersonas(args.kibanaUrl, args.esUrl, adminAuth, PERSONAS);
+    process.exit(1);
+  }
+
+  let seedCtx: SeedContext | null = null;
+
+  try {
+    // Step 2: Seed the test entity
+    log(`\n[2/4] Seeding test entity (ea-audit-test-user)...`);
+    seedCtx = await seedTestEntity(args.kibanaUrl, args.esUrl, adminAuth, args.space);
+
+    // Step 3: Browser probe (API calls + DOM checks + flyout probe)
+    log(
+      `\n[3/4] Running browser probes ` +
+        `(${PERSONAS.length} personas × ${CORRELATION_MAP.length} UI checks + ` +
+        `${FLYOUT_CORRELATION_MAP.length} flyout panels)...`
+    );
+    const browserResults = await probeBrowserForPersonas(
+      args.kibanaUrl,
+      args.space,
+      PERSONAS,
+      CORRELATION_MAP,
+      FLYOUT_CORRELATION_MAP,
+      args.headed
+    );
+
+    // Step 4: Correlate + render report
+    log('\n[4/4] Correlating and rendering report...');
+    const auditResults = correlate(PERSONAS, CORRELATION_MAP, browserResults);
+    await renderReport(auditResults, PERSONAS, browserResults, KNOWN_GAPS, args.output);
+  } finally {
+    // Cleanup always runs: personas + seeded entity data
+    await cleanupAll(args.kibanaUrl, args.esUrl, adminAuth, args.space, PERSONAS, seedCtx);
+  }
+};
+
+main().catch((runErr) => {
+  process.stderr.write(
+    `Unexpected error: ${runErr instanceof Error ? runErr.message : String(runErr)}\n`
+  );
+  process.exit(1);
+});

--- a/scripts/entity_analytics_permission_audit/personas.ts
+++ b/scripts/entity_analytics_permission_audit/personas.ts
@@ -1,0 +1,337 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Persona, RoleDescriptor } from './types';
+
+const PERSONA_PASSWORD = 'TestEAPermAudit123!';
+const ROLE_PREFIX = 'ea-audit-';
+
+const SIEM_ALL_KIBANA: RoleDescriptor['kibana'] = [
+  { base: [], feature: { siem: ['all'] }, spaces: ['*'] },
+];
+
+// Index patterns (must match server-side constants)
+const IDX = {
+  entityStore: '.entities.*',
+  entityStoreUpdates: '.entities.v1.updates.*',
+  entityStoreHistory: '.entities.*history*',
+  riskScore: 'risk-score.risk-score-*',
+  watchlists: '.entity_analytics.watchlists.*',
+  leads: '.internal.*entity-leads-*',
+  assetCriticality: '.asset-criticality.asset-criticality-*',
+  securitySourceIndices: [
+    'logs-*',
+    'metrics-*',
+    '.ds-*',
+    'auditbeat-*',
+    'filebeat-*',
+    'packetbeat-*',
+    'winlogbeat-*',
+    'endgame-*',
+    '-*security.alerts*',
+  ],
+} as const;
+
+const CLUSTER_ENTITY_STORE = [
+  'manage_index_templates',
+  'manage_transform',
+  'manage_ingest_pipelines',
+  'manage_enrich',
+];
+
+const CLUSTER_RISK_ENABLE = [
+  'manage_index_templates',
+  'manage_transform',
+  'manage_ingest_pipelines',
+];
+
+const fullEntityStoreIndices = [
+  { names: [IDX.entityStore], privileges: ['read', 'manage'] },
+  { names: [IDX.entityStoreUpdates], privileges: ['read', 'manage'] },
+  { names: [IDX.entityStoreHistory], privileges: ['create_index', 'manage', 'read', 'write'] },
+  // Entity Store V2 check_privileges also checks the alias `entities-latest-{namespace}` and
+  // `entities-updates-{namespace}` (no dot prefix). These are NOT covered by `.entities.*`.
+  { names: ['entities-*'], privileges: ['read', 'write'] },
+  {
+    names: IDX.securitySourceIndices as unknown as string[],
+    privileges: ['read', 'view_index_metadata'],
+  },
+];
+
+const buildPersona = (id: string, name: string, roleDescriptor: RoleDescriptor): Persona => ({
+  id,
+  name,
+  username: `ea-audit-${id}`,
+  password: PERSONA_PASSWORD,
+  roleName: `${ROLE_PREFIX}${id}`,
+  roleDescriptor,
+});
+
+export const PERSONAS: Persona[] = [
+  // P1: Kibana feature only — no ES index or cluster grants
+  buildPersona('no_ea_access', 'No EA Access', {
+    elasticsearch: { cluster: [], indices: [] },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P2: read on all EA indices, no write, no cluster privs
+  buildPersona('read_all', 'Read All', {
+    elasticsearch: {
+      cluster: [],
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read'] },
+        { names: [IDX.watchlists], privileges: ['read'] },
+        { names: [IDX.leads], privileges: ['read'] },
+        { names: [IDX.assetCriticality], privileges: ['read'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P3: full access — read+write on all EA indices + all cluster privs
+  buildPersona('full_all', 'Full All', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P4: full_all minus entity store indices
+  buildPersona('entity_store_no', 'No Entity Store', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P5: full_all, entity store: read+view_index_metadata only (no manage)
+  buildPersona('entity_store_read', 'Entity Store Read Only', {
+    elasticsearch: {
+      cluster: [],
+      indices: [
+        { names: [IDX.entityStore], privileges: ['read'] },
+        { names: [IDX.entityStoreUpdates], privileges: ['read'] },
+        { names: [IDX.entityStoreHistory], privileges: ['read'] },
+        {
+          names: IDX.securitySourceIndices as unknown as string[],
+          privileges: ['read', 'view_index_metadata'],
+        },
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P6: full_all minus risk-score index
+  buildPersona('risk_score_no', 'No Risk Score Index', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P7: full_all, risk score: read only (no write, no cluster manage)
+  buildPersona('risk_score_read', 'Risk Score Read Only', {
+    elasticsearch: {
+      cluster: [],
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P8: full_all minus watchlists index
+  buildPersona('watchlists_no', 'No Watchlists', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P9: full_all, watchlists: read only
+  buildPersona('watchlists_read', 'Watchlists Read Only', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P10: full_all minus leads index
+  buildPersona('leads_no', 'No Leads', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P11: full_all, leads: read only
+  buildPersona('leads_read', 'Leads Read Only', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P12: full_all minus asset criticality index
+  buildPersona('asset_crit_no', 'No Asset Criticality', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P13: full_all, asset criticality: read only
+  buildPersona('asset_crit_read', 'Asset Criticality Read Only', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE,
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P14: full_all, cluster: no manage_transform (can't run risk engine)
+  buildPersona('no_manage_transform', 'No manage_transform', {
+    elasticsearch: {
+      cluster: CLUSTER_ENTITY_STORE.filter((p) => p !== 'manage_transform'),
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+
+  // P15: full_all, cluster: no manage_index_templates or manage_ingest_pipelines (can't enable risk engine)
+  buildPersona('no_enable_cluster', 'No Enable Cluster Privs', {
+    elasticsearch: {
+      cluster: ['manage_transform', 'manage_enrich'],
+      indices: [
+        ...fullEntityStoreIndices,
+        { names: [IDX.riskScore], privileges: ['read', 'write'] },
+        { names: [IDX.watchlists], privileges: ['read', 'write'] },
+        { names: [IDX.leads], privileges: ['read', 'write'] },
+        { names: [IDX.assetCriticality], privileges: ['read', 'write'] },
+      ],
+    },
+    kibana: SIEM_ALL_KIBANA,
+  }),
+];
+
+export const createPersona = async (
+  kibanaUrl: string,
+  esUrl: string,
+  adminAuth: string,
+  persona: Persona
+): Promise<void> => {
+  const headers = {
+    Authorization: `Basic ${adminAuth}`,
+    'Content-Type': 'application/json',
+    'kbn-xsrf': 'true',
+  };
+
+  // Kibana API for roles (needed for Kibana feature privileges)
+  const roleRes = await fetch(`${kibanaUrl}/api/security/role/${persona.roleName}`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(persona.roleDescriptor),
+  });
+  if (!roleRes.ok) {
+    const body = await roleRes.text();
+    throw new Error(`Failed to create role ${persona.roleName}: ${roleRes.status} ${body}`);
+  }
+
+  // ES native user API (more reliable than Kibana's /api/security/users in dev configs)
+  const esHeaders = {
+    Authorization: `Basic ${adminAuth}`,
+    'Content-Type': 'application/json',
+  };
+  const userRes = await fetch(`${esUrl}/_security/user/${persona.username}`, {
+    method: 'PUT',
+    headers: esHeaders,
+    body: JSON.stringify({
+      password: persona.password,
+      roles: [persona.roleName],
+      full_name: persona.name,
+      email: '',
+    }),
+  });
+  if (!userRes.ok) {
+    const body = await userRes.text();
+    throw new Error(`Failed to create user ${persona.username}: ${userRes.status} ${body}`);
+  }
+};

--- a/scripts/entity_analytics_permission_audit/probe.ts
+++ b/scripts/entity_analytics_permission_audit/probe.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Persona, EndpointId, PrivilegeResponse, ApiProbeResult } from './types';
+import { personaFetch } from './api';
+import { PRIVILEGE_ENDPOINT_PATHS, buildEndpointUrl, buildSpacePath } from './endpoints';
+
+const ENDPOINT_IDS = Object.keys(PRIVILEGE_ENDPOINT_PATHS) as EndpointId[];
+
+export const probeAllPersonas = async (
+  kibanaUrl: string,
+  space: string,
+  personas: Persona[]
+): Promise<ApiProbeResult[]> => {
+  const spacePath = buildSpacePath(space);
+  const results: ApiProbeResult[] = [];
+
+  for (const persona of personas) {
+    for (const endpointId of ENDPOINT_IDS) {
+      const url = buildEndpointUrl(kibanaUrl, spacePath, PRIVILEGE_ENDPOINT_PATHS[endpointId]);
+      let response: PrivilegeResponse | null = null;
+      let error: string | undefined;
+
+      try {
+        response = (await personaFetch(
+          url,
+          persona.username,
+          persona.password
+        )) as PrivilegeResponse;
+      } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+
+      results.push({ personaId: persona.id, endpointId, response, error });
+    }
+    process.stdout.write('.');
+  }
+  process.stdout.write('\n');
+
+  return results;
+};

--- a/scripts/entity_analytics_permission_audit/report.ts
+++ b/scripts/entity_analytics_permission_audit/report.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { writeFile } from 'node:fs/promises';
+import type { AuditResult, AuditStatus, EndpointId, Persona, PersonaBrowserResult } from './types';
+import { collectFlyoutResults } from './correlate';
+import { PRIVILEGE_ENDPOINT_PATHS } from './endpoints';
+import { TEST_ENTITY_NAME } from './seed';
+
+const STATUS_ICON: Record<AuditStatus | 'SKIP', string> = {
+  PASS: '✅ PASS',
+  API_ONLY: '⚠️ NO SELECTORS',
+  FAIL: '❌ FAIL',
+  ERROR: '🔴 ERROR',
+  SKIP: '⏭️ SKIP',
+};
+
+const fmtBool = (v: boolean | null): string => {
+  if (v === null) return '—';
+  return v ? '✓ yes' : '✗ no';
+};
+
+const row = (cells: string[]): string => `| ${cells.join(' | ')} |`;
+const sep = (n: number): string => `|${Array(n).fill('---').join('|')}|`;
+const h1 = (s: string): string => `# ${s}`;
+const h2 = (s: string): string => `## ${s}`;
+const divider = (): string => '\n---\n';
+
+// ─── Network wiring check ─────────────────────────────────────────────────────
+
+/**
+ * Shows which privilege endpoints the browser actually called during page renders.
+ * A missing entry means the UI never called that endpoint — possible wiring gap.
+ */
+const buildNetworkWiringSection = (
+  personas: Persona[],
+  browserResults: PersonaBrowserResult[]
+): string[] => {
+  const lines: string[] = [];
+  lines.push(h2('Network Wiring (UI → Privilege Endpoints)'));
+  lines.push(
+    '_Privilege API calls intercepted from the browser during page navigation. ' +
+      'A ✗ means the UI never called that endpoint — possible missing privilege check._\n'
+  );
+
+  const endpointIds = Object.keys(PRIVILEGE_ENDPOINT_PATHS) as EndpointId[];
+  const resultIndex = new Map(browserResults.map((r) => [r.personaId, r]));
+
+  lines.push(row(['User', ...endpointIds.map((id) => PRIVILEGE_ENDPOINT_PATHS[id])]));
+  lines.push(sep(1 + endpointIds.length));
+
+  for (const persona of personas) {
+    const pr = resultIndex.get(persona.id);
+    const intercepted = pr?.interceptedNetworkCalls ?? {};
+    const cells = endpointIds.map((id) => (intercepted[id] !== undefined ? '✓' : '✗'));
+    lines.push(row([persona.name, ...cells]));
+  }
+  lines.push('');
+  return lines;
+};
+
+// ─── Section 1: API ──────────────────────────────────────────────────────────
+// Columns: Endpoint | Permission Field | User | Access | Result
+
+const buildApiSection = (results: AuditResult[]): string[] => {
+  const lines: string[] = [];
+  lines.push(h2('API'));
+  lines.push(
+    '_One row per (persona × endpoint × privilege field). ' +
+      'Shows whether the privilege endpoint responded correctly._\n'
+  );
+
+  // Deduplicate by (personaId, endpoint, privilegeField)
+  const seen = new Set<string>();
+  const apiRows: Array<{
+    fullPath: string;
+    field: string;
+    personaName: string;
+    access: boolean | null;
+    status: AuditStatus;
+    error?: string;
+  }> = [];
+
+  for (const r of results) {
+    const key = `${r.persona.id}|${r.endpoint}|${r.privilegeField}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    apiRows.push({
+      fullPath: PRIVILEGE_ENDPOINT_PATHS[r.endpoint] ?? r.endpoint,
+      field: r.privilegeField,
+      personaName: r.persona.name,
+      access: r.apiValue,
+      status: r.apiValue === null ? 'ERROR' : 'PASS',
+      error: r.details,
+    });
+  }
+
+  lines.push(row(['Endpoint', 'Permission Field', 'User', 'Access', 'Result']));
+  lines.push(sep(5));
+  for (const r of apiRows) {
+    lines.push(
+      row([
+        `\`${r.fullPath}\``,
+        `\`${r.field}\``,
+        r.personaName,
+        fmtBool(r.access),
+        r.status === 'ERROR' ? `🔴 ERROR${r.error ? ` — ${r.error.slice(0, 80)}` : ''}` : '✅ PASS',
+      ])
+    );
+  }
+  lines.push('');
+  return lines;
+};
+
+// ─── Section 2: UI ───────────────────────────────────────────────────────────
+// Columns: URL | Feature Gate | User | Expected | Result
+
+const fmtExpected = (apiValue: boolean | null): string => {
+  if (apiValue === null) return '—';
+  return apiValue ? '✓ features visible' : '✗ access blocked';
+};
+
+const buildUiSection = (results: AuditResult[]): string[] => {
+  const lines: string[] = [];
+  lines.push(h2('UI'));
+  lines.push(
+    '_One row per (persona × feature gate). ' +
+      'Checks both granted state (features visible) and denied state (block indicators shown)._\n'
+  );
+
+  lines.push(row(['URL', 'Feature Gate', 'User', 'Expected', 'Result']));
+  lines.push(sep(5));
+
+  for (const r of results) {
+    lines.push(
+      row([
+        `\`${r.page}\``,
+        r.featureName,
+        r.persona.name,
+        fmtExpected(r.apiValue),
+        STATUS_ICON[r.status] ?? r.status,
+      ])
+    );
+  }
+  lines.push('');
+  return lines;
+};
+
+// ─── Section 3: Flyout ───────────────────────────────────────────────────────
+// Columns: Entity | Panel | User | API Access | Result
+
+const buildFlyoutSection = (
+  personas: Persona[],
+  browserResults: PersonaBrowserResult[]
+): string[] => {
+  const lines: string[] = [];
+  lines.push(h2('Flyout'));
+  lines.push(
+    `_One row per (persona × panel). Entity under test: \`${TEST_ENTITY_NAME}\`. ` +
+      'Personas without entity store read access show SKIP._\n'
+  );
+
+  const flyoutRows = collectFlyoutResults(personas, browserResults);
+
+  if (flyoutRows.length === 0) {
+    lines.push('_No flyout checks were recorded._\n');
+    return lines;
+  }
+
+  lines.push(row(['Entity', 'Panel', 'User', 'API Access', 'Result']));
+  lines.push(sep(5));
+
+  for (const { persona, check } of flyoutRows) {
+    const statusLabel =
+      check.status === 'SKIP'
+        ? STATUS_ICON.SKIP
+        : check.status === 'PASS'
+        ? STATUS_ICON.PASS
+        : check.status === 'FAIL'
+        ? STATUS_ICON.FAIL
+        : STATUS_ICON.ERROR;
+    const fullPath = PRIVILEGE_ENDPOINT_PATHS[check.endpoint] ?? check.endpoint;
+    lines.push(
+      row([
+        `\`${TEST_ENTITY_NAME}\``,
+        `${check.panelLabel} (\`${fullPath}\`)`,
+        persona.name,
+        fmtBool(check.apiValue),
+        statusLabel,
+      ])
+    );
+  }
+  lines.push('');
+  return lines;
+};
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+const buildSummary = (
+  results: AuditResult[],
+  personas: Persona[],
+  browserResults: PersonaBrowserResult[]
+): string[] => {
+  const lines: string[] = [];
+  lines.push(h2('Summary'));
+
+  const uiCounts: Record<AuditStatus, number> = { PASS: 0, API_ONLY: 0, FAIL: 0, ERROR: 0 };
+  for (const r of results) uiCounts[r.status]++;
+
+  const flyoutRows = collectFlyoutResults(personas, browserResults);
+  let flyoutPass = 0;
+  let flyoutFail = 0;
+  let flyoutSkip = 0;
+  let flyoutError = 0;
+  for (const { check } of flyoutRows) {
+    if (check.status === 'PASS') flyoutPass++;
+    else if (check.status === 'FAIL') flyoutFail++;
+    else if (check.status === 'SKIP') flyoutSkip++;
+    else flyoutError++;
+  }
+
+  lines.push(row(['Section', 'PASS', 'FAIL', 'NO SELECTORS', 'ERROR']));
+  lines.push(sep(5));
+  lines.push(
+    row([
+      'UI + API',
+      String(uiCounts.PASS),
+      String(uiCounts.FAIL),
+      String(uiCounts.API_ONLY),
+      String(uiCounts.ERROR),
+    ])
+  );
+  lines.push(
+    row(['Flyout', String(flyoutPass), String(flyoutFail), String(flyoutSkip), String(flyoutError)])
+  );
+  lines.push('');
+  return lines;
+};
+
+// ─── Main export ─────────────────────────────────────────────────────────────
+
+export const renderReport = async (
+  results: AuditResult[],
+  personas: Persona[],
+  browserResults: PersonaBrowserResult[],
+  knownGaps: string[],
+  outputPath: string
+): Promise<void> => {
+  const timestamp = new Date().toISOString();
+  const lines: string[] = [];
+
+  lines.push(h1('Entity Analytics — Permission Audit Report'));
+  lines.push(`_Generated: ${timestamp}_\n`);
+
+  lines.push(...buildSummary(results, personas, browserResults));
+  lines.push(divider());
+  lines.push(...buildNetworkWiringSection(personas, browserResults));
+  lines.push(divider());
+  lines.push(...buildApiSection(results));
+  lines.push(divider());
+  lines.push(...buildUiSection(results));
+  lines.push(divider());
+  lines.push(...buildFlyoutSection(personas, browserResults));
+  lines.push(divider());
+
+  lines.push(h2('Known Gaps'));
+  for (const gap of knownGaps) {
+    lines.push(`- ${gap}`);
+  }
+  lines.push('');
+
+  await writeFile(outputPath, lines.join('\n'), 'utf-8');
+  process.stdout.write(`\nReport written to: ${outputPath}\n`);
+};

--- a/scripts/entity_analytics_permission_audit/seed.ts
+++ b/scripts/entity_analytics_permission_audit/seed.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SeedContext } from './types';
+
+export const TEST_ENTITY_NAME = 'ea-audit-test-user';
+
+const adminHeaders = (adminAuth: string): Record<string, string> => ({
+  Authorization: `Basic ${adminAuth}`,
+  'Content-Type': 'application/json',
+  'kbn-xsrf': 'true',
+  'elastic-api-version': '2023-10-31',
+});
+
+const esHeaders = (adminAuth: string): Record<string, string> => ({
+  Authorization: `Basic ${adminAuth}`,
+  'Content-Type': 'application/json',
+});
+
+const log = (msg: string) => process.stdout.write(`  [seed] ${msg}\n`);
+const warn = (msg: string) => process.stderr.write(`  [seed] WARN: ${msg}\n`);
+
+/**
+ * Creates `ea-audit-test-user` across all four data surfaces visible in the entity flyout:
+ * 1. Watchlist membership (Kibana API)
+ * 2. Asset criticality (Kibana API)
+ * 3. Risk score document (Elasticsearch direct)
+ * 4. Entity store record (Elasticsearch direct)
+ */
+export const seedTestEntity = async (
+  kibanaUrl: string,
+  esUrl: string,
+  adminAuth: string,
+  space: string
+): Promise<SeedContext> => {
+  const spacePath = space === 'default' ? '' : `/s/${space}`;
+  let watchlistId: string | null = null;
+
+  // 1. Create a watchlist (riskModifier is required, 0–2; 1.5 = "High Impact" criticality weight)
+  try {
+    const wlRes = await fetch(`${kibanaUrl}${spacePath}/api/entity_analytics/watchlists`, {
+      method: 'POST',
+      headers: adminHeaders(adminAuth),
+      body: JSON.stringify({ name: 'ea-audit-fixture-watchlist', riskModifier: 1.5 }),
+    });
+    if (wlRes.ok) {
+      const wlBody = (await wlRes.json()) as { id: string };
+      watchlistId = wlBody.id;
+      log(`Created watchlist: ${watchlistId}`);
+      // Entity assignment via /entities/assign requires a computed EUID which is only available
+      // after the normal ingestion pipeline runs. Since we seed the entity store record directly
+      // via ES, we embed watchlistId in the entity.attributes.watchlists field instead.
+    } else {
+      const body = await wlRes.text();
+      warn(`Could not create watchlist: ${wlRes.status} ${body.slice(0, 200)}`);
+    }
+  } catch (err) {
+    warn(`Watchlist creation failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 2. Set asset criticality (POST, not PUT — upsert route)
+  try {
+    const acRes = await fetch(`${kibanaUrl}${spacePath}/api/asset_criticality`, {
+      method: 'POST',
+      headers: adminHeaders(adminAuth),
+      body: JSON.stringify({
+        id_field: 'user.name',
+        id_value: TEST_ENTITY_NAME,
+        criticality_level: 'high_impact',
+      }),
+    });
+    if (acRes.ok) {
+      log(`Set asset criticality: high_impact`);
+    } else {
+      const body = await acRes.text();
+      warn(`Could not set asset criticality: ${acRes.status} ${body.slice(0, 200)}`);
+    }
+  } catch (err) {
+    warn(`Asset criticality write failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 3. Write risk score document directly to ES
+  try {
+    const rsIndex = `risk-score.risk-score-latest-${space}`;
+    const rsRes = await fetch(`${esUrl}/${rsIndex}/_doc/${TEST_ENTITY_NAME}`, {
+      method: 'PUT',
+      headers: esHeaders(adminAuth),
+      body: JSON.stringify({
+        '@timestamp': new Date().toISOString(),
+        'user.name': TEST_ENTITY_NAME,
+        'user.risk': {
+          calculated_score_norm: 85,
+          calculated_level: 'High',
+          id_field: 'user.name',
+          id_value: TEST_ENTITY_NAME,
+        },
+      }),
+    });
+    if (rsRes.ok) {
+      log(`Wrote risk score doc (score_norm: 85, level: High)`);
+    } else {
+      const body = await rsRes.text();
+      warn(`Could not write risk score doc to ${rsIndex}: ${rsRes.status} ${body.slice(0, 200)}`);
+    }
+  } catch (err) {
+    warn(`Risk score write failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 4. Write entity store record directly to ES
+  try {
+    const esIndex = `.entities.v2.latest.security_${space}`;
+    const esRes = await fetch(`${esUrl}/${esIndex}/_doc/${TEST_ENTITY_NAME}`, {
+      method: 'PUT',
+      headers: esHeaders(adminAuth),
+      body: JSON.stringify({
+        '@timestamp': new Date().toISOString(),
+        'user.name': TEST_ENTITY_NAME,
+        'entity.type': 'user',
+        'entity.source': 'ea-audit-fixture',
+        'entity.attributes': {
+          Privileged: true,
+          ...(watchlistId ? { watchlists: [watchlistId] } : {}),
+        },
+        'asset.criticality': 'high_impact',
+        'entity.risk': {
+          calculated_score_norm: 85,
+          calculated_level: 'High',
+        },
+      }),
+    });
+    if (esRes.ok) {
+      log(`Wrote entity store record (Privileged: true)`);
+    } else {
+      const body = await esRes.text();
+      warn(
+        `Could not write entity store record to ${esIndex}: ${esRes.status} ${body.slice(0, 200)}`
+      );
+    }
+  } catch (err) {
+    warn(`Entity store write failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return { watchlistId };
+};
+
+/**
+ * Reverses all writes made by seedTestEntity.
+ */
+export const cleanupTestEntity = async (
+  kibanaUrl: string,
+  esUrl: string,
+  adminAuth: string,
+  space: string,
+  ctx: SeedContext
+): Promise<void> => {
+  const spacePath = space === 'default' ? '' : `/s/${space}`;
+
+  // Delete watchlist (also removes the entry)
+  if (ctx.watchlistId) {
+    try {
+      const res = await fetch(
+        `${kibanaUrl}${spacePath}/api/entity_analytics/watchlists/${ctx.watchlistId}`,
+        { method: 'DELETE', headers: adminHeaders(adminAuth) }
+      );
+      if (!res.ok && res.status !== 404) {
+        const body = await res.text();
+        warn(`Could not delete watchlist ${ctx.watchlistId}: ${res.status} ${body.slice(0, 200)}`);
+      } else {
+        log(`Deleted watchlist ${ctx.watchlistId}`);
+      }
+    } catch (err) {
+      warn(`Watchlist delete failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // Delete asset criticality
+  try {
+    const res = await fetch(
+      `${kibanaUrl}${spacePath}/api/asset_criticality?id_field=user.name&id_value=${encodeURIComponent(
+        TEST_ENTITY_NAME
+      )}`,
+      { method: 'DELETE', headers: adminHeaders(adminAuth) }
+    );
+    if (!res.ok && res.status !== 404) {
+      const body = await res.text();
+      warn(`Could not delete asset criticality: ${res.status} ${body.slice(0, 200)}`);
+    } else {
+      log(`Deleted asset criticality for ${TEST_ENTITY_NAME}`);
+    }
+  } catch (err) {
+    warn(`Asset criticality delete failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Delete risk score doc
+  try {
+    const rsIndex = `risk-score.risk-score-latest-${space}`;
+    const res = await fetch(`${esUrl}/${rsIndex}/_doc/${TEST_ENTITY_NAME}`, {
+      method: 'DELETE',
+      headers: esHeaders(adminAuth),
+    });
+    if (!res.ok && res.status !== 404) {
+      const body = await res.text();
+      warn(`Could not delete risk score doc: ${res.status} ${body.slice(0, 200)}`);
+    } else {
+      log(`Deleted risk score doc from ${rsIndex}`);
+    }
+  } catch (err) {
+    warn(`Risk score delete failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Delete entity store record
+  try {
+    const esStoreIndex = `.entities.v2.latest.security_${space}`;
+    const res = await fetch(`${esUrl}/${esStoreIndex}/_doc/${TEST_ENTITY_NAME}`, {
+      method: 'DELETE',
+      headers: esHeaders(adminAuth),
+    });
+    if (!res.ok && res.status !== 404) {
+      const body = await res.text();
+      warn(`Could not delete entity store record: ${res.status} ${body.slice(0, 200)}`);
+    } else {
+      log(`Deleted entity store record from ${esStoreIndex}`);
+    }
+  } catch (err) {
+    warn(`Entity store delete failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+};

--- a/scripts/entity_analytics_permission_audit/types.ts
+++ b/scripts/entity_analytics_permission_audit/types.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface CliArgs {
+  kibanaUrl: string;
+  esUrl: string;
+  user: string;
+  password: string;
+  space: string;
+  output: string;
+  headed: boolean;
+}
+
+export interface Persona {
+  id: string;
+  name: string;
+  username: string;
+  password: string;
+  roleName: string;
+  roleDescriptor: RoleDescriptor;
+}
+
+export interface RoleDescriptor {
+  elasticsearch: {
+    cluster?: string[];
+    indices?: Array<{ names: string[]; privileges: string[] }>;
+  };
+  kibana: Array<{
+    base?: string[];
+    feature?: Record<string, string[]>;
+    spaces: string[];
+  }>;
+}
+
+export type EndpointId =
+  | 'risk_engine'
+  | 'entity_store'
+  | 'leads'
+  | 'watchlists'
+  | 'asset_criticality';
+
+export type PrivilegeField = 'has_all_required' | 'has_read_permissions' | 'has_write_permissions';
+
+export interface PrivilegeResponse {
+  has_all_required: boolean;
+  has_read_permissions: boolean;
+  has_write_permissions: boolean;
+  privileges: {
+    elasticsearch?: {
+      index?: Record<string, Record<string, boolean>>;
+      cluster?: Record<string, boolean>;
+    };
+    kibana?: Record<string, boolean> | Array<Record<string, boolean>>;
+  };
+}
+
+export interface CorrelationEntry {
+  featureName: string;
+  endpoint: EndpointId;
+  privilegeField: PrivilegeField;
+  expectedWhenDenied: string;
+  page: string;
+  /**
+   * Visible text expected in the page when access is DENIED.
+   * Uses substring match — partial strings are fine.
+   */
+  textWhenDenied?: string[];
+  /**
+   * Visible text expected in the page when access is GRANTED.
+   * Uses substring match — partial strings are fine.
+   */
+  textWhenGranted?: string[];
+  /**
+   * Names of buttons (aria-label or button text) that should be
+   * aria-disabled when access is DENIED and enabled when GRANTED.
+   */
+  buttonDisabledWhenDenied?: string[];
+}
+
+export interface ApiProbeResult {
+  personaId: string;
+  endpointId: EndpointId;
+  response: PrivilegeResponse | null;
+  error?: string;
+}
+
+export interface InBrowserApiResult {
+  endpointId: EndpointId;
+  response: PrivilegeResponse | null;
+  error?: string;
+}
+
+export type ObservedState = 'present' | 'absent' | 'disabled' | 'error' | 'skipped';
+
+export interface BrowserCheckResult {
+  featureName: string;
+  observed: ObservedState;
+  details?: string;
+}
+
+export type AuditStatus = 'PASS' | 'API_ONLY' | 'FAIL' | 'ERROR';
+
+export interface AuditResult {
+  persona: Persona;
+  featureName: string;
+  /** Kibana page path for this feature (e.g. /app/security/entity_analytics) */
+  page: string;
+  endpoint: EndpointId;
+  privilegeField: PrivilegeField;
+  apiValue: boolean | null;
+  browserObserved: ObservedState | null;
+  expectedWhenDenied: string;
+  status: AuditStatus;
+  details?: string;
+}
+
+// ─── Flyout types ────────────────────────────────────────────────────────────
+
+/**
+ * One entry per flyout panel that is privilege-gated.
+ * selectorWhenGranted is present in the DOM when the persona has the permission.
+ */
+export interface FlyoutCorrelationEntry {
+  panelLabel: string;
+  endpoint: EndpointId;
+  privilegeField: PrivilegeField;
+  /** CSS selector expected to be PRESENT in the DOM when permission is granted */
+  selectorWhenGranted: string;
+}
+
+export type FlyoutStatus = 'PASS' | 'FAIL' | 'SKIP' | 'ERROR';
+
+export interface FlyoutCheckResult {
+  panelLabel: string;
+  endpoint: EndpointId;
+  privilegeField: PrivilegeField;
+  /** Value returned by the privilege API; null if endpoint errored */
+  apiValue: boolean | null;
+  /** DOM state observed after flyout opened */
+  observed: ObservedState;
+  status: FlyoutStatus;
+  details?: string;
+}
+
+export interface PersonaBrowserResult {
+  personaId: string;
+  apiResults: InBrowserApiResult[];
+  browserChecks: BrowserCheckResult[];
+  flyoutChecks: FlyoutCheckResult[];
+  flyoutSkipReason?: string;
+  /**
+   * Privilege API calls intercepted from the browser during page renders.
+   * Keys are EndpointId; values are the raw response body the UI received.
+   * Used to verify the UI is wired to the correct privilege endpoints.
+   */
+  interceptedNetworkCalls: Record<string, unknown>;
+}
+
+// ─── Seed context ────────────────────────────────────────────────────────────
+
+export interface SeedContext {
+  /** ID of the watchlist created for the test entity; null if creation failed */
+  watchlistId: string | null;
+}

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -155,6 +155,12 @@ export const ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH =
   '/entity_analytics_privileged_user_monitoring' as const;
 export const ENTITY_ANALYTICS_OVERVIEW_PATH = `/entity_analytics_overview` as const;
 export const ENTITY_ANALYTICS_HOME_PAGE_PATH = '/entity_analytics_home_page' as const;
+export const ENTITY_ANALYTICS_DEV_PERMISSION_AUDIT_PATH =
+  '/entity_analytics_dev_permission_audit' as const;
+export const EA_DEV_PERMISSION_AUDIT_RUN_URL =
+  '/internal/entity_analytics/dev/permission_audit/run' as const;
+export const EA_DEV_PERMISSION_AUDIT_LOGS_URL =
+  '/internal/entity_analytics/dev/permission_audit/logs' as const;
 export const APP_ALERTS_PATH = `${APP_PATH}${ALERTS_PATH}` as const;
 export const APP_CASES_PATH = `${APP_PATH}${CASES_PATH}` as const;
 export const APP_ENDPOINTS_PATH = `${APP_PATH}${ENDPOINTS_PATH}` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/routes.tsx
@@ -11,6 +11,7 @@ import { NotFoundPage } from '../app/404';
 import { withSecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
 import {
   ENTITY_ANALYTICS_ASSET_CRITICALITY_PATH,
+  ENTITY_ANALYTICS_DEV_PERMISSION_AUDIT_PATH,
   ENTITY_ANALYTICS_ENTITY_STORE_MANAGEMENT_PATH,
   ENTITY_ANALYTICS_LANDING_PATH,
   ENTITY_ANALYTICS_MANAGEMENT_PATH,
@@ -25,6 +26,7 @@ import { EntityAnalyticsLandingPage } from './pages/entity_analytics_landing';
 import { EntityAnalyticsPrivilegedUserMonitoringPage } from './pages/entity_analytics_privileged_user_monitoring_page';
 import { OverviewDashboard } from './pages/entity_analytics_overview_page';
 import { EntityAnalyticsHomePage } from './pages/entity_analytics_home_page';
+import { DevPermissionAuditPage } from './pages/dev_permission_audit';
 import { useIsExperimentalFeatureEnabled } from '../common/hooks/use_experimental_features';
 
 // ---- Management routes ----
@@ -196,6 +198,9 @@ const EntityAnalyticsHomePageContainer: React.FC = React.memo(() => {
 
 EntityAnalyticsHomePageContainer.displayName = 'EntityAnalyticsHomePageContainer';
 
+// ---- Dev-only: permission audit page ----
+const DevPermissionAuditWrapper = () => <DevPermissionAuditPage />;
+
 // ---- Route definitions ----
 export const routes = [
   {
@@ -240,5 +245,10 @@ export const routes = [
       EntityAnalyticsHomePageContainer,
       SecurityPageName.entityAnalyticsHomePage
     ),
+  },
+  // Dev-only page — no nav link, direct URL access only
+  {
+    path: ENTITY_ANALYTICS_DEV_PERMISSION_AUDIT_PATH,
+    component: DevPermissionAuditWrapper,
   },
 ];

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/register_entity_analytics_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/register_entity_analytics_routes.ts
@@ -16,6 +16,7 @@ import { registerEntityDetailsRoutes } from './entity_details/routes';
 import { registerLeadGenerationRoutes } from './lead_generation/routes/register_lead_generation_routes';
 import { registerWatchlistRoutes } from './watchlists/register_watchlist_routes';
 import { registerEntityResolutionRoutes } from './entity_resolution/routes/register_entity_resolution_routes';
+import { registerPermissionAuditRoute } from './dev_tools/permission_audit_route';
 
 export const registerEntityAnalyticsRoutes = (routeDeps: EntityAnalyticsRoutesDeps) => {
   registerAssetCriticalityRoutes(routeDeps);
@@ -39,4 +40,6 @@ export const registerEntityAnalyticsRoutes = (routeDeps: EntityAnalyticsRoutesDe
   if (!routeDeps.config.experimentalFeatures.entityStoreDisabled) {
     registerEntityResolutionRoutes(routeDeps);
   }
+
+  registerPermissionAuditRoute(routeDeps.router, routeDeps.logger, routeDeps.isDev);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/types.ts
@@ -28,6 +28,7 @@ export interface EntityAnalyticsRoutesDeps {
   getStartServices: StartServicesAccessor<StartPlugins>;
   telemetrySender: ITelemetryEventsSender;
   ml: SetupPlugins['ml'];
+  isDev: boolean;
 }
 
 export interface CalculateRiskScoreAggregations {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -650,7 +650,8 @@ export class Plugin implements ISecuritySolutionPlugin {
       core.docLinks,
       this.endpointContext,
       trialCompanionDeps,
-      enableDataGeneratorRoutes
+      enableDataGeneratorRoutes,
+      pluginContext.env.mode.dev
     );
 
     registerEndpointRoutes(router, this.endpointContext);

--- a/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
@@ -79,7 +79,8 @@ export const initRoutes = (
   docLinks: DocLinksServiceSetup,
   endpointContext: EndpointAppContext,
   trialCompanionDeps: TrialCompanionRoutesDeps,
-  enableDataGeneratorRoutes: boolean
+  enableDataGeneratorRoutes: boolean,
+  isDev: boolean
 ) => {
   registerFleetIntegrationsRoutes(router, logger);
   registerLegacyRuleActionsRoutes(router, logger);
@@ -152,6 +153,7 @@ export const initRoutes = (
     logger,
     telemetrySender,
     ml,
+    isDev,
   });
   registerSiemMigrationsRoutes(router, config, logger);
 


### PR DESCRIPTION

⚠️ AI/LLM generated code as a first hands-on for Spec driven development using [openspec](https://github.com/Fission-AI/OpenSpec/) ⚠️ 

⚠️ DO NOT MERGE ⚠️ 


## What is this PR doing

This PR adds a developer tool for auditing access control across all Entity Analytics features. The idea came from wanting to understand exactly which permissions allow or block which parts of the UI, and being able to verify that automatically instead of manually logging in as different users.

## How the idea was designed first

Before writing any code, we used a spec driven approach. The feature was proposed and designed in openspec/changes/ea_permission_audit/ before a single line of implementation was written. The proposal captured the approach, the data sources, the correlation strategy, and the report format. A tasks file then broke the work into concrete steps. This gave a clear contract to implement against and made it easy to spot gaps early.

## What the script does

The script creates 15 test users, each representing a different permission scenario. For example one user has full access, another has no entity store access, another has only risk score read, and so on. For each user it does three things.

First it calls every Entity Analytics privilege API endpoint directly and records what the server says about that user.

Second it opens a real browser as that user and navigates to each EA page. It checks whether the right text appears on screen, for example whether a privileges required heading shows up when access should be blocked, or whether a callout like insufficient privileges appears. It also checks button states, for example whether the Create watchlist button is disabled when the user lacks write access.

Third it seeds a test entity called ea-audit-test-user with risk score data, asset criticality, and watchlist membership. Then it opens that entity flyout for each user and checks whether the risk score panel and asset criticality selector are visible or hidden based on that user's permissions.

At the end it generates a Markdown report split into three sections: API results, UI results, and flyout results. It also shows a network wiring table that confirms whether the UI is actually calling the privilege endpoints during page load.

All test users, roles, and seeded data are cleaned up after each run.

## Internal Kibana dev page

Rather than running the script from the terminal every time, we also added a dev only page inside Kibana at /app/security/ea_permission_audit. It is hidden from regular users and only accessible in dev mode. From that page you can click a button to kick off the audit, watch the logs stream in as it runs, and then read the full report rendered directly in the browser.

## Test plan

Run the script manually or via the dev page with Kibana running locally and review the generated report. All three sections should show mostly pass results once the entity store alias fix is in place.


## Screenshots

<img width="1886" height="694" alt="image" src="https://github.com/user-attachments/assets/4cf5a5a9-2199-411c-ac6e-420d5301e5c3" />


## ScreenRecording for full webpage view

https://github.com/user-attachments/assets/64c9f316-122a-4777-9871-49d1c5d058fb

