### PR TITLE
test: stabilize serverless Observability Scout navigation and service map

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Observability-specific test framework
-export { test, apiTest, spaceTest } from './src/playwright';
+export { test, apiTest, spaceTest, OBSERVABILITY_SPA_SHELL_TIMEOUT_MS } from './src/playwright';
 
 // Worker fixtures for observability tests (e.g. sloData for API tests)
 export { sloDataFixture } from './src/playwright/fixtures/worker';

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/index.ts
@@ -6,4 +6,5 @@
  */
 
 export * from './fixtures';
+export { OBSERVABILITY_SPA_SHELL_TIMEOUT_MS } from './page_objects';
 export type { ObltPageObjects } from './page_objects';

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/index.ts
@@ -11,6 +11,11 @@ import { OnboardingHomePage } from './onboarding_home';
 import { CustomLogsPage } from './custom_logs';
 import { ObservabilityNavigation } from './observability_navigation';
 
+export {
+  OBSERVABILITY_PRIMARY_NAV_LOAD_TIMEOUT_MS,
+  OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+} from './observability_navigation';
+
 export interface ObltPageObjects extends PageObjects {
   onboardingHome: OnboardingHomePage;
   customLogs: CustomLogsPage;

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/observability_navigation.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/observability_navigation.ts
@@ -7,6 +7,15 @@
 
 import type { Locator, ScoutPage } from '@kbn/scout';
 
+/** Serverless / cloud: primary chrome nav can lag behind Playwright defaults (gh-267186). */
+export const OBSERVABILITY_PRIMARY_NAV_LOAD_TIMEOUT_MS = 45_000;
+
+/**
+ * Budget for app shells after sidenav navigations — bundles + async `data-test-subj` (ex. dashboards
+ * listing mounts `dashboardLandingPage` in an effect; gh-267186 comment).
+ */
+export const OBSERVABILITY_SPA_SHELL_TIMEOUT_MS = OBSERVABILITY_PRIMARY_NAV_LOAD_TIMEOUT_MS;
+
 /** Chrome nav for Observability — locators and actions only; specs own `expect`. */
 export class ObservabilityNavigation {
   public readonly sidenav: Locator;
@@ -41,8 +50,11 @@ export class ObservabilityNavigation {
   }
 
   /** Waits on `primaryNav` (outer layout can be 0-width until CSS vars apply). */
-  async waitForLoad() {
-    await this.primaryNav.waitFor({ state: 'visible' });
+  async waitForLoad(options?: { timeout?: number }) {
+    await this.primaryNav.waitFor({
+      state: 'visible',
+      timeout: options?.timeout ?? OBSERVABILITY_PRIMARY_NAV_LOAD_TIMEOUT_MS,
+    });
   }
 
   /** App root or `kbnNoDataPage` (Discover/Dashboards with no data views). */

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_embeddable.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_embeddable.spec.ts
@@ -49,9 +49,11 @@ test.describe(
         await pageObjects.dashboard.openNewDashboard({ timeout: EXTENDED_TIMEOUT });
       });
 
-      await test.step('set time range to last 1 hour to ensure test data is visible', async () => {
-        await pageObjects.datePicker.setCommonlyUsedTime('Last_1_hour');
-        await expect(page.getByTestId('dateRangePickerControlButton')).toContainText('Last 1 hour');
+      await test.step('set time range to last 24 hours so synth data stays in range vs globalSetup', async () => {
+        await pageObjects.datePicker.setCommonlyUsedTime('Last_24_hours');
+        await expect(page.getByTestId('dateRangePickerControlButton')).toContainText(
+          'Last 24 hours'
+        );
         await page.getByTestId('dateRangePickerControlButton').blur();
       });
 
@@ -87,7 +89,10 @@ test.describe(
           page,
           'apmServiceMapEditorServiceNameComboBox'
         );
-        await serviceNameComboBox.selectSingleOption(SERVICE_MAP_TEST_SERVICE, { useFill: true });
+        await serviceNameComboBox.selectSingleOption(SERVICE_MAP_TEST_SERVICE, {
+          useFill: true,
+          optionVisibilityTimeoutMs: EXTENDED_TIMEOUT,
+        });
 
         // Select environment from dropdown (has a default value so manually type and select)
         const environmentInput = page.testSubj
@@ -98,7 +103,7 @@ test.describe(
         const environmentOption = page.getByRole('option', {
           name: SERVICE_MAP_TEST_ENVIRONMENT_STAGING,
         });
-        await environmentOption.waitFor({ state: 'visible', timeout: 10000 });
+        await environmentOption.waitFor({ state: 'visible', timeout: EXTENDED_TIMEOUT });
         await environmentOption.click();
 
         // Add KQL filter matching the staging transaction
@@ -116,7 +121,7 @@ test.describe(
           page.testSubj.locator(
             `serviceMapNodeContextHighlightFrame > serviceMapNode-service-${SERVICE_MAP_TEST_SERVICE}`
           )
-        ).toBeVisible({ timeout: 10000 });
+        ).toBeVisible({ timeout: EXTENDED_TIMEOUT });
       });
 
       await test.step('verify embeddable fills the panel horizontally', async () => {
@@ -137,7 +142,7 @@ test.describe(
         const serviceNode = page.testSubj.locator(
           `serviceMapNode-service-${SERVICE_MAP_TEST_SERVICE}`
         );
-        await expect(serviceNode).toBeVisible({ timeout: 10000 });
+        await expect(serviceNode).toBeVisible({ timeout: EXTENDED_TIMEOUT });
         await serviceNode.click();
 
         const popover = page.testSubj.locator('serviceMapPopover');

--- a/x-pack/solutions/observability/plugins/serverless_observability/test/scout/ui/parallel_tests/navigation_complete.spec.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/test/scout/ui/parallel_tests/navigation_complete.spec.ts
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { tags } from '@kbn/scout-oblt';
+import { OBSERVABILITY_SPA_SHELL_TIMEOUT_MS, tags } from '@kbn/scout-oblt';
 import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../fixtures';
 
-// Failing: See https://github.com/elastic/kibana/issues/267186
-test.describe.skip(
+test.describe(
   'Serverless Observability Navigation - Complete tier body',
   { tag: [...tags.serverless.observability.complete] },
   () => {
@@ -72,34 +71,56 @@ test.describe.skip(
 
       await test.step('Discover', async () => {
         await nav.navItemInPrimaryByDeepLinkId('discover').click();
-        await expect(nav.pageOrNoData('dscPage')).toBeVisible();
-        await expect(nav.activeNavItemByDeepLinkId('discover')).toBeVisible();
-        await expect(nav.breadcrumb({ deepLinkId: 'discover' })).toBeVisible();
+        await expect(nav.pageOrNoData('dscPage')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
+        await expect(nav.activeNavItemByDeepLinkId('discover')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
+        await expect(nav.breadcrumb({ deepLinkId: 'discover' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('Dashboards', async () => {
         await nav.navItemInPrimaryByDeepLinkId('dashboards').click();
-        await expect(nav.pageOrNoData('dashboardLandingPage')).toBeVisible();
-        await expect(nav.activeNavItemByDeepLinkId('dashboards')).toBeVisible();
-        await expect(nav.breadcrumb({ deepLinkId: 'dashboards' })).toBeVisible();
+        await expect(nav.pageOrNoData('dashboardLandingPage')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
+        await expect(nav.activeNavItemByDeepLinkId('dashboards')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
+        await expect(nav.breadcrumb({ deepLinkId: 'dashboards' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('Workflows', async () => {
         await nav.navItemInPrimaryByDeepLinkId('workflows').click();
-        await expect(page.testSubj.locator('workflowsPage')).toBeVisible();
-        await expect(nav.activeNavItemByDeepLinkId('workflows')).toBeVisible();
+        await expect(page.testSubj.locator('workflowsPage')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
+        await expect(nav.activeNavItemByDeepLinkId('workflows')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('Alerts', async () => {
         await nav.navItemInPrimaryByDeepLinkId('observability-overview:alerts').click();
-        await expect(page.testSubj.locator('alertsPageWithData')).toBeVisible();
-        await expect(nav.activeNavItemByDeepLinkId('observability-overview:alerts')).toBeVisible();
+        await expect(page.testSubj.locator('alertsPageWithData')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
+        await expect(nav.activeNavItemByDeepLinkId('observability-overview:alerts')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('Cases (via More menu)', async () => {
         await nav.openMoreMenu();
         await nav.navItemInMoreByDeepLinkId('observability-overview:cases').click();
-        await expect(nav.breadcrumb({ text: 'Cases' })).toBeVisible();
+        await expect(nav.breadcrumb({ text: 'Cases' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('SLOs (via More menu)', async () => {
@@ -109,13 +130,15 @@ test.describe.skip(
           page.testSubj
             .locator('slosPage')
             .or(page.testSubj.locator('o11ySloListWelcomePromptCreateSloButton'))
-        ).toBeVisible();
+        ).toBeVisible({ timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS });
       });
 
       await test.step('Machine Learning opens its nested panel inside the More menu', async () => {
         await nav.openMoreMenu();
         await nav.navItemInMoreById('machine_learning-landing').click();
-        await expect(nav.nestedPanel('machine_learning-landing')).toBeVisible();
+        await expect(nav.nestedPanel('machine_learning-landing')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
     });
 
@@ -124,46 +147,62 @@ test.describe.skip(
 
       await test.step('data_management → Integrations', async () => {
         await nav.navItemInFooterById('data_management').click();
-        await expect(nav.sidePanel('data_management')).toBeVisible();
+        await expect(nav.sidePanel('data_management')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
 
         await nav
           .sidePanel('data_management')
           .locator('[data-test-subj~="nav-item-deepLinkId-integrations"]')
           .click();
-        await expect(nav.breadcrumb({ deepLinkId: 'integrations' })).toBeVisible();
+        await expect(nav.breadcrumb({ deepLinkId: 'integrations' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('data_management → Fleet', async () => {
         await nav.navItemInFooterById('data_management').click();
-        await expect(nav.sidePanel('data_management')).toBeVisible();
+        await expect(nav.sidePanel('data_management')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
 
         await nav
           .sidePanel('data_management')
           .locator('[data-test-subj~="nav-item-deepLinkId-fleet"]')
           .click();
-        await expect(nav.breadcrumb({ text: 'Fleet' })).toBeVisible();
+        await expect(nav.breadcrumb({ text: 'Fleet' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('admin_and_settings → Tags', async () => {
         await nav.navItemInFooterById('admin_and_settings').click();
-        await expect(nav.sidePanel('admin_and_settings')).toBeVisible();
+        await expect(nav.sidePanel('admin_and_settings')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
 
         await nav
           .sidePanel('admin_and_settings')
           .locator('[data-test-subj~="nav-item-id-management:tags"]')
           .click();
-        await expect(nav.breadcrumb({ text: 'Tags' })).toBeVisible();
+        await expect(nav.breadcrumb({ text: 'Tags' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('admin_and_settings → Maintenance Windows', async () => {
         await nav.navItemInFooterById('admin_and_settings').click();
-        await expect(nav.sidePanel('admin_and_settings')).toBeVisible();
+        await expect(nav.sidePanel('admin_and_settings')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
 
         await nav
           .sidePanel('admin_and_settings')
           .locator('[data-test-subj~="nav-item-id-management:maintenanceWindows"]')
           .click();
-        await expect(nav.breadcrumb({ text: 'Maintenance Windows' })).toBeVisible();
+        await expect(nav.breadcrumb({ text: 'Maintenance Windows' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
     });
 
@@ -171,7 +210,9 @@ test.describe.skip(
       const nav = pageObjects.observabilityNavigation;
       await page.gotoApp('management');
       await nav.waitForLoad();
-      await expect(page.testSubj.locator('cards-navigation-page')).toBeVisible();
+      await expect(page.testSubj.locator('cards-navigation-page')).toBeVisible({
+        timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+      });
     });
 
     test('navigates between apps without a full page reload (SPA) and restores via logo', async ({
@@ -183,31 +224,43 @@ test.describe.skip(
 
       await test.step('Discover via sidenav', async () => {
         await nav.navItemInPrimaryByDeepLinkId('discover').click();
-        await expect(nav.activeNavItemByDeepLinkId('discover')).toBeVisible();
-        await expect(nav.breadcrumb({ deepLinkId: 'discover' })).toBeVisible();
+        await expect(nav.activeNavItemByDeepLinkId('discover')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
+        await expect(nav.breadcrumb({ deepLinkId: 'discover' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('Agents via More', async () => {
         await nav.openMoreMenu();
         await nav.navItemInMoreById('agent_builder').click();
-        await expect(nav.breadcrumb({ text: 'Agents' })).toBeVisible();
+        await expect(nav.breadcrumb({ text: 'Agents' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('admin_and_settings → Tags', async () => {
         await nav.navItemInFooterById('admin_and_settings').click();
-        await expect(nav.sidePanel('admin_and_settings')).toBeVisible();
+        await expect(nav.sidePanel('admin_and_settings')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
 
         await nav
           .sidePanel('admin_and_settings')
           .locator('[data-test-subj~="nav-item-id-management:tags"]')
           .click();
-        await expect(nav.breadcrumb({ text: 'Tags' })).toBeVisible();
+        await expect(nav.breadcrumb({ text: 'Tags' })).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('Logo returns to observability landing', async () => {
         await nav.clickLogo();
         await nav.waitForLoad();
-        await expect(nav.navItemInPrimaryByDeepLinkId('discover')).toBeVisible();
+        await expect(nav.navItemInPrimaryByDeepLinkId('discover')).toBeVisible({
+          timeout: OBSERVABILITY_SPA_SHELL_TIMEOUT_MS,
+        });
       });
 
       await test.step('no page reload happened during the flow', async () => {


### PR DESCRIPTION
## Summary

- Bump default primary navigation / SPA shell wait budgets in `ObservabilityNavigation` (`@kbn/scout-oblt`) and export `OBSERVABILITY_SPA_SHELL_TIMEOUT_MS` for callers.
- Re-enable `navigation_complete.spec.ts` with extended `toBeVisible` timeouts for slow serverless shell transitions (e.g. dashboards landing).
- Reduce flake in the service map embeddable Scout test by using **Last 24 hours** and longer combo / map visibility timeouts.

## References

Closes elastic/kibana#267186  
Closes elastic/kibana#265639

## Validation

**Typecheck (Observability)**

```bash
node x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/type_check.js --project x-pack/solutions/observability/packages/kbn-scout-oblt/tsconfig.json
```

**Scout — serverless Observability Complete (navigation)**

```bash
node scripts/scout.js run-tests --arch serverless --domain observability_complete \
  --testFiles x-pack/solutions/observability/plugins/serverless_observability/test/scout/ui/parallel_tests/navigation_complete.spec.ts
```

**Scout — APM parallel (service map embeddable, serverless)**

```bash
node scripts/scout.js run-tests --arch serverless --domain observability_complete \
  --testFiles x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_embeddable.spec.ts
```

**Both specs (single run)**

```bash
node scripts/scout.js run-tests --arch serverless --domain observability_complete \
  --testFiles x-pack/solutions/observability/plugins/serverless_observability/test/scout/ui/parallel_tests/navigation_complete.spec.ts,x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_embeddable.spec.ts
```

_(For stateful-classic runs, omit `--arch serverless` / adjust tags as needed.)_

## Flaky test runner

Trigger runs via the [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this on the PR (30× each config):

```
/flaky scoutConfig:x-pack/solutions/observability/plugins/serverless_observability/test/scout/ui/parallel.playwright.config.ts:30 scoutConfig:x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel.playwright.config.ts:30
```

A `/flaky` comment has been posted on this PR to kick off the runner.
