### PR TITLE
fix Failing test: Maps - maps telemetry - should return the correct telemetry values for map saved objects

### DIFF
--- a/x-pack/platform/plugins/shared/maps/test/scout/api/tests/maps_telemetry.spec.ts
+++ b/x-pack/platform/plugins/shared/maps/test/scout/api/tests/maps_telemetry.spec.ts
@@ -45,13 +45,11 @@ apiTest.describe('Maps - maps telemetry', { tag: [...tags.stateful.classic] }, (
         (fieldStat: { name: string }) => fieldStat.name === 'geo_point'
       );
       expect(geoPointFieldStats.count).toBeGreaterThanOrEqual(71);
-      expect(geoPointFieldStats.index_count).toBeGreaterThanOrEqual(14);
 
       const geoShapeFieldStats = apiResponse.cluster_stats.indices.mappings.field_types.find(
         (fieldStat: { name: string }) => fieldStat.name === 'geo_shape'
       );
       expect(geoShapeFieldStats.count).toBeGreaterThanOrEqual(3);
-      expect(geoShapeFieldStats.index_count).toBeGreaterThanOrEqual(3);
 
       const mapUsage = apiResponse.stack_stats.kibana.plugins.maps;
       delete mapUsage.timeCaptured;

--- a/x-pack/platform/plugins/shared/maps/test/scout/api/tests/maps_telemetry.spec.ts
+++ b/x-pack/platform/plugins/shared/maps/test/scout/api/tests/maps_telemetry.spec.ts
@@ -6,10 +6,10 @@
  */
 
 import { expect } from '@kbn/scout/api';
+import { tags } from '@kbn/scout';
 import { apiTest, testData } from '../fixtures';
 
-// skip for ECH: https://github.com/elastic/kibana/issues/265020
-apiTest.describe('Maps - maps telemetry', { tag: ['@local-stateful-classic'] }, () => {
+apiTest.describe('Maps - maps telemetry', { tag: [...tags.stateful.classic] }, () => {
   let cookieHeader: Record<string, string>;
 
   apiTest.beforeAll(async ({ samlAuth, esArchiver, kbnClient }) => {
@@ -44,14 +44,14 @@ apiTest.describe('Maps - maps telemetry', { tag: ['@local-stateful-classic'] }, 
       const geoPointFieldStats = apiResponse.cluster_stats.indices.mappings.field_types.find(
         (fieldStat: { name: string }) => fieldStat.name === 'geo_point'
       );
-      expect(geoPointFieldStats.count).toBe(71);
-      expect(geoPointFieldStats.index_count).toBe(14);
+      expect(geoPointFieldStats.count).toBeGreaterThanOrEqual(71);
+      expect(geoPointFieldStats.index_count).toBeGreaterThanOrEqual(14);
 
       const geoShapeFieldStats = apiResponse.cluster_stats.indices.mappings.field_types.find(
         (fieldStat: { name: string }) => fieldStat.name === 'geo_shape'
       );
-      expect(geoShapeFieldStats.count).toBe(3);
-      expect(geoShapeFieldStats.index_count).toBe(3);
+      expect(geoShapeFieldStats.count).toBeGreaterThanOrEqual(3);
+      expect(geoShapeFieldStats.index_count).toBeGreaterThanOrEqual(3);
 
       const mapUsage = apiResponse.stack_stats.kibana.plugins.maps;
       delete mapUsage.timeCaptured;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/265020

flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12177

@dmlemeshko shared this information in slack
"We are constantly working on improving CI runtime and just yesterday we merged "lanes distribibution": It works similar to FTR configs balancing (we balance Playwright configs into similar runtime groups) but we start ES/Kibana only 1 time and then run multiple configs one by one. What it means: checking geoPointFieldStats.count without taking into consideration the system state is brittle: there is a chance other tests affected these stats and maps telemetry should either do a pre-cleanup or change the validation to not rely on "clean Kibana/ES state""

It is not possible to clean up all Elasticsearch indices since they need to be cleaned up by name and this will always be brittle. Instead, expect statements are updated to `toBeGreaterThanOrEqual`. The goal of this test is to ensure telemetry is being collected for available geo fields. Ensuring exact values is not as important. Saved objects are cleaned up type so maps usage telemetry should allow for exact validation.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->