### PR TITLE
[Dashboards] [Docs] Add known issue for dashboards not loading in 9.4.0

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -8,7 +8,7 @@ For Elastic {{observability}} known issues, refer to [Elastic Observability know
 
 For Elastic Security known issues, refer to [Elastic Security known issues](docs-content://release-notes/elastic-security/known-issues.md).
 
-::::{dropdown} Dashboards with controls may fail to open
+::::{dropdown} Dashboards with controls might fail to open
 
 Applies to: {{stack}} 9.4.0
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -18,7 +18,7 @@ Some existing dashboards are failing to load when a pinned control has `"title":
 
 **Workaround**
 
-TBD
+We're working on a way to mitigate the issue and will update this page shortly.
 
 ::::
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -8,6 +8,20 @@ For Elastic {{observability}} known issues, refer to [Elastic Observability know
 
 For Elastic Security known issues, refer to [Elastic Security known issues](docs-content://release-notes/elastic-security/known-issues.md).
 
+::::{dropdown} Dashboards with controls may fail to open
+
+Applies to: {{stack}} 9.4.0
+
+**Details**
+
+Some existing dashboards are failing to load when a pinned control has "title": null in the saved object. This manifests as an error like `Invalid response. [pinned_panels.0.config.title]: expected value of type [string] but got [null].` error on the dashboard app.
+
+**Workaround**
+
+TBD
+
+::::
+
 ::::{dropdown} The connection between agentless integrations and {{fleet-server}} is broken
 :applies_to: ess: ga
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -14,7 +14,7 @@ Applies to: {{stack}} 9.4.0
 
 **Details**
 
-Some existing dashboards are failing to load when a pinned control has "title": null in the saved object. This manifests as an error like `Invalid response. [pinned_panels.0.config.title]: expected value of type [string] but got [null].` error on the dashboard app.
+Some existing dashboards are failing to load when a pinned control has `"title": null` in the saved object. This manifests as an error like `Invalid response. [pinned_panels.0.config.title]: expected value of type [string] but got [null].` error on the dashboard app.
 
 **Workaround**
 


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/268172

## Summary 

Adds a known issue to release notes for dashboards that may not be loading in 9.4.0.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->