### PR TITLE
[8.19] [Scout] Enable `lanes` test distribution strategy for pull-request & on-merge (#264506)

### DIFF
--- a/.buildkite/pipeline-utils/scout/test_distribution_strategies.ts
+++ b/.buildkite/pipeline-utils/scout/test_distribution_strategies.ts
@@ -82,7 +82,7 @@ async function distributeScoutTestsOnLanes() {
         SCOUT_TEST_TARGET_DOMAIN: testTarget.domain,
         SCOUT_TEST_SERVER_CONFIG_SET: server.configSet,
         SCOUT_TEST_SERVER_START_TIMEOUT_SECONDS:
-          process.env.SCOUT_TEST_SERVER_START_TIMEOUT_SECONDS || '180',
+          process.env.SCOUT_TEST_SERVER_START_TIMEOUT_SECONDS || '300',
         ...envVarsIfSet([
           'SERVERLESS_TESTS_ONLY',
           'UIAM_DOCKER_IMAGE',

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -217,9 +217,11 @@ steps:
     depends_on:
       - build
     env:
-      SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests'
-      SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
+      SCOUT_TEST_DISTRIBUTION_STRATEGY: 'lanes'
+      SCOUT_TEST_LANES_GROUP_DEPS: 'build_scout_tests,build'
+      SCOUT_TEST_SERVER_START_TIMEOUT_SECONDS: 300
+      SCOUT_TEST_LANE_ESTIMATED_SETUP_MINUTES: 5
+      SCOUT_TEST_LANE_TARGET_RUNTIME_MINUTES: 20
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -137,9 +137,11 @@ steps:
     depends_on:
       - build
     env:
-      SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests'
-      SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
+      SCOUT_TEST_DISTRIBUTION_STRATEGY: 'lanes'
+      SCOUT_TEST_LANES_GROUP_DEPS: 'build_scout_tests,build'
+      SCOUT_TEST_SERVER_START_TIMEOUT_SECONDS: 300
+      SCOUT_TEST_LANE_ESTIMATED_SETUP_MINUTES: 5
+      SCOUT_TEST_LANE_TARGET_RUNTIME_MINUTES: 20
       SELECTIVE_TESTING_ENABLED: 'true'
     retry:
       automatic:

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -12,11 +12,48 @@ echo '--- Update Scout Test Config Manifests'
 # so they do not cause extra modules to be considered "changed" in the next step.
 node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
 
+echo '--- Evaluate selective testing scope'
+# PR builds: GITHUB_PR_MERGE_BASE is computed by set_git_merge_base() in util.sh.
+# On-merge builds: falls back to HEAD~1 (parent of the merge commit).
+if [[ -n "${GITHUB_PR_MERGE_BASE:-}" ]]; then
+  echo "Merge base (PR): ${GITHUB_PR_MERGE_BASE}"
+else
+  echo "GITHUB_PR_MERGE_BASE not set — using HEAD~1 as merge base (on-merge build)"
+fi
+export AFFECTED_MERGE_BASE="${GITHUB_PR_MERGE_BASE:-HEAD~1}"
+
+mkdir -p .scout
+export AFFECTED_MODULES_FILE=".scout/affected_modules.json"
+
+# Computes affected modules (writes AFFECTED_MODULES_FILE) and checks whether
+# any critical Scout files were touched.
+SCOUT_CRITICAL_FILES_TOUCHED=$(ts-node "$(dirname "${0}")/resolve_selective_testing.ts")
+echo "Critical Scout files touched: ${SCOUT_CRITICAL_FILES_TOUCHED}"
+
+if [[ "${SELECTIVE_TESTING_ENABLED:-}" == "true" ]] \
+  && ! is_pr_with_label "scout:run-all-tests" \
+  && [[ "$SCOUT_CRITICAL_FILES_TOUCHED" != "true" ]]; then
+  echo '--- Selective testing: ON'
+  RUN_WITH_SELECTIVE_TESTING="true"
+else
+  echo '--- Selective testing: OFF'
+  RUN_WITH_SELECTIVE_TESTING="false"
+fi
+echo "Decision made based on the following signals:
+  • SELECTIVE_TESTING_ENABLED=${SELECTIVE_TESTING_ENABLED:-false}
+  • 'scout:run-all-tests' GitHub label present: $(is_pr_with_label "scout:run-all-tests" && echo yes || echo no)
+  • Critical Scout files touched: ${SCOUT_CRITICAL_FILES_TOUCHED}"
+
 SCOUT_TEST_DISTRIBUTION_STRATEGY="${SCOUT_TEST_DISTRIBUTION_STRATEGY:-configs}"
 
 if [[ "$SCOUT_TEST_DISTRIBUTION_STRATEGY" == "lanes" ]]; then
   echo '--- Update Scout Test Config Stats'
   node scripts/scout update-test-config-stats
+
+  SELECTIVE_TESTING_FLAGS=()
+  if [[ "${RUN_WITH_SELECTIVE_TESTING}" == "true" ]]; then
+    SELECTIVE_TESTING_FLAGS=(--moduleFilterPath "$AFFECTED_MODULES_FILE")
+  fi
 
   echo '--- Create Test Tracks'
   SERVERLESS_TARGETS=(
@@ -26,7 +63,6 @@ if [[ "$SCOUT_TEST_DISTRIBUTION_STRATEGY" == "lanes" ]]; then
     local-serverless-security_complete
     local-serverless-security_essentials
     local-serverless-security_ease
-    local-serverless-workplaceai
   )
 
   TEST_TARGET_FLAGS=()
@@ -42,11 +78,11 @@ if [[ "$SCOUT_TEST_DISTRIBUTION_STRATEGY" == "lanes" ]]; then
   fi
 
   node scripts/scout create-test-tracks \
-    --estimatedLaneSetupMinutes "${SCOUT_TEST_LANE_ESTIMATED_SETUP_MINUTES:-3}" \
+    --estimatedLaneSetupMinutes "${SCOUT_TEST_LANE_ESTIMATED_SETUP_MINUTES:-5}" \
     --targetRuntimeMinutes "${SCOUT_TEST_LANE_TARGET_RUNTIME_MINUTES:-15}" \
     "${TEST_TARGET_FLAGS[@]}" \
+    "${SELECTIVE_TESTING_FLAGS[@]}" \
     --showMultiTrackSummary
-
 else
   if [[ "${BUILDKITE_BRANCH:-}" == "main" || "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" == "main" ]]; then
     SCOUT_DISCOVERY_TARGET="local"
@@ -54,33 +90,12 @@ else
     SCOUT_DISCOVERY_TARGET="local-stateful-only"
   fi
 
-  # PR builds: GITHUB_PR_MERGE_BASE is computed by set_git_merge_base() in util.sh.
-  # On-merge builds: falls back to HEAD~1 (parent of the merge commit).
-  if [[ -n "${GITHUB_PR_MERGE_BASE:-}" ]]; then
-    echo "Merge base (PR): ${GITHUB_PR_MERGE_BASE}"
-  else
-    echo "GITHUB_PR_MERGE_BASE not set — using HEAD~1 as merge base (on-merge build)"
-  fi
-  export AFFECTED_MERGE_BASE="${GITHUB_PR_MERGE_BASE:-HEAD~1}"
-
-  mkdir -p .scout
-  export AFFECTED_MODULES_FILE=".scout/affected_modules.json"
-
-  # Computes affected modules (writes AFFECTED_MODULES_FILE) and checks whether
-  # any critical Scout files were touched.
-  SCOUT_CRITICAL_FILES_TOUCHED=$(ts-node "$(dirname "${0}")/resolve_selective_testing.ts")
-  echo "Critical Scout files touched: ${SCOUT_CRITICAL_FILES_TOUCHED}"
-
   echo "--- Discover Playwright Configs and upload to Buildkite artifacts (affected modules detected)"
   SELECTIVE_SCOUT_DISCOVERY_FLAG=()
-  if [[ "${SELECTIVE_TESTING_ENABLED:-}" == "true" ]] \
-    && ! is_pr_with_label "scout:run-all-tests" \
-    && [[ "$SCOUT_CRITICAL_FILES_TOUCHED" != "true" ]]; then
+  if [[ "${RUN_WITH_SELECTIVE_TESTING}" == "true" ]]; then
     SELECTIVE_SCOUT_DISCOVERY_FLAG=(--selective-testing)
-    echo "Selective testing: enabled (--selective-testing flag will be passed to discover-playwright-configs)"
-  else
-    echo "Selective testing is disabled"
-    echo "Reason: SELECTIVE_TESTING_ENABLED=${SELECTIVE_TESTING_ENABLED:-false}, 'scout:run-all-tests' label=$(is_pr_with_label "scout:run-all-tests" && echo yes || echo no), 'critical files touched'=${SCOUT_CRITICAL_FILES_TOUCHED}"
+    echo "The '--selective-testing' flag will be passed to discover-playwright-configs" \
+         " because selective testing is enabled."
   fi
   node scripts/scout discover-playwright-configs \
     --include-custom-servers \

--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts
@@ -11,6 +11,7 @@ import type { ScoutTestConfig, ScoutTestConfigStatsEntry } from '@kbn/scout-repo
 import { ScoutTestConfigStats } from '@kbn/scout-reporting';
 import { ScoutTestTarget } from '@kbn/scout-info';
 import type { ToolingLog } from '@kbn/tooling-log';
+import { findPackageForPath } from '@kbn/repo-packages';
 import {
   msToHuman,
   identifyTestLoads,
@@ -30,6 +31,12 @@ jest.mock('@kbn/scout-reporting', () => {
     },
   };
 });
+
+jest.mock('@kbn/repo-packages', () => ({
+  findPackageForPath: jest.fn(),
+}));
+
+const mockFindPackageForPath = findPackageForPath as jest.Mock;
 
 let mockTestConfigs: ScoutTestConfig[] = [];
 
@@ -155,7 +162,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
     expect(loads).toHaveLength(0);
   });
 
@@ -211,7 +218,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
     expect(loads).toHaveLength(1);
     expect(loads[0].config.path).toBe('matching/config.ts');
   });
@@ -241,7 +248,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
     expect(loads).toHaveLength(1);
     expect(loads[0].enabled).toBe(false);
   });
@@ -263,7 +270,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
     expect(loads).toHaveLength(1);
     expect(loads[0].enabled).toBe(true);
   });
@@ -293,7 +300,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
     expect(loads).toHaveLength(1);
     expect(loads[0].enabled).toBe(false);
   });
@@ -317,7 +324,7 @@ describe('identifyTestLoads', () => {
       configs: [statsEntry],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
     expect(loads).toHaveLength(1);
     expect(loads[0].stats).toBeDefined();
     expect(loads[0].stats!.path).toBe('plugin/config.ts');
@@ -340,9 +347,81 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
     expect(loads).toHaveLength(1);
     expect(loads[0].stats).toBeUndefined();
+  });
+
+  describe('moduleIds filter', () => {
+    const ciConfig: ScoutCIConfig = {
+      plugins: { enabled: [], disabled: [] },
+      packages: { enabled: [], disabled: [] },
+      excluded_configs: [],
+    };
+    const stats = new ScoutTestConfigStats({
+      lastUpdated: new Date(),
+      lookbackDays: 3,
+      buildkite: {},
+      configs: [],
+    });
+
+    beforeEach(() => {
+      mockFindPackageForPath.mockReset();
+    });
+
+    it('includes configs whose resolved module ID is in the filter set', () => {
+      const config = createMockConfig({ path: 'plugin/config.ts' });
+      mockTestConfigs = [config];
+      mockFindPackageForPath.mockReturnValue({ id: '@kbn/test-plugin' });
+
+      const loads = identifyTestLoads(
+        ciConfig,
+        stats,
+        testTarget,
+        new Set(['@kbn/test-plugin']),
+        log
+      );
+      expect(loads).toHaveLength(1);
+    });
+
+    it('excludes configs whose resolved module ID is not in the filter set', () => {
+      const config = createMockConfig({ path: 'plugin/config.ts' });
+      mockTestConfigs = [config];
+      mockFindPackageForPath.mockReturnValue({ id: '@kbn/other-plugin' });
+
+      const loads = identifyTestLoads(
+        ciConfig,
+        stats,
+        testTarget,
+        new Set(['@kbn/test-plugin']),
+        log
+      );
+      expect(loads).toHaveLength(0);
+    });
+
+    it('excludes configs that cannot be resolved to a module ID', () => {
+      const config = createMockConfig({ path: 'plugin/config.ts' });
+      mockTestConfigs = [config];
+      mockFindPackageForPath.mockReturnValue(undefined);
+
+      const loads = identifyTestLoads(
+        ciConfig,
+        stats,
+        testTarget,
+        new Set(['@kbn/test-plugin']),
+        log
+      );
+      expect(loads).toHaveLength(0);
+    });
+
+    it('includes all configs when no module filter is provided', () => {
+      const config = createMockConfig({ path: 'plugin/config.ts' });
+      mockTestConfigs = [config];
+
+      const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+      expect(loads).toHaveLength(1);
+      expect(mockFindPackageForPath).not.toHaveBeenCalled();
+    });
   });
 
   it('returns empty array and logs warning when no configs match', () => {
@@ -361,7 +440,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
     expect(loads).toHaveLength(0);
     expect(log.warning).toHaveBeenCalledWith(expect.stringContaining('No test loads discovered'));
   });

--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
@@ -21,6 +21,8 @@ import dedent from 'dedent';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { writeFileSync } from 'node:fs';
 import path from 'path';
+import { findPackageForPath } from '@kbn/repo-packages';
+import { REPO_ROOT } from '@kbn/repo-info';
 import type { TestTrackLoad } from '../execution/test_track';
 import { TestTrack } from '../execution/test_track';
 
@@ -64,6 +66,7 @@ export function identifyTestLoads(
   scoutCIConfig: ScoutCIConfig,
   testConfigStats: ScoutTestConfigStats,
   testTarget: ScoutTestTarget,
+  moduleIDs: Set<string>,
   log: ToolingLog
 ): ScoutCITestLoad[] {
   const testLoads = testConfigs.all
@@ -73,6 +76,11 @@ export function identifyTestLoads(
         return test.tags.includes(testTarget.playwrightTag);
       })
     )
+    .filter((config) => {
+      if (moduleIDs.size === 0) return true;
+      const resolvedModuleID = findPackageForPath(REPO_ROOT, config.path)?.id;
+      return resolvedModuleID ? moduleIDs.has(resolvedModuleID) : false;
+    })
     .map((config) => {
       let enabled: boolean;
       switch (config.module.type) {
@@ -414,6 +422,7 @@ export const createTestTracks: Command<void> = {
       'targetRuntimeMinutes',
       'minRuntimeMinutes',
       'estimatedLaneSetupMinutes',
+      'moduleFilterPath',
     ],
     boolean: ['showIndividualTrackSummaries', 'showMultiTrackSummary'],
     default: {
@@ -427,9 +436,35 @@ export const createTestTracks: Command<void> = {
     --estimatedLaneSetupMinutes     (optional)  How long a lane setup is expected to take
     --showIndividualTrackSummaries  (optional)  Display individual test track summaries
     --showMultiTrackSummary         (optional)  Display multi-track summary
+    --moduleFilterPath              (optional)  Path to a JSON file of @kbn/ module IDs; only configs belonging to those modules will be distributed
     `,
   },
   run: async ({ flagsReader, log }) => {
+    const moduleIds: Set<string> = new Set();
+    const moduleFilterPath = flagsReader.string('moduleFilterPath');
+
+    if (moduleFilterPath) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(readFileSync(moduleFilterPath, 'utf-8'));
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        throw createFlagError(
+          `Failed to read '${moduleFilterPath}': ${message}. ` +
+            `Ensure the file exists and is a valid JSON array of @kbn/ module IDs.`
+        );
+      }
+
+      if (!Array.isArray(parsed)) {
+        throw createFlagError(`Expected '${moduleFilterPath}' to contain a JSON array.`);
+      }
+
+      parsed.forEach((id) => moduleIds.add(id));
+      log.info(
+        `Limiting test load selection to the following modules: ${Array.from(moduleIds).join(', ')}`
+      );
+    }
+
     const selectedTestTargets: ScoutTestTarget[] = flagsReader
       .requiredArrayOfStrings('testTarget')
       .map(ScoutTestTarget.fromTag);
@@ -453,7 +488,10 @@ export const createTestTracks: Command<void> = {
     const scoutCIConfig = loadScoutCIConfig();
 
     const testLoadsByTarget = selectedTestTargets.reduce((loadsByTarget, target) => {
-      loadsByTarget.set(target, identifyTestLoads(scoutCIConfig, testConfigStats, target, log));
+      loadsByTarget.set(
+        target,
+        identifyTestLoads(scoutCIConfig, testConfigStats, target, moduleIds, log)
+      );
       return loadsByTarget;
     }, new Map<ScoutTestTarget, ScoutCITestLoad[]>());
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Scout] Enable `lanes` test distribution strategy for pull-request & on-merge (#264506)](https://github.com/elastic/kibana/pull/264506)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"David Olaru","email":"dolaru@elastic.co"},"sourceCommit":{"committedDate":"2026-05-06T16:35:30Z","message":"[Scout] Enable `lanes` test distribution strategy for pull-request & on-merge (#264506)\n\nSwitches the test distribution strategy from `configs` to `lanes` for\nthe pull-request & on-merge Buildkite pipelines.\n\n### Other changes\n- Extends `scout create-test-tracks` with a `--moduleFilterPath` flag\nthat accepts a JSON file of `@kbn/` module IDs. When provided,\n`identifyTestLoads` filters configs to only those belonging to the\nlisted modules using `findPackageForPath` for resolution. An empty set\nmeans no filtering.\n- Wires selective testing into the lanes branch of `test_run_builder.sh`\nusing the same guard conditions as the configs strategy\n(SELECTIVE_TESTING_ENABLED, no `scout:run-all-tests` label, no critical\nfiles touched), passing `--moduleFilterPath\n.scout/affected_modules.json` to `create-test-tracks` when enabled.","sha":"4c006f33f1fa45db0ac3c082e31f11a2bd248c36","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","Team:One Workflow","v9.4.0","v9.5.0"],"title":"[Scout] Enable `lanes` test distribution strategy for pull-request & on-merge","number":264506,"url":"https://github.com/elastic/kibana/pull/264506","mergeCommit":{"message":"[Scout] Enable `lanes` test distribution strategy for pull-request & on-merge (#264506)\n\nSwitches the test distribution strategy from `configs` to `lanes` for\nthe pull-request & on-merge Buildkite pipelines.\n\n### Other changes\n- Extends `scout create-test-tracks` with a `--moduleFilterPath` flag\nthat accepts a JSON file of `@kbn/` module IDs. When provided,\n`identifyTestLoads` filters configs to only those belonging to the\nlisted modules using `findPackageForPath` for resolution. An empty set\nmeans no filtering.\n- Wires selective testing into the lanes branch of `test_run_builder.sh`\nusing the same guard conditions as the configs strategy\n(SELECTIVE_TESTING_ENABLED, no `scout:run-all-tests` label, no critical\nfiles touched), passing `--moduleFilterPath\n.scout/affected_modules.json` to `create-test-tracks` when enabled.","sha":"4c006f33f1fa45db0ac3c082e31f11a2bd248c36"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/268015","number":268015,"state":"MERGED","mergeCommit":{"sha":"0dafbdb23ebcb1d4387ded54c6670afeccb57de7","message":"[9.4] [Scout] Enable `lanes` test distribution strategy for pull-request & on-merge (#264506) (#268015)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Scout] Enable `lanes` test distribution strategy for pull-request &\non-merge (#264506)](https://github.com/elastic/kibana/pull/264506)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: David Olaru <dolaru@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264506","number":264506,"mergeCommit":{"message":"[Scout] Enable `lanes` test distribution strategy for pull-request & on-merge (#264506)\n\nSwitches the test distribution strategy from `configs` to `lanes` for\nthe pull-request & on-merge Buildkite pipelines.\n\n### Other changes\n- Extends `scout create-test-tracks` with a `--moduleFilterPath` flag\nthat accepts a JSON file of `@kbn/` module IDs. When provided,\n`identifyTestLoads` filters configs to only those belonging to the\nlisted modules using `findPackageForPath` for resolution. An empty set\nmeans no filtering.\n- Wires selective testing into the lanes branch of `test_run_builder.sh`\nusing the same guard conditions as the configs strategy\n(SELECTIVE_TESTING_ENABLED, no `scout:run-all-tests` label, no critical\nfiles touched), passing `--moduleFilterPath\n.scout/affected_modules.json` to `create-test-tracks` when enabled.","sha":"4c006f33f1fa45db0ac3c082e31f11a2bd248c36"}}]}] BACKPORT-->