### PR TITLE
[Security Solution] Add `rulesClient.bulkCreateRules` with "enabled" rules task scheduling in the background.

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/common/rule_circuit_breaker_error_message.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/rule_circuit_breaker_error_message.ts
@@ -47,6 +47,12 @@ const getBulkEnableRuleErrorSummary = () => {
   });
 };
 
+const getBulkCreateRuleErrorSummary = () => {
+  return i18n.translate('xpack.alerting.ruleCircuitBreaker.error.bulkCreateSummary', {
+    defaultMessage: `Rules cannot be bulk created. The maximum number of runs per minute would be exceeded.`,
+  });
+};
+
 const getRuleCircuitBreakerErrorDetail = ({
   interval,
   intervalAvailable,
@@ -84,7 +90,7 @@ export const getRuleCircuitBreakerErrorMessage = ({
   name?: string;
   interval: number;
   intervalAvailable: number;
-  action: 'update' | 'create' | 'enable' | 'bulkEdit' | 'bulkEnable';
+  action: 'update' | 'create' | 'enable' | 'bulkEdit' | 'bulkEnable' | 'bulkCreate';
   rules?: number;
 }) => {
   let errorMessageSummary: string;
@@ -104,6 +110,9 @@ export const getRuleCircuitBreakerErrorMessage = ({
       break;
     case 'bulkEnable':
       errorMessageSummary = getBulkEnableRuleErrorSummary();
+      break;
+    case 'bulkCreate':
+      errorMessageSummary = getBulkCreateRuleErrorSummary();
       break;
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -403,13 +403,17 @@ describe('bulkCreateRules', () => {
   });
 
   describe('background (after awaiting backgroundWork)', () => {
-    test('schedules tasks with enabled: true for all enabled persisted rules', async () => {
+    test('schedules tasks disabled, then bulkEnables them (runAt stagger) for all enabled persisted rules', async () => {
       unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
         buildBulkResponse([
           { id: 'mock-id-1', enabled: true },
           { id: 'mock-id-2', enabled: true },
         ])
       );
+      taskManager.bulkEnable.mockResolvedValueOnce({
+        tasks: [{ id: 'mock-id-1' }, { id: 'mock-id-2' }],
+        errors: [],
+      } as never);
 
       const result = await rulesClient.bulkCreateRules({
         rules: [
@@ -426,10 +430,74 @@ describe('bulkCreateRules', () => {
         enabled: boolean;
       }>;
       expect(tasks.map((t) => t.id)).toEqual(['mock-id-1', 'mock-id-2']);
-      expect(tasks.every((t) => t.enabled === true)).toBe(true);
-      expect(taskManager.bulkEnable).not.toHaveBeenCalled();
+      // Tasks are created disabled so taskManager.bulkEnable can stagger
+      // their runAt and avoid stampeding the cluster.
+      expect(tasks.every((t) => t.enabled === false)).toBe(true);
+      expect(taskManager.bulkEnable).toHaveBeenCalledTimes(1);
+      expect(taskManager.bulkEnable.mock.calls[0][0]).toEqual(['mock-id-1', 'mock-id-2']);
       // No demotion = no SO update.
       expect(unsecuredSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
+    });
+
+    test('per-id bulkEnable failure: only the failed ids are demoted', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([
+          { id: 'mock-id-1', enabled: true },
+          { id: 'mock-id-2', enabled: true },
+        ])
+      );
+      taskManager.bulkEnable.mockResolvedValueOnce({
+        tasks: [{ id: 'mock-id-1' }],
+        errors: [{ id: 'mock-id-2', error: { message: 'enable failed' } }],
+      } as never);
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'kept', enabled: true }) },
+          { data: baseRule({ name: 'failed', enabled: true }) },
+        ],
+      });
+
+      await expect(result.backgroundWork).resolves.toEqual([
+        expect.objectContaining({
+          rule: expect.objectContaining({ id: 'mock-id-2' }),
+          disabledReason: 'task_enable_failed',
+        }),
+      ]);
+
+      expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      const updateCall = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0][0] as Array<{
+        id: string;
+      }>;
+      expect(updateCall.map((u) => u.id)).toEqual(['mock-id-2']);
+    });
+
+    test('whole-call bulkEnable throw: all scheduled ids are demoted', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([
+          { id: 'mock-id-1', enabled: true },
+          { id: 'mock-id-2', enabled: true },
+        ])
+      );
+      taskManager.bulkEnable.mockRejectedValueOnce(new Error('TM down'));
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'a', enabled: true }) },
+          { data: baseRule({ name: 'b', enabled: true }) },
+        ],
+      });
+
+      const bgErrors = await result.backgroundWork;
+      expect(bgErrors).toHaveLength(2);
+      expect(bgErrors.every((e) => e.disabledReason === 'task_enable_failed')).toBe(true);
+      expect(bgErrors.every((e) => e.message.includes('TM down'))).toBe(true);
+
+      expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      const updateCall = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0][0] as Array<{
+        id: string;
+      }>;
+      expect(updateCall.map((u) => u.id).sort()).toEqual(['mock-id-1', 'mock-id-2']);
     });
 
     test('schedule-limit exceeded: bulkUpdate demotes all enabled persisted rules; result.errors[] unchanged', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -180,14 +180,14 @@ describe('bulkCreateRules', () => {
   });
 
   describe('foreground (synchronous result)', () => {
-    test('empty input returns immediately with a resolved backgroundWork promise', async () => {
+    test('empty input returns immediately with a no-op backgroundWork thunk', async () => {
       const result = await rulesClient.bulkCreateRules({ rules: [] });
 
       expect(result.rules).toEqual([]);
       expect(result.errors).toEqual([]);
       expect(result.total).toBe(0);
-      expect(result.backgroundWork).toBeInstanceOf(Promise);
-      await expect(result.backgroundWork).resolves.toEqual([]);
+      expect(typeof result.backgroundWork).toBe('function');
+      await expect(result.backgroundWork()).resolves.toEqual([]);
 
       expect(unsecuredSavedObjectsClient.bulkCreate).not.toHaveBeenCalled();
       expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
@@ -208,9 +208,9 @@ describe('bulkCreateRules', () => {
       expect(result.errors).toEqual([]);
       expect(result.total).toBe(2);
       expect(result.rules).toHaveLength(2);
-      expect(result.backgroundWork).toBeInstanceOf(Promise);
+      expect(typeof result.backgroundWork).toBe('function');
 
-      await result.backgroundWork;
+      await result.backgroundWork();
 
       expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
       expect(unsecuredSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
@@ -239,7 +239,7 @@ describe('bulkCreateRules', () => {
       expect(result.rules[0].scheduledTaskId).toBe('mock-id-1');
 
       releaseSchedule();
-      await result.backgroundWork;
+      await result.backgroundWork();
     });
 
     test('Phase 1 per-rule prepare error is isolated', async () => {
@@ -279,7 +279,7 @@ describe('bulkCreateRules', () => {
       expect(result.rules).toHaveLength(1);
       expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
 
-      await result.backgroundWork;
+      await result.backgroundWork();
     });
 
     test('Phase 1 API key creation failure: enabled rule degrades to disabled in foreground', async () => {
@@ -321,7 +321,7 @@ describe('bulkCreateRules', () => {
       expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
       expect(result.errors[0].message).toContain('keys disabled');
 
-      await result.backgroundWork;
+      await result.backgroundWork();
 
       // Only the surviving enabled rule was scheduled.
       expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
@@ -348,7 +348,7 @@ describe('bulkCreateRules', () => {
       expect(result.errors[0].status).toBe(409);
       expect(result.errors[0].disabledReason).toBeUndefined();
 
-      await result.backgroundWork;
+      await result.backgroundWork();
 
       // The 409’d row’s key is invalidated; the surviving enabled row’s key
       // is NOT (its rule is live).
@@ -398,11 +398,11 @@ describe('bulkCreateRules', () => {
       // No DISABLE in the foreground.
       expect(actions.filter((a) => a === RuleAuditAction.DISABLE)).toHaveLength(0);
 
-      await result.backgroundWork;
+      await result.backgroundWork();
     });
   });
 
-  describe('background (after awaiting backgroundWork)', () => {
+  describe('background (after invoking backgroundWork())', () => {
     test('schedules tasks disabled, then bulkEnables them (runAt stagger) for all enabled persisted rules', async () => {
       unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
         buildBulkResponse([
@@ -422,7 +422,7 @@ describe('bulkCreateRules', () => {
         ],
       });
 
-      await expect(result.backgroundWork).resolves.toEqual([]);
+      await expect(result.backgroundWork()).resolves.toEqual([]);
 
       expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
       const tasks = taskManager.bulkSchedule.mock.calls[0][0] as Array<{
@@ -458,7 +458,7 @@ describe('bulkCreateRules', () => {
         ],
       });
 
-      await expect(result.backgroundWork).resolves.toEqual([
+      await expect(result.backgroundWork()).resolves.toEqual([
         expect.objectContaining({
           rule: expect.objectContaining({ id: 'mock-id-2' }),
           disabledReason: 'task_enable_failed',
@@ -488,7 +488,7 @@ describe('bulkCreateRules', () => {
         ],
       });
 
-      const bgErrors = await result.backgroundWork;
+      const bgErrors = await result.backgroundWork();
       expect(bgErrors).toHaveLength(2);
       expect(bgErrors.every((e) => e.disabledReason === 'task_enable_failed')).toBe(true);
       expect(bgErrors.every((e) => e.message.includes('TM down'))).toBe(true);
@@ -522,7 +522,7 @@ describe('bulkCreateRules', () => {
       expect(result.errors).toHaveLength(0);
 
       // backgroundWork surfaces the demotion error.
-      await expect(result.backgroundWork).resolves.toEqual([
+      await expect(result.backgroundWork()).resolves.toEqual([
         expect.objectContaining({
           rule: expect.objectContaining({ id: 'mock-id-1' }),
           disabledReason: 'schedule_limit_exceeded',
@@ -568,7 +568,7 @@ describe('bulkCreateRules', () => {
 
       expect(result.errors).toHaveLength(0);
 
-      await expect(result.backgroundWork).resolves.toEqual([
+      await expect(result.backgroundWork()).resolves.toEqual([
         expect.objectContaining({
           rule: expect.objectContaining({ id: 'mock-id-1' }),
           disabledReason: 'task_schedule_failed',
@@ -604,7 +604,7 @@ describe('bulkCreateRules', () => {
 
       expect(result.errors).toHaveLength(0);
 
-      await expect(result.backgroundWork).resolves.toEqual([
+      await expect(result.backgroundWork()).resolves.toEqual([
         expect.objectContaining({
           rule: expect.objectContaining({ id: 'mock-id-2' }),
           disabledReason: 'task_schedule_entry_failed',
@@ -619,7 +619,7 @@ describe('bulkCreateRules', () => {
       expect(taskManager.bulkRemove).not.toHaveBeenCalled();
     });
 
-    test('background bulkUpdate throwing does not reject backgroundWork (caught + logged)', async () => {
+    test('background bulkUpdate throwing does not reject backgroundWork() (caught + logged)', async () => {
       taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
       unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
         buildBulkResponse([{ id: 'mock-id-1', enabled: true }])
@@ -632,7 +632,7 @@ describe('bulkCreateRules', () => {
 
       // Awaiting must not throw; demotion errors were collected before the
       // bulkUpdate failed, so they still surface to the caller.
-      await expect(result.backgroundWork).resolves.toEqual([
+      await expect(result.backgroundWork()).resolves.toEqual([
         expect.objectContaining({
           rule: expect.objectContaining({ id: 'mock-id-1' }),
           disabledReason: 'task_schedule_failed',
@@ -655,7 +655,7 @@ describe('bulkCreateRules', () => {
         rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
       });
 
-      await result.backgroundWork;
+      await result.backgroundWork();
 
       expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
       // No tasks were scheduled (no enabled persisted rules), no bulkUpdate.

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -109,9 +109,13 @@ const baseRule = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const buildBulkResponse = (
-  rules: Array<{ id: string; error?: { message: string; statusCode: number } }>
-) => ({
+interface BulkResponseInput {
+  id: string;
+  enabled?: boolean;
+  error?: { message: string; statusCode: number };
+}
+
+const buildBulkResponse = (rules: BulkResponseInput[]) => ({
   saved_objects: rules.map((r) => ({
     id: r.id,
     type: RULE_SAVED_OBJECT_TYPE,
@@ -122,7 +126,7 @@ const buildBulkResponse = (
           attributes: {
             alertTypeId: '123',
             name: `name-${r.id}`,
-            enabled: false,
+            enabled: r.enabled ?? false,
             consumer: 'bar',
             schedule: { interval: '1m' },
             params: { foo: true },
@@ -140,6 +144,9 @@ const buildBulkResponse = (
             apiKey: null,
             apiKeyOwner: null,
             apiKeyCreatedByUser: null,
+            ...(r.enabled
+              ? { scheduledTaskId: r.id, lastEnabledAt: '2019-02-12T21:01:22.479Z' }
+              : {}),
           },
         }),
   })) as never,
@@ -170,401 +177,422 @@ describe('bulkCreateRules', () => {
     });
     rulesClientParams.isAuthenticationTypeAPIKey.mockReturnValue(false);
     taskManager.bulkSchedule.mockImplementation(async (tasks) => tasks as never);
-    taskManager.bulkEnable.mockResolvedValue({ tasks: [], errors: [] } as never);
   });
 
-  test('returns empty result for empty input without touching SO/TM/key clients', async () => {
-    const result = await rulesClient.bulkCreateRules({ rules: [] });
-    expect(result).toEqual({ rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] });
-    expect(unsecuredSavedObjectsClient.bulkCreate).not.toHaveBeenCalled();
-    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
-    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+  describe('foreground (synchronous result)', () => {
+    test('empty input returns immediately with a resolved backgroundWork promise', async () => {
+      const result = await rulesClient.bulkCreateRules({ rules: [] });
+
+      expect(result.rules).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.backgroundWork).toBeInstanceOf(Promise);
+      await expect(result.backgroundWork).resolves.toEqual([]);
+
+      expect(unsecuredSavedObjectsClient.bulkCreate).not.toHaveBeenCalled();
+      expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+      expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+    });
+
+    test('all-disabled happy path: SO bulkCreate, no task scheduling, no API keys', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [{ data: baseRule({ name: 'a' }) }, { data: baseRule({ name: 'b' }) }],
+      });
+
+      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+      expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+      expect(result.errors).toEqual([]);
+      expect(result.total).toBe(2);
+      expect(result.rules).toHaveLength(2);
+      expect(result.backgroundWork).toBeInstanceOf(Promise);
+
+      await result.backgroundWork;
+
+      expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+      expect(unsecuredSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
+    });
+
+    test('returned rules reflect input intent for enabled rows even before background runs', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1', enabled: true }])
+      );
+      // Stall background work so we observe the foreground state alone.
+      let releaseSchedule!: () => void;
+      const scheduleGate = new Promise<void>((res) => {
+        releaseSchedule = res;
+      });
+      taskManager.bulkSchedule.mockImplementationOnce(async (tasks) => {
+        await scheduleGate;
+        return tasks as never;
+      });
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+      });
+
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].enabled).toBe(true);
+      expect(result.rules[0].scheduledTaskId).toBe('mock-id-1');
+
+      releaseSchedule();
+      await result.backgroundWork;
+    });
+
+    test('Phase 1 per-rule prepare error is isolated', async () => {
+      let calls = 0;
+      ruleTypeRegistry.get.mockImplementation((typeId: string) => {
+        calls += 1;
+        if (calls === 1) throw new Error('rule type not found');
+        return {
+          id: typeId,
+          name: 'Test',
+          actionGroups: [{ id: 'default', name: 'Default' }],
+          recoveryActionGroup: { id: 'recovered', name: 'Recovered' },
+          defaultActionGroupId: 'default',
+          minimumLicenseRequired: 'basic',
+          isExportable: true,
+          async executor() {
+            return { state: {} };
+          },
+          category: 'test',
+          producer: 'alerts',
+          solution: 'stack',
+          validate: { params: { validate: (p: unknown) => p } },
+          validLegacyConsumers: [],
+        } as never;
+      });
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-2' }])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [{ data: baseRule({ name: 'fails' }) }, { data: baseRule({ name: 'ok' }) }],
+      });
+
+      expect(result.total).toBe(2);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].rule.name).toBe('fails');
+      expect(result.rules).toHaveLength(1);
+      expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+
+      await result.backgroundWork;
+    });
+
+    test('Phase 1 API key creation failure: enabled rule degrades to disabled in foreground', async () => {
+      rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('keys disabled'));
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2', enabled: true }])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'enabled-keyfail', enabled: true }) },
+          { data: baseRule({ name: 'enabled-ok', enabled: true }) },
+        ],
+      });
+
+      // Both rules persisted. The first is sent to bulkCreate as already-disabled
+      // (mint failed). The second is sent enabled.
+      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+      expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+      const persistedAttrsByName = new Map(
+        (
+          unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+            attributes: { name: string; enabled: boolean; apiKey: string | null };
+          }>
+        ).map((o) => [o.attributes.name, o.attributes])
+      );
+      expect(persistedAttrsByName.get('enabled-keyfail')?.enabled).toBe(false);
+      expect(persistedAttrsByName.get('enabled-keyfail')?.apiKey).toBeNull();
+      expect(persistedAttrsByName.get('enabled-ok')?.enabled).toBe(true);
+
+      // Foreground demotion (key-mint failure) IS surfaced in errors[].
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toEqual(
+        expect.objectContaining({
+          disabledReason: 'api_key_creation_failed',
+          rule: expect.objectContaining({ name: 'enabled-keyfail' }),
+        })
+      );
+      expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
+      expect(result.errors[0].message).toContain('keys disabled');
+
+      await result.backgroundWork;
+
+      // Only the surviving enabled rule was scheduled.
+      expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+      expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
+    });
+
+    test('per-row SO error invalidates that rule’s API key, no demotion of others', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([
+          { id: 'mock-id-1', error: { message: 'conflict', statusCode: 409 } },
+          { id: 'mock-id-2', enabled: true },
+        ])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'enabled-conflict', enabled: true }) },
+          { data: baseRule({ name: 'enabled-ok', enabled: true }) },
+        ],
+      });
+
+      expect(result.rules).toHaveLength(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].status).toBe(409);
+      expect(result.errors[0].disabledReason).toBeUndefined();
+
+      await result.backgroundWork;
+
+      // The 409’d row’s key is invalidated; the surviving enabled row’s key
+      // is NOT (its rule is live).
+      expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+      // Only the surviving row was scheduled.
+      expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+      expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
+      // No orphan-task cleanup needed: nothing was scheduled for the failed id.
+      expect(taskManager.bulkRemove).not.toHaveBeenCalled();
+    });
+
+    test('whole-call SO bulkCreate failure invalidates all minted keys and rethrows synchronously', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockRejectedValueOnce(new Error('SO down'));
+
+      await expect(
+        rulesClient.bulkCreateRules({
+          rules: [
+            { data: baseRule({ name: 'a', enabled: true }) },
+            { data: baseRule({ name: 'b', enabled: true }) },
+          ],
+        })
+      ).rejects.toThrow('SO down');
+
+      expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+      // Nothing was scheduled, so no orphan cleanup.
+      expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+      expect(taskManager.bulkRemove).not.toHaveBeenCalled();
+    });
+
+    test('emits CREATE for all surviving rules and ENABLE only for enabled rows, in foreground', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1', enabled: true }, { id: 'mock-id-2' }])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'enabled', enabled: true }) },
+          { data: baseRule({ name: 'disabled' }) },
+        ],
+      });
+
+      const actions = (auditLogger.log as jest.Mock).mock.calls
+        .map(([event]) => event?.event?.action)
+        .filter(Boolean);
+      expect(actions.filter((a) => a === RuleAuditAction.CREATE)).toHaveLength(2);
+      expect(actions.filter((a) => a === RuleAuditAction.ENABLE)).toHaveLength(1);
+      // No DISABLE in the foreground.
+      expect(actions.filter((a) => a === RuleAuditAction.DISABLE)).toHaveLength(0);
+
+      await result.backgroundWork;
+    });
   });
 
-  test('all-disabled happy path: single bulkCreate, no TM, no API keys', async () => {
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
-    );
+  describe('background (after awaiting backgroundWork)', () => {
+    test('schedules tasks with enabled: true for all enabled persisted rules', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([
+          { id: 'mock-id-1', enabled: true },
+          { id: 'mock-id-2', enabled: true },
+        ])
+      );
 
-    const result = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'a' }) }, { data: baseRule({ name: 'b' }) }],
-    });
-
-    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
-    expect(taskManager.bulkEnable).not.toHaveBeenCalled();
-    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
-    expect(result.errors).toEqual([]);
-    expect(result.total).toBe(2);
-    expect(result.rules).toHaveLength(2);
-    expect(result.taskIdsFailedToBeEnabled).toEqual([]);
-  });
-
-  test('all-enabled happy path: API keys, bulkSchedule, bulkCreate, bulkEnable', async () => {
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
-    );
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [
-        { data: baseRule({ name: 'a', enabled: true }) },
-        { data: baseRule({ name: 'b', enabled: true }) },
-      ],
-    });
-
-    expect(rulesClientParams.createAPIKey).toHaveBeenCalledTimes(2);
-    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
-    const scheduledIds = (taskManager.bulkSchedule.mock.calls[0][0] as Array<{ id: string }>).map(
-      (t) => t.id
-    );
-    expect(scheduledIds).toEqual(['mock-id-1', 'mock-id-2']);
-    // tasks are scheduled disabled; bulkEnable flips them on
-    expect(
-      (taskManager.bulkSchedule.mock.calls[0][0] as Array<{ enabled: boolean }>).every(
-        (t) => t.enabled === false
-      )
-    ).toBe(true);
-    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-1', 'mock-id-2']);
-    expect(result.errors).toEqual([]);
-    expect(result.total).toBe(2);
-    expect(result.rules).toHaveLength(2);
-    expect(result.taskIdsFailedToBeEnabled).toEqual([]);
-  });
-
-  test('mixed enabled+disabled happy path', async () => {
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
-    );
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'a', enabled: true }) }, { data: baseRule({ name: 'b' }) }],
-    });
-
-    expect(rulesClientParams.createAPIKey).toHaveBeenCalledTimes(1);
-    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
-    expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-1']);
-    expect(result.errors).toEqual([]);
-    expect(result.total).toBe(2);
-  });
-
-  test('Phase 1 per-rule throw is isolated', async () => {
-    let calls = 0;
-    ruleTypeRegistry.get.mockImplementation((typeId: string) => {
-      calls += 1;
-      if (calls === 1) throw new Error('rule type not found');
-      return {
-        id: typeId,
-        name: 'Test',
-        actionGroups: [{ id: 'default', name: 'Default' }],
-        recoveryActionGroup: { id: 'recovered', name: 'Recovered' },
-        defaultActionGroupId: 'default',
-        minimumLicenseRequired: 'basic',
-        isExportable: true,
-        async executor() {
-          return { state: {} };
-        },
-        category: 'test',
-        producer: 'alerts',
-        solution: 'stack',
-        validate: { params: { validate: (p: unknown) => p } },
-        validLegacyConsumers: [],
-      } as never;
-    });
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-2' }])
-    );
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'fails' }) }, { data: baseRule({ name: 'ok' }) }],
-    });
-
-    expect(result.total).toBe(2);
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].rule.name).toBe('fails');
-    expect(result.rules).toHaveLength(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
-  });
-
-  test('Phase 1 API key creation failure: enabled rule degrades to disabled, no key minted, SO still written, no scheduling', async () => {
-    rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('keys disabled'));
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
-    );
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [
-        { data: baseRule({ name: 'enabled-keyfail', enabled: true }) },
-        { data: baseRule({ name: 'enabled-ok', enabled: true }) },
-      ],
-    });
-
-    // Both rules persisted in a single SO bulkCreate. The first one is demoted
-    // to disabled because its key mint failed; the second is scheduled normally.
-    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
-    const persistedAttrsByName = new Map(
-      (
-        unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
-          attributes: { name: string; enabled: boolean; apiKey: string | null };
-        }>
-      ).map((o) => [o.attributes.name, o.attributes])
-    );
-    expect(persistedAttrsByName.get('enabled-keyfail')?.enabled).toBe(false);
-    expect(persistedAttrsByName.get('enabled-keyfail')?.apiKey).toBeNull();
-    expect(persistedAttrsByName.get('enabled-ok')?.enabled).toBe(true);
-    // Only the surviving enabled rule was scheduled / enabled.
-    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
-    expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
-    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-2']);
-    // No key mint succeeded for the demoted rule, so nothing to invalidate.
-    expect(bulkMarkApiKeysForInvalidation).not.toHaveBeenCalled();
-    expect(result.rules).toHaveLength(2);
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toEqual(
-      expect.objectContaining({
-        disabledReason: 'api_key_creation_failed',
-        rule: expect.objectContaining({ name: 'enabled-keyfail' }),
-      })
-    );
-    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
-    expect(result.errors[0].message).toContain('keys disabled');
-  });
-
-  test('Phase 2 schedule-limit trip: enabled rule degrades to disabled, key invalidated, SO still written for both', async () => {
-    (validateScheduleLimit as jest.Mock).mockResolvedValue({
-      interval: 100,
-      intervalAvailable: 50,
-    });
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
-    );
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [
-        { data: baseRule({ name: 'enabled', enabled: true }) },
-        { data: baseRule({ name: 'disabled' }) },
-      ],
-    });
-
-    // The enabled rule contributed an API key → must be invalidated
-    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
-    // Both rules persisted in a single SO bulkCreate; the originally-enabled
-    // one is degraded to disabled (no scheduledTaskId, no API key fields).
-    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
-    const persistedAttrsByName = new Map(
-      (
-        unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
-          attributes: { name: string; enabled: boolean; scheduledTaskId?: string | null };
-        }>
-      ).map((o) => [o.attributes.name, o.attributes])
-    );
-    expect(persistedAttrsByName.get('enabled')?.enabled).toBe(false);
-    expect(persistedAttrsByName.get('enabled')?.scheduledTaskId).toBeUndefined();
-    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
-    expect(result.rules).toHaveLength(2);
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toEqual(
-      expect.objectContaining({
-        disabledReason: 'schedule_limit_exceeded',
-        rule: expect.objectContaining({ name: 'enabled' }),
-      })
-    );
-    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
-  });
-
-  test('Phase 3 whole TM throw: enabled subset degrades to disabled, disabled subset unaffected', async () => {
-    taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
-    );
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [
-        { data: baseRule({ name: 'enabled', enabled: true }) },
-        { data: baseRule({ name: 'disabled' }) },
-      ],
-    });
-
-    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
-    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
-    expect(result.rules).toHaveLength(2);
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toEqual(
-      expect.objectContaining({
-        disabledReason: 'task_schedule_failed',
-        rule: expect.objectContaining({ name: 'enabled' }),
-      })
-    );
-    expect(result.errors[0].message).toContain('cluster unavailable');
-    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
-  });
-
-  test('Phase 3 silent per-task drop: dropped rule degrades to disabled and SO is still written', async () => {
-    taskManager.bulkSchedule.mockImplementationOnce(async (tasks) => {
-      return [tasks[0]] as never;
-    });
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
-    );
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [
-        { data: baseRule({ name: 'kept', enabled: true }) },
-        { data: baseRule({ name: 'dropped', enabled: true }) },
-      ],
-    });
-
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
-    expect(result.rules).toHaveLength(2);
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toEqual(
-      expect.objectContaining({
-        disabledReason: 'task_validation_failed',
-        rule: expect.objectContaining({ name: 'dropped' }),
-      })
-    );
-    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
-  });
-
-  test('Phase 4 per-row error on Phase-3-scheduled id: per-rule key invalidated, bulkRemove called', async () => {
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1', error: { message: 'conflict', statusCode: 409 } }])
-    );
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'enabled', enabled: true }) }],
-    });
-
-    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
-    // Per-row error path now batches TM cleanup into a single bulkRemove.
-    expect(taskManager.bulkRemove).toHaveBeenCalledWith(['mock-id-1']);
-    expect(taskManager.removeIfExists).not.toHaveBeenCalled();
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].status).toBe(409);
-    expect(result.errors[0].disabledReason).toBeUndefined();
-    expect(result.rules).toHaveLength(0);
-  });
-
-  test('Phase 4 per-row error on caller-supplied id NOT in newlyScheduledTaskIds: NO TM cleanup', async () => {
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'caller-id', error: { message: 'conflict', statusCode: 409 } }])
-    );
-
-    await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'disabled-collision' }), options: { id: 'caller-id' } }],
-    });
-
-    expect(taskManager.removeIfExists).not.toHaveBeenCalled();
-    expect(taskManager.bulkRemove).not.toHaveBeenCalled();
-  });
-
-  test('Phase 4 whole-call throw: invalidates every newly-minted key and best-effort bulkRemove of scheduled ids, then rethrows', async () => {
-    unsecuredSavedObjectsClient.bulkCreate.mockRejectedValueOnce(new Error('SO down'));
-
-    await expect(
-      rulesClient.bulkCreateRules({
+      const result = await rulesClient.bulkCreateRules({
         rules: [
           { data: baseRule({ name: 'a', enabled: true }) },
           { data: baseRule({ name: 'b', enabled: true }) },
         ],
-      })
-    ).rejects.toThrow('SO down');
+      });
 
-    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
-    expect(taskManager.bulkRemove).toHaveBeenCalledWith(['mock-id-1', 'mock-id-2']);
-  });
+      await expect(result.backgroundWork).resolves.toEqual([]);
 
-  test('Phase 5 per-task enable error: surfaced in taskIdsFailedToBeEnabled, no SO rollback', async () => {
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }])
-    );
-    taskManager.bulkEnable.mockResolvedValueOnce({
-      tasks: [],
-      errors: [{ id: 'mock-id-1', error: { type: 'foo', message: 'no' } }],
-    } as never);
-
-    const result = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+      expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+      const tasks = taskManager.bulkSchedule.mock.calls[0][0] as Array<{
+        id: string;
+        enabled: boolean;
+      }>;
+      expect(tasks.map((t) => t.id)).toEqual(['mock-id-1', 'mock-id-2']);
+      expect(tasks.every((t) => t.enabled === true)).toBe(true);
+      expect(taskManager.bulkEnable).not.toHaveBeenCalled();
+      // No demotion = no SO update.
+      expect(unsecuredSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
     });
 
-    expect(result.taskIdsFailedToBeEnabled).toEqual(['mock-id-1']);
-    expect(result.rules).toHaveLength(1);
-  });
+    test('schedule-limit exceeded: bulkUpdate demotes all enabled persisted rules; result.errors[] unchanged', async () => {
+      (validateScheduleLimit as jest.Mock).mockResolvedValue({
+        interval: 100,
+        intervalAvailable: 50,
+      });
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1', enabled: true }, { id: 'mock-id-2' }])
+      );
 
-  test('every demotion path stamps a machine-readable disabledReason on the error', async () => {
-    // schedule_limit_exceeded
-    (validateScheduleLimit as jest.Mock).mockResolvedValueOnce({
-      interval: 100,
-      intervalAvailable: 50,
-    });
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
-      buildBulkResponse([{ id: 'mock-id-1' }])
-    );
-    const phase2 = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
-    });
-    expect(phase2.errors[0]).toEqual(
-      expect.objectContaining({ disabledReason: 'schedule_limit_exceeded' })
-    );
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'enabled', enabled: true }) },
+          { data: baseRule({ name: 'disabled' }) },
+        ],
+      });
 
-    // task_schedule_failed
-    taskManager.bulkSchedule.mockRejectedValueOnce(new Error('tm boom'));
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
-      buildBulkResponse([{ id: 'mock-id-2' }])
-    );
-    const phase3a = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'b', enabled: true }) }],
-    });
-    expect(phase3a.errors[0]).toEqual(
-      expect.objectContaining({ disabledReason: 'task_schedule_failed' })
-    );
+      // Caller-visible result reflects input intent even though background
+      // will demote the enabled rule.
+      expect(result.rules).toHaveLength(2);
+      expect(result.errors).toHaveLength(0);
 
-    // task_validation_failed (silent drop)
-    taskManager.bulkSchedule.mockImplementationOnce(async () => [] as never);
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
-      buildBulkResponse([{ id: 'mock-id-3' }])
-    );
-    const phase3b = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'c', enabled: true }) }],
-    });
-    expect(phase3b.errors[0]).toEqual(
-      expect.objectContaining({ disabledReason: 'task_validation_failed' })
-    );
+      // backgroundWork surfaces the demotion error.
+      await expect(result.backgroundWork).resolves.toEqual([
+        expect.objectContaining({
+          rule: expect.objectContaining({ id: 'mock-id-1' }),
+          disabledReason: 'schedule_limit_exceeded',
+        }),
+      ]);
 
-    // api_key_creation_failed
-    rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('no keys'));
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
-      buildBulkResponse([{ id: 'mock-id-4' }])
-    );
-    const phase1 = await rulesClient.bulkCreateRules({
-      rules: [{ data: baseRule({ name: 'd', enabled: true }) }],
-    });
-    expect(phase1.errors[0]).toEqual(
-      expect.objectContaining({ disabledReason: 'api_key_creation_failed' })
-    );
-  });
-
-  test('emits per-rule CREATE audit event for surviving rules and ENABLE for the enabled subset', async () => {
-    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
-    );
-
-    await rulesClient.bulkCreateRules({
-      rules: [
-        { data: baseRule({ name: 'enabled', enabled: true }) },
-        { data: baseRule({ name: 'disabled' }) },
-      ],
+      // Tasks were never scheduled (limit-tripped before bulkSchedule).
+      expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+      // Background bulkUpdate demotes the enabled rule.
+      expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      const updateCall = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0][0] as Array<{
+        id: string;
+        attributes: Record<string, unknown>;
+      }>;
+      expect(updateCall).toHaveLength(1);
+      expect(updateCall[0].id).toBe('mock-id-1');
+      expect(updateCall[0].attributes).toMatchObject({
+        enabled: false,
+        scheduledTaskId: null,
+        lastEnabledAt: null,
+      });
+      // The minted key is queued for invalidation in Phase D.
+      expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+      // DISABLE audit event for the demoted rule.
+      const disableActions = (auditLogger.log as jest.Mock).mock.calls
+        .map(([event]) => event?.event?.action)
+        .filter((a) => a === RuleAuditAction.DISABLE);
+      expect(disableActions).toHaveLength(1);
     });
 
-    const actions = (auditLogger.log as jest.Mock).mock.calls
-      .map(([event]) => event?.event?.action)
-      .filter(Boolean);
-    expect(actions.filter((a) => a === RuleAuditAction.CREATE)).toHaveLength(2);
-    expect(actions.filter((a) => a === RuleAuditAction.ENABLE)).toHaveLength(1);
+    test('whole-call task scheduling failure: bulkUpdate demotes the enabled subset; bulkRemove not called', async () => {
+      taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1', enabled: true }, { id: 'mock-id-2' }])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'enabled', enabled: true }) },
+          { data: baseRule({ name: 'disabled' }) },
+        ],
+      });
+
+      expect(result.errors).toHaveLength(0);
+
+      await expect(result.backgroundWork).resolves.toEqual([
+        expect.objectContaining({
+          rule: expect.objectContaining({ id: 'mock-id-1' }),
+          disabledReason: 'task_schedule_failed',
+        }),
+      ]);
+
+      expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      const updateCall = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0][0] as Array<{
+        id: string;
+      }>;
+      expect(updateCall.map((u) => u.id)).toEqual(['mock-id-1']);
+      // No tasks were created on a whole-call throw.
+      expect(taskManager.bulkRemove).not.toHaveBeenCalled();
+      expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+    });
+
+    test('silent per-task drop: bulkUpdate demotes only the dropped ids', async () => {
+      // bulkSchedule returns only the first task — the second was silently dropped.
+      taskManager.bulkSchedule.mockImplementationOnce(async (tasks) => [tasks[0]] as never);
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([
+          { id: 'mock-id-1', enabled: true },
+          { id: 'mock-id-2', enabled: true },
+        ])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'kept', enabled: true }) },
+          { data: baseRule({ name: 'dropped', enabled: true }) },
+        ],
+      });
+
+      expect(result.errors).toHaveLength(0);
+
+      await expect(result.backgroundWork).resolves.toEqual([
+        expect.objectContaining({
+          rule: expect.objectContaining({ id: 'mock-id-2' }),
+          disabledReason: 'task_schedule_entry_failed',
+        }),
+      ]);
+
+      expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      const updateCall = unsecuredSavedObjectsClient.bulkUpdate.mock.calls[0][0] as Array<{
+        id: string;
+      }>;
+      expect(updateCall.map((u) => u.id)).toEqual(['mock-id-2']);
+      expect(taskManager.bulkRemove).not.toHaveBeenCalled();
+    });
+
+    test('background bulkUpdate throwing does not reject backgroundWork (caught + logged)', async () => {
+      taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1', enabled: true }])
+      );
+      unsecuredSavedObjectsClient.bulkUpdate.mockRejectedValueOnce(new Error('SO write down'));
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+      });
+
+      // Awaiting must not throw; demotion errors were collected before the
+      // bulkUpdate failed, so they still surface to the caller.
+      await expect(result.backgroundWork).resolves.toEqual([
+        expect.objectContaining({
+          rule: expect.objectContaining({ id: 'mock-id-1' }),
+          disabledReason: 'task_schedule_failed',
+        }),
+      ]);
+
+      expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      // Logger.error is called for the bulkUpdate failure.
+      const errorMock = rulesClientParams.logger.error as jest.Mock;
+      const messages = errorMock.mock.calls.map(([msg]) => String(msg));
+      expect(messages.some((m) => m.includes('bulkUpdate to demote'))).toBe(true);
+    });
+
+    test('flushKeysToInvalidate is called even when no demotions occur (queued by per-row SO failures)', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1', error: { message: 'conflict', statusCode: 409 } }])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+      });
+
+      await result.backgroundWork;
+
+      expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+      // No tasks were scheduled (no enabled persisted rules), no bulkUpdate.
+      expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+      expect(unsecuredSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -1,0 +1,439 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  coreFeatureFlagsMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+  savedObjectsRepositoryMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
+import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
+import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
+import type { ActionsAuthorization, ActionsClient } from '@kbn/actions-plugin/server';
+import { createMockConnector } from '@kbn/actions-plugin/server/application/connector/mocks';
+import { ruleTypeRegistryMock } from '../../../../rule_type_registry.mock';
+import { alertingAuthorizationMock } from '../../../../authorization/alerting_authorization.mock';
+import type { AlertingAuthorization } from '../../../../authorization/alerting_authorization';
+import { ConnectorAdapterRegistry } from '../../../../connector_adapters/connector_adapter_registry';
+import { backfillClientMock } from '../../../../backfill_client/backfill_client.mock';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { getBeforeSetup, setGlobalDate } from '../../../../rules_client/tests/lib';
+import type { ConstructorOptions } from '../../../../rules_client/rules_client';
+import { RulesClient } from '../../../../rules_client/rules_client';
+import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
+import { validateScheduleLimit } from '../get_schedule_frequency';
+import { RuleAuditAction } from '../../../../rules_client/common/audit_events';
+
+jest.mock('../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation', () => ({
+  bulkMarkApiKeysForInvalidation: jest.fn(),
+}));
+
+jest.mock('../get_schedule_frequency', () => ({
+  validateScheduleLimit: jest.fn(),
+}));
+
+jest.mock('@kbn/core-saved-objects-utils-server', () => {
+  const actual = jest.requireActual('@kbn/core-saved-objects-utils-server');
+  return {
+    ...actual,
+    SavedObjectsUtils: {
+      generateId: jest.fn(),
+    },
+  };
+});
+
+import { SavedObjectsUtils } from '@kbn/core-saved-objects-utils-server';
+
+const taskManager = taskManagerMock.createStart();
+const ruleTypeRegistry = ruleTypeRegistryMock.create();
+const unsecuredSavedObjectsClient = savedObjectsClientMock.create();
+const encryptedSavedObjects = encryptedSavedObjectsMock.createClient();
+const authorization = alertingAuthorizationMock.create();
+const actionsAuthorization = actionsAuthorizationMock.create();
+const auditLogger = auditLoggerMock.create();
+const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
+
+const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  taskManager,
+  ruleTypeRegistry,
+  unsecuredSavedObjectsClient,
+  authorization: authorization as unknown as AlertingAuthorization,
+  actionsAuthorization: actionsAuthorization as unknown as ActionsAuthorization,
+  spaceId: 'default',
+  namespace: 'default',
+  getUserName: jest.fn(),
+  createAPIKey: jest.fn(),
+  logger: loggingSystemMock.create().get(),
+  internalSavedObjectsRepository,
+  encryptedSavedObjectsClient: encryptedSavedObjects,
+  getActionsClient: jest.fn(),
+  getEventLogClient: jest.fn(),
+  kibanaVersion: 'v8.0.0',
+  auditLogger,
+  maxScheduledPerMinute: 10000,
+  minimumScheduleInterval: { value: '1m', enforce: false },
+  isAuthenticationTypeAPIKey: jest.fn(),
+  getAuthenticationAPIKey: jest.fn(),
+  getAlertIndicesAlias: jest.fn(),
+  alertsService: null,
+  backfillClient: backfillClientMock.create(),
+  connectorAdapterRegistry: new ConnectorAdapterRegistry(),
+  isSystemAction: jest.fn(),
+  uiSettings: uiSettingsServiceMock.createStartContract(),
+  featureFlags: coreFeatureFlagsMock.createStart(),
+  isServerless: false,
+};
+
+setGlobalDate();
+
+const baseRule = (overrides: Record<string, unknown> = {}) => ({
+  enabled: false,
+  name: 'r',
+  tags: [],
+  alertTypeId: '123',
+  consumer: 'bar',
+  schedule: { interval: '1m' },
+  throttle: null,
+  notifyWhen: null,
+  params: { foo: true },
+  actions: [],
+  ...overrides,
+});
+
+const buildBulkResponse = (
+  rules: Array<{ id: string; error?: { message: string; statusCode: number } }>
+) => ({
+  saved_objects: rules.map((r) => ({
+    id: r.id,
+    type: RULE_SAVED_OBJECT_TYPE,
+    references: [],
+    ...(r.error
+      ? { error: { ...r.error, error: 'Conflict' } }
+      : {
+          attributes: {
+            alertTypeId: '123',
+            name: `name-${r.id}`,
+            enabled: false,
+            consumer: 'bar',
+            schedule: { interval: '1m' },
+            params: { foo: true },
+            actions: [],
+            createdBy: 'elastic',
+            updatedBy: 'elastic',
+            createdAt: '2019-02-12T21:01:22.479Z',
+            updatedAt: '2019-02-12T21:01:22.479Z',
+            snoozeSchedule: [],
+            muteAll: false,
+            mutedInstanceIds: [],
+            executionStatus: { status: 'pending', lastExecutionDate: '2019-02-12T21:01:22.479Z' },
+            revision: 0,
+            running: false,
+            apiKey: null,
+            apiKeyOwner: null,
+            apiKeyCreatedByUser: null,
+          },
+        }),
+  })) as never,
+});
+
+describe('bulkCreateRules', () => {
+  let rulesClient: RulesClient;
+  let actionsClient: jest.Mocked<ActionsClient>;
+
+  beforeEach(async () => {
+    getBeforeSetup(rulesClientParams, taskManager, ruleTypeRegistry);
+    (auditLogger.log as jest.Mock).mockClear();
+    (bulkMarkApiKeysForInvalidation as jest.Mock).mockReset();
+    (validateScheduleLimit as jest.Mock).mockReset();
+    let counter = 0;
+    (SavedObjectsUtils.generateId as jest.Mock).mockImplementation(() => `mock-id-${++counter}`);
+    rulesClient = new RulesClient(rulesClientParams);
+    actionsClient = (await rulesClientParams.getActionsClient()) as jest.Mocked<ActionsClient>;
+    actionsClient.getBulk.mockResolvedValue([
+      createMockConnector({ id: '1', actionTypeId: 'test', name: 'a' }),
+    ]);
+    actionsClient.listTypes.mockResolvedValue([]);
+    actionsClient.isSystemAction.mockReturnValue(false);
+    rulesClientParams.getActionsClient.mockResolvedValue(actionsClient);
+    rulesClientParams.createAPIKey.mockResolvedValue({
+      apiKeysEnabled: true,
+      result: { id: 'key-id', name: 'key', api_key: 'key-value' } as never,
+    });
+    rulesClientParams.isAuthenticationTypeAPIKey.mockReturnValue(false);
+    taskManager.bulkSchedule.mockImplementation(async (tasks) => tasks as never);
+    taskManager.bulkEnable.mockResolvedValue({ tasks: [], errors: [] } as never);
+  });
+
+  test('returns empty result for empty input without touching SO/TM/key clients', async () => {
+    const result = await rulesClient.bulkCreateRules({ rules: [] });
+    expect(result).toEqual({ rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] });
+    expect(unsecuredSavedObjectsClient.bulkCreate).not.toHaveBeenCalled();
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+  });
+
+  test('all-disabled happy path: single bulkCreate, no TM, no API keys', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a' }) }, { data: baseRule({ name: 'b' }) }],
+    });
+
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(taskManager.bulkEnable).not.toHaveBeenCalled();
+    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+    expect(result.rules).toHaveLength(2);
+    expect(result.taskIdsFailedToBeEnabled).toEqual([]);
+  });
+
+  test('all-enabled happy path: API keys, bulkSchedule, bulkCreate, bulkEnable', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'a', enabled: true }) },
+        { data: baseRule({ name: 'b', enabled: true }) },
+      ],
+    });
+
+    expect(rulesClientParams.createAPIKey).toHaveBeenCalledTimes(2);
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    const scheduledIds = (taskManager.bulkSchedule.mock.calls[0][0] as Array<{ id: string }>).map(
+      (t) => t.id
+    );
+    expect(scheduledIds).toEqual(['mock-id-1', 'mock-id-2']);
+    // tasks are scheduled disabled; bulkEnable flips them on
+    expect(
+      (taskManager.bulkSchedule.mock.calls[0][0] as Array<{ enabled: boolean }>).every(
+        (t) => t.enabled === false
+      )
+    ).toBe(true);
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-1', 'mock-id-2']);
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+    expect(result.rules).toHaveLength(2);
+    expect(result.taskIdsFailedToBeEnabled).toEqual([]);
+  });
+
+  test('mixed enabled+disabled happy path', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }, { data: baseRule({ name: 'b' }) }],
+    });
+
+    expect(rulesClientParams.createAPIKey).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-1']);
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+  });
+
+  test('Phase 1 per-rule throw is isolated', async () => {
+    let calls = 0;
+    ruleTypeRegistry.get.mockImplementation((typeId: string) => {
+      calls += 1;
+      if (calls === 1) throw new Error('rule type not found');
+      return {
+        id: typeId,
+        name: 'Test',
+        actionGroups: [{ id: 'default', name: 'Default' }],
+        recoveryActionGroup: { id: 'recovered', name: 'Recovered' },
+        defaultActionGroupId: 'default',
+        minimumLicenseRequired: 'basic',
+        isExportable: true,
+        async executor() {
+          return { state: {} };
+        },
+        category: 'test',
+        producer: 'alerts',
+        solution: 'stack',
+        validate: { params: { validate: (p: unknown) => p } },
+        validLegacyConsumers: [],
+      } as never;
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'fails' }) }, { data: baseRule({ name: 'ok' }) }],
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('fails');
+    expect(result.rules).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+  });
+
+  test('Phase 2 schedule-limit trip: enabled keys invalidated, disabled subset still created', async () => {
+    (validateScheduleLimit as jest.Mock).mockResolvedValue({
+      interval: 100,
+      intervalAvailable: 50,
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    // The enabled rule contributed an API key → must be invalidated
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
+    // The disabled rule must still be persisted
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('enabled');
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('Phase 3 whole TM throw: enabled subset failed, disabled subset still created', async () => {
+    taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('enabled');
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('Phase 3 silent per-task drop: per-rule error pushed and rule dropped before SO write', async () => {
+    // Simulate task_store dropping one of the two scheduled tasks.
+    taskManager.bulkSchedule.mockImplementationOnce(async (tasks) => {
+      return [tasks[0]] as never;
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'kept', enabled: true }) },
+        { data: baseRule({ name: 'dropped', enabled: true }) },
+      ],
+    });
+
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('dropped');
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('Phase 4 per-row error on Phase-3-scheduled id: per-rule key invalidated, removeIfExists called', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1', error: { message: 'conflict', statusCode: 409 } }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'enabled', enabled: true }) }],
+    });
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+    // the only key in the call → only the failed rule's key
+    expect(taskManager.removeIfExists).toHaveBeenCalledWith('mock-id-1');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].status).toBe(409);
+    expect(result.rules).toHaveLength(0);
+  });
+
+  test('Phase 4 per-row error on caller-supplied id NOT in scheduledTaskIdsThisCall: NO removeIfExists', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'caller-id', error: { message: 'conflict', statusCode: 409 } }])
+    );
+
+    await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'disabled-collision' }), options: { id: 'caller-id' } }],
+    });
+
+    expect(taskManager.removeIfExists).not.toHaveBeenCalled();
+  });
+
+  test('Phase 4 whole-call throw: invalidates every newly-minted key and best-effort bulkRemove of scheduled ids, then rethrows', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockRejectedValueOnce(new Error('SO down'));
+
+    await expect(
+      rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'a', enabled: true }) },
+          { data: baseRule({ name: 'b', enabled: true }) },
+        ],
+      })
+    ).rejects.toThrow('SO down');
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkRemove).toHaveBeenCalledWith(['mock-id-1', 'mock-id-2']);
+  });
+
+  test('Phase 5 per-task enable error: surfaced in taskIdsFailedToBeEnabled, no SO rollback', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }])
+    );
+    taskManager.bulkEnable.mockResolvedValueOnce({
+      tasks: [],
+      errors: [{ id: 'mock-id-1', error: { type: 'foo', message: 'no' } }],
+    } as never);
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+    });
+
+    expect(result.taskIdsFailedToBeEnabled).toEqual(['mock-id-1']);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('emits per-rule CREATE audit event for surviving rules and ENABLE for the enabled subset', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    const actions = (auditLogger.log as jest.Mock).mock.calls
+      .map(([event]) => event?.event?.action)
+      .filter(Boolean);
+    expect(actions.filter((a) => a === RuleAuditAction.CREATE)).toHaveLength(2);
+    expect(actions.filter((a) => a === RuleAuditAction.ENABLE)).toHaveLength(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -373,7 +373,7 @@ describe('bulkCreateRules', () => {
     expect(result.rules).toHaveLength(0);
   });
 
-  test('Phase 4 per-row error on caller-supplied id NOT in scheduledTaskIdsThisCall: NO removeIfExists', async () => {
+  test('Phase 4 per-row error on caller-supplied id NOT in newlyScheduledTaskIds: NO removeIfExists', async () => {
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
       buildBulkResponse([{ id: 'caller-id', error: { message: 'conflict', statusCode: 409 } }])
     );

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -31,6 +31,8 @@ import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_a
 import { validateScheduleLimit } from '../get_schedule_frequency';
 import { RuleAuditAction } from '../../../../rules_client/common/audit_events';
 
+const BULK_CREATE_AS_DISABLED_PREFIX = 'Rule created in a disabled state: ';
+
 jest.mock('../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation', () => ({
   bulkMarkApiKeysForInvalidation: jest.fn(),
 }));
@@ -286,13 +288,58 @@ describe('bulkCreateRules', () => {
     expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
   });
 
-  test('Phase 2 schedule-limit trip: enabled keys invalidated, disabled subset still created', async () => {
+  test('Phase 1 API key creation failure: enabled rule degrades to disabled, no key minted, SO still written, no scheduling', async () => {
+    rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('keys disabled'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled-keyfail', enabled: true }) },
+        { data: baseRule({ name: 'enabled-ok', enabled: true }) },
+      ],
+    });
+
+    // Both rules persisted in a single SO bulkCreate. The first one is demoted
+    // to disabled because its key mint failed; the second is scheduled normally.
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    const persistedAttrsByName = new Map(
+      (
+        unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+          attributes: { name: string; enabled: boolean; apiKey: string | null };
+        }>
+      ).map((o) => [o.attributes.name, o.attributes])
+    );
+    expect(persistedAttrsByName.get('enabled-keyfail')?.enabled).toBe(false);
+    expect(persistedAttrsByName.get('enabled-keyfail')?.apiKey).toBeNull();
+    expect(persistedAttrsByName.get('enabled-ok')?.enabled).toBe(true);
+    // Only the surviving enabled rule was scheduled / enabled.
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-2']);
+    // No key mint succeeded for the demoted rule, so nothing to invalidate.
+    expect(bulkMarkApiKeysForInvalidation).not.toHaveBeenCalled();
+    expect(result.rules).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'api_key_creation_failed',
+        rule: expect.objectContaining({ name: 'enabled-keyfail' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
+    expect(result.errors[0].message).toContain('keys disabled');
+  });
+
+  test('Phase 2 schedule-limit trip: enabled rule degrades to disabled, key invalidated, SO still written for both', async () => {
     (validateScheduleLimit as jest.Mock).mockResolvedValue({
       interval: 100,
       intervalAvailable: 50,
     });
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-2' }])
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
     );
 
     const result = await rulesClient.bulkCreateRules({
@@ -304,19 +351,35 @@ describe('bulkCreateRules', () => {
 
     // The enabled rule contributed an API key → must be invalidated
     expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
-    // The disabled rule must still be persisted
+    // Both rules persisted in a single SO bulkCreate; the originally-enabled
+    // one is degraded to disabled (no scheduledTaskId, no API key fields).
     expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    const persistedAttrsByName = new Map(
+      (
+        unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+          attributes: { name: string; enabled: boolean; scheduledTaskId?: string | null };
+        }>
+      ).map((o) => [o.attributes.name, o.attributes])
+    );
+    expect(persistedAttrsByName.get('enabled')?.enabled).toBe(false);
+    expect(persistedAttrsByName.get('enabled')?.scheduledTaskId).toBeUndefined();
     expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(result.rules).toHaveLength(2);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].rule.name).toBe('enabled');
-    expect(result.rules).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'schedule_limit_exceeded',
+        rule: expect.objectContaining({ name: 'enabled' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
   });
 
-  test('Phase 3 whole TM throw: enabled subset failed, disabled subset still created', async () => {
+  test('Phase 3 whole TM throw: enabled subset degrades to disabled, disabled subset unaffected', async () => {
     taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-2' }])
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
     );
 
     const result = await rulesClient.bulkCreateRules({
@@ -328,19 +391,25 @@ describe('bulkCreateRules', () => {
 
     expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
     expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    expect(result.rules).toHaveLength(2);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].rule.name).toBe('enabled');
-    expect(result.rules).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'task_schedule_failed',
+        rule: expect.objectContaining({ name: 'enabled' }),
+      })
+    );
+    expect(result.errors[0].message).toContain('cluster unavailable');
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
   });
 
-  test('Phase 3 silent per-task drop: per-rule error pushed and rule dropped before SO write', async () => {
-    // Simulate task_store dropping one of the two scheduled tasks.
+  test('Phase 3 silent per-task drop: dropped rule degrades to disabled and SO is still written', async () => {
     taskManager.bulkSchedule.mockImplementationOnce(async (tasks) => {
       return [tasks[0]] as never;
     });
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
-      buildBulkResponse([{ id: 'mock-id-1' }])
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
     );
 
     const result = await rulesClient.bulkCreateRules({
@@ -350,13 +419,19 @@ describe('bulkCreateRules', () => {
       ],
     });
 
-    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    expect(result.rules).toHaveLength(2);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].rule.name).toBe('dropped');
-    expect(result.rules).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'task_validation_failed',
+        rule: expect.objectContaining({ name: 'dropped' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
   });
 
-  test('Phase 4 per-row error on Phase-3-scheduled id: per-rule key invalidated, removeIfExists called', async () => {
+  test('Phase 4 per-row error on Phase-3-scheduled id: per-rule key invalidated, bulkRemove called', async () => {
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
       buildBulkResponse([{ id: 'mock-id-1', error: { message: 'conflict', statusCode: 409 } }])
     );
@@ -366,14 +441,16 @@ describe('bulkCreateRules', () => {
     });
 
     expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
-    // the only key in the call → only the failed rule's key
-    expect(taskManager.removeIfExists).toHaveBeenCalledWith('mock-id-1');
+    // Per-row error path now batches TM cleanup into a single bulkRemove.
+    expect(taskManager.bulkRemove).toHaveBeenCalledWith(['mock-id-1']);
+    expect(taskManager.removeIfExists).not.toHaveBeenCalled();
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].status).toBe(409);
+    expect(result.errors[0].disabledReason).toBeUndefined();
     expect(result.rules).toHaveLength(0);
   });
 
-  test('Phase 4 per-row error on caller-supplied id NOT in newlyScheduledTaskIds: NO removeIfExists', async () => {
+  test('Phase 4 per-row error on caller-supplied id NOT in newlyScheduledTaskIds: NO TM cleanup', async () => {
     unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
       buildBulkResponse([{ id: 'caller-id', error: { message: 'conflict', statusCode: 409 } }])
     );
@@ -383,6 +460,7 @@ describe('bulkCreateRules', () => {
     });
 
     expect(taskManager.removeIfExists).not.toHaveBeenCalled();
+    expect(taskManager.bulkRemove).not.toHaveBeenCalled();
   });
 
   test('Phase 4 whole-call throw: invalidates every newly-minted key and best-effort bulkRemove of scheduled ids, then rethrows', async () => {
@@ -416,6 +494,59 @@ describe('bulkCreateRules', () => {
 
     expect(result.taskIdsFailedToBeEnabled).toEqual(['mock-id-1']);
     expect(result.rules).toHaveLength(1);
+  });
+
+  test('every demotion path stamps a machine-readable disabledReason on the error', async () => {
+    // schedule_limit_exceeded
+    (validateScheduleLimit as jest.Mock).mockResolvedValueOnce({
+      interval: 100,
+      intervalAvailable: 50,
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-1' }])
+    );
+    const phase2 = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+    });
+    expect(phase2.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'schedule_limit_exceeded' })
+    );
+
+    // task_schedule_failed
+    taskManager.bulkSchedule.mockRejectedValueOnce(new Error('tm boom'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+    const phase3a = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'b', enabled: true }) }],
+    });
+    expect(phase3a.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'task_schedule_failed' })
+    );
+
+    // task_validation_failed (silent drop)
+    taskManager.bulkSchedule.mockImplementationOnce(async () => [] as never);
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-3' }])
+    );
+    const phase3b = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'c', enabled: true }) }],
+    });
+    expect(phase3b.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'task_validation_failed' })
+    );
+
+    // api_key_creation_failed
+    rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('no keys'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-4' }])
+    );
+    const phase1 = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'd', enabled: true }) }],
+    });
+    expect(phase1.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'api_key_creation_failed' })
+    );
   });
 
   test('emits per-rule CREATE audit event for surviving rules and ENABLE for the enabled subset', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -5,121 +5,44 @@
  * 2.0.
  */
 
-import Boom from '@hapi/boom';
-import Semver from 'semver';
 import pMap from 'p-map';
-import { i18n } from '@kbn/i18n';
 import { withSpan } from '@kbn/apm-utils';
-import type {
-  SavedObject,
-  SavedObjectReference,
-  SavedObjectsBulkCreateObject,
-} from '@kbn/core/server';
+import type { SavedObject, SavedObjectsBulkCreateObject } from '@kbn/core/server';
 import { SavedObjectsUtils } from '@kbn/core/server';
-import type { TaskInstanceWithDeprecatedFields } from '@kbn/task-manager-plugin/server/task';
 
-import { validateAndAuthorizeSystemActions } from '../../../../lib/validate_authorize_system_actions';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
-import { parseDuration, getRuleCircuitBreakerErrorMessage } from '../../../../../common';
-import { WriteOperations, AlertingAuthorizationEntity } from '../../../../authorization';
-import {
-  validateRuleTypeParams,
-  getRuleNotifyWhenType,
-  getDefaultMonitoringRuleDomainProperties,
-} from '../../../../lib';
-import { getRuleExecutionStatusPending } from '../../../../lib/rule_execution_status';
-import {
-  addGeneratedActionValues,
-  createNewAPIKeySet,
-  extractReferences,
-  updateMeta,
-  validateActions,
-} from '../../../../rules_client/lib';
-import {
-  apiKeyAsAlertAttributes,
-  apiKeyAsRuleDomainProperties,
-} from '../../../../rules_client/common';
+import { getRuleCircuitBreakerErrorMessage } from '../../../../../common';
+import { updateMeta } from '../../../../rules_client/lib';
 import { API_KEY_GENERATE_CONCURRENCY } from '../../../../rules_client/common/constants';
 import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
-import { tryToEnableTasks } from '../bulk_enable/bulk_enable_rules';
-import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
 import { bulkCreateRulesSo } from '../../../../data/rule';
-import type { RawRule, RuleTypeRegistry, SanitizedRule } from '../../../../types';
-import type { IntervalSchedule } from '../../../../../common';
+import type { RawRule, SanitizedRule } from '../../../../types';
 import type { BulkOperationError, RulesClientContext } from '../../../../rules_client/types';
-import type { RuleDomain, RuleParams } from '../../types';
-import {
-  transformRuleAttributesToRuleDomain,
-  transformRuleDomainToRule,
-  transformRuleDomainToRuleAttributes,
-} from '../../transforms';
-import { ruleDomainSchema } from '../../schemas';
-import { createRuleDataSchema } from '../create/schemas';
+import type { RuleParams } from '../../types';
 import { validateScheduleLimit } from '../get_schedule_frequency';
 import type {
   BulkCreateOperationError,
-  BulkCreateDisabledReason,
-  BulkCreateRulesItem,
   BulkCreateRulesParams,
   BulkCreateRulesResult,
 } from './types';
+import {
+  buildTaskInstance,
+  collectNewKeysToInvalidate,
+  demotePersistedRules,
+  flushKeysToInvalidate,
+  prepareRule,
+  toSanitizedRule,
+} from './utils';
+import type { ApiKeyEntry, DemotionEntry, PreparedRule } from './utils';
 
-const getBulkCreateAsDisabledMessage = (message: string): string =>
-  i18n.translate('xpack.alerting.rulesClient.bulkCreate.ruleCreatedDisabledErrorMessage', {
-    defaultMessage: 'Rule created in a disabled state: {message}',
-    values: { message },
-  });
-
-interface PreparedRule {
-  id: string;
-  name: string;
-  enabled: boolean;
-  rawRule: RawRule;
-  references: SavedObjectReference[];
-  schedule: IntervalSchedule;
-  consumer: string;
-  ruleTypeId: string;
-}
-
-interface ApiKeyEntry {
-  apiKey: string | null;
-  uiamApiKey: string | null;
-  apiKeyCreatedByUser: boolean | null;
-}
-
-const collectNewKeysToInvalidate = (entries: Iterable<ApiKeyEntry>): string[] => {
-  const keys: string[] = [];
-  for (const { apiKey, uiamApiKey, apiKeyCreatedByUser } of entries) {
-    if (apiKey && !apiKeyCreatedByUser) keys.push(apiKey);
-    if (uiamApiKey && !apiKeyCreatedByUser) keys.push(uiamApiKey);
-  }
-  return keys;
-};
-
-const buildTaskInstance = (
-  context: RulesClientContext,
-  prepared: PreparedRule
-): TaskInstanceWithDeprecatedFields => ({
-  id: prepared.id,
-  taskType: `alerting:${prepared.ruleTypeId}`,
-  schedule: prepared.schedule,
-  params: {
-    alertId: prepared.id,
-    spaceId: context.spaceId,
-    consumer: prepared.consumer,
-  },
-  state: {
-    previousStartedAt: null,
-    alertTypeState: {},
-    alertInstances: {},
-  },
-  scope: ['alerting'],
-  // Tasks are scheduled disabled. Phase 5 enables them via taskManager.bulkEnable
-  // so per-task validation drops never produce a running task without a rule SO,
-  // and the activation can randomise schedule datetimes across the batch.
-  enabled: false,
-});
-
+/**
+ * Persist-first bulk rule create. 2 parts:
+ * 1. Foreground: SO bulkCreate, audit, return.
+ * 2. Background (`result.backgroundWork`): Scheduling - limit checks, task scheduling, demotion / rule SO update (-> disabled), key invalidation.
+ *
+ * Returned `rules[]` reflect input intent; the background promise may
+ * later demote rules to "disabled" if related tasks failed to schedule.
+ */
 export async function bulkCreateRules<Params extends RuleParams = never>(
   context: RulesClientContext,
   params: BulkCreateRulesParams<Params>
@@ -129,7 +52,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   const total = rules.length;
 
   if (total === 0) {
-    return { rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] };
+    return { rules: [], errors: [], total: 0, backgroundWork: Promise.resolve([]) };
   }
 
   const username = await context.getUserName();
@@ -147,7 +70,6 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   const preparedRules = new Map<string, PreparedRule>();
   const errors: BulkOperationError[] = [];
   const apiKeysMap = new Map<string, ApiKeyEntry>();
-  // Key invalidation involves call to ES so we invalidate keys at the end to reduce round-trips.
   const keysToInvalidate = new Set<string>();
 
   await pMap(
@@ -169,100 +91,9 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     { concurrency: API_KEY_GENERATE_CONCURRENCY }
   );
 
-  // Phase 2: validate schedule-limits, enabled subset only.
-  const enabled = [...preparedRules.values()].filter((p) => p.enabled);
-
-  if (enabled.length > 0) {
-    const updatedInterval = enabled.map((r) => r.schedule.interval);
-    const validationPayload = await validateScheduleLimit({ context, updatedInterval });
-    const enabledIds = enabled.map((p) => p.id);
-    if (validationPayload) {
-      const reasonMessage = getRuleCircuitBreakerErrorMessage({
-        interval: validationPayload.interval,
-        intervalAvailable: validationPayload.intervalAvailable,
-        action: 'bulkCreate',
-        rules: enabledIds.length,
-      });
-      logger.warn(`Demoting ${enabledIds.length} rules -> disabled, schedule limit exceeded.`);
-      demotePreparedRules({
-        ids: enabledIds,
-        reason: 'schedule_limit_exceeded',
-        message: reasonMessage,
-        preparedRules,
-        apiKeysMap,
-        keysToInvalidate,
-        errors,
-        username,
-      });
-    }
-  }
-
-  // Phase 3: schedule tasks for the surviving enabled subset.
-  const survivingEnabled = [...preparedRules.values()].filter((p) => p.enabled);
-  const newlyScheduledTaskIds = new Set<string>();
-
-  if (survivingEnabled.length > 0) {
-    const tasksToSchedule = survivingEnabled.map((preparedRule) =>
-      buildTaskInstance(context, preparedRule)
-    );
-
-    let scheduledIds: string[] = [];
-    const survivingEnabledIds = survivingEnabled.map((p) => p.id);
-    try {
-      const scheduledTasks = await withSpan(
-        { name: 'taskManager.bulkSchedule', type: 'tasks' },
-        () => context.taskManager.bulkSchedule(tasksToSchedule)
-      );
-      scheduledIds = scheduledTasks.map((task) => task.id);
-    } catch (error) {
-      // Whole-call TM throw: demote enabled subset to disabled, continue.
-      logger.warn(
-        `Demoting ${survivingEnabledIds.length} rules -> disabled, task scheduling failed.`
-      );
-      demotePreparedRules({
-        ids: survivingEnabledIds,
-        reason: 'task_schedule_failed',
-        message: `Failed to schedule tasks: ${error.message}`,
-        preparedRules,
-        apiKeysMap,
-        keysToInvalidate,
-        errors,
-        username,
-      });
-    }
-
-    if (scheduledIds.length > 0) {
-      scheduledIds.forEach((id) => newlyScheduledTaskIds.add(id));
-    }
-
-    // Silent per-task drops: bulkSchedule's `taskInstanceToAttributes` validation
-    // logs+skips invalid instances. Diff requested vs returned and demote the
-    // missing ones — re-enabling later will hit the same validation, but at
-    // least the rule definition isn't lost.
-    if (preparedRules.size > 0 && scheduledIds.length < survivingEnabledIds.length) {
-      const returned = new Set(scheduledIds);
-      const dropped = survivingEnabledIds.filter((id) => !returned.has(id));
-      if (dropped.length > 0) {
-        logger.warn(`Demoting ${dropped.length} rules -> disabled, task validation failed.`);
-        demotePreparedRules({
-          ids: dropped,
-          reason: 'task_validation_failed',
-          message: 'Task scheduling silently dropped this rule (validation failure in task store)',
-          preparedRules,
-          apiKeysMap,
-          keysToInvalidate,
-          errors,
-          username,
-        });
-      }
-    }
-  }
-
-  // No survivors at all: still flush any pending key invalidations from
-  // Phase 1 demotions (no keys to flush in that case, but keep it explicit).
   if (preparedRules.size === 0) {
     await flushKeysToInvalidate(keysToInvalidate, context);
-    return { rules: [], errors, total, taskIdsFailedToBeEnabled: [] };
+    return { rules: [], errors, total, backgroundWork: Promise.resolve([]) };
   }
 
   // Audit per-rule CREATE event before persistence (mirrors createRuleSavedObject).
@@ -276,7 +107,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     );
   }
 
-  // Phase 4: bulk SO create (no overwrite — id collisions surface as per-row 409)
+  // Phase 2: bulk SO create (no overwrite — id collisions surface as per-row 409).
   const bulkObjects: Array<SavedObjectsBulkCreateObject<RawRule>> = [...preparedRules.values()].map(
     (prepared) => ({
       type: RULE_SAVED_OBJECT_TYPE,
@@ -297,32 +128,14 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         })
     );
   } catch (error) {
-    // Whole-call SO failure (auth, timeout, etc): invalidate every newly-minted
-    // key (those tracked in `apiKeysMap`, plus anything previous phases queued
-    // into `keysToInvalidate`), best-effort orphan-task cleanup scoped to ids we
-    // actually scheduled in Phase 3, then rethrow. Inline flush — control flow
-    // never reaches the end-of-function flush.
+    // Nothing was scheduled — invalidate minted keys and rethrow.
     for (const k of collectNewKeysToInvalidate(apiKeysMap.values())) keysToInvalidate.add(k);
     await flushKeysToInvalidate(keysToInvalidate, context);
-    if (newlyScheduledTaskIds.size > 0) {
-      try {
-        await context.taskManager.bulkRemove([...newlyScheduledTaskIds]);
-      } catch (cleanupError) {
-        logger.error(
-          `bulkCreateRules: failed to clean up tasks ${[...newlyScheduledTaskIds].join(
-            ', '
-          )} after SO bulkCreate threw: ${cleanupError.message}`
-        );
-      }
-    }
     throw error;
   }
 
-  // Phase 4 per-row outcomes.
+  // Phase 3: per-row outcome split.
   const successfulSos: Array<SavedObject<RawRule>> = [];
-  const taskIdsToEnable: string[] = [];
-  const taskIdsToCleanUp: string[] = [];
-
   for (const so of bulkResponse.saved_objects) {
     if (so.error) {
       errors.push({
@@ -334,18 +147,12 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
       const apiKey = apiKeysMap.get(so.id);
       if (apiKey) {
         for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
-      }
-
-      // Only ids we scheduled in Phase 3. Skipping caller-supplied id collisions
-      // avoids nuking a pre-existing rule's task on a 409.
-      if (newlyScheduledTaskIds.has(so.id)) {
-        taskIdsToCleanUp.push(so.id);
+        apiKeysMap.delete(so.id);
       }
     } else {
       successfulSos.push(so as SavedObject<RawRule>);
-      if (newlyScheduledTaskIds.has(so.id)) {
-        taskIdsToEnable.push(so.id);
-        // Audit per-rule ENABLE for the enabled subset (mirrors single-rule semantics).
+      if (so.attributes.enabled) {
+        // Background may later demote this rule and emit a DISABLE audit.
         context.auditLogger?.log(
           ruleAuditEvent({
             action: RuleAuditAction.ENABLE,
@@ -361,334 +168,112 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
   }
 
-  // Single batched TM cleanup for per-row failures.
-  if (taskIdsToCleanUp.length > 0) {
+  const enabledPersistedIds = successfulSos
+    .filter((so) => so.attributes.enabled)
+    .map((so) => so.id);
+
+  // Phase 4: detached background work — wrapped so the promise never rejects.
+  // Resolves to one error per demoted rule (empty array on full success).
+  const backgroundWork = (async (): Promise<BulkCreateOperationError[]> => {
+    const bgErrors: BulkCreateOperationError[] = [];
     try {
-      logger.warn(`Cleaning up ${taskIdsToCleanUp.length} tasks where SO creation failed.`);
-      await context.taskManager.bulkRemove(taskIdsToCleanUp);
-    } catch (cleanupError) {
-      logger.error(
-        `bulkCreateRules: failed to clean up tasks ${taskIdsToCleanUp.join(
-          ', '
-        )} after SO per-row errors: ${cleanupError.message}`
-      );
+      const demotedIds = new Map<string, DemotionEntry>();
+
+      // Phase 4A: schedule-limit check.
+      if (enabledPersistedIds.length > 0) {
+        const updatedInterval = enabledPersistedIds.map(
+          (id) => preparedRules.get(id)!.schedule.interval
+        );
+        const validationPayload = await validateScheduleLimit({ context, updatedInterval });
+        if (validationPayload) {
+          const reasonMessage = getRuleCircuitBreakerErrorMessage({
+            interval: validationPayload.interval,
+            intervalAvailable: validationPayload.intervalAvailable,
+            action: 'bulkCreate',
+            rules: enabledPersistedIds.length,
+          });
+          logger.warn(
+            `Demoting ${enabledPersistedIds.length} rules -> disabled, schedule limit exceeded.`
+          );
+          for (const id of enabledPersistedIds) {
+            demotedIds.set(id, { reason: 'schedule_limit_exceeded', message: reasonMessage });
+          }
+        }
+      }
+
+      // Phase 4B: schedule tasks for ids not already demoted by Phase 4A.
+      const idsToSchedule = enabledPersistedIds.filter((id) => !demotedIds.has(id));
+      if (idsToSchedule.length > 0) {
+        const tasksToSchedule = idsToSchedule.map((id) =>
+          buildTaskInstance(context, preparedRules.get(id)!)
+        );
+
+        let scheduledIds: string[] = [];
+        let bulkScheduleThrew = false;
+        try {
+          const scheduledTasks = await withSpan(
+            { name: 'taskManager.bulkSchedule', type: 'tasks' },
+            () => context.taskManager.bulkSchedule(tasksToSchedule)
+          );
+          scheduledIds = scheduledTasks.map((task) => task.id);
+        } catch (error) {
+          // Whole-call TM throw: demote everything we tried to schedule.
+          bulkScheduleThrew = true;
+          logger.warn(
+            `Demoting ${idsToSchedule.length} rules -> disabled, task scheduling failed.`
+          );
+          for (const id of idsToSchedule) {
+            demotedIds.set(id, {
+              reason: 'task_schedule_failed',
+              message: `Failed to schedule tasks: ${error.message}`,
+            });
+          }
+        }
+
+        // Silent per-task drops: bulkSchedule logs+skips invalid instances.
+        // Skip when the whole call threw — those ids are already accounted for
+        // under `task_schedule_failed` and must not be reclassified.
+        if (!bulkScheduleThrew && scheduledIds.length < idsToSchedule.length) {
+          const returned = new Set(scheduledIds);
+          const dropped = idsToSchedule.filter((id) => !returned.has(id));
+          if (dropped.length > 0) {
+            logger.warn(`Demoting ${dropped.length} rules -> disabled, task validation failed.`);
+            for (const id of dropped) {
+              demotedIds.set(id, {
+                reason: 'task_schedule_entry_failed',
+                message:
+                  'Task scheduling silently dropped this rule (validation failure in task store)',
+              });
+            }
+          }
+        }
+      }
+
+      // Phase 4C: persist demotions (bulkUpdate SOs to disabled).
+      if (demotedIds.size > 0) {
+        const demotionErrors = await demotePersistedRules({
+          context,
+          demotedIds,
+          preparedRules,
+          apiKeysMap,
+          keysToInvalidate,
+          username,
+        });
+        bgErrors.push(...demotionErrors);
+      }
+
+      // Phase 4D: flush queued API key invalidations.
+      await flushKeysToInvalidate(keysToInvalidate, context);
+    } catch (err) {
+      logger.error(`bulkCreateRules background phases failed: ${err.message}`);
     }
-  }
+    return bgErrors;
+  })();
 
-  // Phase 5: enable tasks for successfully persisted enabled rules.
-  const taskIdsFailedToBeEnabled = await tryToEnableTasks({
-    taskIdsToEnable,
-    logger,
-    taskManager: context.taskManager,
-  });
-
-  // Single end-of-function flush for all collected key invalidations.
-  await flushKeysToInvalidate(keysToInvalidate, context);
-
-  // Phase 6: domain transform + return.
+  // Phase 5: domain transform + return (reflects input intent).
   const sanitizedRules: Array<SanitizedRule<Params>> = successfulSos.map((so) =>
     toSanitizedRule<Params>(context, so, context.ruleTypeRegistry)
   );
 
-  return {
-    rules: sanitizedRules,
-    errors,
-    total,
-    taskIdsFailedToBeEnabled, // <-- same as bulkEnableRules().
-  };
+  return { rules: sanitizedRules, errors, total, backgroundWork };
 }
-
-const toSanitizedRule = <Params extends RuleParams = never>(
-  context: RulesClientContext,
-  so: SavedObject<RawRule>,
-  ruleTypeRegistry: RuleTypeRegistry
-): SanitizedRule<Params> => {
-  const ruleType = ruleTypeRegistry.get(so.attributes.alertTypeId);
-  const ruleDomain: RuleDomain<Params> = transformRuleAttributesToRuleDomain<Params>(
-    so.attributes,
-    {
-      id: so.id,
-      logger: context.logger,
-      ruleType,
-      references: so.references,
-      omitGeneratedValues: false,
-    },
-    context.isSystemAction
-  );
-
-  try {
-    ruleDomainSchema.validate(ruleDomain);
-  } catch (e) {
-    context.logger.warn(`Error validating bulk-created rule domain object for id: ${so.id}, ${e}`);
-  }
-
-  return transformRuleDomainToRule<Params>(ruleDomain, { isPublic: true }) as SanitizedRule<Params>;
-};
-
-interface PrepareRuleArgs<Params extends RuleParams> {
-  context: RulesClientContext;
-  actionsClient: Awaited<ReturnType<RulesClientContext['getActionsClient']>>;
-  username: string | null;
-  id: string;
-  rule: BulkCreateRulesItem<Params>;
-  authzCache: Map<string, Promise<void>>;
-  errors: BulkCreateOperationError[];
-  apiKeysMap: Map<string, ApiKeyEntry>;
-}
-
-const prepareRule = async <Params extends RuleParams>({
-  context,
-  actionsClient,
-  username,
-  id,
-  rule,
-  authzCache,
-  errors,
-  apiKeysMap,
-}: PrepareRuleArgs<Params>): Promise<{ prepared?: PreparedRule; error?: BulkOperationError }> => {
-  const { allowMissingConnectorSecrets } = rule;
-
-  try {
-    const { actions: genActions, systemActions: genSystemActions } = await addGeneratedActionValues(
-      rule.data.actions,
-      rule.data.systemActions,
-      context
-    );
-    const data = { ...rule.data, actions: genActions, systemActions: genSystemActions };
-
-    try {
-      createRuleDataSchema.validate(data);
-    } catch (validationError) {
-      throw Boom.badRequest(`Error validating create data - ${validationError.message}`);
-    }
-
-    // ruleTypeRegistry.get throws 400 if not registered.
-    context.ruleTypeRegistry.get(data.alertTypeId);
-
-    const authzKey = `${data.alertTypeId}::${data.consumer}`;
-    if (!authzCache.has(authzKey)) {
-      authzCache.set(
-        authzKey,
-        context.authorization.ensureAuthorized({
-          ruleTypeId: data.alertTypeId,
-          consumer: data.consumer,
-          operation: WriteOperations.Create,
-          entity: AlertingAuthorizationEntity.Rule,
-        })
-      );
-    }
-    try {
-      await authzCache.get(authzKey)!;
-    } catch (authzError) {
-      context.auditLogger?.log(
-        ruleAuditEvent({
-          action: RuleAuditAction.CREATE,
-          savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: data.name },
-          error: authzError,
-        })
-      );
-      throw authzError;
-    }
-
-    context.ruleTypeRegistry.ensureRuleTypeEnabled(data.alertTypeId);
-    const ruleType = context.ruleTypeRegistry.get(data.alertTypeId);
-    const validatedRuleTypeParams = validateRuleTypeParams(data.params, ruleType.validate.params);
-
-    await validateActions(context, ruleType, data, allowMissingConnectorSecrets);
-    await validateAndAuthorizeSystemActions({
-      actionsClient,
-      actionsAuthorization: context.actionsAuthorization,
-      connectorAdapterRegistry: context.connectorAdapterRegistry,
-      systemActions: data.systemActions ?? [],
-      rule: { consumer: data.consumer, producer: ruleType.producer },
-    });
-
-    const intervalInMs = parseDuration(data.schedule.interval);
-    if (
-      intervalInMs < context.minimumScheduleIntervalInMs &&
-      context.minimumScheduleInterval.enforce
-    ) {
-      throw Boom.badRequest(
-        `Error creating rule: the interval is less than the allowed minimum interval of ${context.minimumScheduleInterval.value}`
-      );
-    }
-    if (
-      intervalInMs < context.minimumScheduleIntervalInMs &&
-      !context.minimumScheduleInterval.enforce
-    ) {
-      context.logger.warn(
-        `Rule schedule interval (${data.schedule.interval}) for "${ruleType.id}" rule type with ID "${id}" is less than the minimum value (${context.minimumScheduleInterval.value}). Running rules at this interval may impact alerting performance. Set "xpack.alerting.rules.minimumScheduleInterval.enforce" to true to prevent creation of these rules.`
-      );
-    }
-
-    // Mint API key for enabled rules.
-    // Soft-fail: a key-mint failure does NOT reject the rule. We persist it as
-    // disabled, push a degraded error so the caller knows, and let downstream
-    // phases treat it as a never-enabled rule. Re-enabling later will re-mint.
-    let effectiveEnabled = data.enabled;
-    let apiKeyProps:
-      | ReturnType<typeof apiKeyAsRuleDomainProperties>
-      | Awaited<ReturnType<typeof createNewAPIKeySet>> = apiKeyAsRuleDomainProperties(
-      null,
-      username,
-      false
-    );
-    if (data.enabled) {
-      try {
-        apiKeyProps = await createNewAPIKeySet(context, {
-          id: ruleType.id,
-          ruleName: data.name,
-          username,
-          shouldUpdateApiKey: true,
-          errorMessage: 'Error creating rule: could not create API key',
-        });
-        apiKeysMap.set(id, {
-          apiKey: apiKeyProps.apiKey ?? null,
-          uiamApiKey: apiKeyProps.uiamApiKey ?? null,
-          apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
-        });
-      } catch (apiKeyErr) {
-        effectiveEnabled = false;
-        apiKeyProps = apiKeyAsRuleDomainProperties(null, username, false);
-        errors.push({
-          message: getBulkCreateAsDisabledMessage(apiKeyErr.message),
-          status: apiKeyErr.output?.statusCode,
-          rule: { id, name: data.name },
-          disabledReason: 'api_key_creation_failed',
-        });
-      }
-    }
-
-    const allActions = [...data.actions, ...(data.systemActions ?? [])];
-    const artifacts = data.artifacts ?? {};
-    const {
-      references,
-      params: updatedParams,
-      actions: actionsWithRefs,
-      artifacts: artifactsWithRefs,
-    } = await extractReferences(context, ruleType, allActions, validatedRuleTypeParams, artifacts);
-
-    const createTime = Date.now();
-    const lastRunTimestamp = new Date();
-    const legacyId = Semver.lt(context.kibanaVersion, '8.0.0') ? id : null;
-    const notifyWhen = getRuleNotifyWhenType(data.notifyWhen ?? null, data.throttle ?? null);
-    const throttle = data.throttle ?? null;
-    const { systemActions: _sa, actions: _a, ...restData } = data;
-
-    const ruleAttributes = transformRuleDomainToRuleAttributes({
-      actionsWithRefs,
-      artifactsWithRefs,
-      rule: {
-        ...restData,
-        ...apiKeyProps,
-        enabled: effectiveEnabled,
-        id,
-        createdBy: username,
-        updatedBy: username,
-        createdAt: new Date(createTime),
-        updatedAt: new Date(createTime),
-        snoozeSchedule: [],
-        muteAll: false,
-        mutedInstanceIds: [],
-        notifyWhen,
-        throttle,
-        executionStatus: getRuleExecutionStatusPending(lastRunTimestamp.toISOString()),
-        monitoring: getDefaultMonitoringRuleDomainProperties(lastRunTimestamp.toISOString()),
-        revision: 0,
-        running: false,
-      } as unknown as RuleDomain<Params>,
-      params: { legacyId, paramsWithRefs: updatedParams },
-    });
-
-    if (effectiveEnabled) {
-      ruleAttributes.lastEnabledAt = new Date(createTime).toISOString();
-      ruleAttributes.scheduledTaskId = id;
-    }
-
-    const prepared = {
-      id,
-      name: data.name,
-      enabled: effectiveEnabled,
-      rawRule: ruleAttributes,
-      references,
-      schedule: data.schedule,
-      consumer: data.consumer,
-      ruleTypeId: data.alertTypeId,
-    };
-    return { prepared };
-  } catch (err) {
-    const error = {
-      message: err.message,
-      status: err.output?.statusCode,
-      rule: { id, name: rule.data?.name ?? 'n/a' },
-    };
-    return { error };
-  }
-};
-
-/**
- * Demote in-memory (enabled -> disabled): flips a set of currently-enabled
- * prepared rules to disabled, queues their API keys for invalidation, records a degraded
- * error so the caller can surface "rule was created in a disabled state".
- */
-const demotePreparedRules = ({
-  ids,
-  reason,
-  message,
-  preparedRules,
-  apiKeysMap,
-  keysToInvalidate,
-  errors,
-  username,
-}: {
-  ids: string[];
-  reason: BulkCreateDisabledReason;
-  message: string;
-  preparedRules: Map<string, PreparedRule>;
-  apiKeysMap: Map<string, ApiKeyEntry>;
-  keysToInvalidate: Set<string>;
-  errors: BulkCreateOperationError[];
-  username: string | null;
-}): void => {
-  for (const id of ids) {
-    const prepared = preparedRules.get(id);
-    if (!prepared || !prepared.enabled) continue;
-
-    const apiKey = apiKeysMap.get(id);
-    if (apiKey) {
-      for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
-      apiKeysMap.delete(id);
-    }
-
-    // Re-shape `rawRule` to the disabled-rule form.
-    const nullKey = apiKeyAsAlertAttributes(null, username, false);
-    prepared.rawRule = {
-      ...prepared.rawRule,
-      ...nullKey,
-      uiamApiKey: null,
-      enabled: false,
-    };
-    delete prepared.rawRule.scheduledTaskId;
-    delete prepared.rawRule.lastEnabledAt;
-    prepared.enabled = false;
-
-    errors.push({
-      message: getBulkCreateAsDisabledMessage(message),
-      rule: { id, name: prepared.name },
-      disabledReason: reason,
-    });
-  }
-};
-
-const flushKeysToInvalidate = async (
-  keysToInvalidate: Set<string>,
-  context: RulesClientContext
-): Promise<void> => {
-  if (keysToInvalidate.size === 0) return;
-  await bulkMarkApiKeysForInvalidation(
-    { apiKeys: [...keysToInvalidate] },
-    context.logger,
-    context.unsecuredSavedObjectsClient
-  );
-  keysToInvalidate.clear();
-};

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -39,12 +39,13 @@ import type { ApiKeyEntry, DemotionEntry, PreparedRule } from './utils';
 /**
  * Persist-first bulk rule create. 2 parts:
  * 1. Foreground: SO bulkCreate, audit, return.
- * 2. Background (`result.backgroundWork`): Scheduling - limit checks,
+ * 2. Background (`result.backgroundWork()`): Scheduling - limit checks,
  *    task scheduling (created disabled), task enabling via
  *    taskManager.bulkEnable, key invalidation.
  *
- * Returned `rules[]` reflect input intent; the background promise may
+ * Returned `rules[]` reflect input intent; invoking `backgroundWork()` may
  * later demote rules to "disabled" if related tasks failed to schedule.
+ * The thunk is not auto-invoked — callers decide when (and whether) to run it.
  */
 export async function bulkCreateRules<Params extends RuleParams = never>(
   context: RulesClientContext,
@@ -55,7 +56,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   const total = rules.length;
 
   if (total === 0) {
-    return { rules: [], errors: [], total: 0, backgroundWork: Promise.resolve([]) };
+    return { rules: [], errors: [], total: 0, backgroundWork: () => Promise.resolve([]) };
   }
 
   const username = await context.getUserName();
@@ -74,6 +75,8 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   const errors: BulkOperationError[] = [];
   const apiKeysMap = new Map<string, ApiKeyEntry>();
   const keysToInvalidate = new Set<string>();
+
+  logger.debug('Bulk creation. prepareRule().');
 
   await pMap(
     inputsWithIds,
@@ -94,9 +97,11 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     { concurrency: API_KEY_GENERATE_CONCURRENCY }
   );
 
+  logger.debug('Bulk creation. ruleAuditEvent(RuleAuditAction.CREATE).');
+
   if (preparedRules.size === 0) {
     await flushKeysToInvalidate(keysToInvalidate, context);
-    return { rules: [], errors, total, backgroundWork: Promise.resolve([]) };
+    return { rules: [], errors, total, backgroundWork: () => Promise.resolve([]) };
   }
 
   // Audit per-rule CREATE event before persistence (mirrors createRuleSavedObject).
@@ -109,6 +114,8 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
       })
     );
   }
+
+  logger.debug('Bulk creation. bulkCreateRulesSo()');
 
   // Phase 2: bulk SO create (no overwrite — id collisions surface as per-row 409).
   const bulkObjects: Array<SavedObjectsBulkCreateObject<RawRule>> = [...preparedRules.values()].map(
@@ -136,6 +143,8 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     await flushKeysToInvalidate(keysToInvalidate, context);
     throw error;
   }
+
+  logger.debug('Bulk creation. ruleAuditEvent(RuleAuditAction.ENABLE).');
 
   // Phase 3: per-row outcome split.
   const successfulSos: Array<SavedObject<RawRule>> = [];
@@ -175,11 +184,15 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     .filter((so) => so.attributes.enabled)
     .map((so) => so.id);
 
-  // Phase 4: detached background work — wrapped so the promise never rejects.
-  // Resolves to one error per demoted rule (empty array on full success).
-  const backgroundWork = (async (): Promise<BulkCreateOperationError[]> => {
+  // Phase 4: deferred background work — returned as a thunk. Caller invokes
+  // when ready; the inner promise is wrapped so it never rejects. Resolves to
+  // one error per demoted rule (empty array on full success).
+  const backgroundWork = async (): Promise<BulkCreateOperationError[]> => {
     const bgErrors: BulkCreateOperationError[] = [];
     try {
+      logger.debug(
+        `Starting background work -> scheduling TM tasks for ${enabledPersistedIds.length} rules.`
+      );
       const demotedIds = new Map<string, DemotionEntry>();
 
       // Phase 4A: schedule-limit check.
@@ -251,7 +264,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
           }
         }
 
-        // Phase 4C: enable scheduled tasks via taskManager.bulkEnable. 
+        // Phase 4C: enable scheduled tasks via taskManager.bulkEnable.
         await bulkEnableScheduledTasks({ context, scheduledIds, demotedIds });
       }
 
@@ -273,8 +286,12 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     } catch (err) {
       logger.error(`bulkCreateRules background phases failed: ${err.message}`);
     }
+
+    logger.debug(`Finished background work -> tasks for ${enabledPersistedIds.length} rules.`);
     return bgErrors;
-  })();
+  };
+
+  logger.debug('Bulk creation. toSanitizedRule().');
 
   // Phase 5: domain transform + return (reflects input intent).
   const sanitizedRules: Array<SanitizedRule<Params>> = successfulSos.map((so) =>

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -27,6 +27,7 @@ import type {
 } from './types';
 import {
   buildTaskInstance,
+  bulkEnableScheduledTasks,
   collectNewKeysToInvalidate,
   demotePersistedRules,
   flushKeysToInvalidate,
@@ -38,7 +39,9 @@ import type { ApiKeyEntry, DemotionEntry, PreparedRule } from './utils';
 /**
  * Persist-first bulk rule create. 2 parts:
  * 1. Foreground: SO bulkCreate, audit, return.
- * 2. Background (`result.backgroundWork`): Scheduling - limit checks, task scheduling, demotion / rule SO update (-> disabled), key invalidation.
+ * 2. Background (`result.backgroundWork`): Scheduling - limit checks,
+ *    task scheduling (created disabled), task enabling via
+ *    taskManager.bulkEnable, key invalidation.
  *
  * Returned `rules[]` reflect input intent; the background promise may
  * later demote rules to "disabled" if related tasks failed to schedule.
@@ -247,9 +250,12 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
             }
           }
         }
+
+        // Phase 4C: enable scheduled tasks via taskManager.bulkEnable. 
+        await bulkEnableScheduledTasks({ context, scheduledIds, demotedIds });
       }
 
-      // Phase 4C: persist demotions (bulkUpdate SOs to disabled).
+      // Phase 4D: persist demotions (bulkUpdate SOs to disabled).
       if (demotedIds.size > 0) {
         const demotionErrors = await demotePersistedRules({
           context,
@@ -262,7 +268,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         bgErrors.push(...demotionErrors);
       }
 
-      // Phase 4D: flush queued API key invalidations.
+      // Phase 4E: flush queued API key invalidations.
       await flushKeysToInvalidate(keysToInvalidate, context);
     } catch (err) {
       logger.error(`bulkCreateRules background phases failed: ${err.message}`);

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -1,0 +1,614 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import Semver from 'semver';
+import pMap from 'p-map';
+import { withSpan } from '@kbn/apm-utils';
+import type {
+  SavedObject,
+  SavedObjectReference,
+  SavedObjectsBulkCreateObject,
+} from '@kbn/core/server';
+import { SavedObjectsUtils } from '@kbn/core/server';
+import type { TaskInstanceWithDeprecatedFields } from '@kbn/task-manager-plugin/server/task';
+
+import { validateAndAuthorizeSystemActions } from '../../../../lib/validate_authorize_system_actions';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { parseDuration, getRuleCircuitBreakerErrorMessage } from '../../../../../common';
+import { WriteOperations, AlertingAuthorizationEntity } from '../../../../authorization';
+import {
+  validateRuleTypeParams,
+  getRuleNotifyWhenType,
+  getDefaultMonitoringRuleDomainProperties,
+} from '../../../../lib';
+import { getRuleExecutionStatusPending } from '../../../../lib/rule_execution_status';
+import {
+  addGeneratedActionValues,
+  createNewAPIKeySet,
+  extractReferences,
+  updateMeta,
+  validateActions,
+} from '../../../../rules_client/lib';
+import { apiKeyAsRuleDomainProperties } from '../../../../rules_client/common';
+import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
+import { tryToEnableTasks } from '../bulk_enable/bulk_enable_rules';
+import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
+import { bulkCreateRulesSo } from '../../../../data/rule';
+import type { RawRule, RuleTypeRegistry, SanitizedRule } from '../../../../types';
+import type { IntervalSchedule } from '../../../../../common';
+import type { RulesClientContext, BulkOperationError } from '../../../../rules_client/types';
+import type { RuleDomain, RuleParams } from '../../types';
+import {
+  transformRuleAttributesToRuleDomain,
+  transformRuleDomainToRule,
+  transformRuleDomainToRuleAttributes,
+} from '../../transforms';
+import { ruleDomainSchema } from '../../schemas';
+import { createRuleDataSchema } from '../create/schemas';
+import { validateScheduleLimit } from '../get_schedule_frequency';
+import type { BulkCreateRulesItem, BulkCreateRulesParams, BulkCreateRulesResult } from './types';
+
+/**
+ * Bound the per-rule prepare phase to avoid overwhelming downstream services
+ * (security plugin API key minting, action validation).
+ */
+const PREPARE_CONCURRENCY = 10;
+
+interface PreparedRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  rawRule: RawRule;
+  references: SavedObjectReference[];
+  schedule: IntervalSchedule;
+  consumer: string;
+  ruleTypeId: string;
+}
+
+interface ApiKeyEntry {
+  apiKey: string | null;
+  uiamApiKey: string | null;
+  apiKeyCreatedByUser: boolean | null;
+}
+
+const collectNewKeysToInvalidate = (entries: Iterable<ApiKeyEntry>): string[] => {
+  const keys: string[] = [];
+  for (const { apiKey, uiamApiKey, apiKeyCreatedByUser } of entries) {
+    if (apiKey && !apiKeyCreatedByUser) keys.push(apiKey);
+    if (uiamApiKey && !apiKeyCreatedByUser) keys.push(uiamApiKey);
+  }
+  return keys;
+};
+
+const buildTaskInstance = (
+  context: RulesClientContext,
+  prepared: PreparedRule
+): TaskInstanceWithDeprecatedFields => ({
+  id: prepared.id,
+  taskType: `alerting:${prepared.ruleTypeId}`,
+  schedule: prepared.schedule,
+  params: {
+    alertId: prepared.id,
+    spaceId: context.spaceId,
+    consumer: prepared.consumer,
+  },
+  state: {
+    previousStartedAt: null,
+    alertTypeState: {},
+    alertInstances: {},
+  },
+  scope: ['alerting'],
+  // Tasks are scheduled disabled. Phase 5 enables them via taskManager.bulkEnable
+  // so per-task validation drops never produce a running task without a rule SO,
+  // and the activation can randomise schedule datetimes across the batch.
+  enabled: false,
+});
+
+export async function bulkCreateRules<Params extends RuleParams = never>(
+  context: RulesClientContext,
+  params: BulkCreateRulesParams<Params>
+): Promise<BulkCreateRulesResult<Params>> {
+  const { rules: inputs } = params;
+  const total = inputs.length;
+
+  if (total === 0) {
+    return { rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] };
+  }
+
+  const errors: BulkOperationError[] = [];
+  const username = await context.getUserName();
+  const actionsClient = await context.getActionsClient();
+
+  // Phase 0: assign ids up-front, partition by enabled flag (tracked per item id below).
+  const inputsWithIds = inputs.map((input) => ({
+    id: input.options?.id ?? SavedObjectsUtils.generateId(),
+    input,
+  }));
+
+  // Phase 1: per-rule prepare (per-pair authorization dedupe done first).
+  const authzCache = new Map<string, Promise<void>>();
+  const preparedRules = new Map<string, PreparedRule>();
+  const apiKeysMap = new Map<string, ApiKeyEntry>();
+
+  await pMap(
+    inputsWithIds,
+    async ({ id, input }) => {
+      const prepared = await prepareRule({
+        context,
+        actionsClient,
+        username,
+        id,
+        input,
+        authzCache,
+        errors,
+        apiKeysMap,
+      });
+      if (prepared) preparedRules.set(id, prepared);
+    },
+    { concurrency: PREPARE_CONCURRENCY }
+  );
+
+  // Phase 2: schedule-limit gate, scoped to the enabled subset only.
+  const enabledIds = [...preparedRules.values()].filter((p) => p.enabled).map((p) => p.id);
+
+  if (enabledIds.length > 0) {
+    const updatedInterval = enabledIds.map((id) => preparedRules.get(id)!.schedule.interval);
+    const validationPayload = await validateScheduleLimit({ context, updatedInterval });
+    if (validationPayload) {
+      const message = getRuleCircuitBreakerErrorMessage({
+        interval: validationPayload.interval,
+        intervalAvailable: validationPayload.intervalAvailable,
+        action: 'bulkCreate',
+        rules: enabledIds.length,
+      });
+      await dropEnabledSubset({
+        context,
+        enabledIds,
+        preparedRules,
+        apiKeysMap,
+        errors,
+        message,
+      });
+    }
+  }
+
+  // Phase 3: schedule tasks for the surviving enabled subset.
+  const survivingEnabledIds = [...preparedRules.values()].filter((p) => p.enabled).map((p) => p.id);
+  const scheduledTaskIdsThisCall = new Set<string>();
+
+  if (survivingEnabledIds.length > 0) {
+    const tasksToSchedule = survivingEnabledIds.map((id) =>
+      buildTaskInstance(context, preparedRules.get(id)!)
+    );
+
+    let scheduledIds: string[] = [];
+    try {
+      const scheduledTasks = await withSpan(
+        { name: 'taskManager.bulkSchedule', type: 'tasks' },
+        () => context.taskManager.bulkSchedule(tasksToSchedule)
+      );
+      scheduledIds = scheduledTasks.map((task) => task.id);
+    } catch (error) {
+      // Whole-call TM throw: fail enabled subset only, continue with disabled subset.
+      await dropEnabledSubset({
+        context,
+        enabledIds: survivingEnabledIds,
+        preparedRules,
+        apiKeysMap,
+        errors,
+        message: `Failed to schedule tasks: ${error.message}`,
+      });
+    }
+
+    if (scheduledIds.length > 0) {
+      scheduledIds.forEach((id) => scheduledTaskIdsThisCall.add(id));
+    }
+
+    // Silent per-task drops: bulkSchedule's `taskInstanceToAttributes` validation
+    // logs+skips invalid instances. Diff requested vs returned and surface them as
+    // per-rule errors so we don't write a rule SO whose scheduledTaskId is dangling.
+    if (preparedRules.size > 0 && scheduledIds.length < survivingEnabledIds.length) {
+      const returned = new Set(scheduledIds);
+      const dropped = survivingEnabledIds.filter((id) => !returned.has(id));
+      if (dropped.length > 0) {
+        await dropEnabledSubset({
+          context,
+          enabledIds: dropped,
+          preparedRules,
+          apiKeysMap,
+          errors,
+          message: 'Task scheduling silently dropped this rule (validation failure in task store)',
+        });
+      }
+    }
+  }
+
+  // No survivors at all: short-circuit before SO write.
+  if (preparedRules.size === 0) {
+    return { rules: [], errors, total, taskIdsFailedToBeEnabled: [] };
+  }
+
+  // Audit per-rule CREATE event before persistence (mirrors createRuleSavedObject).
+  for (const prepared of preparedRules.values()) {
+    context.auditLogger?.log(
+      ruleAuditEvent({
+        action: RuleAuditAction.CREATE,
+        outcome: 'unknown',
+        savedObject: { type: RULE_SAVED_OBJECT_TYPE, id: prepared.id, name: prepared.name },
+      })
+    );
+  }
+
+  // Phase 4: bulk SO create (no overwrite — id collisions surface as per-row 409).
+  const bulkObjects: Array<SavedObjectsBulkCreateObject<RawRule>> = [...preparedRules.values()].map(
+    (prepared) => ({
+      type: RULE_SAVED_OBJECT_TYPE,
+      id: prepared.id,
+      attributes: updateMeta(context, prepared.rawRule),
+      references: prepared.references,
+    })
+  );
+
+  let bulkResponse;
+  try {
+    bulkResponse = await withSpan(
+      { name: 'unsecuredSavedObjectsClient.bulkCreate', type: 'rules' },
+      () =>
+        bulkCreateRulesSo({
+          savedObjectsClient: context.unsecuredSavedObjectsClient,
+          bulkCreateRuleAttributes: bulkObjects,
+        })
+    );
+  } catch (error) {
+    // Whole-call SO throw: invalidate every newly-minted key, best-effort orphan-task
+    // cleanup scoped to ids we actually scheduled in Phase 3, then rethrow.
+    const keysToInvalidate = collectNewKeysToInvalidate(apiKeysMap.values());
+    if (keysToInvalidate.length > 0) {
+      await bulkMarkApiKeysForInvalidation(
+        { apiKeys: keysToInvalidate },
+        context.logger,
+        context.unsecuredSavedObjectsClient
+      );
+    }
+    if (scheduledTaskIdsThisCall.size > 0) {
+      try {
+        await context.taskManager.bulkRemove([...scheduledTaskIdsThisCall]);
+      } catch (cleanupError) {
+        context.logger.error(
+          `bulkCreateRules: failed to clean up tasks ${[...scheduledTaskIdsThisCall].join(
+            ', '
+          )} after SO bulkCreate threw: ${cleanupError.message}`
+        );
+      }
+    }
+    throw error;
+  }
+
+  // Phase 4 per-row outcomes.
+  const successfulSos: Array<SavedObject<RawRule>> = [];
+  const taskIdsToEnable: string[] = [];
+
+  for (const so of bulkResponse.saved_objects) {
+    if (so.error) {
+      errors.push({
+        message: so.error.message ?? 'n/a',
+        status: so.error.statusCode,
+        rule: { id: so.id, name: preparedRules.get(so.id)?.name ?? 'n/a' },
+      });
+
+      // Per-row API key invalidation (only the failed rule's key).
+      const apiKey = apiKeysMap.get(so.id);
+      if (apiKey) {
+        const keys = collectNewKeysToInvalidate([apiKey]);
+        if (keys.length > 0) {
+          await bulkMarkApiKeysForInvalidation(
+            { apiKeys: keys },
+            context.logger,
+            context.unsecuredSavedObjectsClient
+          );
+        }
+      }
+
+      // Best-effort orphan-task cleanup, but ONLY if this id was scheduled by us
+      // in Phase 3. Avoids nuking a pre-existing rule's task on a 409 caused by a
+      // caller-supplied id collision.
+      if (scheduledTaskIdsThisCall.has(so.id)) {
+        try {
+          await context.taskManager.removeIfExists(so.id);
+        } catch (cleanupError) {
+          context.logger.error(
+            `bulkCreateRules: failed to clean up task ${so.id} after SO per-row error: ${cleanupError.message}`
+          );
+        }
+      }
+      continue;
+    }
+
+    successfulSos.push(so as SavedObject<RawRule>);
+    if (scheduledTaskIdsThisCall.has(so.id)) {
+      taskIdsToEnable.push(so.id);
+      // Audit per-rule ENABLE for the enabled subset (mirrors single-rule semantics).
+      context.auditLogger?.log(
+        ruleAuditEvent({
+          action: RuleAuditAction.ENABLE,
+          outcome: 'unknown',
+          savedObject: {
+            type: RULE_SAVED_OBJECT_TYPE,
+            id: so.id,
+            name: preparedRules.get(so.id)?.name,
+          },
+        })
+      );
+    }
+  }
+
+  // Phase 5: enable tasks for successfully persisted enabled rules.
+  const taskIdsFailedToBeEnabled = await tryToEnableTasks({
+    taskIdsToEnable,
+    logger: context.logger,
+    taskManager: context.taskManager,
+  });
+
+  // Phase 6: domain transform + return.
+  const sanitizedRules: Array<SanitizedRule<Params>> = successfulSos.map((so) =>
+    toSanitizedRule<Params>(context, so, context.ruleTypeRegistry)
+  );
+
+  return {
+    rules: sanitizedRules,
+    errors,
+    total,
+    taskIdsFailedToBeEnabled,
+  };
+}
+
+const toSanitizedRule = <Params extends RuleParams = never>(
+  context: RulesClientContext,
+  so: SavedObject<RawRule>,
+  ruleTypeRegistry: RuleTypeRegistry
+): SanitizedRule<Params> => {
+  const ruleType = ruleTypeRegistry.get(so.attributes.alertTypeId);
+  const ruleDomain: RuleDomain<Params> = transformRuleAttributesToRuleDomain<Params>(
+    so.attributes,
+    {
+      id: so.id,
+      logger: context.logger,
+      ruleType,
+      references: so.references,
+      omitGeneratedValues: false,
+    },
+    context.isSystemAction
+  );
+
+  try {
+    ruleDomainSchema.validate(ruleDomain);
+  } catch (e) {
+    context.logger.warn(`Error validating bulk-created rule domain object for id: ${so.id}, ${e}`);
+  }
+
+  return transformRuleDomainToRule<Params>(ruleDomain, { isPublic: true }) as SanitizedRule<Params>;
+};
+
+interface PrepareRuleArgs<Params extends RuleParams> {
+  context: RulesClientContext;
+  actionsClient: Awaited<ReturnType<RulesClientContext['getActionsClient']>>;
+  username: string | null;
+  id: string;
+  input: BulkCreateRulesItem<Params>;
+  authzCache: Map<string, Promise<void>>;
+  errors: BulkOperationError[];
+  apiKeysMap: Map<string, ApiKeyEntry>;
+}
+
+const prepareRule = async <Params extends RuleParams>({
+  context,
+  actionsClient,
+  username,
+  id,
+  input,
+  authzCache,
+  errors,
+  apiKeysMap,
+}: PrepareRuleArgs<Params>): Promise<PreparedRule | null> => {
+  const { allowMissingConnectorSecrets } = input;
+
+  try {
+    const { actions: genActions, systemActions: genSystemActions } = await addGeneratedActionValues(
+      input.data.actions,
+      input.data.systemActions,
+      context
+    );
+    const data = { ...input.data, actions: genActions, systemActions: genSystemActions };
+
+    try {
+      createRuleDataSchema.validate(data);
+    } catch (validationError) {
+      throw Boom.badRequest(`Error validating create data - ${validationError.message}`);
+    }
+
+    // ruleTypeRegistry.get throws 400 if not registered.
+    context.ruleTypeRegistry.get(data.alertTypeId);
+
+    const authzKey = `${data.alertTypeId}::${data.consumer}`;
+    if (!authzCache.has(authzKey)) {
+      authzCache.set(
+        authzKey,
+        context.authorization.ensureAuthorized({
+          ruleTypeId: data.alertTypeId,
+          consumer: data.consumer,
+          operation: WriteOperations.Create,
+          entity: AlertingAuthorizationEntity.Rule,
+        })
+      );
+    }
+    try {
+      await authzCache.get(authzKey)!;
+    } catch (authzError) {
+      context.auditLogger?.log(
+        ruleAuditEvent({
+          action: RuleAuditAction.CREATE,
+          savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: data.name },
+          error: authzError,
+        })
+      );
+      throw authzError;
+    }
+
+    context.ruleTypeRegistry.ensureRuleTypeEnabled(data.alertTypeId);
+    const ruleType = context.ruleTypeRegistry.get(data.alertTypeId);
+    const validatedRuleTypeParams = validateRuleTypeParams(data.params, ruleType.validate.params);
+
+    await validateActions(context, ruleType, data, allowMissingConnectorSecrets);
+    await validateAndAuthorizeSystemActions({
+      actionsClient,
+      actionsAuthorization: context.actionsAuthorization,
+      connectorAdapterRegistry: context.connectorAdapterRegistry,
+      systemActions: data.systemActions ?? [],
+      rule: { consumer: data.consumer, producer: ruleType.producer },
+    });
+
+    const intervalInMs = parseDuration(data.schedule.interval);
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      context.minimumScheduleInterval.enforce
+    ) {
+      throw Boom.badRequest(
+        `Error creating rule: the interval is less than the allowed minimum interval of ${context.minimumScheduleInterval.value}`
+      );
+    }
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      !context.minimumScheduleInterval.enforce
+    ) {
+      context.logger.warn(
+        `Rule schedule interval (${data.schedule.interval}) for "${ruleType.id}" rule type with ID "${id}" is less than the minimum value (${context.minimumScheduleInterval.value}). Running rules at this interval may impact alerting performance. Set "xpack.alerting.rules.minimumScheduleInterval.enforce" to true to prevent creation of these rules.`
+      );
+    }
+
+    // Mint API key for enabled rules. createNewAPIKeySet returns the encoded
+    // `{ apiKey, apiKeyOwner, apiKeyCreatedByUser, uiamApiKey? }` shape suitable
+    // for direct use as rule attributes; for disabled rules we mirror createRule
+    // and use apiKeyAsRuleDomainProperties(null, ...) (all-null props).
+    const apiKeyProps = data.enabled
+      ? await createNewAPIKeySet(context, {
+          id: ruleType.id,
+          ruleName: data.name,
+          username,
+          shouldUpdateApiKey: true,
+          errorMessage: 'Error creating rule: could not create API key',
+        })
+      : apiKeyAsRuleDomainProperties(null, username, false);
+
+    if (data.enabled) {
+      apiKeysMap.set(id, {
+        apiKey: apiKeyProps.apiKey ?? null,
+        uiamApiKey: apiKeyProps.uiamApiKey ?? null,
+        apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
+      });
+    }
+
+    const allActions = [...data.actions, ...(data.systemActions ?? [])];
+    const artifacts = data.artifacts ?? {};
+    const {
+      references,
+      params: updatedParams,
+      actions: actionsWithRefs,
+      artifacts: artifactsWithRefs,
+    } = await extractReferences(context, ruleType, allActions, validatedRuleTypeParams, artifacts);
+
+    const createTime = Date.now();
+    const lastRunTimestamp = new Date();
+    const legacyId = Semver.lt(context.kibanaVersion, '8.0.0') ? id : null;
+    const notifyWhen = getRuleNotifyWhenType(data.notifyWhen ?? null, data.throttle ?? null);
+    const throttle = data.throttle ?? null;
+    const { systemActions: _sa, actions: _a, ...restData } = data;
+
+    const ruleAttributes = transformRuleDomainToRuleAttributes({
+      actionsWithRefs,
+      artifactsWithRefs,
+      rule: {
+        ...restData,
+        ...apiKeyProps,
+        id,
+        createdBy: username,
+        updatedBy: username,
+        createdAt: new Date(createTime),
+        updatedAt: new Date(createTime),
+        snoozeSchedule: [],
+        muteAll: false,
+        mutedInstanceIds: [],
+        notifyWhen,
+        throttle,
+        executionStatus: getRuleExecutionStatusPending(lastRunTimestamp.toISOString()),
+        monitoring: getDefaultMonitoringRuleDomainProperties(lastRunTimestamp.toISOString()),
+        revision: 0,
+        running: false,
+      } as unknown as RuleDomain<Params>,
+      params: { legacyId, paramsWithRefs: updatedParams },
+    });
+
+    if (data.enabled) {
+      ruleAttributes.lastEnabledAt = new Date(createTime).toISOString();
+      ruleAttributes.scheduledTaskId = id;
+    }
+
+    return {
+      id,
+      name: data.name,
+      enabled: data.enabled,
+      rawRule: ruleAttributes,
+      references,
+      schedule: data.schedule,
+      consumer: data.consumer,
+      ruleTypeId: data.alertTypeId,
+    };
+  } catch (error) {
+    errors.push({
+      message: error.message,
+      status: error.output?.statusCode,
+      rule: { id, name: input.data?.name ?? 'n/a' },
+    });
+    return null;
+  }
+};
+
+const dropEnabledSubset = async ({
+  context,
+  enabledIds,
+  preparedRules,
+  apiKeysMap,
+  errors,
+  message,
+}: {
+  context: RulesClientContext;
+  enabledIds: string[];
+  preparedRules: Map<string, PreparedRule>;
+  apiKeysMap: Map<string, ApiKeyEntry>;
+  errors: BulkOperationError[];
+  message: string;
+}) => {
+  const keysToInvalidate: string[] = [];
+  for (const id of enabledIds) {
+    const prepared = preparedRules.get(id);
+    if (!prepared) continue;
+    errors.push({ message, rule: { id, name: prepared.name } });
+    const apiKey = apiKeysMap.get(id);
+    if (apiKey) {
+      keysToInvalidate.push(...collectNewKeysToInvalidate([apiKey]));
+      apiKeysMap.delete(id);
+    }
+    preparedRules.delete(id);
+  }
+  if (keysToInvalidate.length > 0) {
+    await bulkMarkApiKeysForInvalidation(
+      { apiKeys: keysToInvalidate },
+      context.logger,
+      context.unsecuredSavedObjectsClient
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -8,6 +8,7 @@
 import Boom from '@hapi/boom';
 import Semver from 'semver';
 import pMap from 'p-map';
+import { i18n } from '@kbn/i18n';
 import { withSpan } from '@kbn/apm-utils';
 import type {
   SavedObject,
@@ -34,14 +35,17 @@ import {
   updateMeta,
   validateActions,
 } from '../../../../rules_client/lib';
-import { apiKeyAsRuleDomainProperties } from '../../../../rules_client/common';
+import {
+  apiKeyAsAlertAttributes,
+  apiKeyAsRuleDomainProperties,
+} from '../../../../rules_client/common';
 import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
 import { tryToEnableTasks } from '../bulk_enable/bulk_enable_rules';
 import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
 import { bulkCreateRulesSo } from '../../../../data/rule';
 import type { RawRule, RuleTypeRegistry, SanitizedRule } from '../../../../types';
 import type { IntervalSchedule } from '../../../../../common';
-import type { RulesClientContext, BulkOperationError } from '../../../../rules_client/types';
+import type { BulkOperationError, RulesClientContext } from '../../../../rules_client/types';
 import type { RuleDomain, RuleParams } from '../../types';
 import {
   transformRuleAttributesToRuleDomain,
@@ -51,13 +55,25 @@ import {
 import { ruleDomainSchema } from '../../schemas';
 import { createRuleDataSchema } from '../create/schemas';
 import { validateScheduleLimit } from '../get_schedule_frequency';
-import type { BulkCreateRulesItem, BulkCreateRulesParams, BulkCreateRulesResult } from './types';
+import type {
+  BulkCreateOperationError,
+  BulkCreateDisabledReason,
+  BulkCreateRulesItem,
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+} from './types';
 
 /**
  * Bound the per-rule prepare phase to avoid overwhelming downstream services
  * (security plugin API key minting, action validation).
  */
 const PREPARE_CONCURRENCY = 10;
+
+const getBulkCreateAsDisabledMessage = (message: string): string =>
+  i18n.translate('xpack.alerting.rulesClient.bulkCreate.ruleCreatedDisabledErrorMessage', {
+    defaultMessage: 'Rule created in a disabled state: {message}',
+    values: { message },
+  });
 
 interface PreparedRule {
   id: string;
@@ -114,6 +130,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   params: BulkCreateRulesParams<Params>
 ): Promise<BulkCreateRulesResult<Params>> {
   const { rules } = params;
+  const { logger } = context;
   const total = rules.length;
 
   if (total === 0) {
@@ -123,17 +140,20 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   const username = await context.getUserName();
   const actionsClient = await context.getActionsClient();
 
-  // Phase 0: assign ids up-front, partition by enabled flag (tracked per item id below).
   const inputsWithIds = rules.map((rule) => ({
     id: rule.options?.id ?? SavedObjectsUtils.generateId(),
     rule,
   }));
+
+  logger.debug(`Bulk creating batch of ${total} rules`);
 
   // Phase 1: per-rule prepare (per-pair authorization dedupe done first).
   const authzCache = new Map<string, Promise<void>>();
   const preparedRules = new Map<string, PreparedRule>();
   const errors: BulkOperationError[] = [];
   const apiKeysMap = new Map<string, ApiKeyEntry>();
+  // Key invalidation involves call to ES so we invalidate keys at the end to reduce round-trips.
+  const keysToInvalidate = new Set<string>();
 
   await pMap(
     inputsWithIds,
@@ -162,20 +182,22 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     const validationPayload = await validateScheduleLimit({ context, updatedInterval });
     const enabledIds = enabled.map((p) => p.id);
     if (validationPayload) {
-      const message = getRuleCircuitBreakerErrorMessage({
+      const reasonMessage = getRuleCircuitBreakerErrorMessage({
         interval: validationPayload.interval,
         intervalAvailable: validationPayload.intervalAvailable,
         action: 'bulkCreate',
         rules: enabledIds.length,
       });
-      // removes rules and invalidate keys
-      await dropEnabledSubset({
-        context,
-        enabledIds,
+      logger.warn(`Demoting ${enabledIds.length} rules -> disabled, schedule limit exceeded.`);
+      demotePreparedRules({
+        ids: enabledIds,
+        reason: 'schedule_limit_exceeded',
+        message: reasonMessage,
         preparedRules,
         apiKeysMap,
+        keysToInvalidate,
         errors,
-        message,
+        username,
       });
     }
   }
@@ -198,14 +220,19 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
       );
       scheduledIds = scheduledTasks.map((task) => task.id);
     } catch (error) {
-      // Whole-call TM throw: fail enabled subset only, continue with disabled subset.
-      await dropEnabledSubset({
-        context,
-        enabledIds: survivingEnabledIds,
+      // Whole-call TM throw: demote enabled subset to disabled, continue.
+      logger.warn(
+        `Demoting ${survivingEnabledIds.length} rules -> disabled, task scheduling failed.`
+      );
+      demotePreparedRules({
+        ids: survivingEnabledIds,
+        reason: 'task_schedule_failed',
+        message: `Failed to schedule tasks: ${error.message}`,
         preparedRules,
         apiKeysMap,
+        keysToInvalidate,
         errors,
-        message: `Failed to schedule tasks: ${error.message}`,
+        username,
       });
     }
 
@@ -214,26 +241,32 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
 
     // Silent per-task drops: bulkSchedule's `taskInstanceToAttributes` validation
-    // logs+skips invalid instances. Diff requested vs returned and surface them as
-    // per-rule errors so we don't write a rule SO whose scheduledTaskId is dangling.
+    // logs+skips invalid instances. Diff requested vs returned and demote the
+    // missing ones — re-enabling later will hit the same validation, but at
+    // least the rule definition isn't lost.
     if (preparedRules.size > 0 && scheduledIds.length < survivingEnabledIds.length) {
       const returned = new Set(scheduledIds);
       const dropped = survivingEnabledIds.filter((id) => !returned.has(id));
       if (dropped.length > 0) {
-        await dropEnabledSubset({
-          context,
-          enabledIds: dropped,
+        logger.warn(`Demoting ${dropped.length} rules -> disabled, task validation failed.`);
+        demotePreparedRules({
+          ids: dropped,
+          reason: 'task_validation_failed',
+          message: 'Task scheduling silently dropped this rule (validation failure in task store)',
           preparedRules,
           apiKeysMap,
+          keysToInvalidate,
           errors,
-          message: 'Task scheduling silently dropped this rule (validation failure in task store)',
+          username,
         });
       }
     }
   }
 
-  // No survivors at all: return before SO write.
+  // No survivors at all: still flush any pending key invalidations from
+  // Phase 1 demotions (no keys to flush in that case, but keep it explicit).
   if (preparedRules.size === 0) {
+    await flushKeysToInvalidate(keysToInvalidate, context);
     return { rules: [], errors, total, taskIdsFailedToBeEnabled: [] };
   }
 
@@ -269,23 +302,18 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         })
     );
   } catch (error) {
-    // Normally, `bulkResponse` will contain per-row errors, however certain issues
-    // (auth, timeout etc) will cause a whole-response error, in this case
-    // we invalidate every newly-minted key, and perform best-effort orphan-task
-    // cleanup scoped to ids we actually scheduled in Phase 3, then rethrow.
-    const keysToInvalidate = collectNewKeysToInvalidate(apiKeysMap.values());
-    if (keysToInvalidate.length > 0) {
-      await bulkMarkApiKeysForInvalidation(
-        { apiKeys: keysToInvalidate },
-        context.logger,
-        context.unsecuredSavedObjectsClient
-      );
-    }
+    // Whole-call SO failure (auth, timeout, etc): invalidate every newly-minted
+    // key (those tracked in `apiKeysMap`, plus anything previous phases queued
+    // into `keysToInvalidate`), best-effort orphan-task cleanup scoped to ids we
+    // actually scheduled in Phase 3, then rethrow. Inline flush — control flow
+    // never reaches the end-of-function flush.
+    for (const k of collectNewKeysToInvalidate(apiKeysMap.values())) keysToInvalidate.add(k);
+    await flushKeysToInvalidate(keysToInvalidate, context);
     if (newlyScheduledTaskIds.size > 0) {
       try {
         await context.taskManager.bulkRemove([...newlyScheduledTaskIds]);
       } catch (cleanupError) {
-        context.logger.error(
+        logger.error(
           `bulkCreateRules: failed to clean up tasks ${[...newlyScheduledTaskIds].join(
             ', '
           )} after SO bulkCreate threw: ${cleanupError.message}`
@@ -298,6 +326,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   // Phase 4 per-row outcomes.
   const successfulSos: Array<SavedObject<RawRule>> = [];
   const taskIdsToEnable: string[] = [];
+  const taskIdsToCleanUp: string[] = [];
 
   for (const so of bulkResponse.saved_objects) {
     if (so.error) {
@@ -307,30 +336,15 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         rule: { id: so.id, name: preparedRules.get(so.id)?.name ?? 'n/a' },
       });
 
-      // Per-row API key invalidation (only the failed rule's key).
       const apiKey = apiKeysMap.get(so.id);
       if (apiKey) {
-        const keys = collectNewKeysToInvalidate([apiKey]);
-        if (keys.length > 0) {
-          await bulkMarkApiKeysForInvalidation(
-            { apiKeys: keys },
-            context.logger,
-            context.unsecuredSavedObjectsClient
-          );
-        }
+        for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
       }
 
-      // Best-effort orphan-task cleanup, but ONLY if this id was scheduled by us
-      // in Phase 3. Avoids nuking a pre-existing rule's task on a 409 caused by a
-      // caller-supplied id collision.
+      // Only ids we scheduled in Phase 3. Skipping caller-supplied id collisions
+      // avoids nuking a pre-existing rule's task on a 409.
       if (newlyScheduledTaskIds.has(so.id)) {
-        try {
-          await context.taskManager.removeIfExists(so.id);
-        } catch (cleanupError) {
-          context.logger.error(
-            `bulkCreateRules: failed to clean up task ${so.id} after SO per-row error: ${cleanupError.message}`
-          );
-        }
+        taskIdsToCleanUp.push(so.id);
       }
     } else {
       successfulSos.push(so as SavedObject<RawRule>);
@@ -352,12 +366,29 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
   }
 
+  // Single batched TM cleanup for per-row failures.
+  if (taskIdsToCleanUp.length > 0) {
+    try {
+      logger.warn(`Cleaning up ${taskIdsToCleanUp.length} tasks where SO creation failed.`);
+      await context.taskManager.bulkRemove(taskIdsToCleanUp);
+    } catch (cleanupError) {
+      logger.error(
+        `bulkCreateRules: failed to clean up tasks ${taskIdsToCleanUp.join(
+          ', '
+        )} after SO per-row errors: ${cleanupError.message}`
+      );
+    }
+  }
+
   // Phase 5: enable tasks for successfully persisted enabled rules.
   const taskIdsFailedToBeEnabled = await tryToEnableTasks({
     taskIdsToEnable,
-    logger: context.logger,
+    logger,
     taskManager: context.taskManager,
   });
+
+  // Single end-of-function flush for all collected key invalidations.
+  await flushKeysToInvalidate(keysToInvalidate, context);
 
   // Phase 6: domain transform + return.
   const sanitizedRules: Array<SanitizedRule<Params>> = successfulSos.map((so) =>
@@ -368,7 +399,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     rules: sanitizedRules,
     errors,
     total,
-    taskIdsFailedToBeEnabled,
+    taskIdsFailedToBeEnabled, // <-- same as bulkEnableRules().
   };
 }
 
@@ -406,7 +437,7 @@ interface PrepareRuleArgs<Params extends RuleParams> {
   id: string;
   rule: BulkCreateRulesItem<Params>;
   authzCache: Map<string, Promise<void>>;
-  errors: BulkOperationError[];
+  errors: BulkCreateOperationError[];
   apiKeysMap: Map<string, ApiKeyEntry>;
 }
 
@@ -495,26 +526,42 @@ const prepareRule = async <Params extends RuleParams>({
       );
     }
 
-    // Mint API key for enabled rules. createNewAPIKeySet returns the encoded
-    // `{ apiKey, apiKeyOwner, apiKeyCreatedByUser, uiamApiKey? }` shape suitable
-    // for direct use as rule attributes; for disabled rules we mirror createRule
-    // and use apiKeyAsRuleDomainProperties(null, ...) (all-null props).
-    const apiKeyProps = data.enabled
-      ? await createNewAPIKeySet(context, {
+    // Mint API key for enabled rules.
+    // Soft-fail: a key-mint failure does NOT reject the rule. We persist it as
+    // disabled, push a degraded error so the caller knows, and let downstream
+    // phases treat it as a never-enabled rule. Re-enabling later will re-mint.
+    let effectiveEnabled = data.enabled;
+    let apiKeyProps:
+      | ReturnType<typeof apiKeyAsRuleDomainProperties>
+      | Awaited<ReturnType<typeof createNewAPIKeySet>> = apiKeyAsRuleDomainProperties(
+      null,
+      username,
+      false
+    );
+    if (data.enabled) {
+      try {
+        apiKeyProps = await createNewAPIKeySet(context, {
           id: ruleType.id,
           ruleName: data.name,
           username,
           shouldUpdateApiKey: true,
           errorMessage: 'Error creating rule: could not create API key',
-        })
-      : apiKeyAsRuleDomainProperties(null, username, false);
-
-    if (data.enabled) {
-      apiKeysMap.set(id, {
-        apiKey: apiKeyProps.apiKey ?? null,
-        uiamApiKey: apiKeyProps.uiamApiKey ?? null,
-        apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
-      });
+        });
+        apiKeysMap.set(id, {
+          apiKey: apiKeyProps.apiKey ?? null,
+          uiamApiKey: apiKeyProps.uiamApiKey ?? null,
+          apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
+        });
+      } catch (apiKeyErr) {
+        effectiveEnabled = false;
+        apiKeyProps = apiKeyAsRuleDomainProperties(null, username, false);
+        errors.push({
+          message: getBulkCreateAsDisabledMessage(apiKeyErr.message),
+          status: apiKeyErr.output?.statusCode,
+          rule: { id, name: data.name },
+          disabledReason: 'api_key_creation_failed',
+        });
+      }
     }
 
     const allActions = [...data.actions, ...(data.systemActions ?? [])];
@@ -539,6 +586,7 @@ const prepareRule = async <Params extends RuleParams>({
       rule: {
         ...restData,
         ...apiKeyProps,
+        enabled: effectiveEnabled,
         id,
         createdBy: username,
         updatedBy: username,
@@ -557,7 +605,7 @@ const prepareRule = async <Params extends RuleParams>({
       params: { legacyId, paramsWithRefs: updatedParams },
     });
 
-    if (data.enabled) {
+    if (effectiveEnabled) {
       ruleAttributes.lastEnabledAt = new Date(createTime).toISOString();
       ruleAttributes.scheduledTaskId = id;
     }
@@ -565,7 +613,7 @@ const prepareRule = async <Params extends RuleParams>({
     const prepared = {
       id,
       name: data.name,
-      enabled: data.enabled,
+      enabled: effectiveEnabled,
       rawRule: ruleAttributes,
       references,
       schedule: data.schedule,
@@ -583,39 +631,69 @@ const prepareRule = async <Params extends RuleParams>({
   }
 };
 
-const dropEnabledSubset = async ({
-  context,
-  enabledIds,
+/**
+ * Demote in-memory (enabled -> disabled): flips a set of currently-enabled
+ * prepared rules to disabled, queues their API keys for invalidation, records a degraded
+ * error so the caller can surface "rule was created in a disabled state".
+ */
+const demotePreparedRules = ({
+  ids,
+  reason,
+  message,
   preparedRules,
   apiKeysMap,
+  keysToInvalidate,
   errors,
-  message,
+  username,
 }: {
-  context: RulesClientContext;
-  enabledIds: string[];
+  ids: string[];
+  reason: BulkCreateDisabledReason;
+  message: string;
   preparedRules: Map<string, PreparedRule>;
   apiKeysMap: Map<string, ApiKeyEntry>;
-  errors: BulkOperationError[];
-  message: string;
-}) => {
-  const keysToInvalidate: string[] = [];
-  for (const id of enabledIds) {
+  keysToInvalidate: Set<string>;
+  errors: BulkCreateOperationError[];
+  username: string | null;
+}): void => {
+  for (const id of ids) {
     const prepared = preparedRules.get(id);
-    if (prepared) {
-      errors.push({ message, rule: { id, name: prepared.name } });
-      const apiKey = apiKeysMap.get(id);
-      if (apiKey) {
-        keysToInvalidate.push(...collectNewKeysToInvalidate([apiKey]));
-        apiKeysMap.delete(id);
-      }
-      preparedRules.delete(id);
+    if (!prepared || !prepared.enabled) continue;
+
+    const apiKey = apiKeysMap.get(id);
+    if (apiKey) {
+      for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
+      apiKeysMap.delete(id);
     }
+
+    // Re-shape `rawRule` to the disabled-rule form.
+    const nullKey = apiKeyAsAlertAttributes(null, username, false);
+    prepared.rawRule = {
+      ...prepared.rawRule,
+      ...nullKey,
+      uiamApiKey: null,
+      enabled: false,
+    };
+    delete prepared.rawRule.scheduledTaskId;
+    delete prepared.rawRule.lastEnabledAt;
+    prepared.enabled = false;
+
+    errors.push({
+      message: getBulkCreateAsDisabledMessage(message),
+      rule: { id, name: prepared.name },
+      disabledReason: reason,
+    });
   }
-  if (keysToInvalidate.length > 0) {
-    await bulkMarkApiKeysForInvalidation(
-      { apiKeys: keysToInvalidate },
-      context.logger,
-      context.unsecuredSavedObjectsClient
-    );
-  }
+};
+
+const flushKeysToInvalidate = async (
+  keysToInvalidate: Set<string>,
+  context: RulesClientContext
+): Promise<void> => {
+  if (keysToInvalidate.size === 0) return;
+  await bulkMarkApiKeysForInvalidation(
+    { apiKeys: [...keysToInvalidate] },
+    context.logger,
+    context.unsecuredSavedObjectsClient
+  );
+  keysToInvalidate.clear();
 };

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -113,52 +113,54 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   context: RulesClientContext,
   params: BulkCreateRulesParams<Params>
 ): Promise<BulkCreateRulesResult<Params>> {
-  const { rules: inputs } = params;
-  const total = inputs.length;
+  const { rules } = params;
+  const total = rules.length;
 
   if (total === 0) {
     return { rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] };
   }
 
-  const errors: BulkOperationError[] = [];
   const username = await context.getUserName();
   const actionsClient = await context.getActionsClient();
 
   // Phase 0: assign ids up-front, partition by enabled flag (tracked per item id below).
-  const inputsWithIds = inputs.map((input) => ({
-    id: input.options?.id ?? SavedObjectsUtils.generateId(),
-    input,
+  const inputsWithIds = rules.map((rule) => ({
+    id: rule.options?.id ?? SavedObjectsUtils.generateId(),
+    rule,
   }));
 
   // Phase 1: per-rule prepare (per-pair authorization dedupe done first).
   const authzCache = new Map<string, Promise<void>>();
   const preparedRules = new Map<string, PreparedRule>();
+  const errors: BulkOperationError[] = [];
   const apiKeysMap = new Map<string, ApiKeyEntry>();
 
   await pMap(
     inputsWithIds,
-    async ({ id, input }) => {
-      const prepared = await prepareRule({
+    async ({ id, rule }) => {
+      const { prepared, error } = await prepareRule({
         context,
         actionsClient,
         username,
         id,
-        input,
+        rule,
         authzCache,
         errors,
         apiKeysMap,
       });
       if (prepared) preparedRules.set(id, prepared);
+      else if (error) errors.push(error);
     },
     { concurrency: PREPARE_CONCURRENCY }
   );
 
-  // Phase 2: schedule-limit gate, scoped to the enabled subset only.
-  const enabledIds = [...preparedRules.values()].filter((p) => p.enabled).map((p) => p.id);
+  // Phase 2: validate schedule-limits, enabled subset only.
+  const enabled = [...preparedRules.values()].filter((p) => p.enabled);
 
-  if (enabledIds.length > 0) {
-    const updatedInterval = enabledIds.map((id) => preparedRules.get(id)!.schedule.interval);
+  if (enabled.length > 0) {
+    const updatedInterval = enabled.map((r) => r.schedule.interval);
     const validationPayload = await validateScheduleLimit({ context, updatedInterval });
+    const enabledIds = enabled.map((p) => p.id);
     if (validationPayload) {
       const message = getRuleCircuitBreakerErrorMessage({
         interval: validationPayload.interval,
@@ -166,6 +168,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         action: 'bulkCreate',
         rules: enabledIds.length,
       });
+      // removes rules and invalidate keys
       await dropEnabledSubset({
         context,
         enabledIds,
@@ -178,15 +181,16 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
   }
 
   // Phase 3: schedule tasks for the surviving enabled subset.
-  const survivingEnabledIds = [...preparedRules.values()].filter((p) => p.enabled).map((p) => p.id);
-  const scheduledTaskIdsThisCall = new Set<string>();
+  const survivingEnabled = [...preparedRules.values()].filter((p) => p.enabled);
+  const newlyScheduledTaskIds = new Set<string>();
 
-  if (survivingEnabledIds.length > 0) {
-    const tasksToSchedule = survivingEnabledIds.map((id) =>
-      buildTaskInstance(context, preparedRules.get(id)!)
+  if (survivingEnabled.length > 0) {
+    const tasksToSchedule = survivingEnabled.map((preparedRule) =>
+      buildTaskInstance(context, preparedRule)
     );
 
     let scheduledIds: string[] = [];
+    const survivingEnabledIds = survivingEnabled.map((p) => p.id);
     try {
       const scheduledTasks = await withSpan(
         { name: 'taskManager.bulkSchedule', type: 'tasks' },
@@ -206,7 +210,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
 
     if (scheduledIds.length > 0) {
-      scheduledIds.forEach((id) => scheduledTaskIdsThisCall.add(id));
+      scheduledIds.forEach((id) => newlyScheduledTaskIds.add(id));
     }
 
     // Silent per-task drops: bulkSchedule's `taskInstanceToAttributes` validation
@@ -228,7 +232,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     }
   }
 
-  // No survivors at all: short-circuit before SO write.
+  // No survivors at all: return before SO write.
   if (preparedRules.size === 0) {
     return { rules: [], errors, total, taskIdsFailedToBeEnabled: [] };
   }
@@ -244,7 +248,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
     );
   }
 
-  // Phase 4: bulk SO create (no overwrite — id collisions surface as per-row 409).
+  // Phase 4: bulk SO create (no overwrite — id collisions surface as per-row 409)
   const bulkObjects: Array<SavedObjectsBulkCreateObject<RawRule>> = [...preparedRules.values()].map(
     (prepared) => ({
       type: RULE_SAVED_OBJECT_TYPE,
@@ -265,7 +269,9 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         })
     );
   } catch (error) {
-    // Whole-call SO throw: invalidate every newly-minted key, best-effort orphan-task
+    // Normally, `bulkResponse` will contain per-row errors, however certain issues
+    // (auth, timeout etc) will cause a whole-response error, in this case
+    // we invalidate every newly-minted key, and perform best-effort orphan-task
     // cleanup scoped to ids we actually scheduled in Phase 3, then rethrow.
     const keysToInvalidate = collectNewKeysToInvalidate(apiKeysMap.values());
     if (keysToInvalidate.length > 0) {
@@ -275,12 +281,12 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         context.unsecuredSavedObjectsClient
       );
     }
-    if (scheduledTaskIdsThisCall.size > 0) {
+    if (newlyScheduledTaskIds.size > 0) {
       try {
-        await context.taskManager.bulkRemove([...scheduledTaskIdsThisCall]);
+        await context.taskManager.bulkRemove([...newlyScheduledTaskIds]);
       } catch (cleanupError) {
         context.logger.error(
-          `bulkCreateRules: failed to clean up tasks ${[...scheduledTaskIdsThisCall].join(
+          `bulkCreateRules: failed to clean up tasks ${[...newlyScheduledTaskIds].join(
             ', '
           )} after SO bulkCreate threw: ${cleanupError.message}`
         );
@@ -317,7 +323,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
       // Best-effort orphan-task cleanup, but ONLY if this id was scheduled by us
       // in Phase 3. Avoids nuking a pre-existing rule's task on a 409 caused by a
       // caller-supplied id collision.
-      if (scheduledTaskIdsThisCall.has(so.id)) {
+      if (newlyScheduledTaskIds.has(so.id)) {
         try {
           await context.taskManager.removeIfExists(so.id);
         } catch (cleanupError) {
@@ -326,24 +332,23 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
           );
         }
       }
-      continue;
-    }
-
-    successfulSos.push(so as SavedObject<RawRule>);
-    if (scheduledTaskIdsThisCall.has(so.id)) {
-      taskIdsToEnable.push(so.id);
-      // Audit per-rule ENABLE for the enabled subset (mirrors single-rule semantics).
-      context.auditLogger?.log(
-        ruleAuditEvent({
-          action: RuleAuditAction.ENABLE,
-          outcome: 'unknown',
-          savedObject: {
-            type: RULE_SAVED_OBJECT_TYPE,
-            id: so.id,
-            name: preparedRules.get(so.id)?.name,
-          },
-        })
-      );
+    } else {
+      successfulSos.push(so as SavedObject<RawRule>);
+      if (newlyScheduledTaskIds.has(so.id)) {
+        taskIdsToEnable.push(so.id);
+        // Audit per-rule ENABLE for the enabled subset (mirrors single-rule semantics).
+        context.auditLogger?.log(
+          ruleAuditEvent({
+            action: RuleAuditAction.ENABLE,
+            outcome: 'unknown',
+            savedObject: {
+              type: RULE_SAVED_OBJECT_TYPE,
+              id: so.id,
+              name: preparedRules.get(so.id)?.name,
+            },
+          })
+        );
+      }
     }
   }
 
@@ -399,7 +404,7 @@ interface PrepareRuleArgs<Params extends RuleParams> {
   actionsClient: Awaited<ReturnType<RulesClientContext['getActionsClient']>>;
   username: string | null;
   id: string;
-  input: BulkCreateRulesItem<Params>;
+  rule: BulkCreateRulesItem<Params>;
   authzCache: Map<string, Promise<void>>;
   errors: BulkOperationError[];
   apiKeysMap: Map<string, ApiKeyEntry>;
@@ -410,20 +415,20 @@ const prepareRule = async <Params extends RuleParams>({
   actionsClient,
   username,
   id,
-  input,
+  rule,
   authzCache,
   errors,
   apiKeysMap,
-}: PrepareRuleArgs<Params>): Promise<PreparedRule | null> => {
-  const { allowMissingConnectorSecrets } = input;
+}: PrepareRuleArgs<Params>): Promise<{ prepared?: PreparedRule; error?: BulkOperationError }> => {
+  const { allowMissingConnectorSecrets } = rule;
 
   try {
     const { actions: genActions, systemActions: genSystemActions } = await addGeneratedActionValues(
-      input.data.actions,
-      input.data.systemActions,
+      rule.data.actions,
+      rule.data.systemActions,
       context
     );
-    const data = { ...input.data, actions: genActions, systemActions: genSystemActions };
+    const data = { ...rule.data, actions: genActions, systemActions: genSystemActions };
 
     try {
       createRuleDataSchema.validate(data);
@@ -557,7 +562,7 @@ const prepareRule = async <Params extends RuleParams>({
       ruleAttributes.scheduledTaskId = id;
     }
 
-    return {
+    const prepared = {
       id,
       name: data.name,
       enabled: data.enabled,
@@ -567,13 +572,14 @@ const prepareRule = async <Params extends RuleParams>({
       consumer: data.consumer,
       ruleTypeId: data.alertTypeId,
     };
-  } catch (error) {
-    errors.push({
-      message: error.message,
-      status: error.output?.statusCode,
-      rule: { id, name: input.data?.name ?? 'n/a' },
-    });
-    return null;
+    return { prepared };
+  } catch (err) {
+    const error = {
+      message: err.message,
+      status: err.output?.statusCode,
+      rule: { id, name: rule.data?.name ?? 'n/a' },
+    };
+    return { error };
   }
 };
 
@@ -595,14 +601,15 @@ const dropEnabledSubset = async ({
   const keysToInvalidate: string[] = [];
   for (const id of enabledIds) {
     const prepared = preparedRules.get(id);
-    if (!prepared) continue;
-    errors.push({ message, rule: { id, name: prepared.name } });
-    const apiKey = apiKeysMap.get(id);
-    if (apiKey) {
-      keysToInvalidate.push(...collectNewKeysToInvalidate([apiKey]));
-      apiKeysMap.delete(id);
+    if (prepared) {
+      errors.push({ message, rule: { id, name: prepared.name } });
+      const apiKey = apiKeysMap.get(id);
+      if (apiKey) {
+        keysToInvalidate.push(...collectNewKeysToInvalidate([apiKey]));
+        apiKeysMap.delete(id);
+      }
+      preparedRules.delete(id);
     }
-    preparedRules.delete(id);
   }
   if (keysToInvalidate.length > 0) {
     await bulkMarkApiKeysForInvalidation(

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -39,6 +39,7 @@ import {
   apiKeyAsAlertAttributes,
   apiKeyAsRuleDomainProperties,
 } from '../../../../rules_client/common';
+import { API_KEY_GENERATE_CONCURRENCY } from '../../../../rules_client/common/constants';
 import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
 import { tryToEnableTasks } from '../bulk_enable/bulk_enable_rules';
 import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
@@ -62,12 +63,6 @@ import type {
   BulkCreateRulesParams,
   BulkCreateRulesResult,
 } from './types';
-
-/**
- * Bound the per-rule prepare phase to avoid overwhelming downstream services
- * (security plugin API key minting, action validation).
- */
-const PREPARE_CONCURRENCY = 10;
 
 const getBulkCreateAsDisabledMessage = (message: string): string =>
   i18n.translate('xpack.alerting.rulesClient.bulkCreate.ruleCreatedDisabledErrorMessage', {
@@ -171,7 +166,7 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
       if (prepared) preparedRules.set(id, prepared);
       else if (error) errors.push(error);
     },
-    { concurrency: PREPARE_CONCURRENCY }
+    { concurrency: API_KEY_GENERATE_CONCURRENCY }
   );
 
   // Phase 2: validate schedule-limits, enabled subset only.

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { BulkCreateRulesItem, BulkCreateRulesParams, BulkCreateRulesResult } from './types';
+export { bulkCreateRules } from './bulk_create_rules';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
@@ -5,5 +5,11 @@
  * 2.0.
  */
 
-export type { BulkCreateRulesItem, BulkCreateRulesParams, BulkCreateRulesResult } from './types';
+export type {
+  BulkCreateDisabledReason,
+  BulkCreateOperationError,
+  BulkCreateRulesItem,
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+} from './types';
 export { bulkCreateRules } from './bulk_create_rules';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -40,10 +40,14 @@ export interface BulkCreateRulesResult<Params extends RuleParams = never> {
   errors: BulkCreateOperationError[];
   total: number;
   /**
-   * Promise that resolves when the detached post-create work finishes:
+   * Thunk that, when invoked, runs the detached post-create work and resolves
+   * with one error per demoted rule (empty on full success):
    *   - Task scheduling
    *   - Failure recovery: rule SO enabled -> disabled.
    *   - API key invalidations
+   *
+   * The returned promise is wrapped to never reject; callers can fire-and-forget.
+   * Not invoking the thunk skips the background phases entirely.
    */
-  backgroundWork: Promise<BulkCreateOperationError[]>;
+  backgroundWork: () => Promise<BulkCreateOperationError[]>;
 }

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -28,7 +28,8 @@ export type BulkCreateDisabledReason =
   | 'api_key_creation_failed'
   | 'schedule_limit_exceeded'
   | 'task_schedule_failed'
-  | 'task_schedule_entry_failed';
+  | 'task_schedule_entry_failed'
+  | 'task_enable_failed';
 
 export interface BulkCreateOperationError extends BulkOperationError {
   disabledReason?: BulkCreateDisabledReason;

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -28,7 +28,7 @@ export type BulkCreateDisabledReason =
   | 'api_key_creation_failed'
   | 'schedule_limit_exceeded'
   | 'task_schedule_failed'
-  | 'task_validation_failed';
+  | 'task_schedule_entry_failed';
 
 export interface BulkCreateOperationError extends BulkOperationError {
   disabledReason?: BulkCreateDisabledReason;
@@ -38,5 +38,11 @@ export interface BulkCreateRulesResult<Params extends RuleParams = never> {
   rules: Array<SanitizedRule<Params>>;
   errors: BulkCreateOperationError[];
   total: number;
-  taskIdsFailedToBeEnabled: string[];
+  /**
+   * Promise that resolves when the detached post-create work finishes:
+   *   - Task scheduling
+   *   - Failure recovery: rule SO enabled -> disabled.
+   *   - API key invalidations
+   */
+  backgroundWork: Promise<BulkCreateOperationError[]>;
 }

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SanitizedRule } from '../../../../types';
+import type { RuleParams } from '../../types';
+import type { CreateRuleData } from '../create/types';
+import type { CreateRuleOptions } from '../create/create_rule';
+import type { BulkOperationError } from '../../../../rules_client/types';
+
+export interface BulkCreateRulesItem<Params extends RuleParams = never> {
+  data: CreateRuleData<Params>;
+  options?: CreateRuleOptions;
+  allowMissingConnectorSecrets?: boolean;
+}
+
+export interface BulkCreateRulesParams<Params extends RuleParams = never> {
+  rules: Array<BulkCreateRulesItem<Params>>;
+}
+
+export interface BulkCreateRulesResult<Params extends RuleParams = never> {
+  rules: Array<SanitizedRule<Params>>;
+  errors: BulkOperationError[];
+  total: number;
+  taskIdsFailedToBeEnabled: string[];
+}

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -21,9 +21,22 @@ export interface BulkCreateRulesParams<Params extends RuleParams = never> {
   rules: Array<BulkCreateRulesItem<Params>>;
 }
 
+/**
+ * Lets callers branch on *why* a rule was created as disabled.
+ */
+export type BulkCreateDisabledReason =
+  | 'api_key_creation_failed'
+  | 'schedule_limit_exceeded'
+  | 'task_schedule_failed'
+  | 'task_validation_failed';
+
+export interface BulkCreateOperationError extends BulkOperationError {
+  disabledReason?: BulkCreateDisabledReason;
+}
+
 export interface BulkCreateRulesResult<Params extends RuleParams = never> {
   rules: Array<SanitizedRule<Params>>;
-  errors: BulkOperationError[];
+  errors: BulkCreateOperationError[];
   total: number;
   taskIdsFailedToBeEnabled: string[];
 }

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/utils.ts
@@ -107,7 +107,9 @@ export const buildTaskInstance = (
     alertInstances: {},
   },
   scope: ['alerting'],
-  enabled: true,
+  // Created disabled (and enable later) to avoid stampede 
+  // @see https://github.com/elastic/kibana/pull/174656
+  enabled: false,
 });
 
 export const toSanitizedRule = <Params extends RuleParams = never>(
@@ -335,6 +337,49 @@ export const prepareRule = async <Params extends RuleParams>({
       rule: { id, name: rule.data?.name ?? 'n/a' },
     };
     return { error };
+  }
+};
+
+/**
+ * Enables freshly-scheduled tasks via `taskManager.bulkEnable`.
+ * Mutates `demotedIds` in place; never re-throws.
+ */
+export const bulkEnableScheduledTasks = async ({
+  context,
+  scheduledIds,
+  demotedIds,
+}: {
+  context: RulesClientContext;
+  scheduledIds: string[];
+  demotedIds: Map<string, DemotionEntry>;
+}): Promise<void> => {
+  if (scheduledIds.length === 0) return;
+
+  try {
+    const enableResult = await withSpan(
+      { name: 'taskManager.bulkEnable', type: 'tasks' },
+      () => context.taskManager.bulkEnable(scheduledIds)
+    );
+    const failedIds = enableResult?.errors?.map((e) => e.id) ?? [];
+    if (failedIds.length === 0) return;
+
+    context.logger.warn(`Demoting ${failedIds.length} rules -> disabled, task enable failed.`);
+    for (const id of failedIds) {
+      demotedIds.set(id, {
+        reason: 'task_enable_failed',
+        message: 'Failed to enable scheduled task',
+      });
+    }
+  } catch (error) {
+    context.logger.warn(
+      `Demoting ${scheduledIds.length} rules -> disabled, taskManager.bulkEnable threw.`
+    );
+    for (const id of scheduledIds) {
+      demotedIds.set(id, {
+        reason: 'task_enable_failed',
+        message: `Failed to enable scheduled tasks: ${error.message}`,
+      });
+    }
   }
 };
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/utils.ts
@@ -107,7 +107,7 @@ export const buildTaskInstance = (
     alertInstances: {},
   },
   scope: ['alerting'],
-  // Created disabled (and enable later) to avoid stampede 
+  // Created disabled (and enable later) to avoid stampede
   // @see https://github.com/elastic/kibana/pull/174656
   enabled: false,
 });
@@ -356,9 +356,8 @@ export const bulkEnableScheduledTasks = async ({
   if (scheduledIds.length === 0) return;
 
   try {
-    const enableResult = await withSpan(
-      { name: 'taskManager.bulkEnable', type: 'tasks' },
-      () => context.taskManager.bulkEnable(scheduledIds)
+    const enableResult = await withSpan({ name: 'taskManager.bulkEnable', type: 'tasks' }, () =>
+      context.taskManager.bulkEnable(scheduledIds)
     );
     const failedIds = enableResult?.errors?.map((e) => e.id) ?? [];
     if (failedIds.length === 0) return;

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/utils.ts
@@ -1,0 +1,438 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import Semver from 'semver';
+import { i18n } from '@kbn/i18n';
+import { withSpan } from '@kbn/apm-utils';
+import type { SavedObject, SavedObjectReference } from '@kbn/core/server';
+import type { TaskInstanceWithDeprecatedFields } from '@kbn/task-manager-plugin/server/task';
+
+import { validateAndAuthorizeSystemActions } from '../../../../lib/validate_authorize_system_actions';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { parseDuration } from '../../../../../common';
+import { WriteOperations, AlertingAuthorizationEntity } from '../../../../authorization';
+import {
+  validateRuleTypeParams,
+  getRuleNotifyWhenType,
+  getDefaultMonitoringRuleDomainProperties,
+} from '../../../../lib';
+import { getRuleExecutionStatusPending } from '../../../../lib/rule_execution_status';
+import {
+  addGeneratedActionValues,
+  createNewAPIKeySet,
+  extractReferences,
+  validateActions,
+} from '../../../../rules_client/lib';
+import {
+  apiKeyAsAlertAttributes,
+  apiKeyAsRuleDomainProperties,
+} from '../../../../rules_client/common';
+import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
+import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
+import { bulkUpdateRuleSo } from '../../../../data/rule';
+import type { RawRule, RuleTypeRegistry, SanitizedRule } from '../../../../types';
+import type { IntervalSchedule } from '../../../../../common';
+import type { BulkOperationError, RulesClientContext } from '../../../../rules_client/types';
+import type { RuleDomain, RuleParams } from '../../types';
+import {
+  transformRuleAttributesToRuleDomain,
+  transformRuleDomainToRule,
+  transformRuleDomainToRuleAttributes,
+} from '../../transforms';
+import { ruleDomainSchema } from '../../schemas';
+import { createRuleDataSchema } from '../create/schemas';
+import type {
+  BulkCreateDisabledReason,
+  BulkCreateOperationError,
+  BulkCreateRulesItem,
+} from './types';
+
+export interface PreparedRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  rawRule: RawRule;
+  references: SavedObjectReference[];
+  schedule: IntervalSchedule;
+  consumer: string;
+  ruleTypeId: string;
+}
+
+export interface ApiKeyEntry {
+  apiKey: string | null;
+  uiamApiKey: string | null;
+  apiKeyCreatedByUser: boolean | null;
+}
+
+export interface DemotionEntry {
+  reason: BulkCreateDisabledReason;
+  message: string;
+}
+
+export const getBulkCreateAsDisabledMessage = (message: string): string =>
+  i18n.translate('xpack.alerting.rulesClient.bulkCreate.ruleCreatedDisabledErrorMessage', {
+    defaultMessage: 'Rule created in a disabled state: {message}',
+    values: { message },
+  });
+
+export const collectNewKeysToInvalidate = (entries: Iterable<ApiKeyEntry>): string[] => {
+  const keys: string[] = [];
+  for (const { apiKey, uiamApiKey, apiKeyCreatedByUser } of entries) {
+    if (apiKey && !apiKeyCreatedByUser) keys.push(apiKey);
+    if (uiamApiKey && !apiKeyCreatedByUser) keys.push(uiamApiKey);
+  }
+  return keys;
+};
+
+export const buildTaskInstance = (
+  context: RulesClientContext,
+  prepared: PreparedRule
+): TaskInstanceWithDeprecatedFields => ({
+  id: prepared.id,
+  taskType: `alerting:${prepared.ruleTypeId}`,
+  schedule: prepared.schedule,
+  params: {
+    alertId: prepared.id,
+    spaceId: context.spaceId,
+    consumer: prepared.consumer,
+  },
+  state: {
+    previousStartedAt: null,
+    alertTypeState: {},
+    alertInstances: {},
+  },
+  scope: ['alerting'],
+  enabled: true,
+});
+
+export const toSanitizedRule = <Params extends RuleParams = never>(
+  context: RulesClientContext,
+  so: SavedObject<RawRule>,
+  ruleTypeRegistry: RuleTypeRegistry
+): SanitizedRule<Params> => {
+  const ruleType = ruleTypeRegistry.get(so.attributes.alertTypeId);
+  const ruleDomain: RuleDomain<Params> = transformRuleAttributesToRuleDomain<Params>(
+    so.attributes,
+    {
+      id: so.id,
+      logger: context.logger,
+      ruleType,
+      references: so.references,
+      omitGeneratedValues: false,
+    },
+    context.isSystemAction
+  );
+
+  try {
+    ruleDomainSchema.validate(ruleDomain);
+  } catch (e) {
+    context.logger.warn(`Error validating bulk-created rule domain object for id: ${so.id}, ${e}`);
+  }
+
+  return transformRuleDomainToRule<Params>(ruleDomain, { isPublic: true }) as SanitizedRule<Params>;
+};
+
+interface PrepareRuleArgs<Params extends RuleParams> {
+  context: RulesClientContext;
+  actionsClient: Awaited<ReturnType<RulesClientContext['getActionsClient']>>;
+  username: string | null;
+  id: string;
+  rule: BulkCreateRulesItem<Params>;
+  authzCache: Map<string, Promise<void>>;
+  errors: BulkCreateOperationError[];
+  apiKeysMap: Map<string, ApiKeyEntry>;
+}
+
+export const prepareRule = async <Params extends RuleParams>({
+  context,
+  actionsClient,
+  username,
+  id,
+  rule,
+  authzCache,
+  errors,
+  apiKeysMap,
+}: PrepareRuleArgs<Params>): Promise<{ prepared?: PreparedRule; error?: BulkOperationError }> => {
+  const { allowMissingConnectorSecrets } = rule;
+
+  try {
+    const { actions: genActions, systemActions: genSystemActions } = await addGeneratedActionValues(
+      rule.data.actions,
+      rule.data.systemActions,
+      context
+    );
+    const data = { ...rule.data, actions: genActions, systemActions: genSystemActions };
+
+    try {
+      createRuleDataSchema.validate(data);
+    } catch (validationError) {
+      throw Boom.badRequest(`Error validating create data - ${validationError.message}`);
+    }
+
+    // ruleTypeRegistry.get throws 400 if not registered.
+    context.ruleTypeRegistry.get(data.alertTypeId);
+
+    const authzKey = `${data.alertTypeId}::${data.consumer}`;
+    if (!authzCache.has(authzKey)) {
+      authzCache.set(
+        authzKey,
+        context.authorization.ensureAuthorized({
+          ruleTypeId: data.alertTypeId,
+          consumer: data.consumer,
+          operation: WriteOperations.Create,
+          entity: AlertingAuthorizationEntity.Rule,
+        })
+      );
+    }
+    try {
+      await authzCache.get(authzKey)!;
+    } catch (authzError) {
+      context.auditLogger?.log(
+        ruleAuditEvent({
+          action: RuleAuditAction.CREATE,
+          savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: data.name },
+          error: authzError,
+        })
+      );
+      throw authzError;
+    }
+
+    context.ruleTypeRegistry.ensureRuleTypeEnabled(data.alertTypeId);
+    const ruleType = context.ruleTypeRegistry.get(data.alertTypeId);
+    const validatedRuleTypeParams = validateRuleTypeParams(data.params, ruleType.validate.params);
+
+    await validateActions(context, ruleType, data, allowMissingConnectorSecrets);
+    await validateAndAuthorizeSystemActions({
+      actionsClient,
+      actionsAuthorization: context.actionsAuthorization,
+      connectorAdapterRegistry: context.connectorAdapterRegistry,
+      systemActions: data.systemActions ?? [],
+      rule: { consumer: data.consumer, producer: ruleType.producer },
+    });
+
+    const intervalInMs = parseDuration(data.schedule.interval);
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      context.minimumScheduleInterval.enforce
+    ) {
+      throw Boom.badRequest(
+        `Error creating rule: the interval is less than the allowed minimum interval of ${context.minimumScheduleInterval.value}`
+      );
+    }
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      !context.minimumScheduleInterval.enforce
+    ) {
+      context.logger.warn(
+        `Rule schedule interval (${data.schedule.interval}) for "${ruleType.id}" rule type with ID "${id}" is less than the minimum value (${context.minimumScheduleInterval.value}). Running rules at this interval may impact alerting performance. Set "xpack.alerting.rules.minimumScheduleInterval.enforce" to true to prevent creation of these rules.`
+      );
+    }
+
+    // Mint API key for enabled rules.
+    // Soft-fail: a key-mint failure does NOT reject the rule. We persist it as
+    // disabled, push a degraded error so the caller knows, and let downstream
+    // phases treat it as a never-enabled rule. Re-enabling later will re-mint.
+    let effectiveEnabled = data.enabled;
+    let apiKeyProps:
+      | ReturnType<typeof apiKeyAsRuleDomainProperties>
+      | Awaited<ReturnType<typeof createNewAPIKeySet>> = apiKeyAsRuleDomainProperties(
+      null,
+      username,
+      false
+    );
+    if (data.enabled) {
+      try {
+        apiKeyProps = await createNewAPIKeySet(context, {
+          id: ruleType.id,
+          ruleName: data.name,
+          username,
+          shouldUpdateApiKey: true,
+          errorMessage: 'Error creating rule: could not create API key',
+        });
+        apiKeysMap.set(id, {
+          apiKey: apiKeyProps.apiKey ?? null,
+          uiamApiKey: apiKeyProps.uiamApiKey ?? null,
+          apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
+        });
+      } catch (apiKeyErr) {
+        effectiveEnabled = false;
+        apiKeyProps = apiKeyAsRuleDomainProperties(null, username, false);
+        errors.push({
+          message: getBulkCreateAsDisabledMessage(apiKeyErr.message),
+          status: apiKeyErr.output?.statusCode,
+          rule: { id, name: data.name },
+          disabledReason: 'api_key_creation_failed',
+        });
+      }
+    }
+
+    const allActions = [...data.actions, ...(data.systemActions ?? [])];
+    const artifacts = data.artifacts ?? {};
+    const {
+      references,
+      params: updatedParams,
+      actions: actionsWithRefs,
+      artifacts: artifactsWithRefs,
+    } = await extractReferences(context, ruleType, allActions, validatedRuleTypeParams, artifacts);
+
+    const createTime = Date.now();
+    const lastRunTimestamp = new Date();
+    const legacyId = Semver.lt(context.kibanaVersion, '8.0.0') ? id : null;
+    const notifyWhen = getRuleNotifyWhenType(data.notifyWhen ?? null, data.throttle ?? null);
+    const throttle = data.throttle ?? null;
+    const { systemActions: _sa, actions: _a, ...restData } = data;
+
+    const ruleAttributes = transformRuleDomainToRuleAttributes({
+      actionsWithRefs,
+      artifactsWithRefs,
+      rule: {
+        ...restData,
+        ...apiKeyProps,
+        enabled: effectiveEnabled,
+        id,
+        createdBy: username,
+        updatedBy: username,
+        createdAt: new Date(createTime),
+        updatedAt: new Date(createTime),
+        snoozeSchedule: [],
+        muteAll: false,
+        mutedInstanceIds: [],
+        notifyWhen,
+        throttle,
+        executionStatus: getRuleExecutionStatusPending(lastRunTimestamp.toISOString()),
+        monitoring: getDefaultMonitoringRuleDomainProperties(lastRunTimestamp.toISOString()),
+        revision: 0,
+        running: false,
+      } as unknown as RuleDomain<Params>,
+      params: { legacyId, paramsWithRefs: updatedParams },
+    });
+
+    if (effectiveEnabled) {
+      ruleAttributes.lastEnabledAt = new Date(createTime).toISOString();
+      ruleAttributes.scheduledTaskId = id;
+    }
+
+    const prepared: PreparedRule = {
+      id,
+      name: data.name,
+      enabled: effectiveEnabled,
+      rawRule: ruleAttributes,
+      references,
+      schedule: data.schedule,
+      consumer: data.consumer,
+      ruleTypeId: data.alertTypeId,
+    };
+    return { prepared };
+  } catch (err) {
+    const error = {
+      message: err.message,
+      status: err.output?.statusCode,
+      rule: { id, name: rule.data?.name ?? 'n/a' },
+    };
+    return { error };
+  }
+};
+
+/**
+ * Persists demotions for the background path of `bulkCreateRules`:
+ * bulkUpdate the SOs to disabled, queue minted keys for invalidation,
+ * emit DISABLE audits. Returns one structured error per demoted rule
+ * for surfacing via `result.backgroundWork`. Failures are logged —
+ * never re-thrown.
+ */
+export const demotePersistedRules = async ({
+  context,
+  demotedIds,
+  preparedRules,
+  apiKeysMap,
+  keysToInvalidate,
+  username,
+}: {
+  context: RulesClientContext;
+  demotedIds: Map<string, DemotionEntry>;
+  preparedRules: Map<string, PreparedRule>;
+  apiKeysMap: Map<string, ApiKeyEntry>;
+  keysToInvalidate: Set<string>;
+  username: string | null;
+}): Promise<BulkCreateOperationError[]> => {
+  const errors: BulkCreateOperationError[] = [];
+  if (demotedIds.size === 0) return errors;
+
+  const nullKey = apiKeyAsAlertAttributes(null, username, false);
+  const rulesToUpdate: Array<{ id: string; attributes: Partial<RawRule> }> = [];
+
+  for (const [id, { reason, message }] of demotedIds) {
+    const prepared = preparedRules.get(id);
+    if (!prepared) continue;
+
+    const apiKey = apiKeysMap.get(id);
+    if (apiKey) {
+      for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
+      apiKeysMap.delete(id);
+    }
+
+    // `null` clears `scheduledTaskId`/`lastEnabledAt` in ES; the RawRule type
+    // models them as `string | undefined`, so cast through `unknown`.
+    const cleared = {
+      ...nullKey,
+      enabled: false,
+      scheduledTaskId: null,
+      lastEnabledAt: null,
+    } as unknown as Partial<RawRule>;
+
+    rulesToUpdate.push({ id, attributes: cleared });
+
+    errors.push({
+      message: getBulkCreateAsDisabledMessage(message),
+      rule: { id, name: prepared.name },
+      disabledReason: reason,
+    });
+
+    context.logger.warn(
+      `bulkCreateRules: ${getBulkCreateAsDisabledMessage(message)} (id=${id}, reason=${reason})`
+    );
+
+    context.auditLogger?.log(
+      ruleAuditEvent({
+        action: RuleAuditAction.DISABLE,
+        outcome: 'unknown',
+        savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: prepared.name },
+      })
+    );
+  }
+
+  if (rulesToUpdate.length === 0) return errors;
+
+  try {
+    await withSpan({ name: 'unsecuredSavedObjectsClient.bulkUpdate', type: 'rules' }, () =>
+      bulkUpdateRuleSo({
+        savedObjectsClient: context.unsecuredSavedObjectsClient,
+        rules: rulesToUpdate,
+      })
+    );
+  } catch (err) {
+    context.logger.error(
+      `bulkCreateRules: bulkUpdate to demote ${rulesToUpdate.length} rules failed: ${err.message}`
+    );
+  }
+
+  return errors;
+};
+
+export const flushKeysToInvalidate = async (
+  keysToInvalidate: Set<string>,
+  context: RulesClientContext
+): Promise<void> => {
+  if (keysToInvalidate.size === 0) return;
+  await bulkMarkApiKeysForInvalidation(
+    { apiKeys: [...keysToInvalidate] },
+    context.logger,
+    context.unsecuredSavedObjectsClient
+  );
+  keysToInvalidate.clear();
+};

--- a/x-pack/platform/plugins/shared/alerting/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/index.ts
@@ -40,6 +40,8 @@ export { RuleNotifyWhen } from '../common';
 export type { AlertingServerSetup, AlertingServerStart } from './plugin';
 export type { FindResult, BulkEditOperation, BulkOperationError } from './rules_client';
 export type {
+  BulkCreateDisabledReason,
+  BulkCreateOperationError,
   BulkCreateRulesItem,
   BulkCreateRulesParams,
   BulkCreateRulesResult,

--- a/x-pack/platform/plugins/shared/alerting/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/index.ts
@@ -39,6 +39,11 @@ export { RULE_SAVED_OBJECT_TYPE, API_KEY_PENDING_INVALIDATION_TYPE } from './sav
 export { RuleNotifyWhen } from '../common';
 export type { AlertingServerSetup, AlertingServerStart } from './plugin';
 export type { FindResult, BulkEditOperation, BulkOperationError } from './rules_client';
+export type {
+  BulkCreateRulesItem,
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+} from './application/rule/methods/bulk_create';
 export type { Rule } from './application/rule/types';
 export type { PublicAlert as Alert } from './alert';
 export { parseDuration, isRuleSnoozed } from './lib';

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
@@ -52,9 +52,12 @@ const createRulesClientMock = () => {
     bulkGetRules: jest.fn(),
     bulkEdit: jest.fn(),
     bulkEditRuleParamsWithReadAuth: jest.fn(),
-    bulkCreateRules: jest
-      .fn()
-      .mockResolvedValue({ rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] }),
+    bulkCreateRules: jest.fn().mockResolvedValue({
+      rules: [],
+      errors: [],
+      total: 0,
+      backgroundWork: Promise.resolve([]),
+    }),
     bulkDeleteRules: jest.fn(),
     bulkEnableRules: jest.fn(),
     bulkDisableRules: jest.fn(),

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
@@ -56,7 +56,7 @@ const createRulesClientMock = () => {
       rules: [],
       errors: [],
       total: 0,
-      backgroundWork: Promise.resolve([]),
+      backgroundWork: () => Promise.resolve([]),
     }),
     bulkDeleteRules: jest.fn(),
     bulkEnableRules: jest.fn(),

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
@@ -52,6 +52,9 @@ const createRulesClientMock = () => {
     bulkGetRules: jest.fn(),
     bulkEdit: jest.fn(),
     bulkEditRuleParamsWithReadAuth: jest.fn(),
+    bulkCreateRules: jest
+      .fn()
+      .mockResolvedValue({ rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] }),
     bulkDeleteRules: jest.fn(),
     bulkEnableRules: jest.fn(),
     bulkDisableRules: jest.fn(),

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
@@ -60,6 +60,8 @@ import type { BulkEditRuleParamsOptions } from '../application/rule/methods/bulk
 import { bulkEditRuleParamsWithReadAuth } from '../application/rule/methods/bulk_edit_params/bulk_edit_rule_params';
 import type { BulkEnableRulesParams } from '../application/rule/methods/bulk_enable';
 import { bulkEnableRules } from '../application/rule/methods/bulk_enable';
+import type { BulkCreateRulesParams } from '../application/rule/methods/bulk_create';
+import { bulkCreateRules } from '../application/rule/methods/bulk_create';
 import { enableRule } from '../application/rule/methods/enable_rule/enable_rule';
 import { updateRuleApiKey } from '../application/rule/methods/update_api_key/update_rule_api_key';
 import { disableRule } from '../application/rule/methods/disable/disable_rule';
@@ -200,6 +202,9 @@ export class RulesClient {
 
   public bulkGetRules = <Params extends RuleTypeParams = never>(params: BulkGetRulesParams) =>
     bulkGetRules<Params>(this.context, params);
+  public bulkCreateRules = <Params extends RuleTypeParams = never>(
+    params: BulkCreateRulesParams<Params>
+  ) => bulkCreateRules<Params>(this.context, params);
   public bulkDeleteRules = (options: BulkDeleteRulesRequestBody) =>
     bulkDeleteRules(this.context, options);
   public bulkEdit = <Params extends RuleTypeParams>(options: BulkEditOptions<Params>) =>

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -23,6 +23,16 @@ export const allowedExperimentalValues = Object.freeze({
   previewTelemetryUrlEnabled: false,
 
   /**
+   * When enabled, prebuilt rule installation (POST .../prebuilt_rules/installation/_perform)
+   * and rule import (POST .../rules/_import) use the new alerting `rulesClient.bulkCreateRules`
+   * path, which handles both disabled and enabled rules (API key minting + task scheduling)
+   * in a single bulk call instead of the per-rule create loop.
+   *
+   * Release: TBD
+   */
+  bulkCreateRulesEnabled: false,
+
+  /**
    * Enables extended rule execution logging to Event Log. When this setting is enabled:
    * - Rules write their console error, info, debug, and trace messages to Event Log,
    *   in addition to other events they log there (status changes and execution metrics).

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
@@ -110,16 +110,15 @@ export const performRuleInstallationHandler = async (
       ruleInstallQueue.push(...(await excludeLicenseRestrictedRules(allInstallableRules, mlAuthz)));
     }
 
+    const { bulkCreateRulesEnabled } = ctx.securitySolution.getConfig().experimentalFeatures;
     const BATCH_SIZE = 100;
     while (ruleInstallQueue.length > 0) {
       const rulesToInstall = ruleInstallQueue.splice(0, BATCH_SIZE);
       const ruleAssets = await ruleAssetsClient.fetchAssetsByVersion(rulesToInstall);
 
-      const { results, errors } = await createPrebuiltRules(
-        detectionRulesClient,
-        ruleAssets,
-        logger
-      );
+      const { results, errors } = bulkCreateRulesEnabled
+        ? await detectionRulesClient.bulkCreatePrebuiltRules({ rules: ruleAssets })
+        : await createPrebuiltRules(detectionRulesClient, ruleAssets, logger);
 
       const batchInstalledRules = results.map(({ result: rule }) =>
         pick(rule, ['id', 'rule_id', 'version'])

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -198,6 +198,7 @@ export const importRulesRoute = (
             ruleSourceImporter,
             detectionRulesClient,
             experimentalFeatures,
+            logger,
           });
 
           const parseErrors = parsedRuleErrors.map((error) =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -189,12 +189,15 @@ export const importRulesRoute = (
 
           const ruleChunks = chunk(CHUNK_PARSED_OBJECT_SIZE, validatedResponseActionsRules);
 
+          const experimentalFeatures = ctx.securitySolution.getConfig().experimentalFeatures;
+
           const importRuleResponse = await importRules({
             ruleChunks,
             overwriteRules: request.query.overwrite,
             allowMissingConnectorSecrets: !!actionConnectors.length,
             ruleSourceImporter,
             detectionRulesClient,
+            experimentalFeatures,
           });
 
           const parseErrors = parsedRuleErrors.map((error) =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
@@ -22,7 +22,9 @@ const createDetectionRulesClientMock = () => {
     revertPrebuiltRule: jest.fn(),
     importRule: jest.fn(),
     importRules: jest.fn(),
-    bulkImportRules: jest.fn().mockResolvedValue([]),
+    bulkImportRules: jest
+      .fn()
+      .mockResolvedValue({ responses: [], backgroundWork: () => Promise.resolve([]) }),
     getRuleCustomizationStatus: jest.fn(),
   };
   return mocked;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
@@ -13,6 +13,7 @@ const createDetectionRulesClientMock = () => {
   const mocked: DetectionRulesClientMock = {
     createCustomRule: jest.fn(),
     createPrebuiltRule: jest.fn(),
+    bulkCreatePrebuiltRules: jest.fn().mockResolvedValue({ results: [], errors: [] }),
     updateRule: jest.fn(),
     patchRule: jest.fn(),
     deleteRule: jest.fn(),
@@ -21,6 +22,7 @@ const createDetectionRulesClientMock = () => {
     revertPrebuiltRule: jest.fn(),
     importRule: jest.fn(),
     importRules: jest.fn(),
+    bulkImportRules: jest.fn().mockResolvedValue([]),
     getRuleCustomizationStatus: jest.fn(),
   };
   return mocked;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_create_prebuilt_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_create_prebuilt_rules.test.ts
@@ -55,7 +55,7 @@ describe('DetectionRulesClient.bulkCreatePrebuiltRules', () => {
       rules: [getRuleMock(getQueryRuleParams()), getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 2,
-      backgroundWork: Promise.resolve([]),
+      backgroundWork: () => Promise.resolve([]),
     });
 
     const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
@@ -80,7 +80,7 @@ describe('DetectionRulesClient.bulkCreatePrebuiltRules', () => {
         rules: [],
         errors: [{ message: 'boom', status: 500, rule: { id, name: asset.name } }],
         total: 1,
-        backgroundWork: Promise.resolve([]),
+        backgroundWork: () => Promise.resolve([]),
       };
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_create_prebuilt_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_create_prebuilt_rules.test.ts
@@ -55,7 +55,7 @@ describe('DetectionRulesClient.bulkCreatePrebuiltRules', () => {
       rules: [getRuleMock(getQueryRuleParams()), getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 2,
-      taskIdsFailedToBeEnabled: [],
+      backgroundWork: Promise.resolve([]),
     });
 
     const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
@@ -80,7 +80,7 @@ describe('DetectionRulesClient.bulkCreatePrebuiltRules', () => {
         rules: [],
         errors: [{ message: 'boom', status: 500, rule: { id, name: asset.name } }],
         total: 1,
-        taskIdsFailedToBeEnabled: [],
+        backgroundWork: Promise.resolve([]),
       };
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_create_prebuilt_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_create_prebuilt_rules.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rulesClientMock } from '@kbn/alerting-plugin/server/mocks';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { licenseMock } from '@kbn/licensing-plugin/common/licensing.mock';
+
+import { getCreateRulesSchemaMock } from '../../../../../../common/api/detection_engine/model/rule_schema/mocks';
+import { getRuleMock } from '../../../routes/__mocks__/request_responses';
+import { getQueryRuleParams } from '../../../rule_schema/mocks';
+import { buildMlAuthz } from '../../../../machine_learning/authz';
+import { throwAuthzError } from '../../../../machine_learning/validation';
+import { createDetectionRulesClient } from './detection_rules_client';
+import type { IDetectionRulesClient } from './detection_rules_client_interface';
+import { createProductFeaturesServiceMock } from '../../../../product_features_service/mocks';
+import { getMockRulesAuthz } from '../../__mocks__/authz';
+
+jest.mock('../../../../machine_learning/authz');
+jest.mock('../../../../machine_learning/validation');
+
+describe('DetectionRulesClient.bulkCreatePrebuiltRules', () => {
+  let rulesClient: ReturnType<typeof rulesClientMock.create>;
+  let detectionRulesClient: IDetectionRulesClient;
+
+  const mlAuthz = (buildMlAuthz as jest.Mock)();
+  const rulesAuthz = getMockRulesAuthz();
+  const actionsClient: jest.Mocked<ActionsClient> = {
+    isSystemAction: jest.fn(),
+  } as unknown as jest.Mocked<ActionsClient>;
+
+  beforeEach(() => {
+    rulesClient = rulesClientMock.create();
+    (throwAuthzError as jest.Mock).mockReset();
+    detectionRulesClient = createDetectionRulesClient({
+      actionsClient,
+      rulesClient,
+      mlAuthz,
+      rulesAuthz,
+      savedObjectsClient: savedObjectsClientMock.create(),
+      license: licenseMock.createLicenseMock(),
+      productFeaturesService: createProductFeaturesServiceMock(),
+    });
+  });
+
+  it('issues a single bulkCreateRules call with disabled, immutable rules', async () => {
+    const asset1 = { ...getCreateRulesSchemaMock(), version: 1, rule_id: 'rule-1' };
+    const asset2 = { ...getCreateRulesSchemaMock(), version: 1, rule_id: 'rule-2' };
+
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams()), getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 2,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
+      rules: [asset1, asset2],
+    });
+
+    expect(rulesClient.bulkCreateRules).toHaveBeenCalledTimes(1);
+    const callArgs = rulesClient.bulkCreateRules.mock.calls[0][0];
+    expect(callArgs.rules).toHaveLength(2);
+    expect(callArgs.rules.every((r) => r.data.enabled === false)).toBe(true);
+    expect(callArgs.rules.every((r) => r.data.params.immutable === true)).toBe(true);
+    expect(results).toHaveLength(2);
+    expect(errors).toEqual([]);
+  });
+
+  it('reports per-rule errors from the alerting layer', async () => {
+    const asset = { ...getCreateRulesSchemaMock(), version: 1, rule_id: 'rule-1' };
+
+    rulesClient.bulkCreateRules.mockImplementationOnce(async (args) => {
+      const id = (args.rules[0].options as { id: string }).id;
+      return {
+        rules: [],
+        errors: [{ message: 'boom', status: 500, rule: { id, name: asset.name } }],
+        total: 1,
+        taskIdsFailedToBeEnabled: [],
+      };
+    });
+
+    const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
+      rules: [asset],
+    });
+
+    expect(results).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].item).toBe(asset);
+    expect(errors[0].error.message).toBe('boom');
+  });
+
+  it('returns ML-auth failures as per-rule errors without calling bulkCreateRules', async () => {
+    const asset = { ...getCreateRulesSchemaMock(), version: 1, rule_id: 'rule-1' };
+    (throwAuthzError as jest.Mock).mockImplementation(() => {
+      throw new Error('ML auth denied');
+    });
+
+    const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
+      rules: [asset],
+    });
+
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+    expect(errors[0].error.message).toBe('ML auth denied');
+  });
+
+  it('returns empty result for empty input', async () => {
+    const result = await detectionRulesClient.bulkCreatePrebuiltRules({ rules: [] });
+    expect(result).toEqual({ results: [], errors: [] });
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_import_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_import_rules.test.ts
@@ -56,7 +56,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [],
       errors: [],
       total: 0,
-      backgroundWork: Promise.resolve([]),
+      backgroundWork: () => Promise.resolve([]),
     });
 
     mockRuleSourceImporter = ruleSourceImporterMock.create();
@@ -72,7 +72,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 1,
-      backgroundWork: Promise.resolve([]),
+      backgroundWork: () => Promise.resolve([]),
     });
 
     await subject.bulkImportRules({
@@ -94,7 +94,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 1,
-      backgroundWork: Promise.resolve([]),
+      backgroundWork: () => Promise.resolve([]),
     });
 
     await subject.bulkImportRules({
@@ -119,7 +119,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 1,
-      backgroundWork: Promise.resolve([]),
+      backgroundWork: () => Promise.resolve([]),
     });
 
     const result = await subject.bulkImportRules({
@@ -129,7 +129,9 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [r1, r2],
     });
 
-    const conflicts = result.filter((r) => isRuleImportError(r) && r.error.type === 'conflict');
+    const conflicts = result.responses.filter(
+      (r) => isRuleImportError(r) && r.error.type === 'conflict'
+    );
     expect(conflicts).toHaveLength(1);
     expect(isRuleImportError(conflicts[0]) && conflicts[0].error.ruleId).toBe('existing-rule');
     expect(rulesClient.bulkCreateRules.mock.calls[0][0].rules).toHaveLength(1);
@@ -147,7 +149,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 1,
-      backgroundWork: Promise.resolve([]),
+      backgroundWork: () => Promise.resolve([]),
     });
 
     await subject.bulkImportRules({
@@ -172,7 +174,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
         rules: [],
         errors: [{ message: 'boom', status: 500, rule: { id, name: ruleToImport.name } }],
         total: 1,
-        backgroundWork: Promise.resolve([]),
+        backgroundWork: () => Promise.resolve([]),
       };
     });
 
@@ -183,7 +185,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [ruleToImport],
     });
 
-    const errors = result.filter(isRuleImportError);
+    const errors = result.responses.filter(isRuleImportError);
     expect(errors).toHaveLength(1);
     expect(errors[0].error.ruleId).toBe(ruleToImport.rule_id);
     expect(errors[0].error.message).toBe('boom');
@@ -197,9 +199,31 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [],
     });
 
-    expect(result).toEqual([]);
+    expect(result.responses).toEqual([]);
+    expect(typeof result.backgroundWork).toBe('function');
     expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
     expect(findRules).not.toHaveBeenCalled();
+  });
+
+  it('returns the alerting backgroundWork thunk untouched (not auto-invoked)', async () => {
+    const ruleToImport = { ...getImportRulesSchemaMock(), enabled: true };
+    const backgroundWork = jest.fn(() => Promise.resolve([]));
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      backgroundWork,
+    });
+
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    expect(backgroundWork).not.toHaveBeenCalled();
+    expect(result.backgroundWork).toBe(backgroundWork);
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_import_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_import_rules.test.ts
@@ -56,7 +56,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [],
       errors: [],
       total: 0,
-      taskIdsFailedToBeEnabled: [],
+      backgroundWork: Promise.resolve([]),
     });
 
     mockRuleSourceImporter = ruleSourceImporterMock.create();
@@ -72,7 +72,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 1,
-      taskIdsFailedToBeEnabled: [],
+      backgroundWork: Promise.resolve([]),
     });
 
     await subject.bulkImportRules({
@@ -94,7 +94,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 1,
-      taskIdsFailedToBeEnabled: [],
+      backgroundWork: Promise.resolve([]),
     });
 
     await subject.bulkImportRules({
@@ -119,7 +119,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 1,
-      taskIdsFailedToBeEnabled: [],
+      backgroundWork: Promise.resolve([]),
     });
 
     const result = await subject.bulkImportRules({
@@ -147,7 +147,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
       rules: [getRuleMock(getQueryRuleParams())],
       errors: [],
       total: 1,
-      taskIdsFailedToBeEnabled: [],
+      backgroundWork: Promise.resolve([]),
     });
 
     await subject.bulkImportRules({
@@ -172,7 +172,7 @@ describe('detectionRulesClient.bulkImportRules', () => {
         rules: [],
         errors: [{ message: 'boom', status: 500, rule: { id, name: ruleToImport.name } }],
         total: 1,
-        taskIdsFailedToBeEnabled: [],
+        backgroundWork: Promise.resolve([]),
       };
     });
 
@@ -187,34 +187,6 @@ describe('detectionRulesClient.bulkImportRules', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0].error.ruleId).toBe(ruleToImport.rule_id);
     expect(errors[0].error.message).toBe('boom');
-  });
-
-  it('taskIdsFailedToBeEnabled surfaces as a per-rule warning', async () => {
-    const ruleToImport = { ...getImportRulesSchemaMock(), enabled: true };
-    const created = getRuleMock(getQueryRuleParams());
-    rulesClient.bulkCreateRules.mockImplementationOnce(async (args) => {
-      const id = (args.rules[0].options as { id: string }).id;
-      return {
-        rules: [created],
-        errors: [],
-        total: 1,
-        taskIdsFailedToBeEnabled: [id],
-      };
-    });
-
-    const result = await subject.bulkImportRules({
-      allowMissingConnectorSecrets: false,
-      overwriteRules: false,
-      ruleSourceImporter: mockRuleSourceImporter,
-      rules: [ruleToImport],
-    });
-
-    expect(result.length).toBeGreaterThanOrEqual(2);
-    const warnings = result.filter(
-      (r) => isRuleImportError(r) && r.error.message.includes('task could not be enabled')
-    );
-    expect(warnings).toHaveLength(1);
-    expect(isRuleImportError(warnings[0]) && warnings[0].error.ruleId).toBe(ruleToImport.rule_id);
   });
 
   it('returns empty result for empty input without calling alerting/findRules', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_import_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.bulk_import_rules.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rulesClientMock } from '@kbn/alerting-plugin/server/mocks';
+import { actionsClientMock } from '@kbn/actions-plugin/server/actions_client/actions_client.mock';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { licenseMock } from '@kbn/licensing-plugin/common/licensing.mock';
+
+import { buildMlAuthz } from '../../../../machine_learning/__mocks__/authz';
+import { getImportRulesSchemaMock } from '../../../../../../common/api/detection_engine/rule_management/mocks';
+import { getRulesSchemaMock } from '../../../../../../common/api/detection_engine/model/rule_schema/mocks';
+import { getRuleMock } from '../../../routes/__mocks__/request_responses';
+import { getQueryRuleParams } from '../../../rule_schema/mocks';
+import { ruleSourceImporterMock } from '../import/rule_source_importer/rule_source_importer.mock';
+import { createDetectionRulesClient } from './detection_rules_client';
+import { importRule } from './methods/import_rule';
+import { checkRuleExceptionReferences } from '../import/check_rule_exception_references';
+import { findRules } from '../search/find_rules';
+import { createProductFeaturesServiceMock } from '../../../../product_features_service/mocks';
+import { getMockRulesAuthz } from '../../__mocks__/authz';
+import { __testing_escapeKql } from './methods/bulk_import_rules';
+import { isRuleImportError } from '../import/errors';
+
+jest.mock('./methods/import_rule');
+jest.mock('../import/check_rule_exception_references');
+jest.mock('../search/find_rules');
+
+describe('detectionRulesClient.bulkImportRules', () => {
+  let rulesClient: ReturnType<typeof rulesClientMock.create>;
+  let subject: ReturnType<typeof createDetectionRulesClient>;
+  let mockRuleSourceImporter: ReturnType<typeof ruleSourceImporterMock.create>;
+  const rulesAuthz = getMockRulesAuthz();
+
+  beforeEach(() => {
+    (findRules as jest.Mock).mockReset();
+    (importRule as jest.Mock).mockReset();
+    rulesClient = rulesClientMock.create();
+    subject = createDetectionRulesClient({
+      actionsClient: actionsClientMock.create(),
+      rulesClient,
+      mlAuthz: buildMlAuthz(),
+      rulesAuthz,
+      savedObjectsClient: savedObjectsClientMock.create(),
+      license: licenseMock.createLicenseMock(),
+      productFeaturesService: createProductFeaturesServiceMock(),
+    });
+
+    (checkRuleExceptionReferences as jest.Mock).mockReturnValue([[], []]);
+    (findRules as jest.Mock).mockResolvedValue({ data: [] });
+    (importRule as jest.Mock).mockResolvedValue(getRulesSchemaMock());
+    rulesClient.bulkCreateRules.mockResolvedValue({
+      rules: [],
+      errors: [],
+      total: 0,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    mockRuleSourceImporter = ruleSourceImporterMock.create();
+    mockRuleSourceImporter.calculateRuleSource.mockReturnValue({
+      ruleSource: { type: 'internal' },
+      immutable: false,
+    });
+  });
+
+  it('all-new disabled rules: single bulkCreateRules call, no findRules conflicts', async () => {
+    const ruleToImport = { ...getImportRulesSchemaMock(), enabled: false };
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    expect(rulesClient.bulkCreateRules).toHaveBeenCalledTimes(1);
+    const args = rulesClient.bulkCreateRules.mock.calls[0][0];
+    expect(args.rules[0].data.enabled).toBe(false);
+    expect(importRule).not.toHaveBeenCalled();
+  });
+
+  it('all-new enabled rules: preserves enabled flag in single bulk call', async () => {
+    const ruleToImport = { ...getImportRulesSchemaMock(), enabled: true };
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    const args = rulesClient.bulkCreateRules.mock.calls[0][0];
+    expect(args.rules[0].data.enabled).toBe(true);
+  });
+
+  it('mixed new+existing with overwriteRules:false reports conflict for existing', async () => {
+    const r1 = { ...getImportRulesSchemaMock(), rule_id: 'new-rule' };
+    const r2 = { ...getImportRulesSchemaMock(), rule_id: 'existing-rule' };
+
+    (findRules as jest.Mock).mockResolvedValueOnce({
+      data: [getRuleMock({ ...getQueryRuleParams(), ruleId: 'existing-rule' })],
+    });
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [r1, r2],
+    });
+
+    const conflicts = result.filter((r) => isRuleImportError(r) && r.error.type === 'conflict');
+    expect(conflicts).toHaveLength(1);
+    expect(isRuleImportError(conflicts[0]) && conflicts[0].error.ruleId).toBe('existing-rule');
+    expect(rulesClient.bulkCreateRules.mock.calls[0][0].rules).toHaveLength(1);
+    expect(importRule).not.toHaveBeenCalled();
+  });
+
+  it('mixed new+existing with overwriteRules:true: existing fall through to per-rule importRule', async () => {
+    const r1 = { ...getImportRulesSchemaMock(), rule_id: 'new-rule' };
+    const r2 = { ...getImportRulesSchemaMock(), rule_id: 'existing-rule' };
+
+    (findRules as jest.Mock).mockResolvedValueOnce({
+      data: [getRuleMock({ ...getQueryRuleParams(), ruleId: 'existing-rule' })],
+    });
+    rulesClient.bulkCreateRules.mockResolvedValueOnce({
+      rules: [getRuleMock(getQueryRuleParams())],
+      errors: [],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    });
+
+    await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: true,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [r1, r2],
+    });
+
+    expect(importRule).toHaveBeenCalledTimes(1);
+    expect((importRule as jest.Mock).mock.calls[0][0].importRulePayload.ruleToImport.rule_id).toBe(
+      'existing-rule'
+    );
+    expect(rulesClient.bulkCreateRules.mock.calls[0][0].rules).toHaveLength(1);
+  });
+
+  it('per-row bulk error is re-paired to its source rule_id via uuid', async () => {
+    const ruleToImport = getImportRulesSchemaMock();
+    rulesClient.bulkCreateRules.mockImplementationOnce(async (args) => {
+      const id = (args.rules[0].options as { id: string }).id;
+      return {
+        rules: [],
+        errors: [{ message: 'boom', status: 500, rule: { id, name: ruleToImport.name } }],
+        total: 1,
+        taskIdsFailedToBeEnabled: [],
+      };
+    });
+
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    const errors = result.filter(isRuleImportError);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error.ruleId).toBe(ruleToImport.rule_id);
+    expect(errors[0].error.message).toBe('boom');
+  });
+
+  it('taskIdsFailedToBeEnabled surfaces as a per-rule warning', async () => {
+    const ruleToImport = { ...getImportRulesSchemaMock(), enabled: true };
+    const created = getRuleMock(getQueryRuleParams());
+    rulesClient.bulkCreateRules.mockImplementationOnce(async (args) => {
+      const id = (args.rules[0].options as { id: string }).id;
+      return {
+        rules: [created],
+        errors: [],
+        total: 1,
+        taskIdsFailedToBeEnabled: [id],
+      };
+    });
+
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [ruleToImport],
+    });
+
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    const warnings = result.filter(
+      (r) => isRuleImportError(r) && r.error.message.includes('task could not be enabled')
+    );
+    expect(warnings).toHaveLength(1);
+    expect(isRuleImportError(warnings[0]) && warnings[0].error.ruleId).toBe(ruleToImport.rule_id);
+  });
+
+  it('returns empty result for empty input without calling alerting/findRules', async () => {
+    const result = await subject.bulkImportRules({
+      allowMissingConnectorSecrets: false,
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      rules: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+    expect(findRules).not.toHaveBeenCalled();
+  });
+});
+
+describe('bulk_import_rules KQL escape', () => {
+  it('escapes backslashes', () => {
+    expect(__testing_escapeKql('foo\\bar')).toBe('foo\\\\bar');
+  });
+  it('escapes double quotes', () => {
+    expect(__testing_escapeKql('a"b')).toBe('a\\"b');
+  });
+  it('escapes both', () => {
+    expect(__testing_escapeKql('a\\"b')).toBe('a\\\\\\"b');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
@@ -18,6 +18,7 @@ import type { MlAuthz } from '../../../../machine_learning/authz';
 import type { ProductFeaturesService } from '../../../../product_features_service';
 import { createPrebuiltRuleAssetsClient } from '../../../prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
 import type { RuleImportErrorObject } from '../import/errors';
+import type { BulkImportRulesResult } from './methods/bulk_import_rules';
 import type {
   BulkCreatePrebuiltRulesArgs,
   BulkDeleteRulesArgs,
@@ -212,9 +213,7 @@ export const createDetectionRulesClient = ({
       });
     },
 
-    async bulkImportRules(
-      args: ImportRulesArgs
-    ): Promise<Array<RuleResponse | RuleImportErrorObject>> {
+    async bulkImportRules(args: ImportRulesArgs): Promise<BulkImportRulesResult> {
       return withSecuritySpan('DetectionRulesClient.bulkImportRules', async () => {
         return bulkImportRules({
           actionsClient,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
@@ -19,6 +19,7 @@ import type { ProductFeaturesService } from '../../../../product_features_servic
 import { createPrebuiltRuleAssetsClient } from '../../../prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
 import type { RuleImportErrorObject } from '../import/errors';
 import type {
+  BulkCreatePrebuiltRulesArgs,
   BulkDeleteRulesArgs,
   BulkDeleteRulesReturn,
   CreateCustomRuleArgs,
@@ -33,7 +34,9 @@ import type {
   UpgradePrebuiltRuleArgs,
 } from './detection_rules_client_interface';
 import { createRule } from './methods/create_rule';
+import { bulkCreatePrebuiltRules } from './methods/bulk_create_prebuilt_rules';
 import { bulkDeleteRules } from './methods/bulk_delete_rules';
+import { bulkImportRules } from './methods/bulk_import_rules';
 import { deleteRule } from './methods/delete_rule';
 import { importRule } from './methods/import_rule';
 import { importRules } from './methods/import_rules';
@@ -112,6 +115,12 @@ export const createDetectionRulesClient = ({
           },
           mlAuthz,
         });
+      });
+    },
+
+    async bulkCreatePrebuiltRules(args: BulkCreatePrebuiltRulesArgs) {
+      return withSecuritySpan('DetectionRulesClient.bulkCreatePrebuiltRules', async () => {
+        return bulkCreatePrebuiltRules({ actionsClient, rulesClient, mlAuthz, args });
       });
     },
 
@@ -199,6 +208,20 @@ export const createDetectionRulesClient = ({
           ...args,
           detectionRulesClient: this,
           savedObjectsClient,
+        });
+      });
+    },
+
+    async bulkImportRules(
+      args: ImportRulesArgs
+    ): Promise<Array<RuleResponse | RuleImportErrorObject>> {
+      return withSecuritySpan('DetectionRulesClient.bulkImportRules', async () => {
+        return bulkImportRules({
+          actionsClient,
+          rulesClient,
+          savedObjectsClient,
+          mlAuthz,
+          args,
         });
       });
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BulkOperationError } from '@kbn/alerting-plugin/server';
+import type { BulkImportRulesResult } from './methods/bulk_import_rules';
 import type {
   RuleCreateProps,
   RuleUpdateProps,
@@ -37,7 +38,7 @@ export interface IDetectionRulesClient {
   revertPrebuiltRule: (args: RevertPrebuiltRuleArgs) => Promise<RuleResponse>;
   importRule: (args: ImportRuleArgs) => Promise<RuleResponse>;
   importRules: (args: ImportRulesArgs) => Promise<Array<RuleResponse | RuleImportErrorObject>>;
-  bulkImportRules: (args: ImportRulesArgs) => Promise<Array<RuleResponse | RuleImportErrorObject>>;
+  bulkImportRules: (args: ImportRulesArgs) => Promise<BulkImportRulesResult>;
 }
 
 export interface CreateCustomRuleArgs {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
@@ -20,11 +20,15 @@ import type { RuleImportErrorObject } from '../import/errors';
 import type { PrebuiltRuleAsset } from '../../../prebuilt_rules';
 import type { PrebuiltRulesCustomizationStatus } from '../../../../../../common/detection_engine/prebuilt_rules/prebuilt_rule_customization_status';
 import type { RuleAlertType } from '../../../rule_schema';
+import type { BulkCreatePrebuiltRulesResult } from './methods/bulk_create_prebuilt_rules';
 
 export interface IDetectionRulesClient {
   getRuleCustomizationStatus: () => PrebuiltRulesCustomizationStatus;
   createCustomRule: (args: CreateCustomRuleArgs) => Promise<RuleResponse>;
   createPrebuiltRule: (args: CreatePrebuiltRuleArgs) => Promise<RuleResponse>;
+  bulkCreatePrebuiltRules: (
+    args: BulkCreatePrebuiltRulesArgs
+  ) => Promise<BulkCreatePrebuiltRulesResult>;
   updateRule: (args: UpdateRuleArgs) => Promise<RuleResponse>;
   patchRule: (args: PatchRuleArgs) => Promise<RuleResponse>;
   deleteRule: (args: DeleteRuleArgs) => Promise<void>;
@@ -33,6 +37,7 @@ export interface IDetectionRulesClient {
   revertPrebuiltRule: (args: RevertPrebuiltRuleArgs) => Promise<RuleResponse>;
   importRule: (args: ImportRuleArgs) => Promise<RuleResponse>;
   importRules: (args: ImportRulesArgs) => Promise<Array<RuleResponse | RuleImportErrorObject>>;
+  bulkImportRules: (args: ImportRulesArgs) => Promise<Array<RuleResponse | RuleImportErrorObject>>;
 }
 
 export interface CreateCustomRuleArgs {
@@ -41,6 +46,10 @@ export interface CreateCustomRuleArgs {
 
 export interface CreatePrebuiltRuleArgs {
   params: RuleCreateProps;
+}
+
+export interface BulkCreatePrebuiltRulesArgs {
+  rules: PrebuiltRuleAsset[];
 }
 
 export interface UpdateRuleArgs {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_create_prebuilt_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_create_prebuilt_rules.ts
@@ -102,6 +102,10 @@ export const bulkCreatePrebuiltRules = async ({
 
   const result = await rulesClient.bulkCreateRules<RuleParams>({ rules: bulkInputs });
 
+  // Prebuilt rules are always created disabled, so background work is just key
+  // invalidation flushing on error rows. Fire and forget; never rejects.
+  void result.backgroundWork();
+
   result.rules.forEach((createdRule) => {
     results.push({ result: convertAlertingRuleToRuleResponse(createdRule) });
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_create_prebuilt_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_create_prebuilt_rules.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type { RulesClient } from '@kbn/alerting-plugin/server';
+import { ruleTypeMappings } from '@kbn/securitysolution-rules';
+import { SERVER_APP_ID } from '../../../../../../../common';
+import type { PrebuiltRuleAsset } from '../../../../prebuilt_rules';
+import type { MlAuthz } from '../../../../../machine_learning/authz';
+import type { RuleParams } from '../../../../rule_schema';
+import { convertAlertingRuleToRuleResponse } from '../converters/convert_alerting_rule_to_rule_response';
+import { convertRuleResponseToAlertingRule } from '../converters/convert_rule_response_to_alerting_rule';
+import { applyRuleDefaults } from '../mergers/apply_rule_defaults';
+import { validateMlAuth } from '../utils';
+
+export interface BulkCreatePrebuiltRulesArgs {
+  rules: PrebuiltRuleAsset[];
+}
+
+export interface BulkCreatePrebuiltRulesResult {
+  results: Array<{ result: ReturnType<typeof convertAlertingRuleToRuleResponse> }>;
+  errors: Array<{ item: PrebuiltRuleAsset; error: Error }>;
+}
+
+interface BulkCreatePrebuiltRulesOptions {
+  actionsClient: ActionsClient;
+  rulesClient: RulesClient;
+  mlAuthz: MlAuthz;
+  args: BulkCreatePrebuiltRulesArgs;
+}
+
+/**
+ * Bulk-installs prebuilt rules in a single `rulesClient.bulkCreateRules` call.
+ * Prebuilt rules are always created disabled, so this never triggers Phase 3/5
+ * (task scheduling/enable) on the alerting side.
+ *
+ * Returns the same `{ results, errors }` shape as `createPrebuiltRules` for
+ * drop-in compatibility with `performRuleInstallationHandler`.
+ */
+export const bulkCreatePrebuiltRules = async ({
+  actionsClient,
+  rulesClient,
+  mlAuthz,
+  args,
+}: BulkCreatePrebuiltRulesOptions): Promise<BulkCreatePrebuiltRulesResult> => {
+  const { rules } = args;
+  const results: BulkCreatePrebuiltRulesResult['results'] = [];
+  const errors: BulkCreatePrebuiltRulesResult['errors'] = [];
+
+  if (rules.length === 0) return { results, errors };
+
+  // Per-type ML auth dedupe: each unique rule type is checked once.
+  const checkedTypes = new Set<string>();
+  const mlAuthErrorByType = new Map<string, Error>();
+  for (const rule of rules) {
+    if (!checkedTypes.has(rule.type)) {
+      checkedTypes.add(rule.type);
+      try {
+        await validateMlAuth(mlAuthz, rule.type);
+      } catch (e) {
+        mlAuthErrorByType.set(rule.type, e instanceof Error ? e : new Error(String(e)));
+      }
+    }
+  }
+
+  // Pre-assign uuids so per-rule successes/failures from the alerting bulk call
+  // can be re-paired with their input PrebuiltRuleAsset by id.
+  const itemById = new Map<string, PrebuiltRuleAsset>();
+  const bulkInputs: Array<{
+    data: ReturnType<typeof convertRuleResponseToAlertingRule> & {
+      alertTypeId: string;
+      consumer: string;
+      enabled: boolean;
+    };
+    options: { id: string };
+  }> = [];
+
+  for (const rule of rules) {
+    const mlError = mlAuthErrorByType.get(rule.type);
+    if (mlError) {
+      errors.push({ item: rule, error: mlError });
+    } else {
+      const id = uuidv4();
+      itemById.set(id, rule);
+      const ruleWithDefaults = applyRuleDefaults({ ...rule, immutable: true });
+      const data = {
+        ...convertRuleResponseToAlertingRule(ruleWithDefaults, actionsClient),
+        alertTypeId: ruleTypeMappings[rule.type],
+        consumer: SERVER_APP_ID,
+        enabled: false,
+      };
+      bulkInputs.push({ data, options: { id } });
+    }
+  }
+
+  if (bulkInputs.length === 0) return { results, errors };
+
+  const result = await rulesClient.bulkCreateRules<RuleParams>({ rules: bulkInputs });
+
+  result.rules.forEach((createdRule) => {
+    results.push({ result: convertAlertingRuleToRuleResponse(createdRule) });
+  });
+
+  result.errors.forEach((err) => {
+    const item = itemById.get(err.rule.id);
+    if (!item) return;
+    errors.push({
+      item,
+      error: Object.assign(new Error(err.message), { statusCode: err.status }),
+    });
+  });
+
+  return { results, errors };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
@@ -271,20 +271,6 @@ export const bulkImportRules = async ({
     );
   });
 
-  // Surface task-enable failures as warnings: the rule was created but its
-  // task didn't start. We map back via id → rule_id and report a partial
-  // success so callers know to retry enabling.
-  bulkResult.taskIdsFailedToBeEnabled.forEach((taskId) => {
-    const source = inputById.get(taskId);
-    if (!source) return;
-    responses.push(
-      createRuleImportErrorObject({
-        ruleId: source.rule.rule_id,
-        message: 'Rule was created but its task could not be enabled; please retry enable.',
-      })
-    );
-  });
-
   return responses;
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
@@ -9,7 +9,7 @@ import pMap from 'p-map';
 import { i18n } from '@kbn/i18n';
 import { v4 as uuidv4 } from 'uuid';
 import type { ActionsClient } from '@kbn/actions-plugin/server';
-import type { RulesClient } from '@kbn/alerting-plugin/server';
+import type { BulkCreateOperationError, RulesClient } from '@kbn/alerting-plugin/server';
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { ruleTypeMappings } from '@kbn/securitysolution-rules';
 import { SERVER_APP_ID } from '../../../../../../../common';
@@ -55,11 +55,27 @@ interface BulkImportRulesOptions {
  */
 const escapeKql = (id: string) => id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
+export interface BulkImportRulesResult {
+  responses: Array<RuleResponse | RuleImportErrorObject>;
+  /**
+   * Deferred post-create work from `rulesClient.bulkCreateRules` (task scheduling,
+   * key invalidation, demotion bookkeeping). Caller decides when to invoke; the
+   * inner promise never rejects. Returns a no-op thunk when nothing was bulk-created.
+   */
+  backgroundWork: () => Promise<BulkCreateOperationError[]>;
+}
+
+const NOOP_BACKGROUND_WORK: () => Promise<BulkCreateOperationError[]> = () => Promise.resolve([]);
+
 /**
  * Bulk-import rules in a single chunk. Performs per-rule pre-checks, a single
  * `findRules` lookup for `rule_id` conflicts, and one `rulesClient.bulkCreateRules`
  * call for new rules (mixed enabled/disabled). Existing rules with `overwriteRules`
  * still fall through to the per-rule `importRule` path under a small concurrency cap.
+ *
+ * Returns the alerting `bulkCreateRules` background-work thunk untouched — the
+ * orchestrator (`importRules`) is responsible for invoking it after all batches
+ * have completed their foreground work.
  */
 export const bulkImportRules = async ({
   actionsClient,
@@ -67,9 +83,9 @@ export const bulkImportRules = async ({
   savedObjectsClient,
   mlAuthz,
   args,
-}: BulkImportRulesOptions): Promise<Array<RuleResponse | RuleImportErrorObject>> => {
+}: BulkImportRulesOptions): Promise<BulkImportRulesResult> => {
   const { rules, overwriteRules, ruleSourceImporter, allowMissingConnectorSecrets } = args;
-  if (rules.length === 0) return [];
+  if (rules.length === 0) return { responses: [], backgroundWork: NOOP_BACKGROUND_WORK };
 
   const responses: Array<RuleResponse | RuleImportErrorObject> = [];
 
@@ -151,7 +167,7 @@ export const bulkImportRules = async ({
     }
   }
 
-  if (prepared.length === 0) return responses;
+  if (prepared.length === 0) return { responses, backgroundWork: NOOP_BACKGROUND_WORK };
 
   // Bulk lookup for `rule_id` conflicts: single KQL parenthesized OR-list.
   const ruleIds = prepared.map((p) => p.rule.rule_id);
@@ -229,7 +245,7 @@ export const bulkImportRules = async ({
     responses.push(...overwriteResults);
   }
 
-  if (toBulkCreate.length === 0) return responses;
+  if (toBulkCreate.length === 0) return { responses, backgroundWork: NOOP_BACKGROUND_WORK };
 
   // Bulk-create new rules in a single alerting call. Pre-assign uuids so we
   // can re-pair successes/failures back to the source `rule_id`.
@@ -271,7 +287,7 @@ export const bulkImportRules = async ({
     );
   });
 
-  return responses;
+  return { responses, backgroundWork: bulkResult.backgroundWork };
 };
 
 export { escapeKql as __testing_escapeKql };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
@@ -1,0 +1,291 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import pMap from 'p-map';
+import { i18n } from '@kbn/i18n';
+import { v4 as uuidv4 } from 'uuid';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type { RulesClient } from '@kbn/alerting-plugin/server';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { ruleTypeMappings } from '@kbn/securitysolution-rules';
+import { SERVER_APP_ID } from '../../../../../../../common';
+import type { RuleResponse, RuleToImport } from '../../../../../../../common/api/detection_engine';
+import { ruleToImportHasVersion } from '../../../../../../../common/api/detection_engine/rule_management';
+import type { MlAuthz } from '../../../../../machine_learning/authz';
+import type { RuleParams } from '../../../../rule_schema';
+import { findRules } from '../../search/find_rules';
+import { convertAlertingRuleToRuleResponse } from '../converters/convert_alerting_rule_to_rule_response';
+import { convertRuleResponseToAlertingRule } from '../converters/convert_rule_response_to_alerting_rule';
+import { applyRuleDefaults } from '../mergers/apply_rule_defaults';
+import { validateMlAuth } from '../utils';
+import {
+  type RuleImportErrorObject,
+  createRuleImportErrorObject,
+  isRuleImportError,
+} from '../../import/errors';
+import { checkRuleExceptionReferences } from '../../import/check_rule_exception_references';
+import { getReferencedExceptionLists } from '../../import/gather_referenced_exceptions';
+import type { IRuleSourceImporter } from '../../import/rule_source_importer';
+import { importRule as importRuleSingle } from './import_rule';
+import { createPrebuiltRuleAssetsClient } from '../../../../prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+
+const OVERWRITE_FALLBACK_CONCURRENCY = 10;
+
+interface BulkImportRulesOptions {
+  actionsClient: ActionsClient;
+  rulesClient: RulesClient;
+  savedObjectsClient: SavedObjectsClientContract;
+  mlAuthz: MlAuthz;
+  args: {
+    rules: RuleToImport[];
+    overwriteRules: boolean;
+    ruleSourceImporter: IRuleSourceImporter;
+    allowMissingConnectorSecrets?: boolean;
+  };
+}
+
+/**
+ * KQL escape — `rule_id` is free-form (`RuleSignatureId`), not guaranteed to be
+ * a UUID, so backslashes and double quotes need escaping when used as a
+ * value in a KQL string.
+ */
+const escapeKql = (id: string) => id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+/**
+ * Bulk-import rules in a single chunk. Performs per-rule pre-checks, a single
+ * `findRules` lookup for `rule_id` conflicts, and one `rulesClient.bulkCreateRules`
+ * call for new rules (mixed enabled/disabled). Existing rules with `overwriteRules`
+ * still fall through to the per-rule `importRule` path under a small concurrency cap.
+ */
+export const bulkImportRules = async ({
+  actionsClient,
+  rulesClient,
+  savedObjectsClient,
+  mlAuthz,
+  args,
+}: BulkImportRulesOptions): Promise<Array<RuleResponse | RuleImportErrorObject>> => {
+  const { rules, overwriteRules, ruleSourceImporter, allowMissingConnectorSecrets } = args;
+  if (rules.length === 0) return [];
+
+  const responses: Array<RuleResponse | RuleImportErrorObject> = [];
+
+  const existingLists = await getReferencedExceptionLists({ rules, savedObjectsClient });
+  await ruleSourceImporter.setup(rules);
+
+  // Per-rule pre-checks (in-process, isolated try/catch). Output: only rules
+  // that pass all checks proceed to classification.
+  interface PreparedImport {
+    rule: RuleToImport;
+    immutable: boolean;
+    ruleSource: ReturnType<IRuleSourceImporter['calculateRuleSource']>['ruleSource'];
+    exceptionsList: RuleToImport['exceptions_list'];
+  }
+  const prepared: PreparedImport[] = [];
+  const checkedTypes = new Set<string>();
+  const mlAuthErrorByType = new Map<string, Error>();
+
+  for (const rule of rules) {
+    if (!ruleSourceImporter.isPrebuiltRule(rule)) {
+      rule.version = rule.version ?? 1;
+    }
+    if (!ruleToImportHasVersion(rule)) {
+      responses.push(
+        createRuleImportErrorObject({
+          ruleId: rule.rule_id,
+          message: i18n.translate(
+            'xpack.securitySolution.detectionEngine.rules.cannotImportPrebuiltRuleWithoutVersion',
+            {
+              defaultMessage:
+                'Prebuilt rules must specify a "version" to be imported. [rule_id: {ruleId}]',
+              values: { ruleId: rule.rule_id },
+            }
+          ),
+        })
+      );
+    } else {
+      if (!checkedTypes.has(rule.type)) {
+        checkedTypes.add(rule.type);
+        try {
+          await validateMlAuth(mlAuthz, rule.type);
+        } catch (e) {
+          mlAuthErrorByType.set(rule.type, e instanceof Error ? e : new Error(String(e)));
+        }
+      }
+      const mlError = mlAuthErrorByType.get(rule.type);
+      if (mlError) {
+        responses.push(
+          createRuleImportErrorObject({ ruleId: rule.rule_id, message: mlError.message })
+        );
+      } else {
+        const [exceptionErrors, exceptionsList] = checkRuleExceptionReferences({
+          rule,
+          existingLists,
+        });
+        responses.push(...exceptionErrors);
+
+        let ruleSourceResult;
+        try {
+          ruleSourceResult = ruleSourceImporter.calculateRuleSource(rule);
+        } catch (e) {
+          responses.push(
+            createRuleImportErrorObject({
+              ruleId: rule.rule_id,
+              message: e instanceof Error ? e.message : String(e),
+            })
+          );
+        }
+
+        if (ruleSourceResult) {
+          prepared.push({
+            rule,
+            immutable: ruleSourceResult.immutable,
+            ruleSource: ruleSourceResult.ruleSource,
+            exceptionsList,
+          });
+        }
+      }
+    }
+  }
+
+  if (prepared.length === 0) return responses;
+
+  // Bulk lookup for `rule_id` conflicts: single KQL parenthesized OR-list.
+  const ruleIds = prepared.map((p) => p.rule.rule_id);
+  const filter = `alert.attributes.params.ruleId: (${ruleIds
+    .map((id) => `"${escapeKql(id)}"`)
+    .join(' OR ')})`;
+  const found = await findRules({
+    rulesClient,
+    filter,
+    page: 1,
+    perPage: ruleIds.length,
+    fields: undefined,
+    sortField: undefined,
+    sortOrder: undefined,
+  });
+  const existingByRuleId = new Map<string, RuleResponse>();
+  for (const alertingRule of found.data) {
+    const ruleResponse = convertAlertingRuleToRuleResponse(alertingRule);
+    existingByRuleId.set(ruleResponse.rule_id, ruleResponse);
+  }
+
+  // Classify: conflict | overwrite-fallback | bulk-create.
+  const conflicts: PreparedImport[] = [];
+  const toOverwrite: PreparedImport[] = [];
+  const toBulkCreate: PreparedImport[] = [];
+  for (const p of prepared) {
+    if (existingByRuleId.has(p.rule.rule_id)) {
+      if (overwriteRules) toOverwrite.push(p);
+      else conflicts.push(p);
+    } else {
+      toBulkCreate.push(p);
+    }
+  }
+
+  conflicts.forEach((p) => {
+    responses.push(
+      createRuleImportErrorObject({
+        ruleId: p.rule.rule_id,
+        type: 'conflict',
+        message: 'Rule with this rule_id already exists',
+      })
+    );
+  });
+
+  // Overwrite branch: stays per-rule via existing single-rule importRule.
+  if (toOverwrite.length > 0) {
+    const prebuiltRuleAssetClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
+    const overwriteResults = await pMap(
+      toOverwrite,
+      async (p) => {
+        try {
+          const updated = await importRuleSingle({
+            actionsClient,
+            rulesClient,
+            mlAuthz,
+            prebuiltRuleAssetClient,
+            importRulePayload: {
+              ruleToImport: { ...p.rule, exceptions_list: [...(p.exceptionsList ?? [])] },
+              overrideFields: { rule_source: p.ruleSource, immutable: p.immutable },
+              overwriteRules: true,
+              allowMissingConnectorSecrets,
+            },
+          });
+          return updated as RuleResponse | RuleImportErrorObject;
+        } catch (err) {
+          if (isRuleImportError(err)) return err;
+          return createRuleImportErrorObject({
+            ruleId: p.rule.rule_id,
+            message: err?.message ?? 'unknown error',
+          });
+        }
+      },
+      { concurrency: OVERWRITE_FALLBACK_CONCURRENCY }
+    );
+    responses.push(...overwriteResults);
+  }
+
+  if (toBulkCreate.length === 0) return responses;
+
+  // Bulk-create new rules in a single alerting call. Pre-assign uuids so we
+  // can re-pair successes/failures back to the source `rule_id`.
+  const inputById = new Map<string, PreparedImport>();
+  const bulkInputs = toBulkCreate.map((p) => {
+    const id = uuidv4();
+    inputById.set(id, p);
+    const ruleResponse = applyRuleDefaults({
+      ...p.rule,
+      exceptions_list: [...(p.exceptionsList ?? [])],
+      immutable: p.immutable,
+      rule_source: p.ruleSource,
+    });
+    const data = {
+      ...convertRuleResponseToAlertingRule(ruleResponse, actionsClient),
+      alertTypeId: ruleTypeMappings[p.rule.type],
+      consumer: SERVER_APP_ID,
+      // Preserve the user-requested enabled flag — alerting handles enabled
+      // rules natively (API key + task scheduling) in this single call.
+      enabled: p.rule.enabled ?? false,
+    };
+    return { data, options: { id }, allowMissingConnectorSecrets };
+  });
+
+  const bulkResult = await rulesClient.bulkCreateRules<RuleParams>({ rules: bulkInputs });
+
+  bulkResult.rules.forEach((createdRule) => {
+    responses.push(convertAlertingRuleToRuleResponse(createdRule));
+  });
+
+  bulkResult.errors.forEach((err) => {
+    const source = inputById.get(err.rule.id);
+    if (!source) return;
+    responses.push(
+      createRuleImportErrorObject({
+        ruleId: source.rule.rule_id,
+        message: err.message,
+      })
+    );
+  });
+
+  // Surface task-enable failures as warnings: the rule was created but its
+  // task didn't start. We map back via id → rule_id and report a partial
+  // success so callers know to retry enabling.
+  bulkResult.taskIdsFailedToBeEnabled.forEach((taskId) => {
+    const source = inputById.get(taskId);
+    if (!source) return;
+    responses.push(
+      createRuleImportErrorObject({
+        ruleId: source.rule.rule_id,
+        message: 'Rule was created but its task could not be enabled; please retry enable.',
+      })
+    );
+  });
+
+  return responses;
+};
+
+export { escapeKql as __testing_escapeKql };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
+import type { BulkCreateOperationError } from '@kbn/alerting-plugin/server';
 import type { ExperimentalFeatures } from '../../../../../../common';
 import type { RuleToImport } from '../../../../../../common/api/detection_engine';
 import { type ImportRuleResponse, createBulkErrorObject } from '../../../routes/utils';
@@ -21,7 +23,12 @@ import { isRuleConflictError, isRuleImportError } from './errors';
  * @param detectionRulesClient {object}
  * @param experimentalFeatures - feature flags; when `bulkCreateRulesEnabled` is on,
  *   per-chunk import is dispatched through `detectionRulesClient.bulkImportRules`
- *   (single bulk alerting call) instead of the per-rule loop.
+ *   (single bulk alerting call) instead of the per-rule loop. The bulk path
+ *   defers post-create work (task scheduling, key invalidation, demotion
+ *   bookkeeping); this orchestrator collects each chunk's deferred work and runs
+ *   it serially in a detached task once all foreground batches have completed —
+ *   the response itself is not held back.
+ * @param logger - used to log failures from the detached background runner.
  * @returns {Promise} an array of error and success messages from import
  */
 export const importRules = async ({
@@ -31,6 +38,7 @@ export const importRules = async ({
   ruleSourceImporter,
   allowMissingConnectorSecrets,
   experimentalFeatures,
+  logger,
 }: {
   ruleChunks: RuleToImport[][];
   overwriteRules: boolean;
@@ -38,6 +46,7 @@ export const importRules = async ({
   ruleSourceImporter: IRuleSourceImporter;
   allowMissingConnectorSecrets?: boolean;
   experimentalFeatures?: ExperimentalFeatures;
+  logger?: Logger;
 }): Promise<ImportRuleResponse[]> => {
   const response: ImportRuleResponse[] = [];
 
@@ -46,21 +55,27 @@ export const importRules = async ({
   }
 
   const useBulk = experimentalFeatures?.bulkCreateRulesEnabled ?? false;
+  const deferredBackgroundWork: Array<() => Promise<BulkCreateOperationError[]>> = [];
 
   for (const rules of ruleChunks) {
-    const importedRulesResponse = await (useBulk
-      ? detectionRulesClient.bulkImportRules({
-          allowMissingConnectorSecrets,
-          overwriteRules,
-          ruleSourceImporter,
-          rules,
-        })
-      : detectionRulesClient.importRules({
-          allowMissingConnectorSecrets,
-          overwriteRules,
-          ruleSourceImporter,
-          rules,
-        }));
+    let importedRulesResponse: Awaited<ReturnType<IDetectionRulesClient['importRules']>>;
+    if (useBulk) {
+      const bulkResult = await detectionRulesClient.bulkImportRules({
+        allowMissingConnectorSecrets,
+        overwriteRules,
+        ruleSourceImporter,
+        rules,
+      });
+      importedRulesResponse = bulkResult.responses;
+      deferredBackgroundWork.push(bulkResult.backgroundWork);
+    } else {
+      importedRulesResponse = await detectionRulesClient.importRules({
+        allowMissingConnectorSecrets,
+        overwriteRules,
+        ruleSourceImporter,
+        rules,
+      });
+    }
 
     const importResponses = importedRulesResponse.map((rule) => {
       if (isRuleImportError(rule)) {
@@ -78,6 +93,26 @@ export const importRules = async ({
     });
 
     response.push(...importResponses);
+  }
+
+  // All foreground batches done — kick off background work serially, detached
+  // from the request lifecycle so the caller's response isn't held back.
+  // Inner thunks already swallow their own errors; the outer wrapper guards
+  // against any unexpected throws so it always settles.
+  if (deferredBackgroundWork.length > 0) {
+    void (async () => {
+      for (const work of deferredBackgroundWork) {
+        try {
+          await work();
+        } catch (err) {
+          logger?.error(
+            `importRules: deferred background work threw unexpectedly: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      }
+    })();
   }
 
   return response;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { ExperimentalFeatures } from '../../../../../../common';
 import type { RuleToImport } from '../../../../../../common/api/detection_engine';
 import { type ImportRuleResponse, createBulkErrorObject } from '../../../routes/utils';
 import type { IRuleSourceImporter } from './rule_source_importer';
@@ -18,6 +19,9 @@ import { isRuleConflictError, isRuleImportError } from './errors';
  * @param overwriteRules {boolean} - whether to overwrite existing rules
  * with imported rules if their rule_id matches
  * @param detectionRulesClient {object}
+ * @param experimentalFeatures - feature flags; when `bulkCreateRulesEnabled` is on,
+ *   per-chunk import is dispatched through `detectionRulesClient.bulkImportRules`
+ *   (single bulk alerting call) instead of the per-rule loop.
  * @returns {Promise} an array of error and success messages from import
  */
 export const importRules = async ({
@@ -26,12 +30,14 @@ export const importRules = async ({
   detectionRulesClient,
   ruleSourceImporter,
   allowMissingConnectorSecrets,
+  experimentalFeatures,
 }: {
   ruleChunks: RuleToImport[][];
   overwriteRules: boolean;
   detectionRulesClient: IDetectionRulesClient;
   ruleSourceImporter: IRuleSourceImporter;
   allowMissingConnectorSecrets?: boolean;
+  experimentalFeatures?: ExperimentalFeatures;
 }): Promise<ImportRuleResponse[]> => {
   const response: ImportRuleResponse[] = [];
 
@@ -39,13 +45,22 @@ export const importRules = async ({
     return response;
   }
 
+  const useBulk = experimentalFeatures?.bulkCreateRulesEnabled ?? false;
+
   for (const rules of ruleChunks) {
-    const importedRulesResponse = await detectionRulesClient.importRules({
-      allowMissingConnectorSecrets,
-      overwriteRules,
-      ruleSourceImporter,
-      rules,
-    });
+    const importedRulesResponse = await (useBulk
+      ? detectionRulesClient.bulkImportRules({
+          allowMissingConnectorSecrets,
+          overwriteRules,
+          ruleSourceImporter,
+          rules,
+        })
+      : detectionRulesClient.importRules({
+          allowMissingConnectorSecrets,
+          overwriteRules,
+          ruleSourceImporter,
+          rules,
+        }));
 
     const importResponses = importedRulesResponse.map((rule) => {
       if (isRuleImportError(rule)) {


### PR DESCRIPTION
## Summary

Adds `rulesClient.bulkCreateRules`.

Similar in spirit to https://github.com/elastic/kibana/pull/266713, but **persist first, schedule later**: API-key generation and task scheduling are best-effort and never cancel the batch — if there is an error, affected rules are flipped to `disabled` state with a structured `disabledReason` returned from promise `backgroundWork`.

## Rule Creation Flow

```
   Philosophy: Persist SOs first, schedule tasks later.
   The background promise may later flip some rule SOs to "disabled".

   ┌─────────────────────── FOREGROUND (awaited) ───────────────────────┐
   │  prepare ─▶ mint API keys ─▶ SO bulkCreate ─▶ split rows ─▶ return │
   │  (validate, (for enabled rules;  (no overwrite)  (per-row 409s)    │
   │   authz)     soft-fail ⇒ disabled)                                 │
   │                                                                    │
   │   returns { rules, errors, total, backgroundWork }                 │
   └────────────────────────────────────┬───────────────────────────────┘
                                        │ (kicked off, not awaited)
                                        ▼
   ┌──────────────────── BACKGROUND (result.backgroundWork) ────────────┐
   │  schedule-limit ─▶ bulkSchedule ─▶ demote failed ─▶ flush API keys │
   │  check             tasks           rules (SO →     to invalidate   │
   │                                    disabled)                       │
   │                                                                    │
   │  resolves to bgErrors[] (one per demoted rule); never rejects.     │
   └────────────────────────────────────────────────────────────────────┘

```

**NOTES:**

- Foreground `rules[]` reflects intent. SOs saved as "enabled" even if we haven't created tasks for them.
- Callers needing post-background state should `await result.backgroundWork` which will return a list of `bgErrors` (per rule) if there are problems scheduling enabled tasks.

## Test plan

- [ ] Unit: `bulk_create_rules.test.ts`, `detection_rules_client.bulk_create_prebuilt_rules.test.ts`, `detection_rules_client.bulk_import_rules.test.ts`
- [ ] Manual: import a large rule set behind the experimental flag and verify rules whose tasks fail to schedule come back as `enabled: false` with a `disabledReason`, and the batch as a whole still succeeds