### PR TITLE
[Lens] Schema-driven styles editor (PoC)

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/index.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/index.ts
@@ -49,3 +49,7 @@ export {
 } from './utils';
 
 export * from './schema';
+
+export { buildStylingState as buildDatatableStylingState } from './transforms/charts/datatable/to_state/styling';
+export { convertStylingToAPIFormat as convertDatatableStylingToAPIFormat } from './transforms/charts/datatable/to_api/styling';
+export type { ColumnIdMapping as DatatableColumnIdMapping } from './transforms/charts/datatable/to_api/columns';

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/index.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/index.ts
@@ -52,4 +52,21 @@ export * from './schema';
 
 export { buildStylingState as buildDatatableStylingState } from './transforms/charts/datatable/to_state/styling';
 export { convertStylingToAPIFormat as convertDatatableStylingToAPIFormat } from './transforms/charts/datatable/to_api/styling';
+export {
+  convertLegendToAPIFormat as convertXYLegendToAPIFormat,
+  convertLegendToStateFormat as convertXYLegendToStateFormat,
+} from './transforms/charts/xy/legend';
+export {
+  convertStylingToAPIFormat as convertXYStylingToAPIFormat,
+  convertStylingToStateFormat as convertXYStylingToStateFormat,
+} from './transforms/charts/xy/appearances';
 export type { ColumnIdMapping as DatatableColumnIdMapping } from './transforms/charts/datatable/to_api/columns';
+export {
+  convertMetricStylingToAPIFormat,
+  buildMetricStylingState,
+} from './transforms/charts/metric';
+export { convertGaugeStylingToAPIFormat, buildGaugeStylingState } from './transforms/charts/gauge';
+export {
+  convertTagcloudStylingToAPIFormat,
+  buildTagcloudStylingState,
+} from './transforms/charts/tagcloud';

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/gauge.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/gauge.ts
@@ -312,6 +312,51 @@ export function fromAPItoLensState(config: GaugeConfig): GaugeAttributesWithoutF
   };
 }
 
+/**
+ * Convert gauge visualization state to API styling format.
+ * Used by the schema-driven flyout editor.
+ */
+export function convertGaugeStylingToAPIFormat(
+  state: GaugeVisualizationState
+): Pick<GaugeConfig, 'styling'> {
+  return {
+    styling: stripUndefined({
+      shape:
+        state.shape === 'horizontalBullet'
+          ? { type: 'bullet' as const, orientation: 'horizontal' as const }
+          : state.shape === 'verticalBullet'
+          ? { type: 'bullet' as const, orientation: 'vertical' as const }
+          : {
+              type: (state.shape === 'semiCircle' ? 'semi_circle' : state.shape) as
+                | 'circle'
+                | 'semi_circle'
+                | 'arc',
+            },
+    }),
+  };
+}
+
+/**
+ * Convert API styling config to gauge visualization state properties.
+ * Used by the schema-driven flyout editor.
+ */
+export function buildGaugeStylingState(
+  config: Pick<GaugeConfig, 'styling'>
+): Partial<GaugeVisualizationState> {
+  const shape = config.styling?.shape;
+  if (!shape) return {};
+  return {
+    shape:
+      shape.type === 'bullet'
+        ? shape.orientation === 'horizontal'
+          ? 'horizontalBullet'
+          : 'verticalBullet'
+        : shape.type === 'semi_circle'
+        ? 'semiCircle'
+        : shape.type,
+  };
+}
+
 export function fromLensStateToAPI(
   config: LensAttributes
 ): Extract<LensApiConfig, { type: 'gauge' }> {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/metric.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/metric.ts
@@ -687,6 +687,29 @@ export function fromAPItoLensState(config: MetricConfig): MetricAttributesWithou
   };
 }
 
+/**
+ * Convert metric visualization state to API styling format.
+ * Used by the schema-driven flyout editor.
+ */
+export function convertMetricStylingToAPIFormat(
+  state: MetricVisualizationState
+): Pick<MetricConfig, 'styling'> {
+  const hasSecondary = !!state.secondaryMetricAccessor;
+  const styling = convertStylingToAPIFormat(state, hasSecondary);
+  return { styling };
+}
+
+/**
+ * Convert API styling config to metric visualization state properties.
+ * Used by the schema-driven flyout editor.
+ */
+export function buildMetricStylingState(
+  config: Pick<MetricConfig, 'styling'>,
+  hasSecondary: boolean
+): Partial<MetricVisualizationState> {
+  return convertStylingToStateFormat(config.styling, hasSecondary);
+}
+
 export function fromLensStateToAPI(config: LensAttributes): MetricConfig {
   const { state } = config;
   const visualization = state.visualization as MetricVisualizationState;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/tagcloud.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/tagcloud.ts
@@ -246,6 +246,53 @@ export function fromAPItoLensState(
   };
 }
 
+/**
+ * Convert tagcloud visualization state to API styling format.
+ * Used by the schema-driven flyout editor.
+ */
+export function convertTagcloudStylingToAPIFormat(
+  state: LensTagCloudState
+): Pick<TagcloudConfig, 'styling'> {
+  return {
+    styling: stripUndefined({
+      orientation:
+        state.orientation === TAGCLOUD_ORIENTATION.SINGLE
+          ? ('horizontal' as const)
+          : state.orientation === TAGCLOUD_ORIENTATION.MULTIPLE
+          ? ('angled' as const)
+          : ('vertical' as const),
+      font_size: {
+        min: state.minFontSize,
+        max: state.maxFontSize,
+      },
+      caption: { visible: state.showLabel },
+    }),
+  };
+}
+
+/**
+ * Convert API styling config to tagcloud visualization state properties.
+ * Used by the schema-driven flyout editor.
+ */
+export function buildTagcloudStylingState(
+  config: Pick<TagcloudConfig, 'styling'>
+): Partial<LensTagCloudState> {
+  const styling = config.styling;
+  if (!styling) return {};
+  return stripUndefined({
+    orientation: styling.orientation
+      ? styling.orientation === 'horizontal'
+        ? TAGCLOUD_ORIENTATION.SINGLE
+        : styling.orientation === 'vertical'
+        ? TAGCLOUD_ORIENTATION.RIGHT_ANGLED
+        : TAGCLOUD_ORIENTATION.MULTIPLE
+      : undefined,
+    maxFontSize: styling.font_size?.max ?? undefined,
+    minFontSize: styling.font_size?.min ?? undefined,
+    showLabel: styling.caption?.visible ?? undefined,
+  }) as Partial<LensTagCloudState>;
+}
+
 export function fromLensStateToAPI(
   config: LensAttributes
 ): Extract<LensApiConfig, { type: 'tag_cloud' }> {

--- a/x-pack/platform/plugins/shared/lens/common/feature_flags.ts
+++ b/x-pack/platform/plugins/shared/lens/common/feature_flags.ts
@@ -65,6 +65,15 @@ export const lensFeatureFlags = {
     type: 'boolean',
     fallback: false as boolean,
   },
+  /**
+   * Enables the schema-driven flyout editor powered by @kbn/config-schema
+   * and react-hook-form, replacing per-visualization FlyoutToolbarComponent implementations.
+   */
+  schemaFlyoutEditor: {
+    id: 'lens.schemaFlyoutEditor',
+    type: 'boolean',
+    fallback: false as boolean,
+  },
 } satisfies Record<string, LensFeatureFlag>;
 
 export type LensFeatureFlags = GetFlagTypes<typeof lensFeatureFlags>;

--- a/x-pack/platform/plugins/shared/lens/common/schema_types.ts
+++ b/x-pack/platform/plugins/shared/lens/common/schema_types.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Conditions controlling when a UI schema field is visible.
+ * All specified conditions must be met (AND logic).
+ */
+export interface FieldVisibilityCondition {
+  /** Show this field only when at least one layer matches one of these series types */
+  seriesTypes?: string[];
+  /** Show only when the X axis is time-based */
+  requiresTimeAxis?: boolean;
+  /** Show only when NO text-based (ES|QL) datasource is present */
+  excludeTextBased?: boolean;
+}
+
+/**
+ * Ready-to-render field descriptor returned by the server endpoint.
+ * The client uses this directly — no schema processing needed.
+ */
+export interface FieldDescriptor {
+  path: string;
+  type: string;
+  label: string;
+  description?: string;
+  defaultValue?: unknown;
+  options?: Array<{ value: string; label: string }>;
+  min?: number;
+  max?: number;
+  required?: boolean;
+  widget?: string;
+  props?: Record<string, unknown>;
+  tooltip?: string;
+  children?: FieldDescriptor[];
+  /** Condition that must be met for this field to be visible */
+  condition?: FieldVisibilityCondition;
+}

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/visualization_toolbar.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/visualization_toolbar.tsx
@@ -15,6 +15,11 @@ import {
   selectVisualization,
 } from '../../state_management';
 import { useEditorFrameService } from '../editor_frame_service_context';
+import { getLensFeatureFlags } from '../../get_feature_flags';
+import {
+  SchemaFlyoutEditor,
+  hasSchemaForVisualization,
+} from '../../shared_components/schema_flyout';
 
 export const VisualizationToolbarWrapper = memo(function VisualizationToolbar({
   framePublicAPI,
@@ -50,6 +55,16 @@ export const VisualizationToolbarWrapper = memo(function VisualizationToolbar({
 
   if (!activeVisualization || !visualizationState) {
     return null;
+  }
+
+  const { schemaFlyoutEditor: schemaFlyoutEditorEnabled } = getLensFeatureFlags();
+
+  if (schemaFlyoutEditorEnabled && hasSchemaForVisualization(activeVisualization.id)) {
+    return SchemaFlyoutEditor({
+      visualizationId: activeVisualization.id,
+      state: visualizationState.state,
+      setState: setVisualizationState,
+    });
   }
 
   const { FlyoutToolbarComponent } = activeVisualization;

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/visualization_toolbar.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/visualization_toolbar.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { memo, useCallback } from 'react';
+import React, { memo, useCallback } from 'react';
 import type { FramePublicAPI } from '@kbn/lens-common';
 import {
   useLensDispatch,
@@ -60,11 +60,13 @@ export const VisualizationToolbarWrapper = memo(function VisualizationToolbar({
   const { schemaFlyoutEditor: schemaFlyoutEditorEnabled } = getLensFeatureFlags();
 
   if (schemaFlyoutEditorEnabled && hasSchemaForVisualization(activeVisualization.id)) {
-    return SchemaFlyoutEditor({
-      visualizationId: activeVisualization.id,
-      state: visualizationState.state,
-      setState: setVisualizationState,
-    });
+    return (
+      <SchemaFlyoutEditor
+        visualizationId={activeVisualization.id}
+        state={visualizationState.state}
+        setState={setVisualizationState}
+      />
+    );
   }
 
   const { FlyoutToolbarComponent } = activeVisualization;

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/visualization_toolbar.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/visualization_toolbar.tsx
@@ -8,6 +8,8 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import type { FramePublicAPI } from '@kbn/lens-common';
 import type { VisualizationToolbarProps } from '@kbn/lens-common';
+import { QueryClientProvider } from '@kbn/react-query';
+import { lensQueryClient } from '../../query_client';
 import {
   useLensDispatch,
   updateVisualizationState,
@@ -72,13 +74,15 @@ export const VisualizationToolbarWrapper = memo(function VisualizationToolbar({
 
   if (schemaFlyoutEditorEnabled && hasSchemaForVisualization(activeVisualization.id)) {
     return (
-      <FlyoutToolbar<unknown>
-        frame={framePublicAPI}
-        state={visualizationState.state}
-        setState={setVisualizationState}
-        isInlineEditing={isInlineEditing}
-        contentMap={{ style: SchemaStyleContent }}
-      />
+      <QueryClientProvider client={lensQueryClient}>
+        <FlyoutToolbar<unknown>
+          frame={framePublicAPI}
+          state={visualizationState.state}
+          setState={setVisualizationState}
+          isInlineEditing={isInlineEditing}
+          contentMap={{ style: SchemaStyleContent }}
+        />
+      </QueryClientProvider>
     );
   }
 

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/visualization_toolbar.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/visualization_toolbar.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import type { FramePublicAPI } from '@kbn/lens-common';
+import type { VisualizationToolbarProps } from '@kbn/lens-common';
 import {
   useLensDispatch,
   updateVisualizationState,
@@ -20,6 +21,7 @@ import {
   SchemaFlyoutEditor,
   hasSchemaForVisualization,
 } from '../../shared_components/schema_flyout';
+import { FlyoutToolbar } from '../../shared_components/flyout_toolbar';
 
 export const VisualizationToolbarWrapper = memo(function VisualizationToolbar({
   framePublicAPI,
@@ -59,12 +61,23 @@ export const VisualizationToolbarWrapper = memo(function VisualizationToolbar({
 
   const { schemaFlyoutEditor: schemaFlyoutEditorEnabled } = getLensFeatureFlags();
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const SchemaStyleContent = useMemo(() => {
+    const vizId = activeVisualization.id;
+    const Content = (props: VisualizationToolbarProps<unknown>) => (
+      <SchemaFlyoutEditor visualizationId={vizId} state={props.state} setState={props.setState} />
+    );
+    return Content;
+  }, [activeVisualization.id]);
+
   if (schemaFlyoutEditorEnabled && hasSchemaForVisualization(activeVisualization.id)) {
     return (
-      <SchemaFlyoutEditor
-        visualizationId={activeVisualization.id}
+      <FlyoutToolbar<unknown>
+        frame={framePublicAPI}
         state={visualizationState.state}
         setState={setVisualizationState}
+        isInlineEditing={isInlineEditing}
+        contentMap={{ style: SchemaStyleContent }}
       />
     );
   }

--- a/x-pack/platform/plugins/shared/lens/public/query_client.ts
+++ b/x-pack/platform/plugins/shared/lens/public/query_client.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { QueryClient } from '@kbn/react-query';
+
+export const lensQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: Infinity,
+      cacheTime: Infinity,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      retry: false,
+    },
+  },
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/evaluate_condition.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/evaluate_condition.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FieldDescriptor, FieldVisibilityCondition } from './types';
+import type { FieldDescriptor, FieldVisibilityCondition } from '../../../common/schema_types';
 
 interface ConditionContext {
   /** Series types from all data layers */

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/evaluate_condition.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/evaluate_condition.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FieldDescriptor, FieldVisibilityCondition } from './types';
+
+interface ConditionContext {
+  /** Series types from all data layers */
+  seriesTypes: string[];
+  /** Whether the X axis is time-based */
+  hasTimeAxis: boolean;
+  /** Whether any layer uses a text-based (ES|QL) datasource */
+  hasTextBasedDatasource: boolean;
+}
+
+/**
+ * Extract condition context from visualization state.
+ * Works for XY charts; other viz types return a permissive context.
+ */
+export const extractConditionContext = (state: unknown): ConditionContext => {
+  const defaultContext: ConditionContext = {
+    seriesTypes: [],
+    hasTimeAxis: false,
+    hasTextBasedDatasource: false,
+  };
+
+  if (state == null || typeof state !== 'object') return defaultContext;
+
+  const s = state as Record<string, unknown>;
+  const layers = s.layers;
+  if (!Array.isArray(layers)) return defaultContext;
+
+  const seriesTypes: string[] = [];
+  let hasTextBasedDatasource = false;
+
+  for (const layer of layers) {
+    if (layer == null || typeof layer !== 'object') continue;
+    const l = layer as Record<string, unknown>;
+
+    // Collect series types from data layers
+    if (typeof l.seriesType === 'string') {
+      seriesTypes.push(l.seriesType);
+    }
+
+    // Check for text-based datasource
+    if (l.layerType === 'data' || !l.layerType) {
+      if (typeof l.datasourceId === 'string' && l.datasourceId === 'textBased') {
+        hasTextBasedDatasource = true;
+      }
+    }
+  }
+
+  // Check for time axis — look at the visualization state's xAccessor config
+  // The presence of a date histogram is indicated by the axis scale type
+  const hasTimeAxis =
+    typeof s.xAxisScaleType === 'string' && s.xAxisScaleType === 'time' ? true : false;
+
+  return { seriesTypes, hasTimeAxis, hasTextBasedDatasource };
+};
+
+/**
+ * Evaluate whether a field's condition is met given the current context.
+ * Returns true if the field should be visible.
+ */
+export const evaluateCondition = (
+  condition: FieldVisibilityCondition | undefined,
+  context: ConditionContext
+): boolean => {
+  if (!condition) return true;
+
+  if (condition.seriesTypes && condition.seriesTypes.length > 0) {
+    const hasMatch = context.seriesTypes.some((st) => condition.seriesTypes!.includes(st));
+    if (!hasMatch) return false;
+  }
+
+  if (condition.requiresTimeAxis && !context.hasTimeAxis) {
+    return false;
+  }
+
+  if (condition.excludeTextBased && context.hasTextBasedDatasource) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Filter field descriptors, removing those whose conditions aren't met.
+ */
+export const filterFieldsByCondition = (
+  fields: FieldDescriptor[],
+  state: unknown
+): FieldDescriptor[] => {
+  const context = extractConditionContext(state);
+  return fields.filter((field) => evaluateCondition(field.condition, context));
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+export { SchemaFormField } from './schema_form_field';
+export { ToggleField } from './toggle_field';
+export { SelectField } from './select_field';
+export { NumberField } from './number_field';
+export { TextField } from './text_field';
+export { SectionField } from './section_field';

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
@@ -16,10 +16,10 @@ import React from 'react';
 import { EuiFormRow, EuiFieldNumber } from '@elastic/eui';
 import { useController } from 'react-hook-form';
 import type { Control } from 'react-hook-form';
-import type { FormFieldDescriptor } from '../schema_walker';
+import type { FieldDescriptor } from '../types';
 
 interface NumberFieldProps {
-  descriptor: FormFieldDescriptor;
+  descriptor: FieldDescriptor;
   control: Control;
 }
 

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
@@ -27,7 +27,12 @@ export const NumberField = ({ descriptor, control }: NumberFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (
-    <EuiFormRow label={descriptor.label} helpText={descriptor.description} fullWidth>
+    <EuiFormRow
+      label={descriptor.label}
+      helpText={descriptor.description}
+      display="columnCompressed"
+      fullWidth
+    >
       <EuiFieldNumber
         value={field.value as number | undefined}
         onChange={(e) => field.onChange(e.target.valueAsNumber)}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiFieldNumber } from '@elastic/eui';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+import type { FormFieldDescriptor } from '../schema_walker';
+
+interface NumberFieldProps {
+  descriptor: FormFieldDescriptor;
+  control: Control;
+}
+
+export const NumberField = ({ descriptor, control }: NumberFieldProps) => {
+  const { field } = useController({ name: descriptor.path, control });
+
+  return (
+    <EuiFormRow label={descriptor.label} helpText={descriptor.description} fullWidth>
+      <EuiFieldNumber
+        value={field.value as number | undefined}
+        onChange={(e) => field.onChange(e.target.valueAsNumber)}
+        onBlur={field.onBlur}
+        min={descriptor.min}
+        max={descriptor.max}
+        data-test-subj={`schemaField-${descriptor.path}`}
+        fullWidth
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
@@ -5,25 +5,12 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0"; you may not use this file except in compliance with the "Elastic License
- * 2.0".
- */
-
 import React from 'react';
 import { EuiFormRow, EuiFieldNumber } from '@elastic/eui';
 import { useController } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
-import type { FieldDescriptor } from '../types';
+import type { SchemaFieldProps } from '../types';
 
-interface NumberFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
-
-export const NumberField = ({ descriptor, control }: NumberFieldProps) => {
+export const NumberField = ({ descriptor, control }: SchemaFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/number_field.tsx
@@ -27,12 +27,7 @@ export const NumberField = ({ descriptor, control }: NumberFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (
-    <EuiFormRow
-      label={descriptor.label}
-      helpText={descriptor.description}
-      display="columnCompressed"
-      fullWidth
-    >
+    <EuiFormRow label={descriptor.label} display="columnCompressed" fullWidth>
       <EuiFieldNumber
         value={field.value as number | undefined}
         onChange={(e) => field.onChange(e.target.valueAsNumber)}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/pagination_toggle_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/pagination_toggle_field.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { EuiFormRow, EuiSwitch, EuiToolTip } from '@elastic/eui';
+import type { EuiSwitchEvent } from '@elastic/eui';
 import { useController } from 'react-hook-form';
 import type { Control } from 'react-hook-form';
 import type { FieldDescriptor } from '../types';
@@ -24,7 +25,7 @@ export const PaginationToggleField = ({ descriptor, control }: PaginationToggleF
   // Form value is a number (page size) when enabled, or undefined when disabled.
   const isEnabled = field.value != null && field.value !== false;
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: EuiSwitchEvent) => {
     field.onChange(e.target.checked ? DEFAULT_PAGE_SIZE : undefined);
   };
 

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/pagination_toggle_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/pagination_toggle_field.tsx
@@ -9,17 +9,11 @@ import React from 'react';
 import { EuiFormRow, EuiSwitch, EuiToolTip } from '@elastic/eui';
 import type { EuiSwitchEvent } from '@elastic/eui';
 import { useController } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
-import type { FieldDescriptor } from '../types';
+import type { SchemaFieldProps } from '../types';
 
 const DEFAULT_PAGE_SIZE = 10;
 
-interface PaginationToggleFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
-
-export const PaginationToggleField = ({ descriptor, control }: PaginationToggleFieldProps) => {
+export const PaginationToggleField = ({ descriptor, control }: SchemaFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   // Form value is a number (page size) when enabled, or undefined when disabled.

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/pagination_toggle_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/pagination_toggle_field.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiSwitch, EuiToolTip } from '@elastic/eui';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+import type { FieldDescriptor } from '../types';
+
+const DEFAULT_PAGE_SIZE = 10;
+
+interface PaginationToggleFieldProps {
+  descriptor: FieldDescriptor;
+  control: Control;
+}
+
+export const PaginationToggleField = ({ descriptor, control }: PaginationToggleFieldProps) => {
+  const { field } = useController({ name: descriptor.path, control });
+
+  // Form value is a number (page size) when enabled, or undefined when disabled.
+  const isEnabled = field.value != null && field.value !== false;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    field.onChange(e.target.checked ? DEFAULT_PAGE_SIZE : undefined);
+  };
+
+  const switchElement = (
+    <EuiSwitch
+      label=""
+      compressed
+      checked={isEnabled}
+      onChange={handleChange}
+      onBlur={field.onBlur}
+      data-test-subj={`schemaField-${descriptor.path}`}
+    />
+  );
+
+  return (
+    <EuiFormRow label={descriptor.label} display="columnCompressed" fullWidth>
+      {descriptor.tooltip ? (
+        <EuiToolTip content={descriptor.tooltip} position="top">
+          {switchElement}
+        </EuiToolTip>
+      ) : (
+        switchElement
+      )}
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/range_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/range_field.tsx
@@ -8,17 +8,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { EuiFormRow, EuiRange } from '@elastic/eui';
 import { useController } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
-import type { FieldDescriptor } from '../types';
-
-interface RangeFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
+import type { SchemaFieldProps } from '../types';
 
 const DEBOUNCE_MS = 256;
 
-export const RangeField = ({ descriptor, control }: RangeFieldProps) => {
+export const RangeField = ({ descriptor, control }: SchemaFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   const min = (descriptor.props?.min as number) ?? descriptor.min ?? 0;

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/range_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/range_field.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { EuiFormRow, EuiRange } from '@elastic/eui';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+import type { FieldDescriptor } from '../types';
+
+interface RangeFieldProps {
+  descriptor: FieldDescriptor;
+  control: Control;
+}
+
+const DEBOUNCE_MS = 256;
+
+export const RangeField = ({ descriptor, control }: RangeFieldProps) => {
+  const { field } = useController({ name: descriptor.path, control });
+
+  const min = (descriptor.props?.min as number) ?? descriptor.min ?? 0;
+  const max = (descriptor.props?.max as number) ?? descriptor.max ?? 100;
+  const step = (descriptor.props?.step as number) ?? 0.1;
+
+  const [localValue, setLocalValue] = useState<number>(
+    (field.value as number) ?? (descriptor.defaultValue as number) ?? min
+  );
+
+  // Sync from form → local when external changes arrive
+  useEffect(() => {
+    if (field.value !== undefined && field.value !== localValue) {
+      setLocalValue(field.value as number);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [field.value]);
+
+  // Debounced commit to react-hook-form
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (localValue !== field.value) {
+        field.onChange(localValue);
+      }
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localValue]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLButtonElement>) => {
+      setLocalValue(Number((e.target as HTMLInputElement).value));
+    },
+    []
+  );
+
+  return (
+    <EuiFormRow label={descriptor.label} display="columnCompressed" fullWidth>
+      <EuiRange
+        value={localValue}
+        min={min}
+        max={max}
+        step={step}
+        showInput
+        compressed
+        fullWidth
+        onChange={handleChange}
+        data-test-subj={`schemaField-${descriptor.path}`}
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/range_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/range_field.tsx
@@ -49,7 +49,12 @@ export const RangeField = ({ descriptor, control }: RangeFieldProps) => {
   }, [localValue]);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLButtonElement>) => {
+    (
+      e:
+        | React.ChangeEvent<HTMLInputElement>
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLInputElement>
+    ) => {
       setLocalValue(Number((e.target as HTMLInputElement).value));
     },
     []

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/row_height_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/row_height_field.tsx
@@ -9,7 +9,9 @@ import React from 'react';
 import { useController } from 'react-hook-form';
 import type { Control } from 'react-hook-form';
 import { RowHeightSettings } from '@kbn/unified-data-table';
-import type { RowHeightModeType } from '@kbn/unified-data-table';
+import type { RowHeightSettingsProps } from '@kbn/unified-data-table';
+
+type RowHeightMode = RowHeightSettingsProps['rowHeight'];
 import type { FieldDescriptor } from '../types';
 
 interface RowHeightFieldProps {
@@ -32,7 +34,7 @@ export const RowHeightField = ({ descriptor, control }: RowHeightFieldProps) => 
     defaultValue: 2,
   });
 
-  const onChangeRowHeight = (mode: RowHeightModeType | undefined) => {
+  const onChangeRowHeight = (mode: RowHeightMode | undefined) => {
     typeField.onChange(mode ?? 'auto');
   };
 
@@ -42,7 +44,7 @@ export const RowHeightField = ({ descriptor, control }: RowHeightFieldProps) => 
 
   return (
     <RowHeightSettings
-      rowHeight={(typeField.value as RowHeightModeType) ?? 'auto'}
+      rowHeight={(typeField.value as RowHeightMode) ?? 'auto'}
       lineCountInput={linesField.value as number}
       maxRowHeight={maxRowHeight}
       label={descriptor.label}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/row_height_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/row_height_field.tsx
@@ -7,19 +7,13 @@
 
 import React from 'react';
 import { useController } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
 import { RowHeightSettings } from '@kbn/unified-data-table';
 import type { RowHeightSettingsProps } from '@kbn/unified-data-table';
 
 type RowHeightMode = RowHeightSettingsProps['rowHeight'];
-import type { FieldDescriptor } from '../types';
+import type { SchemaFieldProps } from '../types';
 
-interface RowHeightFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
-
-export const RowHeightField = ({ descriptor, control }: RowHeightFieldProps) => {
+export const RowHeightField = ({ descriptor, control }: SchemaFieldProps) => {
   const maxRowHeight = (descriptor.props?.maxLines as number) ?? 20;
 
   const { field: typeField } = useController({

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/row_height_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/row_height_field.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+import { RowHeightSettings } from '@kbn/unified-data-table';
+import type { RowHeightModeType } from '@kbn/unified-data-table';
+import type { FieldDescriptor } from '../types';
+
+interface RowHeightFieldProps {
+  descriptor: FieldDescriptor;
+  control: Control;
+}
+
+export const RowHeightField = ({ descriptor, control }: RowHeightFieldProps) => {
+  const maxRowHeight = (descriptor.props?.maxLines as number) ?? 20;
+
+  const { field: typeField } = useController({
+    name: `${descriptor.path}.type`,
+    control,
+    defaultValue: 'auto',
+  });
+
+  const { field: linesField } = useController({
+    name: `${descriptor.path}.lines`,
+    control,
+    defaultValue: 2,
+  });
+
+  const onChangeRowHeight = (mode: RowHeightModeType | undefined) => {
+    typeField.onChange(mode ?? 'auto');
+  };
+
+  const onChangeLineCountInput = (lines: number) => {
+    linesField.onChange(lines);
+  };
+
+  return (
+    <RowHeightSettings
+      rowHeight={(typeField.value as RowHeightModeType) ?? 'auto'}
+      lineCountInput={linesField.value as number}
+      maxRowHeight={maxRowHeight}
+      label={descriptor.label}
+      onChangeRowHeight={onChangeRowHeight}
+      onChangeLineCountInput={onChangeLineCountInput}
+      fullWidth
+      data-test-subj={`schemaRowHeight-${descriptor.path}`}
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { SchemaFormField } from './schema_form_field';
-import type { FormFieldDescriptor } from '../schema_walker';
+import type { FieldDescriptor } from '../types';
 
 const Wrapper = ({
   children,
@@ -32,7 +32,7 @@ const Wrapper = ({
   return <Component />;
 };
 
-const renderField = (descriptor: FormFieldDescriptor, defaultValues?: Record<string, unknown>) => {
+const renderField = (descriptor: FieldDescriptor, defaultValues?: Record<string, unknown>) => {
   return render(
     <Wrapper defaultValues={defaultValues}>
       {(control) => <SchemaFormField descriptor={descriptor} control={control} />}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
@@ -98,6 +98,22 @@ describe('SchemaFormField', () => {
     expect(screen.getByRole('switch')).toBeInTheDocument();
   });
 
+  it('renders EuiRange for range widget', () => {
+    renderField(
+      {
+        path: 'fillOpacity',
+        type: 'number',
+        label: 'Fill opacity',
+        widget: 'range',
+        props: { min: 0.1, max: 1, step: 0.1 },
+        defaultValue: 0.8,
+      },
+      { fillOpacity: 0.8 }
+    );
+    expect(screen.getByText('Fill opacity')).toBeInTheDocument();
+    expect(screen.getAllByTestId('schemaField-fillOpacity').length).toBeGreaterThan(0);
+  });
+
   it('renders nothing for unknown type', () => {
     const { container } = renderField({
       path: 'mystery',

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { SchemaFormField } from './schema_form_field';
+import type { FormFieldDescriptor } from '../schema_walker';
+
+const Wrapper = ({
+  children,
+  defaultValues = {},
+}: {
+  children: (control: ReturnType<typeof useForm>['control']) => React.ReactNode;
+  defaultValues?: Record<string, unknown>;
+}) => {
+  const Component = () => {
+    const { control } = useForm({ defaultValues });
+    return <>{children(control)}</>;
+  };
+  return <Component />;
+};
+
+const renderField = (descriptor: FormFieldDescriptor, defaultValues?: Record<string, unknown>) => {
+  return render(
+    <Wrapper defaultValues={defaultValues}>
+      {(control) => <SchemaFormField descriptor={descriptor} control={control} />}
+    </Wrapper>
+  );
+};
+
+describe('SchemaFormField', () => {
+  it('renders EuiSwitch for toggle type', () => {
+    renderField(
+      { path: 'showLabels', type: 'toggle', label: 'Show labels', defaultValue: true },
+      { showLabels: true }
+    );
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+    expect(screen.getByText('Show labels')).toBeInTheDocument();
+  });
+
+  it('renders EuiSelect for select type', () => {
+    renderField(
+      {
+        path: 'position',
+        type: 'select',
+        label: 'Position',
+        options: [
+          { value: 'top', label: 'top' },
+          { value: 'bottom', label: 'bottom' },
+        ],
+        defaultValue: 'top',
+      },
+      { position: 'top' }
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText('Position')).toBeInTheDocument();
+  });
+
+  it('renders EuiFieldNumber for number type', () => {
+    renderField(
+      { path: 'size', type: 'number', label: 'Size', min: 0, max: 100, defaultValue: 10 },
+      { size: 10 }
+    );
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    expect(screen.getByText('Size')).toBeInTheDocument();
+  });
+
+  it('renders EuiFieldText for text type', () => {
+    renderField({ path: 'title', type: 'text', label: 'Title', defaultValue: '' }, { title: '' });
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByText('Title')).toBeInTheDocument();
+  });
+
+  it('renders EuiAccordion for section type with children', () => {
+    renderField(
+      {
+        path: 'legend',
+        type: 'section',
+        label: 'Legend',
+        children: [
+          { path: 'legend.show', type: 'toggle', label: 'Show legend', defaultValue: true },
+        ],
+      },
+      { 'legend.show': true }
+    );
+    expect(screen.getByText('Legend')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  it('renders nothing for unknown type', () => {
+    const { container } = renderField({
+      path: 'mystery',
+      type: 'unknown',
+      label: 'Mystery',
+    });
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
@@ -26,7 +26,7 @@ const Wrapper = ({
   defaultValues?: Record<string, unknown>;
 }) => {
   const Component = () => {
-    const { control } = useForm({ defaultValues });
+    const { control } = useForm({ defaultValues: defaultValues as Record<string, {}> });
     return <>{children(control)}</>;
   };
   return <Component />;

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
@@ -64,8 +64,7 @@ describe('SchemaFormField', () => {
       },
       { position: 'top' }
     );
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
-    expect(screen.getByText('Position')).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Position' })).toBeInTheDocument();
   });
 
   it('renders EuiFieldNumber for number type', () => {

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.test.tsx
@@ -5,18 +5,11 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0"; you may not use this file except in compliance with the "Elastic License
- * 2.0".
- */
-
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { SchemaFormField } from './schema_form_field';
-import type { FieldDescriptor } from '../types';
+import type { FieldDescriptor } from '../../../../common/schema_types';
 
 const Wrapper = ({
   children,

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import type { Control } from 'react-hook-form';
-import type { FormFieldDescriptor } from '../schema_walker';
+import type { FieldDescriptor } from '../types';
 import { ToggleField } from './toggle_field';
 import { SelectField } from './select_field';
 import { NumberField } from './number_field';
@@ -22,7 +22,7 @@ import { TextField } from './text_field';
 import { SectionField } from './section_field';
 
 interface SchemaFormFieldProps {
-  descriptor: FormFieldDescriptor;
+  descriptor: FieldDescriptor;
   control: Control;
 }
 

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import React from 'react';
+import type { Control } from 'react-hook-form';
+import type { FormFieldDescriptor } from '../schema_walker';
+import { ToggleField } from './toggle_field';
+import { SelectField } from './select_field';
+import { NumberField } from './number_field';
+import { TextField } from './text_field';
+import { SectionField } from './section_field';
+
+interface SchemaFormFieldProps {
+  descriptor: FormFieldDescriptor;
+  control: Control;
+}
+
+export const SchemaFormField = ({ descriptor, control }: SchemaFormFieldProps) => {
+  switch (descriptor.type) {
+    case 'toggle':
+      return <ToggleField descriptor={descriptor} control={control} />;
+    case 'select':
+      return <SelectField descriptor={descriptor} control={control} />;
+    case 'number':
+      return <NumberField descriptor={descriptor} control={control} />;
+    case 'text':
+      return <TextField descriptor={descriptor} control={control} />;
+    case 'section':
+      return <SectionField descriptor={descriptor} control={control} />;
+    default:
+      return null;
+  }
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
@@ -5,16 +5,8 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0"; you may not use this file except in compliance with the "Elastic License
- * 2.0".
- */
-
 import React from 'react';
-import type { Control } from 'react-hook-form';
-import type { FieldDescriptor } from '../types';
+import type { SchemaFieldProps } from '../types';
 import { ToggleField } from './toggle_field';
 import { SelectField } from './select_field';
 import { NumberField } from './number_field';
@@ -24,11 +16,6 @@ import { RangeField } from './range_field';
 import { PaginationToggleField } from './pagination_toggle_field';
 import { RowHeightField } from './row_height_field';
 
-interface SchemaFormFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
-
 // Map custom widget names to base field types they should render as.
 // Custom widgets that don't have dedicated renderers yet fall back to
 // the closest generic renderer based on the schema type.
@@ -36,7 +23,7 @@ const widgetToBaseType: Record<string, string> = {
   buttonGroup: 'select',
 };
 
-export const SchemaFormField = ({ descriptor, control }: SchemaFormFieldProps) => {
+export const SchemaFormField = ({ descriptor, control }: SchemaFieldProps) => {
   // Resolve: explicit widget → mapped base type → schema type
   const widget = descriptor.widget ?? descriptor.type;
   const resolved = widgetToBaseType[widget] ?? widget;

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
@@ -21,6 +21,8 @@ import { NumberField } from './number_field';
 import { TextField } from './text_field';
 import { SectionField } from './section_field';
 import { RangeField } from './range_field';
+import { PaginationToggleField } from './pagination_toggle_field';
+import { RowHeightField } from './row_height_field';
 
 interface SchemaFormFieldProps {
   descriptor: FieldDescriptor;
@@ -32,8 +34,6 @@ interface SchemaFormFieldProps {
 // the closest generic renderer based on the schema type.
 const widgetToBaseType: Record<string, string> = {
   buttonGroup: 'select',
-  rowHeight: 'section',
-  paginationToggle: 'toggle',
 };
 
 export const SchemaFormField = ({ descriptor, control }: SchemaFormFieldProps) => {
@@ -42,6 +42,10 @@ export const SchemaFormField = ({ descriptor, control }: SchemaFormFieldProps) =
   const resolved = widgetToBaseType[widget] ?? widget;
 
   switch (resolved) {
+    case 'rowHeight':
+      return <RowHeightField descriptor={descriptor} control={control} />;
+    case 'paginationToggle':
+      return <PaginationToggleField descriptor={descriptor} control={control} />;
     case 'range':
       return <RangeField descriptor={descriptor} control={control} />;
     case 'toggle':

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/schema_form_field.tsx
@@ -20,14 +20,30 @@ import { SelectField } from './select_field';
 import { NumberField } from './number_field';
 import { TextField } from './text_field';
 import { SectionField } from './section_field';
+import { RangeField } from './range_field';
 
 interface SchemaFormFieldProps {
   descriptor: FieldDescriptor;
   control: Control;
 }
 
+// Map custom widget names to base field types they should render as.
+// Custom widgets that don't have dedicated renderers yet fall back to
+// the closest generic renderer based on the schema type.
+const widgetToBaseType: Record<string, string> = {
+  buttonGroup: 'select',
+  rowHeight: 'section',
+  paginationToggle: 'toggle',
+};
+
 export const SchemaFormField = ({ descriptor, control }: SchemaFormFieldProps) => {
-  switch (descriptor.type) {
+  // Resolve: explicit widget → mapped base type → schema type
+  const widget = descriptor.widget ?? descriptor.type;
+  const resolved = widgetToBaseType[widget] ?? widget;
+
+  switch (resolved) {
+    case 'range':
+      return <RangeField descriptor={descriptor} control={control} />;
     case 'toggle':
       return <ToggleField descriptor={descriptor} control={control} />;
     case 'select':

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/section_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/section_field.tsx
@@ -15,11 +15,11 @@
 import React from 'react';
 import { EuiAccordion } from '@elastic/eui';
 import type { Control } from 'react-hook-form';
-import type { FormFieldDescriptor } from '../schema_walker';
+import type { FieldDescriptor } from '../types';
 import { SchemaFormField } from './schema_form_field';
 
 interface SectionFieldProps {
-  descriptor: FormFieldDescriptor;
+  descriptor: FieldDescriptor;
   control: Control;
 }
 

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/section_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/section_field.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import React from 'react';
+import { EuiAccordion } from '@elastic/eui';
+import type { Control } from 'react-hook-form';
+import type { FormFieldDescriptor } from '../schema_walker';
+import { SchemaFormField } from './schema_form_field';
+
+interface SectionFieldProps {
+  descriptor: FormFieldDescriptor;
+  control: Control;
+}
+
+export const SectionField = ({ descriptor, control }: SectionFieldProps) => {
+  if (!descriptor.children?.length) return null;
+
+  return (
+    <EuiAccordion
+      id={`section-${descriptor.path}`}
+      buttonContent={descriptor.label}
+      initialIsOpen
+      data-test-subj={`schemaSection-${descriptor.path}`}
+    >
+      {descriptor.children.map((child) => (
+        <SchemaFormField key={child.path} descriptor={child} control={control} />
+      ))}
+    </EuiAccordion>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/section_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/section_field.tsx
@@ -5,25 +5,12 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0"; you may not use this file except in compliance with the "Elastic License
- * 2.0".
- */
-
 import React from 'react';
 import { EuiAccordion } from '@elastic/eui';
-import type { Control } from 'react-hook-form';
-import type { FieldDescriptor } from '../types';
+import type { SchemaFieldProps } from '../types';
 import { SchemaFormField } from './schema_form_field';
 
-interface SectionFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
-
-export const SectionField = ({ descriptor, control }: SectionFieldProps) => {
+export const SectionField = ({ descriptor, control }: SchemaFieldProps) => {
   if (!descriptor.children?.length) return null;
 
   return (

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+import type { FormFieldDescriptor } from '../schema_walker';
+
+interface SelectFieldProps {
+  descriptor: FormFieldDescriptor;
+  control: Control;
+}
+
+export const SelectField = ({ descriptor, control }: SelectFieldProps) => {
+  const { field } = useController({ name: descriptor.path, control });
+
+  const options = (descriptor.options ?? []).map((opt) => ({
+    value: opt.value,
+    text: opt.label,
+  }));
+
+  return (
+    <EuiFormRow label={descriptor.label} helpText={descriptor.description} fullWidth>
+      <EuiSelect
+        options={options}
+        value={String(field.value ?? '')}
+        onChange={(e) => field.onChange(e.target.value)}
+        onBlur={field.onBlur}
+        data-test-subj={`schemaField-${descriptor.path}`}
+        fullWidth
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
@@ -16,10 +16,10 @@ import React from 'react';
 import { EuiButtonGroup, EuiFormRow, EuiSelect } from '@elastic/eui';
 import { useController } from 'react-hook-form';
 import type { Control } from 'react-hook-form';
-import type { FormFieldDescriptor } from '../schema_walker';
+import type { FieldDescriptor } from '../types';
 
 interface SelectFieldProps {
-  descriptor: FormFieldDescriptor;
+  descriptor: FieldDescriptor;
   control: Control;
 }
 

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
@@ -30,12 +30,7 @@ export const SelectField = ({ descriptor, control }: SelectFieldProps) => {
 
   if (rawOptions.length <= 4) {
     return (
-      <EuiFormRow
-        label={descriptor.label}
-        helpText={descriptor.description}
-        display="columnCompressed"
-        fullWidth
-      >
+      <EuiFormRow label={descriptor.label} display="columnCompressed" fullWidth>
         <EuiButtonGroup
           legend={descriptor.label}
           options={rawOptions.map((opt) => ({ id: opt.value, label: opt.label }))}
@@ -55,12 +50,7 @@ export const SelectField = ({ descriptor, control }: SelectFieldProps) => {
   }));
 
   return (
-    <EuiFormRow
-      label={descriptor.label}
-      helpText={descriptor.description}
-      display="columnCompressed"
-      fullWidth
-    >
+    <EuiFormRow label={descriptor.label} display="columnCompressed" fullWidth>
       <EuiSelect
         options={options}
         value={String(field.value ?? '')}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
@@ -14,6 +14,7 @@
 
 import React from 'react';
 import { EuiButtonGroup, EuiFormRow, EuiSelect } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useController } from 'react-hook-form';
 import type { Control } from 'react-hook-form';
 import type { FieldDescriptor } from '../types';
@@ -24,9 +25,15 @@ interface SelectFieldProps {
 }
 
 export const SelectField = ({ descriptor, control }: SelectFieldProps) => {
-  const { field } = useController({ name: descriptor.path, control });
+  const { field } = useController({
+    name: descriptor.path,
+    control,
+    defaultValue: descriptor.defaultValue,
+  });
 
   const rawOptions = descriptor.options ?? [];
+
+  const isOptional = !descriptor.required;
 
   if (rawOptions.length <= 4) {
     return (
@@ -34,8 +41,14 @@ export const SelectField = ({ descriptor, control }: SelectFieldProps) => {
         <EuiButtonGroup
           legend={descriptor.label}
           options={rawOptions.map((opt) => ({ id: opt.value, label: opt.label }))}
-          idSelected={(field.value as string) ?? ''}
-          onChange={(id) => field.onChange(id)}
+          idSelected={(field.value as string) ?? (descriptor.defaultValue as string) ?? ''}
+          onChange={(id) => {
+            if (isOptional && field.value === id) {
+              field.onChange(undefined);
+            } else {
+              field.onChange(id);
+            }
+          }}
           buttonSize="compressed"
           isFullWidth
           data-test-subj={`schemaField-${descriptor.path}`}
@@ -44,17 +57,29 @@ export const SelectField = ({ descriptor, control }: SelectFieldProps) => {
     );
   }
 
-  const options = rawOptions.map((opt) => ({
-    value: opt.value,
-    text: opt.label,
-  }));
+  const options = [
+    ...(isOptional
+      ? [
+          {
+            value: '',
+            text: i18n.translate('xpack.lens.schemaField.selectNone', {
+              defaultMessage: 'None',
+            }),
+          },
+        ]
+      : []),
+    ...rawOptions.map((opt) => ({
+      value: opt.value,
+      text: opt.label,
+    })),
+  ];
 
   return (
     <EuiFormRow label={descriptor.label} display="columnCompressed" fullWidth>
       <EuiSelect
         options={options}
         value={String(field.value ?? '')}
-        onChange={(e) => field.onChange(e.target.value)}
+        onChange={(e) => field.onChange(e.target.value || undefined)}
         onBlur={field.onBlur}
         compressed
         data-test-subj={`schemaField-${descriptor.path}`}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { EuiButtonGroup, EuiFormRow, EuiSelect } from '@elastic/eui';
 import { useController } from 'react-hook-form';
 import type { Control } from 'react-hook-form';
 import type { FormFieldDescriptor } from '../schema_walker';
@@ -26,18 +26,47 @@ interface SelectFieldProps {
 export const SelectField = ({ descriptor, control }: SelectFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
-  const options = (descriptor.options ?? []).map((opt) => ({
+  const rawOptions = descriptor.options ?? [];
+
+  if (rawOptions.length <= 4) {
+    return (
+      <EuiFormRow
+        label={descriptor.label}
+        helpText={descriptor.description}
+        display="columnCompressed"
+        fullWidth
+      >
+        <EuiButtonGroup
+          legend={descriptor.label}
+          options={rawOptions.map((opt) => ({ id: opt.value, label: opt.label }))}
+          idSelected={(field.value as string) ?? ''}
+          onChange={(id) => field.onChange(id)}
+          buttonSize="compressed"
+          isFullWidth
+          data-test-subj={`schemaField-${descriptor.path}`}
+        />
+      </EuiFormRow>
+    );
+  }
+
+  const options = rawOptions.map((opt) => ({
     value: opt.value,
     text: opt.label,
   }));
 
   return (
-    <EuiFormRow label={descriptor.label} helpText={descriptor.description} fullWidth>
+    <EuiFormRow
+      label={descriptor.label}
+      helpText={descriptor.description}
+      display="columnCompressed"
+      fullWidth
+    >
       <EuiSelect
         options={options}
         value={String(field.value ?? '')}
         onChange={(e) => field.onChange(e.target.value)}
         onBlur={field.onBlur}
+        compressed
         data-test-subj={`schemaField-${descriptor.path}`}
         fullWidth
       />

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/select_field.tsx
@@ -16,15 +16,9 @@ import React from 'react';
 import { EuiButtonGroup, EuiFormRow, EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useController } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
-import type { FieldDescriptor } from '../types';
+import type { SchemaFieldProps } from '../types';
 
-interface SelectFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
-
-export const SelectField = ({ descriptor, control }: SelectFieldProps) => {
+export const SelectField = ({ descriptor, control }: SchemaFieldProps) => {
   const { field } = useController({
     name: descriptor.path,
     control,

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
@@ -16,10 +16,10 @@ import React from 'react';
 import { EuiFormRow, EuiFieldText } from '@elastic/eui';
 import { useController } from 'react-hook-form';
 import type { Control } from 'react-hook-form';
-import type { FormFieldDescriptor } from '../schema_walker';
+import type { FieldDescriptor } from '../types';
 
 interface TextFieldProps {
-  descriptor: FormFieldDescriptor;
+  descriptor: FieldDescriptor;
   control: Control;
 }
 

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
@@ -27,12 +27,7 @@ export const TextField = ({ descriptor, control }: TextFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (
-    <EuiFormRow
-      label={descriptor.label}
-      helpText={descriptor.description}
-      display="columnCompressed"
-      fullWidth
-    >
+    <EuiFormRow label={descriptor.label} display="columnCompressed" fullWidth>
       <EuiFieldText
         value={String(field.value ?? '')}
         onChange={(e) => field.onChange(e.target.value)}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiFieldText } from '@elastic/eui';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+import type { FormFieldDescriptor } from '../schema_walker';
+
+interface TextFieldProps {
+  descriptor: FormFieldDescriptor;
+  control: Control;
+}
+
+export const TextField = ({ descriptor, control }: TextFieldProps) => {
+  const { field } = useController({ name: descriptor.path, control });
+
+  return (
+    <EuiFormRow label={descriptor.label} helpText={descriptor.description} fullWidth>
+      <EuiFieldText
+        value={String(field.value ?? '')}
+        onChange={(e) => field.onChange(e.target.value)}
+        onBlur={field.onBlur}
+        data-test-subj={`schemaField-${descriptor.path}`}
+        fullWidth
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
@@ -27,7 +27,12 @@ export const TextField = ({ descriptor, control }: TextFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (
-    <EuiFormRow label={descriptor.label} helpText={descriptor.description} fullWidth>
+    <EuiFormRow
+      label={descriptor.label}
+      helpText={descriptor.description}
+      display="columnCompressed"
+      fullWidth
+    >
       <EuiFieldText
         value={String(field.value ?? '')}
         onChange={(e) => field.onChange(e.target.value)}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/text_field.tsx
@@ -15,15 +15,9 @@
 import React from 'react';
 import { EuiFormRow, EuiFieldText } from '@elastic/eui';
 import { useController } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
-import type { FieldDescriptor } from '../types';
+import type { SchemaFieldProps } from '../types';
 
-interface TextFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
-
-export const TextField = ({ descriptor, control }: TextFieldProps) => {
+export const TextField = ({ descriptor, control }: SchemaFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
@@ -15,15 +15,9 @@
 import React from 'react';
 import { EuiFormRow, EuiSwitch } from '@elastic/eui';
 import { useController } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
-import type { FieldDescriptor } from '../types';
+import type { SchemaFieldProps } from '../types';
 
-interface ToggleFieldProps {
-  descriptor: FieldDescriptor;
-  control: Control;
-}
-
-export const ToggleField = ({ descriptor, control }: ToggleFieldProps) => {
+export const ToggleField = ({ descriptor, control }: SchemaFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
@@ -16,10 +16,10 @@ import React from 'react';
 import { EuiFormRow, EuiSwitch } from '@elastic/eui';
 import { useController } from 'react-hook-form';
 import type { Control } from 'react-hook-form';
-import type { FormFieldDescriptor } from '../schema_walker';
+import type { FieldDescriptor } from '../types';
 
 interface ToggleFieldProps {
-  descriptor: FormFieldDescriptor;
+  descriptor: FieldDescriptor;
   control: Control;
 }
 

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiSwitch } from '@elastic/eui';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+import type { FormFieldDescriptor } from '../schema_walker';
+
+interface ToggleFieldProps {
+  descriptor: FormFieldDescriptor;
+  control: Control;
+}
+
+export const ToggleField = ({ descriptor, control }: ToggleFieldProps) => {
+  const { field } = useController({ name: descriptor.path, control });
+
+  return (
+    <EuiFormRow label={descriptor.label} helpText={descriptor.description} fullWidth>
+      <EuiSwitch
+        label=""
+        checked={Boolean(field.value)}
+        onChange={(e) => field.onChange(e.target.checked)}
+        onBlur={field.onBlur}
+        data-test-subj={`schemaField-${descriptor.path}`}
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
@@ -27,9 +27,15 @@ export const ToggleField = ({ descriptor, control }: ToggleFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (
-    <EuiFormRow label={descriptor.label} helpText={descriptor.description} fullWidth>
+    <EuiFormRow
+      label={descriptor.label}
+      helpText={descriptor.description}
+      display="columnCompressed"
+      fullWidth
+    >
       <EuiSwitch
         label=""
+        compressed
         checked={Boolean(field.value)}
         onChange={(e) => field.onChange(e.target.checked)}
         onBlur={field.onBlur}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/fields/toggle_field.tsx
@@ -27,12 +27,7 @@ export const ToggleField = ({ descriptor, control }: ToggleFieldProps) => {
   const { field } = useController({ name: descriptor.path, control });
 
   return (
-    <EuiFormRow
-      label={descriptor.label}
-      helpText={descriptor.description}
-      display="columnCompressed"
-      fullWidth
-    >
+    <EuiFormRow label={descriptor.label} display="columnCompressed" fullWidth>
       <EuiSwitch
         label=""
         compressed

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { SchemaFlyoutEditor } from './schema_flyout_editor';
+export { hasSchemaForVisualization } from './viz_schema_map';

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
@@ -15,7 +15,7 @@ import {
   extractSettingsFromState,
   mergeSettingsIntoState,
 } from './schema_flyout_editor';
-import type { FieldDescriptor } from './types';
+import type { FieldDescriptor } from '../../../common/schema_types';
 
 // Mock useKibana to provide http service — stable reference to prevent useEffect loops
 const mockHttpGet = jest.fn();

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  SchemaFlyoutEditor,
+  getByPath,
+  setByPath,
+  extractSettingsFromState,
+  mergeSettingsIntoState,
+} from './schema_flyout_editor';
+import type { FormFieldDescriptor } from './schema_walker';
+
+// Mock the viz_schema_map module
+jest.mock('./viz_schema_map', () => ({
+  getSchemaForVisualization: jest.fn(),
+}));
+
+// Mock the schema_walker module
+jest.mock('./schema_walker', () => ({
+  walkSchema: jest.fn(),
+}));
+
+// Mock the fields module
+jest.mock('./fields', () => ({
+  SchemaFormField: ({ descriptor }: { descriptor: FormFieldDescriptor }) => (
+    <div data-test-subj={`field-${descriptor.path}`}>{descriptor.label}</div>
+  ),
+}));
+
+const { getSchemaForVisualization } = jest.requireMock('./viz_schema_map');
+const { walkSchema } = jest.requireMock('./schema_walker');
+
+describe('getByPath', () => {
+  it('returns nested value', () => {
+    expect(getByPath({ a: { b: { c: 42 } } }, 'a.b.c')).toBe(42);
+  });
+
+  it('returns undefined for missing path', () => {
+    expect(getByPath({ a: 1 }, 'b.c')).toBeUndefined();
+  });
+
+  it('returns top-level value', () => {
+    expect(getByPath({ x: 'hello' }, 'x')).toBe('hello');
+  });
+
+  it('handles null object', () => {
+    expect(getByPath(null, 'a')).toBeUndefined();
+  });
+});
+
+describe('setByPath', () => {
+  it('sets nested value immutably', () => {
+    const original = { a: { b: 1 } };
+    const result = setByPath(original, 'a.b', 2) as Record<string, unknown>;
+    expect((result.a as Record<string, unknown>).b).toBe(2);
+    expect(original.a.b).toBe(1);
+  });
+
+  it('creates intermediate objects', () => {
+    const result = setByPath({}, 'a.b.c', 'value') as Record<string, unknown>;
+    expect(getByPath(result, 'a.b.c')).toBe('value');
+  });
+
+  it('sets top-level value', () => {
+    const result = setByPath({ x: 1 }, 'x', 2) as Record<string, unknown>;
+    expect(result.x).toBe(2);
+  });
+});
+
+describe('extractSettingsFromState', () => {
+  it('extracts leaf values from state', () => {
+    const state = { styling: { paging: 10, density: { mode: 'compact' } } };
+    const fields: FormFieldDescriptor[] = [
+      {
+        path: 'styling',
+        type: 'section',
+        label: 'Styling',
+        children: [
+          { path: 'styling.paging', type: 'number', label: 'Paging' },
+          {
+            path: 'styling.density',
+            type: 'section',
+            label: 'Density',
+            children: [{ path: 'styling.density.mode', type: 'select', label: 'Mode' }],
+          },
+        ],
+      },
+    ];
+    const result = extractSettingsFromState(state, fields);
+    expect(result).toEqual({
+      'styling.paging': 10,
+      'styling.density.mode': 'compact',
+    });
+  });
+});
+
+describe('mergeSettingsIntoState', () => {
+  it('merges form values back into state', () => {
+    const state = { styling: { paging: 10 }, type: 'data_table' };
+    const result = mergeSettingsIntoState(state, { 'styling.paging': 20 }) as Record<
+      string,
+      unknown
+    >;
+    expect((result.styling as Record<string, unknown>).paging).toBe(20);
+    expect(result.type).toBe('data_table');
+  });
+});
+
+describe('SchemaFlyoutEditor', () => {
+  const setState = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when visualization has no schema mapping', () => {
+    getSchemaForVisualization.mockReturnValue(undefined);
+
+    const { container } = render(
+      <SchemaFlyoutEditor visualizationId="unknownViz" state={{}} setState={setState} />
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when there are no visible fields', () => {
+    getSchemaForVisualization.mockReturnValue({
+      schema: {},
+      excludeSections: [],
+    });
+    walkSchema.mockReturnValue([]);
+
+    const { container } = render(
+      <SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders form fields for a mapped visualization', () => {
+    const mockFields: FormFieldDescriptor[] = [
+      { path: 'styling', type: 'section', label: 'Styling', children: [] },
+      { path: 'row_numbers', type: 'toggle', label: 'Row numbers' },
+    ];
+
+    getSchemaForVisualization.mockReturnValue({
+      schema: {},
+      excludeSections: ['type'],
+    });
+    walkSchema.mockReturnValue(mockFields);
+
+    render(<SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />);
+
+    expect(screen.getByTestId('field-styling')).toBeInTheDocument();
+    expect(screen.getByTestId('field-row_numbers')).toBeInTheDocument();
+  });
+
+  it('filters fields by includeSections when specified', () => {
+    const mockFields: FormFieldDescriptor[] = [
+      { path: 'styling', type: 'section', label: 'Styling' },
+      { path: 'other', type: 'section', label: 'Other' },
+    ];
+
+    getSchemaForVisualization.mockReturnValue({
+      schema: {},
+      includeSections: ['styling'],
+    });
+    walkSchema.mockReturnValue(mockFields);
+
+    render(<SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />);
+
+    expect(screen.getByTestId('field-styling')).toBeInTheDocument();
+    expect(screen.queryByTestId('field-other')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
@@ -29,6 +29,15 @@ jest.mock('@kbn/kibana-react-plugin/public', () => ({
   useKibana: () => mockServices,
 }));
 
+// Mock field components to avoid react-hook-form useController registration
+// which causes watch() to fire and creates render loops in tests.
+// Field rendering is tested separately in schema_form_field.test.tsx.
+jest.mock('./fields', () => ({
+  SchemaFormField: ({ descriptor }: { descriptor: { path: string; label: string } }) => (
+    <div data-test-subj={`schemaField-${descriptor.path}`}>{descriptor.label}</div>
+  ),
+}));
+
 describe('getByPath', () => {
   it('returns nested value', () => {
     expect(getByPath({ a: { b: { c: 42 } } }, 'a.b.c')).toBe(42);

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import {
   SchemaFlyoutEditor,
   getByPath,
@@ -37,6 +38,21 @@ jest.mock('./fields', () => ({
     <div data-test-subj={`schemaField-${descriptor.path}`}>{descriptor.label}</div>
   ),
 }));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        cacheTime: 0,
+      },
+    },
+  });
+
+const renderWithQueryClient = (ui: React.ReactElement) => {
+  const queryClient = createTestQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
 
 describe('getByPath', () => {
   it('returns nested value', () => {
@@ -124,7 +140,7 @@ describe('SchemaFlyoutEditor', () => {
   it('renders nothing when fetch returns no data for visualization', async () => {
     mockHttpGet.mockResolvedValue({});
 
-    const { container } = render(
+    const { container } = renderWithQueryClient(
       <SchemaFlyoutEditor visualizationId="unknownViz" state={{}} setState={setState} />
     );
 
@@ -140,7 +156,7 @@ describe('SchemaFlyoutEditor', () => {
       lnsDatatable: { fields: [] },
     });
 
-    const { container } = render(
+    const { container } = renderWithQueryClient(
       <SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />
     );
 
@@ -161,7 +177,9 @@ describe('SchemaFlyoutEditor', () => {
       lnsDatatable: { fields: mockFields },
     });
 
-    render(<SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />);
+    renderWithQueryClient(
+      <SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('schemaField-styling.density.mode')).toBeInTheDocument();
@@ -172,7 +190,7 @@ describe('SchemaFlyoutEditor', () => {
   it('renders nothing when fetch fails', async () => {
     mockHttpGet.mockRejectedValue(new Error('Network error'));
 
-    const { container } = render(
+    const { container } = renderWithQueryClient(
       <SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />
     );
 

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import {
   SchemaFlyoutEditor,
   getByPath,
@@ -16,14 +16,21 @@ import {
 } from './schema_flyout_editor';
 import type { FormFieldDescriptor } from './schema_walker';
 
-// Mock the viz_schema_map module
-jest.mock('./viz_schema_map', () => ({
-  getSchemaForVisualization: jest.fn(),
+// Mock useKibana to provide http service
+const mockHttpGet = jest.fn();
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => ({
+    services: {
+      http: {
+        get: mockHttpGet,
+      },
+    },
+  }),
 }));
 
 // Mock the schema_walker module
 jest.mock('./schema_walker', () => ({
-  walkSchema: jest.fn(),
+  walkSchemaDescription: jest.fn(),
 }));
 
 // Mock the fields module
@@ -33,8 +40,7 @@ jest.mock('./fields', () => ({
   ),
 }));
 
-const { getSchemaForVisualization } = jest.requireMock('./viz_schema_map');
-const { walkSchema } = jest.requireMock('./schema_walker');
+const { walkSchemaDescription } = jest.requireMock('./schema_walker');
 
 describe('getByPath', () => {
   it('returns nested value', () => {
@@ -119,63 +125,74 @@ describe('SchemaFlyoutEditor', () => {
     jest.clearAllMocks();
   });
 
-  it('renders nothing when visualization has no schema mapping', () => {
-    getSchemaForVisualization.mockReturnValue(undefined);
+  it('renders nothing when fetch returns no data for visualization', async () => {
+    mockHttpGet.mockResolvedValue({});
+    walkSchemaDescription.mockReturnValue([]);
 
     const { container } = render(
       <SchemaFlyoutEditor visualizationId="unknownViz" state={{}} setState={setState} />
     );
 
+    await waitFor(() => {
+      expect(mockHttpGet).toHaveBeenCalledWith('/internal/lens/schema_descriptions');
+    });
+
     expect(container.innerHTML).toBe('');
   });
 
-  it('renders nothing when there are no visible fields', () => {
-    getSchemaForVisualization.mockReturnValue({
-      schema: {},
-      excludeSections: [],
+  it('renders nothing when there are no visible fields', async () => {
+    mockHttpGet.mockResolvedValue({
+      lnsDatatable: {
+        description: { type: 'object', keys: {} },
+        excludeSections: [],
+      },
     });
-    walkSchema.mockReturnValue([]);
+    walkSchemaDescription.mockReturnValue([]);
 
     const { container } = render(
       <SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />
     );
 
+    await waitFor(() => {
+      expect(mockHttpGet).toHaveBeenCalled();
+    });
+
     expect(container.innerHTML).toBe('');
   });
 
-  it('renders form fields for a mapped visualization', () => {
+  it('renders form fields for a mapped visualization', async () => {
     const mockFields: FormFieldDescriptor[] = [
       { path: 'styling', type: 'section', label: 'Styling', children: [] },
       { path: 'row_numbers', type: 'toggle', label: 'Row numbers' },
     ];
 
-    getSchemaForVisualization.mockReturnValue({
-      schema: {},
-      excludeSections: ['type'],
+    mockHttpGet.mockResolvedValue({
+      lnsDatatable: {
+        description: { type: 'object', keys: { styling: {}, row_numbers: {} } },
+        excludeSections: ['type'],
+      },
     });
-    walkSchema.mockReturnValue(mockFields);
+    walkSchemaDescription.mockReturnValue(mockFields);
 
     render(<SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />);
 
-    expect(screen.getByTestId('field-styling')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('field-styling')).toBeInTheDocument();
+    });
     expect(screen.getByTestId('field-row_numbers')).toBeInTheDocument();
   });
 
-  it('filters fields by includeSections when specified', () => {
-    const mockFields: FormFieldDescriptor[] = [
-      { path: 'styling', type: 'section', label: 'Styling' },
-      { path: 'other', type: 'section', label: 'Other' },
-    ];
+  it('renders nothing when fetch fails', async () => {
+    mockHttpGet.mockRejectedValue(new Error('Network error'));
 
-    getSchemaForVisualization.mockReturnValue({
-      schema: {},
-      includeSections: ['styling'],
+    const { container } = render(
+      <SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />
+    );
+
+    await waitFor(() => {
+      expect(mockHttpGet).toHaveBeenCalled();
     });
-    walkSchema.mockReturnValue(mockFields);
 
-    render(<SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />);
-
-    expect(screen.getByTestId('field-styling')).toBeInTheDocument();
-    expect(screen.queryByTestId('field-other')).not.toBeInTheDocument();
+    expect(container.innerHTML).toBe('');
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
@@ -14,33 +14,20 @@ import {
   extractSettingsFromState,
   mergeSettingsIntoState,
 } from './schema_flyout_editor';
-import type { FormFieldDescriptor } from './schema_walker';
+import type { FieldDescriptor } from './types';
 
-// Mock useKibana to provide http service
+// Mock useKibana to provide http service — stable reference to prevent useEffect loops
 const mockHttpGet = jest.fn();
-jest.mock('@kbn/kibana-react-plugin/public', () => ({
-  useKibana: () => ({
-    services: {
-      http: {
-        get: mockHttpGet,
-      },
+const mockServices = {
+  services: {
+    http: {
+      get: mockHttpGet,
     },
-  }),
+  },
+};
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => mockServices,
 }));
-
-// Mock the schema_walker module
-jest.mock('./schema_walker', () => ({
-  walkSchemaDescription: jest.fn(),
-}));
-
-// Mock the fields module
-jest.mock('./fields', () => ({
-  SchemaFormField: ({ descriptor }: { descriptor: FormFieldDescriptor }) => (
-    <div data-test-subj={`field-${descriptor.path}`}>{descriptor.label}</div>
-  ),
-}));
-
-const { walkSchemaDescription } = jest.requireMock('./schema_walker');
 
 describe('getByPath', () => {
   it('returns nested value', () => {
@@ -82,7 +69,7 @@ describe('setByPath', () => {
 describe('extractSettingsFromState', () => {
   it('extracts leaf values from state', () => {
     const state = { styling: { paging: 10, density: { mode: 'compact' } } };
-    const fields: FormFieldDescriptor[] = [
+    const fields: FieldDescriptor[] = [
       {
         path: 'styling',
         type: 'section',
@@ -127,7 +114,6 @@ describe('SchemaFlyoutEditor', () => {
 
   it('renders nothing when fetch returns no data for visualization', async () => {
     mockHttpGet.mockResolvedValue({});
-    walkSchemaDescription.mockReturnValue([]);
 
     const { container } = render(
       <SchemaFlyoutEditor visualizationId="unknownViz" state={{}} setState={setState} />
@@ -142,12 +128,8 @@ describe('SchemaFlyoutEditor', () => {
 
   it('renders nothing when there are no visible fields', async () => {
     mockHttpGet.mockResolvedValue({
-      lnsDatatable: {
-        description: { type: 'object', keys: {} },
-        excludeSections: [],
-      },
+      lnsDatatable: { fields: [] },
     });
-    walkSchemaDescription.mockReturnValue([]);
 
     const { container } = render(
       <SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />
@@ -161,25 +143,21 @@ describe('SchemaFlyoutEditor', () => {
   });
 
   it('renders form fields for a mapped visualization', async () => {
-    const mockFields: FormFieldDescriptor[] = [
-      { path: 'styling', type: 'section', label: 'Styling', children: [] },
-      { path: 'row_numbers', type: 'toggle', label: 'Row numbers' },
+    const mockFields: FieldDescriptor[] = [
+      { path: 'styling.density.mode', type: 'select', label: 'Density', widget: 'buttonGroup' },
+      { path: 'styling.row_numbers.visible', type: 'toggle', label: 'Show row numbers' },
     ];
 
     mockHttpGet.mockResolvedValue({
-      lnsDatatable: {
-        description: { type: 'object', keys: { styling: {}, row_numbers: {} } },
-        excludeSections: ['type'],
-      },
+      lnsDatatable: { fields: mockFields },
     });
-    walkSchemaDescription.mockReturnValue(mockFields);
 
     render(<SchemaFlyoutEditor visualizationId="lnsDatatable" state={{}} setState={setState} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('field-styling')).toBeInTheDocument();
+      expect(screen.getByTestId('schemaField-styling.density.mode')).toBeInTheDocument();
     });
-    expect(screen.getByTestId('field-row_numbers')).toBeInTheDocument();
+    expect(screen.getByTestId('schemaField-styling.row_numbers.visible')).toBeInTheDocument();
   });
 
   it('renders nothing when fetch fails', async () => {

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
@@ -198,6 +198,8 @@ describe('SchemaFlyoutEditor', () => {
 
     await waitFor(() => {
       expect(mockHttpGet).toHaveBeenCalled();
+      // After fetch fails, loading is done and no fields → empty
+      expect(container.querySelector('[role="progressbar"]')).not.toBeInTheDocument();
     });
 
     expect(container.innerHTML).toBe('');

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.test.tsx
@@ -145,7 +145,9 @@ describe('SchemaFlyoutEditor', () => {
     );
 
     await waitFor(() => {
-      expect(mockHttpGet).toHaveBeenCalledWith('/internal/lens/schema_descriptions');
+      expect(mockHttpGet).toHaveBeenCalledWith('/internal/lens/schema_descriptions', {
+        query: { vizId: 'unknownViz' },
+      });
     });
 
     expect(container.innerHTML).toBe('');

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -9,8 +9,7 @@ import React, { useMemo, useEffect, useRef, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { walkSchemaDescription } from './schema_walker';
-import type { FormFieldDescriptor } from './schema_walker';
+import type { FieldDescriptor } from './types';
 import { SchemaFormField } from './fields';
 
 interface SchemaFlyoutEditorProps {
@@ -19,9 +18,8 @@ interface SchemaFlyoutEditorProps {
   setState: (newState: unknown) => void;
 }
 
-interface VizSchemaData {
-  description: Record<string, unknown>;
-  excludeSections: string[];
+interface VizSchemaResponse {
+  fields: FieldDescriptor[];
 }
 
 /** Get a nested value by dot-delimited path */
@@ -64,9 +62,9 @@ export const setByPath = (obj: unknown, path: string, value: unknown): unknown =
 };
 
 /** Collect leaf paths from field descriptors */
-const collectLeafPaths = (fields: FormFieldDescriptor[]): string[] => {
+const collectLeafPaths = (fields: FieldDescriptor[]): string[] => {
   const paths: string[] = [];
-  const walk = (descriptors: FormFieldDescriptor[]) => {
+  const walk = (descriptors: FieldDescriptor[]) => {
     for (const f of descriptors) {
       if (f.children && f.children.length > 0) {
         walk(f.children);
@@ -81,7 +79,7 @@ const collectLeafPaths = (fields: FormFieldDescriptor[]): string[] => {
 
 export const extractSettingsFromState = (
   state: unknown,
-  fields: FormFieldDescriptor[]
+  fields: FieldDescriptor[]
 ): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
   const leafPaths = collectLeafPaths(fields);
@@ -105,39 +103,12 @@ export const mergeSettingsIntoState = (
   return result;
 };
 
-export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
-  visualizationId,
-  state,
-  setState,
-}) => {
-  const { services } = useKibana();
-  const [schemaDescriptions, setSchemaDescriptions] = useState<Record<
-    string,
-    VizSchemaData
-  > | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    services.http
-      ?.get<Record<string, VizSchemaData>>('/internal/lens/schema_descriptions')
-      .then((data) => {
-        if (!cancelled) setSchemaDescriptions(data);
-      })
-      .catch(() => {}); // silently fail — falls back to no flyout
-    return () => {
-      cancelled = true;
-    };
-  }, [services.http]);
-
-  const vizData = schemaDescriptions?.[visualizationId];
-
-  const fieldDescriptors = useMemo(() => {
-    if (!vizData) return [];
-    return walkSchemaDescription(vizData.description, {
-      excludePaths: vizData.excludeSections,
-    });
-  }, [vizData]);
-
+/** Inner form component — only mounted when field descriptors are available */
+const SchemaForm: React.FC<{
+  fieldDescriptors: FieldDescriptor[];
+  state: unknown;
+  setState: (newState: unknown) => void;
+}> = ({ fieldDescriptors, state, setState }) => {
   const defaultValues = useMemo(
     () => extractSettingsFromState(state, fieldDescriptors),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -152,17 +123,22 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
   const setStateRef = useRef(setState);
   setStateRef.current = setState;
 
+  const lastEmittedRef = useRef<string>(JSON.stringify(defaultValues));
+
   useEffect(() => {
     const subscription = methods.watch((values) => {
-      const newState = mergeSettingsIntoState(stateRef.current, values as Record<string, unknown>);
-      setStateRef.current(newState);
+      const serialized = JSON.stringify(values);
+      if (serialized !== lastEmittedRef.current) {
+        lastEmittedRef.current = serialized;
+        const newState = mergeSettingsIntoState(
+          stateRef.current,
+          values as Record<string, unknown>
+        );
+        setStateRef.current(newState);
+      }
     });
     return () => subscription.unsubscribe();
   }, [methods]);
-
-  if (!vizData || fieldDescriptors.length === 0) {
-    return null;
-  }
 
   return (
     <FormProvider {...methods}>
@@ -175,4 +151,35 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
       </EuiFlexGroup>
     </FormProvider>
   );
+};
+
+export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
+  visualizationId,
+  state,
+  setState,
+}) => {
+  const { services } = useKibana();
+  const [fieldDescriptors, setFieldDescriptors] = useState<FieldDescriptor[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    services.http
+      ?.get<Record<string, VizSchemaResponse>>('/internal/lens/schema_descriptions')
+      .then((data) => {
+        if (!cancelled) {
+          const vizData = data[visualizationId];
+          setFieldDescriptors(vizData?.fields ?? []);
+        }
+      })
+      .catch(() => {}); // silently fail — falls back to no flyout
+    return () => {
+      cancelled = true;
+    };
+  }, [services.http, visualizationId]);
+
+  if (fieldDescriptors.length === 0) {
+    return null;
+  }
+
+  return <SchemaForm fieldDescriptors={fieldDescriptors} state={state} setState={setState} />;
 };

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useEffect, useRef } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { walkSchema } from './schema_walker';
+import type { FormFieldDescriptor } from './schema_walker';
+import { SchemaFormField } from './fields';
+import { getSchemaForVisualization } from './viz_schema_map';
+
+interface SchemaFlyoutEditorProps {
+  visualizationId: string;
+  state: unknown;
+  setState: (newState: unknown) => void;
+}
+
+/** Get a nested value by dot-delimited path */
+export const getByPath = (obj: unknown, path: string): unknown => {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+};
+
+/** Set a nested value by dot-delimited path, returning a new object (immutable) */
+export const setByPath = (obj: unknown, path: string, value: unknown): unknown => {
+  const parts = path.split('.');
+  if (parts.length === 0) return obj;
+
+  const root =
+    typeof obj === 'object' && obj !== null ? { ...(obj as Record<string, unknown>) } : {};
+
+  if (parts.length === 1) {
+    root[parts[0]] = value;
+    return root;
+  }
+
+  let current = root;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    const existing = current[part];
+    const clone =
+      typeof existing === 'object' && existing !== null
+        ? { ...(existing as Record<string, unknown>) }
+        : {};
+    current[part] = clone;
+    current = clone;
+  }
+  current[parts[parts.length - 1]] = value;
+  return root;
+};
+
+/** Collect leaf paths from field descriptors */
+const collectLeafPaths = (fields: FormFieldDescriptor[]): string[] => {
+  const paths: string[] = [];
+  const walk = (descriptors: FormFieldDescriptor[]) => {
+    for (const f of descriptors) {
+      if (f.children && f.children.length > 0) {
+        walk(f.children);
+      } else {
+        paths.push(f.path);
+      }
+    }
+  };
+  walk(fields);
+  return paths;
+};
+
+export const extractSettingsFromState = (
+  state: unknown,
+  fields: FormFieldDescriptor[]
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  const leafPaths = collectLeafPaths(fields);
+  for (const path of leafPaths) {
+    const value = getByPath(state, path);
+    if (value !== undefined) {
+      result[path] = value;
+    }
+  }
+  return result;
+};
+
+export const mergeSettingsIntoState = (
+  state: unknown,
+  formValues: Record<string, unknown>
+): unknown => {
+  let result = state;
+  for (const [path, value] of Object.entries(formValues)) {
+    result = setByPath(result, path, value);
+  }
+  return result;
+};
+
+export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
+  visualizationId,
+  state,
+  setState,
+}) => {
+  const schemaMapping = useMemo(
+    () => getSchemaForVisualization(visualizationId),
+    [visualizationId]
+  );
+
+  const fieldDescriptors = useMemo(() => {
+    if (!schemaMapping) return [];
+    return walkSchema(schemaMapping.schema, {
+      excludePaths: schemaMapping.excludeSections ?? [],
+    });
+  }, [schemaMapping]);
+
+  const visibleFields = useMemo(() => {
+    if (!schemaMapping?.includeSections) return fieldDescriptors;
+    return fieldDescriptors.filter((f) =>
+      schemaMapping.includeSections!.some(
+        (section) => f.path === section || f.path.startsWith(`${section}.`)
+      )
+    );
+  }, [fieldDescriptors, schemaMapping]);
+
+  const defaultValues = useMemo(
+    () => extractSettingsFromState(state, visibleFields),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [visibleFields]
+  );
+
+  const methods = useForm({ defaultValues });
+
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const setStateRef = useRef(setState);
+  setStateRef.current = setState;
+
+  useEffect(() => {
+    const subscription = methods.watch((values) => {
+      const newState = mergeSettingsIntoState(stateRef.current, values as Record<string, unknown>);
+      setStateRef.current(newState);
+    });
+    return () => subscription.unsubscribe();
+  }, [methods]);
+
+  if (!schemaMapping || visibleFields.length === 0) {
+    return null;
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <EuiFlexGroup direction="column" gutterSize="m">
+        {visibleFields.map((descriptor) => (
+          <EuiFlexItem key={descriptor.path} grow={false}>
+            <SchemaFormField descriptor={descriptor} control={methods.control} />
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    </FormProvider>
+  );
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import React, { useMemo, useEffect, useRef, useState } from 'react';
+import React, { useMemo, useEffect, useRef } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { FieldDescriptor } from './types';
+import { useSchemaDescriptions } from './use_schema_descriptions';
 import { SchemaFormField } from './fields';
 import { getStateAdapter } from './state_adapters';
 
@@ -17,10 +17,6 @@ interface SchemaFlyoutEditorProps {
   visualizationId: string;
   state: unknown;
   setState: (newState: unknown) => void;
-}
-
-interface VizSchemaResponse {
-  fields: FieldDescriptor[];
 }
 
 /** Get a nested value by dot-delimited path */
@@ -165,24 +161,7 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
   state,
   setState,
 }) => {
-  const { services } = useKibana();
-  const [fieldDescriptors, setFieldDescriptors] = useState<FieldDescriptor[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    services.http
-      ?.get<Record<string, VizSchemaResponse>>('/internal/lens/schema_descriptions')
-      .then((data) => {
-        if (!cancelled) {
-          const vizData = data[visualizationId];
-          setFieldDescriptors(vizData?.fields ?? []);
-        }
-      })
-      .catch(() => {}); // silently fail — falls back to no flyout
-    return () => {
-      cancelled = true;
-    };
-  }, [services.http, visualizationId]);
+  const { data: fieldDescriptors } = useSchemaDescriptions(visualizationId);
 
   if (fieldDescriptors.length === 0) {
     return null;

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -5,18 +5,23 @@
  * 2.0.
  */
 
-import React, { useMemo, useEffect, useRef } from 'react';
+import React, { useMemo, useEffect, useRef, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { walkSchema } from './schema_walker';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { walkSchemaDescription } from './schema_walker';
 import type { FormFieldDescriptor } from './schema_walker';
 import { SchemaFormField } from './fields';
-import { getSchemaForVisualization } from './viz_schema_map';
 
 interface SchemaFlyoutEditorProps {
   visualizationId: string;
   state: unknown;
   setState: (newState: unknown) => void;
+}
+
+interface VizSchemaData {
+  description: Record<string, unknown>;
+  excludeSections: string[];
 }
 
 /** Get a nested value by dot-delimited path */
@@ -105,31 +110,38 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
   state,
   setState,
 }) => {
-  const schemaMapping = useMemo(
-    () => getSchemaForVisualization(visualizationId),
-    [visualizationId]
-  );
+  const { services } = useKibana();
+  const [schemaDescriptions, setSchemaDescriptions] = useState<Record<
+    string,
+    VizSchemaData
+  > | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    services.http
+      ?.get<Record<string, VizSchemaData>>('/internal/lens/schema_descriptions')
+      .then((data) => {
+        if (!cancelled) setSchemaDescriptions(data);
+      })
+      .catch(() => {}); // silently fail — falls back to no flyout
+    return () => {
+      cancelled = true;
+    };
+  }, [services.http]);
+
+  const vizData = schemaDescriptions?.[visualizationId];
 
   const fieldDescriptors = useMemo(() => {
-    if (!schemaMapping) return [];
-    return walkSchema(schemaMapping.schema, {
-      excludePaths: schemaMapping.excludeSections ?? [],
+    if (!vizData) return [];
+    return walkSchemaDescription(vizData.description, {
+      excludePaths: vizData.excludeSections,
     });
-  }, [schemaMapping]);
-
-  const visibleFields = useMemo(() => {
-    if (!schemaMapping?.includeSections) return fieldDescriptors;
-    return fieldDescriptors.filter((f) =>
-      schemaMapping.includeSections!.some(
-        (section) => f.path === section || f.path.startsWith(`${section}.`)
-      )
-    );
-  }, [fieldDescriptors, schemaMapping]);
+  }, [vizData]);
 
   const defaultValues = useMemo(
-    () => extractSettingsFromState(state, visibleFields),
+    () => extractSettingsFromState(state, fieldDescriptors),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [visibleFields]
+    [fieldDescriptors]
   );
 
   const methods = useForm({ defaultValues });
@@ -148,14 +160,14 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
     return () => subscription.unsubscribe();
   }, [methods]);
 
-  if (!schemaMapping || visibleFields.length === 0) {
+  if (!vizData || fieldDescriptors.length === 0) {
     return null;
   }
 
   return (
     <FormProvider {...methods}>
       <EuiFlexGroup direction="column" gutterSize="m">
-        {visibleFields.map((descriptor) => (
+        {fieldDescriptors.map((descriptor) => (
           <EuiFlexItem key={descriptor.path} grow={false}>
             <SchemaFormField descriptor={descriptor} control={methods.control} />
           </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo, useEffect, useRef } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSkeletonRectangle } from '@elastic/eui';
 import type { FieldDescriptor } from './types';
 import { useSchemaDescriptions } from './use_schema_descriptions';
 import { SchemaFormField } from './fields';
@@ -161,7 +161,23 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
   state,
   setState,
 }) => {
-  const { data: fieldDescriptors } = useSchemaDescriptions(visualizationId);
+  const { data: fieldDescriptors, isLoading } = useSchemaDescriptions(visualizationId);
+
+  if (isLoading) {
+    return (
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexItem grow={false}>
+          <EuiSkeletonRectangle width="100%" height={32} borderRadius="s" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiSkeletonRectangle width="100%" height={32} borderRadius="s" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiSkeletonRectangle width="100%" height={32} borderRadius="s" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
 
   if (fieldDescriptors.length === 0) {
     return null;

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -144,7 +144,7 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
     [fieldDescriptors]
   );
 
-  const methods = useForm({ defaultValues });
+  const methods = useForm({ defaultValues: defaultValues as Record<string, {}> });
 
   const stateRef = useRef(state);
   stateRef.current = state;

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -8,7 +8,7 @@
 import React, { useMemo, useEffect, useRef } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { EuiFlexGroup, EuiFlexItem, EuiSkeletonRectangle } from '@elastic/eui';
-import type { FieldDescriptor } from './types';
+import type { FieldDescriptor } from '../../../common/schema_types';
 import { useSchemaDescriptions } from './use_schema_descriptions';
 import { SchemaFormField } from './fields';
 import { getStateAdapter } from './state_adapters';

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -11,6 +11,7 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { FieldDescriptor } from './types';
 import { SchemaFormField } from './fields';
+import { getStateAdapter } from './state_adapters';
 
 interface SchemaFlyoutEditorProps {
   visualizationId: string;
@@ -108,11 +109,17 @@ const SchemaForm: React.FC<{
   fieldDescriptors: FieldDescriptor[];
   state: unknown;
   setState: (newState: unknown) => void;
-}> = ({ fieldDescriptors, state, setState }) => {
+  visualizationId: string;
+}> = ({ fieldDescriptors, state, setState, visualizationId }) => {
+  const adapter = useMemo(() => getStateAdapter(visualizationId), [visualizationId]);
+
   const defaultValues = useMemo(
-    () => extractSettingsFromState(state, fieldDescriptors),
+    () =>
+      adapter
+        ? adapter.stateToFormValues(state)
+        : extractSettingsFromState(state, fieldDescriptors),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [fieldDescriptors]
+    [fieldDescriptors, adapter]
   );
 
   const methods = useForm({ defaultValues: defaultValues as Record<string, {}> });
@@ -130,15 +137,15 @@ const SchemaForm: React.FC<{
       const serialized = JSON.stringify(values);
       if (serialized !== lastEmittedRef.current) {
         lastEmittedRef.current = serialized;
-        const newState = mergeSettingsIntoState(
-          stateRef.current,
-          values as Record<string, unknown>
-        );
+        const formValues = values as Record<string, unknown>;
+        const newState = adapter
+          ? adapter.formValuesToState(stateRef.current, formValues)
+          : mergeSettingsIntoState(stateRef.current, formValues);
         setStateRef.current(newState);
       }
     });
     return () => subscription.unsubscribe();
-  }, [methods]);
+  }, [methods, adapter]);
 
   return (
     <FormProvider {...methods}>
@@ -181,5 +188,12 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
     return null;
   }
 
-  return <SchemaForm fieldDescriptors={fieldDescriptors} state={state} setState={setState} />;
+  return (
+    <SchemaForm
+      fieldDescriptors={fieldDescriptors}
+      state={state}
+      setState={setState}
+      visualizationId={visualizationId}
+    />
+  );
 };

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_flyout_editor.tsx
@@ -12,6 +12,7 @@ import type { FieldDescriptor } from './types';
 import { useSchemaDescriptions } from './use_schema_descriptions';
 import { SchemaFormField } from './fields';
 import { getStateAdapter } from './state_adapters';
+import { filterFieldsByCondition } from './evaluate_condition';
 
 interface SchemaFlyoutEditorProps {
   visualizationId: string;
@@ -163,6 +164,11 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
 }) => {
   const { data: fieldDescriptors, isLoading } = useSchemaDescriptions(visualizationId);
 
+  const visibleFields = useMemo(
+    () => filterFieldsByCondition(fieldDescriptors, state),
+    [fieldDescriptors, state]
+  );
+
   if (isLoading) {
     return (
       <EuiFlexGroup direction="column" gutterSize="m">
@@ -179,13 +185,13 @@ export const SchemaFlyoutEditor: React.FC<SchemaFlyoutEditorProps> = ({
     );
   }
 
-  if (fieldDescriptors.length === 0) {
+  if (visibleFields.length === 0) {
     return null;
   }
 
   return (
     <SchemaForm
-      fieldDescriptors={fieldDescriptors}
+      fieldDescriptors={visibleFields}
       state={state}
       setState={setState}
       visualizationId={visualizationId}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import { schema } from '@kbn/config-schema';
+import { walkSchema } from './schema_walker';
+
+describe('walkSchema', () => {
+  const testSchema = schema.object({
+    visible: schema.boolean({
+      defaultValue: true,
+      meta: { description: 'Show the widget' },
+    }),
+    position: schema.oneOf(
+      [
+        schema.literal('top'),
+        schema.literal('bottom'),
+        schema.literal('left'),
+        schema.literal('right'),
+      ],
+      { meta: { description: 'Position' } }
+    ),
+    size: schema.number({
+      min: 0,
+      max: 100,
+      meta: { description: 'Size in pixels' },
+    }),
+    nested: schema.object({
+      enabled: schema.boolean({ meta: { description: 'Enable nested' } }),
+    }),
+  });
+
+  it('should detect boolean as toggle', () => {
+    const fields = walkSchema(testSchema);
+    const visible = fields.find((f) => f.path === 'visible');
+    expect(visible).toBeDefined();
+    expect(visible!.type).toBe('toggle');
+    expect(visible!.defaultValue).toBe(true);
+    expect(visible!.description).toBe('Show the widget');
+  });
+
+  it('should detect oneOf literals as select', () => {
+    const fields = walkSchema(testSchema);
+    const position = fields.find((f) => f.path === 'position');
+    expect(position).toBeDefined();
+    expect(position!.type).toBe('select');
+    expect(position!.options).toEqual([
+      { value: 'top', label: 'top' },
+      { value: 'bottom', label: 'bottom' },
+      { value: 'left', label: 'left' },
+      { value: 'right', label: 'right' },
+    ]);
+  });
+
+  it('should detect number with min/max', () => {
+    const fields = walkSchema(testSchema);
+    const size = fields.find((f) => f.path === 'size');
+    expect(size).toBeDefined();
+    expect(size!.type).toBe('number');
+    expect(size!.min).toBe(0);
+    expect(size!.max).toBe(100);
+  });
+
+  it('should detect nested object as section with children', () => {
+    const fields = walkSchema(testSchema);
+    const nested = fields.find((f) => f.path === 'nested');
+    expect(nested).toBeDefined();
+    expect(nested!.type).toBe('section');
+    expect(nested!.children).toHaveLength(1);
+    expect(nested!.children![0].path).toBe('nested.enabled');
+    expect(nested!.children![0].type).toBe('toggle');
+  });
+
+  it('should produce correct paths', () => {
+    const fields = walkSchema(testSchema);
+    const paths = fields.map((f) => f.path);
+    expect(paths).toEqual(['visible', 'position', 'size', 'nested']);
+  });
+
+  it('should support pathPrefix option', () => {
+    const fields = walkSchema(testSchema, { pathPrefix: 'config' });
+    expect(fields[0].path).toBe('config.visible');
+  });
+
+  it('should support excludePaths option', () => {
+    const fields = walkSchema(testSchema, { excludePaths: ['visible', 'nested'] });
+    const paths = fields.map((f) => f.path);
+    expect(paths).not.toContain('visible');
+    expect(paths).not.toContain('nested');
+  });
+
+  it('should detect string as text', () => {
+    const s = schema.object({
+      name: schema.string({ meta: { description: 'Name' } }),
+    });
+    const fields = walkSchema(s);
+    expect(fields[0].type).toBe('text');
+  });
+
+  it('should detect maybe() as not required', () => {
+    const s = schema.object({
+      optionalField: schema.maybe(schema.string()),
+    });
+    const fields = walkSchema(s);
+    expect(fields[0].required).toBe(false);
+  });
+
+  it('should handle meta title as label', () => {
+    const s = schema.object({
+      myField: schema.string({ meta: { title: 'My Custom Label' } }),
+    });
+    const fields = walkSchema(s);
+    expect(fields[0].label).toBe('My Custom Label');
+  });
+
+  it('should fall back to key name as label', () => {
+    const s = schema.object({
+      myField: schema.string(),
+    });
+    const fields = walkSchema(s);
+    expect(fields[0].label).toBe('myField');
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.test.ts
@@ -5,43 +5,48 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0"; you may not use this file except in compliance with the "Elastic License
- * 2.0".
- */
+import { walkSchemaDescription } from './schema_walker';
 
-import { schema } from '@kbn/config-schema';
-import { walkSchema } from './schema_walker';
-
-describe('walkSchema', () => {
-  const testSchema = schema.object({
-    visible: schema.boolean({
-      defaultValue: true,
-      meta: { description: 'Show the widget' },
-    }),
-    position: schema.oneOf(
-      [
-        schema.literal('top'),
-        schema.literal('bottom'),
-        schema.literal('left'),
-        schema.literal('right'),
-      ],
-      { meta: { description: 'Position' } }
-    ),
-    size: schema.number({
-      min: 0,
-      max: 100,
-      meta: { description: 'Size in pixels' },
-    }),
-    nested: schema.object({
-      enabled: schema.boolean({ meta: { description: 'Enable nested' } }),
-    }),
-  });
+describe('walkSchemaDescription', () => {
+  const testDescription: Record<string, unknown> = {
+    type: 'object',
+    keys: {
+      visible: {
+        type: 'boolean',
+        flags: { default: true, description: 'Show the widget' },
+      },
+      position: {
+        type: 'alternatives',
+        matches: [
+          { schema: { type: 'any', allow: ['top'] } },
+          { schema: { type: 'any', allow: ['bottom'] } },
+          { schema: { type: 'any', allow: ['left'] } },
+          { schema: { type: 'any', allow: ['right'] } },
+        ],
+        metas: [{ description: 'Position' }],
+      },
+      size: {
+        type: 'number',
+        rules: [
+          { name: 'min', args: { limit: 0 } },
+          { name: 'max', args: { limit: 100 } },
+        ],
+        metas: [{ description: 'Size in pixels' }],
+      },
+      nested: {
+        type: 'object',
+        keys: {
+          enabled: {
+            type: 'boolean',
+            metas: [{ description: 'Enable nested' }],
+          },
+        },
+      },
+    },
+  };
 
   it('should detect boolean as toggle', () => {
-    const fields = walkSchema(testSchema);
+    const fields = walkSchemaDescription(testDescription);
     const visible = fields.find((f) => f.path === 'visible');
     expect(visible).toBeDefined();
     expect(visible!.type).toBe('toggle');
@@ -49,8 +54,8 @@ describe('walkSchema', () => {
     expect(visible!.description).toBe('Show the widget');
   });
 
-  it('should detect oneOf literals as select', () => {
-    const fields = walkSchema(testSchema);
+  it('should detect alternatives with literal allows as select', () => {
+    const fields = walkSchemaDescription(testDescription);
     const position = fields.find((f) => f.path === 'position');
     expect(position).toBeDefined();
     expect(position!.type).toBe('select');
@@ -63,7 +68,7 @@ describe('walkSchema', () => {
   });
 
   it('should detect number with min/max', () => {
-    const fields = walkSchema(testSchema);
+    const fields = walkSchemaDescription(testDescription);
     const size = fields.find((f) => f.path === 'size');
     expect(size).toBeDefined();
     expect(size!.type).toBe('number');
@@ -72,7 +77,7 @@ describe('walkSchema', () => {
   });
 
   it('should detect nested object as section with children', () => {
-    const fields = walkSchema(testSchema);
+    const fields = walkSchemaDescription(testDescription);
     const nested = fields.find((f) => f.path === 'nested');
     expect(nested).toBeDefined();
     expect(nested!.type).toBe('section');
@@ -82,52 +87,61 @@ describe('walkSchema', () => {
   });
 
   it('should produce correct paths', () => {
-    const fields = walkSchema(testSchema);
+    const fields = walkSchemaDescription(testDescription);
     const paths = fields.map((f) => f.path);
     expect(paths).toEqual(['visible', 'position', 'size', 'nested']);
   });
 
   it('should support pathPrefix option', () => {
-    const fields = walkSchema(testSchema, { pathPrefix: 'config' });
+    const fields = walkSchemaDescription(testDescription, { pathPrefix: 'config' });
     expect(fields[0].path).toBe('config.visible');
   });
 
   it('should support excludePaths option', () => {
-    const fields = walkSchema(testSchema, { excludePaths: ['visible', 'nested'] });
+    const fields = walkSchemaDescription(testDescription, {
+      excludePaths: ['visible', 'nested'],
+    });
     const paths = fields.map((f) => f.path);
     expect(paths).not.toContain('visible');
     expect(paths).not.toContain('nested');
   });
 
   it('should detect string as text', () => {
-    const s = schema.object({
-      name: schema.string({ meta: { description: 'Name' } }),
-    });
-    const fields = walkSchema(s);
+    const desc: Record<string, unknown> = {
+      type: 'object',
+      keys: {
+        name: { type: 'string', metas: [{ description: 'Name' }] },
+      },
+    };
+    const fields = walkSchemaDescription(desc);
     expect(fields[0].type).toBe('text');
   });
 
-  it('should detect maybe() as not required', () => {
-    const s = schema.object({
-      optionalField: schema.maybe(schema.string()),
-    });
-    const fields = walkSchema(s);
-    expect(fields[0].required).toBe(false);
-  });
-
   it('should handle meta title as label', () => {
-    const s = schema.object({
-      myField: schema.string({ meta: { title: 'My Custom Label' } }),
-    });
-    const fields = walkSchema(s);
+    const desc: Record<string, unknown> = {
+      type: 'object',
+      keys: {
+        myField: { type: 'string', metas: [{ title: 'My Custom Label' }] },
+      },
+    };
+    const fields = walkSchemaDescription(desc);
     expect(fields[0].label).toBe('My Custom Label');
   });
 
   it('should fall back to key name as label', () => {
-    const s = schema.object({
-      myField: schema.string(),
-    });
-    const fields = walkSchema(s);
+    const desc: Record<string, unknown> = {
+      type: 'object',
+      keys: {
+        myField: { type: 'string' },
+      },
+    };
+    const fields = walkSchemaDescription(desc);
     expect(fields[0].label).toBe('myField');
+  });
+
+  it('should return empty array for description without keys', () => {
+    const desc: Record<string, unknown> = { type: 'string' };
+    const fields = walkSchemaDescription(desc);
+    expect(fields).toEqual([]);
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.test.ts
@@ -136,7 +136,7 @@ describe('walkSchemaDescription', () => {
       },
     };
     const fields = walkSchemaDescription(desc);
-    expect(fields[0].label).toBe('myField');
+    expect(fields[0].label).toBe('My Field');
   });
 
   it('should return empty array for description without keys', () => {

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.ts
@@ -1,0 +1,261 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0"; you may not use this file except in compliance with the "Elastic License
+ * 2.0".
+ */
+
+import type { Type } from '@kbn/config-schema';
+import type { ObjectType } from '@kbn/config-schema';
+
+export interface FormFieldDescriptor {
+  path: string;
+  type:
+    | 'toggle'
+    | 'select'
+    | 'number'
+    | 'range'
+    | 'text'
+    | 'color'
+    | 'buttonGroup'
+    | 'section'
+    | 'unknown';
+  label: string;
+  description?: string;
+  defaultValue?: unknown;
+  options?: Array<{ value: string; label: string }>;
+  min?: number;
+  max?: number;
+  required?: boolean;
+  children?: FormFieldDescriptor[];
+}
+
+interface WalkOptions {
+  pathPrefix?: string;
+  excludePaths?: string[];
+}
+
+function isObjectType(t: Type<unknown>): t is ObjectType {
+  return typeof (t as ObjectType).getPropSchemas === 'function';
+}
+
+function extractMeta(desc: Record<string, unknown>): {
+  title?: string;
+  description?: string;
+} {
+  let title: string | undefined;
+  let description: string | undefined;
+
+  // Description is set via Joi's .description() — appears at desc.flags.description or desc.description
+  const flags = desc.flags as Record<string, unknown> | undefined;
+  description =
+    (flags?.description as string | undefined) ?? (desc.description as string | undefined);
+
+  // Title is set via Joi's .meta() — appears in desc.metas array
+  const metas = desc.metas as Array<Record<string, unknown>> | undefined;
+  if (Array.isArray(metas)) {
+    for (const m of metas) {
+      if (m.title) title = m.title as string;
+      if (!description && m.description) description = m.description as string;
+    }
+  }
+
+  return { title, description };
+}
+
+function extractAllowedValues(
+  desc: Record<string, unknown>
+): Array<{ value: string; label: string }> | undefined {
+  const allow = desc.allow as unknown[] | undefined;
+  if (!Array.isArray(allow) || allow.length === 0) return undefined;
+  const stringVals = allow.filter((v): v is string => typeof v === 'string');
+  if (stringVals.length === 0) return undefined;
+  return stringVals.map((v) => ({ value: v, label: v }));
+}
+
+function extractNumberConstraints(desc: Record<string, unknown>): { min?: number; max?: number } {
+  const rules = desc.rules as Array<{ name: string; args?: Record<string, number> }> | undefined;
+  if (!Array.isArray(rules)) return {};
+  const result: { min?: number; max?: number } = {};
+  for (const rule of rules) {
+    if (rule.name === 'min' && rule.args) {
+      result.min = rule.args.limit;
+    }
+    if (rule.name === 'max' && rule.args) {
+      result.max = rule.args.limit;
+    }
+  }
+  return result;
+}
+
+function collectAlternativesAllows(
+  matches: Array<{ schema: Record<string, unknown> }>
+): string[] | undefined {
+  const values: string[] = [];
+  for (const match of matches) {
+    const s = match.schema;
+    if (s.type === 'any' && Array.isArray(s.allow) && s.allow.length === 1) {
+      const val = s.allow[0];
+      if (typeof val === 'string') {
+        values.push(val);
+        continue;
+      }
+    }
+    return undefined;
+  }
+  return values.length > 0 ? values : undefined;
+}
+
+function walkDescription(
+  desc: Record<string, unknown>,
+  key: string,
+  currentPath: string,
+  excludePaths: Set<string>
+): FormFieldDescriptor | null {
+  if (excludePaths.has(currentPath)) return null;
+
+  const meta = extractMeta(desc);
+  const label = meta.title ?? key;
+  const flags = desc.flags as Record<string, unknown> | undefined;
+  const defaultValue = flags?.default;
+  const presence = flags?.presence as string | undefined;
+  const required = presence === 'required';
+
+  const joiType = desc.type as string;
+
+  if (joiType === 'boolean') {
+    return {
+      path: currentPath,
+      type: 'toggle',
+      label,
+      description: meta.description,
+      defaultValue,
+      required,
+    };
+  }
+
+  if (joiType === 'number') {
+    const { min, max } = extractNumberConstraints(desc);
+    return {
+      path: currentPath,
+      type: 'number',
+      label,
+      description: meta.description,
+      defaultValue,
+      min,
+      max,
+      required,
+    };
+  }
+
+  if (joiType === 'string') {
+    const options = extractAllowedValues(desc);
+    if (options) {
+      return {
+        path: currentPath,
+        type: 'select',
+        label,
+        description: meta.description,
+        defaultValue,
+        options,
+        required,
+      };
+    }
+    return {
+      path: currentPath,
+      type: 'text',
+      label,
+      description: meta.description,
+      defaultValue,
+      required,
+    };
+  }
+
+  if (joiType === 'object') {
+    const keys = desc.keys as Record<string, Record<string, unknown>> | undefined;
+    const children: FormFieldDescriptor[] = [];
+    if (keys) {
+      for (const [childKey, childDesc] of Object.entries(keys)) {
+        const childPath = currentPath ? `${currentPath}.${childKey}` : childKey;
+        const child = walkDescription(childDesc, childKey, childPath, excludePaths);
+        if (child) children.push(child);
+      }
+    }
+    return {
+      path: currentPath,
+      type: 'section',
+      label,
+      description: meta.description,
+      required,
+      children: children.length > 0 ? children : undefined,
+    };
+  }
+
+  if (joiType === 'alternatives') {
+    const matches = desc.matches as Array<{ schema: Record<string, unknown> }> | undefined;
+    if (Array.isArray(matches)) {
+      const stringValues = collectAlternativesAllows(matches);
+      if (stringValues) {
+        return {
+          path: currentPath,
+          type: 'select',
+          label,
+          description: meta.description,
+          defaultValue,
+          options: stringValues.map((v) => ({ value: v, label: v })),
+          required,
+        };
+      }
+    }
+    return {
+      path: currentPath,
+      type: 'unknown',
+      label,
+      description: meta.description,
+      required,
+    };
+  }
+
+  return {
+    path: currentPath,
+    type: 'unknown',
+    label,
+    description: meta.description,
+    required,
+  };
+}
+
+export function walkSchema(
+  schemaType: Type<unknown>,
+  options?: WalkOptions
+): FormFieldDescriptor[] {
+  const prefix = options?.pathPrefix ?? '';
+  const excludePaths = new Set(options?.excludePaths ?? []);
+
+  if (!isObjectType(schemaType)) {
+    const desc = schemaType.getSchema().describe() as Record<string, unknown>;
+    const result = walkDescription(desc, prefix || 'root', prefix, excludePaths);
+    return result ? [result] : [];
+  }
+
+  const props = schemaType.getPropSchemas();
+  const results: FormFieldDescriptor[] = [];
+
+  for (const [key, childType] of Object.entries(props)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (excludePaths.has(path)) continue;
+
+    const desc = (childType as Type<unknown>).getSchema().describe() as Record<string, unknown>;
+    const result = walkDescription(desc, key, path, excludePaths);
+    if (result) results.push(result);
+  }
+
+  return results;
+}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.ts
@@ -12,9 +12,6 @@
  * 2.0".
  */
 
-import type { Type } from '@kbn/config-schema';
-import type { ObjectType } from '@kbn/config-schema';
-
 export interface FormFieldDescriptor {
   path: string;
   type:
@@ -40,10 +37,6 @@ export interface FormFieldDescriptor {
 interface WalkOptions {
   pathPrefix?: string;
   excludePaths?: string[];
-}
-
-function isObjectType(t: Type<unknown>): t is ObjectType {
-  return typeof (t as ObjectType).getPropSchemas === 'function';
 }
 
 function extractMeta(desc: Record<string, unknown>): {
@@ -232,30 +225,26 @@ function walkDescription(
   };
 }
 
-export function walkSchema(
-  schemaType: Type<unknown>,
+/**
+ * Walk a pre-computed Joi schema description (from server endpoint)
+ * and produce FormFieldDescriptor[].
+ */
+export function walkSchemaDescription(
+  description: Record<string, unknown>,
   options?: WalkOptions
 ): FormFieldDescriptor[] {
   const prefix = options?.pathPrefix ?? '';
   const excludePaths = new Set(options?.excludePaths ?? []);
 
-  if (!isObjectType(schemaType)) {
-    const desc = schemaType.getSchema().describe() as Record<string, unknown>;
-    const result = walkDescription(desc, prefix || 'root', prefix, excludePaths);
-    return result ? [result] : [];
-  }
+  const keys = description.keys as Record<string, Record<string, unknown>> | undefined;
+  if (!keys) return [];
 
-  const props = schemaType.getPropSchemas();
   const results: FormFieldDescriptor[] = [];
-
-  for (const [key, childType] of Object.entries(props)) {
+  for (const [key, childDesc] of Object.entries(keys)) {
     const path = prefix ? `${prefix}.${key}` : key;
     if (excludePaths.has(path)) continue;
-
-    const desc = (childType as Type<unknown>).getSchema().describe() as Record<string, unknown>;
-    const result = walkDescription(desc, key, path, excludePaths);
+    const result = walkDescription(childDesc, key, path, excludePaths);
     if (result) results.push(result);
   }
-
   return results;
 }

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/schema_walker.ts
@@ -12,6 +12,8 @@
  * 2.0".
  */
 
+import { humanizeLabel } from './utils';
+
 export interface FormFieldDescriptor {
   path: string;
   type:
@@ -115,7 +117,7 @@ function walkDescription(
   if (excludePaths.has(currentPath)) return null;
 
   const meta = extractMeta(desc);
-  const label = meta.title ?? key;
+  const label = meta.title ?? humanizeLabel(key);
   const flags = desc.flags as Record<string, unknown> | undefined;
   const defaultValue = flags?.default;
   const presence = flags?.presence as string | undefined;

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/datatable.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/datatable.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DatatableVisualizationState } from '@kbn/lens-common';
+import { datatableStateAdapter } from './datatable';
+
+const baseState: DatatableVisualizationState = {
+  layerId: 'layer1',
+  layerType: 'data',
+  columns: [{ columnId: 'col1' }],
+};
+
+describe('datatableStateAdapter', () => {
+  describe('stateToFormValues', () => {
+    it('converts density to API form values', () => {
+      const state: DatatableVisualizationState = {
+        ...baseState,
+        density: 'compact',
+      };
+      const result = datatableStateAdapter.stateToFormValues(state);
+      expect(result['styling.density.mode']).toBe('compact');
+    });
+
+    it('converts normal density to "default" in API format', () => {
+      const state: DatatableVisualizationState = {
+        ...baseState,
+        density: 'normal',
+      };
+      const result = datatableStateAdapter.stateToFormValues(state);
+      expect(result['styling.density.mode']).toBe('default');
+    });
+
+    it('converts paging to API form values', () => {
+      const state: DatatableVisualizationState = {
+        ...baseState,
+        paging: { enabled: true, size: 20 },
+      };
+      const result = datatableStateAdapter.stateToFormValues(state);
+      expect(result['styling.paging']).toBe(20);
+    });
+
+    it('does not include paging when disabled', () => {
+      const state: DatatableVisualizationState = {
+        ...baseState,
+        paging: { enabled: false, size: 20 },
+      };
+      const result = datatableStateAdapter.stateToFormValues(state);
+      expect(result['styling.paging']).toBeUndefined();
+    });
+
+    it('converts showRowNumbers to API form values', () => {
+      const state: DatatableVisualizationState = {
+        ...baseState,
+        showRowNumbers: true,
+      };
+      const result = datatableStateAdapter.stateToFormValues(state);
+      expect(result['styling.row_numbers.visible']).toBe(true);
+    });
+
+    it('converts row height to API form values', () => {
+      const state: DatatableVisualizationState = {
+        ...baseState,
+        rowHeight: 'custom',
+        rowHeightLines: 3,
+        headerRowHeight: 'auto',
+      };
+      const result = datatableStateAdapter.stateToFormValues(state);
+      expect(result['styling.density.height.value.type']).toBe('custom');
+      expect(result['styling.density.height.value.lines']).toBe(3);
+      expect(result['styling.density.height.header.type']).toBe('auto');
+    });
+
+    it('returns empty object when no styling properties are set', () => {
+      const result = datatableStateAdapter.stateToFormValues(baseState);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('formValuesToState', () => {
+    it('converts API density mode back to internal state', () => {
+      const result = datatableStateAdapter.formValuesToState(baseState, {
+        'styling.density.mode': 'compact',
+      });
+      expect(result.density).toBe('compact');
+      expect(result.layerId).toBe('layer1');
+      expect(result.columns).toEqual([{ columnId: 'col1' }]);
+    });
+
+    it('converts "default" density to "normal"', () => {
+      const result = datatableStateAdapter.formValuesToState(baseState, {
+        'styling.density.mode': 'default',
+      });
+      expect(result.density).toBe('normal');
+    });
+
+    it('converts API paging back to internal state', () => {
+      const result = datatableStateAdapter.formValuesToState(baseState, {
+        'styling.paging': 30,
+      });
+      expect(result.paging).toEqual({ enabled: true, size: 30 });
+    });
+
+    it('converts API row_numbers back to internal state', () => {
+      const result = datatableStateAdapter.formValuesToState(baseState, {
+        'styling.row_numbers.visible': true,
+      });
+      expect(result.showRowNumbers).toBe(true);
+    });
+
+    it('converts API row height back to internal state', () => {
+      const result = datatableStateAdapter.formValuesToState(baseState, {
+        'styling.density.height.value.type': 'custom',
+        'styling.density.height.value.lines': 3,
+        'styling.density.height.header.type': 'auto',
+      });
+      expect(result.rowHeight).toBe('custom');
+      expect(result.rowHeightLines).toBe(3);
+      expect(result.headerRowHeight).toBe('auto');
+    });
+
+    it('preserves non-styling properties', () => {
+      const stateWithExtras: DatatableVisualizationState = {
+        ...baseState,
+        sorting: { columnId: 'col1', direction: 'asc' },
+      };
+      const result = datatableStateAdapter.formValuesToState(stateWithExtras, {
+        'styling.density.mode': 'compact',
+      });
+      expect(result.sorting).toEqual({ columnId: 'col1', direction: 'asc' });
+      expect(result.layerId).toBe('layer1');
+      expect(result.layerType).toBe('data');
+      expect(result.columns).toEqual([{ columnId: 'col1' }]);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves styling through stateToFormValues → formValuesToState', () => {
+      const state: DatatableVisualizationState = {
+        ...baseState,
+        density: 'compact',
+        rowHeight: 'custom',
+        rowHeightLines: 3,
+        headerRowHeight: 'auto',
+        paging: { enabled: true, size: 20 },
+        showRowNumbers: true,
+      };
+
+      const formValues = datatableStateAdapter.stateToFormValues(state);
+      const result = datatableStateAdapter.formValuesToState(baseState, formValues);
+
+      expect(result.density).toBe('compact');
+      expect(result.rowHeight).toBe('custom');
+      expect(result.rowHeightLines).toBe(3);
+      expect(result.headerRowHeight).toBe('auto');
+      expect(result.paging).toEqual({ enabled: true, size: 20 });
+      expect(result.showRowNumbers).toBe(true);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/datatable.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/datatable.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DatatableVisualizationState, RowHeightMode } from '@kbn/lens-common';
+import { LENS_DATAGRID_DENSITY, LENS_ROW_HEIGHT_MODE } from '@kbn/lens-common';
+import type { VizStateAdapter } from './types';
+import { flattenToDotPaths, unflattenFromDotPaths } from './dot_path_helpers';
+
+// ── Internal State → API Format ──
+
+const buildHeightAPI = (
+  type: 'value' | 'header',
+  heightMode?: RowHeightMode,
+  heightLines?: number
+) => {
+  if (!heightMode && !heightLines) return undefined;
+  if (heightMode === LENS_ROW_HEIGHT_MODE.auto) return { type: LENS_ROW_HEIGHT_MODE.auto };
+  const lines = heightLines ?? 1;
+  return type === 'value'
+    ? { type: LENS_ROW_HEIGHT_MODE.custom, lines }
+    : { type: LENS_ROW_HEIGHT_MODE.custom, max_lines: lines };
+};
+
+const stateToAPIStyling = (state: DatatableVisualizationState): Record<string, unknown> => {
+  const styling: Record<string, unknown> = {};
+
+  // Density
+  const { density, rowHeight, rowHeightLines, headerRowHeight, headerRowHeightLines } = state;
+  if (density || rowHeight || headerRowHeight || rowHeightLines || headerRowHeightLines) {
+    const densityObj: Record<string, unknown> = {};
+    if (density) {
+      densityObj.mode = density === LENS_DATAGRID_DENSITY.NORMAL ? 'default' : density;
+    }
+    const valueHeight = buildHeightAPI('value', rowHeight, rowHeightLines);
+    const headerHeight = buildHeightAPI('header', headerRowHeight, headerRowHeightLines);
+    if (valueHeight || headerHeight) {
+      const height: Record<string, unknown> = {};
+      if (valueHeight) height.value = valueHeight;
+      if (headerHeight) height.header = headerHeight;
+      densityObj.height = height;
+    }
+    styling.density = densityObj;
+  }
+
+  // Paging
+  if (state.paging?.enabled) {
+    const validSizes = [10, 20, 30, 50, 100];
+    styling.paging = validSizes.includes(state.paging.size) ? state.paging.size : 10;
+  }
+
+  // Row numbers
+  if (state.showRowNumbers != null) {
+    styling.row_numbers = { visible: state.showRowNumbers };
+  }
+
+  return Object.keys(styling).length > 0 ? { styling } : {};
+};
+
+// ── API Format → Internal State ──
+
+interface APIStyling {
+  styling?: {
+    density?: {
+      mode?: string;
+      height?: {
+        header?: { type: string; max_lines?: number };
+        value?: { type: string; lines?: number };
+      };
+    };
+    paging?: number;
+    row_numbers?: { visible: boolean };
+    sort_by?: unknown;
+  };
+}
+
+const apiToStylingState = (
+  api: APIStyling
+): Partial<
+  Pick<
+    DatatableVisualizationState,
+    | 'density'
+    | 'rowHeight'
+    | 'rowHeightLines'
+    | 'headerRowHeight'
+    | 'headerRowHeightLines'
+    | 'paging'
+    | 'showRowNumbers'
+  >
+> => {
+  const result: Record<string, unknown> = {};
+  const s = api.styling;
+  if (!s) return result;
+
+  // Density
+  if (s.density?.mode) {
+    result.density = s.density.mode === 'default' ? LENS_DATAGRID_DENSITY.NORMAL : s.density.mode;
+  }
+  if (s.density?.height?.header?.type) {
+    result.headerRowHeight = s.density.height.header.type as RowHeightMode;
+    if (s.density.height.header.type === 'custom' && s.density.height.header.max_lines != null) {
+      result.headerRowHeightLines = s.density.height.header.max_lines;
+    }
+  }
+  if (s.density?.height?.value?.type) {
+    result.rowHeight = s.density.height.value.type as RowHeightMode;
+    if (s.density.height.value.type === 'custom' && s.density.height.value.lines != null) {
+      result.rowHeightLines = s.density.height.value.lines;
+    }
+  }
+
+  // Paging
+  if (s.paging != null) {
+    result.paging = { size: s.paging, enabled: true };
+  }
+
+  // Row numbers
+  if (s.row_numbers != null) {
+    result.showRowNumbers = s.row_numbers.visible;
+  }
+
+  return result;
+};
+
+export const datatableStateAdapter: VizStateAdapter<DatatableVisualizationState> = {
+  stateToFormValues(state) {
+    const apiFormat = stateToAPIStyling(state);
+    return flattenToDotPaths(apiFormat);
+  },
+
+  formValuesToState(currentState, formValues) {
+    const apiConfig = unflattenFromDotPaths(formValues) as APIStyling;
+    const stylingState = apiToStylingState(apiConfig);
+    return { ...currentState, ...stylingState };
+  },
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/datatable.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/datatable.ts
@@ -5,135 +5,24 @@
  * 2.0.
  */
 
-import type { DatatableVisualizationState, RowHeightMode } from '@kbn/lens-common';
-import { LENS_DATAGRID_DENSITY, LENS_ROW_HEIGHT_MODE } from '@kbn/lens-common';
+import type { DatatableVisualizationState } from '@kbn/lens-common';
+import {
+  buildDatatableStylingState,
+  convertDatatableStylingToAPIFormat,
+} from '@kbn/lens-embeddable-utils';
+import type { DatatableConfig } from '@kbn/lens-embeddable-utils';
 import type { VizStateAdapter } from './types';
 import { flattenToDotPaths, unflattenFromDotPaths } from './dot_path_helpers';
 
-// ── Internal State → API Format ──
-
-const buildHeightAPI = (
-  type: 'value' | 'header',
-  heightMode?: RowHeightMode,
-  heightLines?: number
-) => {
-  if (!heightMode && !heightLines) return undefined;
-  if (heightMode === LENS_ROW_HEIGHT_MODE.auto) return { type: LENS_ROW_HEIGHT_MODE.auto };
-  const lines = heightLines ?? 1;
-  return type === 'value'
-    ? { type: LENS_ROW_HEIGHT_MODE.custom, lines }
-    : { type: LENS_ROW_HEIGHT_MODE.custom, max_lines: lines };
-};
-
-const stateToAPIStyling = (state: DatatableVisualizationState): Record<string, unknown> => {
-  const styling: Record<string, unknown> = {};
-
-  // Density
-  const { density, rowHeight, rowHeightLines, headerRowHeight, headerRowHeightLines } = state;
-  if (density || rowHeight || headerRowHeight || rowHeightLines || headerRowHeightLines) {
-    const densityObj: Record<string, unknown> = {};
-    if (density) {
-      densityObj.mode = density === LENS_DATAGRID_DENSITY.NORMAL ? 'default' : density;
-    }
-    const valueHeight = buildHeightAPI('value', rowHeight, rowHeightLines);
-    const headerHeight = buildHeightAPI('header', headerRowHeight, headerRowHeightLines);
-    if (valueHeight || headerHeight) {
-      const height: Record<string, unknown> = {};
-      if (valueHeight) height.value = valueHeight;
-      if (headerHeight) height.header = headerHeight;
-      densityObj.height = height;
-    }
-    styling.density = densityObj;
-  }
-
-  // Paging
-  if (state.paging?.enabled) {
-    const validSizes = [10, 20, 30, 50, 100];
-    styling.paging = validSizes.includes(state.paging.size) ? state.paging.size : 10;
-  }
-
-  // Row numbers
-  if (state.showRowNumbers != null) {
-    styling.row_numbers = { visible: state.showRowNumbers };
-  }
-
-  return Object.keys(styling).length > 0 ? { styling } : {};
-};
-
-// ── API Format → Internal State ──
-
-interface APIStyling {
-  styling?: {
-    density?: {
-      mode?: string;
-      height?: {
-        header?: { type: string; max_lines?: number };
-        value?: { type: string; lines?: number };
-      };
-    };
-    paging?: number;
-    row_numbers?: { visible: boolean };
-    sort_by?: unknown;
-  };
-}
-
-const apiToStylingState = (
-  api: APIStyling
-): Partial<
-  Pick<
-    DatatableVisualizationState,
-    | 'density'
-    | 'rowHeight'
-    | 'rowHeightLines'
-    | 'headerRowHeight'
-    | 'headerRowHeightLines'
-    | 'paging'
-    | 'showRowNumbers'
-  >
-> => {
-  const result: Record<string, unknown> = {};
-  const s = api.styling;
-  if (!s) return result;
-
-  // Density
-  if (s.density?.mode) {
-    result.density = s.density.mode === 'default' ? LENS_DATAGRID_DENSITY.NORMAL : s.density.mode;
-  }
-  if (s.density?.height?.header?.type) {
-    result.headerRowHeight = s.density.height.header.type as RowHeightMode;
-    if (s.density.height.header.type === 'custom' && s.density.height.header.max_lines != null) {
-      result.headerRowHeightLines = s.density.height.header.max_lines;
-    }
-  }
-  if (s.density?.height?.value?.type) {
-    result.rowHeight = s.density.height.value.type as RowHeightMode;
-    if (s.density.height.value.type === 'custom' && s.density.height.value.lines != null) {
-      result.rowHeightLines = s.density.height.value.lines;
-    }
-  }
-
-  // Paging
-  if (s.paging != null) {
-    result.paging = { size: s.paging, enabled: true };
-  }
-
-  // Row numbers
-  if (s.row_numbers != null) {
-    result.showRowNumbers = s.row_numbers.visible;
-  }
-
-  return result;
-};
-
 export const datatableStateAdapter: VizStateAdapter<DatatableVisualizationState> = {
   stateToFormValues(state) {
-    const apiFormat = stateToAPIStyling(state);
+    const apiFormat = convertDatatableStylingToAPIFormat(state, new Map());
     return flattenToDotPaths(apiFormat);
   },
 
   formValuesToState(currentState, formValues) {
-    const apiConfig = unflattenFromDotPaths(formValues) as APIStyling;
-    const stylingState = apiToStylingState(apiConfig);
+    const apiConfig = unflattenFromDotPaths(formValues) as DatatableConfig;
+    const stylingState = buildDatatableStylingState(apiConfig);
     return { ...currentState, ...stylingState };
   },
 };

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/dot_path_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/dot_path_helpers.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Flatten a nested object into dot-path keyed entries.
+ * { styling: { density: { mode: 'compact' } } } → { 'styling.density.mode': 'compact' }
+ */
+export const flattenToDotPaths = (
+  obj: Record<string, unknown>,
+  prefix = ''
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(result, flattenToDotPaths(value as Record<string, unknown>, fullPath));
+    } else {
+      result[fullPath] = value;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Unflatten dot-path keyed entries back into a nested object.
+ * { 'styling.density.mode': 'compact' } → { styling: { density: { mode: 'compact' } } }
+ */
+export const unflattenFromDotPaths = (flat: Record<string, unknown>): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+
+  for (const [path, value] of Object.entries(flat)) {
+    const parts = path.split('.');
+    let current = result;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (!(part in current) || typeof current[part] !== 'object' || current[part] === null) {
+        current[part] = {};
+      }
+      current = current[part] as Record<string, unknown>;
+    }
+    current[parts[parts.length - 1]] = value;
+  }
+
+  return result;
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/gauge.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/gauge.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { GaugeVisualizationState } from '@kbn/lens-common';
+import { gaugeStateAdapter } from './gauge';
+
+const baseState: GaugeVisualizationState = {
+  layerId: 'layer1',
+  layerType: 'data',
+  metricAccessor: 'metric1',
+  shape: 'horizontalBullet',
+  ticksPosition: 'auto',
+  labelMajorMode: 'auto',
+};
+
+describe('gaugeStateAdapter', () => {
+  describe('stateToFormValues', () => {
+    it('converts horizontal bullet shape to API form values', () => {
+      const result = gaugeStateAdapter.stateToFormValues(baseState);
+      expect(result['styling.shape.type']).toBe('bullet');
+      expect(result['styling.shape.orientation']).toBe('horizontal');
+    });
+
+    it('converts vertical bullet shape to API form values', () => {
+      const state: GaugeVisualizationState = {
+        ...baseState,
+        shape: 'verticalBullet',
+      };
+      const result = gaugeStateAdapter.stateToFormValues(state);
+      expect(result['styling.shape.type']).toBe('bullet');
+      expect(result['styling.shape.orientation']).toBe('vertical');
+    });
+
+    it('converts circle shape to API form values', () => {
+      const state: GaugeVisualizationState = {
+        ...baseState,
+        shape: 'circle',
+      };
+      const result = gaugeStateAdapter.stateToFormValues(state);
+      expect(result['styling.shape.type']).toBe('circle');
+    });
+
+    it('converts semiCircle shape to API form values', () => {
+      const state: GaugeVisualizationState = {
+        ...baseState,
+        shape: 'semiCircle',
+      };
+      const result = gaugeStateAdapter.stateToFormValues(state);
+      expect(result['styling.shape.type']).toBe('semi_circle');
+    });
+  });
+
+  describe('formValuesToState', () => {
+    it('converts API bullet shape back to internal state', () => {
+      const result = gaugeStateAdapter.formValuesToState(baseState, {
+        'styling.shape.type': 'bullet',
+        'styling.shape.orientation': 'vertical',
+      });
+      expect(result.shape).toBe('verticalBullet');
+      expect(result.layerId).toBe('layer1');
+    });
+
+    it('converts API circle shape back to internal state', () => {
+      const result = gaugeStateAdapter.formValuesToState(baseState, {
+        'styling.shape.type': 'circle',
+      });
+      expect(result.shape).toBe('circle');
+    });
+
+    it('converts API semi_circle shape back to internal state', () => {
+      const result = gaugeStateAdapter.formValuesToState(baseState, {
+        'styling.shape.type': 'semi_circle',
+      });
+      expect(result.shape).toBe('semiCircle');
+    });
+
+    it('preserves non-styling properties', () => {
+      const stateWithExtras: GaugeVisualizationState = {
+        ...baseState,
+        ticksPosition: 'bands',
+        labelMajorMode: 'custom',
+        labelMajor: 'My Gauge',
+      };
+      const result = gaugeStateAdapter.formValuesToState(stateWithExtras, {
+        'styling.shape.type': 'arc',
+      });
+      expect(result.ticksPosition).toBe('bands');
+      expect(result.labelMajor).toBe('My Gauge');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves styling through stateToFormValues → formValuesToState', () => {
+      const state: GaugeVisualizationState = {
+        ...baseState,
+        shape: 'verticalBullet',
+      };
+
+      const formValues = gaugeStateAdapter.stateToFormValues(state);
+      const result = gaugeStateAdapter.formValuesToState(baseState, formValues);
+
+      expect(result.shape).toBe('verticalBullet');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/gauge.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/gauge.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { GaugeVisualizationState } from '@kbn/lens-common';
+import { buildGaugeStylingState, convertGaugeStylingToAPIFormat } from '@kbn/lens-embeddable-utils';
+import type { GaugeConfig } from '@kbn/lens-embeddable-utils';
+import type { VizStateAdapter } from './types';
+import { flattenToDotPaths, unflattenFromDotPaths } from './dot_path_helpers';
+
+export const gaugeStateAdapter: VizStateAdapter<GaugeVisualizationState> = {
+  stateToFormValues(state) {
+    const apiFormat = convertGaugeStylingToAPIFormat(state);
+    return flattenToDotPaths(apiFormat);
+  },
+
+  formValuesToState(currentState, formValues) {
+    const apiConfig = unflattenFromDotPaths(formValues) as GaugeConfig;
+    const stylingState = buildGaugeStylingState(apiConfig);
+    return { ...currentState, ...stylingState };
+  },
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/heatmap.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/heatmap.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HeatmapVisualizationState } from '@kbn/lens-common';
+import { heatmapStateAdapter } from './heatmap';
+
+const baseState: HeatmapVisualizationState = {
+  layerId: 'layer1',
+  layerType: 'data',
+  shape: 'heatmap',
+  legend: {
+    type: 'heatmap_legend',
+    isVisible: true,
+    position: 'right',
+  },
+  gridConfig: {
+    type: 'heatmap_grid',
+    isCellLabelVisible: false,
+    isXAxisLabelVisible: true,
+    isXAxisTitleVisible: false,
+    isYAxisLabelVisible: true,
+    isYAxisTitleVisible: false,
+  },
+};
+
+describe('heatmapStateAdapter', () => {
+  describe('stateToFormValues', () => {
+    it('converts legend visibility', () => {
+      const result = heatmapStateAdapter.stateToFormValues(baseState);
+      expect(result['legend.visibility']).toBe('visible');
+    });
+
+    it('converts hidden legend', () => {
+      const state: HeatmapVisualizationState = {
+        ...baseState,
+        legend: { ...baseState.legend, isVisible: false },
+      };
+      const result = heatmapStateAdapter.stateToFormValues(state);
+      expect(result['legend.visibility']).toBe('hidden');
+    });
+
+    it('converts legend position', () => {
+      const state: HeatmapVisualizationState = {
+        ...baseState,
+        legend: { ...baseState.legend, position: 'bottom' },
+      };
+      const result = heatmapStateAdapter.stateToFormValues(state);
+      expect(result['legend.position']).toBe('bottom');
+    });
+
+    it('converts cell label visibility', () => {
+      const state: HeatmapVisualizationState = {
+        ...baseState,
+        gridConfig: { ...baseState.gridConfig, isCellLabelVisible: true },
+      };
+      const result = heatmapStateAdapter.stateToFormValues(state);
+      expect(result['styling.cells.labels.visible']).toBe(true);
+    });
+
+    it('converts axis label visibility', () => {
+      const result = heatmapStateAdapter.stateToFormValues(baseState);
+      expect(result['axis.x.labels.visible']).toBe(true);
+      expect(result['axis.y.labels.visible']).toBe(true);
+    });
+
+    it('converts axis title visibility', () => {
+      const state: HeatmapVisualizationState = {
+        ...baseState,
+        gridConfig: { ...baseState.gridConfig, isXAxisTitleVisible: true, xTitle: 'My X' },
+      };
+      const result = heatmapStateAdapter.stateToFormValues(state);
+      expect(result['axis.x.title.visible']).toBe(true);
+      expect(result['axis.x.title.text']).toBe('My X');
+    });
+
+    it('converts x axis label rotation to orientation', () => {
+      const state: HeatmapVisualizationState = {
+        ...baseState,
+        gridConfig: { ...baseState.gridConfig, xAxisLabelRotation: -90 },
+      };
+      const result = heatmapStateAdapter.stateToFormValues(state);
+      expect(result['axis.x.labels.orientation']).toBe('vertical');
+    });
+  });
+
+  describe('formValuesToState', () => {
+    it('applies legend changes while preserving other state', () => {
+      const formValues = { 'legend.visibility': 'hidden', 'legend.position': 'left' };
+      const result = heatmapStateAdapter.formValuesToState(baseState, formValues);
+      expect(result.legend.isVisible).toBe(false);
+      expect(result.legend.position).toBe('left');
+      // Preserves non-styling state
+      expect(result.layerId).toBe('layer1');
+      expect(result.shape).toBe('heatmap');
+    });
+
+    it('applies cell label visibility', () => {
+      const formValues = { 'styling.cells.labels.visible': true };
+      const result = heatmapStateAdapter.formValuesToState(baseState, formValues);
+      expect(result.gridConfig.isCellLabelVisible).toBe(true);
+    });
+
+    it('applies axis orientation as rotation', () => {
+      const formValues = { 'axis.x.labels.orientation': 'angled' };
+      const result = heatmapStateAdapter.formValuesToState(baseState, formValues);
+      expect(result.gridConfig.xAxisLabelRotation).toBe(-45);
+    });
+
+    it('round-trips state through form values', () => {
+      const state: HeatmapVisualizationState = {
+        ...baseState,
+        legend: {
+          ...baseState.legend,
+          isVisible: true,
+          position: 'bottom',
+          maxLines: 2,
+          shouldTruncate: true,
+        },
+        gridConfig: {
+          ...baseState.gridConfig,
+          isCellLabelVisible: true,
+          isXAxisTitleVisible: true,
+          xTitle: 'X Title',
+          xAxisLabelRotation: -45,
+        },
+      };
+      const formValues = heatmapStateAdapter.stateToFormValues(state);
+      const result = heatmapStateAdapter.formValuesToState(baseState, formValues);
+      expect(result.legend.isVisible).toBe(true);
+      expect(result.legend.position).toBe('bottom');
+      expect(result.legend.maxLines).toBe(2);
+      expect(result.gridConfig.isCellLabelVisible).toBe(true);
+      expect(result.gridConfig.isXAxisTitleVisible).toBe(true);
+      expect(result.gridConfig.xTitle).toBe('X Title');
+      expect(result.gridConfig.xAxisLabelRotation).toBe(-45);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/heatmap.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/heatmap.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HeatmapVisualizationState } from '@kbn/lens-common';
+import type { VizStateAdapter } from './types';
+import { flattenToDotPaths, unflattenFromDotPaths } from './dot_path_helpers';
+
+/** Minimal shape of the API config sections relevant for heatmap styling. */
+interface HeatmapAPIStyling {
+  legend?: {
+    visibility?: string;
+    position?: string;
+    truncate_after_lines?: number;
+    size?: string;
+  };
+  axis?: {
+    x?: {
+      labels?: { visible?: boolean; orientation?: string };
+      title?: { visible?: boolean; text?: string };
+    };
+    y?: {
+      labels?: { visible?: boolean };
+      title?: { visible?: boolean; text?: string };
+    };
+  };
+  styling?: {
+    cells?: {
+      labels?: { visible?: boolean };
+    };
+  };
+}
+
+/**
+ * Convert HeatmapVisualizationState → API styling format (legend + axis + styling).
+ */
+const stateToAPIFormat = (state: HeatmapVisualizationState): HeatmapAPIStyling => {
+  const { legend, gridConfig } = state;
+
+  return {
+    legend: {
+      visibility: legend.isVisible ? 'visible' : 'hidden',
+      position: legend.position,
+      ...(legend.maxLines != null ? { truncate_after_lines: legend.maxLines } : {}),
+      ...(legend.legendSize != null ? { size: legend.legendSize } : {}),
+    },
+    axis: {
+      x: {
+        labels: {
+          visible: gridConfig.isXAxisLabelVisible,
+          ...(gridConfig.xAxisLabelRotation != null
+            ? {
+                orientation:
+                  gridConfig.xAxisLabelRotation === -90
+                    ? 'vertical'
+                    : gridConfig.xAxisLabelRotation === -45
+                    ? 'angled'
+                    : 'horizontal',
+              }
+            : {}),
+        },
+        title: {
+          visible: gridConfig.isXAxisTitleVisible,
+          ...(gridConfig.xTitle ? { text: gridConfig.xTitle } : {}),
+        },
+      },
+      y: {
+        labels: { visible: gridConfig.isYAxisLabelVisible },
+        title: {
+          visible: gridConfig.isYAxisTitleVisible,
+          ...(gridConfig.yTitle ? { text: gridConfig.yTitle } : {}),
+        },
+      },
+    },
+    styling: {
+      cells: {
+        labels: { visible: gridConfig.isCellLabelVisible },
+      },
+    },
+  };
+};
+
+/**
+ * Convert API config back to HeatmapVisualizationState styling fields.
+ */
+const apiFormatToState = (apiConfig: HeatmapAPIStyling): Partial<HeatmapVisualizationState> => {
+  const orientationToRotation = (orientation?: string): number | undefined => {
+    switch (orientation) {
+      case 'vertical':
+        return -90;
+      case 'angled':
+        return -45;
+      case 'horizontal':
+        return 0;
+      default:
+        return undefined;
+    }
+  };
+
+  const result: Partial<HeatmapVisualizationState> = {};
+
+  if (apiConfig.legend) {
+    result.legend = {
+      type: 'heatmap_legend',
+      isVisible: apiConfig.legend.visibility !== 'hidden',
+      position: (apiConfig.legend.position ??
+        'right') as HeatmapVisualizationState['legend']['position'],
+      ...(apiConfig.legend.truncate_after_lines != null
+        ? {
+            maxLines: apiConfig.legend.truncate_after_lines,
+            shouldTruncate: true,
+          }
+        : {}),
+      ...(apiConfig.legend.size != null
+        ? {
+            legendSize: apiConfig.legend.size as HeatmapVisualizationState['legend']['legendSize'],
+          }
+        : {}),
+    };
+  }
+
+  if (apiConfig.axis || apiConfig.styling) {
+    result.gridConfig = {
+      type: 'heatmap_grid',
+      isCellLabelVisible: apiConfig.styling?.cells?.labels?.visible ?? false,
+      isXAxisLabelVisible: apiConfig.axis?.x?.labels?.visible ?? true,
+      isXAxisTitleVisible: apiConfig.axis?.x?.title?.visible ?? false,
+      isYAxisLabelVisible: apiConfig.axis?.y?.labels?.visible ?? true,
+      isYAxisTitleVisible: apiConfig.axis?.y?.title?.visible ?? false,
+      ...(apiConfig.axis?.x?.title?.text ? { xTitle: apiConfig.axis.x.title.text } : {}),
+      ...(apiConfig.axis?.y?.title?.text ? { yTitle: apiConfig.axis.y.title.text } : {}),
+      ...(apiConfig.axis?.x?.labels?.orientation != null
+        ? {
+            xAxisLabelRotation: orientationToRotation(apiConfig.axis.x.labels.orientation),
+          }
+        : {}),
+    };
+  }
+
+  return result;
+};
+
+export const heatmapStateAdapter: VizStateAdapter<HeatmapVisualizationState> = {
+  stateToFormValues(state) {
+    const apiFormat = stateToAPIFormat(state);
+    return flattenToDotPaths(apiFormat as Record<string, unknown>);
+  },
+
+  formValuesToState(currentState, formValues) {
+    const apiConfig = unflattenFromDotPaths(formValues) as HeatmapAPIStyling;
+    const stylingState = apiFormatToState(apiConfig);
+    return { ...currentState, ...stylingState };
+  },
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { datatableStateAdapter } from './datatable';
+import type { VizStateAdapter } from './types';
+
+const adapters: Record<string, VizStateAdapter> = {
+  lnsDatatable: datatableStateAdapter,
+};
+
+export const getStateAdapter = (vizId: string): VizStateAdapter | undefined => adapters[vizId];
+
+export type { VizStateAdapter } from './types';

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/index.ts
@@ -6,10 +6,22 @@
  */
 
 import { datatableStateAdapter } from './datatable';
+import { heatmapStateAdapter } from './heatmap';
+import { xyStateAdapter } from './xy';
+import { partitionStateAdapter } from './partition';
+import { metricStateAdapter } from './metric';
+import { gaugeStateAdapter } from './gauge';
+import { tagcloudStateAdapter } from './tagcloud';
 import type { VizStateAdapter } from './types';
 
 const adapters: Record<string, VizStateAdapter> = {
   lnsDatatable: datatableStateAdapter,
+  lnsHeatmap: heatmapStateAdapter,
+  lnsXY: xyStateAdapter,
+  lnsPie: partitionStateAdapter,
+  lnsMetric: metricStateAdapter,
+  lnsGauge: gaugeStateAdapter,
+  lnsTagcloud: tagcloudStateAdapter,
 };
 
 export const getStateAdapter = (vizId: string): VizStateAdapter | undefined => adapters[vizId];

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/metric.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/metric.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MetricVisualizationState } from '@kbn/lens-common';
+import { metricStateAdapter } from './metric';
+
+const baseState: MetricVisualizationState = {
+  layerId: 'layer1',
+  layerType: 'data',
+  metricAccessor: 'metric1',
+};
+
+describe('metricStateAdapter', () => {
+  describe('stateToFormValues', () => {
+    it('converts primary position to API form values', () => {
+      const state: MetricVisualizationState = {
+        ...baseState,
+        primaryPosition: 'top',
+      };
+      const result = metricStateAdapter.stateToFormValues(state);
+      expect(result['styling.primary.position']).toBe('top');
+    });
+
+    it('converts primary value alignment to API form values', () => {
+      const state: MetricVisualizationState = {
+        ...baseState,
+        primaryAlign: 'left',
+      };
+      const result = metricStateAdapter.stateToFormValues(state);
+      expect(result['styling.primary.value.alignment']).toBe('left');
+    });
+
+    it('converts icon to API form values', () => {
+      const state: MetricVisualizationState = {
+        ...baseState,
+        icon: 'sortUp',
+        iconAlign: 'left',
+      };
+      const result = metricStateAdapter.stateToFormValues(state);
+      expect(result['styling.icon.name']).toBe('sort_up');
+      expect(result['styling.icon.alignment']).toBe('left');
+    });
+
+    it('converts valueFontMode to API sizing format', () => {
+      const state: MetricVisualizationState = {
+        ...baseState,
+        valueFontMode: 'fit',
+      };
+      const result = metricStateAdapter.stateToFormValues(state);
+      expect(result['styling.primary.value.sizing']).toBe('fill');
+    });
+
+    it('returns default values when no styling is set', () => {
+      const result = metricStateAdapter.stateToFormValues(baseState);
+      // Should still produce defaults for primary position, alignment, etc.
+      expect(result['styling.primary.position']).toBeDefined();
+    });
+  });
+
+  describe('formValuesToState', () => {
+    it('converts API position back to internal state', () => {
+      const result = metricStateAdapter.formValuesToState(baseState, {
+        'styling.primary.position': 'bottom',
+      });
+      expect(result.primaryPosition).toBe('bottom');
+      expect(result.layerId).toBe('layer1');
+    });
+
+    it('converts API icon back to internal state', () => {
+      const result = metricStateAdapter.formValuesToState(baseState, {
+        'styling.icon.name': 'sort_up',
+        'styling.icon.alignment': 'left',
+        'styling.primary.position': 'top',
+      });
+      expect(result.icon).toBe('sortUp');
+      expect(result.iconAlign).toBe('left');
+    });
+
+    it('preserves non-styling properties', () => {
+      const stateWithExtras: MetricVisualizationState = {
+        ...baseState,
+        subtitle: 'My subtitle',
+        color: '#ff0000',
+      };
+      const result = metricStateAdapter.formValuesToState(stateWithExtras, {
+        'styling.primary.position': 'top',
+      });
+      expect(result.subtitle).toBe('My subtitle');
+      expect(result.color).toBe('#ff0000');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves styling through stateToFormValues → formValuesToState', () => {
+      const state: MetricVisualizationState = {
+        ...baseState,
+        primaryPosition: 'top',
+        primaryAlign: 'center',
+        titlesTextAlign: 'right',
+        valueFontMode: 'fit',
+      };
+
+      const formValues = metricStateAdapter.stateToFormValues(state);
+      const result = metricStateAdapter.formValuesToState(baseState, formValues);
+
+      expect(result.primaryPosition).toBe('top');
+      expect(result.primaryAlign).toBe('center');
+      expect(result.titlesTextAlign).toBe('right');
+      expect(result.valueFontMode).toBe('fit');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/metric.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/metric.ts
@@ -21,9 +21,24 @@ export const metricStateAdapter: VizStateAdapter<MetricVisualizationState> = {
   },
 
   formValuesToState(currentState, formValues) {
-    const apiConfig = unflattenFromDotPaths(formValues) as MetricConfig;
+    // Strip empty/undefined/null values so optional fields are removed from state
+    const cleanedValues = Object.fromEntries(
+      Object.entries(formValues).filter(([, v]) => v !== '' && v !== undefined && v !== null)
+    );
+    const apiConfig = unflattenFromDotPaths(cleanedValues) as MetricConfig;
     const hasSecondary = !!currentState.secondaryMetricAccessor;
     const stylingState = buildMetricStylingState(apiConfig, hasSecondary);
-    return { ...currentState, ...stylingState };
+
+    // buildMetricStylingState uses stripUndefined(), so optional keys absent
+    // from stylingState must be explicitly deleted from currentState to avoid
+    // stale values surviving the spread (e.g. icon removal).
+    const optionalKeys = ['icon', 'iconAlign'] as const;
+    const merged = { ...currentState, ...stylingState };
+    for (const key of optionalKeys) {
+      if (!(key in stylingState)) {
+        delete (merged as Record<string, unknown>)[key];
+      }
+    }
+    return merged;
   },
 };

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/metric.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/metric.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MetricVisualizationState } from '@kbn/lens-common';
+import {
+  buildMetricStylingState,
+  convertMetricStylingToAPIFormat,
+} from '@kbn/lens-embeddable-utils';
+import type { MetricConfig } from '@kbn/lens-embeddable-utils';
+import type { VizStateAdapter } from './types';
+import { flattenToDotPaths, unflattenFromDotPaths } from './dot_path_helpers';
+
+export const metricStateAdapter: VizStateAdapter<MetricVisualizationState> = {
+  stateToFormValues(state) {
+    const apiFormat = convertMetricStylingToAPIFormat(state);
+    return flattenToDotPaths(apiFormat);
+  },
+
+  formValuesToState(currentState, formValues) {
+    const apiConfig = unflattenFromDotPaths(formValues) as MetricConfig;
+    const hasSecondary = !!currentState.secondaryMetricAccessor;
+    const stylingState = buildMetricStylingState(apiConfig, hasSecondary);
+    return { ...currentState, ...stylingState };
+  },
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/partition.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/partition.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LensPartitionVisualizationState } from '@kbn/lens-common';
+import { PARTITION_EMPTY_SIZE_RADIUS } from '@kbn/lens-common';
+import { partitionStateAdapter } from './partition';
+
+const baseLayer = {
+  layerId: 'layer1',
+  layerType: 'data' as const,
+  metrics: ['m1'],
+  primaryGroups: ['g1'],
+  numberDisplay: 'percent' as const,
+  categoryDisplay: 'default' as const,
+  legendDisplay: 'default' as const,
+};
+
+const baseState: LensPartitionVisualizationState = {
+  shape: 'pie',
+  layers: [baseLayer],
+};
+
+describe('partitionStateAdapter', () => {
+  describe('stateToFormValues', () => {
+    it('converts value display to API format', () => {
+      const result = partitionStateAdapter.stateToFormValues(baseState);
+      expect(result['styling.values.visible']).toBe(true);
+      expect(result['styling.values.mode']).toBe('percentage');
+    });
+
+    it('converts hidden values', () => {
+      const state: LensPartitionVisualizationState = {
+        ...baseState,
+        layers: [{ ...baseLayer, numberDisplay: 'hidden' }],
+      };
+      const result = partitionStateAdapter.stateToFormValues(state);
+      expect(result['styling.values.visible']).toBe(false);
+    });
+
+    it('converts donut hole size', () => {
+      const state: LensPartitionVisualizationState = {
+        shape: 'donut',
+        layers: [{ ...baseLayer, emptySizeRatio: PARTITION_EMPTY_SIZE_RADIUS.MEDIUM }],
+      };
+      const result = partitionStateAdapter.stateToFormValues(state);
+      expect(result['styling.donut_hole']).toBe('m');
+    });
+
+    it('converts pie with no donut hole', () => {
+      const result = partitionStateAdapter.stateToFormValues(baseState);
+      expect(result['styling.donut_hole']).toBe('none');
+    });
+
+    it('converts label position for pie', () => {
+      const state: LensPartitionVisualizationState = {
+        ...baseState,
+        layers: [{ ...baseLayer, categoryDisplay: 'inside' }],
+      };
+      const result = partitionStateAdapter.stateToFormValues(state);
+      expect(result['styling.labels.visible']).toBe(true);
+      expect(result['styling.labels.position']).toBe('inside');
+    });
+
+    it('converts hidden labels', () => {
+      const state: LensPartitionVisualizationState = {
+        ...baseState,
+        layers: [{ ...baseLayer, categoryDisplay: 'hide' }],
+      };
+      const result = partitionStateAdapter.stateToFormValues(state);
+      expect(result['styling.labels.visible']).toBe(false);
+    });
+
+    it('converts legend settings', () => {
+      const state: LensPartitionVisualizationState = {
+        ...baseState,
+        layers: [
+          {
+            ...baseLayer,
+            legendDisplay: 'show',
+            nestedLegend: true,
+            truncateLegend: true,
+            legendMaxLines: 3,
+          },
+        ],
+      };
+      const result = partitionStateAdapter.stateToFormValues(state);
+      expect(result['legend.visibility']).toBe('visible');
+      expect(result['legend.nested']).toBe(true);
+      expect(result['legend.truncate_after_lines']).toBe(3);
+    });
+
+    it('omits nested legend for waffle charts', () => {
+      const state: LensPartitionVisualizationState = {
+        shape: 'waffle',
+        layers: [{ ...baseLayer, nestedLegend: true }],
+      };
+      const result = partitionStateAdapter.stateToFormValues(state);
+      expect(result['legend.nested']).toBeUndefined();
+    });
+  });
+
+  describe('formValuesToState', () => {
+    it('applies value display changes', () => {
+      const result = partitionStateAdapter.formValuesToState(baseState, {
+        'styling.values.visible': false,
+      });
+      expect(result.layers[0].numberDisplay).toBe('hidden');
+    });
+
+    it('applies donut hole and changes shape to donut', () => {
+      const result = partitionStateAdapter.formValuesToState(baseState, {
+        'styling.donut_hole': 'm',
+        'styling.values.visible': true,
+        'styling.values.mode': 'percentage',
+        'styling.labels.visible': true,
+        'styling.labels.position': 'outside',
+      });
+      expect(result.shape).toBe('donut');
+      expect(result.layers[0].emptySizeRatio).toBe(PARTITION_EMPTY_SIZE_RADIUS.MEDIUM);
+    });
+
+    it('changes shape back to pie when donut_hole is none', () => {
+      const donutState: LensPartitionVisualizationState = {
+        shape: 'donut',
+        layers: [{ ...baseLayer, emptySizeRatio: PARTITION_EMPTY_SIZE_RADIUS.MEDIUM }],
+      };
+      const result = partitionStateAdapter.formValuesToState(donutState, {
+        'styling.donut_hole': 'none',
+        'styling.values.visible': true,
+        'styling.values.mode': 'percentage',
+        'styling.labels.visible': true,
+        'styling.labels.position': 'outside',
+      });
+      expect(result.shape).toBe('pie');
+      expect(result.layers[0].emptySizeRatio).toBeUndefined();
+    });
+
+    it('applies legend changes', () => {
+      const result = partitionStateAdapter.formValuesToState(baseState, {
+        'legend.visibility': 'hidden',
+        'legend.nested': true,
+        'legend.truncate_after_lines': 2,
+      });
+      expect(result.layers[0].legendDisplay).toBe('hide');
+      expect(result.layers[0].nestedLegend).toBe(true);
+      expect(result.layers[0].legendMaxLines).toBe(2);
+    });
+
+    it('preserves non-styling state', () => {
+      const result = partitionStateAdapter.formValuesToState(baseState, {
+        'styling.values.visible': true,
+        'styling.values.mode': 'percentage',
+      });
+      expect(result.layers[0].metrics).toEqual(['m1']);
+      expect(result.layers[0].primaryGroups).toEqual(['g1']);
+      expect(result.layers[0].layerId).toBe('layer1');
+    });
+
+    it('roundtrips: stateToFormValues → formValuesToState preserves state', () => {
+      const state: LensPartitionVisualizationState = {
+        shape: 'donut',
+        layers: [
+          {
+            ...baseLayer,
+            numberDisplay: 'value',
+            categoryDisplay: 'inside',
+            legendDisplay: 'show',
+            nestedLegend: true,
+            emptySizeRatio: PARTITION_EMPTY_SIZE_RADIUS.LARGE,
+            truncateLegend: true,
+            legendMaxLines: 2,
+          },
+        ],
+      };
+      const formValues = partitionStateAdapter.stateToFormValues(state);
+      const roundtripped = partitionStateAdapter.formValuesToState(state, formValues);
+      expect(roundtripped.shape).toBe('donut');
+      expect(roundtripped.layers[0].numberDisplay).toBe('value');
+      expect(roundtripped.layers[0].categoryDisplay).toBe('inside');
+      expect(roundtripped.layers[0].legendDisplay).toBe('show');
+      expect(roundtripped.layers[0].nestedLegend).toBe(true);
+      expect(roundtripped.layers[0].emptySizeRatio).toBe(PARTITION_EMPTY_SIZE_RADIUS.LARGE);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/partition.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/partition.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LensPartitionVisualizationState } from '@kbn/lens-common';
+import { PARTITION_EMPTY_SIZE_RADIUS } from '@kbn/lens-common';
+import type { PieConfig } from '@kbn/lens-embeddable-utils/config_builder/schema/charts/pie';
+import type { VizStateAdapter } from './types';
+import { flattenToDotPaths, unflattenFromDotPaths } from './dot_path_helpers';
+
+// Maps between API donut_hole values and internal emptySizeRatio numbers
+const DONUT_HOLE_TO_RATIO: Record<string, number> = {
+  s: PARTITION_EMPTY_SIZE_RADIUS.SMALL,
+  m: PARTITION_EMPTY_SIZE_RADIUS.MEDIUM,
+  l: PARTITION_EMPTY_SIZE_RADIUS.LARGE,
+};
+const RATIO_TO_DONUT_HOLE = new Map(Object.entries(DONUT_HOLE_TO_RATIO).map(([k, v]) => [v, k]));
+
+function stateToApiFormat(state: LensPartitionVisualizationState): Record<string, unknown> {
+  const layer = state.layers[0];
+  const result: Record<string, unknown> = {};
+
+  // Styling — values
+  if (layer.numberDisplay === 'hidden') {
+    result.styling = { values: { visible: false } };
+  } else {
+    const values: Record<string, unknown> = { visible: true };
+    if (layer.numberDisplay === 'percent') values.mode = 'percentage';
+    else if (layer.numberDisplay === 'value') values.mode = 'absolute';
+    if (layer.percentDecimals != null) values.percent_decimals = layer.percentDecimals;
+    result.styling = { values };
+  }
+
+  // Pie-specific styling
+  if (state.shape === 'pie' || state.shape === 'donut') {
+    const styling = result.styling as Record<string, unknown>;
+    // Labels
+    if (layer.categoryDisplay === 'hide') {
+      styling.labels = { visible: false };
+    } else if (layer.categoryDisplay === 'inside') {
+      styling.labels = { visible: true, position: 'inside' };
+    } else {
+      styling.labels = { visible: true, position: 'outside' };
+    }
+    // Donut hole
+    const donutHole = RATIO_TO_DONUT_HOLE.get(layer.emptySizeRatio!);
+    if (donutHole) {
+      styling.donut_hole = donutHole;
+    } else if (state.shape === 'pie') {
+      styling.donut_hole = 'none';
+    }
+  }
+
+  // Treemap labels
+  if (state.shape === 'treemap') {
+    const styling = result.styling as Record<string, unknown>;
+    styling.labels = { visible: layer.categoryDisplay !== 'hide' };
+  }
+
+  // Legend
+  const legend: Record<string, unknown> = {};
+  if (layer.legendDisplay === 'default') legend.visibility = 'auto';
+  else if (layer.legendDisplay === 'show') legend.visibility = 'visible';
+  else if (layer.legendDisplay === 'hide') legend.visibility = 'hidden';
+  if (layer.nestedLegend != null && state.shape !== 'waffle') legend.nested = layer.nestedLegend;
+  if (layer.legendSize != null) legend.size = layer.legendSize;
+  if (layer.truncateLegend && layer.legendMaxLines != null) {
+    legend.truncate_after_lines = layer.legendMaxLines;
+  }
+  if (Object.keys(legend).length > 0) result.legend = legend;
+
+  return result;
+}
+
+function apiToState(
+  currentState: LensPartitionVisualizationState,
+  apiConfig: Record<string, unknown>
+): LensPartitionVisualizationState {
+  const styling = apiConfig.styling as PieConfig['styling'];
+  const legendConfig = apiConfig.legend as PieConfig['legend'];
+  const layer = { ...currentState.layers[0] };
+
+  // Values
+  if (styling?.values) {
+    if (styling.values.visible === false) {
+      layer.numberDisplay = 'hidden';
+    } else if (styling.values.mode === 'percentage') {
+      layer.numberDisplay = 'percent';
+    } else if (styling.values.mode === 'absolute') {
+      layer.numberDisplay = 'value';
+    } else {
+      layer.numberDisplay = 'percent';
+    }
+    if (styling.values.percent_decimals != null) {
+      layer.percentDecimals = styling.values.percent_decimals;
+    }
+  }
+
+  // Labels (pie/treemap)
+  if (styling && 'labels' in styling && styling.labels) {
+    const labels = styling.labels as { visible?: boolean; position?: string };
+    if (labels.visible === false) {
+      layer.categoryDisplay = 'hide';
+    } else if (labels.position === 'inside') {
+      layer.categoryDisplay = 'inside';
+    } else {
+      layer.categoryDisplay = 'default';
+    }
+  }
+
+  // Donut hole
+  let newShape = currentState.shape;
+  if (styling && 'donut_hole' in styling) {
+    const donutHole = (styling as { donut_hole?: string }).donut_hole;
+    if (donutHole && donutHole !== 'none') {
+      layer.emptySizeRatio = DONUT_HOLE_TO_RATIO[donutHole] ?? PARTITION_EMPTY_SIZE_RADIUS.SMALL;
+      newShape = 'donut';
+    } else {
+      layer.emptySizeRatio = undefined;
+      if (currentState.shape === 'donut') newShape = 'pie';
+    }
+  }
+
+  // Legend
+  if (legendConfig) {
+    if (legendConfig.visibility === 'auto') layer.legendDisplay = 'default';
+    else if (legendConfig.visibility === 'visible') layer.legendDisplay = 'show';
+    else if (legendConfig.visibility === 'hidden') layer.legendDisplay = 'hide';
+    if (legendConfig.nested != null) layer.nestedLegend = legendConfig.nested;
+    if (legendConfig.size != null) layer.legendSize = legendConfig.size as typeof layer.legendSize;
+    if (legendConfig.truncate_after_lines != null) {
+      layer.truncateLegend = true;
+      layer.legendMaxLines = legendConfig.truncate_after_lines;
+    }
+  }
+
+  return { ...currentState, shape: newShape, layers: [layer] };
+}
+
+export const partitionStateAdapter: VizStateAdapter<LensPartitionVisualizationState> = {
+  stateToFormValues(state) {
+    return flattenToDotPaths(stateToApiFormat(state));
+  },
+
+  formValuesToState(currentState, formValues) {
+    const apiConfig = unflattenFromDotPaths(formValues);
+    return apiToState(currentState, apiConfig);
+  },
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/tagcloud.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/tagcloud.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LensTagCloudState } from '@kbn/lens-common';
+import { TAGCLOUD_ORIENTATION } from '@kbn/lens-common';
+import { tagcloudStateAdapter } from './tagcloud';
+
+const baseState: LensTagCloudState = {
+  layerId: 'layer1',
+  tagAccessor: 'tag1',
+  valueAccessor: 'value1',
+  maxFontSize: 72,
+  minFontSize: 18,
+  orientation: TAGCLOUD_ORIENTATION.SINGLE,
+  showLabel: true,
+};
+
+describe('tagcloudStateAdapter', () => {
+  describe('stateToFormValues', () => {
+    it('converts orientation to API form values', () => {
+      const result = tagcloudStateAdapter.stateToFormValues(baseState);
+      expect(result['styling.orientation']).toBe('horizontal');
+    });
+
+    it('converts right angled orientation to vertical', () => {
+      const state: LensTagCloudState = {
+        ...baseState,
+        orientation: TAGCLOUD_ORIENTATION.RIGHT_ANGLED,
+      };
+      const result = tagcloudStateAdapter.stateToFormValues(state);
+      expect(result['styling.orientation']).toBe('vertical');
+    });
+
+    it('converts multiple orientation to angled', () => {
+      const state: LensTagCloudState = {
+        ...baseState,
+        orientation: TAGCLOUD_ORIENTATION.MULTIPLE,
+      };
+      const result = tagcloudStateAdapter.stateToFormValues(state);
+      expect(result['styling.orientation']).toBe('angled');
+    });
+
+    it('converts font size to API form values', () => {
+      const state: LensTagCloudState = {
+        ...baseState,
+        minFontSize: 10,
+        maxFontSize: 100,
+      };
+      const result = tagcloudStateAdapter.stateToFormValues(state);
+      expect(result['styling.font_size.min']).toBe(10);
+      expect(result['styling.font_size.max']).toBe(100);
+    });
+
+    it('converts showLabel to API form values', () => {
+      const state: LensTagCloudState = {
+        ...baseState,
+        showLabel: false,
+      };
+      const result = tagcloudStateAdapter.stateToFormValues(state);
+      expect(result['styling.caption.visible']).toBe(false);
+    });
+  });
+
+  describe('formValuesToState', () => {
+    it('converts API orientation back to internal state', () => {
+      const result = tagcloudStateAdapter.formValuesToState(baseState, {
+        'styling.orientation': 'vertical',
+      });
+      expect(result.orientation).toBe(TAGCLOUD_ORIENTATION.RIGHT_ANGLED);
+      expect(result.layerId).toBe('layer1');
+    });
+
+    it('converts API angled orientation back to internal state', () => {
+      const result = tagcloudStateAdapter.formValuesToState(baseState, {
+        'styling.orientation': 'angled',
+      });
+      expect(result.orientation).toBe(TAGCLOUD_ORIENTATION.MULTIPLE);
+    });
+
+    it('converts API font size back to internal state', () => {
+      const result = tagcloudStateAdapter.formValuesToState(baseState, {
+        'styling.font_size.min': 12,
+        'styling.font_size.max': 96,
+      });
+      expect(result.minFontSize).toBe(12);
+      expect(result.maxFontSize).toBe(96);
+    });
+
+    it('converts API caption visibility back to internal state', () => {
+      const result = tagcloudStateAdapter.formValuesToState(baseState, {
+        'styling.caption.visible': false,
+      });
+      expect(result.showLabel).toBe(false);
+    });
+
+    it('preserves non-styling properties', () => {
+      const stateWithExtras: LensTagCloudState = {
+        ...baseState,
+        tagAccessor: 'customTag',
+      };
+      const result = tagcloudStateAdapter.formValuesToState(stateWithExtras, {
+        'styling.orientation': 'horizontal',
+      });
+      expect(result.tagAccessor).toBe('customTag');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves styling through stateToFormValues → formValuesToState', () => {
+      const state: LensTagCloudState = {
+        ...baseState,
+        orientation: TAGCLOUD_ORIENTATION.MULTIPLE,
+        minFontSize: 14,
+        maxFontSize: 80,
+        showLabel: false,
+      };
+
+      const formValues = tagcloudStateAdapter.stateToFormValues(state);
+      const result = tagcloudStateAdapter.formValuesToState(baseState, formValues);
+
+      expect(result.orientation).toBe(TAGCLOUD_ORIENTATION.MULTIPLE);
+      expect(result.minFontSize).toBe(14);
+      expect(result.maxFontSize).toBe(80);
+      expect(result.showLabel).toBe(false);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/tagcloud.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/tagcloud.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LensTagCloudState } from '@kbn/lens-common';
+import {
+  buildTagcloudStylingState,
+  convertTagcloudStylingToAPIFormat,
+} from '@kbn/lens-embeddable-utils';
+import type { TagcloudConfig } from '@kbn/lens-embeddable-utils';
+import type { VizStateAdapter } from './types';
+import { flattenToDotPaths, unflattenFromDotPaths } from './dot_path_helpers';
+
+export const tagcloudStateAdapter: VizStateAdapter<LensTagCloudState> = {
+  stateToFormValues(state) {
+    const apiFormat = convertTagcloudStylingToAPIFormat(state);
+    return flattenToDotPaths(apiFormat);
+  },
+
+  formValuesToState(currentState, formValues) {
+    const apiConfig = unflattenFromDotPaths(formValues) as TagcloudConfig;
+    const stylingState = buildTagcloudStylingState(apiConfig);
+    return { ...currentState, ...stylingState };
+  },
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Adapter that converts between API-format form values (dot-path keyed)
+ * and internal visualization state (Redux store format).
+ */
+export interface VizStateAdapter<T = unknown> {
+  /** Convert internal viz state to API-format values for form initialization */
+  stateToFormValues(state: T): Record<string, unknown>;
+  /** Convert API-format form values back to internal viz state, preserving non-styling properties */
+  formValuesToState(currentState: T, formValues: Record<string, unknown>): T;
+}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/xy.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/xy.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { XYVisualizationState } from '@kbn/lens-common';
+import { xyStateAdapter } from './xy';
+
+const baseState: XYVisualizationState = {
+  preferredSeriesType: 'bar',
+  legend: { isVisible: true, position: 'right' },
+  layers: [],
+};
+
+describe('xyStateAdapter', () => {
+  describe('stateToFormValues', () => {
+    it('converts legend visibility', () => {
+      const result = xyStateAdapter.stateToFormValues(baseState);
+      expect(result['legend.visibility']).toBeDefined();
+    });
+
+    it('converts hidden legend', () => {
+      const state: XYVisualizationState = {
+        ...baseState,
+        legend: { isVisible: false, position: 'right' },
+      };
+      const result = xyStateAdapter.stateToFormValues(state);
+      expect(result['legend.visibility']).toBe('hidden');
+    });
+
+    it('converts styling properties', () => {
+      const state: XYVisualizationState = {
+        ...baseState,
+        hideEndzones: true,
+        showCurrentTimeMarker: true,
+        curveType: 'CURVE_MONOTONE_X',
+      };
+      const result = xyStateAdapter.stateToFormValues(state);
+      expect(result['styling.overlays.partial_buckets.visible']).toBe(false);
+      expect(result['styling.overlays.current_time_marker.visible']).toBe(true);
+    });
+  });
+
+  describe('formValuesToState', () => {
+    it('converts legend form values back to state', () => {
+      const result = xyStateAdapter.formValuesToState(baseState, {
+        'legend.visibility': 'hidden',
+      });
+      expect(result.legend.isVisible).toBe(false);
+    });
+
+    it('converts styling form values back to state', () => {
+      const result = xyStateAdapter.formValuesToState(baseState, {
+        'styling.overlays.partial_buckets.visible': false,
+        'styling.overlays.current_time_marker.visible': true,
+      });
+      expect(result.hideEndzones).toBe(true);
+      expect(result.showCurrentTimeMarker).toBe(true);
+    });
+
+    it('preserves non-styling properties', () => {
+      const state: XYVisualizationState = {
+        ...baseState,
+        layers: [
+          {
+            layerId: 'layer1',
+            layerType: 'data',
+            seriesType: 'bar',
+            accessors: ['col1'],
+          } as XYVisualizationState['layers'][0],
+        ],
+      };
+      const result = xyStateAdapter.formValuesToState(state, {
+        'styling.overlays.current_time_marker.visible': true,
+      });
+      expect(result.layers).toHaveLength(1);
+      expect(result.preferredSeriesType).toBe('bar');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves styling through stateToFormValues → formValuesToState', () => {
+      const state: XYVisualizationState = {
+        ...baseState,
+        legend: { isVisible: true, position: 'bottom' },
+        hideEndzones: true,
+        showCurrentTimeMarker: true,
+        fillOpacity: 0.5,
+      };
+
+      const formValues = xyStateAdapter.stateToFormValues(state);
+      const result = xyStateAdapter.formValuesToState(baseState, formValues);
+
+      expect(result.hideEndzones).toBe(true);
+      expect(result.showCurrentTimeMarker).toBe(true);
+      expect(result.legend.isVisible).toBe(true);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/xy.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/state_adapters/xy.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { XYVisualizationState } from '@kbn/lens-common';
+import {
+  convertXYLegendToAPIFormat,
+  convertXYLegendToStateFormat,
+  convertXYStylingToAPIFormat,
+  convertXYStylingToStateFormat,
+} from '@kbn/lens-embeddable-utils';
+import type { XYConfig } from '@kbn/lens-embeddable-utils/config_builder/schema';
+import type { VizStateAdapter } from './types';
+import { flattenToDotPaths, unflattenFromDotPaths } from './dot_path_helpers';
+
+// Default layer presence — expose all styling sections
+const ALL_LAYERS = { hasBars: true, hasLines: true, hasAreas: true };
+
+export const xyStateAdapter: VizStateAdapter<XYVisualizationState> = {
+  stateToFormValues(state) {
+    const legendApi = convertXYLegendToAPIFormat(state.legend);
+    const stylingApi = convertXYStylingToAPIFormat(state, ALL_LAYERS);
+    return flattenToDotPaths({ ...legendApi, styling: stylingApi });
+  },
+
+  formValuesToState(currentState, formValues) {
+    const apiConfig = unflattenFromDotPaths(formValues) as XYConfig;
+    const legendState = apiConfig.legend ? convertXYLegendToStateFormat(apiConfig.legend) : {};
+    const stylingState = apiConfig.styling ? convertXYStylingToStateFormat(apiConfig.styling) : {};
+    return { ...currentState, ...legendState, ...stylingState };
+  },
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/types.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Ready-to-render field descriptor received from the server.
+ * Mirrors server/ui_schemas/types.ts FieldDescriptor.
+ */
+export interface FieldDescriptor {
+  path: string;
+  type: string;
+  label: string;
+  description?: string;
+  defaultValue?: unknown;
+  options?: Array<{ value: string; label: string }>;
+  min?: number;
+  max?: number;
+  required?: boolean;
+  widget?: string;
+  props?: Record<string, unknown>;
+  tooltip?: string;
+  children?: FieldDescriptor[];
+}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/types.ts
@@ -23,4 +23,19 @@ export interface FieldDescriptor {
   props?: Record<string, unknown>;
   tooltip?: string;
   children?: FieldDescriptor[];
+  /** Condition that must be met for this field to be visible */
+  condition?: FieldVisibilityCondition;
+}
+
+/**
+ * Conditions controlling when a field is visible.
+ * All specified conditions must be met (AND logic).
+ */
+export interface FieldVisibilityCondition {
+  /** Show this field only when at least one layer matches one of these series types */
+  seriesTypes?: string[];
+  /** Show only when the X axis is time-based */
+  requiresTimeAxis?: boolean;
+  /** Show only when NO text-based (ES|QL) datasource is present */
+  excludeTextBased?: boolean;
 }

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/types.ts
@@ -5,37 +5,13 @@
  * 2.0.
  */
 
-/**
- * Ready-to-render field descriptor received from the server.
- * Mirrors server/ui_schemas/types.ts FieldDescriptor.
- */
-export interface FieldDescriptor {
-  path: string;
-  type: string;
-  label: string;
-  description?: string;
-  defaultValue?: unknown;
-  options?: Array<{ value: string; label: string }>;
-  min?: number;
-  max?: number;
-  required?: boolean;
-  widget?: string;
-  props?: Record<string, unknown>;
-  tooltip?: string;
-  children?: FieldDescriptor[];
-  /** Condition that must be met for this field to be visible */
-  condition?: FieldVisibilityCondition;
-}
+import type { Control } from 'react-hook-form';
+import type { FieldDescriptor } from '../../../common/schema_types';
 
 /**
- * Conditions controlling when a field is visible.
- * All specified conditions must be met (AND logic).
+ * Shared props for all schema field components.
  */
-export interface FieldVisibilityCondition {
-  /** Show this field only when at least one layer matches one of these series types */
-  seriesTypes?: string[];
-  /** Show only when the X axis is time-based */
-  requiresTimeAxis?: boolean;
-  /** Show only when NO text-based (ES|QL) datasource is present */
-  excludeTextBased?: boolean;
+export interface SchemaFieldProps {
+  descriptor: FieldDescriptor;
+  control: Control;
 }

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/use_schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/use_schema_descriptions.ts
@@ -7,7 +7,7 @@
 
 import { useQuery } from '@kbn/react-query';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import type { FieldDescriptor } from './types';
+import type { FieldDescriptor } from '../../../common/schema_types';
 
 interface VizSchemaResponse {
   fields: FieldDescriptor[];

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/use_schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/use_schema_descriptions.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { FieldDescriptor } from './types';
+
+interface VizSchemaResponse {
+  fields: FieldDescriptor[];
+}
+
+export const useSchemaDescriptions = (visualizationId: string) => {
+  const { services } = useKibana();
+
+  const { data: allDescriptions } = useQuery(
+    ['lens', 'schema_descriptions'],
+    () =>
+      services.http!.get<Record<string, VizSchemaResponse>>('/internal/lens/schema_descriptions'),
+    {
+      staleTime: Infinity,
+      enabled: !!services.http,
+    }
+  );
+
+  return {
+    data: allDescriptions?.[visualizationId]?.fields ?? [],
+    isLoading: !allDescriptions,
+  };
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/use_schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/use_schema_descriptions.ts
@@ -17,9 +17,11 @@ export const useSchemaDescriptions = (visualizationId: string) => {
   const { services } = useKibana();
 
   const { data: allDescriptions } = useQuery(
-    ['lens', 'schema_descriptions'],
+    ['lens', 'schema_descriptions', visualizationId],
     () =>
-      services.http!.get<Record<string, VizSchemaResponse>>('/internal/lens/schema_descriptions'),
+      services.http!.get<Record<string, VizSchemaResponse>>('/internal/lens/schema_descriptions', {
+        query: { vizId: visualizationId },
+      }),
     {
       staleTime: Infinity,
       enabled: !!services.http,

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/use_schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/use_schema_descriptions.ts
@@ -16,7 +16,7 @@ interface VizSchemaResponse {
 export const useSchemaDescriptions = (visualizationId: string) => {
   const { services } = useKibana();
 
-  const { data: allDescriptions } = useQuery(
+  const { data: allDescriptions, isLoading } = useQuery(
     ['lens', 'schema_descriptions', visualizationId],
     () =>
       services.http!.get<Record<string, VizSchemaResponse>>('/internal/lens/schema_descriptions', {
@@ -30,6 +30,6 @@ export const useSchemaDescriptions = (visualizationId: string) => {
 
   return {
     data: allDescriptions?.[visualizationId]?.fields ?? [],
-    isLoading: !allDescriptions,
+    isLoading,
   };
 };

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/utils.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/utils.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const humanizeLabel = (raw: string): string => {
+  if (raw.includes(' ')) return raw;
+  return raw
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^\w/, (c) => c.toUpperCase());
+};

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/viz_schema_map.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/viz_schema_map.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Type } from '@kbn/config-schema';
+import { datatableConfigSchemaNoESQL } from '@kbn/lens-embeddable-utils/config_builder/schema';
+
+interface VizSchemaMapping {
+  schema: Type<unknown>;
+  /** Top-level keys to include as flyout sections. If undefined, include all non-excluded keys */
+  includeSections?: string[];
+  /** Top-level keys to always exclude */
+  excludeSections?: string[];
+}
+
+/**
+ * Map from Lens visualization ID to schema mapping.
+ * Only "settings" portions (styling, appearance) are included —
+ * structural fields (type, layers, data_source, metrics, rows, etc.) are excluded.
+ */
+export const vizSchemaMap: Record<string, VizSchemaMapping> = {
+  lnsDatatable: {
+    schema: datatableConfigSchemaNoESQL,
+    excludeSections: [
+      'type',
+      'title',
+      'description',
+      'data_source',
+      'layer_settings',
+      'metrics',
+      'rows',
+      'split_metrics_by',
+      'references',
+      'filters',
+      'time_shift',
+      'reduce_time_range',
+    ],
+  },
+};
+
+export const hasSchemaForVisualization = (vizId: string): boolean => vizId in vizSchemaMap;
+
+export const getSchemaForVisualization = (vizId: string): VizSchemaMapping | undefined =>
+  vizSchemaMap[vizId];

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/viz_schema_map.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/viz_schema_map.ts
@@ -6,6 +6,14 @@
  */
 
 // Viz IDs that have schema-driven flyout support
-const SUPPORTED_VIZ_IDS = new Set(['lnsDatatable']);
+const SUPPORTED_VIZ_IDS = new Set([
+  'lnsDatatable',
+  'lnsXY',
+  'lnsHeatmap',
+  'lnsPie',
+  'lnsMetric',
+  'lnsGauge',
+  'lnsTagcloud',
+]);
 
 export const hasSchemaForVisualization = (vizId: string): boolean => SUPPORTED_VIZ_IDS.has(vizId);

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/viz_schema_map.ts
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/schema_flyout/viz_schema_map.ts
@@ -5,43 +5,7 @@
  * 2.0.
  */
 
-import type { Type } from '@kbn/config-schema';
-import { datatableConfigSchemaNoESQL } from '@kbn/lens-embeddable-utils/config_builder/schema';
+// Viz IDs that have schema-driven flyout support
+const SUPPORTED_VIZ_IDS = new Set(['lnsDatatable']);
 
-interface VizSchemaMapping {
-  schema: Type<unknown>;
-  /** Top-level keys to include as flyout sections. If undefined, include all non-excluded keys */
-  includeSections?: string[];
-  /** Top-level keys to always exclude */
-  excludeSections?: string[];
-}
-
-/**
- * Map from Lens visualization ID to schema mapping.
- * Only "settings" portions (styling, appearance) are included —
- * structural fields (type, layers, data_source, metrics, rows, etc.) are excluded.
- */
-export const vizSchemaMap: Record<string, VizSchemaMapping> = {
-  lnsDatatable: {
-    schema: datatableConfigSchemaNoESQL,
-    excludeSections: [
-      'type',
-      'title',
-      'description',
-      'data_source',
-      'layer_settings',
-      'metrics',
-      'rows',
-      'split_metrics_by',
-      'references',
-      'filters',
-      'time_shift',
-      'reduce_time_range',
-    ],
-  },
-};
-
-export const hasSchemaForVisualization = (vizId: string): boolean => vizId in vizSchemaMap;
-
-export const getSchemaForVisualization = (vizId: string): VizSchemaMapping | undefined =>
-  vizSchemaMap[vizId];
+export const hasSchemaForVisualization = (vizId: string): boolean => SUPPORTED_VIZ_IDS.has(vizId);

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/index.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/index.ts
@@ -7,9 +7,13 @@
 
 import type { RegisterAPIRoutesArgs } from '../../types';
 import { registerLensInternalVisualizationsAPIRoutes } from './visualizations';
+import { registerSchemaDescriptionsRoute } from './schema_descriptions';
 
 export function registerLensInternalAPIRoutes(args: RegisterAPIRoutesArgs) {
   registerLensInternalVisualizationsAPIRoutes(args);
+
+  const router = args.http.createRouter();
+  registerSchemaDescriptionsRoute(router);
 }
 
 export * from './schema';

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
@@ -6,7 +6,15 @@
  */
 
 import type { IRouter } from '@kbn/core/server';
-import { datatableConfigSchemaNoESQL } from '@kbn/lens-embeddable-utils/config_builder/schema';
+import {
+  datatableConfigSchemaNoESQL,
+  xyConfigSchemaNoESQL,
+  heatmapConfigSchemaNoESQL,
+  pieConfigSchemaNoESQL,
+  metricConfigSchemaNoESQL,
+  gaugeConfigSchemaNoESQL,
+  tagcloudConfigSchemaNoESQL,
+} from '@kbn/lens-embeddable-utils/config_builder/schema';
 import type { FieldDescriptor } from '../../../ui_schemas';
 import { uiSchemaRegistry } from '../../../ui_schemas';
 import { buildFieldDescriptors } from '../../../schema_walker';
@@ -18,6 +26,12 @@ interface VizSchemaConfig {
 // Schema registry mapping viz IDs to their kbn-config-schema instances
 const vizSchemas: Record<string, VizSchemaConfig> = {
   lnsDatatable: { schema: datatableConfigSchemaNoESQL },
+  lnsXY: { schema: xyConfigSchemaNoESQL },
+  lnsHeatmap: { schema: heatmapConfigSchemaNoESQL },
+  lnsPie: { schema: pieConfigSchemaNoESQL },
+  lnsMetric: { schema: metricConfigSchemaNoESQL },
+  lnsGauge: { schema: gaugeConfigSchemaNoESQL },
+  lnsTagcloud: { schema: tagcloudConfigSchemaNoESQL },
 };
 
 // Cache — computed once on first request

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { schema } from '@kbn/config-schema';
 import type { IRouter } from '@kbn/core/server';
 import {
   datatableConfigSchemaNoESQL,
@@ -63,7 +64,11 @@ export function registerSchemaDescriptionsRoute(router: IRouter) {
   router.get(
     {
       path: '/internal/lens/schema_descriptions',
-      validate: {},
+      validate: {
+        query: schema.object({
+          vizId: schema.maybe(schema.string()),
+        }),
+      },
       security: {
         authz: {
           enabled: false,
@@ -72,8 +77,15 @@ export function registerSchemaDescriptionsRoute(router: IRouter) {
       },
     },
     async (context, request, response) => {
+      const { vizId } = request.query;
+      const all = computeFieldDescriptors();
+      if (vizId) {
+        return response.ok({
+          body: vizId in all ? { [vizId]: all[vizId] } : {},
+        });
+      }
       return response.ok({
-        body: computeFieldDescriptors(),
+        body: all,
       });
     }
   );

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRouter } from '@kbn/core/server';
+import { datatableConfigSchemaNoESQL } from '@kbn/lens-embeddable-utils/config_builder/schema';
+
+// Cache — computed once on first request
+let cachedDescriptions: Record<string, unknown> | null = null;
+
+function computeDescriptions(): Record<string, unknown> {
+  if (cachedDescriptions) return cachedDescriptions;
+
+  const schemas: Record<
+    string,
+    { schema: { getSchema: () => { describe: () => unknown } }; excludeSections: string[] }
+  > = {
+    lnsDatatable: {
+      schema: datatableConfigSchemaNoESQL,
+      excludeSections: [
+        'type',
+        'title',
+        'description',
+        'data_source',
+        'layer_settings',
+        'metrics',
+        'rows',
+        'split_metrics_by',
+        'references',
+        'filters',
+        'time_shift',
+        'reduce_time_range',
+      ],
+    },
+  };
+
+  const result: Record<string, unknown> = {};
+  for (const [vizId, { schema, excludeSections }] of Object.entries(schemas)) {
+    result[vizId] = {
+      description: schema.getSchema().describe(),
+      excludeSections,
+    };
+  }
+
+  cachedDescriptions = result;
+  return result;
+}
+
+export function registerSchemaDescriptionsRoute(router: IRouter) {
+  router.get(
+    {
+      path: '/internal/lens/schema_descriptions',
+      validate: {},
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route returns static schema metadata for the Lens editor UI',
+        },
+      },
+    },
+    async (context, request, response) => {
+      return response.ok({
+        body: computeDescriptions(),
+      });
+    }
+  );
+}

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
@@ -16,7 +16,7 @@ import {
   gaugeConfigSchemaNoESQL,
   tagcloudConfigSchemaNoESQL,
 } from '@kbn/lens-embeddable-utils/config_builder/schema';
-import type { FieldDescriptor } from '../../../ui_schemas';
+import type { FieldDescriptor } from '../../../../common/schema_types';
 import { uiSchemaRegistry } from '../../../ui_schemas';
 import { buildFieldDescriptors } from '../../../schema_walker';
 

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/schema_descriptions.ts
@@ -7,45 +7,41 @@
 
 import type { IRouter } from '@kbn/core/server';
 import { datatableConfigSchemaNoESQL } from '@kbn/lens-embeddable-utils/config_builder/schema';
+import type { FieldDescriptor } from '../../../ui_schemas';
+import { uiSchemaRegistry } from '../../../ui_schemas';
+import { buildFieldDescriptors } from '../../../schema_walker';
+
+interface VizSchemaConfig {
+  schema: { getSchema: () => { describe: () => Record<string, unknown> } };
+}
+
+// Schema registry mapping viz IDs to their kbn-config-schema instances
+const vizSchemas: Record<string, VizSchemaConfig> = {
+  lnsDatatable: { schema: datatableConfigSchemaNoESQL },
+};
 
 // Cache — computed once on first request
-let cachedDescriptions: Record<string, unknown> | null = null;
+let cachedResult: Record<string, { fields: FieldDescriptor[] }> | null = null;
 
-function computeDescriptions(): Record<string, unknown> {
-  if (cachedDescriptions) return cachedDescriptions;
+function computeFieldDescriptors(): Record<string, { fields: FieldDescriptor[] }> {
+  if (cachedResult) return cachedResult;
 
-  const schemas: Record<
-    string,
-    { schema: { getSchema: () => { describe: () => unknown } }; excludeSections: string[] }
-  > = {
-    lnsDatatable: {
-      schema: datatableConfigSchemaNoESQL,
-      excludeSections: [
-        'type',
-        'title',
-        'description',
-        'data_source',
-        'layer_settings',
-        'metrics',
-        'rows',
-        'split_metrics_by',
-        'references',
-        'filters',
-        'time_shift',
-        'reduce_time_range',
-      ],
-    },
-  };
+  const result: Record<string, { fields: FieldDescriptor[] }> = {};
 
-  const result: Record<string, unknown> = {};
-  for (const [vizId, { schema, excludeSections }] of Object.entries(schemas)) {
-    result[vizId] = {
-      description: schema.getSchema().describe(),
-      excludeSections,
-    };
+  for (const [vizId, config] of Object.entries(vizSchemas)) {
+    const uiSchema = uiSchemaRegistry[vizId];
+    if (!uiSchema) continue;
+
+    const description = config.schema.getSchema().describe() as Record<string, unknown>;
+    const fields = buildFieldDescriptors(
+      description as Parameters<typeof buildFieldDescriptors>[0],
+      uiSchema
+    );
+
+    result[vizId] = { fields };
   }
 
-  cachedDescriptions = result;
+  cachedResult = result;
   return result;
 }
 
@@ -63,7 +59,7 @@ export function registerSchemaDescriptionsRoute(router: IRouter) {
     },
     async (context, request, response) => {
       return response.ok({
-        body: computeDescriptions(),
+        body: computeFieldDescriptors(),
       });
     }
   );

--- a/x-pack/platform/plugins/shared/lens/server/schema_walker.test.ts
+++ b/x-pack/platform/plugins/shared/lens/server/schema_walker.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildFieldDescriptors } from './schema_walker';
+import type { JoiDescription } from './schema_walker';
+import type { UISchemaEntry } from './ui_schemas';
+
+describe('buildFieldDescriptors', () => {
+  it('returns only fields listed in the UI schema (allowlist)', () => {
+    const description = {
+      type: 'object',
+      keys: {
+        styling: {
+          type: 'object',
+          keys: {
+            density: {
+              type: 'object',
+              keys: {
+                mode: {
+                  type: 'string',
+                  allow: ['compact', 'default', 'expanded'],
+                  flags: { default: 'default', description: 'Display density mode.' },
+                },
+              },
+            },
+            paging: {
+              type: 'number',
+              flags: { description: 'Rows per page.' },
+            },
+            row_numbers: {
+              type: 'object',
+              keys: {
+                visible: {
+                  type: 'boolean',
+                  flags: { description: 'When true, displays row numbers.' },
+                },
+              },
+            },
+          },
+        },
+        type: { type: 'string', allow: ['data_table'] },
+        title: { type: 'string' },
+      },
+    };
+
+    const uiSchema: UISchemaEntry[] = [
+      { path: 'styling.density.mode', label: 'Density', widget: 'buttonGroup' },
+      { path: 'styling.row_numbers.visible', label: 'Show row numbers' },
+    ];
+
+    const fields = buildFieldDescriptors(description as unknown as JoiDescription, uiSchema);
+
+    expect(fields).toHaveLength(2);
+    expect(fields[0]).toMatchObject({
+      path: 'styling.density.mode',
+      type: 'select',
+      label: 'Density',
+      widget: 'buttonGroup',
+      options: [
+        { value: 'compact', label: 'compact' },
+        { value: 'default', label: 'default' },
+        { value: 'expanded', label: 'expanded' },
+      ],
+    });
+    expect(fields[1]).toMatchObject({
+      path: 'styling.row_numbers.visible',
+      type: 'toggle',
+      label: 'Show row numbers',
+    });
+    // type and title should NOT be in output
+    expect(fields.find((f) => f.path === 'type')).toBeUndefined();
+    expect(fields.find((f) => f.path === 'title')).toBeUndefined();
+  });
+
+  it('applies widget, props, and tooltip from UI schema', () => {
+    const description = {
+      type: 'object',
+      keys: {
+        styling: {
+          type: 'object',
+          keys: {
+            paging: { type: 'number', flags: { description: 'Rows per page.' } },
+          },
+        },
+      },
+    };
+
+    const uiSchema: UISchemaEntry[] = [
+      {
+        path: 'styling.paging',
+        label: 'Paginate table',
+        widget: 'paginationToggle',
+        tooltip: 'Pagination is hidden if there are less than 10 items',
+        props: { options: [10, 20, 50] },
+      },
+    ];
+
+    const fields = buildFieldDescriptors(description as unknown as JoiDescription, uiSchema);
+
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toMatchObject({
+      path: 'styling.paging',
+      label: 'Paginate table',
+      widget: 'paginationToggle',
+      tooltip: 'Pagination is hidden if there are less than 10 items',
+      props: { options: [10, 20, 50] },
+    });
+  });
+
+  it('skips paths not found in the schema description', () => {
+    const description = {
+      type: 'object',
+      keys: { foo: { type: 'string' } },
+    };
+
+    const uiSchema: UISchemaEntry[] = [
+      { path: 'nonexistent.path', label: 'Missing' },
+      { path: 'foo', label: 'Foo' },
+    ];
+
+    const fields = buildFieldDescriptors(description as unknown as JoiDescription, uiSchema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].path).toBe('foo');
+  });
+
+  it('unwraps maybe (alternatives with any) wrappers', () => {
+    // schema.maybe(schema.object({ visible: schema.boolean() })) produces:
+    const description = {
+      type: 'object',
+      keys: {
+        styling: {
+          type: 'alternatives',
+          matches: [
+            {
+              schema: {
+                type: 'object',
+                keys: {
+                  visible: { type: 'boolean', flags: { description: 'Show it' } },
+                },
+              },
+            },
+            { schema: { type: 'any', allow: [undefined] } },
+          ],
+        },
+      },
+    };
+
+    const uiSchema: UISchemaEntry[] = [{ path: 'styling.visible', label: 'Visible' }];
+
+    const fields = buildFieldDescriptors(description as unknown as JoiDescription, uiSchema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toMatchObject({ path: 'styling.visible', type: 'toggle', label: 'Visible' });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { FieldDescriptor, UISchemaEntry } from './ui_schemas';
+import type { FieldDescriptor } from '../common/schema_types';
+import type { UISchemaEntry } from './ui_schemas';
 
 const humanizeLabel = (raw: string): string => {
   if (raw.includes(' ')) return raw;

--- a/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
@@ -234,6 +234,7 @@ export function buildFieldDescriptors(
     if (entry.tooltip) field.tooltip = entry.tooltip;
     if (entry.description) field.description = entry.description;
     if (entry.options) field.options = entry.options;
+    if (entry.condition) field.condition = entry.condition;
 
     // Suppress description when it's redundant with the label
     if (field.description) {

--- a/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FieldDescriptor, UISchemaEntry } from './ui_schemas';
+
+const humanizeLabel = (raw: string): string => {
+  if (raw.includes(' ')) return raw;
+  return raw
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^\w/, (c) => c.toUpperCase());
+};
+
+export interface JoiDescription {
+  type?: string;
+  keys?: Record<string, JoiDescription>;
+  flags?: { default?: unknown; description?: string; presence?: string };
+  metas?: Array<Record<string, unknown>>;
+  description?: string;
+  allow?: unknown[];
+  rules?: Array<{ name: string; args?: Record<string, number> }>;
+  matches?: Array<{ schema: JoiDescription }>;
+}
+
+function extractMeta(desc: JoiDescription): { title?: string; description?: string } {
+  let title: string | undefined;
+  let description: string | undefined;
+
+  description = desc.flags?.description ?? desc.description;
+
+  if (Array.isArray(desc.metas)) {
+    for (const m of desc.metas) {
+      if (m.title) title = m.title as string;
+      if (!description && m.description) description = m.description as string;
+    }
+  }
+
+  return { title, description };
+}
+
+function extractAllowedValues(
+  desc: JoiDescription
+): Array<{ value: string; label: string }> | undefined {
+  const allow = desc.allow;
+  if (!Array.isArray(allow) || allow.length === 0) return undefined;
+  const stringVals = allow.filter((v): v is string => typeof v === 'string');
+  if (stringVals.length === 0) return undefined;
+  return stringVals.map((v) => ({ value: v, label: v }));
+}
+
+function extractNumberConstraints(desc: JoiDescription): { min?: number; max?: number } {
+  const rules = desc.rules;
+  if (!Array.isArray(rules)) return {};
+  const result: { min?: number; max?: number } = {};
+  for (const rule of rules) {
+    if (rule.name === 'min' && rule.args) result.min = rule.args.limit;
+    if (rule.name === 'max' && rule.args) result.max = rule.args.limit;
+  }
+  return result;
+}
+
+function collectAlternativesAllows(
+  matches: Array<{ schema: JoiDescription }>
+): string[] | undefined {
+  const values: string[] = [];
+  for (const match of matches) {
+    const s = match.schema;
+    if (s.type === 'any' && Array.isArray(s.allow) && s.allow.length === 1) {
+      const val = s.allow[0];
+      if (typeof val === 'string') {
+        values.push(val);
+        continue;
+      }
+    }
+    return undefined;
+  }
+  return values.length > 0 ? values : undefined;
+}
+
+/**
+ * Resolve a dot-path in a Joi description tree.
+ * Returns the nested description node, or undefined if not found.
+ */
+function resolveDescriptionPath(
+  root: JoiDescription,
+  path: string
+): { desc: JoiDescription; key: string } | undefined {
+  const parts = path.split('.');
+  let current = root;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    // Handle `maybe` wrapping: if the current node is alternatives with an object match, unwrap
+    const unwrapped = unwrapMaybe(current);
+    if (!unwrapped.keys?.[part]) return undefined;
+    current = unwrapped.keys[part];
+  }
+
+  const lastKey = parts[parts.length - 1];
+  const unwrappedCurrent = unwrapMaybe(current);
+  if (!unwrappedCurrent.keys?.[lastKey]) return undefined;
+
+  return { desc: unwrappedCurrent.keys[lastKey], key: lastKey };
+}
+
+/**
+ * Unwrap schema.maybe() — in Joi describe() output, `maybe(x)` becomes
+ * an alternatives with matches containing the inner schema and `any.allow(undefined)`.
+ * We look for the non-any match.
+ */
+function unwrapMaybe(desc: JoiDescription): JoiDescription {
+  if (desc.type === 'alternatives' && Array.isArray(desc.matches)) {
+    for (const match of desc.matches) {
+      if (match.schema.type !== 'any') {
+        return match.schema;
+      }
+    }
+  }
+  return desc;
+}
+
+/**
+ * Convert a single Joi description node into a FieldDescriptor.
+ */
+function descToField(desc: JoiDescription, key: string, path: string): FieldDescriptor {
+  const unwrapped = unwrapMaybe(desc);
+  const meta = extractMeta(unwrapped);
+  const label = meta.title ?? humanizeLabel(key);
+  const flags = unwrapped.flags;
+  const defaultValue = flags?.default;
+  const required = flags?.presence === 'required';
+  const joiType = unwrapped.type ?? 'unknown';
+
+  if (joiType === 'boolean') {
+    return { path, type: 'toggle', label, description: meta.description, defaultValue, required };
+  }
+
+  if (joiType === 'number') {
+    const { min, max } = extractNumberConstraints(unwrapped);
+    return {
+      path,
+      type: 'number',
+      label,
+      description: meta.description,
+      defaultValue,
+      min,
+      max,
+      required,
+    };
+  }
+
+  if (joiType === 'string') {
+    const options = extractAllowedValues(unwrapped);
+    if (options) {
+      return {
+        path,
+        type: 'select',
+        label,
+        description: meta.description,
+        defaultValue,
+        options,
+        required,
+      };
+    }
+    return { path, type: 'text', label, description: meta.description, defaultValue, required };
+  }
+
+  if (joiType === 'object') {
+    const children: FieldDescriptor[] = [];
+    if (unwrapped.keys) {
+      for (const [childKey, childDesc] of Object.entries(unwrapped.keys)) {
+        children.push(descToField(childDesc, childKey, `${path}.${childKey}`));
+      }
+    }
+    return {
+      path,
+      type: 'section',
+      label,
+      description: meta.description,
+      required,
+      children: children.length > 0 ? children : undefined,
+    };
+  }
+
+  if (joiType === 'alternatives') {
+    if (Array.isArray(unwrapped.matches)) {
+      const stringValues = collectAlternativesAllows(unwrapped.matches);
+      if (stringValues) {
+        return {
+          path,
+          type: 'select',
+          label,
+          description: meta.description,
+          defaultValue,
+          options: stringValues.map((v) => ({ value: v, label: v })),
+          required,
+        };
+      }
+    }
+    return { path, type: 'alternatives', label, description: meta.description, required };
+  }
+
+  return { path, type: 'unknown', label, description: meta.description, required };
+}
+
+/**
+ * Build a flat, ready-to-render field list by:
+ * 1. Walking each UI schema entry's path in the Joi description
+ * 2. Converting the matched node into a FieldDescriptor
+ * 3. Applying UI schema overrides (label, widget, props, tooltip, description)
+ *
+ * Only paths listed in the UI schema appear — it acts as an allowlist.
+ */
+export function buildFieldDescriptors(
+  description: JoiDescription,
+  uiSchema: UISchemaEntry[]
+): FieldDescriptor[] {
+  const fields: FieldDescriptor[] = [];
+
+  for (const entry of uiSchema) {
+    const resolved = resolveDescriptionPath(description, entry.path);
+    if (!resolved) continue;
+
+    const field = descToField(resolved.desc, resolved.key, entry.path);
+
+    // Apply UI schema overrides
+    field.label = entry.label;
+    if (entry.widget) field.widget = entry.widget;
+    if (entry.props) field.props = entry.props;
+    if (entry.tooltip) field.tooltip = entry.tooltip;
+    if (entry.description) field.description = entry.description;
+
+    fields.push(field);
+  }
+
+  return fields;
+}

--- a/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
@@ -233,6 +233,7 @@ export function buildFieldDescriptors(
     if (entry.props) field.props = entry.props;
     if (entry.tooltip) field.tooltip = entry.tooltip;
     if (entry.description) field.description = entry.description;
+    if (entry.options) field.options = entry.options;
 
     // Suppress description when it's redundant with the label
     if (field.description) {

--- a/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
@@ -234,8 +234,57 @@ export function buildFieldDescriptors(
     if (entry.tooltip) field.tooltip = entry.tooltip;
     if (entry.description) field.description = entry.description;
 
+    // Suppress description when it's redundant with the label
+    if (field.description) {
+      field.description = cleanDescription(field.description, field.label);
+    }
+
     fields.push(field);
   }
 
   return fields;
+}
+
+/**
+ * Clean up description text:
+ * - Remove if it's essentially the same as the label
+ * - Strip backtick code artifacts (`true`, `false`, etc.)
+ * - Remove "When `true`," prefixes since the toggle makes it obvious
+ */
+function cleanDescription(description: string, label: string): string | undefined {
+  // Strip backtick code markers
+  let cleaned = description.replace(/`/g, '');
+
+  // Remove trailing period for comparison
+  const descNorm = cleaned
+    .toLowerCase()
+    .replace(/\.\s*$/, '')
+    .trim();
+  const labelNorm = label
+    .toLowerCase()
+    .replace(/\.\s*$/, '')
+    .trim();
+
+  // Suppress if description matches label
+  if (descNorm === labelNorm) return undefined;
+
+  // Suppress if description is just "<label>." with minor variation
+  if (descNorm.length <= labelNorm.length + 5 && descNorm.startsWith(labelNorm)) return undefined;
+
+  // Clean up "When `true`, ..." → just the action part
+  cleaned = cleaned.replace(/^When true,\s*/i, '');
+
+  // Clean up "Accepted values: ..." boilerplate
+  cleaned = cleaned.replace(/\s*Accepted values:.*?\./g, '');
+
+  // Clean up "Defaults to ..." boilerplate
+  cleaned = cleaned.replace(/\s*Defaults to .*?\.?$/g, '');
+
+  // Capitalize first letter after cleanup
+  cleaned = cleaned.replace(/^\w/, (c) => c.toUpperCase()).trim();
+
+  // If nothing meaningful left, suppress
+  if (cleaned.length < 5) return undefined;
+
+  return cleaned;
 }

--- a/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
+++ b/x-pack/platform/plugins/shared/lens/server/schema_walker.ts
@@ -234,6 +234,7 @@ export function buildFieldDescriptors(
     if (entry.tooltip) field.tooltip = entry.tooltip;
     if (entry.description) field.description = entry.description;
     if (entry.options) field.options = entry.options;
+    if (entry.defaultValue !== undefined) field.defaultValue = entry.defaultValue;
     if (entry.condition) field.condition = entry.condition;
 
     // Suppress description when it's redundant with the label

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/datatable.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/datatable.ts
@@ -13,6 +13,20 @@ export const datatableUISchema: UISchemaEntry[] = [
     path: 'styling.density.mode',
     label: i18n.translate('xpack.lens.table.densityLabel', { defaultMessage: 'Density' }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'compact',
+        label: i18n.translate('xpack.lens.table.densityCompact', { defaultMessage: 'Compact' }),
+      },
+      {
+        value: 'default',
+        label: i18n.translate('xpack.lens.table.densityNormal', { defaultMessage: 'Normal' }),
+      },
+      {
+        value: 'expanded',
+        label: i18n.translate('xpack.lens.table.densityExpanded', { defaultMessage: 'Expanded' }),
+      },
+    ],
   },
   {
     path: 'styling.density.height.header',

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/datatable.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/datatable.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { UISchemaEntry } from './types';
+
+export const datatableUISchema: UISchemaEntry[] = [
+  {
+    path: 'styling.density.mode',
+    label: i18n.translate('xpack.lens.table.densityLabel', { defaultMessage: 'Density' }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.density.height.header',
+    label: i18n.translate('xpack.lens.table.headerRowHeightLabel', {
+      defaultMessage: 'Max header cell lines',
+    }),
+    widget: 'rowHeight',
+    props: { maxLines: 5 },
+  },
+  {
+    path: 'styling.density.height.value',
+    label: i18n.translate('xpack.lens.table.bodyCellLinesLabel', {
+      defaultMessage: 'Body cell lines',
+    }),
+    widget: 'rowHeight',
+  },
+  {
+    path: 'styling.paging',
+    label: i18n.translate('xpack.lens.table.paginateTableLabel', {
+      defaultMessage: 'Paginate table',
+    }),
+    widget: 'paginationToggle',
+    tooltip: i18n.translate('xpack.lens.table.paginateTableTooltip', {
+      defaultMessage: 'Pagination is hidden if there are less than 10 items',
+    }),
+  },
+  {
+    path: 'styling.row_numbers.visible',
+    label: i18n.translate('xpack.lens.table.showRowNumbersLabel', {
+      defaultMessage: 'Show row numbers',
+    }),
+  },
+];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/gauge.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/gauge.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { UISchemaEntry } from './types';
+
+export const gaugeUISchema: UISchemaEntry[] = [
+  {
+    path: 'styling.shape.type',
+    label: i18n.translate('xpack.lens.gauge.shapeLabel', {
+      defaultMessage: 'Shape',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.shape.orientation',
+    label: i18n.translate('xpack.lens.gauge.orientationLabel', {
+      defaultMessage: 'Orientation',
+    }),
+    widget: 'buttonGroup',
+  },
+];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/gauge.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/gauge.ts
@@ -15,6 +15,26 @@ export const gaugeUISchema: UISchemaEntry[] = [
       defaultMessage: 'Shape',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'arc',
+        label: i18n.translate('xpack.lens.gauge.shapeArc', { defaultMessage: 'Arc' }),
+      },
+      {
+        value: 'circle',
+        label: i18n.translate('xpack.lens.gauge.shapeCircle', { defaultMessage: 'Circle' }),
+      },
+      {
+        value: 'semi_circle',
+        label: i18n.translate('xpack.lens.gauge.shapeSemiCircle', {
+          defaultMessage: 'Semi circle',
+        }),
+      },
+      {
+        value: 'bullet',
+        label: i18n.translate('xpack.lens.gauge.shapeBullet', { defaultMessage: 'Bullet' }),
+      },
+    ],
   },
   {
     path: 'styling.shape.orientation',
@@ -22,5 +42,19 @@ export const gaugeUISchema: UISchemaEntry[] = [
       defaultMessage: 'Orientation',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'horizontal',
+        label: i18n.translate('xpack.lens.gauge.orientationHorizontal', {
+          defaultMessage: 'Horizontal',
+        }),
+      },
+      {
+        value: 'vertical',
+        label: i18n.translate('xpack.lens.gauge.orientationVertical', {
+          defaultMessage: 'Vertical',
+        }),
+      },
+    ],
   },
 ];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/heatmap.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/heatmap.ts
@@ -28,6 +28,26 @@ export const heatmapUISchema: UISchemaEntry[] = [
       defaultMessage: 'X axis label orientation',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'horizontal',
+        label: i18n.translate('xpack.lens.heatmap.orientationHorizontal', {
+          defaultMessage: 'Horizontal',
+        }),
+      },
+      {
+        value: 'vertical',
+        label: i18n.translate('xpack.lens.heatmap.orientationVertical', {
+          defaultMessage: 'Vertical',
+        }),
+      },
+      {
+        value: 'angled',
+        label: i18n.translate('xpack.lens.heatmap.orientationAngled', {
+          defaultMessage: 'Angled',
+        }),
+      },
+    ],
   },
   {
     path: 'axis.x.title.visible',
@@ -66,6 +86,26 @@ export const heatmapUISchema: UISchemaEntry[] = [
       defaultMessage: 'Legend visibility',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'auto',
+        label: i18n.translate('xpack.lens.heatmap.legendVisibilityAuto', {
+          defaultMessage: 'Auto',
+        }),
+      },
+      {
+        value: 'visible',
+        label: i18n.translate('xpack.lens.heatmap.legendVisibilityShow', {
+          defaultMessage: 'Show',
+        }),
+      },
+      {
+        value: 'hidden',
+        label: i18n.translate('xpack.lens.heatmap.legendVisibilityHide', {
+          defaultMessage: 'Hide',
+        }),
+      },
+    ],
   },
   {
     path: 'legend.position',
@@ -79,6 +119,32 @@ export const heatmapUISchema: UISchemaEntry[] = [
     label: i18n.translate('xpack.lens.heatmap.legendSizeLabel', {
       defaultMessage: 'Legend size',
     }),
+    options: [
+      {
+        value: 'auto',
+        label: i18n.translate('xpack.lens.heatmap.legendSizeAuto', { defaultMessage: 'Auto' }),
+      },
+      {
+        value: 's',
+        label: i18n.translate('xpack.lens.heatmap.legendSizeSmall', { defaultMessage: 'Small' }),
+      },
+      {
+        value: 'm',
+        label: i18n.translate('xpack.lens.heatmap.legendSizeMedium', {
+          defaultMessage: 'Medium',
+        }),
+      },
+      {
+        value: 'l',
+        label: i18n.translate('xpack.lens.heatmap.legendSizeLarge', { defaultMessage: 'Large' }),
+      },
+      {
+        value: 'xl',
+        label: i18n.translate('xpack.lens.heatmap.legendSizeExtraLarge', {
+          defaultMessage: 'Extra large',
+        }),
+      },
+    ],
   },
   {
     path: 'legend.truncate_after_lines',

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/heatmap.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/heatmap.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { UISchemaEntry } from './types';
+
+export const heatmapUISchema: UISchemaEntry[] = [
+  // Style section
+  {
+    path: 'styling.cells.labels.visible',
+    label: i18n.translate('xpack.lens.heatmap.cellLabelsLabel', {
+      defaultMessage: 'Show cell labels',
+    }),
+  },
+  {
+    path: 'axis.x.labels.visible',
+    label: i18n.translate('xpack.lens.heatmap.xAxisLabelsVisibleLabel', {
+      defaultMessage: 'Show X axis labels',
+    }),
+  },
+  {
+    path: 'axis.x.labels.orientation',
+    label: i18n.translate('xpack.lens.heatmap.xAxisLabelsOrientationLabel', {
+      defaultMessage: 'X axis label orientation',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'axis.x.title.visible',
+    label: i18n.translate('xpack.lens.heatmap.xAxisTitleVisibleLabel', {
+      defaultMessage: 'Show X axis title',
+    }),
+  },
+  {
+    path: 'axis.x.title.text',
+    label: i18n.translate('xpack.lens.heatmap.xAxisTitleLabel', {
+      defaultMessage: 'X axis title',
+    }),
+  },
+  {
+    path: 'axis.y.labels.visible',
+    label: i18n.translate('xpack.lens.heatmap.yAxisLabelsVisibleLabel', {
+      defaultMessage: 'Show Y axis labels',
+    }),
+  },
+  {
+    path: 'axis.y.title.visible',
+    label: i18n.translate('xpack.lens.heatmap.yAxisTitleVisibleLabel', {
+      defaultMessage: 'Show Y axis title',
+    }),
+  },
+  {
+    path: 'axis.y.title.text',
+    label: i18n.translate('xpack.lens.heatmap.yAxisTitleLabel', {
+      defaultMessage: 'Y axis title',
+    }),
+  },
+  // Legend section
+  {
+    path: 'legend.visibility',
+    label: i18n.translate('xpack.lens.heatmap.legendVisibilityLabel', {
+      defaultMessage: 'Legend visibility',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'legend.position',
+    label: i18n.translate('xpack.lens.heatmap.legendPositionLabel', {
+      defaultMessage: 'Legend position',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'legend.size',
+    label: i18n.translate('xpack.lens.heatmap.legendSizeLabel', {
+      defaultMessage: 'Legend size',
+    }),
+  },
+  {
+    path: 'legend.truncate_after_lines',
+    label: i18n.translate('xpack.lens.heatmap.legendTruncateLabel', {
+      defaultMessage: 'Truncate legend after lines',
+    }),
+  },
+];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/index.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/index.ts
@@ -7,6 +7,12 @@
 
 import type { UISchemaEntry } from './types';
 import { datatableUISchema } from './datatable';
+import { xyUISchema } from './xy';
+import { heatmapUISchema } from './heatmap';
+import { partitionUISchema } from './partition';
+import { metricUISchema } from './metric';
+import { gaugeUISchema } from './gauge';
+import { tagcloudUISchema } from './tagcloud';
 
 export type { UISchemaEntry } from './types';
 export type { FieldDescriptor } from './types';
@@ -16,4 +22,10 @@ export type { FieldDescriptor } from './types';
  */
 export const uiSchemaRegistry: Record<string, UISchemaEntry[]> = {
   lnsDatatable: datatableUISchema,
+  lnsXY: xyUISchema,
+  lnsHeatmap: heatmapUISchema,
+  lnsPie: partitionUISchema,
+  lnsMetric: metricUISchema,
+  lnsGauge: gaugeUISchema,
+  lnsTagcloud: tagcloudUISchema,
 };

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/index.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/index.ts
@@ -15,7 +15,6 @@ import { gaugeUISchema } from './gauge';
 import { tagcloudUISchema } from './tagcloud';
 
 export type { UISchemaEntry } from './types';
-export type { FieldDescriptor } from './types';
 
 /**
  * Registry mapping visualization IDs to their UI schemas.

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/index.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UISchemaEntry } from './types';
+import { datatableUISchema } from './datatable';
+
+export type { UISchemaEntry } from './types';
+export type { FieldDescriptor } from './types';
+
+/**
+ * Registry mapping visualization IDs to their UI schemas.
+ */
+export const uiSchemaRegistry: Record<string, UISchemaEntry[]> = {
+  lnsDatatable: datatableUISchema,
+};

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/metric.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/metric.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { LENS_METRIC_STATE_DEFAULTS } from '@kbn/lens-common';
 import type { UISchemaEntry } from './types';
 
 export const metricUISchema: UISchemaEntry[] = [
@@ -15,6 +16,7 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Position',
     }),
     widget: 'buttonGroup',
+    defaultValue: LENS_METRIC_STATE_DEFAULTS.primaryPosition,
     options: [
       {
         value: 'top',
@@ -36,6 +38,7 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Value alignment',
     }),
     widget: 'buttonGroup',
+    defaultValue: LENS_METRIC_STATE_DEFAULTS.primaryAlign,
     options: [
       {
         value: 'left',
@@ -57,6 +60,7 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Font size',
     }),
     widget: 'buttonGroup',
+    defaultValue: 'auto', // maps to LENS_METRIC_STATE_DEFAULTS.valueFontMode ('default' → 'auto')
     options: [
       {
         value: 'auto',
@@ -74,6 +78,7 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Labels alignment',
     }),
     widget: 'buttonGroup',
+    defaultValue: LENS_METRIC_STATE_DEFAULTS.titlesTextAlign,
     options: [
       {
         value: 'left',
@@ -99,6 +104,7 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Secondary value alignment',
     }),
     widget: 'buttonGroup',
+    defaultValue: LENS_METRIC_STATE_DEFAULTS.secondaryAlign,
     options: [
       {
         value: 'left',
@@ -132,6 +138,7 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Icon position',
     }),
     widget: 'buttonGroup',
+    defaultValue: LENS_METRIC_STATE_DEFAULTS.iconAlign,
     options: [
       {
         value: 'left',

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/metric.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/metric.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { UISchemaEntry } from './types';
+
+export const metricUISchema: UISchemaEntry[] = [
+  {
+    path: 'styling.primary.position',
+    label: i18n.translate('xpack.lens.metric.appearancePopover.position', {
+      defaultMessage: 'Position',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.primary.value.alignment',
+    label: i18n.translate('xpack.lens.metric.appearancePopover.valueAlignment', {
+      defaultMessage: 'Value alignment',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.primary.value.sizing',
+    label: i18n.translate('xpack.lens.metric.appearancePopover.fontSize', {
+      defaultMessage: 'Font size',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.primary.labels.alignment',
+    label: i18n.translate('xpack.lens.metric.appearancePopover.labelsAlignment', {
+      defaultMessage: 'Labels alignment',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.secondary.value.alignment',
+    label: i18n.translate('xpack.lens.metric.appearancePopover.secondaryAlignment', {
+      defaultMessage: 'Secondary value alignment',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.icon.name',
+    label: i18n.translate('xpack.lens.metric.icon', {
+      defaultMessage: 'Icon',
+    }),
+  },
+  {
+    path: 'styling.icon.alignment',
+    label: i18n.translate('xpack.lens.metric.appearancePopover.iconPosition', {
+      defaultMessage: 'Icon position',
+    }),
+    widget: 'buttonGroup',
+  },
+];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/metric.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/metric.ts
@@ -15,6 +15,20 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Position',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'top',
+        label: i18n.translate('xpack.lens.metric.positionTop', { defaultMessage: 'Top' }),
+      },
+      {
+        value: 'middle',
+        label: i18n.translate('xpack.lens.metric.positionMiddle', { defaultMessage: 'Middle' }),
+      },
+      {
+        value: 'bottom',
+        label: i18n.translate('xpack.lens.metric.positionBottom', { defaultMessage: 'Bottom' }),
+      },
+    ],
   },
   {
     path: 'styling.primary.value.alignment',
@@ -22,6 +36,20 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Value alignment',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'left',
+        label: i18n.translate('xpack.lens.metric.alignmentLeft', { defaultMessage: 'Left' }),
+      },
+      {
+        value: 'center',
+        label: i18n.translate('xpack.lens.metric.alignmentCenter', { defaultMessage: 'Center' }),
+      },
+      {
+        value: 'right',
+        label: i18n.translate('xpack.lens.metric.alignmentRight', { defaultMessage: 'Right' }),
+      },
+    ],
   },
   {
     path: 'styling.primary.value.sizing',
@@ -29,6 +57,16 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Font size',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'auto',
+        label: i18n.translate('xpack.lens.metric.sizingAuto', { defaultMessage: 'Auto' }),
+      },
+      {
+        value: 'fill',
+        label: i18n.translate('xpack.lens.metric.sizingFill', { defaultMessage: 'Fill' }),
+      },
+    ],
   },
   {
     path: 'styling.primary.labels.alignment',
@@ -36,6 +74,24 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Labels alignment',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'left',
+        label: i18n.translate('xpack.lens.metric.labelsAlignmentLeft', { defaultMessage: 'Left' }),
+      },
+      {
+        value: 'center',
+        label: i18n.translate('xpack.lens.metric.labelsAlignmentCenter', {
+          defaultMessage: 'Center',
+        }),
+      },
+      {
+        value: 'right',
+        label: i18n.translate('xpack.lens.metric.labelsAlignmentRight', {
+          defaultMessage: 'Right',
+        }),
+      },
+    ],
   },
   {
     path: 'styling.secondary.value.alignment',
@@ -43,11 +99,31 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Secondary value alignment',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'left',
+        label: i18n.translate('xpack.lens.metric.secondaryAlignmentLeft', {
+          defaultMessage: 'Left',
+        }),
+      },
+      {
+        value: 'center',
+        label: i18n.translate('xpack.lens.metric.secondaryAlignmentCenter', {
+          defaultMessage: 'Center',
+        }),
+      },
+      {
+        value: 'right',
+        label: i18n.translate('xpack.lens.metric.secondaryAlignmentRight', {
+          defaultMessage: 'Right',
+        }),
+      },
+    ],
   },
   {
     path: 'styling.icon.name',
     label: i18n.translate('xpack.lens.metric.icon', {
-      defaultMessage: 'Icon',
+      defaultMessage: 'Icon decoration',
     }),
   },
   {
@@ -56,5 +132,15 @@ export const metricUISchema: UISchemaEntry[] = [
       defaultMessage: 'Icon position',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'left',
+        label: i18n.translate('xpack.lens.metric.iconAlignmentLeft', { defaultMessage: 'Left' }),
+      },
+      {
+        value: 'right',
+        label: i18n.translate('xpack.lens.metric.iconAlignmentRight', { defaultMessage: 'Right' }),
+      },
+    ],
   },
 ];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/partition.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/partition.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { UISchemaEntry } from './types';
+
+export const partitionUISchema: UISchemaEntry[] = [
+  // Style section — value display
+  {
+    path: 'styling.values.visible',
+    label: i18n.translate('xpack.lens.pie.valuesVisibleLabel', {
+      defaultMessage: 'Show values',
+    }),
+  },
+  {
+    path: 'styling.values.mode',
+    label: i18n.translate('xpack.lens.pie.valuesModeLabel', {
+      defaultMessage: 'Value format',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.values.percent_decimals',
+    label: i18n.translate('xpack.lens.pie.percentDecimalsLabel', {
+      defaultMessage: 'Decimal places',
+    }),
+  },
+  // Style section — labels (pie/donut specific)
+  {
+    path: 'styling.labels.visible',
+    label: i18n.translate('xpack.lens.pie.labelsVisibleLabel', {
+      defaultMessage: 'Show labels',
+    }),
+  },
+  {
+    path: 'styling.labels.position',
+    label: i18n.translate('xpack.lens.pie.labelsPositionLabel', {
+      defaultMessage: 'Label position',
+    }),
+    widget: 'buttonGroup',
+  },
+  // Style section — donut hole (pie/donut specific)
+  {
+    path: 'styling.donut_hole',
+    label: i18n.translate('xpack.lens.pie.donutHoleLabel', {
+      defaultMessage: 'Inner area size',
+    }),
+    widget: 'buttonGroup',
+  },
+  // Legend section
+  {
+    path: 'legend.visibility',
+    label: i18n.translate('xpack.lens.pie.legendVisibilityLabel', {
+      defaultMessage: 'Legend visibility',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'legend.nested',
+    label: i18n.translate('xpack.lens.pie.nestedLegendLabel', {
+      defaultMessage: 'Nested legend',
+    }),
+  },
+  {
+    path: 'legend.size',
+    label: i18n.translate('xpack.lens.pie.legendSizeLabel', {
+      defaultMessage: 'Legend size',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'legend.truncate_after_lines',
+    label: i18n.translate('xpack.lens.pie.legendTruncateLabel', {
+      defaultMessage: 'Max legend lines',
+    }),
+  },
+];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/partition.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/partition.ts
@@ -22,6 +22,18 @@ export const partitionUISchema: UISchemaEntry[] = [
       defaultMessage: 'Value format',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'absolute',
+        label: i18n.translate('xpack.lens.pie.valuesModeAbsolute', { defaultMessage: 'Value' }),
+      },
+      {
+        value: 'percentage',
+        label: i18n.translate('xpack.lens.pie.valuesModePercentage', {
+          defaultMessage: 'Percent',
+        }),
+      },
+    ],
   },
   {
     path: 'styling.values.percent_decimals',
@@ -42,6 +54,20 @@ export const partitionUISchema: UISchemaEntry[] = [
       defaultMessage: 'Label position',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'inside',
+        label: i18n.translate('xpack.lens.pie.labelsPositionInside', {
+          defaultMessage: 'Inside',
+        }),
+      },
+      {
+        value: 'outside',
+        label: i18n.translate('xpack.lens.pie.labelsPositionOutside', {
+          defaultMessage: 'Outside',
+        }),
+      },
+    ],
   },
   // Style section — donut hole (pie/donut specific)
   {
@@ -50,6 +76,24 @@ export const partitionUISchema: UISchemaEntry[] = [
       defaultMessage: 'Inner area size',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'none',
+        label: i18n.translate('xpack.lens.pie.donutHoleNone', { defaultMessage: 'None' }),
+      },
+      {
+        value: 's',
+        label: i18n.translate('xpack.lens.pie.donutHoleSmall', { defaultMessage: 'Small' }),
+      },
+      {
+        value: 'm',
+        label: i18n.translate('xpack.lens.pie.donutHoleMedium', { defaultMessage: 'Medium' }),
+      },
+      {
+        value: 'l',
+        label: i18n.translate('xpack.lens.pie.donutHoleLarge', { defaultMessage: 'Large' }),
+      },
+    ],
   },
   // Legend section
   {
@@ -58,6 +102,20 @@ export const partitionUISchema: UISchemaEntry[] = [
       defaultMessage: 'Legend visibility',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'auto',
+        label: i18n.translate('xpack.lens.pie.legendVisibilityAuto', { defaultMessage: 'Auto' }),
+      },
+      {
+        value: 'visible',
+        label: i18n.translate('xpack.lens.pie.legendVisibilityShow', { defaultMessage: 'Show' }),
+      },
+      {
+        value: 'hidden',
+        label: i18n.translate('xpack.lens.pie.legendVisibilityHide', { defaultMessage: 'Hide' }),
+      },
+    ],
   },
   {
     path: 'legend.nested',
@@ -71,6 +129,30 @@ export const partitionUISchema: UISchemaEntry[] = [
       defaultMessage: 'Legend size',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'auto',
+        label: i18n.translate('xpack.lens.pie.legendSizeAuto', { defaultMessage: 'Auto' }),
+      },
+      {
+        value: 's',
+        label: i18n.translate('xpack.lens.pie.legendSizeSmall', { defaultMessage: 'Small' }),
+      },
+      {
+        value: 'm',
+        label: i18n.translate('xpack.lens.pie.legendSizeMedium', { defaultMessage: 'Medium' }),
+      },
+      {
+        value: 'l',
+        label: i18n.translate('xpack.lens.pie.legendSizeLarge', { defaultMessage: 'Large' }),
+      },
+      {
+        value: 'xl',
+        label: i18n.translate('xpack.lens.pie.legendSizeExtraLarge', {
+          defaultMessage: 'Extra large',
+        }),
+      },
+    ],
   },
   {
     path: 'legend.truncate_after_lines',

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/tagcloud.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/tagcloud.ts
@@ -15,6 +15,26 @@ export const tagcloudUISchema: UISchemaEntry[] = [
       defaultMessage: 'Orientation',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'horizontal',
+        label: i18n.translate('xpack.lens.tagcloud.orientationHorizontal', {
+          defaultMessage: 'Horizontal',
+        }),
+      },
+      {
+        value: 'vertical',
+        label: i18n.translate('xpack.lens.tagcloud.orientationVertical', {
+          defaultMessage: 'Vertical',
+        }),
+      },
+      {
+        value: 'angled',
+        label: i18n.translate('xpack.lens.tagcloud.orientationAngled', {
+          defaultMessage: 'Angled',
+        }),
+      },
+    ],
   },
   {
     path: 'styling.font_size.min',

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/tagcloud.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/tagcloud.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { UISchemaEntry } from './types';
+
+export const tagcloudUISchema: UISchemaEntry[] = [
+  {
+    path: 'styling.orientation',
+    label: i18n.translate('xpack.lens.label.tagcloud.orientationLabel', {
+      defaultMessage: 'Orientation',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'styling.font_size.min',
+    label: i18n.translate('xpack.lens.label.tagcloud.minFontSizeLabel', {
+      defaultMessage: 'Minimum font size',
+    }),
+  },
+  {
+    path: 'styling.font_size.max',
+    label: i18n.translate('xpack.lens.label.tagcloud.maxFontSizeLabel', {
+      defaultMessage: 'Maximum font size',
+    }),
+  },
+  {
+    path: 'styling.caption.visible',
+    label: i18n.translate('xpack.lens.label.tagcloud.showLabel', {
+      defaultMessage: 'Show label',
+    }),
+  },
+];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
@@ -22,6 +22,8 @@ export interface UISchemaEntry {
   tooltip?: string;
   /** Description override (replaces Joi meta description) */
   description?: string;
+  /** Override option labels for enum/select fields. Keys are raw schema values, values are i18n'd labels. */
+  options?: Array<{ value: string; label: string }>;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
@@ -24,6 +24,8 @@ export interface UISchemaEntry {
   description?: string;
   /** Override option labels for enum/select fields. Keys are raw schema values, values are i18n'd labels. */
   options?: Array<{ value: string; label: string }>;
+  /** Default value when the field is not present in the visualization state */
+  defaultValue?: unknown;
   /** Condition that must be met for this field to be visible */
   condition?: FieldVisibilityCondition;
 }

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { FieldVisibilityCondition } from '../../common/schema_types';
+
 /**
  * UI schema entry — per-field overrides provided by visualization authors.
  * Acts as an allowlist: only fields listed here appear in the response.
@@ -26,41 +28,6 @@ export interface UISchemaEntry {
   options?: Array<{ value: string; label: string }>;
   /** Default value when the field is not present in the visualization state */
   defaultValue?: unknown;
-  /** Condition that must be met for this field to be visible */
-  condition?: FieldVisibilityCondition;
-}
-
-/**
- * Conditions controlling when a UI schema field is visible.
- * All specified conditions must be met (AND logic).
- */
-export interface FieldVisibilityCondition {
-  /** Show this field only when at least one layer matches one of these series types */
-  seriesTypes?: string[];
-  /** Show only when the X axis is time-based */
-  requiresTimeAxis?: boolean;
-  /** Show only when NO text-based (ES|QL) datasource is present */
-  excludeTextBased?: boolean;
-}
-
-/**
- * Ready-to-render field descriptor returned by the server endpoint.
- * The client uses this directly — no schema processing needed.
- */
-export interface FieldDescriptor {
-  path: string;
-  type: string;
-  label: string;
-  description?: string;
-  defaultValue?: unknown;
-  options?: Array<{ value: string; label: string }>;
-  min?: number;
-  max?: number;
-  required?: boolean;
-  widget?: string;
-  props?: Record<string, unknown>;
-  tooltip?: string;
-  children?: FieldDescriptor[];
   /** Condition that must be met for this field to be visible */
   condition?: FieldVisibilityCondition;
 }

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * UI schema entry — per-field overrides provided by visualization authors.
+ * Acts as an allowlist: only fields listed here appear in the response.
+ */
+export interface UISchemaEntry {
+  /** Dot-delimited path into the Joi schema, e.g. 'styling.density.mode' */
+  path: string;
+  /** Human-readable label (i18n) */
+  label: string;
+  /** Override widget type (e.g. 'buttonGroup', 'rowHeight', 'paginationToggle') */
+  widget?: string;
+  /** Extra props forwarded to the widget component */
+  props?: Record<string, unknown>;
+  /** Tooltip text */
+  tooltip?: string;
+  /** Description override (replaces Joi meta description) */
+  description?: string;
+}
+
+/**
+ * Ready-to-render field descriptor returned by the server endpoint.
+ * The client uses this directly — no schema processing needed.
+ */
+export interface FieldDescriptor {
+  path: string;
+  type: string;
+  label: string;
+  description?: string;
+  defaultValue?: unknown;
+  options?: Array<{ value: string; label: string }>;
+  min?: number;
+  max?: number;
+  required?: boolean;
+  widget?: string;
+  props?: Record<string, unknown>;
+  tooltip?: string;
+  children?: FieldDescriptor[];
+}

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/types.ts
@@ -24,6 +24,21 @@ export interface UISchemaEntry {
   description?: string;
   /** Override option labels for enum/select fields. Keys are raw schema values, values are i18n'd labels. */
   options?: Array<{ value: string; label: string }>;
+  /** Condition that must be met for this field to be visible */
+  condition?: FieldVisibilityCondition;
+}
+
+/**
+ * Conditions controlling when a UI schema field is visible.
+ * All specified conditions must be met (AND logic).
+ */
+export interface FieldVisibilityCondition {
+  /** Show this field only when at least one layer matches one of these series types */
+  seriesTypes?: string[];
+  /** Show only when the X axis is time-based */
+  requiresTimeAxis?: boolean;
+  /** Show only when NO text-based (ES|QL) datasource is present */
+  excludeTextBased?: boolean;
 }
 
 /**
@@ -44,4 +59,6 @@ export interface FieldDescriptor {
   props?: Record<string, unknown>;
   tooltip?: string;
   children?: FieldDescriptor[];
+  /** Condition that must be met for this field to be visible */
+  condition?: FieldVisibilityCondition;
 }

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/xy.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/xy.ts
@@ -44,12 +44,14 @@ export const xyUISchema: UISchemaEntry[] = [
     label: i18n.translate('xpack.lens.xy.showPartialBucketsLabel', {
       defaultMessage: 'Show partial buckets',
     }),
+    condition: { requiresTimeAxis: true },
   },
   {
     path: 'styling.overlays.current_time_marker.visible',
     label: i18n.translate('xpack.lens.xy.showCurrentTimeMarkerLabel', {
       defaultMessage: 'Show current time marker',
     }),
+    condition: { requiresTimeAxis: true },
   },
   // Styling — line/area interpolation
   {
@@ -58,6 +60,9 @@ export const xyUISchema: UISchemaEntry[] = [
       defaultMessage: 'Line interpolation',
     }),
     widget: 'buttonGroup',
+    condition: {
+      seriesTypes: ['line', 'area', 'area_stacked', 'area_percentage_stacked'],
+    },
     options: [
       {
         value: 'linear',
@@ -82,6 +87,9 @@ export const xyUISchema: UISchemaEntry[] = [
       defaultMessage: 'Points visibility',
     }),
     widget: 'buttonGroup',
+    condition: {
+      seriesTypes: ['line', 'area', 'area_stacked', 'area_percentage_stacked'],
+    },
     options: [
       {
         value: 'auto',
@@ -105,6 +113,9 @@ export const xyUISchema: UISchemaEntry[] = [
     }),
     widget: 'range',
     props: { min: 0.1, max: 1, step: 0.1 },
+    condition: {
+      seriesTypes: ['area', 'area_stacked', 'area_percentage_stacked'],
+    },
   },
   // Styling — bars
   {
@@ -112,6 +123,16 @@ export const xyUISchema: UISchemaEntry[] = [
     label: i18n.translate('xpack.lens.xy.barDataLabelsLabel', {
       defaultMessage: 'Show bar data labels',
     }),
+    condition: {
+      seriesTypes: [
+        'bar',
+        'bar_stacked',
+        'bar_percentage',
+        'bar_horizontal',
+        'bar_horizontal_stacked',
+        'bar_horizontal_percentage',
+      ],
+    },
   },
   // Styling — fitting
   {
@@ -120,6 +141,10 @@ export const xyUISchema: UISchemaEntry[] = [
       defaultMessage: 'Missing values',
     }),
     widget: 'buttonGroup',
+    condition: {
+      seriesTypes: ['line', 'area', 'area_stacked'],
+      excludeTextBased: true,
+    },
     options: [
       {
         value: 'none',

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/xy.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/xy.ts
@@ -16,6 +16,20 @@ export const xyUISchema: UISchemaEntry[] = [
       defaultMessage: 'Legend visibility',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'auto',
+        label: i18n.translate('xpack.lens.xy.legendVisibilityAuto', { defaultMessage: 'Auto' }),
+      },
+      {
+        value: 'visible',
+        label: i18n.translate('xpack.lens.xy.legendVisibilityShow', { defaultMessage: 'Show' }),
+      },
+      {
+        value: 'hidden',
+        label: i18n.translate('xpack.lens.xy.legendVisibilityHide', { defaultMessage: 'Hide' }),
+      },
+    ],
   },
   {
     path: 'legend.position',
@@ -44,6 +58,22 @@ export const xyUISchema: UISchemaEntry[] = [
       defaultMessage: 'Line interpolation',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'linear',
+        label: i18n.translate('xpack.lens.xy.interpolationLinear', { defaultMessage: 'Linear' }),
+      },
+      {
+        value: 'smooth',
+        label: i18n.translate('xpack.lens.xy.interpolationSmooth', { defaultMessage: 'Smooth' }),
+      },
+      {
+        value: 'stepped',
+        label: i18n.translate('xpack.lens.xy.interpolationStepped', {
+          defaultMessage: 'Stepped',
+        }),
+      },
+    ],
   },
   // Styling — points
   {
@@ -52,6 +82,20 @@ export const xyUISchema: UISchemaEntry[] = [
       defaultMessage: 'Points visibility',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'auto',
+        label: i18n.translate('xpack.lens.xy.pointsVisibilityAuto', { defaultMessage: 'Auto' }),
+      },
+      {
+        value: 'visible',
+        label: i18n.translate('xpack.lens.xy.pointsVisibilityShow', { defaultMessage: 'Show' }),
+      },
+      {
+        value: 'hidden',
+        label: i18n.translate('xpack.lens.xy.pointsVisibilityHide', { defaultMessage: 'Hide' }),
+      },
+    ],
   },
   // Styling — areas
   {
@@ -59,6 +103,8 @@ export const xyUISchema: UISchemaEntry[] = [
     label: i18n.translate('xpack.lens.xy.areaFillOpacityLabel', {
       defaultMessage: 'Area fill opacity',
     }),
+    widget: 'range',
+    props: { min: 0.1, max: 1, step: 0.1 },
   },
   // Styling — bars
   {
@@ -74,5 +120,35 @@ export const xyUISchema: UISchemaEntry[] = [
       defaultMessage: 'Missing values',
     }),
     widget: 'buttonGroup',
+    options: [
+      {
+        value: 'none',
+        label: i18n.translate('xpack.lens.xy.fittingNone', { defaultMessage: 'Hide' }),
+      },
+      {
+        value: 'zero',
+        label: i18n.translate('xpack.lens.xy.fittingZero', { defaultMessage: 'Zero' }),
+      },
+      {
+        value: 'linear',
+        label: i18n.translate('xpack.lens.xy.fittingLinear', { defaultMessage: 'Linear' }),
+      },
+      {
+        value: 'carry',
+        label: i18n.translate('xpack.lens.xy.fittingCarry', { defaultMessage: 'Last' }),
+      },
+      {
+        value: 'lookahead',
+        label: i18n.translate('xpack.lens.xy.fittingLookahead', { defaultMessage: 'Next' }),
+      },
+      {
+        value: 'average',
+        label: i18n.translate('xpack.lens.xy.fittingAverage', { defaultMessage: 'Average' }),
+      },
+      {
+        value: 'nearest',
+        label: i18n.translate('xpack.lens.xy.fittingNearest', { defaultMessage: 'Nearest' }),
+      },
+    ],
   },
 ];

--- a/x-pack/platform/plugins/shared/lens/server/ui_schemas/xy.ts
+++ b/x-pack/platform/plugins/shared/lens/server/ui_schemas/xy.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { UISchemaEntry } from './types';
+
+export const xyUISchema: UISchemaEntry[] = [
+  // Legend
+  {
+    path: 'legend.visibility',
+    label: i18n.translate('xpack.lens.xy.legendVisibilityLabel', {
+      defaultMessage: 'Legend visibility',
+    }),
+    widget: 'buttonGroup',
+  },
+  {
+    path: 'legend.position',
+    label: i18n.translate('xpack.lens.xy.legendPositionLabel', {
+      defaultMessage: 'Legend position',
+    }),
+    widget: 'buttonGroup',
+  },
+  // Styling — overlays
+  {
+    path: 'styling.overlays.partial_buckets.visible',
+    label: i18n.translate('xpack.lens.xy.showPartialBucketsLabel', {
+      defaultMessage: 'Show partial buckets',
+    }),
+  },
+  {
+    path: 'styling.overlays.current_time_marker.visible',
+    label: i18n.translate('xpack.lens.xy.showCurrentTimeMarkerLabel', {
+      defaultMessage: 'Show current time marker',
+    }),
+  },
+  // Styling — line/area interpolation
+  {
+    path: 'styling.interpolation',
+    label: i18n.translate('xpack.lens.xy.interpolationLabel', {
+      defaultMessage: 'Line interpolation',
+    }),
+    widget: 'buttonGroup',
+  },
+  // Styling — points
+  {
+    path: 'styling.points.visibility',
+    label: i18n.translate('xpack.lens.xy.pointsVisibilityLabel', {
+      defaultMessage: 'Points visibility',
+    }),
+    widget: 'buttonGroup',
+  },
+  // Styling — areas
+  {
+    path: 'styling.areas.fill_opacity',
+    label: i18n.translate('xpack.lens.xy.areaFillOpacityLabel', {
+      defaultMessage: 'Area fill opacity',
+    }),
+  },
+  // Styling — bars
+  {
+    path: 'styling.bars.data_labels.visible',
+    label: i18n.translate('xpack.lens.xy.barDataLabelsLabel', {
+      defaultMessage: 'Show bar data labels',
+    }),
+  },
+  // Styling — fitting
+  {
+    path: 'styling.fitting.type',
+    label: i18n.translate('xpack.lens.xy.fittingTypeLabel', {
+      defaultMessage: 'Missing values',
+    }),
+    widget: 'buttonGroup',
+  },
+];

--- a/x-pack/platform/plugins/shared/lens/tsconfig.json
+++ b/x-pack/platform/plugins/shared/lens/tsconfig.json
@@ -148,7 +148,8 @@
     "@kbn/as-code-shared-schemas",
     "@kbn/as-code-shared-telemetry",
     "@kbn/core-http-browser",
-    "@kbn/use-observable"
+    "@kbn/use-observable",
+    "@kbn/react-query"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

This PoC replaces hand-crafted per-visualization `FlyoutToolbarComponent` implementations with a single, auto-generated form system powered by `@kbn/config-schema` and `react-hook-form`.

 ### How it works

 1. Schema introspection: Walks existing `@kbn/config-schema` schemas from `kbn-lens-embeddable-utils/config_builder/schema/` server-side to produce UI schema descriptions (covering xy, metric, gauge, heatmap, datatable, pie, treemap, mosaic, waffle, tagcloud, region_map, legacy_metric)
 2. Auto-generated forms: Renders form fields automatically via `react-hook-form` in a flyout — range sliders, toggles, selects, button groups — with conditional visibility and default values
 3. Bidirectional transforms: Reuses existing config_builder/transforms/ to convert between API config and internal Lens visualization state
 4. Feature-flagged: Gated behind `lens.schemaFlyoutEditor` in `kibana.dev.yml` — a single switch in `visualization_toolbar.tsx` renders either the schema-driven flyout or the legacy component

 ### What's included

 - Server-side schema walker and `/api/lens/schema_descriptions` endpoint with `vizId` filtering
 - Tanstack Query integration for fetching schema descriptions
 - Shared schema types in `common/schema_types`
 - Compressed flyout layout with `FlyoutToolbar`
 - Conditional field visibility for chart-type-specific options
 - Support for optional fields (revertible dropdowns, default values)
 - Skeleton loading state during schema fetch

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



