### PR TITLE
[UII] Gate fetch enrollment tokens until agent policies are loaded

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
@@ -106,8 +106,9 @@ export const EnrollmentTokenListPage: React.FunctionComponent<{}> = () => {
     kuery,
   });
 
-  const total = enrollmentAPIKeysRequest?.data?.total ?? 0;
-  const rowItems = enrollmentAPIKeysRequest?.data?.items ?? [];
+  const agentPoliciesLoaded = !agentPoliciesRequest.isLoading;
+  const total = agentPoliciesLoaded ? enrollmentAPIKeysRequest?.data?.total ?? 0 : 0;
+  const rowItems = agentPoliciesLoaded ? enrollmentAPIKeysRequest?.data?.items ?? [] : [];
 
   const refresh = () => {
     clearSelection();


### PR DESCRIPTION
## Summary

Does what it says on the tin. Resolves https://github.com/elastic/kibana/issues/268166 flickering issue.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.