### PR TITLE
[Controls as Code] Handle null titles

### DIFF
--- a/src/platform/packages/shared/controls/controls-schemas/src/legacy_types.ts
+++ b/src/platform/packages/shared/controls/controls-schemas/src/legacy_types.ts
@@ -69,6 +69,7 @@ export interface LegacyStoredESQLControlExplicitInput {
     hideExists?: boolean;
     hideSort?: boolean;
   };
+  title?: string;
   esqlQuery: string;
   selectedOptions: string[];
   singleSelect?: boolean;

--- a/src/platform/plugins/shared/controls/server/transforms/data_control_transforms.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/data_control_transforms.ts
@@ -71,8 +71,8 @@ export function transformDataControlOut<
   const dataViewId = dataViewRef?.id ?? data_view_id ?? '';
   const convertedState = {
     ...DEFAULT_DATA_CONTROL_STATE,
-    title,
     data_view_id: dataViewId,
+    ...(typeof title === 'string' && { title }), // title may be null, so just return undefined in this case
     ...(typeof use_global_filters === 'boolean' && { use_global_filters }),
     ...(typeof ignore_validations === 'boolean' && { ignore_validations }),
     field_name: field_name ?? '',

--- a/src/platform/plugins/shared/controls/server/transforms/data_control_transforms.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/data_control_transforms.ts
@@ -72,7 +72,7 @@ export function transformDataControlOut<
   const convertedState = {
     ...DEFAULT_DATA_CONTROL_STATE,
     data_view_id: dataViewId,
-    ...(typeof title === 'string' && { title }), // title may be null, so just return undefined in this case
+    ...(title && { title }),
     ...(typeof use_global_filters === 'boolean' && { use_global_filters }),
     ...(typeof ignore_validations === 'boolean' && { ignore_validations }),
     field_name: field_name ?? '',

--- a/src/platform/plugins/shared/controls/server/transforms/esql_control_transforms.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/esql_control_transforms.ts
@@ -39,6 +39,7 @@ export const registerESQLControlTransforms = (embeddable: EmbeddableSetup) => {
           esql_query,
           selected_options,
           single_select,
+          title,
           variable_name,
           variable_type,
         } = convertCamelCasedKeysToSnakeCase<LegacyStoredESQLControlExplicitInput>(
@@ -52,6 +53,7 @@ export const registerESQLControlTransforms = (embeddable: EmbeddableSetup) => {
           single_select: single_select ?? DEFAULT_ESQL_OPTIONS_LIST_STATE.single_select,
           variable_name: variable_name ?? '',
           variable_type: variable_type as OptionsListESQLControlState['variable_type'],
+          ...(typeof title === 'string' && { title }), // title may be null, so just return undefined in this case
         };
         return control_type === EsqlControlType.STATIC_VALUES
           ? {

--- a/src/platform/plugins/shared/controls/server/transforms/esql_control_transforms.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/esql_control_transforms.ts
@@ -53,7 +53,7 @@ export const registerESQLControlTransforms = (embeddable: EmbeddableSetup) => {
           single_select: single_select ?? DEFAULT_ESQL_OPTIONS_LIST_STATE.single_select,
           variable_name: variable_name ?? '',
           variable_type: variable_type as OptionsListESQLControlState['variable_type'],
-          ...(typeof title === 'string' && { title }), // title may be null, so just return undefined in this case
+          ...(title && { title }),
         };
         return control_type === EsqlControlType.STATIC_VALUES
           ? {

--- a/src/platform/plugins/shared/controls/server/transforms/options_list_control_transforms.test.ts
+++ b/src/platform/plugins/shared/controls/server/transforms/options_list_control_transforms.test.ts
@@ -45,6 +45,7 @@ describe('options list control transforms', () => {
           searchTechnique: 'prefix',
           selectedOptions: ['val'],
           singleSelect: null,
+          title: null,
         },
         panelReferences,
         undefined,
@@ -61,7 +62,6 @@ describe('options list control transforms', () => {
           "selected_options": Array [
             "val",
           ],
-          "title": "Test",
           "use_global_filters": true,
         }
       `);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/268172

## Summary

This PR ensures that `null` values for control titles return `undefined` after transforms so that validation passes.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->