### PR TITLE
[Security Solution] fix wrong banner shown in Discover document flyout because of missing services

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
@@ -286,6 +286,24 @@ describe('AlertFlyoutHeader', () => {
     );
   });
 
+  it('renders nothing while services or store are not yet resolved', () => {
+    const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
+    const history = createMemoryHistory({ initialEntries: ['/discover'] });
+
+    const { container } = render(
+      <Router history={history}>
+        <AlertFlyoutHeader
+          hit={hit}
+          servicesPromise={new Promise(() => {})}
+          storePromise={new Promise(() => {})}
+          onAlertUpdated={jest.fn()}
+        />
+      </Router>
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('shows a callout when _id or _index are missing from hit.raw', async () => {
     const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
     const store = createStore(() => ({}));
@@ -335,6 +353,39 @@ describe('AlertFlyoutHeader', () => {
       expect(
         screen.getByText(
           'This event originates from a remote cluster. Some features may not be available.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows linked project callout text for remote docs in serverless', async () => {
+    const hit = {
+      id: '1',
+      raw: { _id: '1', _index: 'remote-cluster:logs-system-default' },
+      flattened: {},
+    } as unknown as DataTableRecord;
+    const store = createStore(() => ({}));
+    const history = createMemoryHistory({ initialEntries: ['/discover'] });
+    const serverlessServicesMock = {
+      ...servicesMock,
+      cloud: { isServerlessEnabled: true },
+    } as unknown as StartServices;
+
+    render(
+      <Router history={history}>
+        <AlertFlyoutHeader
+          hit={hit}
+          servicesPromise={Promise.resolve(serverlessServicesMock)}
+          storePromise={Promise.resolve(store as never)}
+          onAlertUpdated={jest.fn()}
+        />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'This event originates from a linked project. Some features may not be available.'
         )
       ).toBeInTheDocument();
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
@@ -138,43 +138,35 @@ export const AlertFlyoutHeader = ({
     };
   }, [servicesPromise, storePromise]);
 
-  const isMissingMetadata = !hit.raw._id || !hit.raw._index;
-
-  const metadataCallout = isMissingMetadata ? (
-    <>
-      <EuiCallOut announceOnMount size="s" title={MISSING_METADATA_CALLOUT} />
-      <EuiSpacer size="s" />
-    </>
-  ) : null;
-  const remoteDocumentCallout = (
-    <RemoteDocumentCallout hit={hit}>
-      <EuiSpacer size="s" />
-    </RemoteDocumentCallout>
-  );
-
   if (!services || !store) {
-    return (
-      <>
-        {metadataCallout}
-        {remoteDocumentCallout}
-      </>
-    );
+    return null;
   }
+
+  const isMissingMetadata = !hit.raw._id || !hit.raw._index;
 
   return (
     <>
-      {metadataCallout}
-      {remoteDocumentCallout}
+      {isMissingMetadata ? (
+        <>
+          <EuiCallOut announceOnMount size="s" title={MISSING_METADATA_CALLOUT} />
+          <EuiSpacer size="s" />
+        </>
+      ) : null}
       {flyoutProviders({
         services,
         store,
         children: (
-          <Header
-            hit={hit}
-            renderCellActions={renderCellActions}
-            onAlertUpdated={onAlertUpdated}
-            onShowNotes={openNotesFlyout}
-          />
+          <>
+            <RemoteDocumentCallout hit={hit}>
+              <EuiSpacer size="s" />
+            </RemoteDocumentCallout>
+            <Header
+              hit={hit}
+              renderCellActions={renderCellActions}
+              onAlertUpdated={onAlertUpdated}
+              onShowNotes={openNotesFlyout}
+            />
+          </>
         ),
       })}
     </>


### PR DESCRIPTION
## Summary

This PR makes a super small couple of changes:

#### Fix wrong banner message

Move the `RemoteDocumentCallout` inside the `flyoutProviders` to ensure that the `services` are setup correctly. There was an inconsistency when opening the flyout in Discover (which was showing `This attack originates from a linked project. Some features may not be available.`) and opening the same flyout in a Dashboard where Discover is embedded (which was showing `This attack originates from a remote cluster. Some features may not be available.`).

#### Remove the `metadataCallout`

Remove the `EuiCallOut` for missing metadata when the `services` or `store` aren't defined. This is for better consistency with the header and footer sections of the flyout, which are currently both returning `null`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->