### PR TITLE
[WIP] skipFetchFields on ES|QL dataview

### DIFF
--- a/src/platform/packages/shared/kbn-data-view-utils/src/utils/convert_to_data_view_field_spec.ts
+++ b/src/platform/packages/shared/kbn-data-view-utils/src/utils/convert_to_data_view_field_spec.ts
@@ -33,7 +33,8 @@ export function convertDatatableColumnToDataViewFieldSpec(column: DatatableColum
     searchable: true,
     aggregatable: false,
     isNull: Boolean(column?.isNull),
-    isComputedColumn: true,
+    // Use the column's isComputedColumn property if set, otherwise default to true for backward compatibility
+    isComputedColumn: column.isComputedColumn ?? true,
     ...(timeSeriesMetric ? { timeSeriesMetric } : {}),
   };
 }

--- a/src/platform/packages/shared/kbn-data-view-utils/src/utils/get_data_view_field_or_create.ts
+++ b/src/platform/packages/shared/kbn-data-view-utils/src/utils/get_data_view_field_or_create.ts
@@ -12,6 +12,10 @@ import type { DataView } from '@kbn/data-views-plugin/public';
 import type { DatatableColumnMeta } from '@kbn/expressions-plugin/common';
 import { convertDatatableColumnToDataViewFieldSpec } from './convert_to_data_view_field_spec';
 
+export interface ColumnMetaWithComputedInfo extends DatatableColumnMeta {
+  isComputedColumn?: boolean;
+}
+
 export const getDataViewFieldOrCreateFromColumnMeta = ({
   dataView,
   fieldName,
@@ -19,7 +23,7 @@ export const getDataViewFieldOrCreateFromColumnMeta = ({
 }: {
   dataView: DataView;
   fieldName: string;
-  columnMeta?: DatatableColumnMeta; // based on ES|QL query
+  columnMeta?: ColumnMetaWithComputedInfo; // based on ES|QL query
 }) => {
   const dataViewField = dataView.fields.getByName(fieldName);
 
@@ -31,6 +35,7 @@ export const getDataViewFieldOrCreateFromColumnMeta = ({
     name: fieldName,
     id: fieldName,
     meta: columnMeta,
+    isComputedColumn: columnMeta.isComputedColumn,
   });
 
   if (

--- a/src/platform/packages/shared/kbn-discover-utils/src/types.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/types.ts
@@ -58,6 +58,7 @@ export type DataTableColumnsMeta = Record<
   {
     type: DatatableColumnMeta['type'];
     esType?: DatatableColumnMeta['esType'];
+    isComputedColumn?: boolean;
   }
 >;
 

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/get_esql_data_view.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/get_esql_data_view.ts
@@ -44,6 +44,7 @@ export async function getEsqlDataView(
         // otherwise a single mutated data view instance would be used across tabs (inside currentDataView$) which would be incorrect
         // https://github.com/elastic/kibana/issues/234719
         createNewInstanceEvenIfCachedOneAvailable: !currentDataView || onlyTimeFieldChanged,
+        skipFetchFields: true,
       },
       http: services.http,
     });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.test.ts
@@ -78,7 +78,7 @@ describe('getInitialESQLQuery', () => {
         filterable: false,
       },
     ] as DataView['fields'];
-    const dataView = getDataView('logs*', fields, 'timestamp');
+    const dataView = getDataView('logs*', fields, '@timestamp');
     expect(getInitialESQLQuery(dataView)).toBe('FROM logs*');
   });
 
@@ -151,7 +151,7 @@ describe('getInitialESQLQuery', () => {
         filterable: false,
       },
     ] as DataView['fields'];
-    const dataView = getDataView('logs*', fields, 'timestamp');
+    const dataView = getDataView('logs*', fields, '@timestamp');
     expect(getInitialESQLQuery(dataView, { language: 'lucene', query: 'error' })).toBe(
       'FROM logs* | WHERE QSTR("""error""")'
     );
@@ -176,7 +176,7 @@ describe('getInitialESQLQuery', () => {
         filterable: false,
       },
     ] as DataView['fields'];
-    const dataView = getDataView('logs*', fields, 'timestamp');
+    const dataView = getDataView('logs*', fields, '@timestamp');
     expect(getInitialESQLQuery(dataView, { language: 'unknown', query: 'error' })).toBe(
       'FROM logs*'
     );

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_initial_esql_query.ts
@@ -34,7 +34,7 @@ const getFinalWhereClause = (
  * @param filters - DSL filters to convert to ES|QL WHERE clauses
  */
 export function getInitialESQLQuery(dataView: DataView, query?: Query, filters?: Filter[]): string {
-  const hasAtTimestampField = dataView?.fields?.getByName?.('@timestamp')?.type === 'date';
+  const hasAtTimestampField = dataView?.timeFieldName === '@timestamp';
   const timeFieldName = dataView?.timeFieldName;
   const filterByTimeParams =
     !hasAtTimestampField && timeFieldName

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/compare_documents.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/compare_documents.tsx
@@ -18,7 +18,7 @@ import type {
 } from '@elastic/eui';
 import { EuiDataGrid, useGeneratedHtmlId } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import type { DataTableRecord } from '@kbn/discover-utils/types';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils/types';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { memoize } from 'lodash';
 import React, { useMemo, useState } from 'react';
@@ -45,6 +45,7 @@ export interface CompareDocumentsProps {
   forceShowAllFields: boolean;
   showFullScreenButton?: boolean;
   fieldFormats: FieldFormatsStart;
+  columnsMeta?: DataTableColumnsMeta;
   getDocById: (id: string) => DataTableRecord | undefined;
   replaceSelectedDocs: (docIds: string[]) => void;
   setIsCompareActive: (isCompareActive: boolean) => void;
@@ -74,6 +75,7 @@ const CompareDocuments = ({
   forceShowAllFields,
   showFullScreenButton,
   fieldFormats,
+  columnsMeta,
   getDocById,
   replaceSelectedDocs,
   setIsCompareActive,
@@ -195,6 +197,7 @@ const CompareDocuments = ({
     diffMode: showDiff ? diffMode : undefined,
     fieldFormats,
     getDocById: memoizedGetDocById,
+    columnsMeta,
   });
   const comparisonCss = useComparisonCss({
     diffMode: showDiff ? diffMode : undefined,

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_cell_value.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_cell_value.tsx
@@ -11,9 +11,9 @@ import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import { formatFieldValueReact } from '@kbn/discover-utils';
-import type { DataTableRecord } from '@kbn/discover-utils/types';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils/types';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
-import { getFieldIconProps } from '@kbn/field-utils';
+import { getFieldIconProps, getTextBasedColumnIconType } from '@kbn/field-utils';
 import { FieldIcon } from '@kbn/react-field';
 import classNames from 'classnames';
 import { isEqual, memoize } from 'lodash';
@@ -40,6 +40,7 @@ export interface UseComparisonCellValueProps {
   diffMode: DocumentDiffMode | undefined;
   fieldFormats: FieldFormatsStart;
   getDocById: (id: string) => DataTableRecord | undefined;
+  columnsMeta?: DataTableColumnsMeta;
 }
 
 export const useComparisonCellValue = ({
@@ -50,6 +51,7 @@ export const useComparisonCellValue = ({
   diffMode,
   fieldFormats,
   getDocById,
+  columnsMeta,
 }: UseComparisonCellValueProps) => {
   const baseDocId = selectedDocIds[0];
   const baseDoc = useMemo(() => getDocById(baseDocId)?.flattened, [baseDocId, getDocById]);
@@ -67,6 +69,7 @@ export const useComparisonCellValue = ({
           diffMode={diffMode}
           fieldFormats={fieldFormats}
           getDocById={getDocById}
+          columnsMeta={columnsMeta}
           {...props}
         />
       </DiffProvider>
@@ -75,6 +78,7 @@ export const useComparisonCellValue = ({
       baseDoc,
       baseDocId,
       calculateDiffMemoized,
+      columnsMeta,
       comparisonFields,
       dataView,
       diffMode,
@@ -89,17 +93,21 @@ type CellValueProps = Omit<UseComparisonCellValueProps, 'selectedDocIds'> &
   EuiDataGridCellValueElementProps & {
     baseDocId: string;
     baseDoc: DataTableRecord['flattened'] | undefined;
+    columnsMeta?: DataTableColumnsMeta;
   };
 
 const EMPTY_VALUE = '-';
 
 const CellValue = (props: CellValueProps) => {
-  const { dataView, comparisonFields, fieldColumnId, rowIndex, columnId, getDocById } = props;
+  const { dataView, comparisonFields, fieldColumnId, rowIndex, columnId, getDocById, columnsMeta } =
+    props;
   const fieldName = comparisonFields[rowIndex];
   const field = useMemo(() => dataView.fields.getByName(fieldName), [dataView.fields, fieldName]);
   const comparisonDoc = useMemo(() => getDocById(columnId), [columnId, getDocById]);
   if (columnId === fieldColumnId) {
-    return <FieldCellValue field={field} fieldName={fieldName} />;
+    return (
+      <FieldCellValue field={field} fieldName={fieldName} columnMeta={columnsMeta?.[fieldName]} />
+    );
   }
 
   if (!comparisonDoc) {
@@ -114,16 +122,21 @@ const CellValue = (props: CellValueProps) => {
 interface FieldCellValueProps {
   field: DataViewField | undefined;
   fieldName: string;
+  columnMeta?: DataTableColumnsMeta[string];
 }
 
-const FieldCellValue = ({ field, fieldName }: FieldCellValueProps) => {
+const FieldCellValue = ({ field, fieldName, columnMeta }: FieldCellValueProps) => {
+  const iconNode = useMemo(() => {
+    if (field) {
+      return <FieldIcon {...getFieldIconProps(field)} />;
+    }
+    const iconType = columnMeta ? getTextBasedColumnIconType(columnMeta) : undefined;
+    return <FieldIcon type={iconType ?? 'unknown'} />;
+  }, [field, columnMeta]);
+
   return (
     <EuiFlexGroup responsive={false} gutterSize="s">
-      {field && (
-        <EuiFlexItem grow={false}>
-          <FieldIcon {...getFieldIconProps(field)} />
-        </EuiFlexItem>
-      )}
+      {iconNode && <EuiFlexItem grow={false}>{iconNode}</EuiFlexItem>}
       <EuiFlexItem>
         <EuiText
           size="relative"

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_cell_value.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_cell_value.tsx
@@ -10,10 +10,11 @@
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
+import { getDataViewFieldOrCreateFromColumnMeta } from '@kbn/data-view-utils';
 import { formatFieldValueReact } from '@kbn/discover-utils';
 import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils/types';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
-import { getFieldIconProps, getTextBasedColumnIconType } from '@kbn/field-utils';
+import { getFieldIconProps } from '@kbn/field-utils';
 import { FieldIcon } from '@kbn/react-field';
 import classNames from 'classnames';
 import { isEqual, memoize } from 'lodash';
@@ -102,12 +103,18 @@ const CellValue = (props: CellValueProps) => {
   const { dataView, comparisonFields, fieldColumnId, rowIndex, columnId, getDocById, columnsMeta } =
     props;
   const fieldName = comparisonFields[rowIndex];
-  const field = useMemo(() => dataView.fields.getByName(fieldName), [dataView.fields, fieldName]);
+  const field = useMemo(
+    () =>
+      getDataViewFieldOrCreateFromColumnMeta({
+        dataView,
+        fieldName,
+        columnMeta: columnsMeta?.[fieldName],
+      }),
+    [dataView, fieldName, columnsMeta]
+  );
   const comparisonDoc = useMemo(() => getDocById(columnId), [columnId, getDocById]);
   if (columnId === fieldColumnId) {
-    return (
-      <FieldCellValue field={field} fieldName={fieldName} columnMeta={columnsMeta?.[fieldName]} />
-    );
+    return <FieldCellValue field={field} fieldName={fieldName} />;
   }
 
   if (!comparisonDoc) {
@@ -122,17 +129,12 @@ const CellValue = (props: CellValueProps) => {
 interface FieldCellValueProps {
   field: DataViewField | undefined;
   fieldName: string;
-  columnMeta?: DataTableColumnsMeta[string];
 }
 
-const FieldCellValue = ({ field, fieldName, columnMeta }: FieldCellValueProps) => {
+const FieldCellValue = ({ field, fieldName }: FieldCellValueProps) => {
   const iconNode = useMemo(() => {
-    if (field) {
-      return <FieldIcon {...getFieldIconProps(field)} />;
-    }
-    const iconType = columnMeta ? getTextBasedColumnIconType(columnMeta) : undefined;
-    return <FieldIcon type={iconType ?? 'unknown'} />;
-  }, [field, columnMeta]);
+    return field ? <FieldIcon {...getFieldIconProps(field)} /> : <FieldIcon type="unknown" />;
+  }, [field]);
 
   return (
     <EuiFlexGroup responsive={false} gutterSize="s">

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_fields.test.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_fields.test.ts
@@ -147,4 +147,57 @@ describe('useComparisonFields', () => {
     expect(comparisonFields).toHaveLength(fields.length - overflow);
     expect(totalFields).toBe(fields.length);
   });
+
+  it('should extract fields from documents when dataView.fields is empty (ES|QL mode)', () => {
+    const dataViewWithNoFields = buildDataViewMock({
+      name: 'esql-data-view',
+      fields: fieldList([]),
+      timeFieldName: '@timestamp',
+    });
+    const docs = [
+      buildDataTableRecord(
+        {
+          _index: 'test',
+          _id: '0',
+          fields: {
+            '@timestamp': ['2024-01-01T00:00:00Z'],
+            message: ['test message 0'],
+            'host.name': ['host-0'],
+          },
+        },
+        dataViewWithNoFields
+      ),
+      buildDataTableRecord(
+        {
+          _index: 'test',
+          _id: '1',
+          fields: {
+            '@timestamp': ['2024-01-01T00:00:01Z'],
+            message: ['test message 1'],
+            'host.name': ['host-1'],
+            status: ['ok'],
+          },
+        },
+        dataViewWithNoFields
+      ),
+    ];
+    const getDocById = (id: string) => docs.find((doc) => doc.raw._id === id);
+    const {
+      result: {
+        current: { comparisonFields, totalFields },
+      },
+    } = renderHook(() =>
+      useComparisonFields({
+        dataView: dataViewWithNoFields,
+        selectedFieldNames: ['message'],
+        selectedDocIds: ['0', '1'],
+        showAllFields: true,
+        showMatchingValues: true,
+        getDocById,
+      })
+    );
+    // Should include @timestamp first, then other fields alphabetically extracted from documents
+    expect(comparisonFields).toEqual(['@timestamp', '_index', 'host.name', 'message', 'status']);
+    expect(totalFields).toBe(5);
+  });
 });

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_fields.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_fields.ts
@@ -43,22 +43,29 @@ export const useComparisonFields = ({
   }, [getDocById, selectedDocIds]);
 
   return useMemo(() => {
+    const hasFieldValue = (fieldName: string) =>
+      baseDoc?.flattened[fieldName] != null ||
+      comparisonDocs.some((doc) => doc.flattened[fieldName] != null);
+
     let comparisonFields = selectedFieldNames;
 
     if (showAllFields) {
-      const sortedFields = dataView.fields
-        .filter((field) => {
-          if (field.name === dataView.timeFieldName) {
-            return false;
-          }
+      const dataViewFields = dataView.fields.getAll();
+      const useDataViewFields = dataViewFields.length > 0;
 
-          return (
-            baseDoc?.flattened[field.name] != null ||
-            comparisonDocs.some((doc) => doc.flattened[field.name] != null)
-          );
-        })
+      // Get field names from data view fields or extract from documents (ES|QL fallback)
+      const fieldEntries: Array<{ name: string; displayName: string }> = useDataViewFields
+        ? dataViewFields.map((field) => ({ name: field.name, displayName: field.displayName }))
+        : [
+            ...new Set(
+              [baseDoc, ...comparisonDocs].flatMap((doc) => Object.keys(doc?.flattened ?? {}))
+            ),
+          ].map((name) => ({ name, displayName: name }));
+
+      const sortedFields = fieldEntries
+        .filter(({ name }) => name !== dataView.timeFieldName && hasFieldValue(name))
         .sort((a, b) => a.displayName.localeCompare(b.displayName))
-        .map((field) => field.name);
+        .map(({ name }) => name);
 
       comparisonFields = dataView.isTimeBased()
         ? [dataView.timeFieldName, ...sortedFields]

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -1432,6 +1432,7 @@ const InternalUnifiedDataTable = React.forwardRef<
                 forceShowAllFields={defaultColumns}
                 showFullScreenButton={showFullScreenButton}
                 fieldFormats={fieldFormats}
+                columnsMeta={columnsMeta}
                 getDocById={getDocById}
                 replaceSelectedDocs={replaceSelectedDocs}
                 setIsCompareActive={setIsCompareActive}

--- a/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_columns_meta.test.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_columns_meta.test.ts
@@ -39,17 +39,51 @@ describe('getColumnTypes', () => {
       expect(result).toMatchInlineSnapshot(`
         Object {
           "@timestamp": Object {
+            "esType": undefined,
+            "isComputedColumn": undefined,
             "type": "date",
           },
           "agent.keyword": Object {
             "esType": "keyword",
+            "isComputedColumn": undefined,
             "type": "string",
           },
           "bytes": Object {
+            "esType": undefined,
+            "isComputedColumn": undefined,
             "type": "number",
           },
         }
       `);
+    });
+
+    test('preserves isComputedColumn property', async () => {
+      const result = getTextBasedColumnsMeta([
+        {
+          id: 'category',
+          name: 'category',
+          meta: { type: 'string', esType: 'keyword' },
+          isComputedColumn: false, // Grouping field from BY clause
+        },
+        {
+          id: 'avg_price',
+          name: 'avg_price',
+          meta: { type: 'number' },
+          isComputedColumn: true, // Computed aggregation
+        },
+      ]);
+      expect(result).toEqual({
+        category: {
+          type: 'string',
+          esType: 'keyword',
+          isComputedColumn: false,
+        },
+        avg_price: {
+          type: 'number',
+          esType: undefined,
+          isComputedColumn: true,
+        },
+      });
     });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_columns_meta.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_columns_meta.ts
@@ -7,9 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DatatableColumn, DatatableColumnMeta } from '@kbn/expressions-plugin/common';
-
-type TextBasedColumnTypes = Record<string, DatatableColumnMeta>;
+import type { DataTableColumnsMeta } from '@kbn/discover-utils';
+import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 
 /**
  * Columns meta for text based searches
@@ -17,9 +16,13 @@ type TextBasedColumnTypes = Record<string, DatatableColumnMeta>;
  */
 export const getTextBasedColumnsMeta = (
   textBasedColumns: DatatableColumn[]
-): TextBasedColumnTypes => {
-  return textBasedColumns.reduce<TextBasedColumnTypes>((map, next) => {
-    map[next.name] = next.meta;
+): DataTableColumnsMeta => {
+  return textBasedColumns.reduce<DataTableColumnsMeta>((map, next) => {
+    map[next.name] = {
+      type: next.meta.type,
+      esType: next.meta.esType,
+      isComputedColumn: next.isComputedColumn,
+    };
     return map;
   }, {});
 };

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_edit_visualization.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_edit_visualization.ts
@@ -36,7 +36,7 @@ export const useEditVisualization = ({
     if (!dataView.id || isPlainRecord) {
       return false;
     }
-    if (!dataView.isTimeBased() || !dataView.getTimeField().visualizable) {
+    if (!dataView.isTimeBased() || !dataView.getTimeField()?.visualizable) {
       return false;
     }
 

--- a/src/platform/plugins/shared/data/common/query/timefilter/get_time.ts
+++ b/src/platform/plugins/shared/data/common/query/timefilter/get_time.ts
@@ -80,7 +80,7 @@ export function getRelativeTime(
 }
 
 function getTimeField(indexPattern?: DataView, fieldName?: string) {
-  if (!indexPattern && fieldName) {
+  if ((!indexPattern || !indexPattern.fields.length) && fieldName) {
     return { name: fieldName, type: KBN_FIELD_TYPES.DATE };
   }
 

--- a/src/platform/plugins/shared/data_views/common/data_views/data_view.ts
+++ b/src/platform/plugins/shared/data_views/common/data_views/data_view.ts
@@ -46,7 +46,7 @@ export interface TimeBasedDataView extends DataView {
   /**
    * The timestamp field.
    */
-  getTimeField: () => DataViewField;
+  getTimeField: () => DataViewField | undefined;
 }
 
 /**
@@ -231,7 +231,7 @@ export class DataView extends AbstractDataView implements DataViewBase {
    */
 
   isTimeBased(): this is TimeBasedDataView {
-    return !!this.timeFieldName && (!this.fields || !!this.getTimeField());
+    return !!this.timeFieldName && (this.fields?.length === 0 || !!this.getTimeField());
   }
 
   /**

--- a/src/platform/plugins/shared/discover/public/application/main/components/no_results/no_results_suggestions/no_results_suggestions.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/no_results/no_results_suggestions/no_results_suggestions.tsx
@@ -14,6 +14,7 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import { isOfQueryType, type Query, type AggregateQuery, type Filter } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { ESQL_TYPE } from '@kbn/data-view-utils';
 import { NoResultsSuggestionDefault } from './no_results_suggestion_default';
 import type { NoResultsSuggestionWhenFiltersProps } from './no_results_suggestion_when_filters';
 import { NoResultsSuggestionWhenFilters } from './no_results_suggestion_when_filters';
@@ -88,7 +89,10 @@ export const NoResultsSuggestions: React.FC<NoResultsSuggestionProps> = ({
     }
   }, [fetch, setTimeRangeExtendingStatus, timefilter, toastNotifications]);
 
-  const canAdjustSearchCriteria = isTimeBased || hasFilters || hasQuery;
+  const canSuggestTimeRangeAdjustments =
+    (dataView.type === ESQL_TYPE && isTimeBased) || (isTimeBased && dataView.getTimeField());
+
+  const canAdjustSearchCriteria = canSuggestTimeRangeAdjustments || hasFilters || hasQuery;
 
   const body = canAdjustSearchCriteria ? (
     <>
@@ -102,7 +106,7 @@ export const NoResultsSuggestions: React.FC<NoResultsSuggestionProps> = ({
           display: inline-block;
         `}
       >
-        {isTimeBased && (
+        {canSuggestTimeRangeAdjustments && (
           <li>
             <NoResultsSuggestionWhenTimeRange timeRangeExtendingStatus={timeRangeExtendingStatus} />
           </li>

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_state_data_view.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_state_data_view.ts
@@ -15,6 +15,7 @@ import {
   SORT_DEFAULT_ORDER_SETTING,
   DEFAULT_COLUMNS_SETTING,
 } from '@kbn/discover-utils';
+import { ESQL_TYPE } from '@kbn/data-view-utils';
 import {
   internalStateSlice,
   type TabActionPayload,
@@ -91,7 +92,11 @@ export const changeDataView: InternalStateThunkActionCreator<
       // If nextDataView is an ad hoc data view with no fields, refresh its field list.
       // This can happen when default profile data views are created without fields
       // to avoid unnecessary requests on startup.
-      if (!nextDataView.isPersisted() && !nextDataView.fields.length) {
+      if (
+        !nextDataView.isPersisted() &&
+        !nextDataView.fields.length &&
+        nextDataView.type !== ESQL_TYPE
+      ) {
         await dataViews.refreshFields(nextDataView);
       }
     } catch (e) {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/default_profile_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/default_profile_state.test.ts
@@ -21,9 +21,15 @@ import {
   getFieldsToReset,
   getProfileStateSnapshot,
 } from './default_profile_state';
+import { ESQL_TYPE } from '@kbn/data-view-utils';
 
 const emptyDataView = buildDataViewMock({
   name: 'emptyDataView',
+  fields: fieldList(),
+});
+const emptyESQLDataView = buildDataViewMock({
+  name: 'emptyESQLDataView',
+  type: ESQL_TYPE,
   fields: fieldList(),
 });
 const { profilesManagerMock, scopedEbtManagerMock } = createContextAwarenessMocks();
@@ -66,6 +72,17 @@ describe('getDefaultProfileState', () => {
       }).getPreFetchState();
 
       expect(appStateWithoutBreakdownField).toBeUndefined();
+    });
+
+    it('should return breakdownField in ES|QL mode even with empty data view', () => {
+      const appState = getDefaultProfileState({
+        scopedProfilesManager,
+        defaultProfileState: createDefaultProfileState(['breakdownField']),
+        dataView: emptyESQLDataView,
+      }).getPreFetchState();
+      expect(appState).toEqual({
+        breakdownField: 'extension',
+      });
     });
 
     it('should return expected hideChart', () => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/default_profile_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/default_profile_state.ts
@@ -10,6 +10,7 @@
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DiscoverGridSettings } from '@kbn/saved-search-plugin/common';
 import { pick, uniqBy } from 'lodash';
+import { ESQL_TYPE } from '@kbn/data-view-utils';
 import {
   type DiscoverAppState,
   DEFAULT_PROFILE_STATE_FIELDS,
@@ -44,10 +45,15 @@ export const getDefaultProfileState = ({
 
       if (
         shouldResetDefaultProfileField(defaultProfileState, 'breakdownField') &&
-        defaultState.breakdownField !== undefined &&
-        dataView.fields.getByName(defaultState.breakdownField)
+        defaultState.breakdownField !== undefined
       ) {
-        stateUpdate.breakdownField = defaultState.breakdownField;
+        // In ES|QL mode, we skip validation since the data view may not have fields
+        // (skipFetchFields: true) and columns are determined by the query result
+        const isValidBreakdownField =
+          dataView.type === ESQL_TYPE || dataView.fields.getByName(defaultState.breakdownField);
+        if (isValidBreakdownField) {
+          stateUpdate.breakdownField = defaultState.breakdownField;
+        }
       }
 
       if (

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/resolve_data_view.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/resolve_data_view.ts
@@ -232,7 +232,8 @@ export const loadAndResolveDataView = async ({
   // If dataView is an ad hoc data view with no fields, refresh its field list.
   // This can happen when default profile data views are created without fields
   // to avoid unnecessary requests on startup.
-  if (!dataView.isPersisted() && !dataView.fields.length) {
+  // ES|QL dataviews never have fields.
+  if (!dataView.isPersisted() && !dataView.fields.length && !isEsqlMode) {
     await dataViews.refreshFields(dataView);
   }
 

--- a/src/platform/plugins/shared/discover/public/components/data_types/logs/service_name_cell.tsx
+++ b/src/platform/plugins/shared/discover/public/components/data_types/logs/service_name_cell.tsx
@@ -21,6 +21,7 @@ import {
 } from '@kbn/discover-utils';
 import { extractTextFromReactNode } from '@kbn/discover-contextual-components/src/data_types/logs/components/utils';
 import { FieldBadgeWithActions } from '@kbn/discover-contextual-components/src/data_types/logs/components/cell_actions_popover';
+import { getDataViewFieldOrCreateFromColumnMeta } from '@kbn/data-view-utils';
 import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import type { CellRenderersExtensionParams } from '../../../context_awareness';
 import { AGENT_NAME_FIELD } from '../../../../common/data_types/logs/constants';
@@ -37,7 +38,11 @@ export const getServiceNameCell =
   (props: DataGridCellValueElementProps) => {
     const { core, share } = useDiscoverServices();
     const serviceNameValue = getFieldValue(props.row, serviceNameField);
-    const field = props.dataView.getFieldByName(serviceNameField);
+    const field = getDataViewFieldOrCreateFromColumnMeta({
+      dataView: props.dataView,
+      fieldName: serviceNameField,
+      columnMeta: props.columnsMeta?.[serviceNameField],
+    });
     const agentName = getFieldValue(props.row, AGENT_NAME_FIELD) as AgentName;
     const otelSdkLanguage = getFieldValue(
       props.row,

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -45,11 +45,11 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = React.memo(
     onFullScreenChange,
     ...props
   }) => {
-    const { dataView, setExpandedDoc, renderDocumentView } = props;
+    const { dataView, columnsMeta, setExpandedDoc, renderDocumentView } = props;
     const getRowIndicatorProvider = useProfileAccessor('getRowIndicatorProvider');
     const getRowIndicator = useMemo(() => {
-      return getRowIndicatorProvider(() => undefined)({ dataView: props.dataView });
-    }, [getRowIndicatorProvider, props.dataView]);
+      return getRowIndicatorProvider(() => undefined)({ dataView, columnsMeta });
+    }, [getRowIndicatorProvider, dataView, columnsMeta]);
 
     const getRowAdditionalLeadingControlsAccessor = useProfileAccessor(
       'getRowAdditionalLeadingControls'

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/accessors/get_row_indicator_provider.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/accessors/get_row_indicator_provider.ts
@@ -19,9 +19,13 @@ import type { DataSourceProfileProvider } from '../../../../profiles';
 export const getRowIndicatorProvider: DataSourceProfileProvider['profile']['getRowIndicatorProvider'] =
 
     () =>
-    ({ dataView }) => {
-      // Check if the data view has any of the log level fields.
-      if (!LOG_LEVEL_FIELDS.some((field) => dataView.getFieldByName(field))) {
+    ({ dataView, columnsMeta }) => {
+      // Check if the data view or ES|QL columns have any of the log level fields.
+      const hasLogLevelField = LOG_LEVEL_FIELDS.some(
+        (field) => dataView.getFieldByName(field) || columnsMeta?.[field]
+      );
+
+      if (!hasLogLevelField) {
         // Otherwise, don't set the row indicator color so the color indicator control column is not added to the grid at all.
         return undefined;
       }

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.test.ts
@@ -162,6 +162,7 @@ describe('logsDataSourceProfileProvider', () => {
         });
       const getRowIndicator = getRowIndicatorProvider?.({
         dataView: dataViewWithLogLevel,
+        columnsMeta: undefined,
       });
 
       expect(getRowIndicator).toBeDefined();
@@ -177,6 +178,7 @@ describe('logsDataSourceProfileProvider', () => {
         });
       const getRowIndicator = getRowIndicatorProvider?.({
         dataView: dataViewWithLogLevel,
+        columnsMeta: undefined,
       });
 
       expect(getRowIndicator).toBeDefined();
@@ -190,10 +192,29 @@ describe('logsDataSourceProfileProvider', () => {
         });
       const getRowIndicator = getRowIndicatorProvider?.({
         dataView: dataViewWithoutLogLevel,
+        columnsMeta: undefined,
       });
 
       expect(getRowIndicator).toBeUndefined();
     });
+  });
+
+  it('should set the color indicator handler if columnsMeta has log level field', () => {
+    const row = buildDataTableRecord({ fields: { 'log.level': 'info' } });
+    const euiTheme = { euiTheme: { colors: {} } } as unknown as EuiThemeComputed;
+    const getRowIndicatorProvider = logsDataSourceProfileProvider.profile.getRowIndicatorProvider?.(
+      () => undefined,
+      {
+        context: RESOLUTION_MATCH.context,
+      }
+    );
+    const getRowIndicator = getRowIndicatorProvider?.({
+      dataView: dataViewWithoutLogLevel,
+      columnsMeta: { 'log.level': { type: 'string' } },
+    });
+
+    expect(getRowIndicator).toBeDefined();
+    expect(getRowIndicator?.(row, euiTheme)).toEqual({ color: '#adccff', label: 'Info' });
   });
 
   describe('getCellRenderers', () => {

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -16,7 +16,7 @@ import type {
   CustomGridColumnsConfiguration,
 } from '@kbn/unified-data-table';
 import type { DocViewsRegistry } from '@kbn/unified-doc-viewer';
-import type { AppMenuRegistry, DataTableRecord } from '@kbn/discover-utils';
+import type { AppMenuRegistry, DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
 import type { CellAction, CellActionExecutionContext, CellActionsData } from '@kbn/cell-actions';
 import type { EuiIconType } from '@elastic/eui/src/components/icon/icon';
 import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
@@ -250,6 +250,10 @@ export interface RowIndicatorExtensionParams {
    * The current data view
    */
   dataView: DataView;
+  /**
+   * The columns metadata from ES|QL query response (optional, only available in ES|QL mode)
+   */
+  columnsMeta: DataTableColumnsMeta | undefined;
 }
 
 /**

--- a/x-pack/examples/testing_embedded_lens/public/app.tsx
+++ b/x-pack/examples/testing_embedded_lens/public/app.tsx
@@ -378,7 +378,7 @@ function getFieldsByType(dataView: DataView) {
     number: aggregatableFields.find((f) => f.type === 'number')?.displayName,
   };
   if (dataView.isTimeBased()) {
-    fields.date = dataView.getTimeField().displayName;
+    fields.date = dataView.getTimeField()?.displayName ?? dataView.timeFieldName;
   }
   // remove undefined values
   for (const type of ['string', 'number', 'date'] as const) {

--- a/x-pack/platform/plugins/shared/lens/moon.yml
+++ b/x-pack/platform/plugins/shared/lens/moon.yml
@@ -154,6 +154,7 @@ dependsOn:
   - '@kbn/as-code-shared-telemetry'
   - '@kbn/core-http-browser'
   - '@kbn/use-observable'
+  - '@kbn/data-view-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/lens/public/data_views_service/loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/data_views_service/loader.ts
@@ -23,6 +23,7 @@ import type {
   IndexPatternRef,
   TextBasedPersistedState,
 } from '@kbn/lens-common';
+import { ESQL_TYPE } from '@kbn/data-view-utils';
 import { documentField } from '../datasources/form_based/document_field';
 import { sortDataViewRefs } from '../utils';
 
@@ -265,7 +266,10 @@ export async function loadIndexPatterns({
 
   indexPatterns.push(
     ...(await Promise.all(
-      Object.values(adHocDataViews || {}).map((spec) => dataViews.create(spec))
+      Object.values(adHocDataViews || {}).map((spec) =>
+        // Skip fetching fields for ES|QL data views: field metadata comes from the query result (columnsMeta).
+        dataViews.create(spec, spec.type === ESQL_TYPE)
+      )
     ))
   );
 

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/update_data_views.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/update_data_views.ts
@@ -7,6 +7,7 @@
 
 import { uniqBy } from 'lodash';
 import type { LensRuntimeState } from '@kbn/lens-common';
+import { ESQL_TYPE } from '@kbn/data-view-utils';
 import { getIndexPatternsObjects } from '../../utils';
 import type { LensEmbeddableStartServices } from '../types';
 
@@ -22,7 +23,10 @@ export async function getUsedDataViews(
       dataViews
     ),
 
-    ...Object.values(adHocDataViewsSpecs ?? {}).map((spec) => dataViews.create(spec)),
+    // Skip fetching fields for ES|QL data views: field metadata comes from the query result (columnsMeta).
+    ...Object.values(adHocDataViewsSpecs ?? {}).map((spec) =>
+      dataViews.create(spec, spec.type === ESQL_TYPE)
+    ),
   ]);
 
   return uniqBy(indexPatterns.concat(adHocDataViews), 'id');

--- a/x-pack/platform/plugins/shared/lens/tsconfig.json
+++ b/x-pack/platform/plugins/shared/lens/tsconfig.json
@@ -148,7 +148,8 @@
     "@kbn/as-code-shared-schemas",
     "@kbn/as-code-shared-telemetry",
     "@kbn/core-http-browser",
-    "@kbn/use-observable"
+    "@kbn/use-observable",
+    "@kbn/data-view-utils"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
- Addresses https://github.com/elastic/kibana/issues/179703

## Summary
We stop fetching `/data_views/fields` when building an ES|QL dataview. This implies not having fields available at `dataview.fields` and rely purely in `columnsMeta` helper.

This PR:
* Computes correctly `isComputedColumn` on `columnsMeta`.
* `dataview.isTimeBased()` now returns true if there is a `timeFieldName` and if the fields list is empty.
* `dataView.fields` is not usable anymore in ES|QL paths, all usages were backed up with `columnsMeta`.
* Documents comparison feature now uses `columnsMeta`, fixes a bug where computed fields were not showing icons.
* WIP: Make Cascade Leaf (Group by) work with `columnsMeta`.
* WIP: fix `dataView.fields.getByType('ip')` on security profile.
* WIP: Review some cases on fieldFormatting.

Many of the fixes in this PR were taken from https://github.com/elastic/kibana/pull/255335

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



