### PR TITLE
[Entity Store] Enhance probe by remove count all documents

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/ccs_logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/ccs_logs_extraction_query_builder.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`buildCcsLogsExtractionEsqlQuery generates expected query for host entity type 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM remote:metrics-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -169,28 +169,18 @@ data_stream*,
 | LIMIT 5000"
 `;
 
-exports[`buildCcsLogsExtractionEsqlQuery generates expected query with log-slice cursor bounds 1`] = `
+exports[
+  `buildCcsLogsExtractionEsqlQuery generates expected query with log-slice cursor bounds 1`
+] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM remote:logs-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
       AND (NOT(\`host.id\` IS NULL) AND COALESCE(\`host.id\` != \\"\\", TRUE) OR NOT(\`host.name\` IS NULL) AND COALESCE(\`host.name\` != \\"\\", TRUE) OR NOT(\`host.hostname\` IS NULL) AND COALESCE(\`host.hostname\` != \\"\\", TRUE))
-      AND (
-      @timestamp > TO_DATETIME(\\"2022-01-01T06:00:00.000Z\\")
-      OR (
-        @timestamp == TO_DATETIME(\\"2022-01-01T06:00:00.000Z\\")
-        AND \`_id\` > \\"start-doc-id\\"
-      )
-    )
-      AND (
-      @timestamp < TO_DATETIME(\\"2022-01-01T12:00:00.000Z\\")
-      OR (
-        @timestamp == TO_DATETIME(\\"2022-01-01T12:00:00.000Z\\")
-        AND \`_id\` <= \\"end-doc-id\\"
-      )
-    )
+      AND @timestamp >= TO_DATETIME(\\"2022-01-01T06:00:00.000Z\\")
+      AND @timestamp <= TO_DATETIME(\\"2022-01-01T12:00:00.000Z\\")
 | EVAL _src_entity_source0 = MV_FIRST(event.module),
  _src_entity_source1 = MV_FIRST(event.dataset),
  _src_entity_source2 = MV_FIRST(data_stream.dataset),
@@ -355,7 +345,7 @@ data_stream*,
 exports[`buildCcsLogsExtractionEsqlQuery generates expected query with pagination 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM remote:logs-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -512,7 +502,7 @@ host*,
 exports[`buildCcsLogsExtractionEsqlQuery generates query for generic entity type 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM remote_cluster:logs-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
@@ -1,16 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildLogPaginationCursorProbeEsql adds sort, cap, inline count, and slice-end row after the probe WHERE 1`] = `
+exports[`buildLogPaginationCursorProbeEsql sorts, limits to maxLogsPerPage + 1, and reads slice-end + bounded count via terminal STATS 1`] = `
 "FROM logs-*
     METADATA _index, _id
   | WHERE
       @timestamp >= TO_DATETIME(\\"2024-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2024-01-02T00:00:00.000Z\\")
       AND ((\`event.outcome\` IS NULL OR COALESCE(\`event.outcome\` != \\"failure\\", TRUE)) AND (NOT(\`user.email\` IS NULL) AND COALESCE(\`user.email\` != \\"\\", TRUE) OR NOT(\`user.id\` IS NULL) AND COALESCE(\`user.id\` != \\"\\", TRUE) OR NOT(\`user.name\` IS NULL) AND COALESCE(\`user.name\` != \\"\\", TRUE)))
-  | INLINE STATS total_logs = count(*)
   | SORT @timestamp ASC, \`_id\` ASC
-  | LIMIT 100
-  | SORT @timestamp DESC, \`_id\` DESC
-  | LIMIT 1
+  | LIMIT 101
+  | STATS @timestamp = LAST(@timestamp, @timestamp), \`_id\` = LAST(\`_id\`, @timestamp), total_logs = COUNT(*)
   | KEEP @timestamp, \`_id\`, total_logs"
 `;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildLogPaginationCursorProbeEsql sorts, limits to maxLogsPerPage, and reads slice-end + bounded count via terminal STATS 1`] = `
+exports[
+  `buildLogPaginationCursorProbeEsql sorts by @timestamp only, limits to maxLogsPerPage, reads slice-end + min_ts + bounded count via terminal STATS 1`
+] = `
 "FROM logs-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2024-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2024-01-02T00:00:00.000Z\\")
       AND ((\`event.outcome\` IS NULL OR COALESCE(\`event.outcome\` != \\"failure\\", TRUE)) AND (NOT(\`user.email\` IS NULL) AND COALESCE(\`user.email\` != \\"\\", TRUE) OR NOT(\`user.id\` IS NULL) AND COALESCE(\`user.id\` != \\"\\", TRUE) OR NOT(\`user.name\` IS NULL) AND COALESCE(\`user.name\` != \\"\\", TRUE)))
-  | SORT @timestamp ASC, \`_id\` ASC
+  | SORT @timestamp ASC
   | LIMIT 100
-  | STATS @timestamp = LAST(@timestamp, @timestamp), \`_id\` = LAST(\`_id\`, @timestamp), total_logs = COUNT(*)
-  | KEEP @timestamp, \`_id\`, total_logs"
+  | STATS @timestamp = LAST(@timestamp, @timestamp), min_ts = MIN(@timestamp), total_logs = COUNT(*)
+  | KEEP @timestamp, min_ts, total_logs"
 `;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/log_pagination_probe_query_builder.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildLogPaginationCursorProbeEsql sorts, limits to maxLogsPerPage + 1, and reads slice-end + bounded count via terminal STATS 1`] = `
+exports[`buildLogPaginationCursorProbeEsql sorts, limits to maxLogsPerPage, and reads slice-end + bounded count via terminal STATS 1`] = `
 "FROM logs-*
     METADATA _index, _id
   | WHERE
@@ -8,7 +8,7 @@ exports[`buildLogPaginationCursorProbeEsql sorts, limits to maxLogsPerPage + 1, 
       AND @timestamp <= TO_DATETIME(\\"2024-01-02T00:00:00.000Z\\")
       AND ((\`event.outcome\` IS NULL OR COALESCE(\`event.outcome\` != \\"failure\\", TRUE)) AND (NOT(\`user.email\` IS NULL) AND COALESCE(\`user.email\` != \\"\\", TRUE) OR NOT(\`user.id\` IS NULL) AND COALESCE(\`user.id\` != \\"\\", TRUE) OR NOT(\`user.name\` IS NULL) AND COALESCE(\`user.name\` != \\"\\", TRUE)))
   | SORT @timestamp ASC, \`_id\` ASC
-  | LIMIT 101
+  | LIMIT 100
   | STATS @timestamp = LAST(@timestamp, @timestamp), \`_id\` = LAST(\`_id\`, @timestamp), total_logs = COUNT(*)
   | KEEP @timestamp, \`_id\`, total_logs"
 `;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/__snapshots__/logs_extraction_query_builder.test.ts.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildLogsExtractionEsqlQuery generates the expected query for generic entity description 1`] = `
+exports[
+  `buildLogsExtractionEsqlQuery generates the expected query for generic entity description 1`
+] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -277,9 +279,11 @@ asset*,
 @timestamp"
 `;
 
-exports[`buildLogsExtractionEsqlQuery generates the expected query for host entity description 1`] = `
+exports[
+  `buildLogsExtractionEsqlQuery generates the expected query for host entity description 1`
+] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -594,7 +598,7 @@ data_stream*,
 
 exports[`buildLogsExtractionEsqlQuery generates the expected query for host with pagination 1`] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -912,7 +916,7 @@ data_stream*,
 
 exports[`buildLogsExtractionEsqlQuery generates the expected query for host with recoveryId 1`] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1228,9 +1232,11 @@ data_stream*,
 @timestamp"
 `;
 
-exports[`buildLogsExtractionEsqlQuery generates the expected query for service entity description 1`] = `
+exports[
+  `buildLogsExtractionEsqlQuery generates the expected query for service entity description 1`
+] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1476,9 +1482,11 @@ data_stream*,
 @timestamp"
 `;
 
-exports[`buildLogsExtractionEsqlQuery generates the expected query for user entity description 1`] = `
+exports[
+  `buildLogsExtractionEsqlQuery generates the expected query for user entity description 1`
+] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1755,7 +1763,7 @@ host*,
 
 exports[`buildRemainingLogsCountQuery generates the expected query for generic entity type 1`] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1765,7 +1773,7 @@ exports[`buildRemainingLogsCountQuery generates the expected query for generic e
 
 exports[`buildRemainingLogsCountQuery generates the expected query for host entity type 1`] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1775,7 +1783,7 @@ exports[`buildRemainingLogsCountQuery generates the expected query for host enti
 
 exports[`buildRemainingLogsCountQuery generates the expected query for service entity type 1`] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")
@@ -1785,7 +1793,7 @@ exports[`buildRemainingLogsCountQuery generates the expected query for service e
 
 exports[`buildRemainingLogsCountQuery generates the expected query for user entity type 1`] = `
 "FROM test-index-*
-    METADATA _index, _id
+    METADATA _index
   | WHERE
       @timestamp >= TO_DATETIME(\\"2022-01-01T00:00:00.000Z\\")
       AND @timestamp <= TO_DATETIME(\\"2022-01-01T23:59:59.999Z\\")

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.test.ts
@@ -254,6 +254,10 @@ describe('CcsLogsExtractionClient', () => {
         ['2024-06-15T11:00:00.000Z', '2024-06-15T10:30:00.000Z', 'host:h4'],
       ],
     };
+    const probe3EntityPage: ESQLSearchResponse = {
+      columns: slice1EntityPage.columns,
+      values: [],
+    };
 
     // Probe 1: total_logs=4 > maxLogsPerPage=2 → not the last slice
     // Probe 2: total_logs=2 = maxLogsPerPage=2 → last slice
@@ -261,7 +265,8 @@ describe('CcsLogsExtractionClient', () => {
       .mockResolvedValueOnce(makeProbeResponse('2024-06-15T10:00:00.000Z', 'doc-2', 4))
       .mockResolvedValueOnce(slice1EntityPage)
       .mockResolvedValueOnce(makeProbeResponse('2024-06-15T11:00:00.000Z', 'doc-4', 2))
-      .mockResolvedValueOnce(slice2EntityPage);
+      .mockResolvedValueOnce(slice2EntityPage)
+      .mockResolvedValueOnce(probe3EntityPage);
 
     const result = await client.extractToUpdates({
       ...defaultExtractParams,
@@ -271,7 +276,7 @@ describe('CcsLogsExtractionClient', () => {
 
     expect(result).toEqual({ count: 4, pages: 2 });
     // 2 probes + 2 entity pages
-    expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(4);
+    expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(5);
     expect(mockIngestEntities).toHaveBeenCalledTimes(2);
 
     // Slice boundary state persisted after each slice completes

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.test.ts
@@ -35,14 +35,20 @@ const mockExecuteEsqlQuery = executeEsqlQuery as jest.MockedFunction<typeof exec
 const mockIngestEntities = ingestEntities as jest.MockedFunction<typeof ingestEntities>;
 
 /** Returns a probe response with one row: the slice end boundary. */
-function makeProbeResponse(ts: string, id: string, totalLogs: number): ESQLSearchResponse {
+function makeProbeResponse(
+  ts: string,
+  // Kept for call-site compatibility — the probe no longer carries an id; this argument is ignored.
+  _ignoredId: string,
+  totalLogs: number,
+  minTs: string = ts
+): ESQLSearchResponse {
   return {
     columns: [
       { name: '@timestamp', type: 'date' },
-      { name: '_id', type: 'keyword' },
+      { name: 'min_ts', type: 'date' },
       { name: 'total_logs', type: 'long' },
     ],
-    values: [[ts, id, totalLogs]],
+    values: [[ts, minTs, totalLogs]],
   };
 }
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../common/domain/definitions/entity_schema';
 import {
   ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD,
+  type LogSlicePaginationCursor,
   type PaginationParams,
 } from './query_builder_commons';
 import {
@@ -217,7 +218,8 @@ export class CcsLogsExtractionClient {
 
     let effectiveFromDateISO = initialFromDateISO;
     let recoveryId = initialRecoveryId;
-    let sliceStart: PaginationParams | undefined;
+    let sliceStart: LogSlicePaginationCursor | undefined;
+    let previousSliceEndTs: string | undefined;
 
     let isLastLogsPage = false;
 
@@ -236,8 +238,26 @@ export class CcsLogsExtractionClient {
         break;
       }
 
-      const { logsPaginationCursor: sliceEnd } = logPaginationCursor;
+      // Stuck-detection: when the cursor doesn't advance AND the whole slice was at one
+      // timestamp AND the slice is saturated, > maxLogsPerPage docs share that millisecond.
+      // Bump the cursor by 1ms to escape; idempotent upserts absorbed the prior reprocessing.
+      const probeCursorTs = logPaginationCursor.logsPaginationCursor.timestampCursor;
+      const allAtOneMs = logPaginationCursor.minTimestamp === probeCursorTs;
+      const saturated = !logPaginationCursor.isLastLogsPage;
+      const stuck = previousSliceEndTs === probeCursorTs && allAtOneMs && saturated;
+
+      let sliceEnd: LogSlicePaginationCursor = logPaginationCursor.logsPaginationCursor;
+      if (stuck) {
+        const bumpedTs = moment(probeCursorTs).add(1, 'ms').toISOString();
+        this.logger.warn(
+          `CCS log extraction tie-group at @timestamp=${probeCursorTs} exceeds maxLogsPerPage=${maxLogsPerPage}; ` +
+            `bumping cursor to ${bumpedTs}. Some docs at this timestamp may be skipped.`
+        );
+        sliceEnd = { timestampCursor: bumpedTs };
+      }
+
       isLastLogsPage = logPaginationCursor.isLastLogsPage;
+      previousSliceEndTs = probeCursorTs;
 
       // Recovery cursor is only used in the first slice; clear it after consumption
       const recoveryIdForThisSlice = recoveryId;
@@ -294,7 +314,7 @@ export class CcsLogsExtractionClient {
     type: EntityType;
     fromDateISO: string;
     toDateISO: string;
-    sliceStart: PaginationParams | undefined;
+    sliceStart: LogSlicePaginationCursor | undefined;
     maxLogsPerPage: number;
     abortController?: AbortController;
   }): Promise<LogPaginationCursor> {
@@ -359,8 +379,8 @@ export class CcsLogsExtractionClient {
     docsLimit: number;
     entityDefinition: ManagedEntityDefinition;
     abortController?: AbortController;
-    sliceStart: PaginationParams | undefined;
-    sliceEnd: PaginationParams;
+    sliceStart: LogSlicePaginationCursor | undefined;
+    sliceEnd: LogSlicePaginationCursor;
     recoveryId: string | undefined;
     skipStateUpdates: boolean;
   }): Promise<{ count: number; pages: number }> {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_query_builder.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_query_builder.test.ts
@@ -60,16 +60,14 @@ describe('buildCcsLogsExtractionEsqlQuery', () => {
       docsLimit: 10000,
       logsPageCursorStart: {
         timestampCursor: '2022-01-01T06:00:00.000Z',
-        idCursor: 'start-doc-id',
       },
       logsPageCursorEnd: {
         timestampCursor: '2022-01-01T12:00:00.000Z',
-        idCursor: 'end-doc-id',
       },
     });
-    // Start filter: exclusive lower bound
+    // Start filter: inclusive lower bound on @timestamp
     expect(query).toContain('2022-01-01T06:00:00.000Z');
-    // End filter: inclusive upper bound
+    // End filter: inclusive upper bound on @timestamp
     expect(query).toContain('2022-01-01T12:00:00.000Z');
     expect(query).toMatchSnapshot();
     await expect(validateQuery(query)).resolves.toHaveProperty('errors', []);

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_query_builder.ts
@@ -13,6 +13,7 @@ import {
   buildExtractionSourceClause,
   buildFieldEvaluations,
   buildSetFieldsByCondition,
+  type LogSlicePaginationCursor,
   type PaginationParams,
   ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD,
   MAIN_ENTITY_ID_FIELD,
@@ -44,8 +45,8 @@ export interface CcsLogsExtractionQueryParams {
   docsLimit: number;
   recoveryId?: string;
   pagination?: PaginationParams;
-  logsPageCursorStart?: PaginationParams;
-  logsPageCursorEnd?: PaginationParams;
+  logsPageCursorStart?: LogSlicePaginationCursor;
+  logsPageCursorEnd?: LogSlicePaginationCursor;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.test.ts
@@ -15,7 +15,7 @@ import {
 } from './log_pagination_probe_query_builder';
 
 describe('buildLogPaginationCursorProbeEsql', () => {
-  it('sorts, limits to maxLogsPerPage + 1, and reads slice-end + bounded count via terminal STATS', () => {
+  it('sorts, limits to maxLogsPerPage, and reads slice-end + bounded count via terminal STATS', () => {
     const q = buildLogPaginationCursorProbeEsql({
       indexPatterns: ['logs-*'],
       type: 'user',
@@ -32,7 +32,7 @@ describe('interpretLogPaginationCursorRows', () => {
     expect(interpretLogPaginationCursorRows(undefined, 100)).toEqual({ hasLogsToProcess: false });
   });
 
-  it('returns isLastLogsPage false at saturation marker (total_logs == maxLogsPerPage + 1)', () => {
+  it('returns isLastLogsPage false at saturation marker (total_logs == maxLogsPerPage)', () => {
     const row = {
       logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z', idCursor: 'a' },
       missingLogsToProcess: 101,
@@ -52,7 +52,7 @@ describe('interpretLogPaginationCursorRows', () => {
     expect(interpretLogPaginationCursorRows(row, 100)).toEqual({
       hasLogsToProcess: true,
       logsPaginationCursor: row.logsPaginationCursor,
-      isLastLogsPage: true,
+      isLastLogsPage: false,
     });
   });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.test.ts
@@ -8,6 +8,7 @@
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import { TIMESTAMP_FIELD } from './query_builder_commons';
 import {
+  LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD,
   LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD,
   buildLogPaginationCursorProbeEsql,
   interpretLogPaginationCursorRows,
@@ -15,7 +16,7 @@ import {
 } from './log_pagination_probe_query_builder';
 
 describe('buildLogPaginationCursorProbeEsql', () => {
-  it('sorts, limits to maxLogsPerPage, and reads slice-end + bounded count via terminal STATS', () => {
+  it('sorts by @timestamp only, limits to maxLogsPerPage, reads slice-end + min_ts + bounded count via terminal STATS', () => {
     const q = buildLogPaginationCursorProbeEsql({
       indexPatterns: ['logs-*'],
       type: 'user',
@@ -34,63 +35,53 @@ describe('interpretLogPaginationCursorRows', () => {
 
   it('returns isLastLogsPage false at saturation marker (total_logs == maxLogsPerPage)', () => {
     const row = {
-      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z', idCursor: 'a' },
-      missingLogsToProcess: 101,
-    };
-    expect(interpretLogPaginationCursorRows(row, 100)).toEqual({
-      hasLogsToProcess: true,
-      logsPaginationCursor: row.logsPaginationCursor,
-      isLastLogsPage: false,
-    });
-  });
-
-  it('returns isLastLogsPage true when exactly maxLogsPerPage logs remain (last full page)', () => {
-    const row = {
-      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z', idCursor: 'a' },
+      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z' },
+      minTimestamp: '2024-01-01T00:00:00.000Z',
       missingLogsToProcess: 100,
     };
     expect(interpretLogPaginationCursorRows(row, 100)).toEqual({
       hasLogsToProcess: true,
       logsPaginationCursor: row.logsPaginationCursor,
+      minTimestamp: row.minTimestamp,
       isLastLogsPage: false,
     });
   });
 
   it('returns isLastLogsPage true when fewer than maxLogsPerPage logs remain', () => {
     const row = {
-      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z', idCursor: 'a' },
+      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z' },
+      minTimestamp: '2024-01-01T00:00:00.000Z',
       missingLogsToProcess: 3,
     };
     expect(interpretLogPaginationCursorRows(row, 100)).toEqual({
       hasLogsToProcess: true,
       logsPaginationCursor: row.logsPaginationCursor,
+      minTimestamp: row.minTimestamp,
       isLastLogsPage: true,
     });
   });
 });
 
 describe('parseLogPaginationCursorRow', () => {
-  it('maps columns to slice end and total log count', () => {
+  it('maps columns to slice end, min @timestamp, and total log count', () => {
     const resp: ESQLSearchResponse = {
       columns: [
         { name: TIMESTAMP_FIELD, type: 'date' },
-        { name: '_id', type: 'keyword' },
+        { name: LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD, type: 'date' },
         { name: LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD, type: 'long' },
       ],
-      values: [['2024-01-01T00:00:00.000Z', 'doc1', 42]],
+      values: [['2024-01-01T00:00:05.000Z', '2024-01-01T00:00:00.000Z', 42]],
     };
     expect(parseLogPaginationCursorRow(resp)).toEqual({
-      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z', idCursor: 'doc1' },
+      logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:05.000Z' },
+      minTimestamp: '2024-01-01T00:00:00.000Z',
       missingLogsToProcess: 42,
     });
   });
 
-  it('returns undefined when there are no values without requiring total_logs column', () => {
+  it('returns undefined when there are no values without requiring all columns', () => {
     const resp: ESQLSearchResponse = {
-      columns: [
-        { name: TIMESTAMP_FIELD, type: 'date' },
-        { name: '_id', type: 'keyword' },
-      ],
+      columns: [{ name: TIMESTAMP_FIELD, type: 'date' }],
       values: [],
     };
     expect(parseLogPaginationCursorRow(resp)).toBeUndefined();

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.test.ts
@@ -15,7 +15,7 @@ import {
 } from './log_pagination_probe_query_builder';
 
 describe('buildLogPaginationCursorProbeEsql', () => {
-  it('adds sort, cap, inline count, and slice-end row after the probe WHERE', () => {
+  it('sorts, limits to maxLogsPerPage + 1, and reads slice-end + bounded count via terminal STATS', () => {
     const q = buildLogPaginationCursorProbeEsql({
       indexPatterns: ['logs-*'],
       type: 'user',
@@ -32,7 +32,7 @@ describe('interpretLogPaginationCursorRows', () => {
     expect(interpretLogPaginationCursorRows(undefined, 100)).toEqual({ hasLogsToProcess: false });
   });
 
-  it('returns isLastLogsPage false when more matching logs remain than one page', () => {
+  it('returns isLastLogsPage false at saturation marker (total_logs == maxLogsPerPage + 1)', () => {
     const row = {
       logsPaginationCursor: { timestampCursor: '2024-01-01T00:00:00.000Z', idCursor: 'a' },
       missingLogsToProcess: 101,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
@@ -14,12 +14,22 @@ import {
   type PaginationParams,
 } from './query_builder_commons';
 
-/** Column produced by {@link buildLogPaginationCursorProbeEsql} via `INLINE STATS` before `LIMIT` (total matching raw rows in the window from the probe). */
+/** Column produced by {@link buildLogPaginationCursorProbeEsql} via terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage + 1` stream — bounded; `> maxLogsPerPage` ⇔ a next page exists. */
 export const LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD = 'total_logs';
 
 /**
- * Returns at most one row: the inclusive slice end (N-th doc in sort order, or last doc if fewer than N remain),
- * plus how many raw logs are still to be processed
+ * Returns at most one row holding the slice-end cursor and a bounded count.
+ *
+ * Pipeline: `SORT @timestamp ASC, _id ASC | LIMIT maxLogsPerPage + 1 | STATS LAST(...) , COUNT(*)`.
+ * `LIMIT N+1` upstream of a terminal `STATS` keeps the count within `[0, maxLogsPerPage + 1]`,
+ * avoiding the full-window scan that an `INLINE STATS count(*)` upstream of `LIMIT` would force
+ * (ES|QL forbids `LIMIT` before `INLINE STATS`). The terminal `STATS` collapses to one row, so
+ * `esql.query.result_truncation_max_size` does not constrain `maxLogsPerPage`.
+ *
+ * In the saturated case (`total_logs === maxLogsPerPage + 1`) the cursor lands on the row at
+ * ASC position `N+1` rather than `N`; the next slice's exclusive lower-bound `WHERE` consumes
+ * one extra row's worth of progress per iteration. Idempotent upserts absorb any minor
+ * reprocessing if `LAST` ties on `@timestamp` resolve to a non-maximal `_id`.
  */
 export function buildLogPaginationCursorProbeEsql(
   params: LogPageProbeSourceClauseParams & { maxLogsPerPage: number }
@@ -27,21 +37,17 @@ export function buildLogPaginationCursorProbeEsql(
   const { maxLogsPerPage, ...sourceParams } = params;
   return (
     buildLogPageProbeSourceClause(sourceParams) +
-    // The INLINE STATS will return more than maxLogsPerPage if there are more logs to be processed on purpose,
-    // since we can't have INLINE STATS after LIMIT. Yet, this communicates if there are more than 40k logs to be processed.
     `
-  | INLINE STATS ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD} = count(*)
   | SORT ${TIMESTAMP_FIELD} ASC, \`${DOCUMENT_ID_FIELD}\` ASC
-  | LIMIT ${maxLogsPerPage}
-  | SORT ${TIMESTAMP_FIELD} DESC, \`${DOCUMENT_ID_FIELD}\` DESC
-  | LIMIT 1
+  | LIMIT ${maxLogsPerPage + 1}
+  | STATS ${TIMESTAMP_FIELD} = LAST(${TIMESTAMP_FIELD}, ${TIMESTAMP_FIELD}), \`${DOCUMENT_ID_FIELD}\` = LAST(\`${DOCUMENT_ID_FIELD}\`, ${TIMESTAMP_FIELD}), ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD} = COUNT(*)
   | KEEP ${TIMESTAMP_FIELD}, \`${DOCUMENT_ID_FIELD}\`, ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD}`
   );
 }
 
 export interface LogPaginationCursorParsedRow {
   logsPaginationCursor: PaginationParams;
-  /** Total raw log rows matching the probe `WHERE` before `LIMIT` (remaining in the window from the cursor). */
+  /** Bounded count from terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage + 1` stream — values in `[0, maxLogsPerPage + 1]`. */
   missingLogsToProcess: number;
 }
 
@@ -88,8 +94,8 @@ export function interpretLogPaginationCursorRows(
     return { hasLogsToProcess: false };
   }
   const { logsPaginationCursor, missingLogsToProcess } = row;
-  // total_logs is count(*) before LIMIT — total rows still in the window. If that fits in one slice (<= max),
-  // this slice exhausts the window (including the exact full-page case).
+  // total_logs is bounded by LIMIT maxLogsPerPage + 1; total_logs <= maxLogsPerPage means this
+  // slice exhausts the window, the value maxLogsPerPage + 1 is the saturation marker for "more pages exist".
   return {
     hasLogsToProcess: true,
     logsPaginationCursor,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
@@ -8,18 +8,33 @@
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import {
   buildLogPageProbeSourceClause,
-  DOCUMENT_ID_FIELD,
   TIMESTAMP_FIELD,
   type LogPageProbeSourceClauseParams,
-  type PaginationParams,
+  type LogSlicePaginationCursor,
 } from './query_builder_commons';
 
-/** Column produced by {@link buildLogPaginationCursorProbeEsql} via terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage` stream — bounded; ` = maxLogsPerPage` ⇔ assume next page exists. */
+/** Column produced by {@link buildLogPaginationCursorProbeEsql} via terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage` stream — bounded; `=== maxLogsPerPage` is the saturation marker that signals "more pages may exist". */
 export const LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD = 'total_logs';
 
+/** Column produced by {@link buildLogPaginationCursorProbeEsql} via terminal `STATS MIN(@timestamp)` — used by the loop's stuck-detection guard to identify a tie group of `>= maxLogsPerPage` docs at one timestamp. */
+export const LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD = 'min_ts';
+
 /**
- * Returns at most one row: the inclusive slice end (N-th doc in sort order, or last doc if fewer than N remain),
- * plus how many logs are present in this window
+ * Returns at most one row holding the slice-end cursor, the slice's minimum `@timestamp`, and a bounded count.
+ *
+ * Pipeline: `SORT @timestamp ASC | LIMIT maxLogsPerPage | STATS LAST(...) , MIN(...) , COUNT(*)`.
+ * The single-key `SORT` lets ES|QL push the `TopN` down to Lucene on a time-sorted data stream
+ * (the `_id` tiebreaker is gone — `_id` is read from Lucene stored fields per-doc and would
+ * block index-order traversal). `LIMIT N` upstream of a terminal `STATS` keeps the count within
+ * `[0, maxLogsPerPage]`, avoiding the full-window scan that an `INLINE STATS count(*)` upstream
+ * of `LIMIT` would force (ES|QL forbids `LIMIT` before `INLINE STATS`). Output is one row, so
+ * `esql.query.result_truncation_max_size` does not constrain `maxLogsPerPage`.
+ *
+ * `total_logs === maxLogsPerPage` is treated as "more pages may exist" — in the rare exact-fit
+ * case the next iteration's probe returns 0 rows and the loop terminates with one extra
+ * round-trip. `min_ts` lets the caller detect a tie group of docs that all share one
+ * `@timestamp` (when `min_ts === slice-end @timestamp`) so it can break out via a 1ms cursor
+ * bump if `>= maxLogsPerPage` docs share a single millisecond.
  */
 export function buildLogPaginationCursorProbeEsql(
   params: LogPageProbeSourceClauseParams & { maxLogsPerPage: number }
@@ -28,15 +43,17 @@ export function buildLogPaginationCursorProbeEsql(
   return (
     buildLogPageProbeSourceClause(sourceParams) +
     `
-  | SORT ${TIMESTAMP_FIELD} ASC, \`${DOCUMENT_ID_FIELD}\` ASC
+  | SORT ${TIMESTAMP_FIELD} ASC
   | LIMIT ${maxLogsPerPage}
-  | STATS ${TIMESTAMP_FIELD} = LAST(${TIMESTAMP_FIELD}, ${TIMESTAMP_FIELD}), \`${DOCUMENT_ID_FIELD}\` = LAST(\`${DOCUMENT_ID_FIELD}\`, ${TIMESTAMP_FIELD}), ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD} = COUNT(*)
-  | KEEP ${TIMESTAMP_FIELD}, \`${DOCUMENT_ID_FIELD}\`, ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD}`
+  | STATS ${TIMESTAMP_FIELD} = LAST(${TIMESTAMP_FIELD}, ${TIMESTAMP_FIELD}), ${LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD} = MIN(${TIMESTAMP_FIELD}), ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD} = COUNT(*)
+  | KEEP ${TIMESTAMP_FIELD}, ${LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD}, ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD}`
   );
 }
 
 export interface LogPaginationCursorParsedRow {
-  logsPaginationCursor: PaginationParams;
+  logsPaginationCursor: LogSlicePaginationCursor;
+  /** Earliest `@timestamp` in the slice (`MIN(@timestamp)` over the LIMITed stream). Equal to the cursor when the whole slice sits at one timestamp. */
+  minTimestamp: string;
   /** Bounded count from terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage` stream — values in `[0, maxLogsPerPage]`. */
   missingLogsToProcess: number;
 }
@@ -49,21 +66,23 @@ export function parseLogPaginationCursorRow(
   }
 
   const tsIdx = esqlResponse.columns.findIndex(({ name }) => name === TIMESTAMP_FIELD);
-  const idIdx = esqlResponse.columns.findIndex(({ name }) => name === DOCUMENT_ID_FIELD);
+  const minTsIdx = esqlResponse.columns.findIndex(
+    ({ name }) => name === LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD
+  );
   const totalIdx = esqlResponse.columns.findIndex(
     ({ name }) => name === LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD
   );
-  if (tsIdx === -1 || idIdx === -1 || totalIdx === -1) {
+  if (tsIdx === -1 || minTsIdx === -1 || totalIdx === -1) {
     throw new Error(
-      `Expected ${TIMESTAMP_FIELD}, ${DOCUMENT_ID_FIELD}, and ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD} columns in log pagination cursor probe response`
+      `Expected ${TIMESTAMP_FIELD}, ${LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD}, and ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD} columns in log pagination cursor probe response`
     );
   }
   const row = esqlResponse.values[0];
   return {
     logsPaginationCursor: {
       timestampCursor: String(row[tsIdx]),
-      idCursor: String(row[idIdx]),
     },
+    minTimestamp: String(row[minTsIdx]),
     missingLogsToProcess: Number(row[totalIdx]),
   };
 }
@@ -72,7 +91,8 @@ export type LogPaginationCursor =
   | { hasLogsToProcess: false }
   | {
       hasLogsToProcess: true;
-      logsPaginationCursor: PaginationParams;
+      logsPaginationCursor: LogSlicePaginationCursor;
+      minTimestamp: string;
       isLastLogsPage: boolean;
     };
 
@@ -83,12 +103,14 @@ export function interpretLogPaginationCursorRows(
   if (row === undefined) {
     return { hasLogsToProcess: false };
   }
-  const { logsPaginationCursor, missingLogsToProcess } = row;
-  // total_logs is bounded by LIMIT maxLogsPerPage; total_logs < maxLogsPerPage means this
-  // slice exhausts the window, the value maxLogsPerPage is the saturation marker for "more pages exist".
+  const { logsPaginationCursor, minTimestamp, missingLogsToProcess } = row;
+  // total_logs is bounded by LIMIT maxLogsPerPage. total_logs < maxLogsPerPage ⇒ window
+  // exhausted by this slice; total_logs === maxLogsPerPage ⇒ saturated, more pages may exist
+  // (the rare exact-fit case terminates the loop on the next iteration with hasLogsToProcess=false).
   return {
     hasLogsToProcess: true,
     logsPaginationCursor,
+    minTimestamp,
     isLastLogsPage: missingLogsToProcess < maxLogsPerPage,
   };
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/log_pagination_probe_query_builder.ts
@@ -14,22 +14,12 @@ import {
   type PaginationParams,
 } from './query_builder_commons';
 
-/** Column produced by {@link buildLogPaginationCursorProbeEsql} via terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage + 1` stream — bounded; `> maxLogsPerPage` ⇔ a next page exists. */
+/** Column produced by {@link buildLogPaginationCursorProbeEsql} via terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage` stream — bounded; ` = maxLogsPerPage` ⇔ assume next page exists. */
 export const LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD = 'total_logs';
 
 /**
- * Returns at most one row holding the slice-end cursor and a bounded count.
- *
- * Pipeline: `SORT @timestamp ASC, _id ASC | LIMIT maxLogsPerPage + 1 | STATS LAST(...) , COUNT(*)`.
- * `LIMIT N+1` upstream of a terminal `STATS` keeps the count within `[0, maxLogsPerPage + 1]`,
- * avoiding the full-window scan that an `INLINE STATS count(*)` upstream of `LIMIT` would force
- * (ES|QL forbids `LIMIT` before `INLINE STATS`). The terminal `STATS` collapses to one row, so
- * `esql.query.result_truncation_max_size` does not constrain `maxLogsPerPage`.
- *
- * In the saturated case (`total_logs === maxLogsPerPage + 1`) the cursor lands on the row at
- * ASC position `N+1` rather than `N`; the next slice's exclusive lower-bound `WHERE` consumes
- * one extra row's worth of progress per iteration. Idempotent upserts absorb any minor
- * reprocessing if `LAST` ties on `@timestamp` resolve to a non-maximal `_id`.
+ * Returns at most one row: the inclusive slice end (N-th doc in sort order, or last doc if fewer than N remain),
+ * plus how many logs are present in this window
  */
 export function buildLogPaginationCursorProbeEsql(
   params: LogPageProbeSourceClauseParams & { maxLogsPerPage: number }
@@ -39,7 +29,7 @@ export function buildLogPaginationCursorProbeEsql(
     buildLogPageProbeSourceClause(sourceParams) +
     `
   | SORT ${TIMESTAMP_FIELD} ASC, \`${DOCUMENT_ID_FIELD}\` ASC
-  | LIMIT ${maxLogsPerPage + 1}
+  | LIMIT ${maxLogsPerPage}
   | STATS ${TIMESTAMP_FIELD} = LAST(${TIMESTAMP_FIELD}, ${TIMESTAMP_FIELD}), \`${DOCUMENT_ID_FIELD}\` = LAST(\`${DOCUMENT_ID_FIELD}\`, ${TIMESTAMP_FIELD}), ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD} = COUNT(*)
   | KEEP ${TIMESTAMP_FIELD}, \`${DOCUMENT_ID_FIELD}\`, ${LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD}`
   );
@@ -47,7 +37,7 @@ export function buildLogPaginationCursorProbeEsql(
 
 export interface LogPaginationCursorParsedRow {
   logsPaginationCursor: PaginationParams;
-  /** Bounded count from terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage + 1` stream — values in `[0, maxLogsPerPage + 1]`. */
+  /** Bounded count from terminal `STATS COUNT(*)` over the `LIMIT maxLogsPerPage` stream — values in `[0, maxLogsPerPage]`. */
   missingLogsToProcess: number;
 }
 
@@ -94,11 +84,11 @@ export function interpretLogPaginationCursorRows(
     return { hasLogsToProcess: false };
   }
   const { logsPaginationCursor, missingLogsToProcess } = row;
-  // total_logs is bounded by LIMIT maxLogsPerPage + 1; total_logs <= maxLogsPerPage means this
-  // slice exhausts the window, the value maxLogsPerPage + 1 is the saturation marker for "more pages exist".
+  // total_logs is bounded by LIMIT maxLogsPerPage; total_logs < maxLogsPerPage means this
+  // slice exhausts the window, the value maxLogsPerPage is the saturation marker for "more pages exist".
   return {
     hasLogsToProcess: true,
     logsPaginationCursor,
-    isLastLogsPage: missingLogsToProcess <= maxLogsPerPage,
+    isLastLogsPage: missingLogsToProcess < maxLogsPerPage,
   };
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -19,23 +19,29 @@ import {
   ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD,
   TIMESTAMP_FIELD,
 } from './query_builder_commons';
-import { LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD } from './log_pagination_probe_query_builder';
+import {
+  LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD,
+  LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD,
+} from './log_pagination_probe_query_builder';
 
 const LOG_PAGINATION_CURSOR_PROBE_COLUMNS: ESQLSearchResponse['columns'] = [
   { name: TIMESTAMP_FIELD, type: 'date' },
-  { name: '_id', type: 'keyword' },
+  { name: LOG_PAGINATION_CURSOR_MIN_TIMESTAMP_FIELD, type: 'date' },
   { name: LOG_PAGINATION_CURSOR_TOTAL_LOGS_FIELD, type: 'long' },
 ];
 
-/** Default total_logs > maxLogsPerPage so interpret marks a non-final slice (matches default config cap). */
+/** Default total_logs == maxLogsPerPage so interpret marks a non-final slice (saturated). */
 function mockLogPaginationCursorProbeRow(
   timestamp: string,
-  id: string,
-  totalLogsInSlice: number = LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT + 1
+  // Kept for call-site compatibility with the previous (timestamp, id) signature, even though
+  // the probe no longer carries an id; existing tests pass an arbitrary string and ignore it.
+  _ignoredId: string,
+  totalLogsInSlice: number = LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT,
+  minTimestamp: string = timestamp
 ): ESQLSearchResponse {
   return {
     columns: LOG_PAGINATION_CURSOR_PROBE_COLUMNS,
-    values: [[timestamp, id, totalLogsInSlice]],
+    values: [[timestamp, minTimestamp, totalLogsInSlice]],
   };
 }
 
@@ -1176,7 +1182,7 @@ describe('LogsExtractionClient', () => {
       });
     });
 
-    it('should pass persisted log-slice start into remaining-count ESQL when present on engine', async () => {
+    it('should pass persisted log-slice start timestamp into remaining-count ESQL when present on engine', async () => {
       const fixedNow = new Date('2025-01-15T12:00:00.000Z');
       jest.useFakeTimers({ now: fixedNow.getTime() });
       const mockEsqlResponse: ESQLSearchResponse = {
@@ -1187,7 +1193,6 @@ describe('LogsExtractionClient', () => {
         getIndexPattern: jest.fn().mockReturnValue('logs-*'),
       };
       const paginationTimestamp = '2025-01-15T10:00:00.000Z';
-      const sliceStartId = 'slice-start';
       const sliceStartTs = '2025-01-15T10:20:00.000Z';
       mockEngineDescriptorClient.findOrThrow.mockResolvedValue(
         createMockEngineDescriptor('user', {
@@ -1195,7 +1200,6 @@ describe('LogsExtractionClient', () => {
           delay: '1m',
           paginationTimestamp,
           logsPageCursorStartTimestamp: sliceStartTs,
-          logsPageCursorStartId: sliceStartId,
         }) as Awaited<ReturnType<EngineDescriptorClient['findOrThrow']>>
       );
       mockDataViewsService.get.mockResolvedValue(mockDataView as any);
@@ -1209,7 +1213,7 @@ describe('LogsExtractionClient', () => {
       });
       expect(mockExecuteEsqlQuery).toHaveBeenCalledWith({
         esClient: mockEsClient,
-        query: expect.stringContaining(sliceStartId),
+        query: expect.stringContaining(sliceStartTs),
       });
       jest.useRealTimers();
     });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../../common/domain/definitions/entity_schema';
 import { getEntityDefinition } from '../../../common/domain/definitions/registry';
 import {
+  type LogSlicePaginationCursor,
   type PaginationParams,
   ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD,
 } from './query_builder_commons';
@@ -191,9 +192,8 @@ export class LogsExtractionClient {
       const indexPatterns = await this.getLocalIndexPatterns(config.additionalIndexPatterns);
       const { fromDateISO } = this.getExtractionWindow(config, engineState, delayMs);
       const toDateISO = moment().utc().toISOString();
-      const logsPageCursorStart = paginationFromOptionalFields(
-        engineState.logsPageCursorStartTimestamp,
-        engineState.logsPageCursorStartId
+      const logsPageCursorStart = logSliceCursorFromOptionalTimestamp(
+        engineState.logsPageCursorStartTimestamp
       );
       const query = buildRemainingLogsCountQuery({
         indexPatterns,
@@ -337,6 +337,8 @@ export class LogsExtractionClient {
       let lastLogsPages = false;
       /** First outer iteration of this `extractLogs` run: run the boundary probe from the time window only, not the persisted log-slice start. */
       let isFirstRunInThisCycle = true;
+      /** Previous iteration's slice-end cursor — used by the stuck-detection guard to break out of unbounded tie groups at one timestamp. */
+      let previousLogPageCursorTs: string | undefined;
       do {
         const entityPagination = paginationFromOptionalFields(
           state.paginationTimestamp,
@@ -345,10 +347,7 @@ export class LogsExtractionClient {
         // always find a new cursor via probe on first run
         const logsPageCursorStart = isFirstRunInThisCycle
           ? undefined
-          : paginationFromOptionalFields(
-              state.logsPageCursorStartTimestamp,
-              state.logsPageCursorStartId
-            );
+          : logSliceCursorFromOptionalTimestamp(state.logsPageCursorStartTimestamp);
 
         const probePromise = this.runLogPaginationCursorProbeForNextPage({
           indexPatterns,
@@ -365,12 +364,30 @@ export class LogsExtractionClient {
           break;
         }
 
-        const logsPageCursorEnd = probeOutcome.logsPaginationCursor;
+        // Stuck-detection: when the cursor doesn't advance AND the whole slice was at one
+        // timestamp AND the slice is saturated, > maxLogsPerPage docs share that millisecond.
+        // Bump the cursor by 1ms to escape; idempotent upserts absorbed the prior reprocessing.
+        const probeCursorTs = probeOutcome.logsPaginationCursor.timestampCursor;
+        const allAtOneMs = probeOutcome.minTimestamp === probeCursorTs;
+        const saturated = !probeOutcome.isLastLogsPage;
+        const stuck = previousLogPageCursorTs === probeCursorTs && allAtOneMs && saturated;
+
+        let logsPageCursorEnd = probeOutcome.logsPaginationCursor;
+        if (stuck) {
+          const bumpedTs = moment(probeCursorTs).add(1, 'ms').toISOString();
+          this.logger.warn(
+            `Log extraction tie-group at @timestamp=${probeCursorTs} exceeds maxLogsPerPage=${maxLogsPerPage}; ` +
+              `bumping cursor to ${bumpedTs}. Some docs at this timestamp may be skipped.`
+          );
+          logsPageCursorEnd = { timestampCursor: bumpedTs };
+        }
+
         lastLogsPages = probeOutcome.isLastLogsPage;
+        previousLogPageCursorTs = probeCursorTs;
         state = {
           ...state,
           logsPageCursorEndTimestamp: logsPageCursorEnd.timestampCursor,
-          logsPageCursorEndId: logsPageCursorEnd.idCursor,
+          logsPageCursorEndId: null,
         };
 
         const sliceIngestOutcome = await this.ingestEntityPagesWithinCurrentLogPage({
@@ -427,7 +444,7 @@ export class LogsExtractionClient {
     type: EntityType;
     fromDateISO: string;
     toDateISO: string;
-    logsPageCursorStart: PaginationParams | undefined;
+    logsPageCursorStart: LogSlicePaginationCursor | undefined;
     maxLogsPerPage: number;
     opts?: LogsExtractionOptions;
   }): Promise<LogPaginationCursor> {
@@ -455,19 +472,11 @@ export class LogsExtractionClient {
 
     if (parsedLogPaginationCursor) {
       this.logger.debug(
-        `Log pagination cursor probe: missing logs to process ${parsedLogPaginationCursor.missingLogsToProcess}, next page starts at ${parsedLogPaginationCursor.logsPaginationCursor.timestampCursor} | ${parsedLogPaginationCursor.logsPaginationCursor.idCursor}`
+        `Log pagination cursor probe: counted ${parsedLogPaginationCursor.missingLogsToProcess} log(s), slice ends at ${parsedLogPaginationCursor.logsPaginationCursor.timestampCursor} (min @timestamp in slice: ${parsedLogPaginationCursor.minTimestamp})`
       );
     }
 
-    if (!interpretedLogPaginationCursor.hasLogsToProcess) {
-      return { hasLogsToProcess: false };
-    }
-
-    return {
-      hasLogsToProcess: true,
-      logsPaginationCursor: interpretedLogPaginationCursor.logsPaginationCursor,
-      isLastLogsPage: interpretedLogPaginationCursor.isLastLogsPage,
-    };
+    return interpretedLogPaginationCursor;
   }
 
   /**
@@ -496,8 +505,8 @@ export class LogsExtractionClient {
     docsLimit: number;
     fromDateISO: string;
     toDateISO: string;
-    logsPageCursorStart: PaginationParams | undefined;
-    logsPageCursorEnd: PaginationParams;
+    logsPageCursorStart: LogSlicePaginationCursor | undefined;
+    logsPageCursorEnd: LogSlicePaginationCursor;
     entityPagination: PaginationParams | undefined;
     recoveryId: string | undefined;
     state: EngineLogExtractionState;
@@ -565,9 +574,9 @@ export class LogsExtractionClient {
           paginationTimestamp: pagination.timestampCursor,
           paginationId: pagination.idCursor,
           logsPageCursorEndTimestamp: logsPageCursorEnd.timestampCursor,
-          logsPageCursorEndId: logsPageCursorEnd.idCursor,
+          logsPageCursorEndId: null,
           logsPageCursorStartTimestamp: logsPageCursorStart?.timestampCursor ?? null,
-          logsPageCursorStartId: logsPageCursorStart?.idCursor ?? null,
+          logsPageCursorStartId: null,
         };
         await this.persistMainLogExtractionStateIfNotManualWindow(type, opts, state);
       }
@@ -581,7 +590,7 @@ export class LogsExtractionClient {
    */
   private advanceEngineStateAfterLogPageCompletes(
     state: EngineLogExtractionState,
-    logsPageCursorEnd: PaginationParams
+    logsPageCursorEnd: LogSlicePaginationCursor
   ): EngineLogExtractionState {
     return {
       ...state,
@@ -591,7 +600,7 @@ export class LogsExtractionClient {
       logsPageCursorEndTimestamp: null,
       logsPageCursorEndId: null,
       logsPageCursorStartTimestamp: logsPageCursorEnd.timestampCursor,
-      logsPageCursorStartId: logsPageCursorEnd.idCursor,
+      logsPageCursorStartId: null,
     };
   }
 
@@ -725,6 +734,15 @@ function paginationFromOptionalFields(
 ): PaginationParams | undefined {
   if (id && ts) {
     return { timestampCursor: ts, idCursor: id };
+  }
+  return undefined;
+}
+
+function logSliceCursorFromOptionalTimestamp(
+  ts: string | null
+): LogSlicePaginationCursor | undefined {
+  if (ts) {
+    return { timestampCursor: ts };
   }
   return undefined;
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_query_builder.ts
@@ -23,6 +23,7 @@ import {
   buildLogPageProbeSourceClause,
   buildFieldEvaluations,
   buildSetFieldsByCondition,
+  type LogSlicePaginationCursor,
   type PaginationParams,
   type PaginationFields,
   ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD,
@@ -67,8 +68,8 @@ interface LogsExtractionQueryParams {
   toDateISO: string;
   recoveryId?: string;
   pagination?: PaginationParams;
-  logsPageCursorStart?: PaginationParams;
-  logsPageCursorEnd?: PaginationParams;
+  logsPageCursorStart?: LogSlicePaginationCursor;
+  logsPageCursorEnd?: LogSlicePaginationCursor;
 }
 
 export function buildRemainingLogsCountQuery(params: {
@@ -76,7 +77,7 @@ export function buildRemainingLogsCountQuery(params: {
   type: EntityType;
   fromDateISO: string;
   toDateISO: string;
-  logsPageCursorStart?: PaginationParams;
+  logsPageCursorStart?: LogSlicePaginationCursor;
 }): string {
   return (
     buildLogPageProbeSourceClause(params) +

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/query_builder_commons.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/query_builder_commons.test.ts
@@ -63,10 +63,10 @@ describe('buildExtractionSourceClause', () => {
   it('should always use inclusive >= lower bound on @timestamp regardless of cursor', () => {
     const withCursor = buildExtractionSourceClause({
       ...baseParams,
-      logsPageCursorStart: { timestampCursor: '2024-01-01T00:00:00.000Z', idCursor: '1' },
+      logsPageCursorStart: { timestampCursor: '2024-01-01T00:00:00.000Z' },
     });
     expect(withCursor).toContain('FROM logs-*, metrics-*');
-    expect(withCursor).toContain('METADATA _index, _id');
+    expect(withCursor).toContain('METADATA _index');
     expect(withCursor).toContain(`${TIMESTAMP_FIELD} >= TO_DATETIME("2024-01-01T00:00:00.000Z")`);
     expect(withCursor).toContain(`${TIMESTAMP_FIELD} <= TO_DATETIME("2024-01-02T00:00:00.000Z")`);
     expect(withCursor).toContain(getEuidEsqlDocumentsContainsIdFilter('host'));

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/query_builder_commons.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/query_builder_commons.ts
@@ -45,11 +45,21 @@ export const TIMESTAMP_FIELD = '@timestamp';
 
 export const DOCUMENT_ID_FIELD = '_id';
 
-const METADATA_FIELDS = ['_index', '_id'];
+const METADATA_FIELDS = ['_index'];
 
 export interface PaginationParams {
   timestampCursor: string;
   idCursor: string;
+}
+
+/**
+ * Doc-level cursor for log-slice pagination — `@timestamp` only. Splits from {@link PaginationParams}
+ * (which is still used by entity-level pagination on `entity.EngineMetadata.UntypedId`) because the
+ * probe no longer carries `_id`: ES|QL reads `_id` from Lucene stored fields per-doc, and including
+ * it in `SORT` blocks index-order traversal on time-sorted data streams.
+ */
+export interface LogSlicePaginationCursor {
+  timestampCursor: string;
 }
 
 export interface PaginationFields {
@@ -66,22 +76,23 @@ export interface LogPageProbeSourceClauseParams {
   type: EntityType;
   fromDateISO: string;
   toDateISO: string;
-  /** Exclusive lower bound on (@timestamp, _id) for log-slice pagination within the time window. */
-  logsPageCursorStart?: PaginationParams;
+  /** Inclusive lower bound on `@timestamp` for log-slice pagination within the time window. */
+  logsPageCursorStart?: LogSlicePaginationCursor;
 }
 
-/** Bounded extraction: same as probe plus optional inclusive upper bound on (@timestamp, _id). */
+/** Bounded extraction: same as probe plus optional inclusive upper bound on `@timestamp`. */
 export type ExtractionSourceClauseParams = LogPageProbeSourceClauseParams & {
-  logsPageCursorEnd?: PaginationParams;
+  logsPageCursorEnd?: LogSlicePaginationCursor;
 };
 
 export function buildLogPageProbeSourceClause(params: LogPageProbeSourceClauseParams): string {
   const { indexPatterns, type, fromDateISO, toDateISO, logsPageCursorStart } = params;
 
-  // Always use >= for the time-window start. When logsPageCursorStart is set its compound filter
-  // (@timestamp > T OR (@timestamp = T AND _id > id)) owns the exclusive lower bound. Using >
-  // here would drop documents with @timestamp = fromDateISO when the cursor timestamp equals
-  // fromDateISO (e.g. second recovery slice where all remaining logs share the same timestamp).
+  // The time-window start uses `>=` so the inclusive `logsPageCursorStart` filter (also `>=`)
+  // composes correctly. The cursor is non-strict on purpose: any doc at `cursorTs` not consumed
+  // by the prior slice is re-included in the next one and absorbed by idempotent upserts. The
+  // outer loop's stuck-detection guard handles the pathological "tie group bigger than
+  // maxLogsPerPage" path by bumping the cursor by 1ms.
   const baseWhere = `FROM ${indexPatterns.join(', ')}
     METADATA ${METADATA_FIELDS.join(', ')}
   | WHERE
@@ -98,7 +109,7 @@ export function buildLogPageProbeSourceClause(params: LogPageProbeSourceClausePa
 }
 
 export function buildExtractionSourceClause(
-  params: LogPageProbeSourceClauseParams & { logsPageCursorEnd?: PaginationParams }
+  params: LogPageProbeSourceClauseParams & { logsPageCursorEnd?: LogSlicePaginationCursor }
 ): string {
   if (params.logsPageCursorEnd) {
     const { logsPageCursorEnd, ...probeParams } = params;
@@ -110,26 +121,12 @@ export function buildExtractionSourceClause(
   return buildLogPageProbeSourceClause(params);
 }
 
-function buildLogsPageStartFilter(cursor: PaginationParams): string {
-  const escapedId = escapeEsqlStringLiteral(cursor.idCursor);
-  return `(
-      ${TIMESTAMP_FIELD} > TO_DATETIME("${cursor.timestampCursor}")
-      OR (
-        ${TIMESTAMP_FIELD} == TO_DATETIME("${cursor.timestampCursor}")
-        AND \`${DOCUMENT_ID_FIELD}\` > "${escapedId}"
-      )
-    )`;
+function buildLogsPageStartFilter(cursor: LogSlicePaginationCursor): string {
+  return `${TIMESTAMP_FIELD} >= TO_DATETIME("${cursor.timestampCursor}")`;
 }
 
-function buildLogsPageEndFilter(end: PaginationParams): string {
-  const escapedId = escapeEsqlStringLiteral(end.idCursor);
-  return `(
-      ${TIMESTAMP_FIELD} < TO_DATETIME("${end.timestampCursor}")
-      OR (
-        ${TIMESTAMP_FIELD} == TO_DATETIME("${end.timestampCursor}")
-        AND \`${DOCUMENT_ID_FIELD}\` <= "${escapedId}"
-      )
-    )`;
+function buildLogsPageEndFilter(end: LogSlicePaginationCursor): string {
+  return `${TIMESTAMP_FIELD} <= TO_DATETIME("${end.timestampCursor}")`;
 }
 
 export function aggregationStats(fields: EntityField[], renameToRecent: boolean = true): string {


### PR DESCRIPTION
Previous to this PR we were performing a `INLINE STATS COUNT(*)` for all documents in the seen window. We don't need it. This PR counts only after the limit, causing us to have at most `maxLogsPerPage`. If we have a full page, we assume there is a next page. There will be a wasteful call to elasticsearch if the last page has perfect size `maxLogsPerPage`. But we gain performance on most cases.