### PR TITLE
test: include `noDataViewsPrompt` in Observability Scout `pageOrNoData`

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/observability_navigation.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/observability_navigation.ts
@@ -57,9 +57,17 @@ export class ObservabilityNavigation {
     });
   }
 
-  /** App root or `kbnNoDataPage` (Discover/Dashboards with no data views). */
+  /**
+   * App root or one of the shared no-data shells. Discover/Dashboards delegate to
+   * `KibanaNoDataPage`, which renders either `kbnNoDataPage` (cluster has no data) or
+   * `noDataViewsPrompt` (cluster has data but no user data view), depending on cluster
+   * state. The shells are mutually exclusive, so an `.or()` chain is enough — see gh-267186.
+   */
   pageOrNoData(testSubj: string): Locator {
-    return this.page.testSubj.locator(testSubj).or(this.page.testSubj.locator('kbnNoDataPage'));
+    return this.page.testSubj
+      .locator(testSubj)
+      .or(this.page.testSubj.locator('kbnNoDataPage'))
+      .or(this.page.testSubj.locator('noDataViewsPrompt'));
   }
 
   navItemInPrimaryByDeepLinkId(deepLinkId: string): Locator {


### PR DESCRIPTION
## Summary

Fix the `Serverless Observability Navigation - Complete tier body — clicking body nav items …` Scout test (and two siblings) by widening the shared `pageOrNoData` helper to include the `noDataViewsPrompt` shell.

### What we observed

The `Dashboards` step kept failing with `element(s) not found` after waiting the full 45 s SPA-shell budget bumped in #268240:

```
Locator: locator('[data-test-subj="dashboardLandingPage"]').or(locator('[data-test-subj="kbnNoDataPage"]'))
Expected: visible
Timeout: 45000ms
Error: element(s) not found
```

A local repro screenshot showed the navigation actually worked: the `Dashboards` sidenav item is highlighted and the breadcrumb is `Project / Dashboards`. The body, however, rendered the **"How do you want to explore your data?"** prompt — which is `noDataViewsPrompt`, not `dashboardLandingPage` and not `kbnNoDataPage`.

### Why it matters

`DashboardListingPage` (and Discover) delegates the no-data state to `KibanaNoDataPage`, which renders one of three mutually exclusive shells:

- the app's own listing (e.g. `dashboardLandingPage` / `dscPage`) — when a user data view exists,
- `kbnNoDataPage` — when the cluster has no data at all,
- `noDataViewsPrompt` — when the cluster **has** data but no user data view (the Serverless Observability complete-tier test environment falls into this branch).

`pageOrNoData` only matched the first two, so on a fresh project the locator could never resolve and we burned the full 45 s budget waiting for nothing. The earlier fix (#268240) only widened the timeout, which is why the failure shape persisted.

### Fix

Add `noDataViewsPrompt` as a third `.or()` branch on `pageOrNoData` in `kbn-scout-oblt`:

```ts
pageOrNoData(testSubj: string): Locator {
  return this.page.testSubj
    .locator(testSubj)
    .or(this.page.testSubj.locator('kbnNoDataPage'))
    .or(this.page.testSubj.locator('noDataViewsPrompt'));
}
```

Same signature, just one extra fallback. The shells are mutually exclusive, so any of the three matching is sufficient evidence the SPA navigated.

### Wider impact

`pageOrNoData` is also used by:

- `x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/navigation/navigation_sidebar.spec.ts`
- `x-pack/solutions/observability/plugins/serverless_observability/test/scout/ui/parallel_tests/navigation_logs_essentials.spec.ts`

so this also closes the same blind spot for the traditional oblt and logs-essentials navigation suites — no spec edits needed.

### Local repro

```bash
npx playwright test \
  --config=x-pack/solutions/observability/plugins/serverless_observability/test/scout/ui/parallel.playwright.config.ts \
  --grep="@local-serverless-observability_complete" \
  --project=local \
  -g "clicking body nav items"
```

### References

Closes elastic/kibana#267186
Closes #263863

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->