### PR TITLE
[Streams][Scout] Disable discover.isEsqlDefault in streams_app suite

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/global.setup.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/global.setup.ts
@@ -8,6 +8,13 @@
 import { globalSetupHook } from '@kbn/scout';
 
 globalSetupHook('Setup environment for streams tests', async ({ apiServices, log }) => {
+  log.debug('[setup] turning off discover.isEsqlDefault');
+  await apiServices.core.settings({
+    'feature_flags.overrides': {
+      'discover.isEsqlDefault': false,
+    },
+  });
+
   log.debug('[setup] Enabling streams...');
   await apiServices.streams.enable();
 });


### PR DESCRIPTION
## Summary

Fixes the current re-opening pattern of #246886 (and the four sibling streams_app Scout failures it currently masks).

The streams_app Scout UI tests (`discover_integration_classic.spec.ts`, `discover_integration_wired.spec.ts`, `esql_source_enrichment.spec.ts`) assume Discover loads in **Data view mode** so they can call `selectDataView(...)`. In the MKI QA serverless environment the `discover.isEsqlDefault` feature flag is enabled, the observability root profile then provides a default ES|QL query (added in #257268), and Discover boots straight into ES|QL — hiding the data-view switcher.

**Evidence this is the root cause:**
- Failure screenshot from build shows query `FROM logs*,-logstash*,filebeat-*` — the observability root profile's `getDefaultEsqlQuery` output.
- `get_initial_app_state.ts:124-131` only initializes with that ES|QL default when `getIsEsqlDefault()` returns `true`.
- Same MKI flag flip caused #267910 in the Discover plugin's own Scout suite, opened the same day.

## Fix

Disable `discover.isEsqlDefault` in the suite's `globalSetupHook`, mirroring exactly what the Discover Scout suite does in #267910 and what `discover_enhanced` already does in its global setup. Each Scout suite has its own setup hook, so the override is suite-scoped — that's why it has to be repeated per plugin.

## Caveat

Same as #267910: this pins the flag off rather than adapting tests to the future ES|QL-default product direction. A coordinated follow-up with the Discover team is the proper resolution. For now, this restores green CI for the streams_app Scout suite.
