### PR TITLE
[profiling] fix failing profiling tests due to [fleet-agent-policies/policy-elastic-agent-on-cloud] not found

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/worker/profiling/profiling_setup_fixture.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/worker/profiling/profiling_setup_fixture.ts
@@ -47,10 +47,20 @@ export const profilingSetupFixture = base.extend<{}, { profilingSetup: Profiling
               'content-type': 'application/json',
               'kbn-xsrf': 'reporting',
             },
+            // The route is not idempotent on retry; we want a fast, clear failure so the
+            // underlying error (logged in Kibana by handleRouteHandlerError) is the first
+            // thing the developer sees instead of a series of 500s.
+            retries: 0,
           });
           log.info('Profiling resources set up successfully');
-        } catch (error) {
-          log.error(`Error setting up profiling resources: ${error}`);
+        } catch (error: any) {
+          const status = error?.response?.status ?? error?.originalError?.response?.status;
+          const body = error?.response?.data ?? error?.originalError?.response?.data;
+          log.error(
+            `Error setting up profiling resources POST /api/profiling/setup/es_resources: status=${status} body=${JSON.stringify(
+              body
+            )}`
+          );
           throw error;
         }
       };
@@ -97,20 +107,25 @@ export const profilingSetupFixture = base.extend<{}, { profilingSetup: Profiling
       const cleanup = async (): Promise<void> => {
         log.info(`Unloading Profiling data`);
 
-        const indices = await esClient.cat.indices({ format: 'json' });
+        const ignoreNotFound = (error: any) => {
+          if (error?.meta?.statusCode === 404) return undefined;
+          throw error;
+        };
 
-        const profilingIndices = indices
-          .filter((index) => index.index !== undefined)
+        const profilingIndices = (await esClient.cat.indices({ format: 'json' }))
           .map((index) => index.index)
-          .filter((index) => {
-            return index!.startsWith('profiling') || index!.startsWith('.profiling');
-          }) as string[];
+          .filter(
+            (name): name is string =>
+              !!name && (name.startsWith('profiling') || name.startsWith('.profiling'))
+          );
 
         await Promise.all([
-          ...profilingIndices.map((index) => esClient.indices.delete({ index })),
-          esClient.indices.deleteDataStream({
-            name: 'profiling-events*',
-          }),
+          ...profilingIndices.map((index) =>
+            esClient.indices.delete({ index, ignore_unavailable: true }).catch(ignoreNotFound)
+          ),
+          // 'profiling-events*' may not exist on a fresh cluster; tolerate the 404 so we
+          // do not abort the whole Promise.all and leave preceding cleanup work half-done.
+          esClient.indices.deleteDataStream({ name: 'profiling-events*' }).catch(ignoreNotFound),
         ]);
         log.info('Unloaded Profiling data');
       };

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
@@ -17,7 +17,12 @@ apiTest.describe(
   () => {
     let viewerApiCreditials: RoleApiCredentials;
     let adminApiCreditials: RoleApiCredentials;
-    apiTest.beforeAll(async ({ profilingSetup, requestAuth }) => {
+    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
+      // Ensure the agent policy that the cloud setup attaches the profiler_collector and
+      // profiler_symbolizer package policies to exists. Without this, setupResources()
+      // returns 500 when this spec runs ahead of (or independently of) has_no_setup.spec.
+      await profilingHelper.installPolicies();
+
       if (!(await profilingSetup.checkStatus()).has_setup) {
         await profilingSetup.setupResources();
       }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_data.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_data.spec.ts
@@ -14,7 +14,16 @@ import { esArchiversPath, esResourcesEndpoint } from '../../common/fixtures/cons
 apiTest.describe('Profiling is setup and data is loaded', { tag: tags.stateful.classic }, () => {
   let viewerApiCreditials: RoleApiCredentials;
   let adminApiCreditials: RoleApiCredentials;
-  apiTest.beforeAll(async ({ requestAuth, profilingSetup }) => {
+  apiTest.beforeAll(async ({ requestAuth, profilingHelper, profilingSetup }) => {
+    // Make this spec self-sufficient instead of relying on has_no_setup.spec running first:
+    // ensure the cloud agent policy exists and profiling resources are set up before
+    // attempting to load data.
+    await profilingHelper.installPolicies();
+
+    if (!(await profilingSetup.checkStatus()).has_setup) {
+      await profilingSetup.setupResources();
+    }
+
     await profilingSetup.loadData(esArchiversPath);
     viewerApiCreditials = await requestAuth.getApiKey('viewer');
     adminApiCreditials = await requestAuth.getApiKey('admin');


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/268400
Closes https://github.com/elastic/kibana/issues/268399

Profiling's `setupResources` POST takes the cloud branch (Scout's stateful Kibana runs with `xpack.cloud.id` set), so it tries to create the `profiler_collector` and `profiler_symbolizer` Fleet package policies on the `policy-elastic-agent-on-cloud` agent policy, which only `has_no_setup.spec.ts` provisions via `profilingHelper.installPolicies()`.

When the UX Scout tests ran first, the worker order/state shifted just enough that `has_setup_apm_not_installed.spec.ts`'s `beforeAll` reached `setupResources` before `has_no_setup.spec.ts` had created the agent policy, so Fleet's `packagePolicyClient.create` blew up with `Saved object [fleet-agent-policies/policy-elastic-agent-on-cloud] not found`, which the route surfaced as the opaque 500.

The fix makes each spec self-provision the agent policy instead of relying on test ordering.

Tested locally:

```
# start servers
node scripts/scout start-server --arch stateful --domain classic

# run ux tests first
npx playwright test --project local --grep @local-stateful-classic --config x-pack/solutions/observability/plugins/ux/test/scout/ui/playwright.config.ts

# run profiling tests
npx playwright test --project local --grep @local-stateful-classic --config x-pack/solutions/observability/plugins/profiling/test/scout/api/playwright.config.ts
```

Before the fix the following error occured:

```
 proc [kibana] [2026-05-08T14:05:35.889+02:00][ERROR][plugins.profiling] Error: Saved object [fleet-agent-policies/policy-elastic-agent-on-cloud] not found
 proc [kibana]     at SavedObjectsErrorHelpers.createGenericNotFoundError (saved_objects_error_helpers.ts:284:28)
 proc [kibana]     at agent_policy.ts:752:40
 proc [kibana]     at processTicksAndRejections (node:internal/process/task_queues:104:5)
 proc [kibana]     at AgentPolicyService.get (agent_policy.ts:747:27)
 proc [kibana]     at PackagePolicyClientImpl.create (package_policy.ts:547:27)
 proc [kibana]     at createCollectorPackagePolicy (fleet_policies.ts:89:3)
 proc [kibana]     at async Promise.all (index 0)
 proc [kibana]     at setupCloud (setup_cloud.ts:36:3)
 proc [kibana]     at route.ts:139:11
 proc [kibana]     at handle (route.ts:161:26)
 proc [kibana]     at handler (route.ts:78:14)
 proc [kibana]     at Router.handle (router.ts:209:30)
 proc [kibana]     at exports.Manager.execute (/Users/dmle/elastic/github/kibana/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
 proc [kibana]     at Object.internals.handler (/Users/dmle/elastic/github/kibana/node_modules/@hapi/hapi/lib/handler.js:46:20)
 proc [kibana]     at exports.execute (/Users/dmle/elastic/github/kibana/node_modules/@hapi/hapi/lib/handler.js:31:20)
 proc [kibana]     at Request._lifecycle (/Users/dmle/elastic/github/kibana/node_modules/@hapi/hapi/lib/request.js:384:32)
 proc [kibana]     at Request._execute (/Users/dmle/elastic/github/kibana/node_modules/@hapi/hapi/lib/request.js:294:9) {"service":{"version":"9.5.0","type":"kibana","state":"available","node":{"roles":["background_tasks","ui"]},"id":"_jN54-qzRc2aypW_5PVHdw"}}
```



<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->