### PR TITLE
[CI] Increase resources for version bump DRA step

### DIFF
--- a/.buildkite/pipelines/version_bump.yml
+++ b/.buildkite/pipelines/version_bump.yml
@@ -2,7 +2,8 @@ notify:
   - slack:
       channels:
         - '#kibana-operations-alerts'
-    if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) && (build.state == 'passed' || build.state == 'failed')
+    if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) &&
+      (build.state == 'passed' || build.state == 'failed')
   - slack:
       channels:
         - '#mission-control'
@@ -30,9 +31,9 @@ steps:
     depends_on: bump-version
     agents:
       image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
-      cpu: 250m
-      memory: 512Mi
-      ephemeralStorage: 1Gi
+      cpu: 2
+      memory: 4G
+      ephemeralStorage: 10G
     command:
       - echo "Starting DRA artifacts retrieval..."
     timeout_in_minutes: 240


### PR DESCRIPTION
## Summary

Agent is crashing:

https://buildkite.com/elastic/kibana-version-bump/builds/40
https://buildkite-stats.elastic.dev/app/metrics/detail/pod/0368bb92-1032-4cd1-83f6-77eec8f223cf?_a=(autoReload:!f,refreshInterval:5000,time:(from:%272026-05-06T15:47:00.011Z%27,interval:%3E%3D1m,to:%272026-05-06T16:02:00.011Z%27))

