### PR TITLE
[Scout] Don't attempt to upload empty lanes group

### DIFF
--- a/.buildkite/pipeline-utils/scout/test_distribution_strategies.ts
+++ b/.buildkite/pipeline-utils/scout/test_distribution_strategies.ts
@@ -111,6 +111,11 @@ async function distributeScoutTestsOnLanes() {
       loadIDsByStepKey[stepKey] = lane.loads;
     });
 
+  if (steps.length === 0) {
+    // Stop early. No test steps to upload. ✨
+    return;
+  }
+
   const bk = new BuildkiteClient();
 
   const lanesGroupStepDependencies: string[] = [];


### PR DESCRIPTION
If selective testing is enabled and no Scout tests are identified to be relevant for a PR, we currently end up in a situation where we attempt to upload an empty Buildkite group step, which is not allowed:

```
buildkite-agent: fatal: Failed to upload and process pipeline: Pipeline upload rejected: There must be at least 1 step in a group
Error: Command failed: buildkite-agent pipeline upload
```

This PR updates the `lanes` distribution strategy to fix this scenario by not attempting to upload the `Scout Test Lanes` at all if no test steps have beeen identified.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->