### PR TITLE
[Dashboards] [Docs] Add known issue action for dashboards not loading in 9.4.0.

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -16,9 +16,15 @@ Applies to: {{stack}} 9.4.0
 
 Some existing dashboards are failing to load when a pinned control has `"title": null` in the saved object. This manifests as an error like `Invalid response. [pinned_panels.0.config.title]: expected value of type [string] but got [null].` error on the dashboard app.
 
-**Workaround**
+**Action**
 
-We're working on a way to mitigate the issue and will update this page shortly.
+If you have existing dashboards with controls, do not upgrade to {{stack}} 9.4.0. Upgrade to {{stack}} 9.4.1 when it becomes available.
+
+If you already upgraded to {{stack}} 9.4.0 and dashboards fail to open with this error, contact Elastic Support for remediation guidance.
+
+**Fix**
+
+A fix is planned for {{stack}} 9.4.1.
 
 ::::
 


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/268191 
Related to https://github.com/elastic/kibana/issues/268172

## Summary 

Adds a known issue action to release notes for dashboards that may not be loading in 9.4.0.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->