### PR TITLE
Fix broken translation string

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/snowflake/snowflake.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/snowflake/snowflake.ts
@@ -243,7 +243,10 @@ export const Snowflake: ConnectorSpec = {
                 'core.kibanaConnectorSpecs.snowflake.auth.oauth.tokenUrl.helpText',
                 {
                   defaultMessage:
-                    'Snowflake OAuth token endpoint. Replace <account> with your Snowflake account identifier.',
+                    'Snowflake OAuth token endpoint. Replace {accountPlaceholder} with your Snowflake account identifier.',
+                  values: {
+                    accountPlaceholder: '<account>',
+                  },
                 }
               ),
             },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/snowflake/snowflake.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/snowflake/snowflake.ts
@@ -245,7 +245,7 @@ export const Snowflake: ConnectorSpec = {
                   defaultMessage:
                     'Snowflake OAuth token endpoint. Replace {accountPlaceholder} with your Snowflake account identifier.',
                   values: {
-                    accountPlaceholder: '<account>',
+                    accountPlaceholder: '{account}',
                   },
                 }
               ),


### PR DESCRIPTION
## Summary

This is a quick fix for a broken translating string that was spamming the browser console.




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->