### PR TITLE
Bump @elastic/elasticsearch to 9.4.0

### DIFF
--- a/examples/saved_objects/server/esql_example_routes.ts
+++ b/examples/saved_objects/server/esql_example_routes.ts
@@ -62,9 +62,7 @@ export function registerEsqlExampleRoutes(router: IRouter, log: Logger) {
   // Parameterized query — when the pipeline includes user-provided values,
   // use ES|QL named params (`?paramName`) to prevent injection attacks.
   // Values are passed via the `params` array as `{ name: value }` entries
-  // and are never interpolated into the query string.
-  // Note: the ES client types don't include the named param record format,
-  // but Elasticsearch supports named params at runtime.
+  // (typed as `EsqlNamedValue`) and are never interpolated into the query string.
   router.versioned
     .post({
       path: '/api/saved_objects_example/_esql_query_parameterized',
@@ -92,7 +90,7 @@ export function registerEsqlExampleRoutes(router: IRouter, log: Logger) {
             type: TYPE_A,
             namespaces: ['default'],
             pipeline: `| WHERE ${TYPE_A}.myField == ?searchTerm | LIMIT 10`,
-            params: [{ searchTerm }] as unknown as estypes.EsqlESQLParam[],
+            params: [{ searchTerm } satisfies estypes.EsqlNamedValue],
           });
           return res.ok({
             body: {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@elastic/datemath": "5.0.3",
     "@elastic/ebt": "1.4.1",
     "@elastic/ecs": "9.3.0",
-    "@elastic/elasticsearch": "9.3.4",
+    "@elastic/elasticsearch": "9.4.0",
     "@elastic/ems-client": "8.7.0",
     "@elastic/esql": "3.0.0",
     "@elastic/eui": "114.3.0",

--- a/src/core/packages/security/common/src/authentication/authenticated_user.ts
+++ b/src/core/packages/security/common/src/authentication/authenticated_user.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { SecurityApiKeyManagedBy } from '@elastic/elasticsearch/lib/api/types';
+import type { SecurityCredentialManagedBy } from '@elastic/elasticsearch/lib/api/types';
 import type { AuthenticationProvider } from './authentication_provider';
 import type { User } from './user';
 
@@ -43,7 +43,7 @@ export interface ApiKeyDescriptor {
   /**
    * Which entity manages this API key
    */
-  managed_by: SecurityApiKeyManagedBy;
+  managed_by: SecurityCredentialManagedBy;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/get_query_payload.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/get_query_payload.ts
@@ -6,7 +6,7 @@
  */
 
 import { hasStartEndParams } from '@kbn/esql-utils';
-import type { EsqlESQLParam, EsqlQueryRequest } from '@elastic/elasticsearch/lib/api/types';
+import type { EsqlNamedValue, EsqlQueryRequest } from '@elastic/elasticsearch/lib/api/types';
 import { RESERVED_ESQL_PARAMS } from '@kbn/alerting-v2-constants';
 import { parseDurationToMs } from '../duration';
 
@@ -59,10 +59,9 @@ export function getQueryPayload({
   }
 
   const paramValues: Record<string, string> = { _tstart: dateStart, _tend: dateEnd };
-  // TODO: wait until client is fixed: https://github.com/elastic/elasticsearch-specification/issues/5083
   const params: EsqlQueryRequest['params'] = RESERVED_ESQL_PARAMS.filter((name) =>
     new RegExp(`\\?${name}`, 'i').test(query)
-  ).map((name) => ({ [name]: paramValues[name] } as unknown as EsqlESQLParam));
+  ).map((name): EsqlNamedValue => ({ [name]: paramValues[name] }));
 
   return { dateStart, dateEnd, filter, ...(params.length ? { params } : {}) };
 }

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/eis_utils.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/eis_utils.ts
@@ -58,6 +58,9 @@ export const TASK_TYPE_DISPLAY_NAME: Record<InferenceTaskType, string> = {
   rerank: i18n.translate('xpack.searchInferenceEndpoints.eisUtils.taskType.rerank', {
     defaultMessage: 'rerank',
   }),
+  embedding: i18n.translate('xpack.searchInferenceEndpoints.eisUtils.taskType.embedding', {
+    defaultMessage: 'embedding',
+  }),
 };
 
 export interface GroupedModel {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph_entities/fetch.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph_entities/fetch.ts
@@ -62,7 +62,6 @@ export const fetchEntities = async ({
       columnar: false,
       filter: buildDslFilter(entityIds, start, end),
       query,
-      // @ts-expect-error - esql helper params types are not up to date
       params: entityIds.map((id, idx) => ({ [`entity_id${idx}`]: id })),
     })
     .toRecords<EntityRecord>();

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph_events/fetch.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph_events/fetch.ts
@@ -61,7 +61,6 @@ export const fetchEvents = async ({
       columnar: false,
       filter: buildDslFilter(eventIds, start, end),
       query,
-      // @ts-expect-error - esql helper params types are not up to date
       params: eventIds.map((id, idx) => ({ [`doc_id${idx}`]: id })),
     })
     .toRecords<EventRecord>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2347,13 +2347,12 @@
     "@elastic/transport" "^8.3.1"
     tslib "^2.4.0"
 
-"@elastic/elasticsearch@9.3.4":
-  version "9.3.4"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-9.3.4.tgz#b124f33ba8ddd98267798672dba5ad4aee9d6c89"
-  integrity sha512-Mp14fPEYx+WTfZdcvAaZ9WkLYGHQCbwMx6EP5VCucYdhv4cn/g2sbnMT5HzK+gX3XEpBnnkEK/+WysCKzxuo3A==
+"@elastic/elasticsearch@9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-9.4.0.tgz#3ae5e4ef9d4167cc36782c0658a6a0f783e51b4a"
+  integrity sha512-UbvHAtGAqiQdAsAmb3vfCMwOTIf6BoSf6MDpz7mw5UzpU3pRSl4KeFzaXRfrk4+PrgiudYx14socGCI6frgguQ==
   dependencies:
     "@elastic/transport" "^9.3.5"
-    apache-arrow "18.x - 21.x"
     tslib "^2.4.0"
 
 "@elastic/ems-client@8.7.0":


### PR DESCRIPTION
## Summary

Updates `@elastic/elasticsearch` from `9.3.4` to `9.4.0`.

### Consumer updates for type changes

A few `@elastic/elasticsearch/lib/api/types` symbols changed in `9.4.0`; this PR updates Kibana's consumers to match:

- `SecurityApiKeyManagedBy` → `SecurityCredentialManagedBy` (same `'cloud' | 'elasticsearch'` values), used by `AuthenticatedUser.api_key.managed_by` in `@kbn/core-security-common`.
- `EsqlESQLParam` (singular) was removed in favour of the better-typed `EsqlNamedValue` for named ES|QL params. Updated:
  - `x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/get_query_payload.ts` (drops the prior `as unknown as` workaround)
  - `examples/saved_objects/server/esql_example_routes.ts` (uses `satisfies estypes.EsqlNamedValue`)
  - `x-pack/solutions/security/plugins/cloud_security_posture/server/routes/graph_entities/fetch.ts` and `graph_events/fetch.ts` (drops `@ts-expect-error` directives whose underlying [elasticsearch-specification#5083](https://github.com/elastic/elasticsearch-specification/issues/5083) is now fixed)
- `InferenceTaskType` gained a new `'embedding'` value; `search_inference_endpoints/eis_utils.ts` adds a display-name entry to keep its `Record<InferenceTaskType, string>` exhaustive.

### Note on `apache-arrow`

In `9.4.0`, `apache-arrow` is no longer declared as a runtime dependency of `@elastic/elasticsearch`. This is fine for Kibana because `apache-arrow` is already an explicit direct dependency in the root `package.json` (currently `21.1.0`), and is used by `x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.ts` (`AsyncRecordBatchStreamReader` from `apache-arrow/Arrow.node`). The lockfile entry for `apache-arrow@21.1.0` is preserved.

Fixes: https://github.com/elastic/rna-program/issues/470