### PR TITLE
[Entity Store] Fix flaky Scout API tests

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/ccs_logs_extraction.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/ccs_logs_extraction.spec.ts
@@ -1,0 +1,677 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import type { EsClient } from '@kbn/scout-security';
+import { get } from 'lodash';
+import {
+  PUBLIC_HEADERS,
+  INTERNAL_HEADERS,
+  ENTITY_STORE_ROUTES,
+  ENTITY_STORE_TAGS,
+  LATEST_ALIAS,
+  UPDATES_INDEX,
+} from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+import { clearEntityStoreIndices } from '../fixtures/helpers';
+
+const DOCS_LIMIT = 2;
+const CCS_TEST_LOGS_INDEX = 'ccs-test-logs';
+const FROM_DATE = '2026-02-25T10:00:00Z';
+const TO_DATE = '2026-02-25T12:00:00Z';
+// CCS writes entities with @timestamp = now + Nms; use a future date so local extraction picks them up
+const MAX_DATE_OF_UPDATES = new Date(Date.now() + 5 * 60_000).toISOString();
+
+async function createCcsTestLogsIndex(esClient: EsClient) {
+  await esClient.indices.delete({ index: CCS_TEST_LOGS_INDEX }, { ignore: [404] });
+  await esClient.indices.create({
+    index: CCS_TEST_LOGS_INDEX,
+    mappings: {
+      properties: {
+        '@timestamp': { type: 'date' },
+        host: {
+          properties: {
+            entity: {
+              properties: {
+                id: { type: 'keyword' },
+                sub_type: { type: 'keyword' },
+              },
+            },
+            id: { type: 'keyword' },
+            name: { type: 'keyword' },
+            domain: { type: 'keyword' },
+            hostname: { type: 'keyword' },
+            architecture: { type: 'keyword' },
+          },
+        },
+        user: {
+          properties: {
+            name: { type: 'keyword' },
+            id: { type: 'keyword' },
+            email: { type: 'keyword' },
+          },
+        },
+        event: {
+          properties: {
+            kind: { type: 'keyword' },
+            category: { type: 'keyword' },
+            type: { type: 'keyword' },
+            module: { type: 'keyword' },
+          },
+        },
+        data_stream: {
+          properties: {
+            dataset: { type: 'keyword' },
+          },
+        },
+        service: {
+          properties: {
+            name: { type: 'keyword' },
+            version: { type: 'keyword' },
+          },
+        },
+        entity: {
+          properties: {
+            id: { type: 'keyword' },
+            name: { type: 'keyword' },
+          },
+        },
+      },
+    },
+  });
+}
+
+async function ingestDoc(
+  esClient: EsClient,
+  index: string,
+  doc: Record<string, unknown> & { '@timestamp': string }
+) {
+  await esClient.index({
+    index,
+    refresh: 'wait_for',
+    body: doc,
+  });
+}
+
+apiTest.describe(
+  'Entity Store CCS logs extraction (test against local instance)',
+  { tag: ENTITY_STORE_TAGS },
+  () => {
+    let defaultHeaders: Record<string, string>;
+    let internalHeaders: Record<string, string>;
+
+    apiTest.beforeAll(async ({ samlAuth, apiClient, kbnClient }) => {
+      const credentials = await samlAuth.asInteractiveUser('admin');
+      defaultHeaders = {
+        ...credentials.cookieHeader,
+        ...PUBLIC_HEADERS,
+      };
+      internalHeaders = {
+        ...credentials.cookieHeader,
+        ...INTERNAL_HEADERS,
+      };
+
+      await kbnClient.uiSettings.update({
+        [FF_ENABLE_ENTITY_STORE_V2]: true,
+      });
+
+      await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {
+          logExtraction: {
+            docsLimit: DOCS_LIMIT,
+          },
+        },
+      });
+    });
+
+    apiTest.afterAll(async ({ apiClient, esClient }) => {
+      await esClient.indices.delete({ index: CCS_TEST_LOGS_INDEX }, { ignore: [404] });
+
+      await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {
+          logExtraction: {
+            docsLimit: DOCS_LIMIT,
+          },
+        },
+      });
+      await clearEntityStoreIndices(esClient);
+    });
+
+    apiTest(
+      'Should run CCS extraction for host and write to updates then latest index',
+      async ({ apiClient, esClient }) => {
+        await createCcsTestLogsIndex(esClient);
+
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:00:01Z',
+          host: { name: 'name-a1', architecture: 'x86_64', entity: { sub_type: 'bare-metal' } },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:05:00Z',
+          host: { name: 'name-a1', architecture: 'aarch64', entity: { sub_type: 'vm' } },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:10:00Z',
+          host: { name: 'name-a1', architecture: 'arm64', entity: { sub_type: 'container' } },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:15:00Z',
+          host: { id: 'host-id-b', name: 'server-b' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:20:00Z',
+          host: { hostname: 'server-c' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:25:00Z',
+          host: { name: 'server-d', domain: 'example.com', hostname: 'server-d-hostname' },
+        });
+
+        const extractResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_CCS_EXTRACT_TO_UPDATES('host'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              indexPatterns: [CCS_TEST_LOGS_INDEX],
+              fromDateISO: FROM_DATE,
+              toDateISO: TO_DATE,
+              docsLimit: DOCS_LIMIT,
+            },
+          }
+        );
+        expect(extractResponse.statusCode).toBe(200);
+        expect(extractResponse.body).toMatchObject({ count: 4, pages: 2 });
+
+        const logExtractionResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('host'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              fromDateISO: TO_DATE,
+              toDateISO: MAX_DATE_OF_UPDATES,
+            },
+          }
+        );
+        expect(logExtractionResponse.statusCode).toBe(200);
+        expect(logExtractionResponse.body.success).toBe(true);
+
+        await esClient.indices.refresh({ index: LATEST_ALIAS });
+
+        const latestSearchResponse = await esClient.search({
+          index: LATEST_ALIAS,
+          size: 100,
+          query: {
+            bool: {
+              filter: [
+                { term: { 'entity.EngineMetadata.Type': 'host' } },
+                {
+                  terms: {
+                    'entity.id': [
+                      'host:name-a1',
+                      'host:host-id-b',
+                      'host:server-c',
+                      'host:server-d',
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        const latestHits = latestSearchResponse.hits.hits as Array<{
+          _source: Record<string, unknown>;
+        }>;
+        expect(latestHits).toHaveLength(4);
+
+        const byId = Object.fromEntries(
+          latestHits.map((h) => [get(h._source, ['entity', 'id']), h._source])
+        );
+
+        const entityA = byId['host:name-a1'] as Record<string, unknown>;
+        expect(entityA).toBeDefined();
+        expect(get(entityA, ['entity', 'name'])).toBe('name-a1');
+        expect(get(entityA, ['entity', 'sub_type'])).toBe('container');
+
+        const hostArchitectureA = get(entityA, ['host', 'architecture']);
+        expect(Array.isArray(hostArchitectureA)).toBe(true);
+        expect((hostArchitectureA as string[]).sort()).toStrictEqual([
+          'aarch64',
+          'arm64',
+          'x86_64',
+        ]);
+
+        const entityB = byId['host:host-id-b'] as Record<string, unknown>;
+        expect(entityB).toBeDefined();
+        expect(get(entityB, ['entity', 'name'])).toBe('server-b');
+
+        const entityC = byId['host:server-c'] as Record<string, unknown>;
+        expect(entityC).toBeDefined();
+
+        const entityD = byId['host:server-d'] as Record<string, unknown>;
+        expect(entityD).toBeDefined();
+      }
+    );
+
+    apiTest(
+      'Should run CCS extraction for user and write to updates then latest index',
+      async ({ apiClient, esClient }) => {
+        await createCcsTestLogsIndex(esClient);
+
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:30:00Z',
+          user: { name: 'alice', domain: 'elastic.co' },
+          event: { kind: 'asset', module: 'entityanalytics_ad' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:35:00Z',
+          user: { email: 'bob@email.com', id: 'u2', name: 'bob' },
+          event: { kind: 'asset', module: 'aws' },
+        });
+
+        // Shared module user
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:35:01Z',
+          user: { name: 'romulo.farias' },
+          event: { kind: 'asset', module: 'okta' },
+        });
+
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:35:01Z',
+          user: { name: 'romulo.farias' },
+          event: { kind: 'asset', module: 'entityanalytics_okta' },
+        });
+
+        // User with two different data_stream.dataset values (no event.module); both resolve to okta
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:35:02Z',
+          user: { name: 'cecilia' },
+          event: { kind: 'asset' },
+          data_stream: { dataset: 'entityanalytics_okta.users' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:35:03Z',
+          user: { name: 'cecilia' },
+          event: { kind: 'asset' },
+          data_stream: { dataset: 'okta.logs' },
+        });
+
+        // User with empty event.module and data_stream.dataset → namespace fallback 'unknown'
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:35:04Z',
+          user: { name: 'flora' },
+          event: { kind: 'asset', module: '' },
+          data_stream: { dataset: '' },
+        });
+
+        const extractResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_CCS_EXTRACT_TO_UPDATES('user'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              indexPatterns: [CCS_TEST_LOGS_INDEX],
+              fromDateISO: FROM_DATE,
+              toDateISO: TO_DATE,
+              docsLimit: DOCS_LIMIT,
+            },
+          }
+        );
+        expect(extractResponse.statusCode).toBe(200);
+        expect(extractResponse.body).toMatchObject({ count: 5, pages: 3 });
+
+        const logExtractionResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('user'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              fromDateISO: TO_DATE,
+              toDateISO: MAX_DATE_OF_UPDATES,
+            },
+          }
+        );
+        expect(logExtractionResponse.statusCode).toBe(200);
+        expect(logExtractionResponse.body.success).toBe(true);
+
+        await esClient.indices.refresh({ index: LATEST_ALIAS });
+
+        const latestSearchResponse = await esClient.search({
+          index: LATEST_ALIAS,
+          size: 100,
+          query: {
+            bool: {
+              filter: [
+                { term: { 'entity.EngineMetadata.Type': 'user' } },
+                {
+                  terms: {
+                    'entity.id': [
+                      'user:alice@elastic.co@active_directory',
+                      'user:bob@email.com@aws',
+                      'user:romulo.farias@okta',
+                      'user:cecilia@okta',
+                      'user:flora@unknown',
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        const byId = Object.fromEntries(
+          latestSearchResponse.hits.hits.map((h) => [get(h._source, ['entity', 'id']), h._source])
+        );
+
+        const entityA = byId['user:alice@elastic.co@active_directory'];
+        expect(entityA).toBeDefined();
+        expect(get(entityA, ['entity', 'name'])).toBe('alice');
+        expect(get(entityA, ['entity', 'namespace'])).toBe('active_directory');
+        expect(get(entityA, ['user', 'domain'])).toBe('elastic.co');
+        expect(get(entityA, ['event', 'kind'])).toBe('asset');
+
+        const entityB = byId['user:bob@email.com@aws'];
+        expect(entityB).toBeDefined();
+        expect(get(entityB, ['entity', 'name'])).toBe('bob');
+        expect(get(entityB, ['entity', 'namespace'])).toBe('aws');
+        expect(get(entityB, ['user', 'email'])).toBe('bob@email.com');
+        expect(get(entityB, ['event', 'kind'])).toBe('asset');
+
+        const entityC = byId['user:romulo.farias@okta'];
+        expect(entityC).toBeDefined();
+        expect(get(entityC, ['entity', 'name'])).toBe('romulo.farias');
+        expect(get(entityC, ['entity', 'namespace'])).toBe('okta');
+        expect(get(entityC, ['event', 'module'])).toMatchObject(['entityanalytics_okta', 'okta']);
+        expect(get(entityC, ['event', 'kind'])).toBe('asset');
+
+        const entityD = byId['user:cecilia@okta'];
+        expect(entityD).toBeDefined();
+        expect(get(entityD, ['entity', 'name'])).toBe('cecilia');
+        expect(get(entityD, ['entity', 'namespace'])).toBe('okta');
+        expect(get(entityD, ['event', 'kind'])).toBe('asset');
+        expect(get(entityD, ['data_stream', 'dataset'])).toMatchObject([
+          'entityanalytics_okta.users',
+          'okta.logs',
+        ]);
+
+        const entityE = byId['user:flora@unknown'];
+        expect(entityE).toBeDefined();
+        expect(get(entityE, ['entity', 'name'])).toBe('flora');
+        expect(get(entityE, ['entity', 'namespace'])).toBe('unknown');
+        expect(get(entityE, ['event', 'kind'])).toBe('asset');
+      }
+    );
+
+    apiTest(
+      'Should run CCS extraction for service and write to updates then latest index',
+      async ({ apiClient, esClient }) => {
+        await createCcsTestLogsIndex(esClient);
+
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:40:00Z',
+          service: { name: 'svc-a', version: '1.0' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:45:00Z',
+          service: { name: 'svc-b' },
+        });
+
+        const extractResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_CCS_EXTRACT_TO_UPDATES('service'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              indexPatterns: [CCS_TEST_LOGS_INDEX],
+              fromDateISO: FROM_DATE,
+              toDateISO: TO_DATE,
+              docsLimit: DOCS_LIMIT,
+            },
+          }
+        );
+        expect(extractResponse.statusCode).toBe(200);
+        expect(extractResponse.body).toMatchObject({ count: 2, pages: 1 });
+
+        const logExtractionResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('service'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              fromDateISO: TO_DATE,
+              toDateISO: MAX_DATE_OF_UPDATES,
+            },
+          }
+        );
+        expect(logExtractionResponse.statusCode).toBe(200);
+        expect(logExtractionResponse.body.success).toBe(true);
+
+        await esClient.indices.refresh({ index: LATEST_ALIAS });
+
+        const latestSearchResponse = await esClient.search({
+          index: LATEST_ALIAS,
+          size: 100,
+          query: {
+            bool: {
+              filter: [
+                { term: { 'entity.EngineMetadata.Type': 'service' } },
+                {
+                  terms: {
+                    'entity.id': ['service:svc-a', 'service:svc-b'],
+                  },
+                },
+              ],
+            },
+          },
+          sort: 'entity.id:asc',
+        });
+
+        expect(latestSearchResponse.hits.hits).toHaveLength(2);
+        const hits = latestSearchResponse.hits.hits;
+        expect(get(hits[0], ['_source', 'entity', 'id'])).toBe('service:svc-a');
+        expect(get(hits[0], ['_source', 'service', 'name'])).toBe('svc-a');
+        expect(get(hits[0], ['_source', 'service', 'version'])).toBe('1.0');
+
+        expect(get(hits[1], ['_source', 'entity', 'id'])).toBe('service:svc-b');
+        expect(get(hits[1], ['_source', 'service', 'name'])).toBe('svc-b');
+      }
+    );
+
+    apiTest(
+      'Should run CCS extraction for generic and write to updates then latest index',
+      async ({ apiClient, esClient }) => {
+        await createCcsTestLogsIndex(esClient);
+
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:50:00Z',
+          entity: { id: 'gen-1', name: 'Generic One' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:55:00Z',
+          entity: { id: 'gen-2', name: 'Generic Two' },
+        });
+
+        const extractResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_CCS_EXTRACT_TO_UPDATES('generic'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              indexPatterns: [CCS_TEST_LOGS_INDEX],
+              fromDateISO: FROM_DATE,
+              toDateISO: TO_DATE,
+              docsLimit: DOCS_LIMIT,
+            },
+          }
+        );
+        expect(extractResponse.statusCode).toBe(200);
+        expect(extractResponse.body).toMatchObject({ count: 2, pages: 1 });
+
+        const logExtractionResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('generic'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              fromDateISO: TO_DATE,
+              toDateISO: MAX_DATE_OF_UPDATES,
+            },
+          }
+        );
+        expect(logExtractionResponse.statusCode).toBe(200);
+        expect(logExtractionResponse.body.success).toBe(true);
+
+        await esClient.indices.refresh({ index: LATEST_ALIAS });
+
+        const latestSearchResponse = await esClient.search({
+          index: LATEST_ALIAS,
+          size: 100,
+          query: {
+            bool: {
+              filter: [
+                { term: { 'entity.EngineMetadata.Type': 'generic' } },
+                {
+                  terms: {
+                    'entity.id': ['gen-1', 'gen-2'],
+                  },
+                },
+              ],
+            },
+          },
+          sort: 'entity.id:asc',
+        });
+
+        expect(latestSearchResponse.hits.hits).toHaveLength(2);
+        const hits = latestSearchResponse.hits.hits;
+        expect(get(hits[0], ['_source', 'entity', 'id'])).toBe('gen-1');
+        expect(get(hits[0], ['_source', 'entity', 'name'])).toBe('Generic One');
+
+        expect(get(hits[1], ['_source', 'entity', 'id'])).toBe('gen-2');
+        expect(get(hits[1], ['_source', 'entity', 'name'])).toBe('Generic Two');
+      }
+    );
+
+    apiTest(
+      'Should paginate correctly across outer log-slice loop and inner entity-page loop',
+      async ({ apiClient, esClient }) => {
+        await createCcsTestLogsIndex(esClient);
+
+        // 6 distinct hosts: one doc each. With maxLogsPerPage=3 and docsLimit=2:
+        // - Outer loop: 2 slices (3 raw docs each)
+        // - Inner loop: 2 entity pages per slice (2 + 1 entities each)
+        // Total: count=6, pages=4
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:00:00Z',
+          host: { name: 'pagination-host-1' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:01:00Z',
+          host: { name: 'pagination-host-2' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:02:00Z',
+          host: { name: 'pagination-host-3' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:03:00Z',
+          host: { name: 'pagination-host-4' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:04:00Z',
+          host: { name: 'pagination-host-5' },
+        });
+        await ingestDoc(esClient, CCS_TEST_LOGS_INDEX, {
+          '@timestamp': '2026-02-25T10:05:00Z',
+          host: { name: 'pagination-host-6' },
+        });
+
+        const extractResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_CCS_EXTRACT_TO_UPDATES('host'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              indexPatterns: [CCS_TEST_LOGS_INDEX],
+              fromDateISO: FROM_DATE,
+              toDateISO: TO_DATE,
+              docsLimit: DOCS_LIMIT,
+              maxLogsPerPage: 3,
+            },
+          }
+        );
+        expect(extractResponse.statusCode).toBe(200);
+        expect(extractResponse.body).toMatchObject({ count: 6, pages: 4 });
+
+        // Ensure documents written by CCS extraction are visible before reading them
+        await esClient.indices.refresh({ index: UPDATES_INDEX });
+
+        const logExtractionResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('host'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              fromDateISO: TO_DATE,
+              toDateISO: MAX_DATE_OF_UPDATES,
+            },
+          }
+        );
+        expect(logExtractionResponse.statusCode).toBe(200);
+        expect(
+          logExtractionResponse.body,
+          `Log extraction failed: ${JSON.stringify(logExtractionResponse.body)}`
+        ).toMatchObject({ success: true });
+
+        await esClient.indices.refresh({ index: LATEST_ALIAS });
+
+        const latestSearchResponse = await esClient.search({
+          index: LATEST_ALIAS,
+          size: 100,
+          query: {
+            bool: {
+              filter: [
+                { term: { 'entity.EngineMetadata.Type': 'host' } },
+                {
+                  terms: {
+                    'entity.id': [
+                      'host:pagination-host-1',
+                      'host:pagination-host-2',
+                      'host:pagination-host-3',
+                      'host:pagination-host-4',
+                      'host:pagination-host-5',
+                      'host:pagination-host-6',
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        expect(latestSearchResponse.hits.hits).toHaveLength(6);
+        const entityIds = latestSearchResponse.hits.hits.map((h) =>
+          get(h._source, ['entity', 'id'])
+        );
+        expect(entityIds.sort()).toStrictEqual([
+          'host:pagination-host-1',
+          'host:pagination-host-2',
+          'host:pagination-host-3',
+          'host:pagination-host-4',
+          'host:pagination-host-5',
+          'host:pagination-host-6',
+        ]);
+      }
+    );
+  }
+);

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_extraction_paginated.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_extraction_paginated.spec.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import {
+  PUBLIC_HEADERS,
+  INTERNAL_HEADERS,
+  ENTITY_STORE_ROUTES,
+  ENTITY_STORE_TAGS,
+  LATEST_ALIAS,
+} from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+import { assertEntitiesEqual, expectedHostEntities } from '../fixtures/entity_extraction_expected';
+import { clearEntityStoreIndices } from '../fixtures/helpers';
+
+apiTest.describe(
+  'Entity Store Logs Extraction with pagination (entity pages + maxLogsPerPage)',
+  { tag: ENTITY_STORE_TAGS },
+  () => {
+    let defaultHeaders: Record<string, string>;
+    let internalHeaders: Record<string, string>;
+
+    apiTest.beforeAll(async ({ samlAuth, apiClient, esArchiver, kbnClient }) => {
+      const credentials = await samlAuth.asInteractiveUser('admin');
+      defaultHeaders = {
+        ...credentials.cookieHeader,
+        ...PUBLIC_HEADERS,
+      };
+      internalHeaders = {
+        ...credentials.cookieHeader,
+        ...INTERNAL_HEADERS,
+      };
+
+      // enable feature flag
+      await kbnClient.uiSettings.update({
+        [FF_ENABLE_ENTITY_STORE_V2]: true,
+      });
+
+      // Install the entity store
+      const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {
+          logExtraction: {
+            docsLimit: 5,
+          },
+        },
+      });
+      expect(response.statusCode).toBe(201);
+
+      await esArchiver.loadIfNeeded(
+        'x-pack/solutions/security/plugins/entity_store/test/scout/api/es_archives/updates'
+      );
+    });
+
+    apiTest.afterAll(async ({ apiClient, esClient }) => {
+      const response = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+      expect(response.statusCode).toBe(200);
+      await clearEntityStoreIndices(esClient);
+    });
+
+    apiTest(
+      'Should extract host with entity pagination (docsLimit 5, wide log slices)',
+      async ({ apiClient, esClient, log }) => {
+        const expectedPageCount = 5;
+
+        // Clear any host entities left by previous test runs to prevent cross-test contamination.
+        await esClient.deleteByQuery({
+          index: LATEST_ALIAS,
+          refresh: true,
+          query: { bool: { filter: { term: { 'entity.EngineMetadata.Type': 'host' } } } },
+        });
+
+        const extractionResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('host'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              fromDateISO: '2026-01-20T11:00:00Z',
+              toDateISO: '2026-01-20T13:00:00Z',
+            },
+          }
+        );
+        expect(extractionResponse.statusCode).toBe(200);
+        expect(extractionResponse.body.success).toBe(true);
+        expect(extractionResponse.body.count).toBe(expectedHostEntities.length);
+        expect(extractionResponse.body.pages).toBe(expectedPageCount);
+
+        const entities = await esClient.search({
+          index: LATEST_ALIAS,
+          query: {
+            bool: {
+              filter: {
+                term: { 'entity.EngineMetadata.Type': 'host' },
+              },
+            },
+          },
+          size: 1000, // a lot just to be sure we are not capping it
+        });
+
+        assertEntitiesEqual(expectedHostEntities, entities.hits.hits, (msg) => log.error(msg));
+      }
+    );
+
+    apiTest(
+      'Should run more ESQL pages when maxLogsPerPage narrows log slices',
+      async ({ apiClient, esClient, log }) => {
+        const minimumPagesWithEntityPaginationOnly = 4;
+
+        // Clear any host entities left by the previous test or prior runs to prevent interference.
+        await esClient.deleteByQuery({
+          index: LATEST_ALIAS,
+          refresh: true,
+          query: { bool: { filter: { term: { 'entity.EngineMetadata.Type': 'host' } } } },
+        });
+
+        const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+          headers: defaultHeaders,
+          responseType: 'json',
+          body: { logExtraction: { maxLogsPerPage: 2 } },
+        });
+        expect(update.statusCode).toBe(200);
+
+        const extractionResponse = await apiClient.post(
+          ENTITY_STORE_ROUTES.internal.FORCE_LOG_EXTRACTION('host'),
+          {
+            headers: internalHeaders,
+            responseType: 'json',
+            body: {
+              fromDateISO: '2026-01-20T11:00:00Z',
+              toDateISO: '2026-01-20T13:00:00Z',
+            },
+          }
+        );
+        expect(extractionResponse.statusCode).toBe(200);
+        expect(extractionResponse.body.success).toBe(true);
+        // We process some entities twice because they didn't fall in the same logs page
+        expect(extractionResponse.body.count).toBeGreaterThan(expectedHostEntities.length);
+        expect(extractionResponse.body.pages).toBeGreaterThan(minimumPagesWithEntityPaginationOnly);
+
+        const entities = await esClient.search({
+          index: LATEST_ALIAS,
+          query: {
+            bool: {
+              filter: {
+                term: { 'entity.EngineMetadata.Type': 'host' },
+              },
+            },
+          },
+          sort: '@timestamp:asc,entity.id:asc',
+          size: 1000,
+        });
+
+        assertEntitiesEqual(expectedHostEntities, entities.hits.hits, (msg) => log.error(msg));
+      }
+    );
+  }
+);

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import {
+  PUBLIC_HEADERS,
+  INTERNAL_HEADERS,
+  ENTITY_STORE_ROUTES,
+  ENTITY_STORE_TAGS,
+} from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2, type GetEntityMaintainersResponse } from '../../../../common';
+
+apiTest.describe('Entity Store install / update API tests', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+  let internalHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = {
+      ...credentials.cookieHeader,
+      ...PUBLIC_HEADERS,
+    };
+    internalHeaders = {
+      ...credentials.cookieHeader,
+      ...INTERNAL_HEADERS,
+    };
+  });
+
+  // Always uninstall after each test so a failed install mid-test doesn't
+  // pollute the next test with an already-installed store.
+  apiTest.afterEach(async ({ apiClient }) => {
+    await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+  });
+
+  apiTest(
+    'Should install the entity store happy path with feature flag enabled',
+    async ({ apiClient, kbnClient }) => {
+      await kbnClient.uiSettings.update({
+        [FF_ENABLE_ENTITY_STORE_V2]: true,
+      });
+
+      const install = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+      expect(install.statusCode).toBe(201);
+
+      const maintainersResponse = await apiClient.get(
+        ENTITY_STORE_ROUTES.internal.ENTITY_MAINTAINERS_GET,
+        {
+          headers: internalHeaders,
+          responseType: 'json',
+        }
+      );
+      expect(maintainersResponse.statusCode).toBe(200);
+      const { maintainers } = maintainersResponse.body as GetEntityMaintainersResponse;
+      expect(maintainers.length).toBeGreaterThan(0);
+      expect(maintainers.every((m) => m.taskStatus === 'started')).toBe(true);
+
+      const uninstall = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+      expect(uninstall.statusCode).toBe(200);
+    }
+  );
+
+  apiTest('Should fail with feature flag disabled', async ({ apiClient, kbnClient }) => {
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: false,
+    });
+
+    const install = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(install.statusCode).toBe(403);
+  });
+
+  apiTest('logExtraction is not mandatory on install', async ({ apiClient, kbnClient }) => {
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+
+    const install = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(install.statusCode).toBe(201);
+
+    await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+  });
+
+  apiTest('Update on uninstalled store should return 404', async ({ apiClient, kbnClient }) => {
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+
+    await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+
+    const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: { logExtraction: { frequency: '1m' } },
+    });
+    expect(update.statusCode).toBe(404);
+  });
+
+  apiTest('logExtraction is mandatory on update', async ({ apiClient, kbnClient }) => {
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+
+    await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+
+    const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(update.statusCode).toBe(400);
+
+    await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+  });
+
+  apiTest(
+    'Update should change installed logExtraction params',
+    async ({ apiClient, kbnClient }) => {
+      await kbnClient.uiSettings.update({
+        [FF_ENABLE_ENTITY_STORE_V2]: true,
+      });
+
+      await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { logExtraction: { delay: '2m' } },
+      });
+
+      const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { logExtraction: { delay: '5m' } },
+      });
+      expect(update.statusCode).toBe(200);
+
+      const status = await apiClient.get(ENTITY_STORE_ROUTES.public.STATUS, {
+        headers: defaultHeaders,
+        responseType: 'json',
+      });
+      expect(status.statusCode).toBe(200);
+      const engines = (status.body as { engines: Array<{ delay: string }> }).engines;
+      expect(engines.length).toBeGreaterThan(0);
+      expect(engines[0].delay).toBe('5m');
+
+      await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+    }
+  );
+
+  apiTest(
+    'Update should not change logExtraction properties that were not included in the update',
+    async ({ apiClient, kbnClient }) => {
+      await kbnClient.uiSettings.update({
+        [FF_ENABLE_ENTITY_STORE_V2]: true,
+      });
+
+      await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { logExtraction: { delay: '2m', frequency: '1m' } },
+      });
+
+      const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { logExtraction: { delay: '5m' } },
+      });
+      expect(update.statusCode).toBe(200);
+
+      const status = await apiClient.get(ENTITY_STORE_ROUTES.public.STATUS, {
+        headers: defaultHeaders,
+        responseType: 'json',
+      });
+      expect(status.statusCode).toBe(200);
+      const engines = (status.body as { engines: Array<{ delay: string; frequency: string }> })
+        .engines;
+      expect(engines.length).toBeGreaterThan(0);
+      expect(engines[0].delay).toBe('5m');
+      expect(engines[0].frequency).toBe('1m');
+
+      await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/start_stop.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/start_stop.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-security/api';
+import { apiTest } from '@kbn/scout-security';
+import { PUBLIC_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+
+/**
+ * Polls for a task saved object to exist, retrying until it appears or timeout.
+ * Task registration after start/install is asynchronous so a direct read can 404.
+ */
+const waitForTask = async (
+  kbnClient: Parameters<Parameters<typeof apiTest>[2]>[0]['kbnClient'],
+  taskId: string,
+  { timeoutMs = 15_000, intervalMs = 500 } = {}
+) => {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return await kbnClient.savedObjects.get({ type: 'task', id: taskId });
+    } catch (err) {
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+  throw lastError ?? new Error(`Task ${taskId} not found after ${timeoutMs}ms`);
+};
+
+/**
+ * Task ID format used by the entity store extract entity task.
+ * Must match server/tasks/extract_entity_task.ts getTaskId(entityType, namespace).
+ * Default namespace is 'default' when request has no space context.
+ */
+const getExtractEntityTaskId = (entityType: string, namespace: string = 'default'): string =>
+  `entity_store:v2:extract_entity_task:${entityType}:${namespace}`;
+
+apiTest.describe('Entity Store stop/start API tests', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = {
+      ...credentials.cookieHeader,
+      ...PUBLIC_HEADERS,
+    };
+  });
+
+  apiTest(
+    'Should stop and start the extract entity task after install',
+    async ({ apiClient, kbnClient }) => {
+      await kbnClient.uiSettings.update({
+        [FF_ENABLE_ENTITY_STORE_V2]: true,
+      });
+
+      const entityTypes = ['user'] as const;
+      const taskId = getExtractEntityTaskId('user');
+
+      // 1. Install entity store for user only
+      const installResponse = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { entityTypes },
+      });
+      expect(installResponse.statusCode).toBe(201);
+
+      // 2. Verify the task for the entity is running (scheduled).
+      // Task registration after install is async, so poll until it appears.
+      let task = await waitForTask(kbnClient, taskId);
+      expect(task).toBeDefined();
+      expect(task.id).toBe(taskId);
+      expect(task.attributes?.taskType).toBe('entity_store:v2:extract_entity_task:user');
+
+      // 3. Trigger stop endpoint
+      const stopResponse = await apiClient.put(ENTITY_STORE_ROUTES.public.STOP, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { entityTypes },
+      });
+      expect(stopResponse.statusCode).toBe(200);
+
+      // 4. Verify the task has been stopped (task removed from task manager)
+      let taskNotFoundAfterStop = false;
+      try {
+        await kbnClient.savedObjects.get({ type: 'task', id: taskId });
+      } catch {
+        taskNotFoundAfterStop = true;
+      }
+      expect(taskNotFoundAfterStop).toBe(true);
+
+      // 5. Trigger start endpoint
+      const startResponse = await apiClient.put(ENTITY_STORE_ROUTES.public.START, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { entityTypes },
+      });
+      expect(startResponse.statusCode).toBe(200);
+
+      // 6. Verify the task is running again.
+      // Task re-registration after start is async, so poll until it appears.
+      task = await waitForTask(kbnClient, taskId);
+      expect(task).toBeDefined();
+      expect(task.id).toBe(taskId);
+      expect(task.attributes?.taskType).toBe('entity_store:v2:extract_entity_task:user');
+
+      // 7. Trigger uninstall endpoint
+      const uninstallResponse = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { entityTypes },
+      });
+      expect(uninstallResponse.statusCode).toBe(200);
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/uninstall.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/uninstall.spec.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import {
+  PUBLIC_HEADERS,
+  ENTITY_STORE_ROUTES,
+  ENTITY_STORE_TAGS,
+  LATEST_INDEX,
+} from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+
+type ApiWorkerFixtures = Parameters<Parameters<typeof apiTest>[2]>[0];
+
+const HISTORY_SNAPSHOT_TASK_ID = `entity_store:v2:history_snapshot_task:default`;
+const STATUS_REPORT_TASK_ID = `entity_store:v2:status_report_task:default`;
+
+const getExtractEntityTaskId = (entityType: string) =>
+  `entity_store:v2:extract_entity_task:${entityType}:default`;
+
+apiTest.describe('Entity Store uninstall', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth, kbnClient }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = {
+      ...credentials.cookieHeader,
+      ...PUBLIC_HEADERS,
+    };
+    await kbnClient.uiSettings.update({ [FF_ENABLE_ENTITY_STORE_V2]: true });
+  });
+
+  const install = async (
+    apiClient: ApiWorkerFixtures['apiClient'],
+    body: Record<string, unknown> = {}
+  ) => {
+    const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body,
+    });
+    expect(response.statusCode).toBe(201);
+  };
+
+  const uninstall = async (
+    apiClient: ApiWorkerFixtures['apiClient'],
+    body: Record<string, unknown> = {}
+  ) => {
+    const response = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body,
+    });
+    expect(response.statusCode).toBe(200);
+  };
+
+  /**
+   * Polls until the task saved object is gone (404), retrying to handle async task deletion.
+   */
+  const assertTaskGone = async (
+    kbnClient: ApiWorkerFixtures['kbnClient'],
+    taskId: string,
+    { timeoutMs = 15_000, intervalMs = 500 } = {}
+  ) => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        await kbnClient.savedObjects.get({ type: 'task', id: taskId });
+        // Task still exists — wait and retry
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('404')) {
+          return; // Task is gone as expected
+        }
+        throw err; // Unexpected error
+      }
+    }
+    throw new Error(`Task ${taskId} still exists after ${timeoutMs}ms — expected it to be deleted`);
+  };
+
+  apiTest('stops the history snapshot task on uninstall', async ({ apiClient, kbnClient }) => {
+    await install(apiClient, { historySnapshot: { frequency: '24h' } });
+
+    const task = await kbnClient.savedObjects.get({
+      type: 'task',
+      id: HISTORY_SNAPSHOT_TASK_ID,
+    });
+    expect(task.id).toBe(HISTORY_SNAPSHOT_TASK_ID);
+
+    await uninstall(apiClient);
+
+    await assertTaskGone(kbnClient, HISTORY_SNAPSHOT_TASK_ID);
+  });
+
+  apiTest('stops the status report task on uninstall', async ({ apiClient, kbnClient }) => {
+    await install(apiClient);
+
+    const task = await kbnClient.savedObjects.get({
+      type: 'task',
+      id: STATUS_REPORT_TASK_ID,
+    });
+    expect(task.id).toBe(STATUS_REPORT_TASK_ID);
+
+    await uninstall(apiClient);
+
+    await assertTaskGone(kbnClient, STATUS_REPORT_TASK_ID);
+  });
+
+  apiTest('stops extract entity tasks on uninstall', async ({ apiClient, kbnClient }) => {
+    const entityTypes = ['user', 'host'] as const;
+    await install(apiClient, { entityTypes });
+
+    for (const entityType of entityTypes) {
+      const taskId = getExtractEntityTaskId(entityType);
+      const task = await kbnClient.savedObjects.get({ type: 'task', id: taskId });
+      expect(task.id).toBe(taskId);
+    }
+
+    await uninstall(apiClient, { entityTypes });
+
+    for (const entityType of entityTypes) {
+      await assertTaskGone(kbnClient, getExtractEntityTaskId(entityType));
+    }
+  });
+
+  apiTest('deletes the latest entities index on uninstall', async ({ apiClient, esClient }) => {
+    await install(apiClient);
+
+    const existsBefore = await esClient.indices.exists({ index: LATEST_INDEX });
+    expect(existsBefore).toBe(true);
+
+    await uninstall(apiClient);
+
+    const existsAfter = await esClient.indices.exists({ index: LATEST_INDEX });
+    expect(existsAfter).toBe(false);
+  });
+
+  apiTest('uninstall is a no-op when entity store is not installed', async ({ apiClient }) => {
+    const response = await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+    expect(response.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes flakiness in 5 Scout API test specs for the Entity Store, identified as blockers for the Security quality gate (#260448).

### Root causes & fixes

| Spec | Issue(s) | Root cause | Fix |
|---|---|---|---|
| `ccs_logs_extraction.spec.ts` | #267869 | `FORCE_CCS_EXTRACT_TO_UPDATES` writes to the updates index but ES hadn't refreshed it before `FORCE_LOG_EXTRACTION` read from it | Add `esClient.indices.refresh({ index: UPDATES_INDEX })` between the two calls |
| `start_stop.spec.ts` | #254547 | Task Manager registers tasks asynchronously; immediate `savedObjects.get` after `start` returns 404 | Replace direct reads with a `waitForTask` polling helper (500 ms / 15 s) |
| `uninstall.spec.ts` | #268074, #268075 | Task deletion after `uninstall` is async; `assertTaskGone` checked immediately | Convert to a polling loop (500 ms / 15 s) |
| `install_update.spec.ts` | #266337, #266338, #268262, #268263 | A failed mid-test assertion left the store installed, polluting subsequent tests | Add `afterEach` that always calls `uninstall` (no-op when not installed) |
| `entity_extraction_paginated.spec.ts` | #263067, #263926 | Host entities from other tests lingered in `LATEST_ALIAS` and caused `assertEntitiesEqual` to see wrong IDs | Delete all host entities from `LATEST_ALIAS` at the start of each test |

## Test plan

- [ ] Run the flaky test suites via CI with `@elasticmachine run flaky-test-runner` to validate reduction in flake rate

Made with [Cursor](https://cursor.com)