### PR TITLE
[Streams] Fix loop in retention tab

### DIFF
--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/phases.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/phases.ts
@@ -6,6 +6,7 @@
  */
 
 import { useEuiTheme } from '@elastic/eui';
+import { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 
 /**
@@ -117,11 +118,20 @@ export type PhaseColorMap = Record<IlmPhase, string>;
 export const usePhaseColors = (): PhaseColorMap => {
   const { euiTheme } = useEuiTheme();
 
-  return {
-    hot: euiTheme.colors.severity.risk,
-    warm: euiTheme.colors.severity.warning,
-    cold: euiTheme.colors.severity.neutral,
-    frozen: euiTheme.colors.vis.euiColorVis3,
-    delete: euiTheme.colors.backgroundBaseSubdued,
-  };
+  return useMemo(
+    () => ({
+      hot: euiTheme.colors.severity.risk,
+      warm: euiTheme.colors.severity.warning,
+      cold: euiTheme.colors.severity.neutral,
+      frozen: euiTheme.colors.vis.euiColorVis3,
+      delete: euiTheme.colors.backgroundBaseSubdued,
+    }),
+    [
+      euiTheme.colors.severity.risk,
+      euiTheme.colors.severity.warning,
+      euiTheme.colors.severity.neutral,
+      euiTheme.colors.vis.euiColorVis3,
+      euiTheme.colors.backgroundBaseSubdued,
+    ]
+  );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/hooks/use_ilm_phases_color_and_description.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/hooks/use_ilm_phases_color_and_description.tsx
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
+import { useMemo } from 'react';
 import { usePhaseColors, PHASE_DESCRIPTIONS } from '@kbn/data-lifecycle-phases';
 
 export const useIlmPhasesColorAndDescription = () => {
   const phaseColors = usePhaseColors();
 
-  return {
-    ilmPhases: {
+  const ilmPhases = useMemo(
+    () => ({
       hot: {
         color: phaseColors.hot,
         description: PHASE_DESCRIPTIONS.hot,
@@ -32,6 +33,9 @@ export const useIlmPhasesColorAndDescription = () => {
         color: phaseColors.delete,
         description: PHASE_DESCRIPTIONS.delete,
       },
-    },
-  };
+    }),
+    [phaseColors]
+  );
+
+  return { ilmPhases };
 };


### PR DESCRIPTION
## Summary

On the Streams retention management page (`/app/streams/{name}/management/retention`), the `GET /internal/streams/{name}/lifecycle/_explain` endpoint was being called in an infinite loop. Every render triggered a new fetch, which caused a state update, which triggered another render, and so on.

The root cause was referential instability in `usePhaseColors` (`kbn-data-lifecycle-phases`): it returned a plain object literal on every render with no memoization. This made `ilmPhases` (built from `phaseColors` in `useIlmPhasesColorAndDescription`) also a new reference every render. Since `ilmPhases` was in the dependency array of `useIngestionRatePerTier`, the fetch — including the `_explain` call — re-ran on every render. This was caused by https://github.com/elastic/kibana/pull/266680

Two fixes:

- `usePhaseColors` now wraps its return value in `useMemo`, keyed on the individual EUI theme color tokens. The color map is only recreated on theme changes (e.g. dark/light mode toggle).
- `useIlmPhasesColorAndDescription` now wraps `ilmPhases` in `useMemo` keyed on `phaseColors`. Since `phaseColors` is now stable, `ilmPhases` is also stable, and `useIngestionRatePerTier` no longer re-fires on every render.

### Test plan

- Navigate to `/app/streams/{name}/management/retention` on a non-serverless environment with a stream that has an ILM policy.
- Open the browser network tab and filter for `lifecycle/_explain`.
- Verify the endpoint is called once on page load (and again only when the time range changes), not continuously.
