### PR TITLE
[Agent Builder] Fix 2 flaky tests + smoke test config

### DIFF
--- a/.buildkite/pipelines/agent_builder/smoke_tests.yml
+++ b/.buildkite/pipelines/agent_builder/smoke_tests.yml
@@ -77,6 +77,7 @@ steps:
     env:
       FTR_GEN_AI: '1'
       FTR_EIS_CCM: '1'
+      FTR_GEN_AI_LLM_SAMPLE_SIZE: 'all'
       SCOUT_CONFIG: 'x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder_smoke/api/playwright.config.ts'
       SCOUT_CONFIG_GROUP_TYPE: 'scout-agent-builder-smoke-tests'
       SCOUT_SERVER_RUN_FLAGS: '--arch stateful --domain classic'

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/spaces_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/spaces_api.spec.ts
@@ -11,8 +11,6 @@ import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
 import type { ListAgentResponse } from '../../../../common/http_api/agents';
 import type { ListToolsResponse } from '../../../../common/http_api/tools';
-import { deleteAllAgentsFromEs } from '../../../scout_agent_builder_shared/lib/agents_kbn';
-import { CHAT_AGENTS_INDEX } from '../../../scout_agent_builder_shared/lib/constants';
 import { apiTest } from '../fixtures';
 import { API_AGENT_BUILDER } from '../fixtures/constants';
 import { spaceUrl } from '../fixtures/space_paths';
@@ -21,25 +19,26 @@ apiTest.describe(
   'Agent Builder — spaces API',
   { tag: [...tags.stateful.classic, ...tags.serverless.search] },
   () => {
+    const SPACE_1 = 'spaces-api-test-1';
+    const SPACE_2 = 'spaces-api-test-2';
+
     const testTools: Array<{ toolId: string; spaceId: string }> = [
       { toolId: 'default-tool-1', spaceId: 'default' },
       { toolId: 'default-tool-2', spaceId: 'default' },
-      { toolId: 'space1-tool-1', spaceId: 'space-1' },
-      { toolId: 'space1-tool-2', spaceId: 'space-1' },
-      { toolId: 'space2-tool-1', spaceId: 'space-2' },
+      { toolId: 'space1-tool-1', spaceId: SPACE_1 },
+      { toolId: 'space1-tool-2', spaceId: SPACE_1 },
+      { toolId: 'space2-tool-1', spaceId: SPACE_2 },
     ];
     const testAgents: Array<{ agentId: string; spaceId: string }> = [
       { agentId: 'default-agent-1', spaceId: 'default' },
       { agentId: 'default-agent-2', spaceId: 'default' },
-      { agentId: 'space1-agent-1', spaceId: 'space-1' },
-      { agentId: 'space1-agent-2', spaceId: 'space-1' },
-      { agentId: 'space2-agent-1', spaceId: 'space-2' },
+      { agentId: 'space1-agent-1', spaceId: SPACE_1 },
+      { agentId: 'space1-agent-2', spaceId: SPACE_1 },
+      { agentId: 'space2-agent-1', spaceId: SPACE_2 },
     ];
 
     apiTest.beforeAll(async ({ kbnClient, esClient }) => {
-      await deleteAllAgentsFromEs(esClient, CHAT_AGENTS_INDEX);
-
-      for (const spaceId of ['space-1', 'space-2']) {
+      for (const spaceId of [SPACE_1, SPACE_2]) {
         await kbnClient.request({
           method: 'POST',
           path: '/api/spaces/space',
@@ -94,7 +93,7 @@ apiTest.describe(
         });
       }
       await esClient.indices.delete({ index: 'spaces-test-index' });
-      for (const spaceId of ['space-1', 'space-2']) {
+      for (const spaceId of [SPACE_1, SPACE_2]) {
         await kbnClient.request({
           method: 'DELETE',
           path: `/api/spaces/space/${encodeURIComponent(spaceId)}`,
@@ -102,19 +101,56 @@ apiTest.describe(
       }
     });
 
-    for (const spaceId of ['default', 'space-1', 'space-2'] as const) {
+    // The default space is shared with other concurrent test suites,
+    // so we only verify the expected tools/agents are present (toContain).
+    apiTest('lists tools in space default', async ({ asAdmin }) => {
+      const response = await asAdmin.get(spaceUrl(`${API_AGENT_BUILDER}/tools`, 'default'), {
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      const res = response.body as ListToolsResponse;
+      const toolIds = res.results.filter((tool) => !tool.readonly).map((tool) => tool.id);
+      const expectedTools = testTools
+        .filter((tool) => tool.spaceId === 'default')
+        .map((tool) => tool.toolId);
+      for (const expected of expectedTools) {
+        expect(toolIds).toContain(expected);
+      }
+    });
+
+    apiTest('lists agents in space default', async ({ asAdmin }) => {
+      const response = await asAdmin.get(spaceUrl(`${API_AGENT_BUILDER}/agents`, 'default'), {
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      const res = response.body as ListAgentResponse;
+      const agentIds = res.results.filter((agent) => !agent.readonly).map((agent) => agent.id);
+      const expectedAgents = [
+        agentBuilderDefaultAgentId,
+        ...testAgents.filter((agent) => agent.spaceId === 'default').map((agent) => agent.agentId),
+      ];
+      for (const expected of expectedAgents) {
+        expect(agentIds).toContain(expected);
+      }
+    });
+
+    // Custom spaces are fully owned by this suite, so we can assert exact lists.
+    for (const spaceId of [SPACE_1, SPACE_2] as const) {
       apiTest(`lists tools in space ${spaceId}`, async ({ asAdmin }) => {
         const response = await asAdmin.get(spaceUrl(`${API_AGENT_BUILDER}/tools`, spaceId), {
           responseType: 'json',
         });
         expect(response).toHaveStatusCode(200);
         const res = response.body as ListToolsResponse;
-        const tools = res.results.filter((tool) => !tool.readonly);
+        const toolIds = res.results
+          .filter((tool) => !tool.readonly)
+          .map((tool) => tool.id)
+          .sort();
         const expectedTools = testTools
           .filter((tool) => tool.spaceId === spaceId)
           .map((tool) => tool.toolId)
           .sort();
-        expect(tools.map((tool) => tool.id).sort()).toStrictEqual(expectedTools);
+        expect(toolIds).toStrictEqual(expectedTools);
       });
 
       apiTest(`lists agents in space ${spaceId}`, async ({ asAdmin }) => {
@@ -123,12 +159,15 @@ apiTest.describe(
         });
         expect(response).toHaveStatusCode(200);
         const res = response.body as ListAgentResponse;
-        const agents = res.results.filter((agent) => !agent.readonly);
+        const agentIds = res.results
+          .filter((agent) => !agent.readonly)
+          .map((agent) => agent.id)
+          .sort();
         const expectedAgents = [
           agentBuilderDefaultAgentId,
           ...testAgents.filter((agent) => agent.spaceId === spaceId).map((agent) => agent.agentId),
         ].sort();
-        expect(agents.map((agent) => agent.id).sort()).toStrictEqual(expectedAgents);
+        expect(agentIds).toStrictEqual(expectedAgents);
       });
     }
   }

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/edit_agent.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/edit_agent.spec.ts
@@ -80,7 +80,11 @@ test.describe(
         await page.testSubj
           .locator('agentBuilderAgentsListPageTitle')
           .waitFor({ state: 'visible' });
-        expect(await pageObjects.agentBuilder.getAgentRowDisplayName(agent.id)).toBe(editedName);
+        // The list page renders before React-Query's background refetch lands, so
+        // the row can briefly show the previous name. Poll until the refresh hits.
+        await expect(async () => {
+          expect(await pageObjects.agentBuilder.getAgentRowDisplayName(agent.id)).toBe(editedName);
+        }).toPass({ timeout: 30_000 });
       });
 
       await test.step('clones agent', async () => {


### PR DESCRIPTION
Closes #268260
Closes #268247

## Summary

Fixes two flaky Agent Builder Scout tests and ensures the daily smoke pipeline exercises all connectors.

**spaces_api.spec.ts** — The `default` space is shared with other concurrent test suites, so asserting exact agent/tool lists caused intermittent failures. Now uses unique space IDs (`spaces-api-test-1/2`), asserts `toContain` for the default space and exact lists only for spaces fully owned by this suite. Also removes the global `deleteAllAgentsFromEs` call that wiped agents across suites.

**edit_agent.spec.ts** — After renaming an agent the list page can briefly show the old name until React Query's background refetch lands. Wraps the assertion in `expect().toPass()` to poll until the updated name appears.

**smoke_tests.yml** — Adds `FTR_GEN_AI_LLM_SAMPLE_SIZE: 'all'` so the daily smoke run exercises every connector instead of a random subset.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [NA] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [NA] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [NA] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [NA] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [NA] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

No risks — test-only changes and a CI config tweak.