### PR TITLE
[FTR] Flush captured debug logs to stdout on failure

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
@@ -14,7 +14,12 @@ import { ToolingLogTextWriter } from '@kbn/tooling-log';
 import { CiStatsReporter } from '@kbn/ci-stats-reporter';
 import moment from 'moment';
 
-import { recordLog, snapshotLogsForRunnable, setupJUnitReportGeneration } from '../../../../mocha';
+import {
+  recordLog,
+  snapshotLogsForRunnable,
+  getSnapshotOfRunnableLogs,
+  setupJUnitReportGeneration,
+} from '../../../../mocha';
 import * as colors from './colors';
 import * as symbols from './symbols';
 import { ms } from './ms';
@@ -215,6 +220,18 @@ export function MochaReporterProvider({ getService }) {
       // failed hooks trigger the `onFail(runnable)` callback, so we snapshot the logs for
       // them here. Tests will re-capture the snapshot in `onTestEnd()`
       snapshotLogsForRunnable(runnable);
+
+      // When captureLogOutput is on, buffered debug logs would otherwise only reach CI stats; flush them to stdout on failure too.
+      if (originalLogWriters) {
+        const captured = getSnapshotOfRunnableLogs(runnable);
+        if (captured) {
+          process.stdout.write(
+            `\n${colors.fail(
+              `debug logs leading up to failure of: ${runnable.fullTitle()}`
+            )}\n${captured}\n`
+          );
+        }
+      }
     };
 
     onEnd = () => {


### PR DESCRIPTION
## Summary

When `mochaReporter.captureLogOutput` is enabled (the default in CI), the FTR mocha reporter buffers per-suite debug logs into a `WeakMap` cache via `recordLog`/`snapshotLogsForRunnable`. Today that cache is only consumed by the CI stats reporter (`ci_stats_ftr_reporter.ts:93`) — so when a test fails in Buildkite, the **assertion** is in the build log but the **debug context leading up to it is not**. You have to bounce to CI stats to read it.

This PR flushes the captured snapshot to `stdout` in `onFail` whenever capture is active, so the diagnostic context shows up inline with the failure in the build log. Passing tests stay quiet (snapshots are only flushed on fail).

- Writes directly to `process.stdout` to bypass the active error-level + `ignoreSources: ['ProcRunner', '@kbn/es Cluster']` writer that would otherwise drop most of the buffered content.
- Guarded by `originalLogWriters`, which is only set inside `onStart` when `captureLogOutput: true` — so configs with capture disabled (or non-CI local runs without `CI=true`) see no behavior change.

### Why now

Passing FTR runs in CI today are dominated by Kibana subprocess `proc [kibana]` lines streamed during the **boot** and **teardown** phases (outside the capture window), so the noise is high. Inside the capture window the test phase is actually quiet — but on failure the relevant debug logs were going to a channel most engineers don't check. This makes the "quiet pass / loud fail" pattern actually deliver on its promise.

## Test plan

- [ ] `node scripts/jest_integration src/platform/packages/shared/kbn-test/src/functional_test_runner/integration_tests/` (existing failure_hooks/basic/exit_code suites still pass — already verified locally)
- [ ] Manual: run any FTR config with `CI=true` and a deliberately failing test → confirm the buffered debug log appears in stdout under a `debug logs leading up to failure of: ...` banner, and passing runs are unchanged
- [ ] Manual: run the same config without `CI=true` (capture off) → confirm no behavior change