### PR TITLE
[Chrome Next] POC Discover tabs as part of App Header

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
@@ -29,13 +29,26 @@ export interface AppHeaderViewProps {
   menu?: AppMenuConfig;
   onShare?: () => void;
   favorite?: ReactNode;
+  titleAppend?: ReactNode;
   sticky?: boolean;
   padding?: AppHeaderPadding;
   docLink?: string;
 }
 
 export const AppHeaderView = React.memo<AppHeaderViewProps>(
-  ({ title, back, tabs, badges, menu, onShare, favorite, sticky, padding, docLink }) => {
+  ({
+    title,
+    back,
+    tabs,
+    badges,
+    menu,
+    onShare,
+    favorite,
+    titleAppend,
+    sticky,
+    padding,
+    docLink,
+  }) => {
     const hasLegacyActionMenu = useHasLegacyActionMenu();
     const shareAction = useShareAction(menu, onShare);
     const show =
@@ -44,6 +57,7 @@ export const AppHeaderView = React.memo<AppHeaderViewProps>(
       !!tabs?.length ||
       !!badges?.length ||
       !!menu?.items?.length ||
+      titleAppend != null ||
       hasLegacyActionMenu;
 
     if (!show) {
@@ -55,8 +69,9 @@ export const AppHeaderView = React.memo<AppHeaderViewProps>(
         title={<TitleArea title={title} back={back} />}
         badges={<AppBadges badges={badges} />}
         titleActions={<TitleActions shareAction={shareAction} favorite={favorite} />}
+        titleAppend={titleAppend}
         trailing={<AppMenu menu={menu} hasExplicitShare={!!onShare} docLink={docLink} />}
-        tabs={tabs?.length ? <AppTabs tabs={tabs} /> : undefined} 
+        tabs={tabs?.length ? <AppTabs tabs={tabs} /> : undefined}
         sticky={sticky}
         padding={padding}
       />

--- a/src/core/packages/chrome/app-header/src/app_header/app_header_shell.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header_shell.tsx
@@ -19,6 +19,7 @@ export interface AppHeaderShellProps {
   title?: ReactNode;
   badges?: ReactNode;
   titleActions?: ReactNode;
+  titleAppend?: ReactNode;
   trailing?: ReactNode;
   tabs?: ReactNode;
   sticky?: boolean;
@@ -63,7 +64,8 @@ const resolveLayoutProps = (
 const useHeaderStyles = (
   sticky: boolean,
   padding: AppHeaderPadding | undefined,
-  hasTabs: boolean
+  hasTabs: boolean,
+  hasPrimaryContent: boolean
 ) => {
   const { euiTheme } = useEuiTheme();
 
@@ -138,6 +140,13 @@ const useHeaderStyles = (
     `;
 
     const titleClusterSpacer = css`
+      flex: ${hasPrimaryContent ? '0 0 auto' : '1 1 auto'};
+      min-width: 0;
+    `;
+
+    const titleAppend = css`
+      display: flex;
+      align-items: center;
       flex: 1 1 auto;
       min-width: 0;
     `;
@@ -163,15 +172,17 @@ const useHeaderStyles = (
       titleCluster,
       titleGroup,
       titleClusterSpacer,
+      titleAppend,
       titleActionsReveal,
       tabsRow,
     };
-  }, [euiTheme, sticky, padding, hasTabs]);
+  }, [euiTheme, sticky, padding, hasTabs, hasPrimaryContent]);
 };
 
 export const AppHeaderShell = React.memo<AppHeaderShellProps>(
-  ({ title, badges, titleActions, trailing, tabs, sticky = true, padding }) => {
-    const styles = useHeaderStyles(sticky, padding, !!tabs);
+  ({ title, badges, titleActions, titleAppend, trailing, tabs, sticky = true, padding }) => {
+    const hasTitleAppend = titleAppend != null;
+    const styles = useHeaderStyles(sticky, padding, !!tabs, hasTitleAppend);
 
     return (
       <div css={styles.root} data-test-subj="appHeader">
@@ -186,6 +197,7 @@ export const AppHeaderShell = React.memo<AppHeaderShellProps>(
                 </div>
               )}
             </div>
+            {hasTitleAppend && <div css={styles.titleAppend}>{titleAppend}</div>}
             <div css={styles.titleClusterSpacer} aria-hidden />
           </div>
           {trailing}

--- a/src/core/packages/chrome/app-header/src/app_header_with_fallback.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header_with_fallback.tsx
@@ -39,6 +39,7 @@ export const AppHeaderWithFallback: FC<AppHeaderWithFallbackProps> = ({
   menu,
   onShare,
   favorite,
+  titleAppend,
   fallback,
   sticky,
   padding,
@@ -71,6 +72,7 @@ export const AppHeaderWithFallback: FC<AppHeaderWithFallbackProps> = ({
       menu={menu}
       onShare={onShare}
       favorite={favorite}
+      titleAppend={titleAppend}
       sticky={sticky}
       padding={padding}
       docLink={docLink}

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.tsx
@@ -56,6 +56,7 @@ export interface TabbedContentProps
   services: TabsServices;
   hideTabsBar?: boolean;
   renderContent?: (selectedItem: TabItem) => React.ReactNode;
+  renderTabsBar?: (tabsBar: React.ReactNode) => React.ReactNode;
   createItem: () => TabItem;
   customNewTabButton?: React.ReactElement;
   onChanged: (state: TabbedContentState) => void;
@@ -97,6 +98,7 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
   services,
   hideTabsBar = false,
   renderContent,
+  renderTabsBar,
   createItem,
   onChanged,
   tabContentIdOverride,
@@ -481,8 +483,10 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
     </EuiFlexGroup>
   );
 
+  const renderedTabsBar = hideTabsBar ? null : tabsBar;
+
   if (!renderContent) {
-    return tabsBar;
+    return <>{renderTabsBar ? renderTabsBar(renderedTabsBar) : renderedTabsBar}</>;
   }
 
   return (
@@ -492,7 +496,11 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
       gutterSize="none"
       className="eui-fullHeight"
     >
-      {!hideTabsBar && <EuiFlexItem grow={false}>{tabsBar}</EuiFlexItem>}
+      {renderTabsBar ? (
+        <EuiFlexItem grow={false}>{renderTabsBar(renderedTabsBar)}</EuiFlexItem>
+      ) : (
+        renderedTabsBar && <EuiFlexItem grow={false}>{renderedTabsBar}</EuiFlexItem>
+      )}
       {selectedItem ? (
         <EuiFlexItem
           data-test-subj="unifiedTabs_selectedTabContent"

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -56,6 +56,7 @@ import { useDataState } from '../../hooks/use_data_state';
 import { SavedSearchURLConflictCallout } from '../../../../components/saved_search_url_conflict_callout/saved_search_url_conflict_callout';
 import { ErrorCallout } from '../../../../components/common/error_callout';
 import { addLog } from '../../../../utils/add_log';
+import { useDiscoverCustomizationContext } from '../../../../customizations';
 import { DiscoverResizableLayout } from './discover_resizable_layout';
 import { PanelsToggle } from '../../../../components/panels_toggle';
 import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
@@ -75,6 +76,8 @@ import { isCascadedDocumentsVisible } from './cascaded_documents';
 
 const queryClient = new QueryClient();
 const SidebarMemoized = React.memo(DiscoverSidebarResponsive);
+const DISCOVER_TOP_NAV_HEIGHT_OFFSET = '40px';
+const DISCOVER_INLINE_APP_HEADER_HEIGHT_OFFSET = '120px';
 
 const TopNavMemoized = React.memo((props: DiscoverTopNavProps) => (
   // QueryClientProvider is used to allow querying the authorized rules api hook
@@ -96,7 +99,9 @@ export function DiscoverLayout() {
     observabilityAIAssistant,
     dataVisualizer: dataVisualizerService,
     fieldsMetadata,
+    chrome,
   } = useDiscoverServices();
+  const customizationContext = useDiscoverCustomizationContext();
   const { scopedEBTManager } = useScopedServices();
   const dispatch = useInternalStateDispatch();
   const updateAppState = useCurrentTabAction(internalStateActions.updateAppState);
@@ -445,6 +450,12 @@ export function DiscoverLayout() {
     },
     [dispatch, onDataViewCreatedAction]
   );
+  const fullBodyHeightOffset =
+    customizationContext.displayMode === 'standalone' &&
+    chrome.next.isEnabled &&
+    chrome.getChromeStyle() === 'project'
+      ? DISCOVER_INLINE_APP_HEADER_HEIGHT_OFFSET
+      : DISCOVER_TOP_NAV_HEIGHT_OFFSET;
 
   return (
     <EuiPage
@@ -456,7 +467,7 @@ export function DiscoverLayout() {
         styles.dscPage,
         css`
           ${useEuiBreakpoint(['m', 'l', 'xl'])} {
-            ${kbnFullBodyHeightCss('40px')}
+            ${kbnFullBodyHeightCss(fullBodyHeightOffset)}
           }
         `,
       ]}

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
@@ -10,6 +10,7 @@
 import React, { useCallback } from 'react';
 import { EuiResizeObserver } from '@elastic/eui';
 import { UnifiedTabs, type UnifiedTabsProps } from '@kbn/unified-tabs';
+import { AppHeader } from '@kbn/app-header';
 import { AppMenuComponent } from '@kbn/core-chrome-app-menu-components';
 import { SingleTabView, type SingleTabViewProps } from '../single_tab_view';
 import {
@@ -28,13 +29,17 @@ import { useAppMenuData } from './use_app_menu_data';
 
 const MAX_TABS_COUNT = 25;
 
-export const TabsView = (props: SingleTabViewProps) => {
+interface TabsViewProps extends SingleTabViewProps {
+  headerTitle?: string;
+}
+
+export const TabsView = ({ headerTitle, ...singleTabViewProps }: TabsViewProps) => {
   const services = useDiscoverServices();
   const dispatch = useInternalStateDispatch();
   const items = useInternalStateSelector(selectAllTabs);
   const recentlyClosedItems = useInternalStateSelector(selectRecentlyClosedTabs);
   const currentTabId = useInternalStateSelector((state) => state.tabs.unsafeCurrentId);
-  const { getPreviewData } = usePreviewData(props.runtimeStateManager);
+  const { getPreviewData } = usePreviewData(singleTabViewProps.runtimeStateManager);
   const hideTabsBar = useInternalStateSelector(selectIsTabsBarHidden);
   const unsavedTabIds = useInternalStateSelector((state) => state.tabs.unsavedIds);
   const currentDataView = useCurrentTabRuntimeState((tab) => tab.currentDataView$);
@@ -72,8 +77,22 @@ export const TabsView = (props: SingleTabViewProps) => {
   );
 
   const renderContent: UnifiedTabsProps['renderContent'] = useCallback(
-    () => <SingleTabView key={currentTabId} {...props} />,
-    [currentTabId, props]
+    () => <SingleTabView key={currentTabId} {...singleTabViewProps} />,
+    [currentTabId, singleTabViewProps]
+  );
+
+  const renderTabsBar = useCallback<NonNullable<UnifiedTabsProps['renderTabsBar']>>(
+    (tabsBar) => (
+      <AppHeader
+        title={headerTitle ?? 'Discover'}
+        menu={topNavMenuItems}
+        fallback={null}
+        sticky={false}
+        padding="m"
+        titleAppend={tabsBar}
+      />
+    ),
+    [headerTitle, topNavMenuItems]
   );
 
   return (
@@ -100,6 +119,7 @@ export const TabsView = (props: SingleTabViewProps) => {
             onClearRecentlyClosed={onClearRecentlyClosed}
             getTopTabMenuItems={getTopTabMenuItems}
             getAdditionalTabMenuItems={getAdditionalTabMenuItems}
+            renderTabsBar={isNextChrome ? renderTabsBar : undefined}
             appendRight={
               !isNextChrome ? (
                 <AppMenuComponent config={topNavMenuItems} isCollapsed={shouldCollapseAppMenu} />

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -16,7 +16,7 @@ import type { AppMountParameters } from '@kbn/core/public';
 import { useExecutionContext } from '@kbn/kibana-react-plugin/public';
 import useLatest from 'react-use/lib/useLatest';
 import { i18n } from '@kbn/i18n';
-import { DiscoverAppHeader } from '../../components/discover_app_header';
+import { AppHeader } from '@kbn/app-header';
 import { useTopNavMenuItems } from './components/top_nav/use_top_nav_menu_items';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
 import type { CustomizationCallback, DiscoverCustomizationContext } from '../../customizations';
@@ -107,7 +107,7 @@ export const DiscoverMainRoute = ({
 
 const DiscoverMainAppHeader: React.FC<{ title: string }> = ({ title }) => {
   const appMenu = useTopNavMenuItems();
-  return <DiscoverAppHeader title={title} appMenu={appMenu} />;
+  return <AppHeader title={title} menu={appMenu} fallback={null} sticky={false} padding="m" />;
 };
 
 const DiscoverMainRouteContent = (props: SingleTabViewProps) => {

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -271,7 +271,7 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
     <ChartPortalsRenderer runtimeStateManager={runtimeStateManager}>
       <DiscoverTopNavMenuProvider customizationContext={customizationContext}>
         <>
-          {customizationContext.displayMode === 'standalone' && (
+          {customizationContext.displayMode === 'standalone' && !tabsEnabled && (
             <DiscoverMainAppHeader title={persistedDiscoverSession?.title || 'Discover'} />
           )}
           <h1 className="euiScreenReaderOnly" data-test-subj="discoverSavedSearchTitle">
@@ -294,7 +294,7 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
              * - If tabs are disabled and Discover is standalone, hide the tabs bar but show the app menu.
              */
             tabsEnabled ? (
-              <TabsView {...props} />
+              <TabsView {...props} headerTitle={persistedDiscoverSession?.title || 'Discover'} />
             ) : customizationContext.displayMode === 'embedded' ? (
               <SingleTabView {...props} />
             ) : (


### PR DESCRIPTION
## Summary


Part of https://github.com/elastic/kibana/issues/268029 

Do not merge, just a POC. 

<img width="2108" height="1313" alt="Screenshot 2026-05-11 at 13 05 32" src="https://github.com/user-attachments/assets/bdb24f81-e218-4c8a-b71f-20edf79dfbe0" />

The idea is the following: 

1. https://github.com/elastic/kibana/commit/54bc29d2840dd2ed3bedb34d9a50f720954010b1, switch Discover from chrome based header to inline header approach 
2. https://github.com/elastic/kibana/commit/54bc29d2840dd2ed3bedb34d9a50f720954010b1 Allow rendering custom content as part of the header. Make discover render the header instead of tabs and passing the tabs inside as custom content


