### PR TITLE
[FTR] add mocha retry support (testing only — do not merge)

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts
@@ -40,12 +40,25 @@ export function runFtrCli() {
       }
 
       const esVersion = esVersionInput ? new EsVersion(esVersionInput) : EsVersion.getDefault();
+
+      const retriesFlag = flagsReader.string('retries');
+      let retriesOverride: number | undefined;
+      if (retriesFlag !== undefined) {
+        const parsed = Number(retriesFlag);
+        if (!Number.isInteger(parsed) || parsed < 0) {
+          throw createFlagError(`--retries must be a non-negative integer, got "${retriesFlag}"`);
+        }
+        retriesOverride = parsed;
+      }
+
       const settingOverrides = {
         mochaOpts: {
           bail: flagsReader.boolean('bail'),
           dryRun: flagsReader.boolean('dry-run'),
           grep: flagsReader.string('grep'),
           invert: flagsReader.boolean('invert'),
+          // Only override the schema default (1) when --retries is explicitly passed
+          ...(retriesOverride !== undefined ? { retries: retriesOverride } : {}),
         },
         kbnTestServer: {
           installDir: flagsReader.path('kibana-install-dir'),
@@ -141,6 +154,7 @@ export function runFtrCli() {
           'exclude-tag',
           'kibana-install-dir',
           'es-version',
+          'retries',
         ],
         boolean: [
           'bail',
@@ -179,6 +193,8 @@ export function runFtrCli() {
           --headless         run browser in headless mode
           --dry-run          report tests without executing them
           --pauseOnError     pause test runner on error
+          --retries=N        retry failed tests up to N times before reporting failure
+                               (default: 1, i.e. each test runs at least twice on failure)
         `,
       },
     }

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts
@@ -152,6 +152,10 @@ export const schema = Joi.object()
         slow: Joi.number().default(30000),
         timeout: Joi.number().default(INSPECTING ? 360000 * 100 : 360000),
         ui: Joi.string().default('bdd'),
+        // Number of times mocha will retry a failed test (0 = no retry).
+        // Default of 1 means each test runs at least twice on failure. The final
+        // attempt is the one reported to lifecycle hooks, junit and ci-stats.
+        retries: Joi.number().integer().min(0).default(1),
         // Currently supporting beforeAll and afterAll.
         rootHooks: Joi.object()
           .keys({

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/decorate_mocha_ui.js
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/decorate_mocha_ui.js
@@ -201,6 +201,16 @@ export function decorateMochaUi(lifecycle, context, { rootTags }) {
     return wrapNonSuiteFunction(
       name,
       wrapRunnableArgs(fn, lifecycle, async (err, test) => {
+        // Mocha will retry tests when `retries > 0`. On non-final attempts we
+        // suppress the `testFailure` lifecycle event so that screenshot capture,
+        // snapshot updates, ES dumps and --pauseOnError only run for the
+        // *final* failure. Mocha exposes `_currentRetry` (0-indexed attempt
+        // number) and `_retries` (max additional attempts allowed) on the test.
+        const currentRetry = typeof test?._currentRetry === 'number' ? test._currentRetry : 0;
+        const maxRetries = typeof test?._retries === 'number' ? test._retries : 0;
+        if (currentRetry < maxRetries) {
+          return;
+        }
         await errorPauseHandler(err, test, async () => {
           await lifecycle.testFailure.trigger(err, test);
         });

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/ci_stats_ftr_reporter.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/ci_stats_ftr_reporter.ts
@@ -94,15 +94,29 @@ export function setupCiStatsFtrTestGroupReporter({
     });
   }
 
+  // True while mocha is going to retry a runnable; set by the 'retry' event
+  // and cleared on the next 'test'/'hook'. Used to suppress fail accounting
+  // for non-final attempts so retried-then-passed tests aren't counted twice.
+  const willRetry = new WeakSet<Runnable>();
+  runner.on('retry', (runnable: Runnable) => {
+    willRetry.add(runnable);
+  });
+
+  const isFinalAttempt = (runnable: Runnable) => !willRetry.has(runnable);
+
   const errors = new Map<Runnable, Error>();
   runner.on('fail', (test: Runnable, error: Error) => {
+    if (!isFinalAttempt(test)) return;
     errors.set(test, error);
   });
 
   let passCount = 0;
   let failCount = 0;
   runner.on('pass', () => (passCount += 1));
-  runner.on('fail', () => (failCount += 1));
+  runner.on('fail', (test: Runnable) => {
+    if (!isFinalAttempt(test)) return;
+    failCount += 1;
+  });
 
   runner.on('hook end', (hook: Runnable) => {
     if (hook.isFailed()) {
@@ -119,6 +133,13 @@ export function setupCiStatsFtrTestGroupReporter({
   });
 
   runner.on('test end', (test: Runnable) => {
+    // Skip non-final attempts of a retried test: mocha will run this test
+    // again, and we'll record the final outcome on a later 'test end'.
+    if (!isFinalAttempt(test)) {
+      willRetry.delete(test);
+      return;
+    }
+
     const error = errors.get(test);
     if (test.isFailed() && !error) {
       throw new Error('no error recorded for failed test');

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
@@ -171,6 +171,11 @@ export function MochaReporterProvider({ getService }) {
           err && err.message ? err.message : err
         }`
       );
+      // Mocha fires 'test' (=> onTestStart, +2 indent) at the start of every
+      // attempt but only fires 'test end' (=> onTestEnd, -2 indent) ONCE after
+      // the final attempt. Without unwinding here, each retried test leaks +2
+      // indent and subsequent tests appear progressively nested in the log.
+      log.indent(-2);
     };
 
     onFail = (runnable) => {

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
@@ -42,6 +42,7 @@ export function MochaReporterProvider({ getService }) {
       runner.on('pending', this.onPending);
       runner.on('pass', this.onPass);
       runner.on('fail', this.onFail);
+      runner.on('retry', this.onRetry);
       runner.on('test end', this.onTestEnd);
       runner.on('suite end', this.onSuiteEnd);
       runner.on('end', this.onEnd);
@@ -162,7 +163,28 @@ export function MochaReporterProvider({ getService }) {
       log.write(`- ${pass} ${time}`);
     };
 
+    onRetry = (test, err) => {
+      const attempt = (test._currentRetry ?? 0) + 1;
+      const total = (test._retries ?? 0) + 1;
+      log.write(
+        `- ${colors.fail(`${symbols.err} attempt ${attempt}/${total} failed, retrying`)}: ${
+          err && err.message ? err.message : err
+        }`
+      );
+    };
+
     onFail = (runnable) => {
+      // If mocha will retry this test, suppress the full failure block; the
+      // 'retry' handler above already logged a concise message. We only want
+      // the noisy multi-line failure output for the *final* attempt.
+      if (
+        runnable.type === 'test' &&
+        typeof runnable._currentRetry === 'number' &&
+        typeof runnable._retries === 'number' &&
+        runnable._currentRetry < runnable._retries
+      ) {
+        return;
+      }
       // NOTE: this is super gross
       //
       //  - I started by trying to extract the Base.list() logic from mocha

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/scout_ftr_reporter.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/scout_ftr_reporter.ts
@@ -86,10 +86,20 @@ export class ScoutFTRReporter {
       end: this.onRunEnd,
       test: this.onTestStart,
       'test end': this.onTestEnd,
+      retry: this.onRetry,
     })) {
       runner.on(eventName, listener);
     }
   }
+
+  // Tracks tests that mocha is about to retry; used to skip emitting a
+  // TEST_END event for non-final attempts so the report only contains the
+  // final outcome of each test.
+  private willRetry = new WeakSet<Test>();
+
+  onRetry = (test: Test) => {
+    this.willRetry.add(test);
+  };
 
   private getFileOwners(filePath: string): string[] {
     return getOwningTeamsForPath(filePath, this.codeOwnersEntries);
@@ -168,8 +178,14 @@ export class ScoutFTRReporter {
 
   onTestEnd = (test: Test) => {
     /**
-     * Test execution ended
+     * Test execution ended. Skip non-final attempts so retried-then-passed
+     * tests appear only once in the report with their final status.
      */
+    if (this.willRetry.has(test)) {
+      this.willRetry.delete(test);
+      return;
+    }
+
     this.report.logEvent({
       ...datasources.environmentMetadata,
       reporter: {


### PR DESCRIPTION
## Testing only — do not merge

This PR is opened **purely for testing purposes** to exercise the FTR mocha retry behavior in CI. It is not intended to be merged in its current form.

## What's in here

Three commits adding a retry mechanism to the Functional Test Runner:

1. **`mochaOpts.retries` config + `--retries` CLI flag** — new schema field with default `1` (each test runs at least twice on failure). Explicit `--retries N` overrides per-run; config files can opt out via `mochaOpts.retries: 0`.
2. **Lifecycle gating** — `wrapTestFunction` in `decorate_mocha_ui.js` now suppresses `lifecycle.testFailure` (and `--pauseOnError`) on non-final retry attempts, so screenshots/snapshots/ES dumps only run for the real final failure.
3. **Reporter updates** — `reporter.js`, `ci_stats_ftr_reporter.ts`, and `scout_ftr_reporter.ts` now handle mocha's `'retry'` event so retried-then-passed tests aren't double-counted in logs, ci-stats, or Scout reports.

## Things to validate before this could land for real

- JUnit reporter (`@kbn/mocha`) hasn't been audited for retry awareness yet.
- Default of `retries: 1` may produce false-positive passes in CRUD-style FTR suites that share state across `it` blocks.
- CI-stats accounting on flaky tests should be sanity-checked against a known-flaky config.