### PR TITLE
[Streams] Remote direct ES cluster support

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/dataset_analysis.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/dataset_analysis.ts
@@ -28,7 +28,8 @@ This is useful for understanding what fields are available for querying and what
 
     const formattedAnalysis = formatDocumentAnalysis(analysis, {
       dropEmpty: true,
-      dropUnmapped: false,
+      dropUnmapped: true,
+      limit: 150,
     });
 
     return {

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/dataset_analysis.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/dataset_analysis.ts
@@ -18,10 +18,10 @@ export const datasetAnalysisGenerator: ComputedFeatureGenerator = {
 Use the \`properties.analysis\` field to understand available fields and their value distributions.
 This is useful for understanding what fields are available for querying and what values they typically contain.`,
 
-  generate: async ({ stream, start, end, esClient }) => {
+  generate: async ({ indexPattern, start, end, esClient }) => {
     const analysis = await describeDataset({
       esClient,
-      index: stream.name,
+      index: indexPattern,
       start,
       end,
     });

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.test.ts
@@ -42,6 +42,7 @@ describe('errorLogsGenerator', () => {
 
     const result = await errorLogsGenerator.generate({
       stream,
+      indexPattern: stream.name,
       start: 100,
       end: 200,
       esClient,

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.ts
@@ -32,10 +32,10 @@ export const errorLogsGenerator: ComputedFeatureGenerator = {
 Use the \`properties.samples\` array to see actual error log entries.
 This is useful for understanding error patterns, identifying recurring issues, and diagnosing problems in the system.`,
 
-  generate: async ({ stream, start, end, esClient }) => {
+  generate: async ({ indexPattern, start, end, esClient }) => {
     const { hits } = await getSampleDocumentsEsql({
       esClient,
-      index: stream.name,
+      index: indexPattern,
       start,
       end,
       sampleSize: SAMPLE_SIZE,

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/index.ts
@@ -82,12 +82,49 @@ function toComputedFeature(
  * Generates all computed features by running all registered generators in parallel.
  */
 export async function generateAllComputedFeatures(
-  options: ComputedFeatureGeneratorOptions
+  options: Omit<ComputedFeatureGeneratorOptions, 'indexPattern'> & { indexPattern?: string }
 ): Promise<BaseFeature[]> {
-  return Promise.all(
+  const resolvedOptions: ComputedFeatureGeneratorOptions = {
+    ...options,
+    indexPattern: options.indexPattern ?? options.stream.name,
+  };
+  const results = await Promise.allSettled(
     registry.getAll().map(async (generator) => {
-      const value = await generator.generate(options);
-      return toComputedFeature(generator, value, options.stream.name);
+      resolvedOptions.logger.debug(
+        `Running computed feature generator [${generator.type}] on index [${resolvedOptions.indexPattern}]`
+      );
+      try {
+        const value = await generator.generate(resolvedOptions);
+        return toComputedFeature(generator, value, options.stream.name);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const body =
+          err != null &&
+          typeof err === 'object' &&
+          'meta' in err &&
+          (err as Record<string, unknown>).meta != null &&
+          typeof (err as Record<string, unknown>).meta === 'object' &&
+          'body' in ((err as Record<string, unknown>).meta as object)
+            ? JSON.stringify(
+                ((err as Record<string, unknown>).meta as Record<string, unknown>).body
+              )
+            : undefined;
+        resolvedOptions.logger.warn(
+          `Computed feature generator [${generator.type}] failed for index [${
+            resolvedOptions.indexPattern
+          }]: ${msg}${body ? `\nResponse body: ${body}` : ''}`
+        );
+        throw err;
+      }
     })
   );
+
+  const features: BaseFeature[] = [];
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      features.push(result.value);
+    }
+    // rejections already logged above; swallow so other generators still contribute
+  }
+  return features;
 }

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_patterns.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_patterns.ts
@@ -49,7 +49,7 @@ Use the \`properties.patterns\` array to see both common and rare log patterns. 
 Each pattern includes: field (source field name), pattern (normalized message with placeholders), count (frequency), and sample (a real example message, possibly truncated).
 This is useful for understanding the types of logs in the stream and identifying anomalies or trends.`,
 
-  generate: async ({ stream, start, end, esClient, logger }) => {
+  generate: async ({ indexPattern, start, end, esClient, logger }) => {
     const tracedClient = createTracedEsClient({
       client: esClient,
       logger,
@@ -58,7 +58,7 @@ This is useful for understanding the types of logs in the stream and identifying
 
     const patterns = await getLogPatterns({
       esClient: tracedClient,
-      index: stream.name,
+      index: indexPattern,
       start,
       end,
       fields: LOG_MESSAGE_FIELDS,

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_samples.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_samples.test.ts
@@ -42,6 +42,7 @@ describe('logSamplesGenerator', () => {
 
     const result = await logSamplesGenerator.generate({
       stream,
+      indexPattern: stream.name,
       start: 100,
       end: 200,
       esClient,

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_samples.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_samples.ts
@@ -22,10 +22,10 @@ export const logSamplesGenerator: ComputedFeatureGenerator = {
 Use the \`properties.samples\` array to see actual log entries and their field values.
 This is useful for understanding the format of logs, identifying patterns, and seeing real examples of data in the stream.`,
 
-  generate: async ({ stream, start, end, esClient }) => {
+  generate: async ({ indexPattern, start, end, esClient }) => {
     const { hits } = await getSampleDocumentsEsql({
       esClient,
-      index: stream.name,
+      index: indexPattern,
       start,
       end,
       sampleSize: SAMPLE_SIZE,

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/types.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/types.ts
@@ -13,6 +13,12 @@ import type { Streams } from '@kbn/streams-schema';
  */
 export interface ComputedFeatureGeneratorOptions {
   stream: Streams.all.Definition;
+  /**
+   * The index or index pattern to query on the data cluster.
+   * Defaults to `stream.name` but overridden for remote streams
+   * where `remote_index_pattern` differs from the stream name.
+   */
+  indexPattern: string;
   start: number;
   end: number;
   esClient: ElasticsearchClient;

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/significant_events/generate_significant_events.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/significant_events/generate_significant_events.ts
@@ -78,6 +78,7 @@ function getErrorMessage(error: unknown): string {
  */
 export async function generateSignificantEvents({
   stream,
+  indexPattern,
   esClient,
   getFeatures,
   inferenceClient,
@@ -90,6 +91,12 @@ export async function generateSignificantEvents({
   maxExistingQueriesForContext = DEFAULT_MAX_EXISTING_QUERIES_FOR_CONTEXT,
 }: {
   stream: Streams.all.Definition;
+  /**
+   * The index or index pattern to use in ES|QL FROM clauses.
+   * Defaults to `stream.name`; override for remote streams where the
+   * backing index differs from the stream name.
+   */
+  indexPattern?: string;
   esClient: ElasticsearchClient;
   getFeatures(params?: {
     type?: string[];
@@ -130,11 +137,13 @@ export async function generateSignificantEvents({
       )
     : '';
 
+  const effectiveIndexPattern = indexPattern ?? stream.name;
+
   logger.trace('Generating significant events via reasoning agent');
   const response = await withSpan('generate_significant_events', () =>
     executeAsReasoningAgent({
       input: {
-        name: stream.name,
+        name: effectiveIndexPattern,
         description: stream.description,
         available_feature_types: SIGNIFICANT_EVENTS_FEATURE_TOOL_TYPES.join(', '),
         computed_feature_instructions: getComputedFeatureInstructions(),
@@ -228,10 +237,13 @@ export async function generateSignificantEvents({
                 }
 
                 const hints = getStatsQueryHints(rewritten);
+                const validationQuery = `${rewritten}\n| LIMIT 0`;
+
+                logger.debug(`Validating ES|QL query:\n${validationQuery}`);
 
                 await esClient.esql.query(
                   {
-                    query: `${rewritten}\n| LIMIT 0`,
+                    query: validationQuery,
                     format: 'json',
                   },
                   { signal, requestTimeout: '10s' }
@@ -247,11 +259,28 @@ export async function generateSignificantEvents({
                 };
               } catch (error) {
                 hasFailures = true;
+                const errorMessage = getErrorMessage(error);
+                // Log the body of the error response if available (e.g. ES 400 responses
+                // contain the actual reason string in error.meta.body).
+                const body =
+                  error != null &&
+                  typeof error === 'object' &&
+                  'meta' in error &&
+                  error.meta != null &&
+                  typeof error.meta === 'object' &&
+                  'body' in error.meta
+                    ? JSON.stringify(error.meta.body)
+                    : undefined;
+                logger.warn(
+                  `ES|QL query validation failed: ${errorMessage}${
+                    body ? `\nResponse body: ${body}` : ''
+                  }`
+                );
                 return {
                   query,
                   valid: false,
                   status: 'Failed to add',
-                  error: getErrorMessage(error),
+                  error: errorMessage,
                 };
               }
             })

--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -22,6 +22,7 @@ export {
   ClassicIngestUpsertRequest,
 } from './src/models/ingest/classic';
 export { Query, QueryStream } from './src/models/query';
+export { RemoteStream } from './src/models/remote';
 export {
   ESQL_VIEW_PREFIX,
   getEsqlViewName,

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/converters.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/converters.ts
@@ -8,6 +8,7 @@
 import { omit } from 'lodash';
 import { Streams } from '../models/streams';
 import { QueryStream } from '../models/query';
+import { RemoteStream } from '../models/remote';
 
 /**
  * Parses a stream upsert request and converts it into the corresponding stream definition.
@@ -55,6 +56,14 @@ export const convertUpsertRequestIntoDefinition = (
   }
 
   if (QueryStream.UpsertRequest.is(request)) {
+    return {
+      ...request.stream,
+      name,
+      updated_at: now,
+    };
+  }
+
+  if (RemoteStream.UpsertRequest.is(request)) {
     return {
       ...request.stream,
       name,
@@ -111,6 +120,15 @@ export const convertGetResponseIntoUpsertRequest = (
   }
 
   if (QueryStream.GetResponse.is(getResponse)) {
+    return {
+      dashboards: getResponse.dashboards,
+      queries: getResponse.queries,
+      rules: getResponse.rules,
+      stream: omit(getResponse.stream, ['name', 'updated_at']),
+    };
+  }
+
+  if (RemoteStream.GetResponse.is(getResponse)) {
     return {
       dashboards: getResponse.dashboards,
       queries: getResponse.queries,

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/get_stream_type_from_definition.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/get_stream_type_from_definition.ts
@@ -7,7 +7,7 @@
 
 import { Streams } from '../models/streams';
 
-export type StreamType = 'wired' | 'classic' | 'query' | 'unknown';
+export type StreamType = 'wired' | 'classic' | 'query' | 'remote' | 'unknown';
 
 export function getStreamTypeFromDefinition(definition: Streams.all.Definition): StreamType {
   if (Streams.WiredStream.Definition.is(definition)) {
@@ -20,6 +20,10 @@ export function getStreamTypeFromDefinition(definition: Streams.all.Definition):
 
   if (Streams.QueryStream.Definition.is(definition)) {
     return 'query';
+  }
+
+  if (Streams.RemoteStream.Definition.is(definition)) {
+    return 'remote';
   }
 
   return 'unknown';

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/hierarchy_helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/hierarchy_helpers.ts
@@ -18,6 +18,12 @@ export function getIndexPatternsForStream(stream: Streams.all.Definition | undef
   if (Streams.ClassicStream.Definition.is(stream)) {
     return [stream.name];
   }
+  if (Streams.RemoteStream.Definition.is(stream)) {
+    // Remote streams reference an index on a separate cluster.
+    // Use remote_index_pattern if set, otherwise fall back to the stream name.
+    const pattern = stream.remote_index_pattern ?? stream.name;
+    return [pattern];
+  }
   // Returns [name, name.*] for ingest streams. The wildcard matches child ingest
   // data streams but NOT query stream ES|QL views, which live in the $.namespace
   // (e.g. $.name.child). This separation is intentional — see ESQL_VIEW_PREFIX.

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/remote/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/remote/index.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { z } from '@kbn/zod/v4';
+import type { BaseStream } from '../base';
+import {
+  baseStreamDefinitionSchema,
+  baseStreamGetResponseSchema,
+  baseStreamUpsertRequestSchema,
+  baseStreamUpsertDefinitionSchema,
+} from '../base';
+import type { Validation } from '../validation/validation';
+import { validation } from '../validation/validation';
+import type { InheritedFieldDefinition } from '../../fields';
+import { inheritedFieldDefinitionSchema } from '../../fields';
+
+/* eslint-disable @typescript-eslint/no-namespace */
+export namespace RemoteStream {
+  export interface Model {
+    Definition: RemoteStream.Definition;
+    Source: RemoteStream.Source;
+    GetResponse: RemoteStream.GetResponse;
+    UpsertRequest: RemoteStream.UpsertRequest;
+  }
+
+  export interface Definition extends BaseStream.Definition {
+    type: 'remote';
+    /**
+     * The index pattern on the remote cluster that this stream reads from.
+     * Defaults to the stream name when not provided.
+     */
+    remote_index_pattern?: string;
+  }
+
+  export type Source = BaseStream.Source<RemoteStream.Definition>;
+
+  export interface GetResponse extends BaseStream.GetResponse<Definition> {
+    stream: Definition;
+    inherited_fields: InheritedFieldDefinition;
+  }
+
+  export interface UpsertRequest extends BaseStream.UpsertRequest<Definition> {
+    stream: Omit<BaseStream.UpsertRequest<Definition>['stream'], 'remote_index_pattern'> & {
+      remote_index_pattern?: string;
+    };
+  }
+}
+
+const remoteStreamDefinitionSchema = baseStreamDefinitionSchema
+  .extend({
+    type: z.literal('remote'),
+    remote_index_pattern: z.string().optional(),
+  })
+  .meta({ id: 'RemoteStreamDefinition' });
+
+const remoteStreamGetResponseSchema = baseStreamGetResponseSchema
+  .extend({
+    stream: remoteStreamDefinitionSchema,
+    inherited_fields: inheritedFieldDefinitionSchema,
+  })
+  .meta({ id: 'RemoteStreamGetResponse' });
+
+const remoteStreamUpsertRequestSchema = baseStreamUpsertRequestSchema
+  .extend({
+    stream: baseStreamUpsertDefinitionSchema.extend({
+      type: z.literal('remote'),
+      remote_index_pattern: z.string().optional(),
+    }),
+  })
+  .meta({ id: 'RemoteStreamUpsertRequest' });
+
+export const RemoteStream: {
+  Definition: Validation<BaseStream.Model['Definition'], RemoteStream.Definition>;
+  Source: Validation<BaseStream.Model['Definition'], RemoteStream.Source>;
+  GetResponse: Validation<BaseStream.Model['GetResponse'], RemoteStream.GetResponse>;
+  UpsertRequest: Validation<BaseStream.Model['UpsertRequest'], RemoteStream.UpsertRequest>;
+} = {
+  Definition: validation(
+    remoteStreamDefinitionSchema as z.Schema<BaseStream.Model['Definition']>,
+    remoteStreamDefinitionSchema
+  ),
+  Source: validation(
+    remoteStreamDefinitionSchema as z.Schema<BaseStream.Model['Definition']>,
+    remoteStreamDefinitionSchema
+  ),
+  GetResponse: validation(
+    remoteStreamGetResponseSchema as z.Schema<BaseStream.Model['GetResponse']>,
+    remoteStreamGetResponseSchema
+  ),
+  UpsertRequest: validation(
+    remoteStreamUpsertRequestSchema as z.Schema<BaseStream.Model['UpsertRequest']>,
+    remoteStreamUpsertRequestSchema
+  ),
+};
+
+// Optimized implementation for Definition check
+RemoteStream.Definition.is = (
+  stream: BaseStream.Model['Definition']
+): stream is RemoteStream.Definition => (stream as RemoteStream.Definition).type === 'remote';

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/streams.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/streams.ts
@@ -13,6 +13,7 @@ import { IngestStream } from './ingest';
 import { ClassicStream as nClassicStream } from './ingest/classic';
 import { WiredStream as nWiredStream } from './ingest/wired';
 import { QueryStream as nQueryStream } from './query';
+import { RemoteStream as nRemoteStream } from './remote';
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
@@ -22,30 +23,43 @@ export namespace Streams {
   export import WiredStream = nWiredStream;
   export import ClassicStream = nClassicStream;
   export import QueryStream = nQueryStream;
+  export import RemoteStream = nRemoteStream;
 
   export namespace all {
-    export type Model = ingest.all.Model | QueryStream.Model;
-    export type Source = ingest.all.Source | QueryStream.Source;
-    export type Definition = ingest.all.Definition | QueryStream.Definition;
-    export type GetResponse = ingest.all.GetResponse | QueryStream.GetResponse;
-    export type UpsertRequest = ingest.all.UpsertRequest | QueryStream.UpsertRequest;
+    export type Model = ingest.all.Model | QueryStream.Model | RemoteStream.Model;
+    export type Source = ingest.all.Source | QueryStream.Source | RemoteStream.Source;
+    export type Definition =
+      | ingest.all.Definition
+      | QueryStream.Definition
+      | RemoteStream.Definition;
+    export type GetResponse =
+      | ingest.all.GetResponse
+      | QueryStream.GetResponse
+      | RemoteStream.GetResponse;
+    export type UpsertRequest =
+      | ingest.all.UpsertRequest
+      | QueryStream.UpsertRequest
+      | RemoteStream.UpsertRequest;
   }
 
   const allDefinitionSchema = z.union([
     nWiredStream.Definition.right,
     nClassicStream.Definition.right,
     nQueryStream.Definition.right,
+    nRemoteStream.Definition.right,
   ]);
   const allSourceSchema = z.union([
     nWiredStream.Source.right,
     nClassicStream.Source.right,
     nQueryStream.Source.right,
+    nRemoteStream.Source.right,
   ]);
   const allGetResponseSchema = z
     .union([
       nWiredStream.GetResponse.right,
       nClassicStream.GetResponse.right,
       nQueryStream.GetResponse.right,
+      nRemoteStream.GetResponse.right,
     ])
     .meta({ id: 'StreamGetResponse' });
   const allUpsertRequestSchema = z
@@ -53,6 +67,7 @@ export namespace Streams {
       nWiredStream.UpsertRequest.right,
       nClassicStream.UpsertRequest.right,
       nQueryStream.UpsertRequest.right,
+      nRemoteStream.UpsertRequest.right,
     ])
     .meta({ id: 'StreamUpsertRequest' });
 
@@ -85,9 +100,10 @@ Streams.ingest = IngestStream;
 Streams.WiredStream = nWiredStream;
 Streams.ClassicStream = nClassicStream;
 Streams.QueryStream = nQueryStream;
+Streams.RemoteStream = nRemoteStream;
 
 /**
- * Union of all three stream definition schemas, discriminated by the `type`
+ * Union of all four stream definition schemas, discriminated by the `type`
  * literal field. Registered as a named OAS component (`StreamDefinition`) with
  * a `discriminator` extension so code generators can produce properly typed
  * sealed-class / tagged-union structs.
@@ -97,6 +113,7 @@ export const streamDefinitionSchema = z
     nWiredStream.Definition.right,
     nClassicStream.Definition.right,
     nQueryStream.Definition.right,
+    nRemoteStream.Definition.right,
   ])
   .meta({
     id: 'StreamDefinition',
@@ -107,6 +124,7 @@ export const streamDefinitionSchema = z
           wired: '#/components/schemas/WiredStreamDefinition',
           classic: '#/components/schemas/ClassicStreamDefinition',
           query: '#/components/schemas/QueryStreamDefinition',
+          remote: '#/components/schemas/RemoteStreamDefinition',
         },
       },
     },

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/oas_definitions.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/oas_definitions.ts
@@ -16,6 +16,7 @@ import { WiredStream } from './models/ingest/wired';
 import { ClassicStream, ClassicIngest } from './models/ingest/classic';
 import { WiredIngest } from './models/ingest/wired';
 import { QueryStream } from './models/query';
+import { RemoteStream } from './models/remote';
 import { streamDefinitionSchema, Streams } from './models/streams';
 import {
   fieldDefinitionSchema,
@@ -45,6 +46,7 @@ export const streamsOasDefinitions = {
   WiredStreamDefinition: WiredStream.Definition.right,
   ClassicStreamDefinition: ClassicStream.Definition.right,
   QueryStreamDefinition: QueryStream.Definition.right,
+  RemoteStreamDefinition: RemoteStream.Definition.right,
 
   // Get response union and variants
   // .meta({ id }) applied at definition time in their respective files
@@ -52,6 +54,7 @@ export const streamsOasDefinitions = {
   WiredStreamGetResponse: WiredStream.GetResponse.right,
   ClassicStreamGetResponse: ClassicStream.GetResponse.right,
   QueryStreamGetResponse: QueryStream.GetResponse.right,
+  RemoteStreamGetResponse: RemoteStream.GetResponse.right,
 
   // Upsert request union and variants
   // .meta({ id }) applied at definition time in their respective files
@@ -59,6 +62,7 @@ export const streamsOasDefinitions = {
   WiredStreamUpsertRequest: WiredStream.UpsertRequest.right,
   ClassicStreamUpsertRequest: ClassicStream.UpsertRequest.right,
   QueryStreamUpsertRequest: QueryStream.UpsertRequest.right,
+  RemoteStreamUpsertRequest: RemoteStream.UpsertRequest.right,
 
   // Ingest configs
   WiredIngest: WiredIngest.right,

--- a/x-pack/platform/plugins/shared/streams/common/config.ts
+++ b/x-pack/platform/plugins/shared/streams/common/config.ts
@@ -23,6 +23,12 @@ export const configSchema = schema.object({
       taskTimeout: schema.duration({ defaultValue: '30s' }),
     }),
   }),
+  remoteEsCluster: schema.maybe(
+    schema.object({
+      host: schema.uri({ scheme: ['http', 'https'] }),
+      apiKey: schema.string(),
+    })
+  ),
 });
 
 export type StreamsConfig = TypeOf<typeof configSchema>;

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/read/query_documents.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/read/query_documents.ts
@@ -107,12 +107,16 @@ export const createQueryDocumentsTool = ({
   schema: queryDocumentsSchema,
   handler: async ({ name, query: nlQuery, source }, { request, modelProvider }) => {
     try {
-      const { streamsClient, scopedClusterClient } = await getScopedClients({ request });
-      const esClient = scopedClusterClient.asCurrentUser;
-
-      const targetIndex = source === 'failures' ? `${name}${FAILURE_STORE_SELECTOR}` : name;
+      const { streamsClient, scopedClusterClient, getDataClusterClientForStream } =
+        await getScopedClients({ request });
 
       const definition = await streamsClient.getStream(name);
+      const dataClusterClient = getDataClusterClientForStream(definition);
+      const esClient = dataClusterClient.isRemote
+        ? dataClusterClient.esClient
+        : scopedClusterClient.asCurrentUser;
+
+      const targetIndex = source === 'failures' ? `${name}${FAILURE_STORE_SELECTOR}` : name;
       const definitionFieldTypes = getDefinitionFieldTypes(definition);
 
       const [fieldCapsResponse, sampleDocs, model] = await Promise.all([

--- a/x-pack/platform/plugins/shared/streams/server/lib/data_cluster_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/data_cluster_client.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+/**
+ * Abstracts over local vs. remote ES cluster clients.
+ *
+ * - `isRemote === false`: queries go to the local Kibana-managed ES cluster.
+ * - `isRemote === true`: queries go to the remote cluster configured via
+ *   `xpack.streams.remoteEsCluster` in kibana.yml, using a fixed API key.
+ */
+export interface DataClusterClient {
+  readonly esClient: ElasticsearchClient;
+  readonly isRemote: boolean;
+}
+
+export const createLocalDataClusterClient = (esClient: ElasticsearchClient): DataClusterClient => ({
+  esClient,
+  isRemote: false,
+});
+
+export const createRemoteDataClusterClient = (
+  esClient: ElasticsearchClient
+): DataClusterClient => ({ esClient, isRemote: true });

--- a/x-pack/platform/plugins/shared/streams/server/lib/remote_cluster/remote_es_client_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/remote_cluster/remote_es_client_service.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Client } from '@elastic/elasticsearch';
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+export interface RemoteEsClusterConfig {
+  host: string;
+  apiKey: string;
+}
+
+export class RemoteEsClientService {
+  private readonly client: ElasticsearchClient;
+
+  constructor(config: RemoteEsClusterConfig) {
+    this.client = new Client({
+      node: config.host,
+      auth: { apiKey: config.apiKey },
+    }) as unknown as ElasticsearchClient;
+  }
+
+  getClient(): ElasticsearchClient {
+    return this.client;
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/remote_cluster/remote_es_client_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/remote_cluster/remote_es_client_service.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Client } from '@elastic/elasticsearch';
+import { Client, HttpConnection, ClusterConnectionPool } from '@elastic/elasticsearch';
 import type { ElasticsearchClient } from '@kbn/core/server';
 
 export interface RemoteEsClusterConfig {
@@ -20,6 +20,11 @@ export class RemoteEsClientService {
     this.client = new Client({
       node: config.host,
       auth: { apiKey: config.apiKey },
+      // Use ClusterConnectionPool + HttpConnection to disable sniffing.
+      // The default SniffingTransport discovers internal node IPs for cloud
+      // clusters that are unreachable from outside, breaking subsequent requests.
+      Connection: HttpConnection,
+      ConnectionPool: ClusterConnectionPool,
     }) as unknown as ElasticsearchClient;
   }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_computed_features.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_computed_features.ts
@@ -7,7 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
-import type { Feature, Streams } from '@kbn/streams-schema';
+import { type Feature, type Streams, Streams as StreamsNS } from '@kbn/streams-schema';
 import { generateAllComputedFeatures } from '@kbn/streams-ai';
 import type { FeatureClient } from '../../streams/feature/feature_client';
 import { reconcileComputedFeatures } from './reconcile_features';
@@ -35,8 +35,13 @@ export async function identifyComputedFeatures({
   featureTtlDays,
   runId,
 }: IdentifyComputedFeaturesOptions): Promise<Feature[]> {
+  const indexPattern = StreamsNS.RemoteStream.Definition.is(stream)
+    ? stream.remote_index_pattern ?? stream.name
+    : stream.name;
+
   const computedFeatures = await generateAllComputedFeatures({
     stream,
+    indexPattern,
     start,
     end,
     esClient,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_inferred_features.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_inferred_features.ts
@@ -178,6 +178,7 @@ async function tryIdentifyFeatures(
 interface RunInferredIterationOptions {
   esClient: ElasticsearchClient;
   streamName: string;
+  indexPattern: string;
   start: number;
   end: number;
   runId: string;
@@ -217,6 +218,7 @@ type InferredIterationResult =
 async function runInferredIteration({
   esClient,
   streamName,
+  indexPattern,
   start,
   end,
   runId,
@@ -244,7 +246,7 @@ async function runInferredIteration({
 
   const batchResult = await fetchSampleDocuments({
     esClient,
-    index: streamName,
+    index: indexPattern,
     start,
     end,
     features: discoveredFeatures.filter(isFeatureWithFilter),
@@ -348,6 +350,8 @@ export interface IdentifyInferredFeaturesOptions {
   logger: Logger;
   signal: AbortSignal;
   streamName: string;
+  /** Effective index pattern to query — defaults to streamName, overridden for remote streams. */
+  indexPattern?: string;
   streamType: StreamType;
   start: number;
   end: number;
@@ -375,6 +379,7 @@ export async function identifyInferredFeatures({
   logger,
   signal,
   streamName,
+  indexPattern,
   streamType,
   start,
   end,
@@ -384,6 +389,7 @@ export async function identifyInferredFeatures({
   diverseOffset = 0,
   trackFeaturesIdentified,
 }: IdentifyInferredFeaturesOptions): Promise<IdentifyInferredFeaturesResult> {
+  const effectiveIndexPattern = indexPattern ?? streamName;
   const [
     { hits: allFeatures },
     { hits: excludedFeatures },
@@ -401,6 +407,7 @@ export async function identifyInferredFeatures({
   const iterationResult = await runInferredIteration({
     esClient,
     streamName,
+    indexPattern: effectiveIndexPattern,
     start,
     end,
     runId,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/generate_significant_events.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/generate_significant_events.ts
@@ -7,7 +7,11 @@
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { ChatCompletionTokenCount, InferenceClient } from '@kbn/inference-common';
-import type { GeneratedSignificantEventQuery, Streams } from '@kbn/streams-schema';
+import {
+  type GeneratedSignificantEventQuery,
+  type Streams,
+  Streams as StreamsNS,
+} from '@kbn/streams-schema';
 import { QUERY_TYPE_STATS, ensureMetadata } from '@kbn/streams-schema';
 import { generateSignificantEvents } from '@kbn/streams-ai';
 import type { SignificantEventsToolUsage } from '@kbn/streams-ai';
@@ -61,8 +65,13 @@ export async function generateSignificantEventDefinitions(
     connectorId,
   });
 
+  const indexPattern = StreamsNS.RemoteStream.Definition.is(definition)
+    ? definition.remote_index_pattern ?? definition.name
+    : definition.name;
+
   const { queries, tokensUsed, toolUsage } = await generateSignificantEvents({
     stream: definition,
+    indexPattern,
     esClient,
     inferenceClient: boundInferenceClient,
     logger,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/generate_insights.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/generate_insights.ts
@@ -25,6 +25,17 @@ import { createSummarizeStreamsPrompt } from './prompts/summarize_streams/prompt
 import { SUBMIT_INSIGHTS_TOOL_NAME } from './client/insight_tool';
 import { extractInsightsFromResponse, collectQueryData, type QueryData } from './utils';
 
+const CONTEXT_LENGTH_PHRASES = [
+  `The request exceeded the model's maximum context length`, // OpenAI / Azure OpenAI
+  `Input is too long for requested model`, // Amazon Bedrock
+  `prompt is too long`, // Gemini / Vertex AI
+];
+
+const isContextLengthError = (error: unknown) => {
+  const msg = getErrorMessage(error);
+  return CONTEXT_LENGTH_PHRASES.some((phrase) => msg.includes(phrase));
+};
+
 export interface InsightsMemoryTools {
   tools: Record<string, ToolDefinition>;
   callbacks: Record<string, ToolCallback>;
@@ -126,9 +137,7 @@ export async function generateInsights({
       tokens_used: sumTokens({ accumulated: tokensUsed, added: response.tokens }),
     };
   } catch (error) {
-    if (
-      getErrorMessage(error).includes(`The request exceeded the model's maximum context length`)
-    ) {
+    if (isContextLengthError(error)) {
       logger.debug(
         `Context too big when generating system insights, number of streams: ${streamInsightsWithData.length}`,
         { error } as LogMeta
@@ -215,9 +224,7 @@ async function generateStreamInsights({
       tokens_used: response.tokens ?? EMPTY_TOKENS,
     };
   } catch (error) {
-    if (
-      getErrorMessage(error).includes(`The request exceeded the model's maximum context length`)
-    ) {
+    if (isContextLengthError(error)) {
       logger.debug(
         `Context too big when generating insights for stream ${stream.name}, number of queries: ${queryDataList.length}`,
         { error } as LogMeta

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/utils.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/utils.ts
@@ -22,6 +22,7 @@ export interface QueryData {
 
 const SAMPLE_EVENTS_COUNT = 5;
 const CURRENT_WINDOW_MINUTES = 15;
+const SAMPLE_EVENT_MAX_CHARS = 2_000;
 
 /**
  * Safely extracts insights from an LLM response.
@@ -107,9 +108,12 @@ export async function collectQueryData({
     return undefined;
   }
 
-  const sampleEvents = currentResponse.hits.hits.map((hit) =>
-    JSON.stringify(omit(hit._source?.original_source ?? {}, '_id'))
-  );
+  const sampleEvents = currentResponse.hits.hits.map((hit) => {
+    const raw = JSON.stringify(omit(hit._source?.original_source ?? {}, '_id'));
+    return raw.length > SAMPLE_EVENT_MAX_CHARS
+      ? `${raw.slice(0, SAMPLE_EVENT_MAX_CHARS)}…(truncated)`
+      : raw;
+  });
 
   return {
     title: query.query.title,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/preview_significant_events.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/preview_significant_events.ts
@@ -6,7 +6,7 @@
  */
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
-import type { IScopedClusterClient, Logger } from '@kbn/core/server';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { BasicPrettyPrinter, Builder, Parser } from '@elastic/esql';
 import type { ESQLCommand } from '@elastic/esql/types';
 import type { SignificantEventsPreviewResponse } from '@kbn/streams-schema';
@@ -176,12 +176,12 @@ export async function previewSignificantEvents(
     timestampField?: string;
   },
   dependencies: {
-    scopedClusterClient: IScopedClusterClient;
+    esClient: ElasticsearchClient;
     logger?: Logger;
   }
 ): Promise<SignificantEventsPreviewResponse> {
   const { esqlQuery, bucketSize, from, to, timestampField = '@timestamp' } = params;
-  const { scopedClusterClient, logger } = dependencies;
+  const { esClient, logger } = dependencies;
 
   const isStats = hasStatsCommand(esqlQuery);
   const resolvedBucketTarget = isStats ? extractBucketTargetField(esqlQuery) : null;
@@ -206,15 +206,12 @@ export async function previewSignificantEvents(
   };
 
   if (isStats) {
-    return previewStatsQuery(
-      { esqlQuery, filter, from, to, bucketSize },
-      { scopedClusterClient, logger }
-    );
+    return previewStatsQuery({ esqlQuery, filter, from, to, bucketSize }, { esClient, logger });
   }
 
   return previewMatchQuery(
     { esqlQuery, filter, from, to, bucketSize, timestampField: effectiveTimestampField },
-    { scopedClusterClient, logger }
+    { esClient, logger }
   );
 }
 
@@ -227,12 +224,12 @@ async function previewMatchQuery(
     bucketSize: string;
     timestampField?: string;
   },
-  deps: { scopedClusterClient: IScopedClusterClient; logger?: Logger }
+  deps: { esClient: ElasticsearchClient; logger?: Logger }
 ): Promise<SignificantEventsPreviewResponse> {
   const { esqlQuery, filter, from, to, bucketSize, timestampField } = params;
-  const { scopedClusterClient, logger } = deps;
+  const { esClient, logger } = deps;
 
-  const response = await scopedClusterClient.asCurrentUser.esql.query({
+  const response = await esClient.esql.query({
     query: buildHistogramQuery(esqlQuery, bucketSize, timestampField),
     filter,
     drop_null_columns: true,
@@ -305,17 +302,17 @@ async function previewStatsQuery(
     to: Date;
     bucketSize: string;
   },
-  deps: { scopedClusterClient: IScopedClusterClient; logger?: Logger }
+  deps: { esClient: ElasticsearchClient; logger?: Logger }
 ): Promise<SignificantEventsPreviewResponse> {
   const { esqlQuery, filter, from, to, bucketSize } = params;
-  const { scopedClusterClient, logger } = deps;
+  const { esClient, logger } = deps;
 
   const queryWithoutLimit = stripLimitCommand(esqlQuery);
   const composedQuery = `${queryWithoutLimit} | LIMIT ${PREVIEW_STATS_LIMIT}`;
 
   logger?.debug(`STATS preview executing composed query: ${composedQuery}`);
 
-  const response = await scopedClusterClient.asCurrentUser.esql.query({
+  const response = await esClient.esql.query({
     query: composedQuery,
     filter,
     drop_null_columns: true,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/executor.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/executor.ts
@@ -20,109 +20,122 @@ import { MAX_ALERTS_PER_EXECUTION, MAX_DEDUP_IDS, MATCH_LOOKBACK_MINUTES } from 
 import { buildEsqlSearchRequest } from './lib/build_esql_search_request';
 import { executeEsqlRequest } from './lib/execute_esql_request';
 import type { EsqlRuleInstanceState, EsqlRuleParams } from './types';
+import type { RemoteEsClientService } from '../../../remote_cluster/remote_es_client_service';
 
-export async function getRuleExecutor(
-  options: RuleExecutorOptions<
-    EsqlRuleParams,
-    EsqlRuleInstanceState,
-    AlertInstanceState,
-    AlertInstanceContext,
-    'default',
-    Alert
-  > & {
-    services: PersistenceServices;
-  }
-) {
-  const { services, params, logger, state, startedAt, spaceId, rule } = options;
-  const { scopedClusterClient, alertWithPersistence } = services;
+type RuleExecutorArgs = RuleExecutorOptions<
+  EsqlRuleParams,
+  EsqlRuleInstanceState,
+  AlertInstanceState,
+  AlertInstanceContext,
+  'default',
+  Alert
+> & {
+  services: PersistenceServices;
+};
 
-  // The executor cannot self-heal (no rulesClient access); cleanup is
-  // handled by syncQueries / the demotedToStats path in QueryClient.
-  // This guard prevents wasted ES queries until the next sync cycle runs.
-  if (hasStatsCommand(params.query)) {
-    logger.error(
-      `Rule "${rule.id}" contains a STATS query that cannot produce document-level alerts. ` +
-        `This is a transient state — the rule will be uninstalled on the next syncQueries cycle. Skipping execution.`
-    );
-    return { state: { previousOriginalDocumentIds: [] } };
-  }
+/**
+ * Returns a rule executor that, when `params.useRemoteCluster` is true, routes
+ * ES|QL queries through the configured remote cluster client instead of the
+ * default scoped cluster client.
+ */
+export function createRuleExecutor(remoteEsClientService?: RemoteEsClientService) {
+  return async function getRuleExecutor(options: RuleExecutorArgs) {
+    const { services, params, logger, state, startedAt, spaceId, rule } = options;
+    const { scopedClusterClient, alertWithPersistence } = services;
 
-  const previousOriginalDocumentIds = state.previousOriginalDocumentIds ?? [];
+    // The executor cannot self-heal (no rulesClient access); cleanup is
+    // handled by syncQueries / the demotedToStats path in QueryClient.
+    // This guard prevents wasted ES queries until the next sync cycle runs.
+    if (hasStatsCommand(params.query)) {
+      logger.error(
+        `Rule "${rule.id}" contains a STATS query that cannot produce document-level alerts. ` +
+          `This is a transient state — the rule will be uninstalled on the next syncQueries cycle. Skipping execution.`
+      );
+      return { state: { previousOriginalDocumentIds: [] } };
+    }
 
-  const now = moment(startedAt);
+    const previousOriginalDocumentIds = state.previousOriginalDocumentIds ?? [];
 
-  const esqlRequest = buildEsqlSearchRequest({
-    query: params.query,
-    timestampField: params.timestampField,
-    from: now.clone().subtract(MATCH_LOOKBACK_MINUTES, 'minutes').toISOString(),
-    to: now.clone().toISOString(),
-    previousOriginalDocumentIds,
-  });
+    const now = moment(startedAt);
 
-  const results = await executeEsqlRequest({
-    esClient: scopedClusterClient.asCurrentUser,
-    esqlRequest,
-    logger,
-  });
+    const esqlRequest = buildEsqlSearchRequest({
+      query: params.query,
+      timestampField: params.timestampField,
+      from: now.clone().subtract(MATCH_LOOKBACK_MINUTES, 'minutes').toISOString(),
+      to: now.clone().toISOString(),
+      previousOriginalDocumentIds,
+    });
 
-  if (results.length === 0) {
-    return {
-      state: {
-        previousOriginalDocumentIds,
-      },
-    };
-  }
+    const esClient =
+      params.useRemoteCluster && remoteEsClientService
+        ? remoteEsClientService.getClient()
+        : scopedClusterClient.asCurrentUser;
 
-  const alertDocIdToDocumentIdMap = new Map<string, string>();
-  const alerts = results.map((result) => {
-    const alertDocId = objectHash([result._id, rule.id, spaceId]);
-    alertDocIdToDocumentIdMap.set(alertDocId, result._id);
+    const results = await executeEsqlRequest({
+      esClient,
+      esqlRequest,
+      logger,
+    });
 
-    return {
-      _id: alertDocId,
-      _source: {
-        original_source: {
-          _id: result._id,
-          ...result._source,
+    if (results.length === 0) {
+      return {
+        state: {
+          previousOriginalDocumentIds,
         },
-      },
-    };
-  });
+      };
+    }
 
-  const refreshOnIndexingAlerts = false;
-  const { createdAlerts, errors } = await alertWithPersistence(
-    alerts,
-    refreshOnIndexingAlerts,
-    MAX_ALERTS_PER_EXECUTION
-  );
+    const alertDocIdToDocumentIdMap = new Map<string, string>();
+    const alerts = results.map((result) => {
+      const alertDocId = objectHash([result._id, rule.id, spaceId]);
+      alertDocIdToDocumentIdMap.set(alertDocId, result._id);
 
-  if (!isEmpty(errors)) {
-    logger.error(
-      `alertWithPersistence completed with ${errors.length} error(s) (${
-        createdAlerts.length
-      } alerts created): ${JSON.stringify(errors)}`
+      return {
+        _id: alertDocId,
+        _source: {
+          original_source: {
+            _id: result._id,
+            ...result._source,
+          },
+        },
+      };
+    });
+
+    const refreshOnIndexingAlerts = false;
+    const { createdAlerts, errors } = await alertWithPersistence(
+      alerts,
+      refreshOnIndexingAlerts,
+      MAX_ALERTS_PER_EXECUTION
     );
-  }
 
-  const originalDocumentIds: string[] = [];
-  for (const alert of createdAlerts) {
-    const docId = alertDocIdToDocumentIdMap.get(alert._id);
-    if (docId) {
-      originalDocumentIds.push(docId);
-    } else {
-      logger.warn(
-        `Alert "${alert._id}" has no mapped original document ID; skipping dedup entry — this may cause duplicate alerts on the next run`
+    if (!isEmpty(errors)) {
+      logger.error(
+        `alertWithPersistence completed with ${errors.length} error(s) (${
+          createdAlerts.length
+        } alerts created): ${JSON.stringify(errors)}`
       );
     }
-  }
 
-  // Previous IDs come first, new IDs are appended — slice(-N) keeps the most recent ones.
-  const mergedIds = [...new Set([...previousOriginalDocumentIds, ...originalDocumentIds])];
+    const originalDocumentIds: string[] = [];
+    for (const alert of createdAlerts) {
+      const docId = alertDocIdToDocumentIdMap.get(alert._id);
+      if (docId) {
+        originalDocumentIds.push(docId);
+      } else {
+        logger.warn(
+          `Alert "${alert._id}" has no mapped original document ID; skipping dedup entry — this may cause duplicate alerts on the next run`
+        );
+      }
+    }
 
-  return {
-    state: {
-      previousOriginalDocumentIds:
-        mergedIds.length > MAX_DEDUP_IDS ? mergedIds.slice(-MAX_DEDUP_IDS) : mergedIds,
-    },
+    // Previous IDs come first, new IDs are appended — slice(-N) keeps the most recent ones.
+    const mergedIds = [...new Set([...previousOriginalDocumentIds, ...originalDocumentIds])];
+
+    return {
+      state: {
+        previousOriginalDocumentIds:
+          mergedIds.length > MAX_DEDUP_IDS ? mergedIds.slice(-MAX_DEDUP_IDS) : mergedIds,
+      },
+    };
   };
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/register.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/register.ts
@@ -15,16 +15,14 @@ import {
   STREAMS_PRODUCER,
   STREAMS_RULE_REGISTRATION_CONTEXT,
 } from '../../../../../common/constants';
-import { getRuleExecutor } from './executor';
+import { createRuleExecutor } from './executor';
 import type { EsqlRuleParams } from './types';
 import { esqlRuleParams } from './types';
+import type { RemoteEsClientService } from '../../../remote_cluster/remote_es_client_service';
 
-export function esqlRuleType(): PersistenceAlertType<
-  EsqlRuleParams,
-  RuleTypeState,
-  AlertInstanceContext,
-  'default'
-> {
+export function esqlRuleType(
+  remoteEsClientService?: RemoteEsClientService
+): PersistenceAlertType<EsqlRuleParams, RuleTypeState, AlertInstanceContext, 'default'> {
   return {
     id: STREAMS_ESQL_RULE_TYPE_ID,
     name: 'ES|QL Rule',
@@ -51,7 +49,7 @@ export function esqlRuleType(): PersistenceAlertType<
     solution: 'observability',
     isExportable: false,
     actionVariables: {},
-    executor: getRuleExecutor,
+    executor: createRuleExecutor(remoteEsClientService),
     autoRecoverAlerts: false,
     alerts: {
       context: STREAMS_RULE_REGISTRATION_CONTEXT,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/types.ts
@@ -19,9 +19,15 @@ export const esqlRuleInstanceState = z.object({
 export interface EsqlRuleParams extends RuleTypeParams {
   query: string;
   timestampField: string;
+  /**
+   * When true, the executor will use the remote ES cluster client configured
+   * via `xpack.streams.remoteEsCluster` instead of the default scoped client.
+   */
+  useRemoteCluster?: boolean;
 }
 
 export const esqlRuleParams = z.object({
   query: z.string(),
   timestampField: z.string(),
+  useRemoteCluster: z.boolean().optional(),
 }) satisfies z.Schema<EsqlRuleParams>;

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/register_rules.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/register_rules.ts
@@ -15,13 +15,15 @@ import {
 } from '../../../../common/constants';
 import type { StreamsPluginSetupDependencies } from '../../../types';
 import { esqlRuleType } from './esql/register';
+import type { RemoteEsClientService } from '../../remote_cluster/remote_es_client_service';
 
 interface Props {
   plugins: StreamsPluginSetupDependencies;
   logger: Logger;
+  remoteEsClientService?: RemoteEsClientService;
 }
 
-export function registerRules({ plugins, logger }: Props) {
+export function registerRules({ plugins, logger, remoteEsClientService }: Props) {
   const ruleDataClient = plugins.ruleRegistry.ruleDataService.initializeIndex({
     feature: STREAMS_FEATURE_ID,
     registrationContext: STREAMS_RULE_REGISTRATION_CONTEXT,
@@ -41,5 +43,5 @@ export function registerRules({ plugins, logger }: Props) {
     formatAlert: undefined,
   });
 
-  plugins.alerting.registerType(persistenceRuleTypeWrapper(esqlRuleType()));
+  plugins.alerting.registerType(persistenceRuleTypeWrapper(esqlRuleType(remoteEsClientService)));
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/significant_events_queries_generation.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/significant_events_queries_generation.ts
@@ -59,8 +59,8 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                 soClient,
                 getFeatureClient,
                 getQueryClient,
-                scopedClusterClient,
                 uiSettingsClient,
+                getDataClusterClientForStream,
               } = await taskContext.getScopedClients({
                 request: fakeRequest,
               });
@@ -68,10 +68,12 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
               const taskLogger = taskContext.logger.get('significant_events_queries_generation');
 
               try {
-                const [featureClient, queryClient] = await Promise.all([
+                const [featureClient, queryClient, definition] = await Promise.all([
                   getFeatureClient(),
                   getQueryClient(),
+                  streamsClient.getStream(streamName),
                 ]);
+                const dataClusterClient = getDataClusterClientForStream(definition);
 
                 const result = await generateKIQueries(
                   { streamName, connectorId: connectorIdOverride },
@@ -81,7 +83,7 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                     soClient,
                     featureClient,
                     queryClient,
-                    esClient: scopedClusterClient.asCurrentUser,
+                    esClient: dataClusterClient.esClient,
                     uiSettingsClient,
                     searchInferenceEndpoints: taskContext.server.searchInferenceEndpoints,
                     request: fakeRequest,

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/assets/query/query_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/assets/query/query_client.ts
@@ -15,7 +15,7 @@ import type {
   StorageClientSearchResponse,
 } from '@kbn/storage-adapter';
 import { deriveQueryType } from '@kbn/streams-schema/src/helpers/esql_helpers';
-import type { Streams } from '@kbn/streams-schema/src/models/streams';
+import { Streams } from '@kbn/streams-schema/src/models/streams';
 import {
   type QueryType,
   type StreamQuery,
@@ -1175,6 +1175,7 @@ export class QueryClient {
 
   private toCreateRuleParams(queryLink: QueryLink, definition: Streams.all.Definition) {
     const { rule_id: ruleId, query } = queryLink;
+    const useRemoteCluster = Streams.RemoteStream.Definition.is(definition) || undefined;
 
     return {
       data: {
@@ -1185,6 +1186,7 @@ export class QueryClient {
         params: {
           timestampField: '@timestamp',
           query: query.esql.query,
+          ...(useRemoteCluster ? { useRemoteCluster } : {}),
         },
         enabled: true,
         tags: ['streams', definition.name],
@@ -1200,6 +1202,7 @@ export class QueryClient {
 
   private toUpdateRuleParams(queryLink: QueryLink, definition: Streams.all.Definition) {
     const { rule_id: ruleId, query } = queryLink;
+    const useRemoteCluster = Streams.RemoteStream.Definition.is(definition) || undefined;
 
     return {
       id: ruleId,
@@ -1209,6 +1212,7 @@ export class QueryClient {
         params: {
           timestampField: '@timestamp',
           query: query.esql.query,
+          ...(useRemoteCluster ? { useRemoteCluster } : {}),
         },
         tags: ['streams', definition.name],
         schedule: {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -988,7 +988,11 @@ export class StreamsClient {
 
     const privileges = await checkAccessBulk({
       names: streams
-        .filter((stream) => !Streams.QueryStream.Definition.is(stream))
+        .filter(
+          (stream) =>
+            !Streams.QueryStream.Definition.is(stream) &&
+            !Streams.RemoteStream.Definition.is(stream)
+        )
         .map((stream) => stream.name),
       esClient,
       isSecurityEnabled: this.dependencies.isSecurityEnabled,
@@ -996,6 +1000,7 @@ export class StreamsClient {
 
     return streams.filter((stream) => {
       if (Streams.QueryStream.Definition.is(stream)) return true;
+      if (Streams.RemoteStream.Definition.is(stream)) return true;
       return privileges[stream.name]?.read === true;
     });
   }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/stream_active_record/stream_from_definition.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/stream_active_record/stream_from_definition.ts
@@ -12,6 +12,7 @@ import { ClassicStream } from '../streams/classic_stream';
 import { DraftStream } from '../streams/draft_stream';
 import { WiredStream } from '../streams/wired_stream';
 import { QueryStream } from '../streams/query_stream';
+import { RemoteStream } from '../streams/remote_stream';
 
 // This should be the only thing that knows about the various stream types
 export function streamFromDefinition(
@@ -26,6 +27,8 @@ export function streamFromDefinition(
     return new ClassicStream(definition, dependencies);
   } else if (Streams.QueryStream.Definition.is(definition)) {
     return new QueryStream(definition, dependencies);
+  } else if (Streams.RemoteStream.Definition.is(definition)) {
+    return new RemoteStream(definition, dependencies);
   }
 
   throw new Error('Unsupported stream type');

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/remote_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/remote_stream.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cloneDeep, isEqual } from 'lodash';
+import { Streams, validateStreamName } from '@kbn/streams-schema';
+import { StatusError } from '../../errors/status_error';
+import type { ElasticsearchAction } from '../execution_plan/types';
+import type { State } from '../state';
+import type {
+  StreamChangeStatus,
+  StreamChanges,
+  ValidationResult,
+} from '../stream_active_record/stream_active_record';
+import { StreamActiveRecord } from '../stream_active_record/stream_active_record';
+import type { StateDependencies, StreamChange } from '../types';
+
+type RemoteStreamChanges = StreamChanges;
+
+export class RemoteStream extends StreamActiveRecord<Streams.RemoteStream.Definition> {
+  protected _changes: RemoteStreamChanges = {};
+
+  constructor(definition: Streams.RemoteStream.Definition, dependencies: StateDependencies) {
+    super(definition, dependencies);
+  }
+
+  protected doClone(): StreamActiveRecord<Streams.RemoteStream.Definition> {
+    return new RemoteStream(cloneDeep(this._definition), this.dependencies);
+  }
+
+  protected async doHandleUpsertChange(
+    definition: Streams.all.Definition,
+    _desiredState: State,
+    _startingState: State
+  ): Promise<{ cascadingChanges: StreamChange[]; changeStatus: StreamChangeStatus }> {
+    if (definition.name !== this._definition.name) {
+      return { cascadingChanges: [], changeStatus: this.changeStatus };
+    }
+
+    if (!Streams.RemoteStream.Definition.is(definition)) {
+      throw new StatusError('Cannot change stream types', 400);
+    }
+
+    this._definition = definition;
+
+    return { cascadingChanges: [], changeStatus: 'upserted' };
+  }
+
+  protected async doHandleDeleteChange(
+    target: string,
+    _desiredState: State,
+    _startingState: State
+  ): Promise<{ cascadingChanges: StreamChange[]; changeStatus: StreamChangeStatus }> {
+    if (target !== this._definition.name) {
+      return { cascadingChanges: [], changeStatus: this.changeStatus };
+    }
+
+    return { cascadingChanges: [], changeStatus: 'deleted' };
+  }
+
+  protected async doValidateUpsertion(
+    desiredState: State,
+    _startingState: State
+  ): Promise<ValidationResult> {
+    const nameValidation = validateStreamName(this._definition.name);
+    if (!nameValidation.valid) {
+      return { isValid: false, errors: [new Error(nameValidation.message)] };
+    }
+
+    const existingStream = desiredState.get(this._definition.name);
+    if (existingStream && !Streams.RemoteStream.Definition.is(existingStream.definition)) {
+      return {
+        isValid: false,
+        errors: [
+          new Error(
+            `Cannot create remote stream: a stream named "${this._definition.name}" already exists as a different type`
+          ),
+        ],
+      };
+    }
+
+    return { isValid: true, errors: [] };
+  }
+
+  protected async doValidateDeletion(
+    _desiredState: State,
+    startingState: State
+  ): Promise<ValidationResult> {
+    const existing = startingState.get(this._definition.name);
+    if (!existing) {
+      return { isValid: true, errors: [] };
+    }
+
+    if (!Streams.RemoteStream.Definition.is(existing.definition)) {
+      return {
+        isValid: false,
+        errors: [
+          new Error(
+            `Cannot delete as remote stream: stream "${this._definition.name}" is not a remote stream`
+          ),
+        ],
+      };
+    }
+
+    return { isValid: true, errors: [] };
+  }
+
+  protected async doDetermineCreateActions(): Promise<ElasticsearchAction[]> {
+    return [
+      {
+        type: 'upsert_dot_streams_document',
+        request: this._definition,
+      },
+    ];
+  }
+
+  protected async doDetermineUpdateActions(
+    _desiredState: State,
+    _startingState: State,
+    startingStateStream: RemoteStream
+  ): Promise<ElasticsearchAction[]> {
+    const definitionChanged = !isEqual(this._definition, startingStateStream.definition);
+
+    if (!definitionChanged) {
+      return [];
+    }
+
+    return [
+      {
+        type: 'upsert_dot_streams_document',
+        request: this._definition,
+      },
+    ];
+  }
+
+  protected async doDetermineDeleteActions(): Promise<ElasticsearchAction[]> {
+    return [
+      {
+        type: 'delete_dot_streams_document',
+        request: { name: this._definition.name },
+      },
+      {
+        type: 'unlink_assets',
+        request: { name: this._definition.name },
+      },
+      {
+        type: 'unlink_features',
+        request: { name: this._definition.name },
+      },
+    ];
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/storage/streams_storage_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/storage/streams_storage_client.ts
@@ -28,6 +28,7 @@ const streamsStorageSettings = {
       query: types.object({ enabled: false }),
       query_streams: types.object({ enabled: false }),
       field_descriptions: types.object({ enabled: false }),
+      remote_index_pattern: types.keyword(),
     },
   },
 } satisfies StorageSettings;

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.ts
@@ -115,6 +115,11 @@ export class TaskClient<TaskType extends string> {
       last_failed_at: storedTask.last_failed_at,
     };
 
+    // Update storage first so created_at is always refreshed. If TM already has
+    // the task running (version conflict below), the stored doc is still up-to-date
+    // and getStatus will return InProgress rather than Stale.
+    await this.update(taskDoc);
+
     try {
       await this.taskManagerStart.schedule(
         {
@@ -136,7 +141,6 @@ export class TaskClient<TaskType extends string> {
       );
 
       this.logger.debug(`Scheduled ${task.type} task (${task.id})`);
-      await this.update(taskDoc);
     } catch (error) {
       const isVersionConflict =
         isResponseError(error) && error.message.includes('version conflict');

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/fetch_sample_documents.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/fetch_sample_documents.ts
@@ -114,7 +114,6 @@ export async function fetchSampleDocuments({
         end,
         sampleSize: entityFilteredSize,
         whereCondition,
-        loadUnmappedFields: true,
       }).catch((err) => {
         logger.warn(`Entity-filtered sampling query failed: ${parseError(err).message}`);
         return EMPTY_SAMPLE;

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
@@ -97,12 +97,12 @@ async function runFeaturesIdentification(
 
   const {
     taskClient,
-    scopedClusterClient,
     getFeatureClient,
     streamsClient,
     inferenceClient,
     soClient,
     tuningConfig,
+    getDataClusterClientForStream,
   } = await taskContext.getScopedClients({ request: fakeRequest });
 
   const taskLogger = taskContext.logger.get('features_identification', streamName);
@@ -129,7 +129,7 @@ async function runFeaturesIdentification(
 
     const streamType = getStreamTypeFromDefinition(stream);
     const boundInferenceClient = inferenceClient.bindTo({ connectorId });
-    const esClient = scopedClusterClient.asCurrentUser;
+    const { esClient } = getDataClusterClientForStream(stream);
 
     const trackFeaturesIdentified = (
       data: Parameters<typeof taskContext.telemetry.trackFeaturesIdentified>[0]

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
@@ -12,6 +12,7 @@ import {
   type IterationResult,
   type Feature,
   getStreamTypeFromDefinition,
+  Streams,
 } from '@kbn/streams-schema';
 import { v4 as uuid } from 'uuid';
 import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
@@ -130,6 +131,9 @@ async function runFeaturesIdentification(
     const streamType = getStreamTypeFromDefinition(stream);
     const boundInferenceClient = inferenceClient.bindTo({ connectorId });
     const { esClient } = getDataClusterClientForStream(stream);
+    const indexPattern = Streams.RemoteStream.Definition.is(stream)
+      ? stream.remote_index_pattern ?? stream.name
+      : stream.name;
 
     const trackFeaturesIdentified = (
       data: Parameters<typeof taskContext.telemetry.trackFeaturesIdentified>[0]
@@ -195,6 +199,7 @@ async function runFeaturesIdentification(
         logger: taskLogger,
         signal: runContext.abortController.signal,
         streamName: stream.name,
+        indexPattern,
         streamType,
         start,
         end,

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -25,6 +25,10 @@ import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import type { RulesClient, RulesClientCreateOptions } from '@kbn/alerting-plugin/server';
 import { LOGS_ECS_STREAM_NAME, ROOT_STREAM_NAMES, Streams } from '@kbn/streams-schema';
 import { isNotFoundError } from '@kbn/es-errors';
+import {
+  createLocalDataClusterClient,
+  createRemoteDataClusterClient,
+} from './lib/data_cluster_client';
 import type { StreamsConfig } from '../common/config';
 import {
   STREAMS_API_PRIVILEGES,
@@ -73,6 +77,7 @@ import {
   createContinuousKiExtractionWorkflowService,
   type ContinuousKiExtractionWorkflowService,
 } from './lib/workflows/continuous_extraction_workflow';
+import { RemoteEsClientService } from './lib/remote_cluster/remote_es_client_service';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
@@ -96,6 +101,7 @@ export class StreamsPlugin
   private statsTelemetryService = new StatsTelemetryService();
   private processorSuggestionsService: ProcessorSuggestionsService;
   private patternExtractionService?: PatternExtractionService;
+  private remoteEsClientService?: RemoteEsClientService;
 
   constructor(context: PluginInitializerContext<StreamsConfig>) {
     this.isDev = context.env.mode.dev;
@@ -118,6 +124,11 @@ export class StreamsPlugin
       this.logger.get('patternExtraction')
     );
 
+    if (this.config.remoteEsCluster) {
+      this.remoteEsClientService = new RemoteEsClientService(this.config.remoteEsCluster);
+      this.logger.info('Remote ES cluster client initialised');
+    }
+
     this.ebtTelemetryService.setup(core.analytics);
     this.statsTelemetryService.setup(
       core,
@@ -130,7 +141,11 @@ export class StreamsPlugin
       consumers: [STREAMS_CONSUMER],
     }));
 
-    registerRules({ plugins, logger: this.logger.get('rules') });
+    registerRules({
+      plugins,
+      logger: this.logger.get('rules'),
+      remoteEsClientService: this.remoteEsClientService,
+    });
     registerStreamsSavedObjects(core.savedObjects);
     registerSignificantEventsInferenceFeatures(
       plugins.searchInferenceEndpoints,
@@ -224,6 +239,14 @@ export class StreamsPlugin
         this.logger
       );
 
+      const remoteEsClientService = this.remoteEsClientService;
+      const getDataClusterClientForStream = (definition: Streams.all.Definition) => {
+        if (Streams.RemoteStream.Definition.is(definition) && remoteEsClientService) {
+          return createRemoteDataClusterClient(remoteEsClientService.getClient());
+        }
+        return createLocalDataClusterClient(scopedClusterClient.asInternalUser);
+      };
+
       return {
         scopedClusterClient,
         soClient,
@@ -242,6 +265,7 @@ export class StreamsPlugin
         streamsSettingsStorageClient,
         isSecurityEnabled,
         tuningConfig,
+        getDataClusterClientForStream,
       };
     };
 
@@ -357,6 +381,7 @@ export class StreamsPlugin
         patternExtractionService: this.patternExtractionService,
         getScopedClients,
         continuousKiExtractionWorkflowService,
+        remoteEsClientService: this.remoteEsClientService,
       },
       core,
       logger: this.logger,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/extraction/classify_streams.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/extraction/classify_streams.ts
@@ -57,7 +57,8 @@ export const classifyStreams = ({
   for (const stream of allStreams) {
     if (
       !Streams.WiredStream.Definition.is(stream) &&
-      !Streams.ClassicStream.Definition.is(stream)
+      !Streams.ClassicStream.Definition.is(stream) &&
+      !Streams.RemoteStream.Definition.is(stream)
     ) {
       unsupported.push(stream.name);
       continue;

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/features/identify_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/features/identify_route.ts
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { z } from '@kbn/zod/v4';
 import {
   getStreamTypeFromDefinition,
+  Streams,
   STREAMS_SIG_EVENTS_KI_EXTRACTION_INFERENCE_FEATURE_ID,
 } from '@kbn/streams-schema';
 import { isInferenceProviderError } from '@kbn/inference-common';
@@ -65,7 +66,6 @@ const identifyInferredFeaturesRoute = createServerRoute({
   }),
   handler: async ({ params, request, getScopedClients, server, logger, telemetry }) => {
     const {
-      scopedClusterClient,
       getFeatureClient,
       streamsClient,
       inferenceClient,
@@ -73,6 +73,7 @@ const identifyInferredFeaturesRoute = createServerRoute({
       tuningConfig,
       licensing,
       uiSettingsClient,
+      getDataClusterClientForStream,
     } = await getScopedClients({ request });
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
@@ -110,10 +111,15 @@ const identifyInferredFeaturesRoute = createServerRoute({
     ]);
 
     const streamType = getStreamTypeFromDefinition(stream);
+    const { esClient } = getDataClusterClientForStream(stream);
+    const indexPattern = Streams.RemoteStream.Definition.is(stream)
+      ? stream.remote_index_pattern ?? stream.name
+      : stream.name;
 
     try {
       const result = await identifyInferredFeatures({
-        esClient: scopedClusterClient.asCurrentUser,
+        esClient,
+        indexPattern,
         featureClient,
         soClient,
         inferenceClient: inferenceClient.bindTo({ connectorId }),
@@ -206,12 +212,12 @@ const identifyComputedFeaturesRoute = createServerRoute({
   }),
   handler: async ({ params, request, getScopedClients, server, logger }) => {
     const {
-      scopedClusterClient,
       getFeatureClient,
       streamsClient,
       tuningConfig,
       licensing,
       uiSettingsClient,
+      getDataClusterClientForStream,
     } = await getScopedClients({ request });
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
@@ -230,6 +236,7 @@ const identifyComputedFeaturesRoute = createServerRoute({
       getFeatureClient(),
       streamsClient.getStream(streamName),
     ]);
+    const { esClient } = getDataClusterClientForStream(stream);
 
     try {
       const computedFeatures = await identifyComputedFeatures({
@@ -237,7 +244,7 @@ const identifyComputedFeaturesRoute = createServerRoute({
         streamName,
         start,
         end,
-        esClient: scopedClusterClient.asCurrentUser,
+        esClient,
         featureClient,
         logger: routeLogger,
         featureTtlDays,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/crud/route.ts
@@ -77,7 +77,7 @@ export const listStreamsRoute = createServerRoute({
     });
 
     const enrichedStreams = availableStreams.map<ListStreamDetail>(({ stream }) => {
-      if (Streams.QueryStream.Definition.is(stream)) {
+      if (Streams.QueryStream.Definition.is(stream) || Streams.RemoteStream.Definition.is(stream)) {
         return { stream, privileges: { read_failure_store: false } };
       }
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/sig_events/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/sig_events/streams/significant_events/route.ts
@@ -77,10 +77,15 @@ const previewSignificantEventsRoute = createServerRoute({
     server,
     logger,
   }): Promise<SignificantEventsPreviewResponse> => {
-    const { streamsClient, scopedClusterClient, licensing, uiSettingsClient } =
-      await getScopedClients({
-        request,
-      });
+    const {
+      streamsClient,
+      scopedClusterClient,
+      licensing,
+      uiSettingsClient,
+      getDataClusterClientForStream,
+    } = await getScopedClients({
+      request,
+    });
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
     const {
@@ -89,7 +94,8 @@ const previewSignificantEventsRoute = createServerRoute({
       query: { bucketSize, from, to },
     } = params;
 
-    await streamsClient.ensureStream(name);
+    const definition = await streamsClient.getStream(name);
+    const dataClusterClient = getDataClusterClientForStream(definition);
 
     return await previewSignificantEvents(
       {
@@ -99,7 +105,9 @@ const previewSignificantEventsRoute = createServerRoute({
         to,
       },
       {
-        scopedClusterClient,
+        esClient: dataClusterClient.isRemote
+          ? dataClusterClient.esClient
+          : scopedClusterClient.asCurrentUser,
         logger,
       }
     );
@@ -243,6 +251,7 @@ const generateSignificantEventsRoute = createServerRoute({
       getFeatureClient,
       getQueryClient,
       scopedClusterClient,
+      getDataClusterClientForStream,
     } = await getScopedClients({ request });
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
@@ -254,20 +263,24 @@ const generateSignificantEventsRoute = createServerRoute({
       logger,
     });
 
+    const definition = await streamsClient.getStream(params.path.name);
+    const dataClusterClient = getDataClusterClientForStream(definition);
+
     const useMemory = await uiSettingsClient.get<boolean>(OBSERVABILITY_STREAMS_ENABLE_MEMORY);
     const memoryTools = useMemory
       ? createMemoryDiscoveryTools({
           memoryService: new MemoryServiceImpl({
             logger: logger.get('memory'),
-            esClient: scopedClusterClient.asCurrentUser,
+            esClient: dataClusterClient.isRemote
+              ? dataClusterClient.esClient
+              : scopedClusterClient.asCurrentUser,
           }),
         })
       : undefined;
 
-    const [connector, definition, { significantEventsPromptOverride }, featureClient, queryClient] =
+    const [connector, { significantEventsPromptOverride }, featureClient, queryClient] =
       await Promise.all([
         inferenceClient.getConnectorById(connectorId),
-        streamsClient.getStream(params.path.name),
         new PromptsConfigService({ soClient, logger }).getPrompt(),
         getFeatureClient(),
         getQueryClient(),
@@ -286,7 +299,7 @@ const generateSignificantEventsRoute = createServerRoute({
           queryClient,
           logger: logger.get('significant_events'),
           signal: getRequestAbortSignal(request),
-          esClient: scopedClusterClient.asCurrentUser,
+          esClient: dataClusterClient.esClient,
           memoryTools,
         }
       )

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
@@ -69,6 +69,17 @@ export async function readStream({
     return query.query;
   });
 
+  if (Streams.RemoteStream.Definition.is(streamDefinition)) {
+    const remoteStreamResponse: Streams.RemoteStream.GetResponse = {
+      stream: streamDefinition,
+      dashboards,
+      rules,
+      queries,
+      inherited_fields: {},
+    };
+    return remoteStreamResponse;
+  }
+
   if (Streams.QueryStream.Definition.is(streamDefinition)) {
     // Fetch the actual ES|QL from the view (source of truth)
     const esqlView = await getEsqlView({

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
@@ -170,8 +170,15 @@ export const editStreamRoute = createServerRoute({
     request,
     getScopedClients,
     context,
+    remoteEsClientService,
   }): Promise<UpsertStreamResponse> => {
     const { streamsClient } = await getScopedClients({ request });
+
+    if (Streams.RemoteStream.UpsertRequest.is(params.body) && !remoteEsClientService) {
+      throw badData(
+        'Cannot create a remote stream: xpack.streams.remoteEsCluster is not configured in kibana.yml.'
+      );
+    }
 
     // Replicated data streams are managed by the source cluster via CCR.
     // Only Kibana-side data (description, dashboards, queries) can be updated.

--- a/x-pack/platform/plugins/shared/streams/server/routes/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/types.ts
@@ -14,6 +14,7 @@ import type { DefaultRouteHandlerResources } from '@kbn/server-route-repository'
 import type { IUiSettingsClient } from '@kbn/core/server';
 import type { IFieldsMetadataClient } from '@kbn/fields-metadata-plugin/server/services/fields_metadata/types';
 import type { RulesClientCreateOptions } from '@kbn/alerting-plugin/server';
+import type { Streams } from '@kbn/streams-schema';
 import type { ContentClient } from '../lib/content/content_client';
 import type { AttachmentClient } from '../lib/streams/attachments/attachment_client';
 import type { QueryClient } from '../lib/streams/assets/query/query_client';
@@ -29,6 +30,8 @@ import type { InsightClient } from '../lib/sig_events/insights/client/insight_cl
 import type { StreamsSettingsStorageClient } from '../lib/streams/storage/streams_settings_storage_client';
 import type { ContinuousKiExtractionWorkflowService } from '../lib/workflows/continuous_extraction_workflow';
 import type { SigEventsTuningConfig } from '../../common/sig_events_tuning_config';
+import type { DataClusterClient } from '../lib/data_cluster_client';
+import type { RemoteEsClientService } from '../lib/remote_cluster/remote_es_client_service';
 
 export type GetScopedClients = (params: {
   request: KibanaRequest;
@@ -53,6 +56,8 @@ export interface RouteHandlerScopedClients {
   streamsSettingsStorageClient: StreamsSettingsStorageClient;
   isSecurityEnabled: boolean;
   tuningConfig: SigEventsTuningConfig;
+  /** Returns the appropriate cluster client for a given stream definition (local or remote). */
+  getDataClusterClientForStream: (definition: Streams.all.Definition) => DataClusterClient;
 }
 
 export interface RouteDependencies {
@@ -62,6 +67,7 @@ export interface RouteDependencies {
   processorSuggestions: ProcessorSuggestionsService;
   patternExtractionService: IPatternExtractionService;
   continuousKiExtractionWorkflowService?: ContinuousKiExtractionWorkflowService;
+  remoteEsClientService?: RemoteEsClientService;
 }
 
 export type StreamsRouteHandlerResources = RouteDependencies & DefaultRouteHandlerResources;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/tree_table.tsx
@@ -86,7 +86,11 @@ export function StreamsTreeTable({
   // Filter streams by query, including ancestors of matches
   const filteredStreams = React.useMemo(() => {
     return filterStreamsByQuery(
-      streams.filter((stream) => Streams.ingest.all.Definition.is(stream.stream)),
+      streams.filter(
+        (stream) =>
+          Streams.ingest.all.Definition.is(stream.stream) ||
+          Streams.RemoteStream.Definition.is(stream.stream)
+      ),
       searchQuery?.text ?? ''
     );
   }, [streams, searchQuery]);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/utils.ts
@@ -27,7 +27,7 @@ export interface EnrichedStream extends ListStreamDetail {
   nameSortKey: string;
   documentsCount: number;
   retentionMs: number;
-  type: 'wired' | 'root' | 'classic';
+  type: 'wired' | 'root' | 'classic' | 'remote';
   children?: EnrichedStream[];
 }
 
@@ -195,7 +195,9 @@ export const enrichStream = (node: StreamTree | ListStreamDetail): EnrichedStrea
     nameSortKey,
     documentsCount: 0,
     retentionMs,
-    type: Streams.ClassicStream.Definition.is(node.stream)
+    type: Streams.RemoteStream.Definition.is(node.stream)
+      ? 'remote'
+      : Streams.ClassicStream.Definition.is(node.stream)
       ? 'classic'
       : isRootStreamDefinition(node.stream)
       ? 'root'

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
@@ -119,6 +119,38 @@ export function QueryStreamBadge() {
   );
 }
 
+export function RemoteStreamBadge() {
+  return (
+    <EuiToolTip
+      position="top"
+      title={i18n.translate('xpack.streams.badges.remote.title', {
+        defaultMessage: 'Remote Stream',
+      })}
+      content={i18n.translate('xpack.streams.badges.remote.description', {
+        defaultMessage:
+          'Remote streams query data directly from a remote Elasticsearch cluster configured in kibana.yml. They are read-only and cannot be discovered in Discover.',
+      })}
+      anchorProps={{
+        css: css`
+          display: inline-flex;
+        `,
+      }}
+    >
+      <EuiBadge
+        color="hollow"
+        iconType="remote"
+        iconSide="left"
+        tabIndex={0}
+        data-test-subj="remoteStreamBadge"
+      >
+        {i18n.translate('xpack.streams.badges.remote.label', {
+          defaultMessage: 'Remote',
+        })}
+      </EuiBadge>
+    </EuiToolTip>
+  );
+}
+
 export function DeprecatedLogsBadge({
   openFlyout,
   hasNewStreams,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -76,6 +76,7 @@ import {
   DiscoverBadgeButton,
   DraftStreamBadge,
   QueryStreamBadge,
+  RemoteStreamBadge,
 } from '../stream_badges';
 
 const datePickerStyle = css`
@@ -473,6 +474,7 @@ export function StreamsTreeTable({
                     (Streams.WiredStream.Definition.is(item.stream) &&
                       isDraftStream(item.stream))) && <TechnicalPreviewBadge />}
                   {Streams.QueryStream.Definition.is(item.stream) && <QueryStreamBadge />}
+                  {Streams.RemoteStream.Definition.is(item.stream) && <RemoteStreamBadge />}
                   {isDraftStream(item.stream) && <DraftStreamBadge />}
                   {item.stream.name === LOGS_ROOT_STREAM_NAME &&
                     !Streams.QueryStream.Definition.is(item.stream) && (
@@ -484,7 +486,8 @@ export function StreamsTreeTable({
                   {isRoot(item.stream.name) &&
                     item.stream.name !== LOGS_ROOT_STREAM_NAME &&
                     !item.data_stream &&
-                    !Streams.QueryStream.Definition.is(item.stream) && (
+                    !Streams.QueryStream.Definition.is(item.stream) &&
+                    !Streams.RemoteStream.Definition.is(item.stream) && (
                       <EuiToolTip
                         position="right"
                         content={i18n.translate(
@@ -624,6 +627,9 @@ export function StreamsTreeTable({
               !!item.data_stream || Streams.QueryStream.Definition.is(item.stream);
             if (Streams.QueryStream.Definition.is(item.stream)) {
               return <DiscoverBadgeButton hasDataStream={hasDataStream} stream={item.stream} />;
+            }
+            if (Streams.RemoteStream.Definition.is(item.stream)) {
+              return null;
             }
             return (
               <DiscoverBadgeButton

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/management_bottom_bar/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/management_bottom_bar/index.tsx
@@ -23,7 +23,7 @@ interface ManagementBottomBarProps {
   insufficientPrivileges?: boolean;
   isLoading?: boolean;
   isInvalid?: boolean;
-  streamType?: 'classic' | 'wired' | 'query' | 'unknown';
+  streamType?: 'classic' | 'wired' | 'query' | 'remote' | 'unknown';
   onCancel: () => void;
   onConfirm: () => void;
   onViewCodeClick?: () => void;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/schema_editor/field_status.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/schema_editor/field_status.tsx
@@ -17,7 +17,7 @@ export const FieldStatusBadge = ({
 }: {
   status: FieldStatus;
   uncommitted?: boolean;
-  streamType?: 'wired' | 'classic' | 'query' | 'unknown';
+  streamType?: 'wired' | 'classic' | 'query' | 'remote' | 'unknown';
 }) => {
   // Determine the display status - for classic streams, show "dynamic" instead of "unmapped"
   const displayStatus = status === 'unmapped' && streamType === 'classic' ? 'dynamic' : status;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/schema_editor/schema_changes_review_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/schema_editor/schema_changes_review_modal.tsx
@@ -45,7 +45,7 @@ import { FieldStatusBadge } from './field_status';
 
 interface SchemaChangesReviewModalProps {
   onClose: () => void;
-  streamType?: 'wired' | 'classic' | 'query' | 'unknown';
+  streamType?: 'wired' | 'classic' | 'query' | 'remote' | 'unknown';
   definition: Streams.ingest.all.GetResponse;
   fields: SchemaEditorField[];
   storedFields: SchemaEditorField[];

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/stream_enrichment_state_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/stream_enrichment_state_machine.ts
@@ -371,7 +371,7 @@ export const streamEnrichmentMachine = setup({
         input: {
           steps: [],
           streamName: input.definition.stream.name,
-          streamType: streamType === 'query' ? 'unknown' : streamType,
+          streamType: streamType === 'query' || streamType === 'remote' ? 'unknown' : streamType,
         },
       }),
     };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/yaml_mode/yaml_editor_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/yaml_mode/yaml_editor_wrapper.tsx
@@ -42,7 +42,9 @@ export const YamlEditorWrapper = () => {
   const definition = useStreamEnrichmentSelector((state) => state.context.definition);
   const streamType = getStreamTypeFromDefinition(definition.stream);
   const editorStreamType =
-    streamType === 'unknown' || streamType === 'query' ? undefined : streamType;
+    streamType === 'unknown' || streamType === 'query' || streamType === 'remote'
+      ? undefined
+      : streamType;
   const simulation = useSimulatorSelector((snapshot) => snapshot.context.simulation);
   const canSimulate = useStreamEnrichmentSelector(
     (state) => state.context.definition.privileges.simulate

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/index.tsx
@@ -10,6 +10,7 @@ import { useStreamDetail } from '../../../../hooks/use_stream_detail';
 import { WiredStreamDetailManagement } from './wired';
 import { ClassicStreamDetailManagement } from './classic';
 import { QueryStreamDetailManagement } from './query';
+import { RemoteStreamDetailManagement } from './remote';
 
 export function StreamDetailManagement() {
   const { definition, refresh } = useStreamDetail();
@@ -20,6 +21,10 @@ export function StreamDetailManagement() {
 
   if (Streams.QueryStream.GetResponse.is(definition)) {
     return <QueryStreamDetailManagement definition={definition} refreshDefinition={refresh} />;
+  }
+
+  if (Streams.RemoteStream.GetResponse.is(definition)) {
+    return <RemoteStreamDetailManagement definition={definition} refreshDefinition={refresh} />;
   }
 
   return <ClassicStreamDetailManagement definition={definition} refreshDefinition={refresh} />;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/remote.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/remote.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiCode, EuiFlexGroup, EuiPageHeader, EuiText, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { Streams } from '@kbn/streams-schema';
+import React from 'react';
+import { useStreamsAppParams } from '../../../../hooks/use_streams_app_params';
+import { useStreamsAppRouter } from '../../../../hooks/use_streams_app_router';
+import { useStreamsPrivileges } from '../../../../hooks/use_streams_privileges';
+import { useTimeRange } from '../../../../hooks/use_time_range';
+import { RedirectTo } from '../../../redirect_to';
+import { RemoteStreamBadge } from '../../../stream_badges';
+import { StreamDetailAttachments } from '../../../stream_detail_attachments';
+import { StreamOverview } from '../../../stream_detail_overview';
+import { StreamsAppPageTemplate } from '../../../streams_app_page_template';
+import { useStreamsDetailManagementTabs } from './use_streams_detail_management_tabs';
+import type { ManagementTabs } from './wrapper';
+
+const remoteStreamManagementSubTabs = ['overview', 'significantEvents', 'attachments'] as const;
+
+type RemoteStreamManagementSubTab = (typeof remoteStreamManagementSubTabs)[number];
+
+function isValidManagementSubTab(
+  value: string,
+  overviewPageEnabled: boolean
+): value is RemoteStreamManagementSubTab {
+  if (value === 'overview' && !overviewPageEnabled) {
+    return false;
+  }
+  return remoteStreamManagementSubTabs.includes(value as RemoteStreamManagementSubTab);
+}
+
+export function RemoteStreamDetailManagement({
+  definition,
+  refreshDefinition,
+}: {
+  definition: Streams.RemoteStream.GetResponse;
+  refreshDefinition: () => void;
+}) {
+  const router = useStreamsAppRouter();
+  const {
+    path: { key, tab },
+  } = useStreamsAppParams('/{key}/management/{tab}');
+  const { rangeFrom, rangeTo } = useTimeRange();
+  const { euiTheme } = useEuiTheme();
+
+  const {
+    features: { overviewPage },
+  } = useStreamsPrivileges();
+
+  const { significantEvents } = useStreamsDetailManagementTabs({
+    definition,
+    refreshDefinition,
+  });
+
+  const tabs: ManagementTabs = {};
+
+  if (overviewPage.enabled) {
+    tabs.overview = {
+      content: <StreamOverview />,
+      label: i18n.translate('xpack.streams.remoteStreamDetailManagement.overviewTab', {
+        defaultMessage: 'Overview',
+      }),
+    };
+  }
+
+  if (significantEvents) {
+    tabs.significantEvents = significantEvents;
+  }
+
+  tabs.attachments = {
+    content: <StreamDetailAttachments definition={definition} />,
+    label: i18n.translate('xpack.streams.remoteStreamDetailManagement.attachmentsTab', {
+      defaultMessage: 'Attachments',
+    }),
+  };
+
+  const defaultTab = overviewPage.enabled ? 'overview' : 'significantEvents';
+
+  if (!isValidManagementSubTab(tab, overviewPage.enabled) || !tabs[tab]?.content) {
+    return (
+      <RedirectTo path="/{key}/management/{tab}" params={{ path: { key, tab: defaultTab } }} />
+    );
+  }
+
+  return (
+    <>
+      <EuiPageHeader
+        paddingSize="l"
+        bottomBorder="extended"
+        css={css`
+          background: ${euiTheme.colors.backgroundBasePlain};
+        `}
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="s">
+            {key}
+            <RemoteStreamBadge />
+          </EuiFlexGroup>
+        }
+        description={
+          <EuiText size="s" color="subdued">
+            {i18n.translate('xpack.streams.remoteStreamDetailManagement.remoteIndexPatternLabel', {
+              defaultMessage: 'Remote index pattern:',
+            })}{' '}
+            <EuiCode>{definition.stream.remote_index_pattern ?? definition.stream.name}</EuiCode>
+          </EuiText>
+        }
+        tabs={Object.entries(tabs).map(([tabKey, { label }]) => ({
+          label,
+          href: router.link('/{key}/management/{tab}', {
+            path: { key, tab: tabKey },
+            query: { rangeFrom, rangeTo },
+          }),
+          isSelected: tab === tabKey,
+          'data-test-subj': `remoteStreamDetails-${tabKey}-tab`,
+        }))}
+      />
+      <StreamsAppPageTemplate.Body>{tabs[tab].content}</StreamsAppPageTemplate.Body>
+    </>
+  );
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_index_patterns_config.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_index_patterns_config.ts
@@ -6,7 +6,7 @@
  */
 
 import { useMemo } from 'react';
-import { streamMatchesIndexPatterns, DEFAULT_INDEX_PATTERNS } from '@kbn/streams-schema';
+import { streamMatchesIndexPatterns, DEFAULT_INDEX_PATTERNS, Streams } from '@kbn/streams-schema';
 import { OBSERVABILITY_STREAMS_SIG_EVENTS_INDEX_PATTERNS } from '@kbn/management-settings-ids';
 import { useKibana } from './use_kibana';
 
@@ -31,9 +31,14 @@ export function useIndexPatternsConfig() {
 
   const filterStreamsByIndexPatterns = useMemo(() => {
     return <T extends { stream: { name: string } }>(streamsToFilter: T[]): T[] =>
-      streamsToFilter.filter((streamItem) =>
-        streamMatchesIndexPatterns(streamItem.stream.name, indexPatterns)
-      );
+      streamsToFilter.filter((streamItem) => {
+        // Remote streams are always shown regardless of index pattern — their
+        // data lives on a remote cluster and the stream name is not an index.
+        if (Streams.RemoteStream.Definition.is(streamItem.stream as Streams.all.Definition)) {
+          return true;
+        }
+        return streamMatchesIndexPatterns(streamItem.stream.name, indexPatterns);
+      });
   }, [indexPatterns]);
 
   return {

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_detail.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_detail.tsx
@@ -84,6 +84,10 @@ export function StreamDetailContextProvider({
             return response;
           }
 
+          if (Streams.RemoteStream.GetResponse.is(response)) {
+            return response;
+          }
+
           throw new Error('Stream detail only supports Ingest and Query streams.');
         });
     },

--- a/x-pack/platform/plugins/shared/streams_app/public/telemetry/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/telemetry/types.ts
@@ -9,7 +9,7 @@ import type { AttachmentType } from '@kbn/streams-plugin/server/lib/streams/atta
 import type { InsightImpactLevel, InsightUserEvaluation } from '@kbn/streams-schema';
 import type { EnrichmentDataSource } from '../../common/url_schema';
 
-type StreamType = 'wired' | 'classic' | 'query' | 'unknown';
+type StreamType = 'wired' | 'classic' | 'query' | 'remote' | 'unknown';
 
 type ConfigurationMode = 'interactive' | 'yaml';
 


### PR DESCRIPTION
## Summary

Adds a new `"remote"` stream type that queries data directly from a separately-configured Elasticsearch cluster (host + API key in `kibana.yml`), bypassing the local ES cluster entirely. All significant events features (KI extraction, query generation, feature identification) work against the remote cluster.

### What's new

**Config** (`kibana.yml`):
```yaml
xpack.streams.remoteEsCluster:
  host: "https://my-remote-cluster:9243"
  apiKey: "base64_encoded_key"
```

**New stream type**: `PUT /api/streams/my-remote-stream`
```json
{
  "stream": {
    "type": "remote",
    "description": "Logs from remote cluster",
    "remote_index_pattern": "logs-myapp-*"
  },
  "dashboards": [], "rules": [], "queries": []
}
```

### Architecture

- **`RemoteEsClientService`** — instantiated once at plugin setup; creates a direct `@elastic/elasticsearch` `Client` (with `ClusterConnectionPool` + `HttpConnection` to disable sniffing) using the configured host/API key
- **`DataClusterClient`** abstraction — `getDataClusterClientForStream(definition)` returns local or remote client based on stream type; threaded through all sigevents code paths (feature identification tasks, query generation, inferred/computed features, preview routes, agent tools)
- **KI alerting rules (Option B)** — `EsqlRuleParams.useRemoteCluster: true` flag; `createRuleExecutor(remoteEsClientService?)` factory closes over the remote client at registration time
- **`getIndexPatternsForStream`** — handles `RemoteStream`, returning `remote_index_pattern` (or stream name) so `replaceFromSources` rewrites ES|QL `FROM` clauses correctly
- **Privilege checks** — remote streams skip local ES index privilege checks (no local index exists)
- **Discovery UI** — remote streams appear in the significant events discovery Streams tab, are excluded from the local data-stream lookup, bypass the `logs*` index-pattern filter, and are classified as eligible for KI generation

### Restrictions

- Remote streams are completely read-only (no ingest, no pipelines, no Discover data view)
- Creating a remote stream requires `xpack.streams.remoteEsCluster` to be configured

## Test plan

- [ ] Configure `xpack.streams.remoteEsCluster` in `kibana.dev.yml`
- [ ] Create a remote stream via `PUT /api/streams/<name>` with `remote_index_pattern` pointing to a real index on the remote cluster
- [ ] Verify stream appears in the Streams discovery tab
- [ ] Run KI extraction onboarding — features and queries should generate against the remote cluster
- [ ] Verify KI alerting rules execute ES|QL against the remote cluster
- [ ] Verify significant events read from local `.alerts-streams.alerts-default`
- [ ] Verify ingest/routing routes return 400/405 for remote streams

🤖 Generated with [Claude Code](https://claude.ai/claude-code)