### PR TITLE
[APM][Scout] Stabilize service map embeddable test panel time range

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_embeddable.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_embeddable.spec.ts
@@ -61,7 +61,13 @@ test.describe(
         await pageObjects.dashboard.openAddPanelFlyout();
       });
 
-      await test.step('add Service map panel with filters', async () => {
+      await test.step('add Service map panel without filters', async () => {
+        // Add the panel first with no filters. The Service Map embeddable
+        // factory always initializes panels with a custom
+        // `time_range: { from: 'now-15m', to: 'now' }` and that range cannot
+        // be configured from the editor flyout, so we need the panel to
+        // exist before we can widen its time range via the Customize panel
+        // flow below.
         await expect(page.getByRole('heading', { name: 'Add to Dashboard' })).toBeVisible();
         const serviceMapMenuItem = page.getByRole('menuitem', {
           name: 'Service map',
@@ -73,6 +79,41 @@ test.describe(
         await expect(
           page.getByRole('heading', { name: 'Create service map panel', level: 2 })
         ).toBeVisible();
+        await page.testSubj.locator('apmServiceMapEditorSaveButton').click();
+      });
+
+      await test.step('verify panel was added with the default custom time range', async () => {
+        await pageObjects.dashboard.waitForPanelsToLoad(1);
+        expect(await pageObjects.dashboard.getPanelCount()).toBe(1);
+        await expect(page.testSubj.locator('apmServiceMapEmbeddable')).toBeVisible();
+        await pageObjects.dashboard.expectTimeRangeBadgeExists();
+      });
+
+      await test.step('widen the panel custom time range to last 24 hours', async () => {
+        // Bump the panel's custom time range from the default 15 minutes to
+        // 24 hours so it (and the suggestions endpoint when we re-open the
+        // editor below) covers the synth window even with significant delay
+        // between global setup and this test running.
+        await pageObjects.dashboard.openCustomizePanel();
+        await pageObjects.dashboard.enableCustomTimeRange();
+        await page.testSubj
+          .locator('customizePanelTimeRangeDatePicker > superDatePickerToggleQuickMenuButton')
+          .click();
+        await pageObjects.dashboard.clickCommonlyUsedTimeRange('Last_24 hours');
+        await pageObjects.dashboard.saveCustomizePanel();
+        await pageObjects.dashboard.expectTimeRangeBadgeExists();
+      });
+
+      await test.step('edit Service map panel and apply filters', async () => {
+        // Re-open the editor in edit mode. The factory passes the panel's
+        // current `time_range` (now 24 hours) into the suggestions endpoint
+        // so the service / environment combo boxes can resolve
+        // `service-map-test` reliably.
+        await pageObjects.dashboard.clickPanelAction('embeddablePanelAction-editPanel');
+        await expect(
+          page.getByRole('heading', { name: 'Edit service map', level: 2 })
+        ).toBeVisible();
+
         // wait for combobox `isLoading` to finish
         // before interaction (see `euiLoadingSpinner` + `state: 'hidden'`).
         const serviceNameCombo = page.testSubj.locator('apmServiceMapEditorServiceNameComboBox');
@@ -114,9 +155,6 @@ test.describe(
       });
 
       await test.step('verify embeddable panel renders service map with connected nodes', async () => {
-        await pageObjects.dashboard.waitForPanelsToLoad(1);
-        expect(await pageObjects.dashboard.getPanelCount()).toBe(1);
-        await expect(page.testSubj.locator('apmServiceMapEmbeddable')).toBeVisible();
         await expect(
           page.testSubj.locator(
             `serviceMapNodeContextHighlightFrame > serviceMapNode-service-${SERVICE_MAP_TEST_SERVICE}`


### PR DESCRIPTION
## Summary

Fixes the flaky **Service map embeddable** Scout test by removing the
implicit dependency on wall-clock drift between global setup and test
execution.

### Why it was flaky

- Global setup ingests \`serviceMapMultiEnv\` synthtrace data at
  \`now-15m..now\` (anchored to the moment global setup runs).
- The Service Map embeddable factory hard-codes a panel-level default
  \`time_range: { from: 'now-15m', to: 'now' }\` that overrides the
  dashboard's range, and that range **cannot be configured from the
  editor flyout** at panel creation time.
- For the panel's window to contain the synth window, the entire
  parallel suite (global setup + everything that runs before this spec)
  has to complete in well under ~15 minutes. Once the cumulative
  \`testNow - setupNow\` drift exceeds the 15-minute panel window, the
  synth data slides fully outside the panel's range and
  \`service-map-test\`:
  - disappears from the \`/internal/apm/suggestions\` response → the
    \`apmServiceMapEditorServiceNameComboBox\` option never appears →
    \`selectSingleOption\` times out (the original failure in #265639), or
  - is still selectable but the rendered service map shows
    "No services available" → the
    \`serviceMapNode-service-service-map-test\` visibility assertion
    times out.

### Why we have to use the edit flow

The editor flyout exposes only \`service_name\`, \`environment\` and
\`kuery\`; it has no UI for \`time_range\`. The factory always seeds the
new panel with the 15-minute default, so the only way to widen the
panel's queried window is the dashboard-level **Customize panel** flow
*after* the panel exists. To make that widened window actually take
effect for the suggestions endpoint, we then have to re-open the editor
in **edit** mode — \`onEdit\` passes
\`timeRangeManager.api.timeRange\$.getValue()\` (now 24h) into the
flyout, so the combo boxes' suggestions are resolved in the wider
window. We can't apply the filters first and widen later, because the
first \`selectSingleOption\` is exactly what was failing.

### What changed

\`x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_embeddable.spec.ts\`:

1. Add the Service Map panel **without filters** (just save the empty
   editor) → panel exists with the factory's default 15-minute custom
   range and the \`CUSTOM_TIME_RANGE_BADGE\` is asserted.
2. Open the **Customize panel** flyout, ensure the custom time range
   toggle is on, set the panel's range to **Last 24 hours** via the
   panel-scoped \`superDatePicker\` quick menu, save.
3. Re-open the editor in **edit** mode via
   \`embeddablePanelAction-editPanel\` and apply
   \`service_name\` / \`environment\` / \`kuery\`. With the 24h panel
   range, the \`apmServiceMapEditorServiceNameComboBox\` reliably
   resolves \`service-map-test\` even with realistic setup-to-test
   delay.
4. The remaining assertions (visibility, popover, maximize, fills,
   disable-custom-time-range, View full service map) run against the
   24h panel range, so they no longer depend on the 15-minute synth
   window aligning with wall-clock \"now\".

\`global.setup.ts\` is unchanged — synth still ingests at
\`now-15m..now\`. 24h easily covers any realistic delay between global
setup and this spec running.

## References

Closes #265639

## Test plan

- [ ] CI green
- [ ] Local run: \`npx playwright test --config x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel.playwright.config.ts --project local --grep stateful-classic x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_embeddable.spec.ts\`
- [ ] Repeat-each smoke (\`--repeat-each=10\`) to confirm flake is gone


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->