### PR TITLE
[Entity Analytics][Watchlists] MV_CONTAINS for watchlist-filtered ES|QL viz queries

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.ts
@@ -76,7 +76,7 @@ const getEntityStoreJoinBlock = (spaceId: string, watchlistId?: string) => {
   // Filter ensures only entities that exist in the entity store are shown.
   // For watchlists, the watchlist filter implicitly achieves this.
   const entityFilter = watchlistId
-    ? `| WHERE entity.attributes.watchlists == "${watchlistId}"`
+    ? `| WHERE MV_CONTAINS(entity.attributes.watchlists, "${watchlistId}")`
     : `| WHERE entity.name IS NOT NULL`;
 
   return `

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.test.ts
@@ -120,10 +120,10 @@ describe('useRiskLevelsEsqlQuery', () => {
     const generatedQuery = queryKey[1];
 
     expect(generatedQuery).toContain('FROM entities-latest-default');
-    expect(generatedQuery).toContain('entity.attributes.watchlists == "test-watchlist"');
+    expect(generatedQuery).toContain('MV_CONTAINS(entity.attributes.watchlists, "test-watchlist")');
   });
 
-  it('should translate prebuilt watchlist IDs to names in query', () => {
+  it('should include prebuilt watchlist id in MV_CONTAINS filter', () => {
     renderHook(() =>
       useRiskLevelsEsqlQuery({ spaceId: 'default', watchlistId: 'privileged_watchlist_id' })
     );
@@ -131,7 +131,9 @@ describe('useRiskLevelsEsqlQuery', () => {
     const queryKey = mockUseQuery.mock.calls[0][0];
     const generatedQuery = queryKey[1];
 
-    expect(generatedQuery).toContain('entity.attributes.watchlists == "privileged_watchlist_id"');
+    expect(generatedQuery).toContain(
+      'MV_CONTAINS(entity.attributes.watchlists, "privileged_watchlist_id")'
+    );
   });
 
   it('should set enabled to false if skip is true', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/queries/watchlist_risk_level_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/queries/watchlist_risk_level_query.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-export const getWatchlistRiskLevelsQueryBodyV2 = (watchlistName?: string) => `
+export const getWatchlistRiskLevelsQueryBodyV2 = (watchlistId?: string) => `
 | WHERE  entity.EngineMetadata.Type IN ("user", "host", "service")${
-  watchlistName ? ` AND entity.attributes.watchlists == "${watchlistName}"` : ''
+  watchlistId ? ` AND MV_CONTAINS(entity.attributes.watchlists, "${watchlistId}")` : ''
 }
 | STATS count = COUNT(*) BY entity.risk.calculated_level
 | RENAME entity.risk.calculated_level AS level`;


### PR DESCRIPTION
## Summary

ES|QL equality on multi-valued `entity.attributes.watchlists` resolves to null when an entity is enrolled in more than one watchlist, so **Recent Anomalies** and the **Entity Risk Levels** donut on Entity Analytics home omitted those entities whenever a watchlist filter was applied (while the entities table, which uses DSL `term`, did not). The watchlist predicates now use `MV_CONTAINS(entity.attributes.watchlists, "<id>")`, consistent with other entity analytics ES|QL. The risk-level query helper parameter is renamed from `watchlistName` to `watchlistId` to match what callers pass.


## How to test

1. Create two watchlists and assign at least one entity to **both**, with risk scoring and a recent ML anomaly for that entity.
2. Open **Security → Entity Analytics** (home) and filter by one of those watchlists.
3. Confirm the entity appears in **Recent Anomalies** and in the **Entity Risk Levels** donut, not only in the entities table.

```bash
node scripts/jest x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.test.ts
```

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->