### PR TITLE
[ResponseOps] Connector list redesign follow up fix

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
@@ -247,6 +247,7 @@ const ActionsConnectorsList = ({
       ),
       sortable: false,
       truncateText: true,
+      width: '25%',
       render: (value: string, item: ActionConnectorTableItem) => {
         const checkEnabledResult = checkActionTypeEnabled(
           actionTypesIndex && actionTypesIndex[item.actionTypeId],
@@ -465,6 +466,7 @@ const ActionsConnectorsList = ({
     },
     {
       name: '',
+      width: '300px',
       render: (item: ActionConnectorTableItem) => {
         if (!actionTypesIndex || !actionTypesIndex[item.actionTypeId]) {
           return null;
@@ -475,7 +477,7 @@ const ActionsConnectorsList = ({
         const isStackConnector = actionType.source === ACTION_TYPE_SOURCES.stack;
 
         return (
-          <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
+          <EuiFlexGroup justifyContent="flexEnd" alignItems="center" responsive={false}>
             {usesOAuthAuthorizationCode(item) && !isDisabledEarsConnector(item) && (
               <>
                 {connectorAuthStatusError ? (
@@ -545,6 +547,7 @@ const ActionsConnectorsList = ({
       loading={isLoadingActions || isLoadingActionTypes}
       items={actionConnectorTableItems}
       sorting={true}
+      tableLayout="fixed"
       itemId={(item: ActionConnectorTableItem) =>
         item.isPreconfigured ? `preconfigured_${item.id}` : item.id
       }


### PR DESCRIPTION
## Summary
Fixed the following issue in which the actions button overflowed the table (or were not visible at all) when the viewport is narrowed
<img width="2750" height="908" alt="Screenshot 2026-05-07 at 16 21 01 (1)" src="https://github.com/user-attachments/assets/f4181b19-d57f-4efb-95e0-7f131709d3d8" />




