### PR TITLE
[9.3] test: Fix flaky service map Scout accessibility test (#267960)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/service_map.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/service_map.ts
@@ -15,6 +15,21 @@ export class ServiceMapPage {
   public zoomOutBtn: Locator;
   public centerServiceMapBtn: Locator;
   public noServicesPlaceholder: Locator;
+  public serviceMapPopover: Locator;
+  public serviceMapPopoverContent: Locator;
+  public serviceMapPopoverTitle: Locator;
+  public serviceMapServiceDetailsButton: Locator;
+  public serviceMapFocusMapButton: Locator;
+  public serviceMapDependencyDetailsButton: Locator;
+  public serviceMapEdgeExploreTracesButton: Locator;
+  public serviceMapOptionsPanel: Locator;
+  public serviceMapFindInPageInput: Locator;
+  /**
+   * Native search `<input>` (`SERVICE_MAP_FIND_INPUT_ID`). Prefer this for fill/focus so React
+   * `onFocus` runs and find highlights sync (`service_map_find_in_page` gates on `isFocused`).
+   */
+  public serviceMapFindInPageNativeInput: Locator;
+  public serviceMapFindMatchSummary: Locator;
 
   constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
     this.serviceMap = page.testSubj.locator('serviceMap');
@@ -22,6 +37,23 @@ export class ServiceMapPage {
     this.zoomOutBtn = page.locator('button[aria-label="Zoom out"]');
     this.centerServiceMapBtn = page.testSubj.locator('centerServiceMap');
     this.noServicesPlaceholder = page.locator('.euiEmptyPrompt__content .euiTitle');
+    this.serviceMapPopover = page.testSubj.locator('serviceMapPopover');
+    this.serviceMapPopoverContent = page.testSubj.locator('serviceMapPopoverContent');
+    this.serviceMapPopoverTitle = page.testSubj.locator('serviceMapPopoverTitle');
+    this.serviceMapServiceDetailsButton = page.testSubj.locator(
+      'apmServiceContentsServiceDetailsButton'
+    );
+    this.serviceMapFocusMapButton = page.testSubj.locator('apmServiceContentsFocusMapButton');
+    this.serviceMapDependencyDetailsButton = page.testSubj.locator(
+      'apmDependencyContentsDependencyDetailsButton'
+    );
+    this.serviceMapEdgeExploreTracesButton = page.testSubj.locator(
+      'apmEdgeContentsOpenInDiscoverButton'
+    );
+    this.serviceMapOptionsPanel = page.testSubj.locator('serviceMapOptionsPanel');
+    this.serviceMapFindInPageInput = page.testSubj.locator('serviceMapControlsSearch');
+    this.serviceMapFindInPageNativeInput = page.locator('#serviceMapFindInPageInput');
+    this.serviceMapFindMatchSummary = page.testSubj.locator('serviceMapFindMatchSummary');
   }
 
   async gotoWithDateSelected(start: string, end: string) {
@@ -82,5 +114,306 @@ export class ServiceMapPage {
 
   async clickZoomOut() {
     await this.clickZoom('out');
+  }
+
+  async clickMapZoomIn() {
+    await this.zoomInBtnControl.click();
+  }
+
+  async clickMapZoomOut() {
+    await this.zoomOutBtnControl.click();
+  }
+
+  /**
+   * After fit view, the map animates; merging alert/SLO badges can also re-run layout + fitView (see graph.tsx).
+   * Wait briefly so clicks target the final node positions.
+   */
+  async settleServiceMapLayout() {
+    await this.serviceMapGraph.waitFor({ state: 'visible' });
+    await new Promise<void>((resolve) => setTimeout(resolve, 800));
+  }
+
+  async clickFitView() {
+    await this.fitViewBtn.click();
+    await this.settleServiceMapLayout();
+  }
+
+  /**
+   * Click handlers can no-op while nodes remount or the viewport is still animating after fit view / badge merge.
+   * Retries: dismiss, settle, click, until popover content is visible.
+   */
+  private async clickUntilPopoverVisible(clickFn: () => Promise<void>) {
+    const maxAttempts = 4;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      await this.dismissPopoverIfOpen();
+      await this.settleServiceMapLayout();
+      try {
+        await clickFn();
+        await this.serviceMapPopoverContent.waitFor({ state: 'visible', timeout: 15000 });
+        return;
+      } catch (err) {
+        if (attempt === maxAttempts - 1) {
+          throw err;
+        }
+      }
+    }
+  }
+
+  async openServiceNodePopover(serviceName: string) {
+    await this.clickUntilPopoverVisible(async () => {
+      await this.clickServiceNode(serviceName);
+    });
+  }
+
+  async openNodePopover(nodeId: string) {
+    await this.clickUntilPopoverVisible(async () => {
+      await this.clickNode(nodeId);
+    });
+  }
+
+  async openEdgePopover(edgeId: string) {
+    await this.clickUntilPopoverVisible(async () => {
+      await this.clickEdge(edgeId);
+    });
+  }
+
+  getNodeById(nodeId: string) {
+    return this.serviceMapGraph.locator(`[data-id="${nodeId}"]`);
+  }
+
+  /** Wrapper for a service node (icon, badges row, label). `data.id` on the map matches the service name in tests. */
+  getServiceNodeRoot(serviceName: string) {
+    return this.serviceMapGraph.getByTestId(`serviceMapNode-service-${serviceName}`);
+  }
+
+  /**
+   * Highlight frame around the active find-in-page match (`HighlightWrapper` when `isActiveSearchMatch`).
+   */
+  getActiveFindMatchHighlightFrame(serviceName: string) {
+    return this.getServiceNodeRoot(serviceName).locator(
+      'xpath=ancestor::*[@data-test-subj="serviceMapNodeSearchHighlightFrame"][1]'
+    );
+  }
+
+  /**
+   * The clickable/focusable service circle only. Prefer this over role+name: when shown, violated/degrading SLO
+   * badges can also be buttons whose accessible name includes the service name, so `getByRole('button', { name })`
+   * is ambiguous.
+   */
+  getServiceNode(serviceName: string) {
+    return this.getServiceNodeRoot(serviceName).getByTestId('serviceMapNodeServiceCircle');
+  }
+
+  getServiceNodeAlertsBadge(serviceName: string) {
+    return this.getServiceNodeRoot(serviceName).getByTestId('serviceMapNodeAlertsBadge');
+  }
+
+  async waitForNodeToLoad(nodeId: string) {
+    await this.getNodeById(nodeId).waitFor({ state: 'visible', timeout: EXTENDED_TIMEOUT });
+  }
+
+  async waitForServiceNodeToLoad(serviceName: string) {
+    const circle = this.getServiceNode(serviceName);
+    await circle.waitFor({ state: 'attached', timeout: EXTENDED_TIMEOUT });
+    await circle.waitFor({ state: 'visible', timeout: EXTENDED_TIMEOUT });
+  }
+
+  /**
+   * Stable handle on the edge stroke path (see `ServiceMapEdge` + `BaseEdge`); avoids the React Flow
+   * wrapper `[data-id]` which can detach briefly while the graph re-renders after fit view / badge merge.
+   */
+  getEdgeById(edgeId: string) {
+    return this.serviceMapGraph.getByTestId(`serviceMapEdge-${edgeId}`);
+  }
+
+  async waitForEdgeToLoad(edgeId: string) {
+    const edge = this.getEdgeById(edgeId);
+    await edge.waitFor({ state: 'attached', timeout: EXTENDED_TIMEOUT });
+    await edge.waitFor({ state: 'visible', timeout: EXTENDED_TIMEOUT });
+  }
+
+  /**
+   * Nodes and edges can unmount/remount while the map settles (fit view animation, badge API merge).
+   * Re-resolve locators each attempt to avoid "not attached to the DOM" flakes.
+   */
+  private async runWithDomRetry<T>(
+    description: string,
+    run: () => Promise<T>,
+    timeoutMs: number = EXTENDED_TIMEOUT
+  ): Promise<T> {
+    const start = Date.now();
+    let lastError: Error | undefined;
+    while (Date.now() - start < timeoutMs) {
+      try {
+        return await run();
+      } catch (e) {
+        lastError = e instanceof Error ? e : new Error(String(e));
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
+    }
+    throw lastError ?? new Error(`runWithDomRetry failed: ${description}`);
+  }
+
+  /**
+   * Clicks the node's real hit target (service circle or dependency diamond), not the React Flow
+   * wrapper. The wrapper's center often lands on `NodeLabel` (`pointer-events: none`), so the click
+   * passes through to the pane and never opens the popover.
+   */
+  async clickNode(nodeId: string) {
+    await this.runWithDomRetry(`clickNode ${nodeId}`, async () => {
+      const node = this.getNodeById(nodeId);
+      await node.waitFor({ state: 'attached', timeout: 10000 });
+      await node.waitFor({ state: 'visible', timeout: 10000 });
+      const circle = node.getByTestId('serviceMapNodeServiceCircle');
+      const diamond = node.getByTestId('serviceMapNodeDiamondHit');
+      if ((await circle.count()) > 0) {
+        const hit = circle;
+        await hit.scrollIntoViewIfNeeded();
+        await hit.click({ force: true, timeout: 15000 });
+      } else if ((await diamond.count()) > 0) {
+        const hit = diamond;
+        await hit.scrollIntoViewIfNeeded();
+        await hit.click({ force: true, timeout: 15000 });
+      } else {
+        await node.scrollIntoViewIfNeeded();
+        await node.click({ force: true, timeout: 15000 });
+      }
+    });
+  }
+
+  /** Click a service node by its service name (uses role + aria-label). */
+  async clickServiceNode(serviceName: string) {
+    await this.runWithDomRetry(`clickServiceNode ${serviceName}`, async () => {
+      const button = this.getServiceNode(serviceName);
+      await button.waitFor({ state: 'attached', timeout: 10000 });
+      await button.waitFor({ state: 'visible', timeout: 10000 });
+      await button.scrollIntoViewIfNeeded();
+      await button.click({ force: true, timeout: 15000 });
+    });
+  }
+
+  async clickEdge(edgeId: string) {
+    await this.runWithDomRetry(`clickEdge ${edgeId}`, async () => {
+      const edge = this.getEdgeById(edgeId);
+      await edge.waitFor({ state: 'attached', timeout: 10000 });
+      await edge.waitFor({ state: 'visible', timeout: 10000 });
+      await edge.scrollIntoViewIfNeeded();
+      await edge.click({ force: true, timeout: 15000 });
+    });
+  }
+
+  async waitForPopoverToBeVisible() {
+    await this.serviceMapPopover.waitFor({ state: 'visible', timeout: EXTENDED_TIMEOUT });
+    await this.serviceMapPopoverContent.waitFor({ state: 'visible', timeout: EXTENDED_TIMEOUT });
+  }
+
+  async waitForPopoverToBeHidden(options?: { timeout?: number }) {
+    await this.serviceMapPopoverContent.waitFor({
+      state: 'hidden',
+      timeout: options?.timeout ?? EXTENDED_TIMEOUT,
+    });
+  }
+
+  /** Dismiss any open popover (e.g. so a node is not covered). No-op if popover already hidden. */
+  async dismissPopoverIfOpen() {
+    await this.page.keyboard.press('Escape');
+    await this.waitForPopoverToBeHidden({ timeout: 2000 }).catch(() => {});
+  }
+
+  async getPopoverTitle() {
+    return this.serviceMapPopoverTitle.textContent();
+  }
+
+  async focusNodeAndWaitForFocus(nodeId: string) {
+    await this.waitForNodeToLoad(nodeId);
+    const node = this.getNodeById(nodeId);
+    const circle = node.getByTestId('serviceMapNodeServiceCircle');
+    const diamond = node.getByTestId('serviceMapNodeDiamondHit');
+    if ((await circle.count()) > 0) {
+      await circle.focus();
+    } else if ((await diamond.count()) > 0) {
+      await diamond.focus();
+    } else {
+      await node.getByRole('button').focus();
+    }
+    await this.page.waitForFunction(
+      (id) => {
+        const nodeEl = document.querySelector(`[data-id="${id}"]`);
+        const circleEl = nodeEl?.querySelector('[data-test-subj="serviceMapNodeServiceCircle"]');
+        const diamondEl = nodeEl?.querySelector('[data-test-subj="serviceMapNodeDiamondHit"]');
+        const buttonEl = circleEl ?? diamondEl ?? nodeEl?.querySelector('[role="button"]');
+        return (
+          buttonEl === document.activeElement ||
+          nodeEl === document.activeElement ||
+          (nodeEl?.contains(document.activeElement) ?? false)
+        );
+      },
+      nodeId,
+      { timeout: EXTENDED_TIMEOUT }
+    );
+  }
+
+  /** Focus a service node by service name (uses role + aria-label) and wait for focus. */
+  async focusServiceNodeAndWaitForFocus(serviceName: string) {
+    await this.waitForServiceNodeToLoad(serviceName);
+    const button = this.getServiceNode(serviceName);
+    await button.focus();
+    await this.page.waitForFunction(
+      (name: string) => {
+        const focused = document.activeElement;
+        if (!focused || !focused.getAttribute('aria-label')) return false;
+        return focused.getAttribute('aria-label')!.toLowerCase().includes(name.toLowerCase());
+      },
+      serviceName,
+      { timeout: EXTENDED_TIMEOUT }
+    );
+  }
+
+  /**
+   * Focus the node wrapper (element with data-id) so the document keydown handler
+   * sees activeElement.closest('[data-id]') and can open the popover on Enter/Space.
+   */
+  async focusNodeWrapperAndWaitForFocus(nodeId: string) {
+    await this.waitForNodeToLoad(nodeId);
+    const wrapper = this.getNodeById(nodeId);
+    await wrapper.focus();
+    await this.page.waitForFunction(
+      (id: string) => document.activeElement?.getAttribute('data-id') === id,
+      nodeId,
+      { timeout: EXTENDED_TIMEOUT }
+    );
+  }
+
+  async openPopoverWithKeyboard(nodeId: string, key: 'Enter' | ' ') {
+    await this.focusNodeAndWaitForFocus(nodeId);
+    const node = this.getNodeById(nodeId);
+    const circle = node.getByTestId('serviceMapNodeServiceCircle');
+    const diamond = node.getByTestId('serviceMapNodeDiamondHit');
+    if ((await circle.count()) > 0) {
+      await circle.press(key === ' ' ? 'Space' : key);
+    } else if ((await diamond.count()) > 0) {
+      await diamond.press(key === ' ' ? 'Space' : key);
+    } else {
+      await node.getByRole('button').press(key === ' ' ? 'Space' : key);
+    }
+    await this.waitForPopoverToBeVisible();
+  }
+
+  /**
+   * Open popover via keyboard for a service node. Focuses the node wrapper then dispatches keydown
+   * on document so the document listener (use_keyboard_navigation) runs; it uses activeElement
+   * (the focused wrapper) to find the node and open the popover. Dispatching on document avoids
+   * React Flow's node wrapper onKeyDown handling Enter/Space before our listener.
+   */
+  async openPopoverWithKeyboardForService(serviceName: string, key: 'Enter' | ' ') {
+    await this.waitForServiceNodeToLoad(serviceName);
+    await this.focusNodeWrapperAndWaitForFocus(serviceName);
+    const keyToSend = key === ' ' ? ' ' : 'Enter';
+    await this.page.evaluate((k: string) => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: k, code: k === ' ' ? 'Space' : 'Enter', bubbles: true })
+      );
+    }, keyToSend);
+    await this.waitForPopoverToBeVisible();
   }
 }

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_a11y.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_map/service_map_a11y.spec.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt/ui';
+import { tags } from '@kbn/scout-oblt';
+import { test, testData } from '../../fixtures';
+import { SERVICE_OPBEANS_JAVA } from '../../fixtures/constants';
+
+test.describe(
+  'Service map - accessibility',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth, pageObjects: { serviceMapPage } }) => {
+      await browserAuth.loginAsViewer();
+      await serviceMapPage.gotoWithDateSelected(testData.START_DATE, testData.END_DATE);
+      await serviceMapPage.waitForMapToLoad();
+      await serviceMapPage.dismissPopoverIfOpen();
+    });
+
+    test('axe-core automated accessibility checks pass', async ({ page }) => {
+      await test.step('service map container has no accessibility violations', async () => {
+        await page.testSubj.locator('serviceMapGraph').waitFor({ state: 'visible' });
+        const { violations } = await page.checkA11y({
+          include: ['[data-test-subj="serviceMapGraph"]'],
+        });
+        expect(violations).toHaveLength(0);
+      });
+
+      await test.step('service map controls have no accessibility violations', async () => {
+        const { violations } = await page.checkA11y({
+          include: ['[data-testid="rf__controls"]'],
+        });
+        expect(violations).toHaveLength(0);
+      });
+    });
+
+    test('focus management and visible indicators work correctly', async ({
+      page,
+      pageObjects: { serviceMapPage },
+    }) => {
+      await test.step('nodes have visible focus indicators when focused', async () => {
+        await serviceMapPage.waitForServiceNodeToLoad(SERVICE_OPBEANS_JAVA);
+        const node = serviceMapPage.getServiceNode(SERVICE_OPBEANS_JAVA);
+        await node.focus();
+        await expect(node).toBeFocused();
+      });
+
+      await test.step('find-in-page: highlight frame while focused, Enter centers match', async () => {
+        await serviceMapPage.focusBodyForMapShortcuts();
+        await serviceMapPage.openFindInPageWithKeyboardShortcut();
+        // Fill the real input (#serviceMapFindInPageInput) so EuiFieldSearch onFocus runs and
+        // highlight context updates (filling by layout test-subj alone can leave isFocused false).
+        await serviceMapPage.serviceMapFindInPageNativeInput.fill(SERVICE_OPBEANS_JAVA);
+        await expect(serviceMapPage.serviceMapFindMatchSummary).toHaveText(/[1-9]/);
+
+        // Highlights are driven only while the find field is focused; centering the map after Enter
+        // can move focus and clear highlights, so assert the frame before Enter.
+        const highlightFrame =
+          serviceMapPage.getActiveFindMatchHighlightFrame(SERVICE_OPBEANS_JAVA);
+        await expect(highlightFrame).toBeVisible();
+        await expect(highlightFrame).toHaveAttribute('data-search-active-match');
+
+        await serviceMapPage.serviceMapFindInPageNativeInput.press('Enter');
+        await serviceMapPage.settleServiceMapLayout();
+        await expect(serviceMapPage.serviceMapFindMatchSummary).toHaveText(/[1-9]/);
+      });
+
+      await test.step('zoom controls are keyboard accessible', async () => {
+        await serviceMapPage.clickFitView();
+        await expect(serviceMapPage.zoomInBtnControl).toBeVisible();
+        await expect(serviceMapPage.zoomOutBtnControl).toBeVisible();
+        await expect(serviceMapPage.fitViewBtn).toBeVisible();
+        await serviceMapPage.zoomInBtnControl.focus();
+        await page.keyboard.press('Enter');
+        await expect(serviceMapPage.mapControls).toBeVisible();
+      });
+    });
+
+    test('ARIA attributes are properly set for screen readers', async ({
+      page,
+      pageObjects: { serviceMapPage },
+    }) => {
+      await test.step('service map container has aria-label describing the content', async () => {
+        const serviceMapContainer = page.testSubj.locator('serviceMapGraph');
+        await expect(serviceMapContainer).toBeVisible();
+        await expect(serviceMapContainer).toHaveAttribute('aria-label', /Service map/);
+      });
+
+      await test.step('service nodes have proper role and aria-label', async () => {
+        await serviceMapPage.waitForServiceNodeToLoad(SERVICE_OPBEANS_JAVA);
+        const interactiveElement = serviceMapPage.getServiceNode(SERVICE_OPBEANS_JAVA);
+        await expect(interactiveElement).toHaveAttribute('role', 'button');
+        await expect(interactiveElement).toHaveAttribute('aria-label', /service/i);
+        await expect(interactiveElement).toHaveAttribute(
+          'aria-label',
+          new RegExp(SERVICE_OPBEANS_JAVA, 'i')
+        );
+      });
+
+      await test.step('polite live regions exist for keyboard announcements and find-in-page', async () => {
+        const serviceMapContainer = page.testSubj.locator('serviceMapGraph');
+        await expect(page.testSubj.locator('serviceMapControlsSearch')).toBeVisible();
+        const politeLiveRegions = serviceMapContainer.locator('[aria-live="polite"]');
+        await expect(politeLiveRegions).toHaveCount(2);
+        await expect(
+          serviceMapContainer.locator('[data-test-subj="serviceMapFindMatchSummary"]')
+        ).toHaveAttribute('aria-live', 'polite');
+      });
+    });
+  }
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [test: Fix flaky service map Scout accessibility test (#267960)](https://github.com/elastic/kibana/pull/267960)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2026-05-06T14:44:00Z","message":"test: Fix flaky service map Scout accessibility test (#267960)\n\n## Summary\n\n- Fixes the Scout failure tracked in\n[#262609](https://github.com/elastic/kibana/issues/262609):\n`service_map_a11y.spec.ts` expected `toBeFocused()` on the service\ncircle **after** typing in find-in-page. Focusing the node blurs the\nfind field; search highlights are intentionally cleared when the find\ninput loses focus (`isFocused`), which led to unstable focus/DOM during\nthe assertion.\n- Separates **node focus + focus ring** from **find-in-page**: focus the\ncircle without opening find first; cover find in its own step\n(`focusBodyForMapShortcuts`, ⌃K, fill, match summary, Enter to center,\nsettle).\n- **`expect(locator).toBeVisible()` on\n`serviceMapNodeSearchHighlightFrame` failed** even when the counter\nshowed `1/1` because highlight context only updates when React treats\nthe field as focused. `fill()` on\n`data-test-subj=\"serviceMapControlsSearch\"` targets the **layout\nwrapper**; the native input may receive keystrokes without reliably\nfiring `EuiFieldSearch` `onFocus`, so `isFocused` stayed false and\n**`serviceMapNodeSearchHighlightFrame` never rendered**. The test now\nfills and sends Enter via **`#serviceMapFindInPageInput`** (same element\nas `focusServiceMapFindInput()`).\n- Resolves the highlight frame from the service node root with an XPath\nancestor to `[data-test-subj=\"serviceMapNodeSearchHighlightFrame\"]`.\n- Asserts the highlight **before** Enter where possible: map centering\ncan steal focus and clear highlights per existing product behavior.\n\n## References\n\nCloses elastic/kibana#262609\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"7dfcaedda7cc9b0ffd3f09dad17ff2050ff33e6c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.3.0","v9.4.0","Team:obs-presentation","v9.5.0"],"title":"test: Fix flaky service map Scout accessibility test","number":267960,"url":"https://github.com/elastic/kibana/pull/267960","mergeCommit":{"message":"test: Fix flaky service map Scout accessibility test (#267960)\n\n## Summary\n\n- Fixes the Scout failure tracked in\n[#262609](https://github.com/elastic/kibana/issues/262609):\n`service_map_a11y.spec.ts` expected `toBeFocused()` on the service\ncircle **after** typing in find-in-page. Focusing the node blurs the\nfind field; search highlights are intentionally cleared when the find\ninput loses focus (`isFocused`), which led to unstable focus/DOM during\nthe assertion.\n- Separates **node focus + focus ring** from **find-in-page**: focus the\ncircle without opening find first; cover find in its own step\n(`focusBodyForMapShortcuts`, ⌃K, fill, match summary, Enter to center,\nsettle).\n- **`expect(locator).toBeVisible()` on\n`serviceMapNodeSearchHighlightFrame` failed** even when the counter\nshowed `1/1` because highlight context only updates when React treats\nthe field as focused. `fill()` on\n`data-test-subj=\"serviceMapControlsSearch\"` targets the **layout\nwrapper**; the native input may receive keystrokes without reliably\nfiring `EuiFieldSearch` `onFocus`, so `isFocused` stayed false and\n**`serviceMapNodeSearchHighlightFrame` never rendered**. The test now\nfills and sends Enter via **`#serviceMapFindInPageInput`** (same element\nas `focusServiceMapFindInput()`).\n- Resolves the highlight frame from the service node root with an XPath\nancestor to `[data-test-subj=\"serviceMapNodeSearchHighlightFrame\"]`.\n- Asserts the highlight **before** Enter where possible: map centering\ncan steal focus and clear highlights per existing product behavior.\n\n## References\n\nCloses elastic/kibana#262609\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"7dfcaedda7cc9b0ffd3f09dad17ff2050ff33e6c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267960","number":267960,"mergeCommit":{"message":"test: Fix flaky service map Scout accessibility test (#267960)\n\n## Summary\n\n- Fixes the Scout failure tracked in\n[#262609](https://github.com/elastic/kibana/issues/262609):\n`service_map_a11y.spec.ts` expected `toBeFocused()` on the service\ncircle **after** typing in find-in-page. Focusing the node blurs the\nfind field; search highlights are intentionally cleared when the find\ninput loses focus (`isFocused`), which led to unstable focus/DOM during\nthe assertion.\n- Separates **node focus + focus ring** from **find-in-page**: focus the\ncircle without opening find first; cover find in its own step\n(`focusBodyForMapShortcuts`, ⌃K, fill, match summary, Enter to center,\nsettle).\n- **`expect(locator).toBeVisible()` on\n`serviceMapNodeSearchHighlightFrame` failed** even when the counter\nshowed `1/1` because highlight context only updates when React treats\nthe field as focused. `fill()` on\n`data-test-subj=\"serviceMapControlsSearch\"` targets the **layout\nwrapper**; the native input may receive keystrokes without reliably\nfiring `EuiFieldSearch` `onFocus`, so `isFocused` stayed false and\n**`serviceMapNodeSearchHighlightFrame` never rendered**. The test now\nfills and sends Enter via **`#serviceMapFindInPageInput`** (same element\nas `focusServiceMapFindInput()`).\n- Resolves the highlight frame from the service node root with an XPath\nancestor to `[data-test-subj=\"serviceMapNodeSearchHighlightFrame\"]`.\n- Asserts the highlight **before** Enter where possible: map centering\ncan steal focus and clear highlights per existing product behavior.\n\n## References\n\nCloses elastic/kibana#262609\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"7dfcaedda7cc9b0ffd3f09dad17ff2050ff33e6c"}}]}] BACKPORT-->