### PR TITLE
[Security Solution] fix wrong alignment of buttons in Timeline

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/toolbar_additional_controls.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/toolbar_additional_controls.tsx
@@ -4,8 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
-import React, { useMemo, useCallback, useRef } from 'react';
+
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import React, { useCallback, useMemo, useRef } from 'react';
 
 import { isActiveTimeline } from '../../../../../helpers';
 import { TimelineId } from '../../../../../../common/types/timeline';
@@ -69,10 +70,18 @@ export const ToolbarAdditionalControlsComponent: React.FC<Props> = ({ timelineId
 
   return (
     <>
-      <RowRendererSwitch timelineId={timelineId} />
-      <StatefulRowRenderersBrowser timelineId={timelineId} />
-      <LastUpdatedContainer updatedAt={updatedAt} />
-      <span className="rightPosition">
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <RowRendererSwitch timelineId={timelineId} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <StatefulRowRenderersBrowser timelineId={timelineId} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <LastUpdatedContainer updatedAt={updatedAt} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <span style={{ position: 'absolute', right: 0 }}>
         <EuiToolTip
           ref={toolTipRef}
           content={fullScreen ? i18n.EXIT_FULL_SCREEN : i18n.FULL_SCREEN}
@@ -81,7 +90,7 @@ export const ToolbarAdditionalControlsComponent: React.FC<Props> = ({ timelineId
           <EuiButtonIcon
             aria-label={fullScreen ? i18n.EXIT_FULL_SCREEN : i18n.FULL_SCREEN}
             className={`${fullScreen ? EXIT_FULL_SCREEN_CLASS_NAME : ''}`}
-            color={fullScreen ? 'text' : 'primary'}
+            color="text"
             data-test-subj={
               // a full screen button gets created for timeline and for the host page
               // this sets the data-test-subj for each case so that tests can differentiate between them

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/styles.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/styles.tsx
@@ -196,15 +196,6 @@ export const StyledTimelineUnifiedDataTable = styled.div.attrs(({ className = ''
     width: fit-content;
   }
 
-  .udtTimeline .rightPosition {
-    position: absolute;
-    right: 5px;
-
-    button {
-      ${({ theme }) => `color: ${theme.eui.euiColorDarkShade};`}
-    }
-  }
-
   .udtTimeline .euiDataGrid__rightControls {
     padding-right: 30px;
   }


### PR DESCRIPTION
## Summary

This PR fixes a small issue with button alignment on Timeline

| Before  | After |
| ------------- | ------------- |
| <img width="1232" height="371" alt="Screenshot 2026-05-07 at 4 52 58 PM" src="https://github.com/user-attachments/assets/ab31b374-07be-438d-80f4-af2cf5b8e4f3" /> | <img width="1234" height="269" alt="Screenshot 2026-05-07 at 4 52 31 PM" src="https://github.com/user-attachments/assets/4f2522e0-c4ae-4c76-835d-6fed625813a4" /> |

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/268375

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->