### PR TITLE
[Agent Builder] increase followExecution idle timeout from 2 to 5 minutes

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/constants.ts
@@ -27,4 +27,4 @@ export const FOLLOW_TERMINAL_READ_RETRY_DELAY_MS = 500;
 export const FOLLOW_EXECUTION_TIMEOUT_MS = 20 * 60 * 1000; // 20 minutes
 
 /** Idle timeout (ms) for followExecution polling. If no new events are received and the execution status hasn't changed for this duration, polling is aborted. */
-export const FOLLOW_EXECUTION_IDLE_TIMEOUT_MS = 120 * 1000; // 2 minutes
+export const FOLLOW_EXECUTION_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 2 minutes

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/constants.ts
@@ -27,4 +27,4 @@ export const FOLLOW_TERMINAL_READ_RETRY_DELAY_MS = 500;
 export const FOLLOW_EXECUTION_TIMEOUT_MS = 20 * 60 * 1000; // 20 minutes
 
 /** Idle timeout (ms) for followExecution polling. If no new events are received and the execution status hasn't changed for this duration, polling is aborted. */
-export const FOLLOW_EXECUTION_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 2 minutes
+export const FOLLOW_EXECUTION_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes


### PR DESCRIPTION
## Summary

Partial backport of #263004 to 9.4.

Increases `FOLLOW_EXECUTION_IDLE_TIMEOUT_MS` from 2 minutes to 5 minutes.