### PR TITLE
[Fleet] Add config.name field to OpAMP collector metadata

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/mappings.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/mappings.ts
@@ -466,6 +466,9 @@ export const AGENT_MAPPINGS = {
             description: {
               type: 'keyword',
             },
+            name: {
+              type: 'keyword',
+            },
           },
         },
         deployment: {
@@ -525,6 +528,9 @@ export const AGENT_MAPPINGS = {
     config: {
       properties: {
         description: {
+          type: 'keyword',
+        },
+        name: {
           type: 'keyword',
         },
       },

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx
@@ -171,6 +171,7 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
   const [serviceName, setServiceName] = useState('otel-collector-group');
   const [serviceNameOverridden, setServiceNameOverridden] = useState(false);
   const [collectorDisplayName, setCollectorDisplayName] = useState('${env:HOSTNAME}');
+  const [configName, setConfigName] = useState('');
   const [configDescription, setConfigDescription] = useState('');
   const [tags, setTags] = useState('');
   const [environment, setEnvironment] = useState('');
@@ -207,6 +208,7 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
       'elastic.collector.group_name': groupDisplayName,
       'elastic.collector.group': collectorGroup,
       'elastic.display.name': collectorDisplayName,
+      ...(configName ? { 'config.name': configName } : {}),
       ...(configDescription ? { 'config.description': configDescription } : {}),
       ...(tags.trim() ? { tags } : {}),
       ...(environment ? { 'deployment.environment.name': environment } : {}),
@@ -294,6 +296,7 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
     collectorGroup,
     serviceName,
     collectorDisplayName,
+    configName,
     configDescription,
     tags,
     environment,
@@ -417,6 +420,24 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
                 onChange={(e) => setCollectorDisplayName(e.target.value)}
                 onBlur={() => touch('collectorDisplayName')}
                 data-test-subj="collectorDisplayNameInput"
+              />
+            </EuiFormRow>
+            <EuiFormRow
+              fullWidth
+              label={i18n.translate('xpack.fleet.addCollectorFlyout.form.configNameLabel', {
+                defaultMessage: 'Config name',
+              })}
+              helpText={i18n.translate('xpack.fleet.addCollectorFlyout.form.configNameHelpText', {
+                defaultMessage:
+                  'Optional. Short name for this collector configuration, e.g. "webserver-logs". Used as the config label in Fleet.',
+              })}
+            >
+              <EuiFieldText
+                fullWidth
+                prepend="config.name:"
+                value={configName}
+                onChange={(e) => setConfigName(e.target.value)}
+                data-test-subj="configNameInput"
               />
             </EuiFormRow>
             <EuiFormRow


### PR DESCRIPTION
## Summary

Adds `config.name` as a new `non_identifying_attributes` field for OTel collectors managed via OpAMP.

The existing `config.description` field is a free-text description. The Collectors UI was deriving the config display label from its first line, which is fragile. `config.name` provides a dedicated short name for the configuration (e.g. `webserver-logs`), used as the config label in Fleet.

Closes: https://github.com/elastic/ingest-dev/issues/7689
Corresponding ES mapping change to be able to search and group on `config.name`: https://github.com/elastic/elasticsearch/pull/148703

## Test plan

- [ ] Open the Add Collector flyout in Fleet (Agents tab → Add collector)
- [ ] Fill in "Config name" — verify the generated YAML includes `config.name: <value>` under `non_identifying_attributes`
- [ ] Leave "Config name" empty — verify `config.name` is absent from the generated YAML
- [ ] Verify `config.description` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="921" height="1142" alt="image" src="https://github.com/user-attachments/assets/9eb449f0-5fab-4c69-9e02-45e79f5239be" />
<img width="1793" height="778" alt="image" src="https://github.com/user-attachments/assets/51838d63-4cdb-4ce0-ad33-00bdd9815735" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->