### PR TITLE
[ES|QL] Suggest only aggregation functions for SPARKLINE first argument - approach 2

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/generated/aggregation_functions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/generated/aggregation_functions.ts
@@ -4252,6 +4252,9 @@ const sparklineDefinition: FunctionDefinition = {
           optional: false,
           description:
             'Aggregation that calculates the y-axis value of the sparkline graph for each datapoint.',
+          hint: {
+            kind: 'aggregation',
+          },
         },
         {
           name: 'key',
@@ -4288,6 +4291,9 @@ const sparklineDefinition: FunctionDefinition = {
           optional: false,
           description:
             'Aggregation that calculates the y-axis value of the sparkline graph for each datapoint.',
+          hint: {
+            kind: 'aggregation',
+          },
         },
         {
           name: 'key',
@@ -4324,6 +4330,9 @@ const sparklineDefinition: FunctionDefinition = {
           optional: false,
           description:
             'Aggregation that calculates the y-axis value of the sparkline graph for each datapoint.',
+          hint: {
+            kind: 'aggregation',
+          },
         },
         {
           name: 'key',

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/generated/scalar_functions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/generated/scalar_functions.ts
@@ -5233,6 +5233,7 @@ const embeddingDefinition: FunctionDefinition = {
             'Identifier of an existing inference endpoint that will generate the embeddings. The inference endpoint must have the `embedding` task type and should use the same model that was used to embed your indexed data.',
           hint: {
             entityType: 'inference_endpoint',
+            kind: 'entity',
             constraints: {
               task_type: 'embedding',
             },
@@ -19712,6 +19713,7 @@ const textEmbeddingDefinition: FunctionDefinition = {
             'Identifier of an existing inference endpoint that will generate the embeddings. The inference endpoint must have the `text_embedding` task type and should use the same model that was used to embed your indexed data.',
           hint: {
             entityType: 'inference_endpoint',
+            kind: 'entity',
             constraints: {
               task_type: 'text_embedding',
             },

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/types.ts
@@ -103,8 +103,9 @@ export const isReturnType = (str: string | FunctionParameterType): str is Functi
 export const parameterHintEntityTypes = ['inference_endpoint'] as const;
 export type ParameterHintEntityType = (typeof parameterHintEntityTypes)[number];
 export interface ParameterHint {
-  entityType: ParameterHintEntityType;
+  entityType?: ParameterHintEntityType;
   constraints?: Record<string, string>;
+  kind?: string;
 }
 
 export interface FunctionParameter {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
@@ -39,7 +39,7 @@ import {
   buildAddValuePlaceholder,
   findConstantPlaceholderType,
 } from '../../../../../registry/complete_items';
-import { parametersFromHintsResolvers } from '../../parameters_from_hints';
+import { kindBasedResolvers, parametersFromHintsResolvers } from '../../parameters_from_hints';
 
 // functionDefinition is guaranteed by in_function.ts early return
 type FunctionParamContext = NonNullable<ExpressionContext['options']['functionParameterContext']>;
@@ -397,12 +397,25 @@ function buildSuggestionsFromHints(
     (a, b) => a.entityType === b.entityType && isEqual(a.constraints, b.constraints)
   );
 
-  const results = hints.map(
-    (hint) =>
-      parametersFromHintsResolvers[hint.entityType]?.suggestionResolver?.(hint, ctx.context) ?? []
+  // entityType-based dispatch (e.g. inference_endpoint)
+  const entityTypeResults = hints.flatMap((hint) =>
+    hint.entityType !== undefined
+      ? parametersFromHintsResolvers[hint.entityType]?.suggestionResolver?.(hint, ctx.context) ?? []
+      : []
   );
+  if (entityTypeResults.length > 0) {
+    return entityTypeResults;
+  }
 
-  return results.flat();
+  // hint.kind-based dispatch (e.g. 'aggregation' for SPARKLINE's first arg).
+  // The resolver receives the full ExpressionContext so it can apply location,
+  // license, and ignored-name filters consistently.
+  const hintKind = paramDefinitions.find((p) => p.hint?.kind !== undefined)?.hint?.kind;
+  if (hintKind !== undefined) {
+    return kindBasedResolvers[hintKind]?.(ctx) ?? [];
+  }
+
+  return [];
 }
 
 /** Builds suggestions for constant-only literal parameters */

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/parameters_from_hints.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/parameters_from_hints.test.ts
@@ -8,8 +8,10 @@
  */
 
 import type { ICommandContext } from '../../../registry/types';
+import { Location } from '../../../registry/types';
 import type { ParameterHint } from '../../types';
-import { parametersFromHintsResolvers } from './parameters_from_hints';
+import { kindBasedResolvers, parametersFromHintsResolvers } from './parameters_from_hints';
+import type { ExpressionContext } from './expressions/types';
 import type { ESQLCallbacks, InferenceEndpointAutocompleteItem } from '@kbn/esql-types';
 
 describe('Parameters from hints handlers', () => {
@@ -74,6 +76,104 @@ describe('Parameters from hints handlers', () => {
 
       expect(suggestions).toEqual(['text_embedding_endpoint']);
       expect(mockCallbacks.getInferenceEndpoints).toHaveBeenCalledWith('text_embedding');
+    });
+  });
+
+  describe('aggregation kind hint', () => {
+    const buildCtx = (overrides: Partial<ExpressionContext> = {}): ExpressionContext =>
+      ({
+        query: '',
+        cursorPosition: 0,
+        innerText: '',
+        location: Location.STATS,
+        command: {} as ExpressionContext['command'],
+        options: {},
+        ...overrides,
+      } as ExpressionContext);
+
+    const resolver = kindBasedResolvers.aggregation!;
+
+    it('returns AGG functions for the STATS location and excludes scalar/grouping functions', () => {
+      const labels = resolver(buildCtx()).map((s) => s.label);
+
+      // Sanity: known aggregation functions appear
+      expect(labels).toContain('AVG');
+      expect(labels).toContain('SUM');
+      expect(labels).toContain('MAX');
+
+      // Negative: scalar (ROUND, CONCAT) and grouping (BUCKET) functions are excluded
+      expect(labels).not.toContain('ROUND');
+      expect(labels).not.toContain('CONCAT');
+      expect(labels).not.toContain('BUCKET');
+    });
+
+    it('respects functionsToIgnore (e.g. self-recursion guard)', () => {
+      const labels = resolver(
+        buildCtx({
+          options: { functionsToIgnore: { names: ['avg'] } },
+        })
+      ).map((s) => s.label);
+
+      expect(labels).not.toContain('AVG');
+      // Other aggregations still appear
+      expect(labels).toContain('SUM');
+    });
+
+    it('filters by paramDefinitions return types so non-matching aggs are excluded', () => {
+      // Numeric-only param
+      const numericLabels = resolver(
+        buildCtx({
+          options: {
+            functionParameterContext: {
+              paramDefinitions: [{ name: 'aggregation', type: 'double' }],
+              hasMoreMandatoryArgs: false,
+              currentParameterIndex: 0,
+              signatures: [],
+            },
+          },
+        })
+      ).map((s) => s.label);
+
+      // AVG returns double → kept
+      expect(numericLabels).toContain('AVG');
+      // ST_CENTROID_AGG returns geo_point → dropped
+      expect(numericLabels).not.toContain('ST_CENTROID_AGG');
+    });
+
+    it('appends a trailing comma to the inserted text when more mandatory args follow', () => {
+      const item = resolver(
+        buildCtx({
+          options: {
+            functionParameterContext: {
+              paramDefinitions: [{ name: 'aggregation', type: 'double' }],
+              hasMoreMandatoryArgs: true,
+              currentParameterIndex: 0,
+              signatures: [],
+            },
+          },
+        })
+      ).find((s) => s.label === 'AVG');
+
+      expect(item).toBeDefined();
+      expect(item!.text.endsWith(',')).toBe(true);
+    });
+
+    it('does not append a trailing comma when no more mandatory args follow', () => {
+      const item = resolver(
+        buildCtx({
+          options: {
+            functionParameterContext: {
+              paramDefinitions: [{ name: 'aggregation', type: 'double' }],
+              hasMoreMandatoryArgs: false,
+              currentParameterIndex: 0,
+              signatures: [],
+            },
+          },
+        })
+      ).find((s) => s.label === 'AVG');
+
+      expect(item).toBeDefined();
+      expect(item!.text.endsWith(',')).toBe(false);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/parameters_from_hints.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/parameters_from_hints.test.ts
@@ -87,6 +87,10 @@ export async function getSuggestionsForHint(
   formerContext?: ICommandContext,
   callbacks: ESQLCallbacks = {}
 ) {
+  if (hint.entityType === undefined) {
+    throw new Error('Hint entityType is required for resolver lookup');
+  }
+
   const resolversEntry = parametersFromHintsResolvers[hint.entityType];
 
   if (!resolversEntry) {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/parameters_from_hints.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/parameters_from_hints.ts
@@ -11,7 +11,10 @@ import type { ESQLCallbacks } from '@kbn/esql-types';
 import { uniqBy } from 'lodash';
 import type { ParameterHint, ParameterHintEntityType } from '../../..';
 import type { ICommandContext, ISuggestionItem } from '../../../registry/types';
-import { createInferenceEndpointToCompletionItem } from './helpers';
+import { FunctionDefinitionTypes } from '../../types';
+import { filterFunctionDefinitions, getAllFunctions, getFunctionSuggestion } from '../functions';
+import { createInferenceEndpointToCompletionItem, withAutoSuggest } from './helpers';
+import type { ExpressionContext } from './expressions/types';
 
 type SuggestionResolver = (hint: ParameterHint, ctx?: ICommandContext) => ISuggestionItem[];
 
@@ -47,6 +50,49 @@ export const parametersFromHintsResolvers: Partial<
     contextResolver: inferenceEndpointContextResolver,
   },
 };
+
+type KindSuggestionResolver = (ctx: ExpressionContext) => ISuggestionItem[];
+
+/**
+ * Resolvers keyed by `hint.kind`. Returning items from one of these makes the
+ * suggestion exclusive — the composite path (fields + all functions) is skipped.
+ * Add a new entry to support a new kind; nothing else needs to change.
+ */
+export const kindBasedResolvers: Partial<Record<string, KindSuggestionResolver>> = {
+  aggregation: aggregationKindResolver,
+};
+
+// -------- AGGREGATION KIND HINT -------- //
+function aggregationKindResolver(ctx: ExpressionContext): ISuggestionItem[] {
+  const fnParamCtx = ctx.options.functionParameterContext;
+  const ignored = ctx.options.functionsToIgnore?.names ?? [];
+
+  // Filter by the param's accepted return types so e.g. SPARKLINE's numeric first arg
+  // doesn't surface aggregations that return non-numeric types (ST_CENTROID_AGG, etc.).
+  // When no param context is available, accept any return type.
+  const paramTypes = fnParamCtx?.paramDefinitions.map((p) => p.type as string) ?? [];
+  const returnTypes = paramTypes.length > 0 ? paramTypes : ['any'];
+
+  // Append a trailing comma when more mandatory args follow this one,
+  // matching the comma-handling done elsewhere in the suggestion path.
+  const shouldAddComma = fnParamCtx?.hasMoreMandatoryArgs ?? false;
+
+  return filterFunctionDefinitions(
+    getAllFunctions({
+      type: [FunctionDefinitionTypes.AGG, FunctionDefinitionTypes.TIME_SERIES_AGG],
+      includeOperators: false,
+    }),
+    { location: ctx.location, ignored, returnTypes },
+    ctx.callbacks?.hasMinimumLicenseRequired,
+    ctx.context?.activeProduct
+  ).map((fn) => {
+    const item = withAutoSuggest(getFunctionSuggestion(fn));
+    if (shouldAddComma) {
+      item.text += ',';
+    }
+    return item;
+  });
+}
 
 // -------- INFERENCE ENDPOINT HINT -------- //
 function inferenceEndpointSuggestionResolver(

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.test.ts
@@ -420,6 +420,28 @@ describe('STATS Autocomplete', () => {
         await statsExpectSuggestions('from a | stats a=min(b), b=max(', expected, mockCallbacks);
       });
 
+      test('inside a function arg with hint.kind === "aggregation" (e.g. SPARKLINE first arg), only aggregation functions are suggested', async () => {
+        // Mock fields just to verify the resolver's exclusive path skips the composite (fields) branch
+        const allFields = getFieldNamesByType('any');
+        (mockCallbacks.getByType as jest.Mock).mockResolvedValue(
+          allFields.map((name) => ({ label: name, text: name }))
+        );
+
+        const expectedAggregations = getFunctionSignaturesByReturnType(
+          Location.STATS,
+          ['integer', 'long', 'double'],
+          { agg: true, timeseriesAgg: true },
+          undefined,
+          ['sparkline']
+        ).map((s) => `${s},`);
+
+        await statsExpectSuggestions(
+          'from a | stats SPARKLINE(',
+          expectedAggregations,
+          mockCallbacks
+        );
+      });
+
       test('inside function argument list', async () => {
         const expectedFieldsAvg = getFieldNamesByType(AVG_TYPES);
         (mockCallbacks.getByType as jest.Mock).mockResolvedValue(

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.ts
@@ -416,14 +416,30 @@ function buildCustomFilteringContext(
 
   if (!isInBy) {
     statsSpecificFunctionsToIgnore.push(
-      ...getFunctionsToIgnoreForStats(command, finalCommandArgIndex),
-      ...(isAggFunctionUsedAlready(command, finalCommandArgIndex)
-        ? getAllFunctions({ type: FunctionDefinitionTypes.AGG }).map(({ name }) => name)
-        : []),
-      ...(isTimeseriesAggUsedAlready(command, finalCommandArgIndex)
-        ? getAllFunctions({ type: FunctionDefinitionTypes.TIME_SERIES_AGG }).map(({ name }) => name)
-        : [])
+      ...getFunctionsToIgnoreForStats(command, finalCommandArgIndex)
     );
+
+    // The "no nested aggregations" rule applies unless the cursor's param
+    // explicitly expects an aggregation (e.g. SPARKLINE's first arg has
+    // hint.kind === 'aggregation'), in which case nesting is required, not forbidden.
+    const expectsAggregation = basicContext.paramDefinitions.some(
+      (p) => p.hint?.kind === 'aggregation'
+    );
+
+    if (!expectsAggregation) {
+      if (isAggFunctionUsedAlready(command, finalCommandArgIndex)) {
+        statsSpecificFunctionsToIgnore.push(
+          ...getAllFunctions({ type: FunctionDefinitionTypes.AGG }).map(({ name }) => name)
+        );
+      }
+      if (isTimeseriesAggUsedAlready(command, finalCommandArgIndex)) {
+        statsSpecificFunctionsToIgnore.push(
+          ...getAllFunctions({ type: FunctionDefinitionTypes.TIME_SERIES_AGG }).map(
+            ({ name }) => name
+          )
+        );
+      }
+    }
   }
 
   return {

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.parameters_with_hints.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.parameters_with_hints.test.ts
@@ -20,7 +20,7 @@ const allUniqueParameterHints = uniqBy(
   getAllFunctions()
     .flatMap((fn) => fn.signatures)
     .flatMap((signature) => signature.params)
-    .flatMap((param) => (param.hint ? [param.hint] : [])),
+    .flatMap((param) => (param.hint?.entityType ? [param.hint] : [])),
   'entityType'
 );
 

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/get_command_context.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/get_command_context.ts
@@ -157,6 +157,9 @@ export const enhanceWithFunctionsContext = async (
 
   // If the hint needs new data to build the suggestions, we add that data to the context
   for (const hint of uniqueHints) {
+    if (hint.entityType === undefined) {
+      continue;
+    }
     const parameterHandler = parametersFromHintsResolvers[hint.entityType];
     if (parameterHandler?.contextResolver) {
       const resolvedContext = await parameterHandler.contextResolver(

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/esql_validation_meta_tests.json
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/esql_validation_meta_tests.json
@@ -134,6 +134,11 @@
       "userDefined": false
     },
     {
+      "name": "flattenedField",
+      "type": "flattened",
+      "userDefined": false
+    },
+    {
       "name": "any#Char$Field",
       "type": "double",
       "userDefined": false


### PR DESCRIPTION
part of: https://github.com/elastic/kibana/issues/265936

## Summary
This PR addresses only the autocomplete functionality for the SPARKLINE function.

### Problem
ES|QL's SPARKLINE function has a special first parameter that must always be an aggregation expression (e.g. `AVG(bytes)`). Elasticsearch signals this via `hint: { kind: 'aggregation' }` on the param definition, but Kibana's autocomplete ignored that hint entirely:

Inside `STATS SPARKLINE(|, ...)`, all scalar functions (`SUBSTRING`, `ABS`, etc.) were suggested alongside aggregations, plus every field in the index — none of which are valid input.
The existing hint handler (`buildSuggestionsFromHints`) only dispatched on `hint.entityType` (used by `inference_endpoint`), so a `kind`-only hint was a no-op.

### Fix
Extends the existing hint dispatcher to also key off `hint.kind`. The hint produces an _exclusive_ suggestion set, so fields and other functions are skipped automatically — no flag plumbing needed (compared to this approach https://github.com/elastic/kibana/pull/268454):

- `ParameterHint.entityType` → optional, with the three caller-side guards.
- **New** `kindBasedResolvers` map in `parameters_from_hints.ts`, keyed by `hint.kind`. Adding a kind = adding one resolver entry.
- `aggregationKindResolver` uses `getAllFunctions({ type: [AGG, TIME_SERIES_AGG] })` then applies the same predicates the standard path uses (location, license, ignored, paramDefinitions return types) and appends `,` when `hasMoreMandatoryArgs`.
- `buildSuggestionsFromHints` extended to fall back from the existing `entityType` dispatch to a `hint.kind` dispatch. Because this path lives inside `tryExclusiveSuggestions`, returning items short-circuits the composite path → fields are excluded by construction.
- **STATS** `expectsAggregation` **opt-out**: `buildCustomFilteringContext` was adding every AGG name to `functionsToIgnore` (because `isAggFunctionUsedAlready` saw SPARKLINE itself in the AST). When the cursor's param has `hint.kind === 'aggregation'`, the "no nested aggregations" rule does not apply — nesting is required, not forbidden.

3 production files + 3 caller guards + 1 SPARKLINE unit test + 5 focused unit tests for the new resolver (return-type filter, ignored guard, comma handling, etc.).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


