### PR TITLE
[scout] fix cleanup in SO managerment find test

### DIFF
--- a/src/platform/plugins/shared/saved_objects_management/test/scout/api/tests/find_basic.spec.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/api/tests/find_basic.spec.ts
@@ -19,6 +19,7 @@ apiTest.describe('find - basic', { tag: tags.deploymentAgnostic }, () => {
 
   apiTest.beforeAll(async ({ requestAuth, kbnClient }) => {
     adminCredentials = await requestAuth.getApiKey('viewer');
+    await kbnClient.savedObjects.cleanStandardList();
     await kbnClient.importExport.load(KBN_ARCHIVES.BASIC);
   });
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/268021

Cleaning saved objects in `beforeAll` hook to cleanup env as test expects it to be.






<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->