### PR TITLE
[EDR Workflows] Disable Cypress video recording to reduce CI disk pressure

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -42,8 +42,7 @@ export const getCypressBaseConfig = (
       screenshotsFolder:
         '../../../../../target/kibana-security-solution/public/management/cypress/screenshots',
       trashAssetsBeforeRuns: false,
-      video: true,
-      videoCompression: 15,
+      video: false,
       videosFolder:
         '../../../../../target/kibana-security-solution/public/management/cypress/videos',
       viewportHeight: 1200,


### PR DESCRIPTION
Disables video recording in the management Cypress suite (`cypress_base.config.ts`). Videos were previously recorded and then deleted for passing specs via `getVideosForFailedSpecs`, but the recording itself still caused disk writes during the run — contributing to CI disk pressure observed in the vagrant-cluster test environments.

Setting `video: false` avoids the disk I/O entirely. The `getVideosForFailedSpecs` helper is already guarded against this (`if (results && results.video)`) so it becomes a clean no-op.
