### PR TITLE
[Dashboards] Fix workarounds for EUI 114 bugs

### DIFF
--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
@@ -141,7 +141,7 @@ export const MarkdownEditor = ({
                 />
                 <EuiMarkdownEditorHelpButton
                   uiPlugins={uiPlugins}
-                  tooltipProps={{ position: 'bottom', delay: 'regular' }}
+                  tooltipProps={{ position: 'bottom' }}
                 />
               </>
             ),

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_bar_toggle_button/index.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_bar_toggle_button/index.tsx
@@ -41,31 +41,11 @@ export const FilterBarToggleButton: React.FC<{}> = () => {
   const themeContext = useEuiTheme();
   const styles = toggleStyles(themeContext);
 
-  // TODO Workaround for https://github.com/elastic/eui/issues/9520
-  const expandTooltipRef = useRef<EuiToolTip>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const [buttonInFocusNotVisible, setButtonInFocusNotVisible] = useState(false);
-  const onTooltipMouseOut = useCallback(() => {
-    if (buttonInFocusNotVisible) {
-      expandTooltipRef.current?.hideToolTip();
-    }
-  }, [buttonInFocusNotVisible]);
-  const onButtonFocus = useCallback(() => {
-    if (document.querySelector('button:focus-visible') !== buttonRef.current) {
-      setButtonInFocusNotVisible(true);
-    }
-  }, []);
-  const onButtonBlur = useCallback(() => setButtonInFocusNotVisible(false), []);
-  // TODO End workaround, delete above block when EUI fixes this issue
-
   return (
     <EuiToolTip
       ref={expandTooltipRef}
       content={isCollapsed ? expandLabel : collapseLabel}
       disableScreenReaderOutput
-      onMouseOut={
-        /*  TODO Workaround for https://github.com/elastic/eui/issues/9520 */ onTooltipMouseOut
-      }
     >
       <EuiButtonEmpty
         buttonRef={buttonRef}
@@ -77,8 +57,6 @@ export const FilterBarToggleButton: React.FC<{}> = () => {
         css={styles.filterButtonStyle}
         size="s"
         data-test-subj="filterBarToggleButton"
-        onFocus={/* TODO Workaround for https://github.com/elastic/eui/issues/9520 */ onButtonFocus}
-        onBlur={/* TODO Workaround for https://github.com/elastic/eui/issues/9520 */ onButtonBlur}
       >
         <EuiFlexGroup gutterSize="xs">
           <EuiFlexItem>


### PR DESCRIPTION
## Summary

Removes some workarounds related to tooltips that were fixed in EUI v115:

https://github.com/elastic/eui/issues/9520
https://github.com/elastic/eui/issues/9593

Depends on https://github.com/elastic/kibana/pull/266413

