### PR TITLE
[9.2] [Controls] Fix close behaviour of ES|QL control flyout (#267605)

### DIFF
--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.test.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.test.ts
@@ -102,6 +102,15 @@ describe('CreateESQLControlAction', () => {
         },
       });
     });
+
+    it('should open lazy flyout with correct configuration when no cancel is provided', async () => {
+      await action.execute({ ...mockContext, onCancelControl: undefined });
+      expect(mockOpenLazyFlyout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flyoutProps: expect.not.objectContaining({ onClose: expect.any(Function) }),
+        })
+      );
+    });
   });
 
   describe('isCompatible', () => {

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
@@ -113,10 +113,10 @@ export class CreateESQLControlAction implements Action<Context> {
         isResizable: true,
         maxWidth: 800,
         triggerId: 'dashboard-controls-menu-button',
-        // When queryString is present (i.e. flyout opened from the ES|QL editor),
-        // use onCancelControl as the onClose handler to ensure proper nested flyout closing behavior.
+        // When `onCancelControl` is present (i.e. flyout opened from the ES|QL editor),
+        // use the local onClose as the onClose handler to ensure proper nested flyout closing behavior.
         // In other scenarios (opened directly from the dashboard), we keep the default close behavior.
-        ...(queryString && { onClose: onCancelControl }),
+        ...(onCancelControl && { onClose: onCancelControl }),
       },
     });
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Controls] Fix close behaviour of ES|QL control flyout (#267605)](https://github.com/elastic/kibana/pull/267605)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Mudge","email":"Heenawter@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-07T14:09:41Z","message":"[Controls] Fix close behaviour of ES|QL control flyout (#267605)\n\nCloses https://github.com/elastic/kibana/issues/264523\n\n## Summary\n\nThis PR fixes a regression that was introduced in\nhttps://github.com/elastic/kibana/pull/239645.\n\n**Before**\n\nSpecifically, in that PR, we used `queryString` to determine the\n\"context\" of where the edit ES|QL control action was opened from (either\nthe Dashboard app directly or through the ES|QL panel editor). While\nthis works for creating **new** controls from the dashboard or when\nediting `STATIC_VALUE` ES|QL controls (since they don't have a query),\nthe logic falls apart when editing **existing** `VALUES_FROM_QUERY`\nES|QL controls. In this scenario, we **unnecessarily overwrote the\ndefault lazy flyout `onClose` method** with the one meant to handle the\n\"re-open the ES|QL panel editor when the control panel editor closes\"\ncase, which does **not** call `closeOverlays` on the parent. Hence -\nDashboard stays stuck in the \"I have open flyouts!\" state.\n\n\n\nhttps://github.com/user-attachments/assets/d19c380b-ebf9-44c5-8505-b91428b5e64b\n\n\n**After**\n\nWith this PR, I changed the context condition to rely on whether or not\na custom `onCancel` was provided - when opening from the ES|QL panel\neditor, the `onCancel` is sent in order to handle the \"re-open the ES|QL\npanel editor\" case described above; however, when opened from the\nembeddable `onEdit`, no `onCancel` is provided. Therefore, we now get\nthe expected behaviour in all cases.\n\n\n\n\nhttps://github.com/user-attachments/assets/ac572c14-7639-495c-aded-7d3475eaaf41\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"481552198d325b8b4b4f0242057746de1e9d2f59","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","loe:small","impact:high","backport:version","v9.4.0","v9.5.0","v9.2.9","v9.3.5"],"title":"[Controls] Fix close behaviour of ES|QL control flyout","number":267605,"url":"https://github.com/elastic/kibana/pull/267605","mergeCommit":{"message":"[Controls] Fix close behaviour of ES|QL control flyout (#267605)\n\nCloses https://github.com/elastic/kibana/issues/264523\n\n## Summary\n\nThis PR fixes a regression that was introduced in\nhttps://github.com/elastic/kibana/pull/239645.\n\n**Before**\n\nSpecifically, in that PR, we used `queryString` to determine the\n\"context\" of where the edit ES|QL control action was opened from (either\nthe Dashboard app directly or through the ES|QL panel editor). While\nthis works for creating **new** controls from the dashboard or when\nediting `STATIC_VALUE` ES|QL controls (since they don't have a query),\nthe logic falls apart when editing **existing** `VALUES_FROM_QUERY`\nES|QL controls. In this scenario, we **unnecessarily overwrote the\ndefault lazy flyout `onClose` method** with the one meant to handle the\n\"re-open the ES|QL panel editor when the control panel editor closes\"\ncase, which does **not** call `closeOverlays` on the parent. Hence -\nDashboard stays stuck in the \"I have open flyouts!\" state.\n\n\n\nhttps://github.com/user-attachments/assets/d19c380b-ebf9-44c5-8505-b91428b5e64b\n\n\n**After**\n\nWith this PR, I changed the context condition to rely on whether or not\na custom `onCancel` was provided - when opening from the ES|QL panel\neditor, the `onCancel` is sent in order to handle the \"re-open the ES|QL\npanel editor\" case described above; however, when opened from the\nembeddable `onEdit`, no `onCancel` is provided. Therefore, we now get\nthe expected behaviour in all cases.\n\n\n\n\nhttps://github.com/user-attachments/assets/ac572c14-7639-495c-aded-7d3475eaaf41\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"481552198d325b8b4b4f0242057746de1e9d2f59"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/268207","number":268207,"state":"OPEN"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267605","number":267605,"mergeCommit":{"message":"[Controls] Fix close behaviour of ES|QL control flyout (#267605)\n\nCloses https://github.com/elastic/kibana/issues/264523\n\n## Summary\n\nThis PR fixes a regression that was introduced in\nhttps://github.com/elastic/kibana/pull/239645.\n\n**Before**\n\nSpecifically, in that PR, we used `queryString` to determine the\n\"context\" of where the edit ES|QL control action was opened from (either\nthe Dashboard app directly or through the ES|QL panel editor). While\nthis works for creating **new** controls from the dashboard or when\nediting `STATIC_VALUE` ES|QL controls (since they don't have a query),\nthe logic falls apart when editing **existing** `VALUES_FROM_QUERY`\nES|QL controls. In this scenario, we **unnecessarily overwrote the\ndefault lazy flyout `onClose` method** with the one meant to handle the\n\"re-open the ES|QL panel editor when the control panel editor closes\"\ncase, which does **not** call `closeOverlays` on the parent. Hence -\nDashboard stays stuck in the \"I have open flyouts!\" state.\n\n\n\nhttps://github.com/user-attachments/assets/d19c380b-ebf9-44c5-8505-b91428b5e64b\n\n\n**After**\n\nWith this PR, I changed the context condition to rely on whether or not\na custom `onCancel` was provided - when opening from the ES|QL panel\neditor, the `onCancel` is sent in order to handle the \"re-open the ES|QL\npanel editor\" case described above; however, when opened from the\nembeddable `onEdit`, no `onCancel` is provided. Therefore, we now get\nthe expected behaviour in all cases.\n\n\n\n\nhttps://github.com/user-attachments/assets/ac572c14-7639-495c-aded-7d3475eaaf41\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"481552198d325b8b4b4f0242057746de1e9d2f59"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/268206","number":268206,"state":"OPEN"}]}] BACKPORT-->