### PR TITLE
fix(dashboard): stabilize add panel flyout group order and count assertions

### DIFF
--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_add_panel_flyout.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_add_panel_flyout.spec.ts
@@ -13,7 +13,24 @@ import { expect } from '@kbn/scout/ui';
 import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '../constants';
 
 const getExpected = (config: ScoutTestConfig) => {
-  if (config.projectType === 'es' || config.projectType === 'security') {
+  if (config.projectType === 'es') {
+    // In ES serverless, xpack.ml.ad.enabled is false, so the 3 Anomaly Detection
+    // actions (swim lane, anomaly charts, single metric viewer) fail isCompatible
+    // and are excluded from the flyout.
+    return {
+      groups: [
+        'visualizationsGroup',
+        'controlsGroup',
+        'annotation-and-navigationGroup',
+        'mlGroup',
+        'logs-aiopsGroup',
+        'legacyGroup',
+      ],
+      count: 17,
+    };
+  }
+
+  if (config.projectType === 'security') {
     return {
       groups: [
         'visualizationsGroup',
@@ -47,8 +64,7 @@ const getExpected = (config: ScoutTestConfig) => {
  * This test exists to ensures additions to menu
  * notify our team and can be reviewed by design.
  */
-// Failing: See https://github.com/elastic/kibana/issues/268101
-spaceTest.describe.skip(
+spaceTest.describe(
   'Dashboard add panel flyout',
   {
     tag: [
@@ -88,7 +104,9 @@ spaceTest.describe.skip(
 
       await spaceTest.step('verify panel groups', async () => {
         const groups = await pageObjects.dashboard.getAddPanelFlyoutGroups();
-        expect(groups).toStrictEqual(expectedGroups);
+        // Sort before comparing: some groups share the same sort order value and their
+        // relative position is non-deterministic (depends on async action registration order).
+        expect([...groups].sort()).toStrictEqual([...expectedGroups].sort());
       });
 
       await spaceTest.step('verify total panel count', async () => {


### PR DESCRIPTION
## Summary

Fixes the two issues that caused the test to be skipped in #268101.

### 1. Group ordering flakiness

`mlGroup` and `logs-aiopsGroup` both define no explicit `order` in their `PresentableGroup` definition, so both get `order: 0` inside `getMenuItemGroups`. When two groups tie on order, `Array.sort` produces a non-deterministic result — their relative DOM position depends on async action registration order, which varies across CI runs.

Fix: sort both arrays before comparing, so the test verifies that the correct set of groups exists without being sensitive to tie-broken ordering.

### 2. Wrong expected panel count for ES serverless

`config/serverless.es.yml` sets `xpack.ml.ad.enabled: false`. The three Anomaly Detection actions (`create-anomaly-swimlane`, `create-anomaly-charts`, `create-single-metric-viewer`) all call `checkPermissionAsync(getStartServices, 'canGetJobs')` in their `isCompatible` check. With AD disabled, all three return `false` and are excluded from the flyout — 17 panels, not 20.

`security` serverless has `xpack.ml.ad.enabled: true`, so it correctly gets 20. The previous test code grouped `es` and `security` under the same expected values. Fix: split them.

## Related

- Closes #268101
- Follows up on #267973 (unskip add panel flyout tests)