### PR TITLE
Two small follow-ups for the vectordb project type

### DIFF
--- a/src/platform/packages/shared/content-management/access_control/access_control_public/src/components/access_mode_container.tsx
+++ b/src/platform/packages/shared/content-management/access_control/access_control_public/src/components/access_mode_container.tsx
@@ -56,6 +56,7 @@ const getSpaceIcon = (space: Space['solution']) => {
   switch (space) {
     case 'es':
     case 'workplaceai':
+    case 'vectordb':
       return 'logoElasticsearch';
     case 'security':
       return 'logoSecurity';

--- a/src/platform/packages/shared/kbn-mcp-dev-server/src/tools/generate_package.ts
+++ b/src/platform/packages/shared/kbn-mcp-dev-server/src/tools/generate_package.ts
@@ -20,7 +20,7 @@ const generatePackageInputSchema = z.object({
     .describe(
       'The owning Github team of the package. Use list_teams before this to find the appropriate owner'
     ),
-  group: z.enum(['workplaceai', 'search', 'observability', 'security', 'platform']),
+  group: z.enum(['vectordb', 'workplaceai', 'search', 'observability', 'security', 'platform']),
 });
 
 async function generatePackage(input: z.infer<typeof generatePackageInputSchema>): Promise<string> {


### PR DESCRIPTION
## Summary

- Add `'vectordb'` to the `getSpaceIcon` switch in `access_mode_container.tsx` so vectordb spaces render the `logoElasticsearch` icon (matches the existing mapping in `space_solution_badge/badge.tsx`).
- Add `'vectordb'` to the `--group` enum in the `kbn-mcp-dev-server` `generate_package` tool so packages can be scaffolded for the VectorDB solution.

Closes elastic/kibana-team#3357
Closes elastic/kibana-team#3358

## Test plan

- [ ] Verify a vectordb space shows the Elasticsearch logo in the access-mode badge.
- [ ] Verify `generate_kibana_package` accepts `--group vectordb` via the MCP dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)