### PR TITLE
[ES|QL] Suggest only aggregation functions for SPARKLINE first argument - approach 1

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/generated/aggregation_functions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/generated/aggregation_functions.ts
@@ -4252,6 +4252,9 @@ const sparklineDefinition: FunctionDefinition = {
           optional: false,
           description:
             'Aggregation that calculates the y-axis value of the sparkline graph for each datapoint.',
+          hint: {
+            kind: 'aggregation',
+          },
         },
         {
           name: 'key',
@@ -4288,6 +4291,9 @@ const sparklineDefinition: FunctionDefinition = {
           optional: false,
           description:
             'Aggregation that calculates the y-axis value of the sparkline graph for each datapoint.',
+          hint: {
+            kind: 'aggregation',
+          },
         },
         {
           name: 'key',
@@ -4324,6 +4330,9 @@ const sparklineDefinition: FunctionDefinition = {
           optional: false,
           description:
             'Aggregation that calculates the y-axis value of the sparkline graph for each datapoint.',
+          hint: {
+            kind: 'aggregation',
+          },
         },
         {
           name: 'key',

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/generated/scalar_functions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/generated/scalar_functions.ts
@@ -5233,6 +5233,7 @@ const embeddingDefinition: FunctionDefinition = {
             'Identifier of an existing inference endpoint that will generate the embeddings. The inference endpoint must have the `embedding` task type and should use the same model that was used to embed your indexed data.',
           hint: {
             entityType: 'inference_endpoint',
+            kind: 'entity',
             constraints: {
               task_type: 'embedding',
             },
@@ -19712,6 +19713,7 @@ const textEmbeddingDefinition: FunctionDefinition = {
             'Identifier of an existing inference endpoint that will generate the embeddings. The inference endpoint must have the `text_embedding` task type and should use the same model that was used to embed your indexed data.',
           hint: {
             entityType: 'inference_endpoint',
+            kind: 'entity',
             constraints: {
               task_type: 'text_embedding',
             },

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/types.ts
@@ -103,8 +103,9 @@ export const isReturnType = (str: string | FunctionParameterType): str is Functi
 export const parameterHintEntityTypes = ['inference_endpoint'] as const;
 export type ParameterHintEntityType = (typeof parameterHintEntityTypes)[number];
 export interface ParameterHint {
-  entityType: ParameterHintEntityType;
+  entityType?: ParameterHintEntityType;
   constraints?: Record<string, string>;
+  kind?: string;
 }
 
 export interface FunctionParameter {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
@@ -414,9 +414,10 @@ function buildSuggestionsFromHints(
     (a, b) => a.entityType === b.entityType && isEqual(a.constraints, b.constraints)
   );
 
-  const results = hints.map(
-    (hint) =>
-      parametersFromHintsResolvers[hint.entityType]?.suggestionResolver?.(hint, ctx.context) ?? []
+  const results = hints.map((hint) =>
+    hint.entityType !== undefined
+      ? parametersFromHintsResolvers[hint.entityType]?.suggestionResolver?.(hint, ctx.context) ?? []
+      : []
   );
 
   return results.flat();

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
@@ -24,6 +24,7 @@ import type { ExpressionContext } from '../types';
 import { SuggestionBuilder } from '../suggestion_builder';
 import { getControlSuggestion, getVariablePrefix } from '../../helpers';
 import { buildValueDefinitions } from '../../../values';
+import { FunctionDefinitionTypes } from '../../../../types';
 import type {
   FunctionDefinition,
   FunctionParameter,
@@ -43,6 +44,18 @@ import { parametersFromHintsResolvers } from '../../parameters_from_hints';
 
 // functionDefinition is guaranteed by in_function.ts early return
 type FunctionParamContext = NonNullable<ExpressionContext['options']['functionParameterContext']>;
+
+interface HintKindSuggestionConfig {
+  functionTypes?: FunctionDefinitionTypes[];
+  suppressFields?: boolean;
+}
+
+const HINT_KIND_SUGGESTION_CONFIG: Partial<Record<string, HintKindSuggestionConfig>> = {
+  aggregation: {
+    functionTypes: [FunctionDefinitionTypes.AGG, FunctionDefinitionTypes.TIME_SERIES_AGG],
+    suppressFields: true,
+  },
+};
 
 /** Handles suggestions when starting a new expression (empty position) */
 export async function suggestForEmptyExpression(
@@ -223,9 +236,12 @@ async function buildFieldAndFunctionSuggestions(
   const hasConstantOnlyParam = paramDefinitions.some(({ constantOnly }) => constantOnly);
   const hasFieldsOnlyParam = paramDefinitions.some(({ fieldsOnly }) => fieldsOnly);
 
+  const hintKind = paramDefinitions.find((p) => p.hint?.kind !== undefined)?.hint?.kind;
+  const hintConfig = hintKind !== undefined ? HINT_KIND_SUGGESTION_CONFIG[hintKind] : undefined;
+
   // constantOnly params require literal values, not fields
   // (variadic functions work correctly: empty paramDefinitions → hasConstantOnlyParam = false)
-  if (!hasConstantOnlyParam) {
+  if (!hasConstantOnlyParam && !hintConfig?.suppressFields) {
     const canBeMultiValue = paramDefinitions.some(
       (t) => t && (t.supportsMultiValues === true || t.name === 'values')
     );
@@ -244,6 +260,7 @@ async function buildFieldAndFunctionSuggestions(
       types: config.acceptedTypes,
       addComma: config.shouldAddComma,
       excludeParentFunctions: true,
+      functionTypes: hintConfig?.functionTypes,
     });
   }
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_builder.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_builder.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ISuggestionItem } from '../../../../registry/types';
-import type { FunctionParameterType } from '../../../types';
+import type { FunctionParameterType, FunctionDefinitionTypes } from '../../../types';
 import { getFieldsSuggestions, getFunctionsSuggestions, getLiteralsSuggestions } from '../helpers';
 import { getOperatorSuggestions } from '../../operators';
 import type { ExpressionContext } from './types';
@@ -63,6 +63,7 @@ export class SuggestionBuilder {
     addSpaceAfterFunction?: boolean;
     constantGeneratingOnly?: boolean;
     excludeParentFunctions?: boolean;
+    functionTypes?: FunctionDefinitionTypes[];
   }): this {
     const types = options?.types ?? ['any'];
     const excludeParentFunctions = options?.excludeParentFunctions ?? false;
@@ -79,6 +80,7 @@ export class SuggestionBuilder {
         suggestOnlyName: this.context.options.isCursorFollowedByParens,
         addSpaceAfterFunction,
         constantGeneratingOnly,
+        functionTypes: options?.functionTypes,
       },
       context: this.context.context,
       callbacks: {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/helpers.ts
@@ -21,7 +21,7 @@ import type {
   ISuggestionItem,
 } from '../../../registry/types';
 import { Location } from '../../../registry/types';
-import type { SupportedDataType } from '../../types';
+import type { SupportedDataType, FunctionDefinitionTypes } from '../../types';
 import { filterFunctionDefinitions, getAllFunctions, getFunctionSuggestion } from '../functions';
 import { SuggestionCategory } from '../../../../language/autocomplete/utils/sorting/types';
 import { buildConstantsDefinitions, getCompatibleLiterals, getDateLiterals } from '../literals';
@@ -109,6 +109,7 @@ interface FunctionSuggestionOptions {
   addSpaceAfterFunction?: boolean;
   constantGeneratingOnly?: boolean;
   suggestOnlyName?: boolean;
+  functionTypes?: FunctionDefinitionTypes[];
 }
 
 interface GetFunctionsSuggestionsParams {
@@ -132,6 +133,7 @@ export function getFunctionsSuggestions({
     suggestOnlyName = false,
     addSpaceAfterFunction = false,
     constantGeneratingOnly = false,
+    functionTypes,
   } = options;
 
   const predicates = {
@@ -144,7 +146,7 @@ export function getFunctionsSuggestions({
   const activeProduct = context?.activeProduct;
 
   let filteredFunctions = filterFunctionDefinitions(
-    getAllFunctions({ includeOperators: false }),
+    getAllFunctions({ includeOperators: false, type: functionTypes }),
     predicates,
     hasMinimumLicenseRequired,
     activeProduct

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/parameters_from_hints.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/parameters_from_hints.test.ts
@@ -87,6 +87,10 @@ export async function getSuggestionsForHint(
   formerContext?: ICommandContext,
   callbacks: ESQLCallbacks = {}
 ) {
+  if (hint.entityType === undefined) {
+    throw new Error('Hint entityType is required for resolver lookup');
+  }
+
   const resolversEntry = parametersFromHintsResolvers[hint.entityType];
 
   if (!resolversEntry) {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.test.ts
@@ -420,6 +420,28 @@ describe('STATS Autocomplete', () => {
         await statsExpectSuggestions('from a | stats a=min(b), b=max(', expected, mockCallbacks);
       });
 
+      test('inside a function arg with hint.kind === "aggregation" (e.g. SPARKLINE first arg), only aggregation functions are suggested', async () => {
+        // Mock fields just to verify they get suppressed even when the resolver would return them
+        const allFields = getFieldNamesByType('any');
+        (mockCallbacks.getByType as jest.Mock).mockResolvedValue(
+          allFields.map((name) => ({ label: name, text: name }))
+        );
+
+        const expectedAggregations = getFunctionSignaturesByReturnType(
+          Location.STATS,
+          ['integer', 'long', 'double'],
+          { agg: true, timeseriesAgg: true },
+          undefined,
+          ['sparkline']
+        ).map((s) => `${s},`); // trailing comma since SPARKLINE has more mandatory args after the first
+
+        await statsExpectSuggestions(
+          'from a | stats SPARKLINE(',
+          expectedAggregations,
+          mockCallbacks
+        );
+      });
+
       test('inside function argument list', async () => {
         const expectedFieldsAvg = getFieldNamesByType(AVG_TYPES);
         (mockCallbacks.getByType as jest.Mock).mockResolvedValue(

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.ts
@@ -416,14 +416,30 @@ function buildCustomFilteringContext(
 
   if (!isInBy) {
     statsSpecificFunctionsToIgnore.push(
-      ...getFunctionsToIgnoreForStats(command, finalCommandArgIndex),
-      ...(isAggFunctionUsedAlready(command, finalCommandArgIndex)
-        ? getAllFunctions({ type: FunctionDefinitionTypes.AGG }).map(({ name }) => name)
-        : []),
-      ...(isTimeseriesAggUsedAlready(command, finalCommandArgIndex)
-        ? getAllFunctions({ type: FunctionDefinitionTypes.TIME_SERIES_AGG }).map(({ name }) => name)
-        : [])
+      ...getFunctionsToIgnoreForStats(command, finalCommandArgIndex)
     );
+
+    // The "no nested aggregations" rule applies unless the cursor's param
+    // explicitly expects an aggregation (e.g. hint.kind === 'aggregation' from the function definitions),
+    // in which case nesting is required, not forbidden.
+    const expectsAggregation = basicContext.paramDefinitions.some(
+      (p) => p.hint?.kind === 'aggregation'
+    );
+
+    if (!expectsAggregation) {
+      if (isAggFunctionUsedAlready(command, finalCommandArgIndex)) {
+        statsSpecificFunctionsToIgnore.push(
+          ...getAllFunctions({ type: FunctionDefinitionTypes.AGG }).map(({ name }) => name)
+        );
+      }
+      if (isTimeseriesAggUsedAlready(command, finalCommandArgIndex)) {
+        statsSpecificFunctionsToIgnore.push(
+          ...getAllFunctions({ type: FunctionDefinitionTypes.TIME_SERIES_AGG }).map(
+            ({ name }) => name
+          )
+        );
+      }
+    }
   }
 
   return {

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.parameters_with_hints.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.parameters_with_hints.test.ts
@@ -20,7 +20,7 @@ const allUniqueParameterHints = uniqBy(
   getAllFunctions()
     .flatMap((fn) => fn.signatures)
     .flatMap((signature) => signature.params)
-    .flatMap((param) => (param.hint ? [param.hint] : [])),
+    .flatMap((param) => (param.hint?.entityType ? [param.hint] : [])),
   'entityType'
 );
 

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/get_command_context.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/get_command_context.ts
@@ -155,6 +155,9 @@ export const enhanceWithFunctionsContext = async (
 
   // If the hint needs new data to build the suggestions, we add that data to the context
   for (const hint of uniqueHints) {
+    if (hint.entityType === undefined) {
+      continue;
+    }
     const parameterHandler = parametersFromHintsResolvers[hint.entityType];
     if (parameterHandler?.contextResolver) {
       const resolvedContext = await parameterHandler.contextResolver(

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/esql_validation_meta_tests.json
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/esql_validation_meta_tests.json
@@ -134,6 +134,11 @@
       "userDefined": false
     },
     {
+      "name": "flattenedField",
+      "type": "flattened",
+      "userDefined": false
+    },
+    {
       "name": "any#Char$Field",
       "type": "double",
       "userDefined": false


### PR DESCRIPTION
resolves: https://github.com/elastic/kibana/issues/265936

## Summary

### Problem
ES|QL's SPARKLINE function has a special first parameter that must always be an aggregation expression (e.g. `AVG(bytes)`). Elasticsearch signals this via `hint: { kind: 'aggregation' }` on the param definition, but Kibana's autocomplete ignored that hint entirely:

Inside `STATS SPARKLINE(|, ...)`, all scalar functions (`SUBSTRING`, `ABS`, etc.) were suggested alongside aggregations, plus every field in the index — none of which are valid input.
The existing hint handler (`buildSuggestionsFromHints`) only dispatched on `hint.entityType` (used by `inference_endpoint`), so a `kind`-only hint was a no-op.

### Fix
Surfaces the existing `getAllFunctions({ type })` filter through the composite-suggestion path, gated on `hint.kind`:

- `ParameterHint.entityType` → optional, since SPARKLINE's hint has only `kind`. Three callers that index `parametersFromHintsResolvers[hint.entityType]` are guarded.
- New `HINT_KIND_SUGGESTION_CONFIG` map in `empty_expression.ts` translates `hint.kind` → `{ functionTypes, suppressFields }`. Adding a kind = adding one entry; nothing else changes.
- `buildFieldAndFunctionSuggestions` reads `hint.kind` and (a) skips `addFields` when `suppressFields` is set, (b) passes `functionTypes` to `addFunctions`.
- `functionTypes` **threaded** through `SuggestionBuilder.addFunctions` → `getFunctionsSuggestions` → `getAllFunctions`, which already supports type filtering.
- **STATS** `expectsAggregation` **opt-out**: `buildCustomFilteringContext` was adding every AGG name to `functionsToIgnore` (because `isAggFunctionUsedAlready` saw SPARKLINE itself in the AST). When the cursor's param has `hint.kind === 'aggregation'`, the "no nested aggregations" rule does not apply — nesting is required, not forbidden.

Result for `STATS SPARKLINE(|, ...)`: only AGG/TIME_SERIES_AGG functions are suggested, no fields. Self-recursion is still prevented (SPARKLINE itself stays in the ignore list).

5 production files + 3 caller guards + 1 SPARKLINE-on-STATS unit test.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.