### PR TITLE
Add Chrome Next developer toolbar toggle

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -44,7 +44,7 @@ pageLoadAssetSize:
   dataViewManagement: 6250
   dataViews: 66000
   dataVisualizer: 32727
-  developerToolbar: 4467
+  developerToolbar: 5000
   devTools: 8109
   discover: 30501
   discoverEnhanced: 5353

--- a/src/core/packages/chrome/feature-flags/README.md
+++ b/src/core/packages/chrome/feature-flags/README.md
@@ -14,3 +14,7 @@ import { isNextChrome } from '@kbn/core-chrome-feature-flags';
 
 const nextChromeEnabled = isNextChrome(featureFlags);
 ```
+
+`NEXT_CHROME_SESSION_STORAGE_KEY` (`dev.core.chrome.next`) is used by the development toolbar
+toggle. The session override is only read after `core.chrome.next` is enabled, so it can disable
+Chrome Next locally during development but cannot enable Chrome Next when the rollout flag is off.

--- a/src/core/packages/chrome/feature-flags/chrome_next_toggle.tsx
+++ b/src/core/packages/chrome/feature-flags/chrome_next_toggle.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { FeatureFlagsStart } from '@kbn/core-feature-flags-browser';
+import { isNextChrome, toggleNextChrome } from '.';
+
+const badgeStyles = css`
+  cursor: pointer;
+`;
+
+interface ChromeNextToggleProps {
+  featureFlags: Pick<FeatureFlagsStart, 'getBooleanValue'>;
+}
+
+export const ChromeNextToggle: React.FC<ChromeNextToggleProps> = ({ featureFlags }) => {
+  const isEnabled = isNextChrome(featureFlags);
+
+  const onClick = useCallback(() => {
+    toggleNextChrome(featureFlags);
+  }, [featureFlags]);
+
+  return (
+    <EuiToolTip
+      content={`Click to ${isEnabled ? 'disable' : 'enable'} Chrome Next. Page will reload.`}
+    >
+      <EuiBadge
+        color={isEnabled ? 'success' : 'danger'}
+        css={badgeStyles}
+        iconType="beaker"
+        iconSide="left"
+        onClick={onClick}
+        onClickAriaLabel="Toggle Chrome Next"
+      >
+        Chrome Next: {isEnabled ? 'ON' : 'OFF'}
+      </EuiBadge>
+    </EuiToolTip>
+  );
+};

--- a/src/core/packages/chrome/feature-flags/index.ts
+++ b/src/core/packages/chrome/feature-flags/index.ts
@@ -10,8 +10,32 @@
 import type { FeatureFlagsStart } from '@kbn/core-feature-flags-browser';
 
 export const NEXT_CHROME_FEATURE_FLAG_KEY = 'core.chrome.next';
+export const NEXT_CHROME_SESSION_STORAGE_KEY = 'dev.core.chrome.next';
 
 type FeatureFlagsBooleanReader = Pick<FeatureFlagsStart, 'getBooleanValue'>;
 
-export const isNextChrome = (featureFlags: FeatureFlagsBooleanReader): boolean =>
+const isNextChromeFeatureFlagEnabled = (featureFlags: FeatureFlagsBooleanReader): boolean =>
   featureFlags.getBooleanValue(NEXT_CHROME_FEATURE_FLAG_KEY, false);
+
+export const isNextChrome = (featureFlags: FeatureFlagsBooleanReader): boolean => {
+  if (!isNextChromeFeatureFlagEnabled(featureFlags)) {
+    return false;
+  }
+
+  try {
+    const override = sessionStorage.getItem(NEXT_CHROME_SESSION_STORAGE_KEY);
+    return override === null ? true : override === 'true';
+  } catch {
+    return true;
+  }
+};
+
+export const toggleNextChrome = (featureFlags: FeatureFlagsBooleanReader): void => {
+  if (!isNextChromeFeatureFlagEnabled(featureFlags)) {
+    return;
+  }
+
+  const next = !isNextChrome(featureFlags);
+  sessionStorage.setItem(NEXT_CHROME_SESSION_STORAGE_KEY, String(next));
+  window.location.reload();
+};

--- a/src/platform/plugins/shared/developer_toolbar/moon.yml
+++ b/src/platform/plugins/shared/developer_toolbar/moon.yml
@@ -24,6 +24,7 @@ dependsOn:
   - '@kbn/config-schema'
   - '@kbn/core-chrome-browser-internal-types'
   - '@kbn/measure-component'
+  - '@kbn/core-chrome-feature-flags'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
+++ b/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
@@ -15,7 +15,6 @@ import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal-type
 import { BehaviorSubject } from 'rxjs';
 import type { DeveloperToolbarItemProps } from '@kbn/developer-toolbar';
 import { NEXT_CHROME_FEATURE_FLAG_KEY } from '@kbn/core-chrome-feature-flags';
-import { ChromeNextToggle } from '@kbn/core-chrome-feature-flags/chrome_next_toggle';
 
 export type UnregisterItemFn = () => void;
 export interface DeveloperToolbarItemRegistry {
@@ -62,10 +61,12 @@ export class DeveloperToolbarPlugin
     });
 
     if (core.featureFlags.getBooleanValue(NEXT_CHROME_FEATURE_FLAG_KEY, false)) {
-      this.registerItem({
-        id: 'Chrome Next',
-        children: <ChromeNextToggle featureFlags={core.featureFlags} />,
-        priority: 1,
+      import('@kbn/core-chrome-feature-flags/chrome_next_toggle').then(({ ChromeNextToggle }) => {
+        this.registerItem({
+          id: 'Chrome Next',
+          children: <ChromeNextToggle featureFlags={core.featureFlags} />,
+          priority: 1,
+        });
       });
     }
 

--- a/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
+++ b/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
@@ -14,6 +14,8 @@ import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal-type
 
 import { BehaviorSubject } from 'rxjs';
 import type { DeveloperToolbarItemProps } from '@kbn/developer-toolbar';
+import { NEXT_CHROME_FEATURE_FLAG_KEY } from '@kbn/core-chrome-feature-flags';
+import { ChromeNextToggle } from '@kbn/core-chrome-feature-flags/chrome_next_toggle';
 
 export type UnregisterItemFn = () => void;
 export interface DeveloperToolbarItemRegistry {
@@ -58,6 +60,14 @@ export class DeveloperToolbarPlugin
         </Suspense>
       ),
     });
+
+    if (core.featureFlags.getBooleanValue(NEXT_CHROME_FEATURE_FLAG_KEY, false)) {
+      this.registerItem({
+        id: 'Chrome Next',
+        children: <ChromeNextToggle featureFlags={core.featureFlags} />,
+        priority: 1,
+      });
+    }
 
     return {
       registerItem: this.registerItem.bind(this),

--- a/src/platform/plugins/shared/developer_toolbar/tsconfig.json
+++ b/src/platform/plugins/shared/developer_toolbar/tsconfig.json
@@ -13,5 +13,6 @@
     "@kbn/config-schema",
     "@kbn/core-chrome-browser-internal-types",
     "@kbn/measure-component",
+    "@kbn/core-chrome-feature-flags",
   ]
 }


### PR DESCRIPTION
Part of #260015

## Summary

Adds a developer toolbar toggle for Chrome Next so developers can switch the new chrome experience on or off while the rollout feature flag is enabled. The session override remains gated by `core.chrome.next` feature flag, so it cannot enable Chrome Next when the feature flag is off.