### PR TITLE
[APM] Add missing OpenAPI examples to public APIs

### DIFF
--- a/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
+++ b/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
@@ -1,4 +1,4 @@
 {
-  "./oas_docs/output/kibana.yaml": 112,
-  "./oas_docs/output/kibana.serverless.yaml": 94
+  "./oas_docs/output/kibana.yaml": 56,
+  "./oas_docs/output/kibana.serverless.yaml": 53
 }

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/bundled.json
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/bundled.json
@@ -80,6 +80,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -90,6 +95,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -100,6 +110,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/403_response"
+                },
+                "examples": {
+                  "forbiddenResponse": {
+                    "$ref": "#/components/examples/error_403_response"
+                  }
                 }
               }
             }
@@ -110,6 +125,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/500_response"
+                },
+                "examples": {
+                  "internalServerErrorResponse": {
+                    "$ref": "#/components/examples/error_500_response"
+                  }
                 }
               }
             }
@@ -177,6 +197,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/annotation_search_response"
+                },
+                "examples": {
+                  "getAnnotationResponse1": {
+                    "$ref": "#/components/examples/annotation_search_get_200_response1"
+                  }
                 }
               }
             }
@@ -187,6 +212,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -197,6 +227,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -207,6 +242,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/500_response"
+                },
+                "examples": {
+                  "internalServerErrorResponse": {
+                    "$ref": "#/components/examples/error_500_response"
+                  }
                 }
               }
             }
@@ -276,6 +316,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -286,6 +331,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -296,6 +346,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/403_response"
+                },
+                "examples": {
+                  "forbiddenResponse": {
+                    "$ref": "#/components/examples/error_403_response"
+                  }
                 }
               }
             }
@@ -306,6 +361,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -354,6 +414,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -364,6 +429,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -374,6 +444,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -432,6 +507,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -442,6 +522,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -452,6 +537,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/403_response"
+                },
+                "examples": {
+                  "forbiddenResponse": {
+                    "$ref": "#/components/examples/error_403_response"
+                  }
                 }
               }
             }
@@ -462,6 +552,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -530,6 +625,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -540,6 +640,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -550,6 +655,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/403_response"
+                },
+                "examples": {
+                  "forbiddenResponse": {
+                    "$ref": "#/components/examples/error_403_response"
+                  }
                 }
               }
             }
@@ -560,6 +670,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -620,6 +735,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -630,6 +750,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -640,6 +765,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -701,6 +831,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -711,6 +846,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -721,6 +861,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -772,6 +917,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -782,6 +932,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -792,6 +947,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -829,6 +989,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/service_agent_name_response"
+                },
+                "examples": {
+                  "getAgentNameForServiceResponse1": {
+                    "$ref": "#/components/examples/service_agent_name_get_200_response1"
+                  }
                 }
               }
             }
@@ -839,6 +1004,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -849,6 +1019,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -859,6 +1034,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -917,6 +1097,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -927,6 +1112,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -937,6 +1127,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/500_response"
+                },
+                "examples": {
+                  "internalServerErrorResponse": {
+                    "$ref": "#/components/examples/error_500_response"
+                  }
                 }
               }
             }
@@ -947,6 +1142,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/501_response"
+                },
+                "examples": {
+                  "notImplementedResponse": {
+                    "$ref": "#/components/examples/error_501_response"
+                  }
                 }
               }
             }
@@ -980,6 +1180,11 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/upload_source_map_object"
+              },
+              "examples": {
+                "uploadSourceMapRequest": {
+                  "$ref": "#/components/examples/source_maps_upload_request1"
+                }
               }
             }
           }
@@ -1006,6 +1211,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -1016,6 +1226,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -1026,6 +1241,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/403_response"
+                },
+                "examples": {
+                  "forbiddenResponse": {
+                    "$ref": "#/components/examples/error_403_response"
+                  }
                 }
               }
             }
@@ -1036,6 +1256,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/500_response"
+                },
+                "examples": {
+                  "internalServerErrorResponse": {
+                    "$ref": "#/components/examples/error_500_response"
+                  }
                 }
               }
             }
@@ -1046,6 +1271,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/501_response"
+                },
+                "examples": {
+                  "notImplementedResponse": {
+                    "$ref": "#/components/examples/error_501_response"
+                  }
                 }
               }
             }
@@ -1108,6 +1338,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -1118,6 +1353,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -1128,6 +1368,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/403_response"
+                },
+                "examples": {
+                  "forbiddenResponse": {
+                    "$ref": "#/components/examples/error_403_response"
+                  }
                 }
               }
             }
@@ -1138,6 +1383,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/500_response"
+                },
+                "examples": {
+                  "internalServerErrorResponse": {
+                    "$ref": "#/components/examples/error_500_response"
+                  }
                 }
               }
             }
@@ -1148,6 +1398,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/501_response"
+                },
+                "examples": {
+                  "notImplementedResponse": {
+                    "$ref": "#/components/examples/error_501_response"
+                  }
                 }
               }
             }
@@ -1194,6 +1449,16 @@
                     }
                   }
                 }
+              },
+              "examples": {
+                "saveApmServerSchemaRequest": {
+                  "description": "An example request payload for `POST /api/apm/fleet/apm_server_schema`.",
+                  "value": {
+                    "schema": {
+                      "foo": "bar"
+                    }
+                  }
+                }
               }
             }
           }
@@ -1222,6 +1487,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/400_response"
+                },
+                "examples": {
+                  "badRequestResponse": {
+                    "$ref": "#/components/examples/error_400_response"
+                  }
                 }
               }
             }
@@ -1232,6 +1502,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/401_response"
+                },
+                "examples": {
+                  "unauthorizedResponse": {
+                    "$ref": "#/components/examples/error_401_response"
+                  }
                 }
               }
             }
@@ -1242,6 +1517,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/403_response"
+                },
+                "examples": {
+                  "forbiddenResponse": {
+                    "$ref": "#/components/examples/error_403_response"
+                  }
                 }
               }
             }
@@ -1252,6 +1532,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                },
+                "examples": {
+                  "notFoundResponse": {
+                    "$ref": "#/components/examples/error_404_response"
+                  }
                 }
               }
             }
@@ -1988,6 +2273,57 @@
           }
         }
       },
+      "error_400_response": {
+        "description": "An example of a 400 Bad Request response, returned when the request payload or query parameters fail validation.",
+        "value": {
+          "statusCode": 400,
+          "error": "Bad Request",
+          "message": "[request body]: expected value of type [string] but got [undefined]"
+        }
+      },
+      "error_401_response": {
+        "description": "An example of a 401 Unauthorized response, returned when the request is missing valid authentication credentials.",
+        "value": {
+          "statusCode": 401,
+          "error": "Unauthorized",
+          "message": "[security_exception]: missing authentication credentials for REST request"
+        }
+      },
+      "error_403_response": {
+        "description": "An example of a 403 Forbidden response, returned when the authenticated user lacks the required APM and User Experience privileges.",
+        "value": {
+          "statusCode": 403,
+          "error": "Forbidden",
+          "message": "Insufficient privileges to perform this action. The APM and User Experience feature requires `all` privileges."
+        }
+      },
+      "error_500_response": {
+        "description": "An example of a 500 Internal Server Error response, returned when an unexpected error occurs while processing the request.",
+        "value": {
+          "statusCode": 500,
+          "error": "Internal Server Error",
+          "message": "An internal server error occurred. Check the Kibana server logs for details."
+        }
+      },
+      "annotation_search_get_200_response1": {
+        "description": "An example of a successful response from `GET /api/apm/services/{serviceName}/annotation/search`, which returns the annotations associated with a service over the given time range.",
+        "value": {
+          "annotations": [
+            {
+              "type": "version",
+              "id": "opbeans-node@2.0.0",
+              "@timestamp": 1735689600000,
+              "text": "opbeans-node@2.0.0"
+            },
+            {
+              "type": "version",
+              "id": "opbeans-node@2.1.0",
+              "@timestamp": 1736294400000,
+              "text": "opbeans-node@2.1.0"
+            }
+          ]
+        }
+      },
       "annotation_object_post_request1": {
         "description": "Run `POST /api/apm/services/{serviceName}/annotation` to create a deployment annotation for a service.",
         "value": {
@@ -2031,6 +2367,14 @@
               "created": "2020-05-09T02:34:43.937Z"
             }
           }
+        }
+      },
+      "error_404_response": {
+        "description": "An example of a 404 Not Found response, returned when the requested resource does not exist or the feature is not available on the current deployment.",
+        "value": {
+          "statusCode": 404,
+          "error": "Not Found",
+          "message": "Not Found"
         }
       },
       "agent_configuration_intake_object_get_200_response1": {
@@ -2181,6 +2525,12 @@
           ]
         }
       },
+      "service_agent_name_get_200_response1": {
+        "description": "An example of a successful response from `GET /api/apm/settings/agent-configuration/agent_name`, which returns the detected APM agent name for a service.",
+        "value": {
+          "agentName": "nodejs"
+        }
+      },
       "source_maps_get_200_response1": {
         "description": "A successful response from `GET /api/apm/sourcemaps`.",
         "value": {
@@ -2221,6 +2571,23 @@
               "packageName": "apm"
             }
           ]
+        }
+      },
+      "error_501_response": {
+        "description": "An example of a 501 Not Implemented response, returned when the source map feature is not available on the current deployment.",
+        "value": {
+          "statusCode": 501,
+          "error": "Not Implemented",
+          "message": "Not Implemented"
+        }
+      },
+      "source_maps_upload_request1": {
+        "description": "An example of a multipart/form-data request body for `POST /api/apm/sourcemaps`.\nEach field is a separate form part; `sourcemap` is the source map file content (typically uploaded as a file).\n",
+        "value": {
+          "service_name": "opbeans-node",
+          "service_version": "1.0.0",
+          "bundle_filepath": "/test/e2e/general-usecase/bundle.js.map",
+          "sourcemap": "{\"version\":3,\"sources\":[\"bundle.js\"],\"names\":[],\"mappings\":\"AAAA\",\"file\":\"bundle.js\",\"sourcesContent\":[\"console.log('hello');\"]}"
         }
       },
       "source_maps_upload_200_response1": {

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/bundled.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/bundled.yaml
@@ -57,24 +57,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '403':
           description: Forbidden response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/403_response'
+              examples:
+                forbiddenResponse:
+                  $ref: '#/components/examples/error_403_response'
         '500':
           description: Internal Server Error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/500_response'
+              examples:
+                internalServerErrorResponse:
+                  $ref: '#/components/examples/error_500_response'
   /api/apm/services/{serviceName}/annotation/search:
     get:
       summary: Search for annotations
@@ -119,24 +131,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/annotation_search_response'
+              examples:
+                getAnnotationResponse1:
+                  $ref: '#/components/examples/annotation_search_get_200_response1'
         '400':
           description: Bad Request response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '500':
           description: Internal Server Error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/500_response'
+              examples:
+                internalServerErrorResponse:
+                  $ref: '#/components/examples/error_500_response'
   /api/apm/services/{serviceName}/annotation:
     post:
       summary: Create a service annotation
@@ -178,24 +202,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '403':
           description: Forbidden response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/403_response'
+              examples:
+                forbiddenResponse:
+                  $ref: '#/components/examples/error_403_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
       x-codeSamples:
         - lang: Curl
           source: |
@@ -237,18 +273,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
     delete:
       summary: Delete agent configuration
       description: |
@@ -284,24 +329,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '403':
           description: Forbidden response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/403_response'
+              examples:
+                forbiddenResponse:
+                  $ref: '#/components/examples/error_403_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
     put:
       summary: Create or update agent configuration
       description: |
@@ -344,24 +401,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '403':
           description: Forbidden response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/403_response'
+              examples:
+                forbiddenResponse:
+                  $ref: '#/components/examples/error_403_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
   /api/apm/settings/agent-configuration/view:
     get:
       summary: Get single agent configuration
@@ -400,18 +469,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
   /api/apm/settings/agent-configuration/search:
     post:
       summary: Lookup single agent configuration
@@ -449,18 +527,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
   /api/apm/settings/agent-configuration/environments:
     get:
       summary: Get environments for service
@@ -493,18 +580,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
   /api/apm/settings/agent-configuration/agent_name:
     get:
       summary: Get agent name for service
@@ -528,24 +624,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/service_agent_name_response'
+              examples:
+                getAgentNameForServiceResponse1:
+                  $ref: '#/components/examples/service_agent_name_get_200_response1'
         '400':
           description: Bad Request response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
   /api/apm/sourcemaps:
     get:
       summary: Get source maps
@@ -582,24 +690,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '500':
           description: Internal Server Error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/500_response'
+              examples:
+                internalServerErrorResponse:
+                  $ref: '#/components/examples/error_500_response'
         '501':
           description: Not Implemented response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/501_response'
+              examples:
+                notImplementedResponse:
+                  $ref: '#/components/examples/error_501_response'
       x-codeSamples:
         - lang: Curl
           source: |
@@ -624,6 +744,9 @@ paths:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/upload_source_map_object'
+            examples:
+              uploadSourceMapRequest:
+                $ref: '#/components/examples/source_maps_upload_request1'
       responses:
         '200':
           description: Successful response
@@ -640,30 +763,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '403':
           description: Forbidden response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/403_response'
+              examples:
+                forbiddenResponse:
+                  $ref: '#/components/examples/error_403_response'
         '500':
           description: Internal Server Error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/500_response'
+              examples:
+                internalServerErrorResponse:
+                  $ref: '#/components/examples/error_500_response'
         '501':
           description: Not Implemented response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/501_response'
+              examples:
+                notImplementedResponse:
+                  $ref: '#/components/examples/error_501_response'
       x-codeSamples:
         - lang: Curl
           source: |
@@ -710,30 +848,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '403':
           description: Forbidden response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/403_response'
+              examples:
+                forbiddenResponse:
+                  $ref: '#/components/examples/error_403_response'
         '500':
           description: Internal Server Error response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/500_response'
+              examples:
+                internalServerErrorResponse:
+                  $ref: '#/components/examples/error_500_response'
         '501':
           description: Not Implemented response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/501_response'
+              examples:
+                notImplementedResponse:
+                  $ref: '#/components/examples/error_501_response'
       x-codeSamples:
         - lang: Curl
           source: |
@@ -766,6 +919,12 @@ paths:
                   additionalProperties: true
                   example:
                     foo: bar
+            examples:
+              saveApmServerSchemaRequest:
+                description: An example request payload for `POST /api/apm/fleet/apm_server_schema`.
+                value:
+                  schema:
+                    foo: bar
       responses:
         '200':
           description: Successful response
@@ -784,24 +943,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
+              examples:
+                badRequestResponse:
+                  $ref: '#/components/examples/error_400_response'
         '401':
           description: Unauthorized response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/401_response'
+              examples:
+                unauthorizedResponse:
+                  $ref: '#/components/examples/error_401_response'
         '403':
           description: Forbidden response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/403_response'
+              examples:
+                forbiddenResponse:
+                  $ref: '#/components/examples/error_403_response'
         '404':
           description: Not found response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+              examples:
+                notFoundResponse:
+                  $ref: '#/components/examples/error_404_response'
 components:
   parameters:
     elastic_api_version:
@@ -1317,6 +1488,42 @@ components:
           name: apm-key
           api_key: PjGloCGOTzaZr8ilUPvkjA
           encoded: M0RDTG1uMEIzWk1oTFVhN1dCRzk6UGpHbG9DR09UemFacjhpbFVQdmtqQQ==
+    error_400_response:
+      description: An example of a 400 Bad Request response, returned when the request payload or query parameters fail validation.
+      value:
+        statusCode: 400
+        error: Bad Request
+        message: '[request body]: expected value of type [string] but got [undefined]'
+    error_401_response:
+      description: An example of a 401 Unauthorized response, returned when the request is missing valid authentication credentials.
+      value:
+        statusCode: 401
+        error: Unauthorized
+        message: '[security_exception]: missing authentication credentials for REST request'
+    error_403_response:
+      description: An example of a 403 Forbidden response, returned when the authenticated user lacks the required APM and User Experience privileges.
+      value:
+        statusCode: 403
+        error: Forbidden
+        message: Insufficient privileges to perform this action. The APM and User Experience feature requires `all` privileges.
+    error_500_response:
+      description: An example of a 500 Internal Server Error response, returned when an unexpected error occurs while processing the request.
+      value:
+        statusCode: 500
+        error: Internal Server Error
+        message: An internal server error occurred. Check the Kibana server logs for details.
+    annotation_search_get_200_response1:
+      description: An example of a successful response from `GET /api/apm/services/{serviceName}/annotation/search`, which returns the annotations associated with a service over the given time range.
+      value:
+        annotations:
+          - type: version
+            id: opbeans-node@2.0.0
+            '@timestamp': 1735689600000
+            text: opbeans-node@2.0.0
+          - type: version
+            id: opbeans-node@2.1.0
+            '@timestamp': 1736294400000
+            text: opbeans-node@2.1.0
     annotation_object_post_request1:
       description: Run `POST /api/apm/services/{serviceName}/annotation` to create a deployment annotation for a service.
       value:
@@ -1351,6 +1558,12 @@ components:
             type: deployment
           event:
             created: '2020-05-09T02:34:43.937Z'
+    error_404_response:
+      description: An example of a 404 Not Found response, returned when the requested resource does not exist or the feature is not available on the current deployment.
+      value:
+        statusCode: 404
+        error: Not Found
+        message: Not Found
     agent_configuration_intake_object_get_200_response1:
       description: An example of a successful response from `GET /api/apm/settings/agent-configuration`.
       value:
@@ -1454,6 +1667,10 @@ components:
             alreadyConfigured: false
           - name: ALL_OPTION_VALUE
             alreadyConfigured: false
+    service_agent_name_get_200_response1:
+      description: An example of a successful response from `GET /api/apm/settings/agent-configuration/agent_name`, which returns the detected APM agent name for a service.
+      value:
+        agentName: nodejs
     source_maps_get_200_response1:
       description: A successful response from `GET /api/apm/sourcemaps`.
       value:
@@ -1487,6 +1704,21 @@ components:
             encodedSize: 237
             encryptionAlgorithm: none
             packageName: apm
+    error_501_response:
+      description: An example of a 501 Not Implemented response, returned when the source map feature is not available on the current deployment.
+      value:
+        statusCode: 501
+        error: Not Implemented
+        message: Not Implemented
+    source_maps_upload_request1:
+      description: |
+        An example of a multipart/form-data request body for `POST /api/apm/sourcemaps`.
+        Each field is a separate form part; `sourcemap` is the source map file content (typically uploaded as a file).
+      value:
+        service_name: opbeans-node
+        service_version: 1.0.0
+        bundle_filepath: /test/e2e/general-usecase/bundle.js.map
+        sourcemap: '{"version":3,"sources":["bundle.js"],"names":[],"mappings":"AAAA","file":"bundle.js","sourcesContent":["console.log(''hello'');"]}'
     source_maps_upload_200_response1:
       description: A successful response from `POST /api/apm/sourcemaps`.
       value:

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/annotation_search_get_200_response1.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/annotation_search_get_200_response1.yaml
@@ -1,0 +1,11 @@
+description: An example of a successful response from `GET /api/apm/services/{serviceName}/annotation/search`, which returns the annotations associated with a service over the given time range.
+value:
+  annotations:
+    - type: version
+      id: opbeans-node@2.0.0
+      "@timestamp": 1735689600000
+      text: opbeans-node@2.0.0
+    - type: version
+      id: opbeans-node@2.1.0
+      "@timestamp": 1736294400000
+      text: opbeans-node@2.1.0

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_400_response.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_400_response.yaml
@@ -1,0 +1,5 @@
+description: An example of a 400 Bad Request response, returned when the request payload or query parameters fail validation.
+value:
+  statusCode: 400
+  error: Bad Request
+  message: "[request body]: expected value of type [string] but got [undefined]"

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_401_response.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_401_response.yaml
@@ -1,0 +1,5 @@
+description: An example of a 401 Unauthorized response, returned when the request is missing valid authentication credentials.
+value:
+  statusCode: 401
+  error: Unauthorized
+  message: "[security_exception]: missing authentication credentials for REST request"

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_403_response.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_403_response.yaml
@@ -1,0 +1,5 @@
+description: An example of a 403 Forbidden response, returned when the authenticated user lacks the required APM and User Experience privileges.
+value:
+  statusCode: 403
+  error: Forbidden
+  message: "Insufficient privileges to perform this action. The APM and User Experience feature requires `all` privileges."

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_404_response.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_404_response.yaml
@@ -1,0 +1,5 @@
+description: An example of a 404 Not Found response, returned when the requested resource does not exist or the feature is not available on the current deployment.
+value:
+  statusCode: 404
+  error: Not Found
+  message: "Not Found"

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_500_response.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_500_response.yaml
@@ -1,0 +1,5 @@
+description: An example of a 500 Internal Server Error response, returned when an unexpected error occurs while processing the request.
+value:
+  statusCode: 500
+  error: Internal Server Error
+  message: "An internal server error occurred. Check the Kibana server logs for details."

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_501_response.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/error_501_response.yaml
@@ -1,0 +1,5 @@
+description: An example of a 501 Not Implemented response, returned when the source map feature is not available on the current deployment.
+value:
+  statusCode: 501
+  error: Not Implemented
+  message: "Not Implemented"

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/service_agent_name_get_200_response1.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/service_agent_name_get_200_response1.yaml
@@ -1,0 +1,3 @@
+description: An example of a successful response from `GET /api/apm/settings/agent-configuration/agent_name`, which returns the detected APM agent name for a service.
+value:
+  agentName: nodejs

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/source_maps_upload_request1.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/components/examples/source_maps_upload_request1.yaml
@@ -1,0 +1,8 @@
+description: |
+  An example of a multipart/form-data request body for `POST /api/apm/sourcemaps`.
+  Each field is a separate form part; `sourcemap` is the source map file content (typically uploaded as a file).
+value:
+  service_name: opbeans-node
+  service_version: 1.0.0
+  bundle_filepath: /test/e2e/general-usecase/bundle.js.map
+  sourcemap: "{\"version\":3,\"sources\":[\"bundle.js\"],\"names\":[],\"mappings\":\"AAAA\",\"file\":\"bundle.js\",\"sourcesContent\":[\"console.log('hello');\"]}"

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@agent_keys.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@agent_keys.yaml
@@ -37,21 +37,33 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '403':
       description: Forbidden response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/403_response.yaml'
+          examples:
+            forbiddenResponse:
+              $ref: '../components/examples/error_403_response.yaml'
     '500':
       description: Internal Server Error response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/500_response.yaml'
+          examples:
+            internalServerErrorResponse:
+              $ref: '../components/examples/error_500_response.yaml'

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@fleet@apm_server_schema.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@fleet@apm_server_schema.yaml
@@ -24,6 +24,12 @@ post:
               additionalProperties: true
               example:
                 foo: "bar"
+        examples:
+          saveApmServerSchemaRequest:
+            description: An example request payload for `POST /api/apm/fleet/apm_server_schema`.
+            value:
+              schema:
+                foo: bar
   responses:
     '200':
       description: Successful response
@@ -42,21 +48,33 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '403':
       description: Forbidden response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/403_response.yaml'
+          examples:
+            forbiddenResponse:
+              $ref: '../components/examples/error_403_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@services@{service_name}@annotation.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@services@{service_name}@annotation.yaml
@@ -38,23 +38,35 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '403':
       description: Forbidden response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/403_response.yaml'
+          examples:
+            forbiddenResponse:
+              $ref: '../components/examples/error_403_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'
   x-codeSamples:
     - $ref: "../components/examples/annotation_object_post_curl_request1.yaml"

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@services@{service_name}@annotation@search.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@services@{service_name}@annotation@search.yaml
@@ -41,21 +41,33 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/annotation_search_response.yaml'
+          examples:
+            getAnnotationResponse1:
+              $ref: '../components/examples/annotation_search_get_200_response1.yaml'
     '400':
       description: Bad Request response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '500':
       description: Internal Server Error response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/500_response.yaml'
+          examples:
+            internalServerErrorResponse:
+              $ref: '../components/examples/error_500_response.yaml'

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration.yaml
@@ -25,18 +25,27 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'
 delete:
   summary: Delete agent configuration
   description: >
@@ -74,24 +83,36 @@ delete:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '403':
       description: Forbidden response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/403_response.yaml'
+          examples:
+            forbiddenResponse:
+              $ref: '../components/examples/error_403_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'
 put:
   summary: Create or update agent configuration
   description: >
@@ -138,21 +159,33 @@ put:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '403':
       description: Forbidden response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/403_response.yaml'
+          examples:
+            forbiddenResponse:
+              $ref: '../components/examples/error_403_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration@agent_name.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration@agent_name.yaml
@@ -20,21 +20,33 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/service_agent_name_response.yaml'
+          examples:
+            getAgentNameForServiceResponse1:
+              $ref: '../components/examples/service_agent_name_get_200_response1.yaml'
     '400':
       description: Bad Request response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration@environments.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration@environments.yaml
@@ -31,15 +31,24 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration@search.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration@search.yaml
@@ -36,15 +36,24 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration@view.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@settings@agent_configuration@view.yaml
@@ -37,15 +37,24 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '404':
       description: Not found response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+          examples:
+            notFoundResponse:
+              $ref: '../components/examples/error_404_response.yaml'

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@sourcemaps.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@sourcemaps.yaml
@@ -34,24 +34,36 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '500':
       description: Internal Server Error response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/500_response.yaml'
+          examples:
+            internalServerErrorResponse:
+              $ref: '../components/examples/error_500_response.yaml'
     '501':
       description: Not Implemented response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/501_response.yaml'
+          examples:
+            notImplementedResponse:
+              $ref: '../components/examples/error_501_response.yaml'
   x-codeSamples:
     - $ref: "../components/examples/source_maps_get_curl_request1.yaml"
 post:
@@ -75,6 +87,9 @@ post:
       multipart/form-data:
         schema:
           $ref: '../components/schemas/upload_source_map_object.yaml'
+        examples:
+          uploadSourceMapRequest:
+            $ref: '../components/examples/source_maps_upload_request1.yaml'
   responses:
     '200':
       description: Successful response
@@ -91,29 +106,44 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '403':
       description: Forbidden response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/403_response.yaml'
+          examples:
+            forbiddenResponse:
+              $ref: '../components/examples/error_403_response.yaml'
     '500':
       description: Internal Server Error response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/500_response.yaml'
+          examples:
+            internalServerErrorResponse:
+              $ref: '../components/examples/error_500_response.yaml'
     '501':
       description: Not Implemented response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/501_response.yaml'
+          examples:
+            notImplementedResponse:
+              $ref: '../components/examples/error_501_response.yaml'
   x-codeSamples:
     - $ref: "../components/examples/source_maps_upload_curl_request1.yaml"

--- a/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@sourcemaps@{id}.yaml
+++ b/x-pack/solutions/observability/plugins/apm/docs/openapi/apm/paths/api@apm@sourcemaps@{id}.yaml
@@ -33,29 +33,44 @@ delete:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
+          examples:
+            badRequestResponse:
+              $ref: '../components/examples/error_400_response.yaml'
     '401':
       description: Unauthorized response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/401_response.yaml'
+          examples:
+            unauthorizedResponse:
+              $ref: '../components/examples/error_401_response.yaml'
     '403':
       description: Forbidden response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/403_response.yaml'
+          examples:
+            forbiddenResponse:
+              $ref: '../components/examples/error_403_response.yaml'
     '500':
       description: Internal Server Error response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/500_response.yaml'
+          examples:
+            internalServerErrorResponse:
+              $ref: '../components/examples/error_500_response.yaml'
     '501':
       description: Not Implemented response
       content:
         application/json:
           schema:
             $ref: '../components/schemas/501_response.yaml'
+          examples:
+            notImplementedResponse:
+              $ref: '../components/examples/error_501_response.yaml'
   x-codeSamples:
     - $ref: "../components/examples/source_maps_delete_curl_request1.yaml"


### PR DESCRIPTION
## Summary

Closes elastic/kibana#266312.

Adds the missing `examples` blocks on request/response bodies across the APM public OpenAPI surface so that `node scripts/validate_oas_docs.js --path /api/apm` reports zero schema errors on both traditional and serverless (was 56 / 41).

All remaining failures shared the same defect: `must have required property 'examples'` on `requestBody.content.application/json` or `responses[*].content.application/json`. Where the same example pattern fits multiple endpoints (error responses), the examples are reused via `$ref` to a shared component, as suggested in the issue.

### What changed

- 6 reusable error-response example files (`error_400_response.yaml` ... `error_501_response.yaml`).
- 2 missing 200-response examples: `agent_name` GET, `annotation/search` GET.
- 1 multipart request-body example for `POST /api/apm/sourcemaps`.
- `examples` `$ref` blocks wired into every error response across the 11 path files, plus the new 200 / request body slots. Inline `examples` added to the `apm_server_schema` POST body.
- Regenerated `bundled.yaml` / `bundled.json`.

`oas_docs/output/kibana.yaml`, `kibana.serverless.yaml`, and `oas_error_baseline.json` will be regenerated and auto-committed by the CI `capture_oas_snapshot` step.

### Verification

Locally, after running `make merge-api-docs`:

```
node scripts/validate_oas_docs.js --only traditional --path /api/apm
  -> Found 0 errors in ./oas_docs/output/kibana.yaml
node scripts/validate_oas_docs.js --only serverless  --path /api/apm
  -> Found 0 errors in ./oas_docs/output/kibana.serverless.yaml
```

### Checklist

- [x] Local validation passes for `/api/apm` (traditional + serverless).
- [ ] CI `capture_oas_snapshot` step regenerates `kibana.yaml` / `kibana.serverless.yaml` and the validator baseline.