### PR TITLE
[9.3] Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/ml-ui` files (#267698)

### DIFF
--- a/x-pack/platform/packages/private/ml/aiops_components/src/progress_controls/progress_controls.tsx
+++ b/x-pack/platform/packages/private/ml/aiops_components/src/progress_controls/progress_controls.tsx
@@ -139,7 +139,11 @@ export const ProgressControls: FC<PropsWithChildren<ProgressControlProps>> = (pr
         {progress === 1 ? (
           <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="checkInCircleFilled" color={euiTheme.colors.success} />
+              <EuiIcon
+                aria-hidden={true}
+                type="checkInCircleFilled"
+                color={euiTheme.colors.success}
+              />
             </EuiFlexItem>
             <EuiFlexItem grow={false} data-test-subj="aiopsAnalysisComplete">
               <small>

--- a/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/file_status/analysis_explanation.tsx
+++ b/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/file_status/analysis_explanation.tsx
@@ -60,7 +60,7 @@ export const AnalysisExplanation: FC<Props> = ({ fileStatus, index }) => {
         >
           <EuiModalHeader>
             <EuiModalHeaderTitle id={modalTitleId}>
-              <EuiIcon type="inspect" size={'l'} />{' '}
+              <EuiIcon aria-hidden={true} type="inspect" size={'l'} />{' '}
               <FormattedMessage
                 id="xpack.fileUpload.explanationFlyout.title"
                 defaultMessage="Analysis explanation"

--- a/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/file_status/file_clash.tsx
+++ b/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/file_status/file_clash.tsx
@@ -131,7 +131,7 @@ export const FileClashIcon: FC<Props> = ({ fileClash }) => {
       return (
         <EuiToolTip content={getClashText(fileClash)}>
           <EuiBadge color={euiTheme.colors.backgroundBaseDanger}>
-            <EuiIcon type="alert" color="danger" size="s" />
+            <EuiIcon aria-hidden={true} type="alert" color="danger" size="s" />
           </EuiBadge>
         </EuiToolTip>
       );
@@ -139,7 +139,7 @@ export const FileClashIcon: FC<Props> = ({ fileClash }) => {
       return (
         <EuiToolTip content={getClashText(fileClash)}>
           <EuiBadge color={euiTheme.colors.backgroundBaseWarning}>
-            <EuiIcon type="warning" color="warning" size="s" />
+            <EuiIcon aria-hidden={true} type="warning" color="warning" size="s" />
           </EuiBadge>
         </EuiToolTip>
       );

--- a/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/results_links/results_links.tsx
+++ b/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/results_links/results_links.tsx
@@ -181,7 +181,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`discoverApp`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`discoverApp`} />}
             title={
               <FormattedMessage
                 id="xpack.fileUpload.resultsLinks.viewIndexInDiscoverTitle"
@@ -197,7 +197,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`managementApp`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`managementApp`} />}
             title={
               <FormattedMessage
                 id="xpack.fileUpload.resultsLinks.indexManagementTitle"
@@ -213,7 +213,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`managementApp`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`managementApp`} />}
             title={
               <FormattedMessage
                 id="xpack.fileUpload.resultsLinks.dataViewManagementTitle"
@@ -229,7 +229,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`filebeatApp`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`filebeatApp`} />}
             data-test-subj="fileDataVisFilebeatConfigLink"
             title={
               <FormattedMessage
@@ -247,8 +247,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`logoElasticsearch`} />}
-            data-test-subj="fileDataVisFilebeatConfigLink"
+            icon={<EuiIcon aria-hidden={true} size="xxl" type="logoElasticsearch" />}
             title={
               <FormattedMessage
                 id="xpack.fileUpload.resultsLinks.playground"
@@ -266,7 +265,7 @@ export const ResultsLinks: FC<Props> = ({
           <EuiFlexItem key={link.title}>
             <EuiCard
               hasBorder
-              icon={<EuiIcon size="xxl" type={link.icon} />}
+              icon={<EuiIcon aria-hidden={true} size="xxl" type={link.icon} />}
               data-test-subj="fileDataVisLink"
               title={link.title}
               description={link.description}

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/multi_select_picker/multi_select_picker.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/multi_select_picker/multi_select_picker.tsx
@@ -35,7 +35,7 @@ const SELECT_PICKER_HEIGHT = '250px';
 const NoFilterItems = () => {
   return (
     <EuiSelectableMessage>
-      <EuiIcon type="minusInCircle" />
+      <EuiIcon aria-hidden={true} type="minusInCircle" />
       <EuiSpacer size="xs" />
       <p>
         <FormattedMessage

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/not_in_docs_content/not_in_docs_context.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/not_in_docs_content/not_in_docs_context.tsx
@@ -14,7 +14,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 export const NotInDocsContent: FC = () => (
   <Fragment>
     <EuiText textAlign="center">
-      <EuiIcon type="warning" />
+      <EuiIcon aria-hidden={true} type="warning" />
     </EuiText>
     <EuiText textAlign="center" size={'xs'}>
       <FormattedMessage

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/not_in_docs_content/not_supported_content.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/not_in_docs_content/not_supported_content.tsx
@@ -12,7 +12,7 @@ import type { FC } from 'react';
 export const NotSupportedContent: FC = () => (
   <Fragment>
     <EuiText textAlign="center">
-      <EuiIcon type="warning" />
+      <EuiIcon aria-hidden={true} type="warning" />
     </EuiText>
     <EuiText textAlign="center" size={'xs'}>
       <FormattedMessage

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/results_links/results_links.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/results_links/results_links.tsx
@@ -203,7 +203,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`discoverApp`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`discoverApp`} />}
             title={
               <FormattedMessage
                 id="xpack.dataVisualizer.file.resultsLinks.viewIndexInDiscoverTitle"
@@ -219,7 +219,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`managementApp`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`managementApp`} />}
             title={
               <FormattedMessage
                 id="xpack.dataVisualizer.file.resultsLinks.indexManagementTitle"
@@ -235,7 +235,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`managementApp`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`managementApp`} />}
             title={
               <FormattedMessage
                 id="xpack.dataVisualizer.file.resultsLinks.dataViewManagementTitle"
@@ -251,7 +251,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`filebeatApp`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`filebeatApp`} />}
             data-test-subj="fileDataVisFilebeatConfigLink"
             title={
               <FormattedMessage
@@ -269,7 +269,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon size="xxl" type={`logoElasticsearch`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type={`logoElasticsearch`} />}
             data-test-subj="fileDataVisFilebeatConfigLink"
             title={
               <FormattedMessage
@@ -288,7 +288,7 @@ export const ResultsLinks: FC<Props> = ({
           <EuiFlexItem key={link.title}>
             <EuiCard
               hasBorder
-              icon={<EuiIcon size="xxl" type={link.icon} />}
+              icon={<EuiIcon aria-hidden={true} size="xxl" type={link.icon} />}
               data-test-subj="fileDataVisLink"
               title={link.title}
               description={link.description}

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/components/field_data_row/distinct_values.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/components/field_data_row/distinct_values.tsx
@@ -59,7 +59,7 @@ export const DistinctValues = ({ showIcon, config }: Props) => {
         className={'columnHeader__icon'}
       />
     ) : (
-      <EuiIcon type="database" size={'m'} className={'columnHeader__icon'} />
+      <EuiIcon aria-hidden={true} type="database" size={'m'} className={'columnHeader__icon'} />
     )
   ) : null;
 

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/components/field_data_row/document_stats.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/components/field_data_row/document_stats.tsx
@@ -79,7 +79,7 @@ export const DocumentStat = ({ config, showIcon, totalCount }: Props) => {
         size="m"
       />
     ) : (
-      <EuiIcon type="document" size={'m'} className={'columnHeader__icon'} />
+      <EuiIcon aria-hidden={true} type="document" size={'m'} className={'columnHeader__icon'} />
     )
   ) : null;
 

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/data_visualizer_stats_table.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/data_visualizer_stats_table.tsx
@@ -287,7 +287,11 @@ const UnmemoizedDataVisualizerTable = <T extends DataVisualizerTableItem>({
         name: (
           <div className={'columnHeader__title'}>
             {dimensions.showIcon ? (
-              <EuiIcon type={'visBarVertical'} className={'columnHeader__icon'} />
+              <EuiIcon
+                aria-hidden={true}
+                type={'visBarVertical'}
+                className={'columnHeader__icon'}
+              />
             ) : null}
             {i18n.translate('xpack.dataVisualizer.dataGrid.distributionsColumnName', {
               defaultMessage: 'Distributions',

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/embeddables/grid_embeddable/embeddable_field_stats_no_results.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/embeddables/grid_embeddable/embeddable_field_stats_no_results.tsx
@@ -20,7 +20,7 @@ export const EmbeddableNoResultsEmptyPrompt = () => (
     })}
   >
     <EuiText size="xs" color="subdued">
-      <EuiIcon type="visualizeApp" size="m" color="subdued" />
+      <EuiIcon aria-hidden={true} type="visualizeApp" size="m" color="subdued" />
       <EuiSpacer size="m" />
       <FormattedMessage
         id="xpack.dataVisualizer.index.embeddableNoResultsMessage"

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/change_point_type_filter.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/change_point_type_filter.tsx
@@ -111,7 +111,7 @@ export const ChangePointTypeFilter: FC<ChangePointTypeFilterProps> = ({ value, o
       <EuiToolTip position="left" content={description}>
         <EuiFlexGroup gutterSize={'s'} alignItems={'center'}>
           <EuiFlexItem grow={false}>
-            <EuiIcon type="info" color={'primary'} />
+            <EuiIcon aria-hidden={true} type="info" color={'primary'} />
           </EuiFlexItem>
           <EuiFlexItem>{label}</EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/category_table/category_table.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/category_table/category_table.tsx
@@ -152,7 +152,13 @@ export const CategoryTable: FC<Props> = ({
             {i18n.translate('xpack.aiops.logCategorization.column.tokens', {
               defaultMessage: 'Tokens',
             })}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              aria-hidden={true}
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+            />
           </>
         </EuiToolTip>
       ),

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/table_action_button.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/table_action_button.tsx
@@ -28,7 +28,7 @@ export const TableActionButton: FC<TableActionButtonProps> = ({
 }) => {
   const buttonContent = (
     <>
-      <EuiIcon type={iconType} css={{ marginRight: '8px' }} />
+      <EuiIcon aria-hidden={true} type={iconType} css={{ marginRight: '8px' }} />
       {label}
     </>
   );

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx
@@ -462,6 +462,7 @@ export const useColumns = (
           return (
             <>
               <EuiIcon
+                aria-hidden={true}
                 size="s"
                 color="subdued"
                 type={currentAnalysisType === LOG_RATE_ANALYSIS_TYPE.SPIKE ? 'sortUp' : 'sortDown'}

--- a/x-pack/platform/plugins/shared/ml/public/application/components/anomalies_table/anomaly_details.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/anomalies_table/anomaly_details.tsx
@@ -226,7 +226,7 @@ const Details: FC<{
       <EuiText size="xs">
         {isInterimResult === true && (
           <>
-            <EuiIcon type="warning" />
+            <EuiIcon type="warning" aria-hidden={true} />
             <span
               css={{
                 fontStyle: 'italic',

--- a/x-pack/platform/plugins/shared/ml/public/application/components/anomalies_table/description_cell.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/anomalies_table/description_cell.js
@@ -23,7 +23,7 @@ export function DescriptionCell({ actual, typical }) {
     <EuiFlexGroup gutterSize="s" alignItems="center">
       {iconType !== undefined && (
         <EuiFlexItem grow={false}>
-          <EuiIcon type={iconType} size="s" />
+          <EuiIcon type={iconType} size="s" aria-hidden={true} />
         </EuiFlexItem>
       )}
       <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/ml/public/application/components/data_recognizer/recognized_result.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/data_recognizer/recognized_result.js
@@ -31,7 +31,7 @@ export const RecognizedResult = ({ config, indexPattern, savedSearch }) => {
   // if a logo is available, use that, otherwise display the id
   // the logo should be a base64 encoded image or an eui icon
   if (config.logo && config.logo.icon) {
-    logo = <EuiIcon type={config.logo.icon} size="xl" />;
+    logo = <EuiIcon type={config.logo.icon} size="xl" aria-hidden={true} />;
   } else if (config.logo && config.logo.src) {
     logo = <img alt="" src={config.logo.src} />;
   } else {

--- a/x-pack/platform/plugins/shared/ml/public/application/components/job_message_icon/job_message_icon.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/job_message_icon/job_message_icon.tsx
@@ -9,6 +9,7 @@ import type { FC } from 'react';
 import React from 'react';
 
 import { EuiIcon, EuiIconTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { AuditMessageBase } from '../../../../common/types/audit_message';
 
 interface Props {
@@ -37,6 +38,15 @@ export const JobIcon: FC<Props> = ({ message, showTooltip = false }) => {
   if (showTooltip) {
     return <EuiIconTip content={message.text} position="bottom" type={icon} color={color} />;
   } else {
-    return <EuiIcon type={icon} color={color} />;
+    return (
+      <EuiIcon
+        type={icon}
+        color={color}
+        aria-label={i18n.translate('xpack.ml.jobMessageIcon.ariaLabel', {
+          defaultMessage: '{level} message',
+          values: { level: message.level },
+        })}
+      />
+    );
   }
 };

--- a/x-pack/platform/plugins/shared/ml/public/application/components/job_selector/group_or_job_selector_menu/job_selector_button.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/job_selector/group_or_job_selector_menu/job_selector_button.tsx
@@ -8,16 +8,7 @@
 import type { FC } from 'react';
 import React, { useMemo, useState } from 'react';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
-import {
-  EuiButton,
-  EuiContextMenu,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiPopover,
-  EuiText,
-  useGeneratedHtmlId,
-} from '@elastic/eui';
+import { EuiButton, EuiContextMenu, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
 import { useUrlState } from '@kbn/ml-url-state';
 import { ML_PAGES, type MlPages } from '../../../../../common/constants/locator';
 import { useJobInfoFlyouts } from '../../../jobs/components/job_details_flyout';
@@ -97,22 +88,15 @@ export const AnomalyDetectionInfoButton: FC<Props> = ({
   );
 
   const button = (
-    <EuiButton data-test-subj="mlJobSelectionBadge" onClick={onButtonClick} size="s" color="text">
-      <EuiFlexGroup
-        alignItems="center"
-        justifyContent="spaceBetween"
-        gutterSize="s"
-        responsive={false}
-      >
-        <EuiFlexItem grow={true}>
-          <EuiText textAlign="center" size="s">
-            {jobId}
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiIcon type="boxesVertical" aria-hidden={true} />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+    <EuiButton
+      data-test-subj="mlJobSelectionBadge"
+      iconType="boxesVertical"
+      iconSide="right"
+      onClick={onButtonClick}
+      size="s"
+      color="text"
+    >
+      {jobId}
     </EuiButton>
   );
   return (

--- a/x-pack/platform/plugins/shared/ml/public/application/components/job_selector/group_or_job_selector_menu/job_selector_button.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/job_selector/group_or_job_selector_menu/job_selector_button.tsx
@@ -8,7 +8,16 @@
 import type { FC } from 'react';
 import React, { useMemo, useState } from 'react';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
-import { EuiButton, EuiContextMenu, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiContextMenu,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPopover,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { useUrlState } from '@kbn/ml-url-state';
 import { ML_PAGES, type MlPages } from '../../../../../common/constants/locator';
 import { useJobInfoFlyouts } from '../../../jobs/components/job_details_flyout';
@@ -88,15 +97,22 @@ export const AnomalyDetectionInfoButton: FC<Props> = ({
   );
 
   const button = (
-    <EuiButton
-      data-test-subj="mlJobSelectionBadge"
-      iconType="boxesVertical"
-      iconSide="right"
-      onClick={onButtonClick}
-      size="s"
-      color="text"
-    >
-      {jobId}
+    <EuiButton data-test-subj="mlJobSelectionBadge" onClick={onButtonClick} size="s" color="text">
+      <EuiFlexGroup
+        alignItems="center"
+        justifyContent="spaceBetween"
+        gutterSize="s"
+        responsive={false}
+      >
+        <EuiFlexItem grow={true}>
+          <EuiText textAlign="center" size="s">
+            {jobId}
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="boxesVertical" aria-hidden={true} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiButton>
   );
   return (

--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/back_to_list_panel/back_to_list_panel.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/back_to_list_panel/back_to_list_panel.tsx
@@ -22,7 +22,7 @@ export const BackToListPanel: FC = () => {
     <Fragment>
       <EuiCard
         css={{ width: '300px' }}
-        icon={<EuiIcon size="xxl" type="list" />}
+        icon={<EuiIcon size="xxl" type="list" aria-hidden={true} />}
         title={i18n.translate('xpack.ml.dataframe.analytics.create.analyticsListCardTitle', {
           defaultMessage: 'Data Frame Analytics',
         })}

--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/job_type.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/job_type.tsx
@@ -69,7 +69,7 @@ export const JobType: FC<Props> = ({ type, setFormState }) => {
         {(Object.keys(jobDetails) as Array<keyof typeof jobDetails>).map((jobType) => (
           <EuiFlexItem key={jobType} grow={1}>
             <EuiCard
-              icon={<EuiIcon size="xl" type={jobDetails[jobType].icon} />}
+              icon={<EuiIcon size="xl" type={jobDetails[jobType].icon} aria-hidden={true} />}
               title={jobDetails[jobType].title}
               description={jobDetails[jobType].helpText}
               data-test-subj={`mlAnalyticsCreation-${jobType}-option${

--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/validation_step/validation_step_details.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/validation_step/validation_step_details.tsx
@@ -42,7 +42,7 @@ export const ValidationStepDetails: FC<{
               <EuiText size="s">{validationSummary.success}</EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="check" />
+              <EuiIcon type="check" aria-hidden={true} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </>
@@ -61,7 +61,7 @@ export const ValidationStepDetails: FC<{
               <EuiText size="s">{validationSummary.warning}</EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="warning" />
+              <EuiIcon type="warning" aria-hidden={true} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </>

--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/view_results_panel/view_results_panel.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/view_results_panel/view_results_panel.tsx
@@ -34,7 +34,7 @@ export const ViewResultsPanel: FC<Props> = ({ jobId, analysisType }) => {
     <Fragment>
       <EuiCard
         css={{ width: `calc(${size.xxl} * 7.5)` }}
-        icon={<EuiIcon size="xxl" type="visTable" />}
+        icon={<EuiIcon size="xxl" type="visTable" aria-hidden={true} />}
         title={i18n.translate('xpack.ml.dataframe.analytics.create.viewResultsCardTitle', {
           defaultMessage: 'View Results',
         })}

--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/feature_importance/decision_path_chart.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/feature_importance/decision_path_chart.tsx
@@ -44,7 +44,7 @@ interface DecisionPathChartProps {
 
 const DECISION_PATH_MARGIN = 125;
 const DECISION_PATH_ROW_HEIGHT = 10;
-const AnnotationBaselineMarker = <EuiIcon type="dot" size="m" />;
+const AnnotationBaselineMarker = <EuiIcon type="dot" size="m" aria-hidden={true} />;
 
 export const DecisionPathChart = ({
   decisionPathData,

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/components/severity_legend_control/severity_legend_control.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/components/severity_legend_control/severity_legend_control.tsx
@@ -86,6 +86,7 @@ export const SeverityLegendControl: FC<SeverityControlProps> = ({
               <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
                 <EuiFlexItem grow={false}>
                   <EuiIcon
+                    aria-hidden={true}
                     type={isSelected ? 'dot' : 'eyeClosed'}
                     color={isSelected ? severity.color : euiTheme.colors.textDisabled}
                     size={isSelected ? 'm' : 's'}

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx
@@ -496,7 +496,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
                             key="annotation-results-line"
                             domainType={AnnotationDomainType.XDomain}
                             dataValues={annotationData.line}
-                            marker={<EuiIcon type="annotation" />}
+                            marker={<EuiIcon type="annotation" aria-hidden={true} />}
                             markerPosition={Position.Top}
                             style={{
                               line: {
@@ -531,7 +531,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
                           key="model-snapshots-results-line"
                           domainType={AnnotationDomainType.XDomain}
                           dataValues={modelSnapshotDataForTimeRange}
-                          marker={<EuiIcon type="asterisk" />}
+                          marker={<EuiIcon type="asterisk" aria-hidden={true} />}
                           markerPosition={Position.Top}
                           style={{
                             line: {
@@ -554,7 +554,7 @@ export const DatafeedChartFlyout: FC<DatafeedChartFlyoutProps> = ({
                             key="messages-results-line"
                             domainType={AnnotationDomainType.XDomain}
                             dataValues={messageData}
-                            marker={<EuiIcon type="tableDensityNormal" />}
+                            marker={<EuiIcon type="tableDensityNormal" aria-hidden={true} />}
                             markerPosition={Position.Top}
                             style={{
                               line: {

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/multi_job_actions/group_selector/group_list/group_list.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/multi_job_actions/group_selector/group_list/group_list.js
@@ -23,7 +23,7 @@ function Check({ group, selectedGroups }) {
     } else {
       return (
         <div className="check selected">
-          <EuiIcon type="check" />
+          <EuiIcon type="check" aria-hidden={true} />
         </div>
       );
     }

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/overlay_range.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/charts/event_rate_chart/overlay_range.tsx
@@ -53,7 +53,7 @@ export const OverlayRange: FC<Props> = ({ overlayKey, start, end, color, showMar
         }}
         markerPosition={Position.Bottom}
         hideTooltips
-        marker={showMarker ? <EuiIcon type="arrowUp" /> : undefined}
+        marker={showMarker ? <EuiIcon type="arrowUp" aria-hidden={true} /> : undefined}
         markerBody={
           showMarker ? (
             <div style={{ fontWeight: 'normal', color: euiTheme.colors.textParagraph }}>

--- a/x-pack/platform/plugins/shared/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
@@ -131,7 +131,13 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
             {i18n.translate('xpack.ml.trainedModels.nodesList.modelsList.allocationHeader', {
               defaultMessage: 'Allocation',
             })}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              aria-hidden={true}
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+            />
           </span>
         </EuiToolTip>
       ),
@@ -189,7 +195,13 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
                 defaultMessage: 'Throughput',
               }
             )}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              aria-hidden={true}
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+            />
           </span>
         </EuiToolTip>
       ),
@@ -225,7 +237,13 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
               </span>
             </EuiFlexItem>
             <EuiFlexItem grow={false} css={{ minWidth: euiTheme.euiTheme.size.m }}>
-              <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+              <EuiIcon
+                aria-hidden={true}
+                size="s"
+                color="subdued"
+                type="question"
+                className="eui-alignTop"
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiToolTip>

--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/add_model_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/add_model_flyout.tsx
@@ -166,7 +166,7 @@ const ClickToDownloadTabContent: FC<ClickToDownloadTabContentProps> = ({
               <div>
                 <EuiFlexGroup gutterSize={'s'} alignItems={'center'}>
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="logoElastic" size="l" />
+                    <EuiIcon aria-hidden={true} type="logoElastic" size="l" />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiTitle size={'s'}>

--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/test_models/models/ner/ner_output.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/test_models/models/ner/ner_output.tsx
@@ -113,6 +113,7 @@ const Lines: FC<{ result: NerResponse }> = ({ result }) => {
             <div>
               <div>
                 <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type={getClassIcon(entity.class_name)}
                   style={{ marginRight: ICON_PADDING, verticalAlign: 'text-top' }}
@@ -169,6 +170,7 @@ const EntityBadge = ({
       <EuiFlexGroup gutterSize="none">
         <EuiFlexItem grow={false}>
           <EuiIcon
+            aria-hidden={true}
             size="s"
             type={getClassIcon(entity.class_name)}
             style={{ marginRight: ICON_PADDING, marginTop: ICON_PADDING }}

--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/test_models/models/text_expansion/text_expansion_output.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/test_models/models/text_expansion/text_expansion_output.tsx
@@ -78,7 +78,7 @@ export const DocumentResult: FC<{
               <EuiTextColor color={statInfo.color}>
                 <span>
                   {statInfo.icon !== null ? (
-                    <EuiIcon type={statInfo.icon} color={statInfo.color} />
+                    <EuiIcon aria-hidden={true} type={statInfo.icon} color={statInfo.color} />
                   ) : null}
                   {statInfo.text}
                 </span>
@@ -122,7 +122,7 @@ export const DocumentResultWithTokens: FC<{
               <EuiTextColor color={statInfo.color}>
                 <span>
                   {statInfo.icon !== null ? (
-                    <EuiIcon type={statInfo.icon} color={statInfo.color} />
+                    <EuiIcon aria-hidden={true} type={statInfo.icon} color={statInfo.color} />
                   ) : null}
                   {statInfo.text}
                 </span>

--- a/x-pack/platform/plugins/shared/ml/public/application/overview/overview_ml_page.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/overview/overview_ml_page.tsx
@@ -17,6 +17,7 @@ import {
   EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiLink,
   EuiPageBody,
   EuiSpacer,
@@ -98,6 +99,7 @@ export const MLOverviewCard = ({
           data-test-subj={buttonDataTestSubj}
           aria-label={buttonLabel}
         >
+          {iconType ? <EuiIcon aria-hidden={true} type={iconType} /> : null}
           {buttonLabel}
         </ButtonComponent>
       </EuiCard>
@@ -281,6 +283,7 @@ export const OverviewPage: FC = () => {
                           onClick={() => navigateToPath('/aiops/log_categorization_index_select')}
                           data-test-subj="mlOverviewCardLogPatternAnalysisButton"
                         >
+                          <EuiIcon aria-hidden={true} type="pattern" />
                           <FormattedMessage
                             id="xpack.ml.overview.logPatternAnalysis.startAnalysisButton"
                             defaultMessage="Start analysis"
@@ -342,6 +345,7 @@ export const OverviewPage: FC = () => {
                             }
                           )}
                         >
+                          <EuiIcon aria-hidden={true} type="chartChangePoint" />
                           <FormattedMessage
                             id="xpack.ml.overview.changePointDetection.startDetectionButton"
                             defaultMessage="Start detection"

--- a/x-pack/platform/plugins/shared/ml/public/application/supplied_configurations/supplied_configurations.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/supplied_configurations/supplied_configurations.tsx
@@ -172,7 +172,11 @@ export const SuppliedConfigurations = () => {
               <EuiCard
                 data-test-subj={`mlSuppliedConfigurationsCard ${id}`}
                 layout="horizontal"
-                icon={isLogoObject(logo) ? <EuiIcon size="xxl" type={logo.icon} /> : null}
+                icon={
+                  isLogoObject(logo) ? (
+                    <EuiIcon aria-hidden={true} size="xxl" type={logo.icon} />
+                  ) : null
+                }
                 title={title}
                 description={description}
                 onClick={() => {

--- a/x-pack/platform/plugins/shared/ml/public/application/supplied_configurations/supplied_configurations_flyout/flyout.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/supplied_configurations/supplied_configurations_flyout/flyout.tsx
@@ -129,7 +129,9 @@ export const SuppliedConfigurationsFlyout: FC<Props> = ({ module, onClose }) => 
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup gutterSize="m">
           <EuiFlexItem grow={false}>
-            {isLogoObject(module.logo) ? <EuiIcon size="xxl" type={module.logo.icon} /> : null}
+            {isLogoObject(module.logo) ? (
+              <EuiIcon aria-hidden={true} size="xxl" type={module.logo.icon} />
+            ) : null}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiTitle size="m">

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/forecasting_modal/progress_icon.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/forecasting_modal/progress_icon.js
@@ -21,9 +21,9 @@ export function ProgressIcon({ state }) {
   if (state === PROGRESS_STATES.WAITING) {
     return <EuiLoadingSpinner size="m" />;
   } else if (state === PROGRESS_STATES.DONE) {
-    return <EuiIcon type="check" size="m" color="primary" />;
+    return <EuiIcon aria-hidden={true} type="check" size="m" color="primary" />;
   } else if (state === PROGRESS_STATES.ERROR) {
-    return <EuiIcon type="cross" size="m" color="danger" />;
+    return <EuiIcon aria-hidden={true} type="cross" size="m" color="danger" />;
   }
 }
 

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/common/job_details.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/common/job_details.tsx
@@ -359,7 +359,7 @@ export const JobDetails: FC<PropsWithChildren<Props>> = ({
           >
             <EuiFlexItem grow={false}>
               <EuiText size="s">
-                <EuiIcon type="checkInCircleFilled" color="success" />
+                <EuiIcon aria-hidden={true} type="checkInCircleFilled" color="success" />
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/lens/lens_vis_layer_selection_flyout/layer/compatible_layer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/lens/lens_vis_layer_selection_flyout/layer/compatible_layer.tsx
@@ -79,7 +79,7 @@ export const CompatibleLayer: FC<Props> = ({ layer, layerIndex, embeddable }) =>
         <EuiFlexGroup gutterSize="s" data-test-subj="mlLensLayerCompatible">
           <EuiFlexItem grow={false}>
             <EuiText size="s">
-              <EuiIcon type="checkInCircleFilled" color="success" />
+              <EuiIcon aria-hidden={true} type="checkInCircleFilled" color="success" />
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/lens/lens_vis_layer_selection_flyout/layer/incompatible_layer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/lens/lens_vis_layer_selection_flyout/layer/incompatible_layer.tsx
@@ -24,7 +24,7 @@ export const IncompatibleLayer: FC<Props> = ({ layer }) => {
     <EuiFlexGroup gutterSize="s" color="subdued" data-test-subj="mlLensLayerIncompatible">
       <EuiFlexItem grow={false}>
         <EuiText size="s">
-          <EuiIcon type="error" color="subdued" />
+          <EuiIcon aria-hidden={true} type="error" color="subdued" />
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/lens/lens_vis_layer_selection_flyout/layer/layer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/lens/lens_vis_layer_selection_flyout/layer/layer.tsx
@@ -35,7 +35,7 @@ export const Layer: FC<Props> = ({ layer, layerIndex, embeddable }) => {
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             {layer.icon && (
               <EuiFlexItem grow={false}>
-                <EuiIcon type={layer.icon} />
+                <EuiIcon aria-hidden={true} type={layer.icon} />
               </EuiFlexItem>
             )}
             <EuiFlexItem grow>

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/map/map_vis_layer_selection_flyout/layer/compatible_layer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/map/map_vis_layer_selection_flyout/layer/compatible_layer.tsx
@@ -149,7 +149,7 @@ export const CompatibleLayer: FC<Props> = ({ embeddable, layer, layerIndex }) =>
           <EuiFlexGroup gutterSize="s" data-test-subj="mlMapLayerCompatible">
             <EuiFlexItem grow={false}>
               <EuiText size="s">
-                <EuiIcon type="checkInCircleFilled" color="success" />
+                <EuiIcon aria-hidden={true} type="checkInCircleFilled" color="success" />
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/map/map_vis_layer_selection_flyout/layer/incompatible_layer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/map/map_vis_layer_selection_flyout/layer/incompatible_layer.tsx
@@ -19,7 +19,7 @@ export const IncompatibleLayer: FC<Props> = ({ noDataView }) => {
     <EuiFlexGroup gutterSize="s" color="subdued" data-test-subj="mlMapLayerIncompatible">
       <EuiFlexItem grow={false}>
         <EuiText size="s">
-          <EuiIcon type="error" color="subdued" />
+          <EuiIcon aria-hidden={true} type="error" color="subdued" />
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/map/map_vis_layer_selection_flyout/layer/layer.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/map/map_vis_layer_selection_flyout/layer/layer.tsx
@@ -33,7 +33,7 @@ export const Layer: FC<Props> = ({ layer, layerIndex, embeddable }) => (
       <EuiSplitPanel.Inner>
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiIcon type={'tokenGeo'} />
+            <EuiIcon aria-hidden={true} type={'tokenGeo'} />
           </EuiFlexItem>
           <EuiFlexItem grow>
             <EuiText color={layer.dataView?.timeFieldName ? '' : 'subdued'}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/ml-ui` files (#267698)](https://github.com/elastic/kibana/pull/267698)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-06T09:47:06Z","message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/ml-ui` files (#267698)\n\nResolves 74 ESLint `@elastic/eui/icon-accessibility-rules` violations\nacross 47 files owned by `@elastic/ml-ui`.\n\n## Changes\n\n- Added `aria-hidden={true}` to decorative `EuiIcon` components (icons\nadjacent to text labels)\n- Added `aria-label` where icons convey meaning independently (e.g.,\nstatus indicators)\n\nAffected packages/plugins: `@kbn/aiops-components`, `@kbn/file-upload`,\n`data_visualizer`, `aiops`, `ml`\n\n**Example:**\n```tsx\n// Before\n<EuiIcon type=\"checkCircleFill\" color={euiTheme.colors.success} />\n\n// After\n<EuiIcon aria-hidden={true} type=\"checkCircleFill\" color={euiTheme.colors.success} />\n```\n\n## Checklist\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all 47 files listed in the issue\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f31bd6dd505e404abfbafbf64a79eac18f8c7896","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","v9.4.0","a11y:agent-pr","v9.5.0","v9.3.5"],"title":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/ml-ui` files","number":267698,"url":"https://github.com/elastic/kibana/pull/267698","mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/ml-ui` files (#267698)\n\nResolves 74 ESLint `@elastic/eui/icon-accessibility-rules` violations\nacross 47 files owned by `@elastic/ml-ui`.\n\n## Changes\n\n- Added `aria-hidden={true}` to decorative `EuiIcon` components (icons\nadjacent to text labels)\n- Added `aria-label` where icons convey meaning independently (e.g.,\nstatus indicators)\n\nAffected packages/plugins: `@kbn/aiops-components`, `@kbn/file-upload`,\n`data_visualizer`, `aiops`, `ml`\n\n**Example:**\n```tsx\n// Before\n<EuiIcon type=\"checkCircleFill\" color={euiTheme.colors.success} />\n\n// After\n<EuiIcon aria-hidden={true} type=\"checkCircleFill\" color={euiTheme.colors.success} />\n```\n\n## Checklist\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all 47 files listed in the issue\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f31bd6dd505e404abfbafbf64a79eac18f8c7896"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267698","number":267698,"mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/ml-ui` files (#267698)\n\nResolves 74 ESLint `@elastic/eui/icon-accessibility-rules` violations\nacross 47 files owned by `@elastic/ml-ui`.\n\n## Changes\n\n- Added `aria-hidden={true}` to decorative `EuiIcon` components (icons\nadjacent to text labels)\n- Added `aria-label` where icons convey meaning independently (e.g.,\nstatus indicators)\n\nAffected packages/plugins: `@kbn/aiops-components`, `@kbn/file-upload`,\n`data_visualizer`, `aiops`, `ml`\n\n**Example:**\n```tsx\n// Before\n<EuiIcon type=\"checkCircleFill\" color={euiTheme.colors.success} />\n\n// After\n<EuiIcon aria-hidden={true} type=\"checkCircleFill\" color={euiTheme.colors.success} />\n```\n\n## Checklist\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all 47 files listed in the issue\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f31bd6dd505e404abfbafbf64a79eac18f8c7896"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->