### PR TITLE
[User Storage] Minor optimization to server client getAll method

### DIFF
--- a/src/core/packages/user-storage/server-internal/moon.yml
+++ b/src/core/packages/user-storage/server-internal/moon.yml
@@ -25,12 +25,14 @@ dependsOn:
   - '@kbn/core-http-server-internal'
   - '@kbn/core-http-request-handler-context-server'
   - '@kbn/core-saved-objects-api-server'
+  - '@kbn/core-saved-objects-api-server-mocks'
   - '@kbn/core-saved-objects-server'
   - '@kbn/core-saved-objects-server-internal'
   - '@kbn/core-security-server'
   - '@kbn/core-security-server-internal'
   - '@kbn/core-user-storage-common'
   - '@kbn/core-user-storage-server'
+  - '@kbn/logging-mocks'
 tags:
   - shared-server
   - package

--- a/src/core/packages/user-storage/server-internal/src/user_storage_client.test.ts
+++ b/src/core/packages/user-storage/server-internal/src/user_storage_client.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z } from '@kbn/zod/v4';
+import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
+import { loggerMock, type MockedLogger } from '@kbn/logging-mocks';
+import type { UserStorageDefinition } from '@kbn/core-user-storage-common';
+import { UserStorageClient } from './user_storage_client';
+import { USER_STORAGE_SO_TYPE, USER_STORAGE_GLOBAL_SO_TYPE } from './saved_objects';
+
+const PROFILE_UID = 'profile-uid';
+
+const buildClient = (definitions: Map<string, UserStorageDefinition>) => {
+  const savedObjectsClient = savedObjectsClientMock.create();
+  const logger: MockedLogger = loggerMock.create();
+  const client = new UserStorageClient({
+    savedObjectsClient,
+    profileUid: PROFILE_UID,
+    definitions,
+    logger,
+  });
+  return { client, savedObjectsClient, logger };
+};
+
+describe('UserStorageClient.getAll()', () => {
+  it('issues a single bulkGet covering both SO types when both scopes are registered', async () => {
+    const definitions = new Map<string, UserStorageDefinition>([
+      ['space:a', { schema: z.string(), defaultValue: 'a-default', scope: 'space' }],
+      ['global:b', { schema: z.number(), defaultValue: 0, scope: 'global' }],
+    ]);
+    const { client, savedObjectsClient } = buildClient(definitions);
+
+    savedObjectsClient.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: PROFILE_UID,
+          type: USER_STORAGE_SO_TYPE,
+          references: [],
+          attributes: { userId: PROFILE_UID, data: { 'space:a': 'hello' } },
+        },
+        {
+          id: PROFILE_UID,
+          type: USER_STORAGE_GLOBAL_SO_TYPE,
+          references: [],
+          attributes: { userId: PROFILE_UID, data: { 'global:b': 7 } },
+        },
+      ] as any,
+    });
+
+    const result = await client.getAll();
+
+    expect(savedObjectsClient.bulkGet).toHaveBeenCalledTimes(1);
+    expect(savedObjectsClient.bulkGet).toHaveBeenCalledWith([
+      { type: USER_STORAGE_SO_TYPE, id: PROFILE_UID },
+      { type: USER_STORAGE_GLOBAL_SO_TYPE, id: PROFILE_UID },
+    ]);
+    expect(savedObjectsClient.get).not.toHaveBeenCalled();
+    expect(result).toEqual({ 'space:a': 'hello', 'global:b': 7 });
+  });
+
+  it('only requests the registered scope when one scope is unused', async () => {
+    const definitions = new Map<string, UserStorageDefinition>([
+      ['space:a', { schema: z.string(), defaultValue: 'a-default', scope: 'space' }],
+    ]);
+    const { client, savedObjectsClient } = buildClient(definitions);
+
+    savedObjectsClient.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: PROFILE_UID,
+          type: USER_STORAGE_SO_TYPE,
+          references: [],
+          attributes: { userId: PROFILE_UID, data: { 'space:a': 'hello' } },
+        },
+      ] as any,
+    });
+
+    await client.getAll();
+
+    expect(savedObjectsClient.bulkGet).toHaveBeenCalledTimes(1);
+    expect(savedObjectsClient.bulkGet).toHaveBeenCalledWith([
+      { type: USER_STORAGE_SO_TYPE, id: PROFILE_UID },
+    ]);
+  });
+
+  it('skips the SO request entirely when no definitions are registered', async () => {
+    const { client, savedObjectsClient } = buildClient(new Map());
+
+    const result = await client.getAll();
+
+    expect(savedObjectsClient.bulkGet).not.toHaveBeenCalled();
+    expect(savedObjectsClient.get).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+  });
+
+  it('returns defaults when bulkGet reports a missing doc via the error field', async () => {
+    const definitions = new Map<string, UserStorageDefinition>([
+      ['space:a', { schema: z.string(), defaultValue: 'a-default', scope: 'space' }],
+      ['global:b', { schema: z.number(), defaultValue: 42, scope: 'global' }],
+    ]);
+    const { client, savedObjectsClient } = buildClient(definitions);
+
+    savedObjectsClient.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: PROFILE_UID,
+          type: USER_STORAGE_SO_TYPE,
+          references: [],
+          attributes: {} as any,
+          error: {
+            error: 'Not Found',
+            message: 'Saved object [user-storage/profile-uid] not found',
+            statusCode: 404,
+          },
+        },
+        {
+          id: PROFILE_UID,
+          type: USER_STORAGE_GLOBAL_SO_TYPE,
+          references: [],
+          attributes: { userId: PROFILE_UID, data: { 'global:b': 99 } },
+        },
+      ] as any,
+    });
+
+    const result = await client.getAll();
+
+    expect(result).toEqual({ 'space:a': 'a-default', 'global:b': 99 });
+  });
+
+  it('falls back to defaults and warns when a stored value fails schema validation', async () => {
+    const definitions = new Map<string, UserStorageDefinition>([
+      ['space:a', { schema: z.string(), defaultValue: 'a-default', scope: 'space' }],
+    ]);
+    const { client, savedObjectsClient, logger } = buildClient(definitions);
+
+    savedObjectsClient.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: PROFILE_UID,
+          type: USER_STORAGE_SO_TYPE,
+          references: [],
+          attributes: { userId: PROFILE_UID, data: { 'space:a': 123 } },
+        },
+      ] as any,
+    });
+
+    const result = await client.getAll();
+
+    expect(result).toEqual({ 'space:a': 'a-default' });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][0]).toMatch(/space:a/);
+  });
+
+  it('propagates errors thrown by bulkGet itself (e.g. transport failure)', async () => {
+    const definitions = new Map<string, UserStorageDefinition>([
+      ['space:a', { schema: z.string(), defaultValue: 'a-default', scope: 'space' }],
+    ]);
+    const { client, savedObjectsClient } = buildClient(definitions);
+
+    savedObjectsClient.bulkGet.mockRejectedValue(new Error('boom'));
+
+    await expect(client.getAll()).rejects.toThrow('boom');
+  });
+});

--- a/src/core/packages/user-storage/server-internal/src/user_storage_client.ts
+++ b/src/core/packages/user-storage/server-internal/src/user_storage_client.ts
@@ -73,10 +73,27 @@ export class UserStorageClient implements IUserStorageClient {
       if (hasSpace && hasGlobal) break;
     }
 
-    const [spaceData, globalData] = await Promise.all([
-      hasSpace ? this.readSoData(USER_STORAGE_SO_TYPE) : undefined,
-      hasGlobal ? this.readSoData(USER_STORAGE_GLOBAL_SO_TYPE) : undefined,
-    ]);
+    const objectsToFetch: Array<{ type: string; id: string }> = [];
+    if (hasSpace) objectsToFetch.push({ type: USER_STORAGE_SO_TYPE, id: this.profileUid });
+    if (hasGlobal) objectsToFetch.push({ type: USER_STORAGE_GLOBAL_SO_TYPE, id: this.profileUid });
+
+    let spaceData: Record<string, unknown> | undefined;
+    let globalData: Record<string, unknown> | undefined;
+
+    if (objectsToFetch.length > 0) {
+      const { saved_objects: docs } = await this.soClient.bulkGet<UserStorageAttributes>(
+        objectsToFetch
+      );
+      for (const doc of docs) {
+        // bulkGet surfaces a missing SO via `doc.error` rather than throwing.
+        if (doc.error) continue;
+        if (doc.type === USER_STORAGE_SO_TYPE) {
+          spaceData = doc.attributes.data;
+        } else if (doc.type === USER_STORAGE_GLOBAL_SO_TYPE) {
+          globalData = doc.attributes.data;
+        }
+      }
+    }
 
     const result: Record<string, unknown> = {};
     for (const [key, definition] of this.definitions) {
@@ -156,17 +173,5 @@ export class UserStorageClient implements IUserStorageClient {
 
   private getSoType(definition: UserStorageDefinition): string {
     return definition.scope === 'space' ? USER_STORAGE_SO_TYPE : USER_STORAGE_GLOBAL_SO_TYPE;
-  }
-
-  private async readSoData(soType: string): Promise<Record<string, unknown> | undefined> {
-    try {
-      const doc = await this.soClient.get<UserStorageAttributes>(soType, this.profileUid);
-      return doc.attributes.data;
-    } catch (err) {
-      if (SavedObjectsErrorHelpers.isNotFoundError(err)) {
-        return undefined;
-      }
-      throw err;
-    }
   }
 }

--- a/src/core/packages/user-storage/server-internal/tsconfig.json
+++ b/src/core/packages/user-storage/server-internal/tsconfig.json
@@ -19,12 +19,14 @@
     "@kbn/core-http-server-internal",
     "@kbn/core-http-request-handler-context-server",
     "@kbn/core-saved-objects-api-server",
+    "@kbn/core-saved-objects-api-server-mocks",
     "@kbn/core-saved-objects-server",
     "@kbn/core-saved-objects-server-internal",
     "@kbn/core-security-server",
     "@kbn/core-security-server-internal",
     "@kbn/core-user-storage-common",
     "@kbn/core-user-storage-server",
+    "@kbn/logging-mocks",
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
## Summary

This PR implements an optimization opportunity in the `getAll` method implementation of the server side client in the UserStorage service.

* Replaces two parallel soClient.get() calls (one per scope) with a single soClient.bulkGet() request
* Deletes the readSoData helper
* Detects missing docs via doc.error instead of catching isNotFoundError.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- ~[ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
