### PR TITLE
[9.3] [Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test (#268054)

### DIFF
--- a/src/platform/plugins/shared/console/moon.yml
+++ b/src/platform/plugins/shared/console/moon.yml
@@ -18,6 +18,7 @@ project:
   sourceRoot: src/platform/plugins/shared/console
 dependsOn:
   - '@kbn/scout'
+  - '@kbn/test-es-server'
   - '@kbn/core'
   - '@kbn/dev-tools-plugin'
   - '@kbn/es-ui-shared-plugin'

--- a/src/platform/plugins/shared/console/test/scout/api/tests/autocomplete_entities_stateful.spec.ts
+++ b/src/platform/plugins/shared/console/test/scout/api/tests/autocomplete_entities_stateful.spec.ts
@@ -7,13 +7,24 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { RoleApiCredentials } from '@kbn/scout';
+import { UndiciConnection } from '@elastic/elasticsearch';
+import type { EsClient, RoleApiCredentials } from '@kbn/scout';
 import { apiTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
+import { createEsClientForTesting } from '@kbn/test-es-server';
 import { COMMON_HEADERS } from '../fixtures/constants';
 
 const LEGACY_TEMPLATE_NAME = 'test-legacy-template-1';
 const AUTOCOMPLETE_API = 'api/console/autocomplete_entities';
+// `PUT _template` against a wildcard pattern emits one `Warning:` deprecation
+// header per overlapping composable template; on a populated cluster this can
+// exceed Node's default 16 KB `maxHeaderSize` and trip `HPE_HEADER_OVERFLOW`.
+// Use a dedicated client (Undici-backed, since `maxHeaderSize` is only
+// configurable on Undici's agent — Node's `http.Agent` does not accept it)
+// for the legacy-template setup; the assertion against the production route
+// still runs through the shared `apiClient` fixture.
+// See https://github.com/elastic/kibana/issues/268028
+const LEGACY_TEMPLATE_CLIENT_MAX_HEADER_SIZE = 64 * 1024;
 
 apiTest.describe(
   'GET /api/console/autocomplete_entities — legacy templates',
@@ -21,22 +32,35 @@ apiTest.describe(
   () => {
     let credentials: RoleApiCredentials;
     let requestOptions: { headers: Record<string, string>; responseType: 'json' };
+    let legacyTemplateClient: EsClient;
 
-    apiTest.beforeAll(async ({ esClient, requestAuth }) => {
+    apiTest.beforeAll(async ({ config, requestAuth }) => {
       credentials = await requestAuth.getApiKey('admin');
       requestOptions = {
         headers: { ...COMMON_HEADERS, ...credentials.apiKeyHeader },
         responseType: 'json',
       };
 
-      await esClient.indices.putTemplate({
+      legacyTemplateClient = createEsClientForTesting({
+        esUrl: config.hosts.elasticsearch,
+        isCloud: config.isCloud,
+        authOverride: config.auth,
+        Connection: UndiciConnection,
+        agent: { maxHeaderSize: LEGACY_TEMPLATE_CLIENT_MAX_HEADER_SIZE },
+      });
+
+      await legacyTemplateClient.indices.putTemplate({
         name: LEGACY_TEMPLATE_NAME,
         index_patterns: ['*'],
       });
     });
 
-    apiTest.afterAll(async ({ esClient }) => {
-      await esClient.indices.deleteTemplate({ name: LEGACY_TEMPLATE_NAME }, { ignore: [404] });
+    apiTest.afterAll(async () => {
+      await legacyTemplateClient.indices.deleteTemplate(
+        { name: LEGACY_TEMPLATE_NAME },
+        { ignore: [404] }
+      );
+      await legacyTemplateClient.close();
     });
 
     apiTest('returns legacy templates when templates setting is enabled', async ({ apiClient }) => {

--- a/src/platform/plugins/shared/console/tsconfig.json
+++ b/src/platform/plugins/shared/console/tsconfig.json
@@ -6,6 +6,7 @@
   "include": ["common/**/*", "public/**/*", "server/**/*", "packaging/**/*", "test/**/*"],
   "kbn_references": [
     "@kbn/scout",
+    "@kbn/test-es-server",
     "@kbn/core",
     "@kbn/dev-tools-plugin",
     "@kbn/es-ui-shared-plugin",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test (#268054)](https://github.com/elastic/kibana/pull/268054)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-05-07T15:02:54Z","message":"[Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test (#268054)\n\nCloses #268028\n\n## Summary\n\nThe Scout API test\n[`autocomplete_entities_stateful.spec.ts`](https://github.com/elastic/kibana/blob/2c4863f3d050e2c530389da1692f0ac720994398/src/platform/plugins/shared/console/test/scout/api/tests/autocomplete_entities_stateful.spec.ts)\nis failing in `beforeAll` with `ConnectionError: Parse Error: Header\noverflow` (`HPE_HEADER_OVERFLOW`). The setup calls `PUT _template` with\n`index_patterns: ['*']`; on a populated cluster ES emits a single\n`Warning:` deprecation header listing every overlapping composable\ntemplate\n([`MetadataIndexTemplateService.java#L1341-L1352`](https://github.com/elastic/elasticsearch/blob/f4096de27a8ad47955c15230d18db123dae7d013/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java#L1341-L1352)),\nand that single header alone exceeds Node's default 16 KB\n`maxHeaderSize`.\n\nTest-only failure — the\n[`/api/console/autocomplete_entities`](https://github.com/elastic/kibana/blob/2c4863f3d050e2c530389da1692f0ac720994398/src/platform/plugins/shared/console/server/routes/api/console/autocomplete_entities/index.ts#L56-L63)\nproduction route only does `GET _template`.\n\n## Fix\n\nIn the spec only, build a private ES `Client` for the legacy-template\nsetup using `UndiciConnection` with `agent: { maxHeaderSize: 64 * 1024\n}`. `UndiciConnection` is the only `@elastic/transport` connection that\nsurfaces `maxHeaderSize`. The route assertion still runs through the\nshared `apiClient` fixture.\n\n`tsconfig.json` adds `@kbn/test-es-server` as a `kbn_reference` for\n`createEsClientForTesting`.\n\n## Test plan\n\n- [x] `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json`\n- [x] `node scripts/eslint --fix` on the spec\n- [x] `node scripts/check_changes.ts`\n- [x] Local Scout on stateful classic (`node scripts/scout.js run-tests\n--arch stateful --domain classic --testFiles\n…/autocomplete_entities_stateful.spec.ts`) — `1 passed (5.6s)`; ES\nemitted the same multi-KB `legacy template […] matching patterns from\nexisting composable templates […]` warning (~120 entries) that overflows\nin CI\n- [ ] CI on this PR\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ce77dfc8d49c2635ec05ff5c5f0b048d1140c912","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","failed-test","Team:Kibana Management","release_note:skip","backport:version","v9.4.0","v9.5.0","v9.4.1"],"title":"[Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test","number":268054,"url":"https://github.com/elastic/kibana/pull/268054","mergeCommit":{"message":"[Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test (#268054)\n\nCloses #268028\n\n## Summary\n\nThe Scout API test\n[`autocomplete_entities_stateful.spec.ts`](https://github.com/elastic/kibana/blob/2c4863f3d050e2c530389da1692f0ac720994398/src/platform/plugins/shared/console/test/scout/api/tests/autocomplete_entities_stateful.spec.ts)\nis failing in `beforeAll` with `ConnectionError: Parse Error: Header\noverflow` (`HPE_HEADER_OVERFLOW`). The setup calls `PUT _template` with\n`index_patterns: ['*']`; on a populated cluster ES emits a single\n`Warning:` deprecation header listing every overlapping composable\ntemplate\n([`MetadataIndexTemplateService.java#L1341-L1352`](https://github.com/elastic/elasticsearch/blob/f4096de27a8ad47955c15230d18db123dae7d013/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java#L1341-L1352)),\nand that single header alone exceeds Node's default 16 KB\n`maxHeaderSize`.\n\nTest-only failure — the\n[`/api/console/autocomplete_entities`](https://github.com/elastic/kibana/blob/2c4863f3d050e2c530389da1692f0ac720994398/src/platform/plugins/shared/console/server/routes/api/console/autocomplete_entities/index.ts#L56-L63)\nproduction route only does `GET _template`.\n\n## Fix\n\nIn the spec only, build a private ES `Client` for the legacy-template\nsetup using `UndiciConnection` with `agent: { maxHeaderSize: 64 * 1024\n}`. `UndiciConnection` is the only `@elastic/transport` connection that\nsurfaces `maxHeaderSize`. The route assertion still runs through the\nshared `apiClient` fixture.\n\n`tsconfig.json` adds `@kbn/test-es-server` as a `kbn_reference` for\n`createEsClientForTesting`.\n\n## Test plan\n\n- [x] `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json`\n- [x] `node scripts/eslint --fix` on the spec\n- [x] `node scripts/check_changes.ts`\n- [x] Local Scout on stateful classic (`node scripts/scout.js run-tests\n--arch stateful --domain classic --testFiles\n…/autocomplete_entities_stateful.spec.ts`) — `1 passed (5.6s)`; ES\nemitted the same multi-KB `legacy template […] matching patterns from\nexisting composable templates […]` warning (~120 entries) that overflows\nin CI\n- [ ] CI on this PR\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ce77dfc8d49c2635ec05ff5c5f0b048d1140c912"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/268222","number":268222,"state":"MERGED","mergeCommit":{"sha":"b0a51efc24b05825522a7323e12365c89f2819a0","message":"[9.4] [Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test (#268054) (#268222)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test\n(#268054)](https://github.com/elastic/kibana/pull/268054)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/268054","number":268054,"mergeCommit":{"message":"[Console] avoid HPE_HEADER_OVERFLOW in legacy templates Scout test (#268054)\n\nCloses #268028\n\n## Summary\n\nThe Scout API test\n[`autocomplete_entities_stateful.spec.ts`](https://github.com/elastic/kibana/blob/2c4863f3d050e2c530389da1692f0ac720994398/src/platform/plugins/shared/console/test/scout/api/tests/autocomplete_entities_stateful.spec.ts)\nis failing in `beforeAll` with `ConnectionError: Parse Error: Header\noverflow` (`HPE_HEADER_OVERFLOW`). The setup calls `PUT _template` with\n`index_patterns: ['*']`; on a populated cluster ES emits a single\n`Warning:` deprecation header listing every overlapping composable\ntemplate\n([`MetadataIndexTemplateService.java#L1341-L1352`](https://github.com/elastic/elasticsearch/blob/f4096de27a8ad47955c15230d18db123dae7d013/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java#L1341-L1352)),\nand that single header alone exceeds Node's default 16 KB\n`maxHeaderSize`.\n\nTest-only failure — the\n[`/api/console/autocomplete_entities`](https://github.com/elastic/kibana/blob/2c4863f3d050e2c530389da1692f0ac720994398/src/platform/plugins/shared/console/server/routes/api/console/autocomplete_entities/index.ts#L56-L63)\nproduction route only does `GET _template`.\n\n## Fix\n\nIn the spec only, build a private ES `Client` for the legacy-template\nsetup using `UndiciConnection` with `agent: { maxHeaderSize: 64 * 1024\n}`. `UndiciConnection` is the only `@elastic/transport` connection that\nsurfaces `maxHeaderSize`. The route assertion still runs through the\nshared `apiClient` fixture.\n\n`tsconfig.json` adds `@kbn/test-es-server` as a `kbn_reference` for\n`createEsClientForTesting`.\n\n## Test plan\n\n- [x] `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json`\n- [x] `node scripts/eslint --fix` on the spec\n- [x] `node scripts/check_changes.ts`\n- [x] Local Scout on stateful classic (`node scripts/scout.js run-tests\n--arch stateful --domain classic --testFiles\n…/autocomplete_entities_stateful.spec.ts`) — `1 passed (5.6s)`; ES\nemitted the same multi-KB `legacy template […] matching patterns from\nexisting composable templates […]` warning (~120 entries) that overflows\nin CI\n- [ ] CI on this PR\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"ce77dfc8d49c2635ec05ff5c5f0b048d1140c912"}}]}] BACKPORT-->