### PR TITLE
Fix Failing test: APM integration not installed but setup completed

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
@@ -18,7 +18,7 @@ apiTest.describe(
     let viewerApiCreditials: RoleApiCredentials;
     let adminApiCreditials: RoleApiCredentials;
 
-    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, requestAuth }) => {
+    apiTest.beforeAll(async ({ profilingHelper, profilingSetup, esClient, requestAuth }) => {
       // Ensure the agent policy that the cloud setup attaches the profiler_collector and
       // profiler_symbolizer package policies to exists. Without this, setupResources()
       // returns 500 when this spec runs ahead of (or independently of) has_no_setup.spec.
@@ -27,6 +27,25 @@ apiTest.describe(
       if (!(await profilingSetup.checkStatus()).has_setup) {
         await profilingSetup.setupResources();
       }
+
+      // Remove any profiling data left by other specs (e.g. has_setup_with_data) so
+      // has_data evaluates to false regardless of test execution order.
+      // Best-effort: shards of freshly-created profiling data-streams may still be
+      // initialising after setup, causing `search_phase_execution_exception`.  If the
+      // delete fails for that reason there is no data to remove anyway.
+      try {
+        await esClient.deleteByQuery({
+          index: 'profiling-events-*',
+          query: { match_all: {} },
+          ignore_unavailable: true,
+          refresh: true,
+        });
+      } catch (e) {
+        if (!String(e).includes('search_phase_execution_exception')) {
+          throw e;
+        }
+      }
+
       viewerApiCreditials = await requestAuth.getApiKey('viewer');
       adminApiCreditials = await requestAuth.getApiKey('admin');
     });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/268401
Closes https://github.com/elastic/kibana/issues/253221

## Summary

- Fix flaky API test by deleting `profiling-events-*` before the tests


### How to run

#### Server

`node scripts/scout.js start-server --arch stateful --domain classic`

#### Client

`npx playwright test --project local --ui --config x-pack/solutions/observability/plugins/profiling/test/scout/api/playwright.config.ts`

### Checklist

- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
