### PR TITLE
[AI Infra] Increase GenAI Settings Scout navigation outer timeout

### DIFF
--- a/x-pack/platform/plugins/private/gen_ai_settings/test/scout/ui/fixtures/page_objects/gen_ai_settings_page.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/test/scout/ui/fixtures/page_objects/gen_ai_settings_page.ts
@@ -30,7 +30,7 @@ export class GenAiSettingsPage {
         state: 'visible',
         timeout: 10_000,
       });
-    }).toPass({ timeout: 35_000, intervals: [500, 1_000, 2_000] });
+    }).toPass({ timeout: 70_000, intervals: [500, 1_000, 2_000] });
   }
 
   /**


### PR DESCRIPTION
## Summary

Doubles the `.toPass` outer timeout in `GenAiSettingsPage.navigateTo()` from `35_000` to `70_000` ms to accommodate slow CI VMs.

The management app is registered disabled by default and only enabled once `licensing.license$` emits an enterprise license with the required capabilities (`plugin.ts:75`, `plugin.ts:92–104`). On slow CI machines, this subscription can take longer than the previous 35s retry budget, causing the entire suite to fail at `beforeEach` navigation — as observed in #258969 where all 12 tests in the plugin failed on a single CI run with the same timeout error.

With a 10s inner `waitForSelector` timeout and intervals of [500ms, 1s, 2s], the new 70s outer timeout allows ~4–5 full retry attempts, making the navigation resilient to slow `license$` emission.

Relates to #258969
Follows up on #265692

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk — test-only change, no production code affected.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->