### PR TITLE
[Agent Builder] expose sml index workflow step + management app for sml workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ src/platform/plugins/shared/console/packaging/react/translations
 
 # Batched commits marker, e.g.: from quick checks
 .collect_commits_marker
+claude.md
+.claude

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EMPTY, firstValueFrom, lastValueFrom, of, toArray } from 'rxjs';
+import type { Span } from '@opentelemetry/api';
+import type { ChatEvent } from '@kbn/agent-builder-common';
+import { withConverseSpan } from './with_converse_span';
+
+const mockWithActiveInferenceSpan = jest.fn();
+
+jest.mock('@kbn/inference-tracing', () => ({
+  withActiveInferenceSpan: (
+    name: string,
+    opts: { attributes?: Record<string, unknown> },
+    fn: (span?: Span) => unknown
+  ) => {
+    mockWithActiveInferenceSpan(name, opts);
+    return fn(undefined);
+  },
+  ElasticGenAIAttributes: {
+    InferenceSpanKind: 'elastic.inference.span.kind',
+    AgentId: 'elastic.agent.id',
+    AgentConversationId: 'elastic.agent.conversationId',
+  },
+  GenAISemanticConventions: {
+    GenAIConversationId: 'gen_ai.conversation.id',
+  },
+}));
+
+describe('withConverseSpan', () => {
+  beforeEach(() => {
+    mockWithActiveInferenceSpan.mockClear();
+  });
+
+  it('creates a Converse inference span with CHAIN kind and the expected base attributes', async () => {
+    await firstValueFrom(
+      withConverseSpan({ agentId: 'agent-1', conversationId: 'conv-1' }, () => of({} as ChatEvent))
+    );
+
+    expect(mockWithActiveInferenceSpan).toHaveBeenCalledTimes(1);
+    const [name, opts] = mockWithActiveInferenceSpan.mock.calls[0];
+    expect(name).toBe('Converse');
+    expect(opts.attributes).toMatchObject({
+      'elastic.inference.span.kind': 'CHAIN',
+      'elastic.agent.id': 'agent-1',
+      'elastic.agent.conversationId': 'conv-1',
+      'gen_ai.conversation.id': 'conv-1',
+    });
+  });
+
+  it('stamps user.id and user.name attributes when provided', async () => {
+    await firstValueFrom(
+      withConverseSpan(
+        {
+          agentId: 'agent-1',
+          conversationId: 'conv-1',
+          userId: 'profile-uid-123',
+          userName: 'alice',
+        },
+        () => of({} as ChatEvent)
+      )
+    );
+
+    const [, opts] = mockWithActiveInferenceSpan.mock.calls[0];
+    expect(opts.attributes).toMatchObject({
+      'user.id': 'profile-uid-123',
+      'user.name': 'alice',
+    });
+  });
+
+  it('leaves user.id and user.name unset when not provided', async () => {
+    await lastValueFrom(
+      withConverseSpan({ agentId: 'agent-1', conversationId: 'conv-1' }, () => EMPTY).pipe(
+        toArray()
+      )
+    );
+
+    const [, opts] = mockWithActiveInferenceSpan.mock.calls[0];
+    expect(opts.attributes['user.id']).toBeUndefined();
+    expect(opts.attributes['user.name']).toBeUndefined();
+  });
+
+  it('supports stamping just user.name (no profile UID available)', async () => {
+    await firstValueFrom(
+      withConverseSpan({ agentId: 'agent-1', conversationId: 'conv-1', userName: 'bob' }, () =>
+        of({} as ChatEvent)
+      )
+    );
+
+    const [, opts] = mockWithActiveInferenceSpan.mock.calls[0];
+    expect(opts.attributes['user.id']).toBeUndefined();
+    expect(opts.attributes['user.name']).toBe('bob');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/constants.ts
@@ -7,3 +7,4 @@
 
 export const internalApiPath = '/internal/agent_context_layer';
 export const smlSearchPath = `${internalApiPath}/sml/_search`;
+export const smlIndexAttachmentPath = `${internalApiPath}/sml/_index`;

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/features.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/features.ts
@@ -9,4 +9,5 @@ export const AGENT_CONTEXT_LAYER_FEATURE_ID = 'agentContextLayer';
 
 export const apiPrivileges = {
   readAgentContextLayer: `${AGENT_CONTEXT_LAYER_FEATURE_ID}:read`,
+  writeAgentContextLayer: `${AGENT_CONTEXT_LAYER_FEATURE_ID}:write`,
 };

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/http_api/sml.ts
@@ -40,3 +40,88 @@ export interface SmlSearchHttpResultItem {
   score: number;
   content?: string;
 }
+
+/**
+ * Allowed values for the `action` field of the SML index endpoint.
+ */
+export type SmlIndexAttachmentHttpAction = 'create' | 'update' | 'delete';
+
+/**
+ * Max length of `origin_id` for `POST /internal/agent_context_layer/sml/_index`.
+ */
+export const SML_HTTP_INDEX_ORIGIN_ID_MAX_LENGTH = 1024;
+
+/**
+ * Max length of `attachment_type` for `POST /internal/agent_context_layer/sml/_index`.
+ */
+export const SML_HTTP_INDEX_ATTACHMENT_TYPE_MAX_LENGTH = 256;
+
+/**
+ * Max length of a chunk's `title`.
+ */
+export const SML_HTTP_CHUNK_TITLE_MAX_LENGTH = 1024;
+
+/**
+ * Max length of a chunk's `content`.
+ *
+ * Conservative cap to keep request bodies small; callers with larger documents
+ * should split them across multiple chunks.
+ */
+export const SML_HTTP_CHUNK_CONTENT_MAX_LENGTH = 32_768;
+
+/**
+ * Max length of a chunk's optional `description`.
+ */
+export const SML_HTTP_CHUNK_DESCRIPTION_MAX_LENGTH = 4_096;
+
+/**
+ * Max number of chunks accepted in a single `create`/`update` request.
+ */
+export const SML_HTTP_INDEX_MAX_CHUNKS = 100;
+
+/**
+ * Single SML chunk in the HTTP request body. Mirrors {@link import('../../server/services/sml/types').SmlChunk}.
+ */
+export interface SmlIndexAttachmentHttpChunk {
+  /** Type of the chunk (e.g., 'visualization', 'dashboard'). */
+  type: string;
+  /** Display title. */
+  title: string;
+  /** Searchable content (indexed as `semantic_text`). */
+  content: string;
+  /** Optional longer summary for semantic search. */
+  description?: string;
+  /** Optional owner or last-modifier user id. */
+  user_id?: string;
+  /** Optional list of referenced SML chunk ids. */
+  references?: string[];
+  /** Optional Kibana privilege strings required to view this chunk in search results. */
+  permissions?: string[];
+}
+
+/**
+ * Request body for `POST /internal/agent_context_layer/sml/_index`.
+ *
+ * `chunks` is **required** for `create`/`update` actions (caller supplies the
+ * content directly; no `getSmlData` hook is invoked) and **forbidden** for
+ * `delete` (which only needs `origin_id`).
+ */
+export type SmlIndexAttachmentHttpRequest =
+  | {
+      origin_id: string;
+      attachment_type: string;
+      action: 'create' | 'update';
+      chunks: SmlIndexAttachmentHttpChunk[];
+    }
+  | {
+      origin_id: string;
+      attachment_type: string;
+      action: 'delete';
+    };
+
+/**
+ * Response body for `POST /internal/agent_context_layer/sml/_index`.
+ */
+export interface SmlIndexAttachmentHttpResponse {
+  acknowledged: true;
+}

--- a/x-pack/platform/plugins/shared/agent_context_layer/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_context_layer/kibana.jsonc
@@ -9,6 +9,6 @@
     "server": true,
     "browser": true,
     "requiredPlugins": ["features", "taskManager"],
-    "optionalPlugins": ["security", "spaces"]
+    "optionalPlugins": ["security", "spaces", "workflowsExtensions"]
   }
 }

--- a/x-pack/platform/plugins/shared/agent_context_layer/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_context_layer/moon.yml
@@ -38,6 +38,7 @@ dependsOn:
   - '@kbn/core-http-server-mocks'
   - '@kbn/core-logging-server-mocks'
   - '@kbn/logging-mocks'
+  - '@kbn/workflows-extensions'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_context_layer/public/index.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/public/index.ts
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import type { PluginInitializer } from '@kbn/core-plugins-browser';
+import type { PluginInitializer, PluginInitializerContext } from '@kbn/core-plugins-browser';
+import {
+  AgentContextLayerPublicPlugin,
+  type AgentContextLayerPublicPluginSetup,
+  type AgentContextLayerPublicPluginSetupDeps,
+  type AgentContextLayerPublicPluginStart,
+  type AgentContextLayerPublicPluginStartDeps,
+} from './plugin';
 
 export { smlSearchPath, internalApiPath } from '../common/constants';
 export { SML_HTTP_SEARCH_QUERY_MAX_LENGTH, SmlSearchFilterType } from '../common/http_api/sml';
@@ -15,8 +22,9 @@ export type {
   SmlSearchHttpResultItem,
 } from '../common/http_api/sml';
 
-export const plugin: PluginInitializer<{}, {}> = () => ({
-  setup: () => ({}),
-  start: () => ({}),
-  stop: () => {},
-});
+export const plugin: PluginInitializer<
+  AgentContextLayerPublicPluginSetup,
+  AgentContextLayerPublicPluginStart,
+  AgentContextLayerPublicPluginSetupDeps,
+  AgentContextLayerPublicPluginStartDeps
+> = (context: PluginInitializerContext) => new AgentContextLayerPublicPlugin(context);

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/features.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/features.ts
@@ -24,7 +24,7 @@ export const registerFeatures = ({ features }: { features: FeaturesPluginSetup }
     privileges: {
       all: {
         app: [],
-        api: [apiPrivileges.readAgentContextLayer],
+        api: [apiPrivileges.readAgentContextLayer, apiPrivileges.writeAgentContextLayer],
         catalogue: [],
         savedObject: {
           all: [],

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
@@ -16,6 +16,7 @@ import type {
 import { registerFeatures } from './features';
 import { registerUISettings } from './ui_settings';
 import { registerSearchRoute } from './routes/search';
+import { registerIndexAttachmentRoute } from './routes/index_attachment';
 import { createSmlService, type SmlServiceInstance } from './services/sml/sml_service';
 import {
   registerSmlCrawlerTaskDefinition,
@@ -23,6 +24,7 @@ import {
 } from './services/sml/sml_task_definitions';
 import { resolveSmlAttachItems } from './services/sml/execute_sml_attach_items';
 import type { SmlService } from './services/sml/types';
+import { registerAgentContextLayerWorkflowSteps } from './workflow_steps';
 
 export class AgentContextLayerPlugin
   implements
@@ -36,6 +38,8 @@ export class AgentContextLayerPlugin
   private logger: Logger;
   private smlServiceInstance: SmlServiceInstance;
   private smlService?: SmlService;
+  private startContract?: AgentContextLayerPluginStart;
+  private spaces?: AgentContextLayerStartDependencies['spaces'];
 
   constructor(context: PluginInitializerContext) {
     this.logger = context.logger.get();
@@ -82,6 +86,27 @@ export class AgentContextLayerPlugin
       logger: this.logger,
       getSmlService,
     });
+    registerIndexAttachmentRoute({
+      router,
+      coreSetup,
+      logger: this.logger,
+      getSmlService,
+    });
+
+    if (setupDeps.workflowsExtensions) {
+      registerAgentContextLayerWorkflowSteps({
+        workflowsExtensions: setupDeps.workflowsExtensions,
+        getStartContract: () => {
+          if (!this.startContract) {
+            throw new Error(
+              'Agent Context Layer start contract is not available — plugin has not started'
+            );
+          }
+          return this.startContract;
+        },
+        getSpaces: () => this.spaces,
+      });
+    }
 
     return {
       registerType: smlSetup.registerType,
@@ -98,6 +123,7 @@ export class AgentContextLayerPlugin
       logger: this.logger.get('sml'),
       securityAuthz: security?.authz,
     });
+    this.spaces = spaces;
 
     const smlService = this.smlService;
 
@@ -109,7 +135,7 @@ export class AgentContextLayerPlugin
       this.logger.error(`Failed to schedule SML crawler tasks: ${error.message}`);
     });
 
-    return {
+    const startContract: AgentContextLayerPluginStart = {
       search: smlService.search,
       checkItemsAccess: smlService.checkItemsAccess,
       getDocuments: smlService.getDocuments,
@@ -131,9 +157,14 @@ export class AgentContextLayerPlugin
           esClient: elasticsearch.client.asInternalUser,
           savedObjectsClient: soClient,
           logger: this.logger.get('sml'),
+          chunks: params.chunks,
+          source: params.source,
         });
       },
     };
+
+    this.startContract = startContract;
+    return startContract;
   }
 
   stop() {}

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/index_attachment.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/index_attachment.test.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock, httpServiceMock } from '@kbn/core-http-server-mocks';
+import { coreMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { AGENT_CONTEXT_LAYER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
+import { registerIndexAttachmentRoute } from './index_attachment';
+
+const createMockSmlService = () => ({
+  search: jest.fn(),
+  checkItemsAccess: jest.fn(),
+  indexAttachment: jest.fn().mockResolvedValue(undefined),
+  getDocuments: jest.fn(),
+  // Default: treat any type as registered. Individual tests can override.
+  getTypeDefinition: jest.fn().mockImplementation((id: string) => ({ id })),
+  listTypeDefinitions: jest.fn(),
+  getCrawler: jest.fn(),
+});
+
+const createMockUiSettingsClient = (enabled = true) => ({
+  get: jest.fn().mockImplementation(async (key: string) => {
+    if (key === AGENT_CONTEXT_LAYER_EXPERIMENTAL_FEATURES_SETTING_ID) return enabled;
+    return undefined;
+  }),
+});
+
+describe('registerIndexAttachmentRoute', () => {
+  let router: ReturnType<typeof httpServiceMock.createRouter>;
+  let handler: Function;
+  let validate: any;
+  let mockSmlService: ReturnType<typeof createMockSmlService>;
+  const logger = loggingSystemMock.create().get();
+
+  beforeEach(() => {
+    mockSmlService = createMockSmlService();
+    const coreSetup = coreMock.createSetup();
+    (coreSetup.getStartServices as jest.Mock).mockResolvedValue([
+      {},
+      { spaces: { spacesService: { getSpaceId: jest.fn().mockReturnValue('test-space') } } },
+      {},
+    ]);
+    router = httpServiceMock.createRouter();
+    registerIndexAttachmentRoute({
+      router: router as any,
+      coreSetup: coreSetup as any,
+      logger,
+      getSmlService: () => mockSmlService as any,
+    });
+    const [config, registeredHandler] = router.post.mock.calls[0];
+    handler = registeredHandler;
+    validate = config.validate;
+  });
+
+  const validateBody = (body: Record<string, unknown>) => {
+    if (!validate || typeof validate === 'function' || !validate.body) return body;
+    return validate.body.validate(body);
+  };
+
+  const callHandler = async (body: Record<string, unknown>, uiSettingsEnabled = true) => {
+    const request = httpServerMock.createKibanaRequest({ body: validateBody(body) });
+    const response = httpServerMock.createResponseFactory();
+    const ctx = {
+      core: Promise.resolve({
+        uiSettings: { client: createMockUiSettingsClient(uiSettingsEnabled) },
+        elasticsearch: { client: { asInternalUser: { mark: 'internal' }, asCurrentUser: {} } },
+        savedObjects: { client: { mark: 'so-client' } },
+      }),
+    };
+    await handler(ctx, request, response);
+    return response;
+  };
+
+  it('registers a POST route at the expected path with internal access', () => {
+    const [config] = router.post.mock.calls[0];
+    expect(config.path).toBe('/internal/agent_context_layer/sml/_index');
+    expect(config.options).toEqual({ access: 'internal' });
+  });
+
+  describe('schema validation', () => {
+    it('rejects create requests without chunks', () => {
+      expect(() =>
+        validateBody({
+          origin_id: 'viz-1',
+          attachment_type: 'visualization',
+          action: 'create',
+        })
+      ).toThrow();
+    });
+
+    it('rejects create requests with an empty chunks array', () => {
+      expect(() =>
+        validateBody({
+          origin_id: 'viz-1',
+          attachment_type: 'visualization',
+          action: 'create',
+          chunks: [],
+        })
+      ).toThrow();
+    });
+
+    it('rejects delete requests that include chunks', () => {
+      expect(() =>
+        validateBody({
+          origin_id: 'viz-1',
+          attachment_type: 'visualization',
+          action: 'delete',
+          chunks: [{ type: 'visualization', title: 't', content: 'c' }],
+        })
+      ).toThrow();
+    });
+
+    it('accepts a well-formed create request', () => {
+      expect(() =>
+        validateBody({
+          origin_id: 'viz-1',
+          attachment_type: 'visualization',
+          action: 'create',
+          chunks: [{ type: 'visualization', title: 't', content: 'c' }],
+        })
+      ).not.toThrow();
+    });
+  });
+
+  it('returns 400 when the attachment_type is not registered', async () => {
+    mockSmlService.getTypeDefinition.mockReturnValueOnce(undefined);
+    const response = await callHandler({
+      origin_id: 'viz-1',
+      attachment_type: 'unknown',
+      action: 'create',
+      chunks: [{ type: 'unknown', title: 't', content: 'c' }],
+    });
+    expect(response.badRequest).toHaveBeenCalledWith({
+      body: `Unknown SML attachment type: 'unknown'`,
+    });
+    expect(mockSmlService.indexAttachment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the attachment_type is not registered for delete', async () => {
+    mockSmlService.getTypeDefinition.mockReturnValueOnce(undefined);
+    const response = await callHandler({
+      origin_id: 'viz-1',
+      attachment_type: 'unknown',
+      action: 'delete',
+    });
+    expect(response.badRequest).toHaveBeenCalledWith({
+      body: `Unknown SML attachment type: 'unknown'`,
+    });
+    expect(mockSmlService.indexAttachment).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the experimental feature flag is disabled', async () => {
+    const response = await callHandler(
+      {
+        origin_id: 'viz-1',
+        attachment_type: 'visualization',
+        action: 'create',
+        chunks: [{ type: 'visualization', title: 't', content: 'c' }],
+      },
+      false
+    );
+    expect(response.notFound).toHaveBeenCalled();
+    expect(mockSmlService.indexAttachment).not.toHaveBeenCalled();
+  });
+
+  it('passes caller-supplied chunks through to the service for registered types', async () => {
+    const response = await callHandler({
+      origin_id: 'viz-1',
+      attachment_type: 'custom',
+      action: 'create',
+      chunks: [{ type: 'custom', title: 'My title', content: 'My content', description: 'd' }],
+    });
+
+    expect(mockSmlService.getTypeDefinition).toHaveBeenCalledWith('custom');
+    expect(mockSmlService.indexAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originId: 'viz-1',
+        attachmentType: 'custom',
+        action: 'create',
+        spaces: ['test-space'],
+        esClient: expect.objectContaining({ mark: 'internal' }),
+        savedObjectsClient: expect.objectContaining({ mark: 'so-client' }),
+        chunks: [
+          {
+            type: 'custom',
+            title: 'My title',
+            content: 'My content',
+            description: 'd',
+          },
+        ],
+        // HTTP route is always a "direct" write — overrides any crawler chunks.
+        source: 'direct',
+      })
+    );
+    expect(response.ok).toHaveBeenCalledWith({ body: { acknowledged: true } });
+  });
+
+  it('omits optional chunk fields when not provided', async () => {
+    await callHandler({
+      origin_id: 'viz-1',
+      attachment_type: 'visualization',
+      action: 'update',
+      chunks: [{ type: 'visualization', title: 't', content: 'c' }],
+    });
+    const callArgs = mockSmlService.indexAttachment.mock.calls[0][0];
+    expect(callArgs.chunks[0]).toEqual({ type: 'visualization', title: 't', content: 'c' });
+    expect(Object.keys(callArgs.chunks[0])).toEqual(['type', 'title', 'content']);
+  });
+
+  it('handles the delete action without chunks', async () => {
+    const response = await callHandler({
+      origin_id: 'viz-1',
+      attachment_type: 'visualization',
+      action: 'delete',
+    });
+    expect(mockSmlService.indexAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'delete',
+        originId: 'viz-1',
+        // HTTP-driven deletes are direct: they wipe everything for the origin.
+        source: 'direct',
+      })
+    );
+    // No `chunks` should be sent to the service for delete.
+    expect(mockSmlService.indexAttachment.mock.calls[0][0].chunks).toBeUndefined();
+    expect(response.ok).toHaveBeenCalledWith({ body: { acknowledged: true } });
+  });
+
+  it('falls back to default space when the spaces plugin is unavailable', async () => {
+    const localSml = createMockSmlService();
+    const coreSetup = coreMock.createSetup();
+    (coreSetup.getStartServices as jest.Mock).mockResolvedValue([{}, {}, {}]);
+    const localRouter = httpServiceMock.createRouter();
+    registerIndexAttachmentRoute({
+      router: localRouter as any,
+      coreSetup: coreSetup as any,
+      logger,
+      getSmlService: () => localSml as any,
+    });
+    const [config, localHandler] = localRouter.post.mock.calls[0];
+
+    const body = (config.validate as any).body.validate({
+      origin_id: 'viz-1',
+      attachment_type: 'visualization',
+      action: 'create',
+      chunks: [{ type: 'visualization', title: 't', content: 'c' }],
+    });
+    const request = httpServerMock.createKibanaRequest({ body });
+    const response = httpServerMock.createResponseFactory();
+    const ctx = {
+      core: Promise.resolve({
+        uiSettings: { client: createMockUiSettingsClient(true) },
+        elasticsearch: { client: { asInternalUser: {}, asCurrentUser: {} } },
+        savedObjects: { client: {} },
+      }),
+    };
+
+    await localHandler(ctx, request, response);
+    expect(localSml.indexAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({ spaces: ['default'] })
+    );
+  });
+
+  it('propagates errors from sml.indexAttachment', async () => {
+    mockSmlService.indexAttachment.mockRejectedValueOnce(new Error('ES write failed'));
+    await expect(
+      callHandler({
+        origin_id: 'viz-1',
+        attachment_type: 'visualization',
+        action: 'create',
+        chunks: [{ type: 'visualization', title: 't', content: 'c' }],
+      })
+    ).rejects.toThrow('ES write failed');
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('ES write failed'));
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/index_attachment.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/index_attachment.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { RouteSecurity } from '@kbn/core-http-server';
+import { AGENT_CONTEXT_LAYER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
+import { apiPrivileges } from '../../common/features';
+import { smlIndexAttachmentPath } from '../../common/constants';
+import type { SmlIndexAttachmentHttpResponse } from '../../common/http_api/sml';
+import {
+  SML_HTTP_CHUNK_CONTENT_MAX_LENGTH,
+  SML_HTTP_CHUNK_DESCRIPTION_MAX_LENGTH,
+  SML_HTTP_CHUNK_TITLE_MAX_LENGTH,
+  SML_HTTP_INDEX_ATTACHMENT_TYPE_MAX_LENGTH,
+  SML_HTTP_INDEX_MAX_CHUNKS,
+  SML_HTTP_INDEX_ORIGIN_ID_MAX_LENGTH,
+} from '../../common/http_api/sml';
+import type { SmlChunk, SmlService } from '../services/sml/types';
+import type { AgentContextLayerPluginStart, AgentContextLayerStartDependencies } from '../types';
+
+const AGENT_CONTEXT_LAYER_WRITE_SECURITY: RouteSecurity = {
+  authz: { requiredPrivileges: [apiPrivileges.writeAgentContextLayer] },
+};
+
+const chunkSchema = schema.object({
+  type: schema.string({ minLength: 1, maxLength: SML_HTTP_INDEX_ATTACHMENT_TYPE_MAX_LENGTH }),
+  title: schema.string({ minLength: 1, maxLength: SML_HTTP_CHUNK_TITLE_MAX_LENGTH }),
+  content: schema.string({ minLength: 1, maxLength: SML_HTTP_CHUNK_CONTENT_MAX_LENGTH }),
+  description: schema.maybe(
+    schema.string({ minLength: 0, maxLength: SML_HTTP_CHUNK_DESCRIPTION_MAX_LENGTH })
+  ),
+  user_id: schema.maybe(schema.string({ minLength: 1, maxLength: 256 })),
+  references: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+  permissions: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+});
+
+const writeBodySchema = schema.object({
+  origin_id: schema.string({ minLength: 1, maxLength: SML_HTTP_INDEX_ORIGIN_ID_MAX_LENGTH }),
+  attachment_type: schema.string({
+    minLength: 1,
+    maxLength: SML_HTTP_INDEX_ATTACHMENT_TYPE_MAX_LENGTH,
+  }),
+  action: schema.oneOf([schema.literal('create'), schema.literal('update')]),
+  chunks: schema.arrayOf(chunkSchema, { minSize: 1, maxSize: SML_HTTP_INDEX_MAX_CHUNKS }),
+});
+
+const deleteBodySchema = schema.object({
+  origin_id: schema.string({ minLength: 1, maxLength: SML_HTTP_INDEX_ORIGIN_ID_MAX_LENGTH }),
+  attachment_type: schema.string({
+    minLength: 1,
+    maxLength: SML_HTTP_INDEX_ATTACHMENT_TYPE_MAX_LENGTH,
+  }),
+  action: schema.literal('delete'),
+});
+
+const bodySchema = schema.oneOf([writeBodySchema, deleteBodySchema]);
+
+export const registerIndexAttachmentRoute = ({
+  router,
+  coreSetup,
+  logger,
+  getSmlService,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<AgentContextLayerStartDependencies, AgentContextLayerPluginStart>;
+  logger: Logger;
+  getSmlService: () => SmlService;
+}) => {
+  router.post(
+    {
+      path: smlIndexAttachmentPath,
+      validate: { body: bodySchema },
+      options: { access: 'internal' },
+      security: AGENT_CONTEXT_LAYER_WRITE_SECURITY,
+    },
+    async (ctx, request, response) => {
+      try {
+        const coreContext = await ctx.core;
+        const uiSettingsClient = coreContext.uiSettings.client;
+
+        const isEnabled = await uiSettingsClient.get<boolean>(
+          AGENT_CONTEXT_LAYER_EXPERIMENTAL_FEATURES_SETTING_ID
+        );
+        if (!isEnabled) {
+          return response.notFound();
+        }
+
+        const sml = getSmlService();
+        const body = request.body;
+        const originId = body.origin_id;
+        const attachmentType = body.attachment_type;
+
+        if (!sml.getTypeDefinition(attachmentType)) {
+          return response.badRequest({
+            body: `Unknown SML attachment type: '${attachmentType}'`,
+          });
+        }
+
+        const [, startDeps] = await coreSetup.getStartServices();
+        const spaceId = startDeps.spaces?.spacesService?.getSpaceId(request) ?? 'default';
+
+        const baseParams = {
+          originId,
+          attachmentType,
+          spaces: [spaceId],
+          esClient: coreContext.elasticsearch.client.asInternalUser,
+          savedObjectsClient: coreContext.savedObjects.client,
+          logger,
+        };
+
+        if (body.action === 'delete') {
+          // HTTP surface is always a `direct` operation: user-driven deletes
+          // wipe any chunks for the origin regardless of crawler state.
+          await sml.indexAttachment({ ...baseParams, action: 'delete', source: 'direct' });
+        } else {
+          const chunks: SmlChunk[] = body.chunks.map((chunk) => ({
+            type: chunk.type,
+            title: chunk.title,
+            content: chunk.content,
+            ...(chunk.description !== undefined ? { description: chunk.description } : {}),
+            ...(chunk.user_id !== undefined ? { user_id: chunk.user_id } : {}),
+            ...(chunk.references !== undefined ? { references: chunk.references } : {}),
+            ...(chunk.permissions !== undefined ? { permissions: chunk.permissions } : {}),
+          }));
+
+          await sml.indexAttachment({
+            ...baseParams,
+            action: body.action,
+            chunks,
+            source: 'direct',
+          });
+        }
+
+        const responseBody: SmlIndexAttachmentHttpResponse = { acknowledged: true };
+        return response.ok({ body: responseBody });
+      } catch (error) {
+        logger.error(`SML index_attachment route error: ${(error as Error).message}`);
+        throw error;
+      }
+    }
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.test.ts
@@ -89,6 +89,7 @@ describe('registerSearchRoute', () => {
         updated_at: '2024-01-02',
         spaces: ['test-space'],
         permissions: [],
+        source: 'resolved',
         score: 1.5,
       },
     ];
@@ -123,6 +124,7 @@ describe('registerSearchRoute', () => {
         updated_at: '2024-01-02',
         spaces: ['test-space'],
         permissions: [],
+        source: 'resolved',
         score: 1.5,
       },
     ];

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/execute_sml_attach_items.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/execute_sml_attach_items.test.ts
@@ -39,6 +39,7 @@ const createSmlDoc = (overrides: Partial<SmlDocument> = {}): SmlDocument => ({
   updated_at: '2024-01-02',
   spaces: ['default'],
   permissions: [],
+  source: 'resolved',
   ...overrides,
 });
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_crawler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_crawler.test.ts
@@ -406,6 +406,9 @@ describe('SmlCrawlerImpl', () => {
           attachmentType: 'test-type',
           action: 'create',
           spaces: ['default'],
+          // Crawler must label its writes as resolved so direct-mode writes
+          // override them (and vice versa, the indexer skips when direct exists).
+          source: 'resolved',
         })
       );
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_crawler.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_crawler.ts
@@ -372,6 +372,9 @@ export class SmlCrawlerImpl implements SmlCrawler {
                 esClient,
                 savedObjectsClient,
                 logger: this.logger,
+                // Crawler operations are always resolved-mode: they use the
+                // type's `getSmlData` hook and must yield to direct chunks.
+                source: 'resolved',
               });
 
               if (action === 'delete') {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.test.ts
@@ -29,9 +29,16 @@ jest.mock('./sml_service', () => ({
 
 jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
 
-const createMockEsClient = (): jest.Mocked<ElasticsearchClient> =>
+const createMockEsClient = (
+  overrides: Partial<{
+    deleteByQuery: jest.Mock;
+    count: jest.Mock;
+  }> = {}
+): jest.Mocked<ElasticsearchClient> =>
   ({
-    deleteByQuery: jest.fn().mockResolvedValue({ deleted: 0 }),
+    deleteByQuery: overrides.deleteByQuery ?? jest.fn().mockResolvedValue({ deleted: 0 }),
+    // Default to "no direct chunks exist".
+    count: overrides.count ?? jest.fn().mockResolvedValue({ count: 0 }),
   } as unknown as jest.Mocked<ElasticsearchClient>);
 
 const createMockLogger = () => {
@@ -162,6 +169,7 @@ describe('createSmlIndexer', () => {
         updated_at: expect.any(String),
         spaces: ['default', 'space-2'],
         permissions: ['perm1'],
+        source: 'resolved',
       });
     });
 
@@ -404,6 +412,384 @@ describe('createSmlIndexer', () => {
 
       const bulkCall = bulkMock.mock.calls[0][0];
       expect(bulkCall.operations[0].index.document.permissions).toEqual([]);
+    });
+
+    describe('direct mode (caller-supplied chunks)', () => {
+      it('uses caller-supplied chunks and does NOT call getSmlData', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-1',
+            attachmentType: 'lens',
+            action: 'create',
+            spaces: ['s1'],
+            esClient,
+            logger,
+          }),
+          chunks: [
+            {
+              type: 'lens',
+              title: 'Direct title',
+              content: 'Direct content',
+              permissions: ['perm-x'],
+            },
+          ],
+        });
+
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+        const op = bulkMock.mock.calls[0][0].operations[0];
+        expect(op.index._id).toBe('lens:direct-1:mock-uuid');
+        expect(op.index.document).toEqual({
+          id: 'lens:direct-1:mock-uuid',
+          type: 'lens',
+          title: 'Direct title',
+          origin_id: 'direct-1',
+          content: 'Direct content',
+          created_at: expect.any(String),
+          updated_at: expect.any(String),
+          spaces: ['s1'],
+          permissions: ['perm-x'],
+          source: 'direct',
+        });
+      });
+
+      it('indexes direct chunks even when the type is NOT registered', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const registry = createMockRegistry(undefined);
+        registry.list.mockReturnValue([]);
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-2',
+            attachmentType: 'unregistered',
+            action: 'create',
+            esClient,
+            logger,
+          }),
+          chunks: [{ type: 'unregistered', title: 't', content: 'c' }],
+        });
+
+        expect(registry.get).not.toHaveBeenCalled();
+        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('type definition'));
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('treats an empty chunks array as a soft delete', async () => {
+        const bulkMock = jest.fn();
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-3',
+            attachmentType: 'lens',
+            action: 'update',
+            esClient,
+            logger,
+          }),
+          chunks: [],
+        });
+
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+        expect(bulkMock).not.toHaveBeenCalled();
+      });
+
+      it('ignores caller-supplied chunks for the delete action (always deletes)', async () => {
+        const bulkMock = jest.fn();
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-4',
+            attachmentType: 'lens',
+            action: 'delete',
+            esClient,
+            logger,
+          }),
+          chunks: [{ type: 'lens', title: 'ignored', content: 'ignored' }],
+        });
+
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(bulkMock).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('source-based mutual exclusion (direct vs resolved)', () => {
+      it('resolved create: skips when direct chunks already exist for the origin', async () => {
+        const bulkMock = jest.fn();
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn().mockResolvedValue({
+          chunks: [{ type: 'lens', title: 'crawler', content: 'c' }],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        // direct chunks exist for this origin
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 2 }),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment(
+          createIndexerParams({
+            originId: 'mixed-1',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          })
+        );
+
+        expect(esClient.count).toHaveBeenCalledTimes(1);
+        const countCall = (esClient.count as jest.Mock).mock.calls[0][0];
+        expect(countCall.query.bool.filter).toEqual(
+          expect.arrayContaining([
+            { term: { origin_id: 'mixed-1' } },
+            { term: { source: 'direct' } },
+          ])
+        );
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).not.toHaveBeenCalled();
+        expect(bulkMock).not.toHaveBeenCalled();
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.stringContaining('skipping resolved-mode index')
+        );
+      });
+
+      it('resolved delete: skips when direct chunks already exist for the origin', async () => {
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 1 }),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment(
+          createIndexerParams({
+            originId: 'mixed-2',
+            attachmentType: 'lens',
+            action: 'delete',
+            esClient,
+            logger,
+          })
+        );
+
+        expect(esClient.count).toHaveBeenCalledTimes(1);
+        expect(esClient.deleteByQuery).not.toHaveBeenCalled();
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.stringContaining('skipping resolved-mode delete')
+        );
+      });
+
+      it("explicit source='resolved' is respected (skips when direct exists)", async () => {
+        const bulkMock = jest.fn();
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn().mockResolvedValue({
+          chunks: [{ type: 'lens', title: 't', content: 'c' }],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 3 }),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'mixed-3',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          }),
+          source: 'resolved',
+        });
+
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(bulkMock).not.toHaveBeenCalled();
+      });
+
+      it('direct create: overrides existing resolved chunks without checking', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        // even with existing direct chunks (e.g. user re-indexing), direct should override
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 5 }),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'override-1',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          }),
+          chunks: [{ type: 'lens', title: 'override', content: 'new' }],
+        });
+
+        // No precedence check needed in direct mode — direct always wins.
+        expect(esClient.count).not.toHaveBeenCalled();
+        expect(getSmlData).not.toHaveBeenCalled();
+        // deleteByQuery wipes everything for the origin (regardless of source).
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+        expect(esClient.deleteByQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: { term: { origin_id: 'override-1' } },
+          })
+        );
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+        const op = bulkMock.mock.calls[0][0].operations[0];
+        expect(op.index.document.source).toBe('direct');
+      });
+
+      it('direct delete: wipes all chunks regardless of crawler state', async () => {
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 0 }),
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData: jest.fn() })
+        );
+        const logger = createMockLogger();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'override-2',
+            attachmentType: 'lens',
+            action: 'delete',
+            esClient,
+            logger,
+          }),
+          source: 'direct',
+        });
+
+        expect(esClient.count).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+      });
+
+      it('resolved create: proceeds when no direct chunks exist', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn().mockResolvedValue({
+          chunks: [{ type: 'lens', title: 't', content: 'c' }],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient(); // count defaults to 0
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment(
+          createIndexerParams({
+            originId: 'resolved-only',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          })
+        );
+
+        expect(esClient.count).toHaveBeenCalledTimes(1);
+        expect(getSmlData).toHaveBeenCalledTimes(1);
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+        const op = bulkMock.mock.calls[0][0].operations[0];
+        expect(op.index.document.source).toBe('resolved');
+      });
+
+      it('resolved create: fails open when the precedence check throws non-404', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn().mockResolvedValue({
+          chunks: [{ type: 'lens', title: 't', content: 'c' }],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient({
+          count: jest.fn().mockRejectedValue(new Error('cluster_block_exception')),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment(
+          createIndexerParams({
+            originId: 'fail-open-1',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          })
+        );
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('failed to check for direct chunks')
+        );
+        // Failing open means the resolved write proceeds.
+        expect(getSmlData).toHaveBeenCalledTimes(1);
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.ts
@@ -13,7 +13,7 @@ import type {
 } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
 import type { SmlTypeRegistry } from './sml_type_registry';
-import type { SmlIndexAction, SmlContext, SmlDocument } from './types';
+import type { SmlChunk, SmlIndexAction, SmlContext, SmlDocument, SmlDocumentSource } from './types';
 import { createSmlStorage, smlIndexName } from './sml_storage';
 import { isNotFoundError } from './sml_service';
 
@@ -25,6 +25,25 @@ export interface SmlIndexerDeps {
 export interface SmlIndexer {
   /**
    * Index, update, or delete SML data for a specific item.
+   *
+   * The operation runs in one of two modes:
+   *  - **`direct`**: caller supplies `chunks` (or sets `source: 'direct'`
+   *    explicitly). The indexer wipes any pre-existing chunks for `originId`
+   *    (regardless of source) and writes the supplied chunks tagged with
+   *    `source: 'direct'`. For `action: 'delete'` all chunks for the origin
+   *    are wiped.
+   *  - **`resolved`**: caller omits `chunks` (or sets `source: 'resolved'`).
+   *    The indexer looks up the registered type, calls its `getSmlData(originId)`
+   *    hook, and writes the result tagged with `source: 'resolved'`. If chunks
+   *    tagged `source: 'direct'` already exist for this origin, the operation
+   *    is **skipped** to preserve the user's override. The same protection
+   *    applies to `action: 'delete'` in resolved mode.
+   *
+   * `source` is inferred when not provided: `'direct'` if `chunks` is set,
+   * otherwise `'resolved'`.
+   *
+   * Per-`originId` invariant: the index never holds both `resolved` and
+   * `direct` chunks at the same time.
    */
   indexAttachment: (params: {
     originId: string;
@@ -34,6 +53,10 @@ export interface SmlIndexer {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
+    /** Pre-computed chunks (direct mode for `create`/`update`). */
+    chunks?: SmlChunk[];
+    /** Explicit source; defaults to inferred (direct if chunks else resolved). */
+    source?: SmlDocumentSource;
   }) => Promise<void>;
 }
 
@@ -58,6 +81,8 @@ class SmlIndexerImpl implements SmlIndexer {
     esClient,
     savedObjectsClient,
     logger: contextLogger,
+    chunks: directChunks,
+    source: explicitSource,
   }: {
     originId: string;
     attachmentType: string;
@@ -66,54 +91,98 @@ class SmlIndexerImpl implements SmlIndexer {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
+    chunks?: SmlChunk[];
+    source?: SmlDocumentSource;
   }): Promise<void> {
+    const source: SmlDocumentSource =
+      explicitSource ?? (directChunks !== undefined ? 'direct' : 'resolved');
     this.logger.info(
-      `SML indexer: indexAttachment called — originId='${originId}', type='${attachmentType}', action='${action}', spaces=[${spaces.join(
+      `SML indexer: indexAttachment called — originId='${originId}', type='${attachmentType}', action='${action}', source='${source}', spaces=[${spaces.join(
         ', '
       )}]`
     );
 
-    const definition = this.registry.get(attachmentType);
-    if (!definition) {
-      this.logger.warn(
-        `SML indexer: type definition '${attachmentType}' not found — skipping indexing for '${originId}'. Registered types: [${this.registry
-          .list()
-          .map((t) => t.id)
-          .join(', ')}]`
-      );
-      return;
-    }
-
     if (action === 'delete') {
+      if (source === 'resolved') {
+        const hasDirect = await this.hasDirectChunks({ originId, esClient });
+        if (hasDirect) {
+          this.logger.info(
+            `SML indexer: skipping resolved-mode delete for origin '${originId}' — direct chunks exist and take precedence`
+          );
+          return;
+        }
+      }
       this.logger.info(`SML indexer: deleting chunks for origin '${originId}'`);
       await this.deleteChunks({ originId, esClient });
       return;
     }
 
-    const context: SmlContext = {
-      esClient,
-      savedObjectsClient,
-      logger: contextLogger,
-    };
-
-    this.logger.info(
-      `SML indexer: calling getSmlData for origin '${originId}' of type '${attachmentType}'`
-    );
-    const smlData = await definition.getSmlData(originId, context);
-    if (!smlData || smlData.chunks.length === 0) {
+    let chunks: SmlChunk[];
+    if (source === 'direct') {
+      if (directChunks === undefined) {
+        this.logger.warn(
+          `SML indexer: source='direct' but no chunks supplied for origin '${originId}' — treating as delete`
+        );
+        await this.deleteChunks({ originId, esClient });
+        return;
+      }
+      if (directChunks.length === 0) {
+        this.logger.info(
+          `SML indexer: direct mode received empty chunks for origin '${originId}' — deleting existing chunks`
+        );
+        await this.deleteChunks({ originId, esClient });
+        return;
+      }
+      chunks = directChunks;
       this.logger.info(
-        `SML indexer: no SML data returned for origin '${originId}' of type '${attachmentType}' — deleting existing chunks`
+        `SML indexer: direct mode — using ${chunks.length} caller-supplied chunk(s) for origin '${originId}' (will override any existing chunks)`
       );
-      await this.deleteChunks({ originId, esClient });
-      return;
+    } else {
+      const hasDirect = await this.hasDirectChunks({ originId, esClient });
+      if (hasDirect) {
+        this.logger.info(
+          `SML indexer: skipping resolved-mode index for origin '${originId}' — direct chunks exist and take precedence`
+        );
+        return;
+      }
+
+      const definition = this.registry.get(attachmentType);
+      if (!definition) {
+        this.logger.warn(
+          `SML indexer: type definition '${attachmentType}' not found — skipping indexing for '${originId}'. Registered types: [${this.registry
+            .list()
+            .map((t) => t.id)
+            .join(', ')}]`
+        );
+        return;
+      }
+
+      const context: SmlContext = {
+        esClient,
+        savedObjectsClient,
+        logger: contextLogger,
+      };
+
+      this.logger.info(
+        `SML indexer: calling getSmlData for origin '${originId}' of type '${attachmentType}'`
+      );
+      const smlData = await definition.getSmlData(originId, context);
+      if (!smlData || smlData.chunks.length === 0) {
+        this.logger.info(
+          `SML indexer: no SML data returned for origin '${originId}' of type '${attachmentType}' — deleting existing chunks`
+        );
+        await this.deleteChunks({ originId, esClient });
+        return;
+      }
+      chunks = smlData.chunks;
     }
 
     this.logger.info(
-      `SML indexer: getSmlData returned ${
-        smlData.chunks.length
-      } chunk(s) for origin '${originId}'. First chunk title: '${
-        smlData.chunks[0]?.title
-      }', content length: ${smlData.chunks[0]?.content?.length ?? 0}`
+      `SML indexer: indexing ${
+        chunks.length
+      } chunk(s) for origin '${originId}' (source='${source}'). First chunk title: '${
+        chunks[0]?.title
+      }', content length: ${chunks[0]?.content?.length ?? 0}`
     );
 
     await this.deleteChunks({ originId, esClient });
@@ -122,7 +191,7 @@ class SmlIndexerImpl implements SmlIndexer {
     const smlClient = storage.getClient();
 
     const now = new Date().toISOString();
-    const bulkOps = smlData.chunks.map((chunk) => {
+    const bulkOps = chunks.map((chunk) => {
       const chunkId = `${attachmentType}:${originId}:${uuidv4()}`;
       const document: SmlDocument = {
         id: chunkId,
@@ -134,6 +203,7 @@ class SmlIndexerImpl implements SmlIndexer {
         updated_at: now,
         spaces,
         permissions: chunk.permissions ?? [],
+        source,
       };
       if (chunk.description !== undefined) {
         document.description = chunk.description;
@@ -171,7 +241,7 @@ class SmlIndexerImpl implements SmlIndexer {
           );
         } else {
           this.logger.info(
-            `SML indexer: successfully indexed ${smlData.chunks.length} chunk(s) for origin '${originId}'`
+            `SML indexer: successfully indexed ${chunks.length} chunk(s) for origin '${originId}'`
           );
         }
       } catch (error) {
@@ -182,6 +252,48 @@ class SmlIndexerImpl implements SmlIndexer {
         );
         throw error;
       }
+    }
+  }
+
+  /**
+   * Check whether any chunks tagged `source: 'direct'` exist for the given
+   * `originId`. Used to enforce the per-origin mutual-exclusion invariant:
+   * resolved writes are skipped when direct chunks exist.
+   *
+   * Safe to call before the index has been created.
+   */
+  private async hasDirectChunks({
+    originId,
+    esClient,
+  }: {
+    originId: string;
+    esClient: ElasticsearchClient;
+  }): Promise<boolean> {
+    try {
+      const result = await esClient.count({
+        index: smlIndexName,
+        ignore_unavailable: true,
+        allow_no_indices: true,
+        query: {
+          bool: {
+            filter: [{ term: { origin_id: originId } }, { term: { source: 'direct' } }],
+          },
+        },
+      });
+      return (result.count ?? 0) > 0;
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return false;
+      }
+      this.logger.warn(
+        `SML indexer: failed to check for direct chunks for origin '${originId}': ${
+          (error as Error).message
+        }`
+      );
+      // Fail open: treat as no direct chunks rather than blocking the
+      // resolved-mode write. The next direct write will re-establish the
+      // override.
+      return false;
     }
   }
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
@@ -357,6 +357,8 @@ describe('SmlService', () => {
         updated_at: '2024-01-02',
         spaces: ['default'],
         permissions: ['saved_object:lens/get'],
+        // Hit had no `source` (pre-`source` doc) — service defaults to 'resolved'.
+        source: 'resolved',
         score: 1.5,
       });
       expect(result.total).toBe(1);
@@ -848,6 +850,8 @@ describe('SmlService', () => {
         updated_at: '2024-01-02',
         spaces: ['default'],
         permissions: [],
+        // Hit had no `source` (pre-`source` doc) — service defaults to 'resolved'.
+        source: 'resolved',
       });
       expect(result.get('doc-2')).toEqual({
         id: 'doc-2',
@@ -862,6 +866,7 @@ describe('SmlService', () => {
         updated_at: '2024-01-02',
         spaces: ['default'],
         permissions: [],
+        source: 'resolved',
       });
     });
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -109,7 +109,17 @@ class SmlServiceImpl implements SmlServiceInstance {
         });
       },
       indexAttachment: async (params) => {
-        return this.getIndexer().indexAttachment(params);
+        return this.getIndexer().indexAttachment({
+          originId: params.originId,
+          attachmentType: params.attachmentType,
+          action: params.action,
+          spaces: params.spaces,
+          esClient: params.esClient,
+          savedObjectsClient: params.savedObjectsClient,
+          logger: params.logger,
+          chunks: params.chunks,
+          source: params.source,
+        });
       },
       getDocuments: async ({ ids, spaceId, esClient }) => {
         return getDocumentsByIds({ ids, spaceId, esClient, logger });
@@ -488,6 +498,9 @@ const searchSml = async ({
           spaces: source.spaces ?? [],
           permissions: source.permissions ?? [],
           user_id: source.user_id,
+          // Pre-`source` docs in the index default to `resolved` (the crawler
+          // was the only writer before this field existed).
+          source: source.source ?? 'resolved',
           score: hit._score ?? 0,
         };
       });
@@ -556,6 +569,8 @@ const getDocumentsByIds = async ({
         updated_at: source.updated_at ?? '',
         spaces: source.spaces ?? [],
         permissions: source.permissions ?? [],
+        // Pre-`source` docs in the index default to `resolved`.
+        source: source.source ?? 'resolved',
       };
       if (source.description !== undefined) {
         doc.description = source.description;

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_storage.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_storage.ts
@@ -33,6 +33,12 @@ const smlStorageSchemaProperties = {
   updated_at: types.date({}),
   spaces: types.keyword({}),
   permissions: types.keyword({}),
+  /**
+   * How this chunk was produced. `resolved` = crawler / `getSmlData` hook;
+   * `direct` = caller supplied chunks (HTTP, workflow step, ...). Used to
+   * enforce the per-origin-id mutual-exclusion invariant.
+   */
+  source: types.keyword({}),
 };
 
 export const storageSettings = {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
@@ -112,6 +112,20 @@ export interface SmlTypeDefinition {
 }
 
 /**
+ * Where a chunk was produced.
+ *
+ * - `resolved`: produced by the crawler or any caller relying on the registered
+ *   type's `getSmlData(originId)` hook.
+ * - `direct`: produced by a caller that supplied chunks directly (HTTP API,
+ *   workflow step, ...).
+ *
+ * The two modes are mutually exclusive per `origin_id`: a `direct` write
+ * overrides any existing chunks, and a `resolved` write is skipped when
+ * `direct` chunks already exist.
+ */
+export type SmlDocumentSource = 'resolved' | 'direct';
+
+/**
  * An SML document as stored in the system index.
  */
 export interface SmlDocument {
@@ -139,6 +153,8 @@ export interface SmlDocument {
   spaces: string[];
   /** Permissions required to access the underlying element */
   permissions: string[];
+  /** How this chunk was produced. See {@link SmlDocumentSource}. */
+  source: SmlDocumentSource;
 }
 
 /**
@@ -223,7 +239,21 @@ export interface SmlService {
     request: KibanaRequest;
   }) => Promise<Map<string, boolean>>;
 
-  /** Index a single attachment (event-driven) */
+  /**
+   * Index a single attachment (event-driven).
+   *
+   * Behavior depends on the effective `source`:
+   * - `direct`: caller supplies `chunks`. The indexer wipes any pre-existing
+   *   chunks for `originId` (regardless of source) and writes the supplied
+   *   chunks tagged with `source: 'direct'`. For `action: 'delete'` it wipes
+   *   all chunks for the origin.
+   * - `resolved`: the indexer calls `getSmlData(originId)` via the registered
+   *   type. If chunks tagged `source: 'direct'` already exist for this origin,
+   *   the operation is **skipped** to preserve the user's override.
+   *
+   * `source` is inferred when not provided: `'direct'` if `chunks` is set,
+   * otherwise `'resolved'`.
+   */
   indexAttachment: (params: {
     originId: string;
     attachmentType: string;
@@ -232,6 +262,8 @@ export interface SmlService {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract;
     logger: Logger;
+    chunks?: SmlChunk[];
+    source?: SmlDocumentSource;
   }) => Promise<void>;
 
   /** Fetch SML documents by their chunk IDs, scoped to a space */

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/types.ts
@@ -16,18 +16,22 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
 import type {
   SmlTypeDefinition,
   SmlSearchResult,
   SmlSearchFilters,
   SmlDocument,
   SmlIndexAction,
+  SmlChunk,
+  SmlDocumentSource,
 } from './services/sml/types';
 import type { SmlResolvedItemResult } from './services/sml/execute_sml_attach_items';
 
 export interface AgentContextLayerSetupDependencies {
   features: FeaturesPluginSetup;
   taskManager: TaskManagerSetupContract;
+  workflowsExtensions?: WorkflowsExtensionsServerPluginSetup;
 }
 
 export interface AgentContextLayerStartDependencies {
@@ -85,4 +89,19 @@ export interface SmlIndexAttachmentParams {
   action: SmlIndexAction;
   spaceId?: string;
   includedHiddenTypes?: string[];
+  /**
+   * Optional pre-computed chunks. When provided (for `create`/`update`), the
+   * SML service skips the registered type's `getSmlData` hook and indexes the
+   * supplied chunks directly. Ignored for `action: 'delete'`.
+   */
+  chunks?: SmlChunk[];
+  /**
+   * Explicit source for this operation. When not provided, defaults to
+   * `'direct'` if `chunks` is set, otherwise `'resolved'`.
+   *
+   * `direct` writes override any existing chunks for the `originId`.
+   * `resolved` writes are skipped when `direct` chunks already exist for the
+   * `originId` (preserving the user's override).
+   */
+  source?: SmlDocumentSource;
 }

--- a/x-pack/platform/plugins/shared/agent_context_layer/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_context_layer/tsconfig.json
@@ -28,7 +28,5 @@
     "@kbn/core-logging-server-mocks",
     "@kbn/logging-mocks",
     "@kbn/workflows-extensions",
-    "@kbn/workflows",
-    "@kbn/zod"
   ]
 }

--- a/x-pack/platform/plugins/shared/agent_context_layer/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_context_layer/tsconfig.json
@@ -26,6 +26,9 @@
     "@kbn/agent-builder-server",
     "@kbn/core-http-server-mocks",
     "@kbn/core-logging-server-mocks",
-    "@kbn/logging-mocks"
+    "@kbn/logging-mocks",
+    "@kbn/workflows-extensions",
+    "@kbn/workflows",
+    "@kbn/zod"
   ]
 }


### PR DESCRIPTION
## Summary

PoC for https://github.com/elastic/search-team/issues/14477

- updates schema with `source: 'resolved' | 'direct'` to differentiate between entries indexed by crawler / by user
- expands indexAttachment method on server contract with ability to index `direct` entries
- exposes workflow step that allow to index `direct` entries (for users with `sml:write` permissions)
- adds management page from which one can install default workflows, run them and monitor their progress

-- any user with `sml:write` permissions can overwrite any item in sml index

<img width="2392" height="1236" alt="image" src="https://github.com/user-attachments/assets/6020fa32-924f-4362-9f80-5de4453ec4d4" />
