### PR TITLE
[ci] Only use cached es snapshot on pull requests

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -1,3 +1,6 @@
+env:
+  KBN_ES_SNAPSHOT_USE_CACHED: 'true'
+
 steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution

--- a/src/platform/packages/shared/kbn-es/src/artifact.test.js
+++ b/src/platform/packages/shared/kbn-es/src/artifact.test.js
@@ -90,7 +90,11 @@ const createCachedArtifact = ({ contents, etag = 'etag' }) => {
 };
 
 const previousEnvVars = {};
-const ENV_VARS_TO_RESET = ['ES_SNAPSHOT_MANIFEST', 'KBN_ES_SNAPSHOT_USE_UNVERIFIED'];
+const ENV_VARS_TO_RESET = [
+  'ES_SNAPSHOT_MANIFEST',
+  'KBN_ES_SNAPSHOT_USE_UNVERIFIED',
+  'KBN_ES_SNAPSHOT_USE_CACHED',
+];
 
 beforeAll(() => {
   ENV_VARS_TO_RESET.forEach((key) => {

--- a/src/platform/packages/shared/kbn-es/src/artifact.ts
+++ b/src/platform/packages/shared/kbn-es/src/artifact.ts
@@ -232,7 +232,7 @@ export class Artifact {
       const cacheMeta = cache.readMeta(dest);
       const tmpPath = `${dest}.tmp`;
 
-      if (useCached) {
+      if (useCached || process.env.KBN_ES_SNAPSHOT_USE_CACHED === 'true') {
         if (cacheMeta.exists) {
           this.log.info(
             'use-cached passed, forcing to use existing snapshot',


### PR DESCRIPTION
ES snapshots should trigger a cache update within an hour after an upgrade.  

During the interim period, or if there are cache update failures, we're finding the parallelized number of download requests becoming problematic.  If there's a cache update issue, it will be fixed with the same priority as a snapshot build.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->