### PR TITLE
[SLO] Fix list count mismatch when orphan summary documents exist

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/find_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/find_slo.test.ts
@@ -153,6 +153,48 @@ describe('FindSLO', () => {
     });
   });
 
+  describe('orphan summary documents (SDH #6202)', () => {
+    it('decrements total by the number of summary rows whose slo.id has no SO', async () => {
+      const slo = createSLO();
+      // Summary search reports 4 hits total; one row has a real SO, three are orphans.
+      mockSummarySearchClient.search.mockResolvedValueOnce({
+        total: 4,
+        perPage: 25,
+        page: 1,
+        results: [
+          summaryResultFor(slo),
+          summaryResultFor({ id: 'orphan-1' } as SLODefinition),
+          summaryResultFor({ id: 'orphan-2' } as SLODefinition),
+          summaryResultFor({ id: 'orphan-3' } as SLODefinition),
+        ],
+      });
+      mockRepository.findAllByIds.mockResolvedValueOnce([slo]);
+
+      const result = await findSLO.execute({});
+
+      expect(result.total).toBe(1);
+      expect(result.results).toHaveLength(1);
+    });
+
+    it('clamps total to 0 if every row on the page is an orphan', async () => {
+      mockSummarySearchClient.search.mockResolvedValueOnce({
+        total: 2,
+        perPage: 25,
+        page: 1,
+        results: [
+          summaryResultFor({ id: 'orphan-1' } as SLODefinition),
+          summaryResultFor({ id: 'orphan-2' } as SLODefinition),
+        ],
+      });
+      mockRepository.findAllByIds.mockResolvedValueOnce([]);
+
+      const result = await findSLO.execute({});
+
+      expect(result.total).toBe(0);
+      expect(result.results).toHaveLength(0);
+    });
+  });
+
   describe('validation', () => {
     beforeEach(() => {
       const slo = createSLO();
@@ -183,25 +225,27 @@ function summarySearchResult(slo: SLODefinition): Paginated<SummaryResult> {
     total: 1,
     perPage: 25,
     page: 1,
-    results: [
-      {
-        sloId: slo.id,
-        instanceId: slo.groupBy === ALL_VALUE ? ALL_VALUE : 'host-abcde',
-        groupings: {},
-        summary: {
-          status: 'HEALTHY',
-          sliValue: 0.9999,
-          errorBudget: {
-            initial: 0.001,
-            consumed: 0.1,
-            remaining: 0.9,
-            isEstimated: false,
-          },
-          fiveMinuteBurnRate: 0,
-          oneHourBurnRate: 0,
-          oneDayBurnRate: 0,
-        },
+    results: [summaryResultFor(slo)],
+  };
+}
+
+function summaryResultFor(slo: Pick<SLODefinition, 'id'> & Partial<SLODefinition>): SummaryResult {
+  return {
+    sloId: slo.id,
+    instanceId: slo.groupBy === ALL_VALUE ? ALL_VALUE : 'host-abcde',
+    groupings: {},
+    summary: {
+      status: 'HEALTHY',
+      sliValue: 0.9999,
+      errorBudget: {
+        initial: 0.001,
+        consumed: 0.1,
+        remaining: 0.9,
+        isEstimated: false,
       },
-    ],
+      fiveMinuteBurnRate: 0,
+      oneHourBurnRate: 0,
+      oneDayBurnRate: 0,
+    },
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/find_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/find_slo.ts
@@ -44,13 +44,19 @@ export class FindSLO {
         .map((summaryResult) => summaryResult.sloId)
     );
 
+    const results = mergeSloWithSummary(localSloDefinitions, summaryResults.results);
+    // Summary documents whose slo.id no longer maps to a saved object (orphans)
+    // are silently dropped by mergeSloWithSummary. Decrement total accordingly so
+    // the response is internally consistent for this page. SDH #6202.
+    const droppedOnThisPage = summaryResults.results.length - results.length;
+
     return findSLOResponseSchema.encode({
       page: 'page' in summaryResults ? summaryResults.page : DEFAULT_PAGE,
       perPage: 'perPage' in summaryResults ? summaryResults.perPage : DEFAULT_PER_PAGE,
       size: 'size' in summaryResults ? summaryResults.size : undefined,
       searchAfter: 'searchAfter' in summaryResults ? summaryResults.searchAfter : undefined,
-      total: summaryResults.total,
-      results: mergeSloWithSummary(localSloDefinitions, summaryResults.results),
+      total: Math.max(0, summaryResults.total - droppedOnThisPage),
+      results,
     });
   }
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
@@ -382,8 +382,8 @@ describe('UpdateSLO', () => {
 
       expectInstallationOfUpdatedSLOResources();
 
-      const errorMessages = mockLogger.error.mock.calls.map(([msg]) => String(msg));
-      expect(errorMessages).toEqual(
+      const warnMessages = mockLogger.warn.mock.calls.map(([msg]) => String(msg));
+      expect(warnMessages).toEqual(
         expect.arrayContaining([
           expect.stringContaining(
             `previous revision of SLO [id=${slo.id}, revision=${slo.revision}]`

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
@@ -360,6 +360,37 @@ describe('UpdateSLO', () => {
       expectInstallationOfUpdatedSLOResources();
       expectDeletionOfOriginalSLOResources(slo);
     });
+
+    // SDH #6202: previously the catch block in deleteOriginalSLO swallowed
+    // failures silently, leaving stale transforms running and feeding orphan
+    // summary documents into the summary index.
+    it('logs an error but does not throw when cleanup of the previous revision fails', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const originalRollupTransformId = getSLOTransformId(slo.id, slo.revision);
+      mockTransformManager.uninstall.mockImplementation(async (id) => {
+        if (id === originalRollupTransformId) {
+          throw new Error('boom: ES transient failure while uninstalling old transform');
+        }
+      });
+
+      await expect(
+        updateSLO.execute(slo.id, {
+          indicator: createAPMTransactionErrorRateIndicator(),
+        })
+      ).resolves.not.toThrow();
+
+      expectInstallationOfUpdatedSLOResources();
+
+      const errorMessages = mockLogger.error.mock.calls.map(([msg]) => String(msg));
+      expect(errorMessages).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(
+            `previous revision of SLO [id=${slo.id}, revision=${slo.revision}]`
+          ),
+        ])
+      );
+    });
   });
 
   describe('when error happens during the update', () => {

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -212,11 +212,10 @@ export class UpdateSLO {
       // Don't block the update on cleanup failures, but surface them in logs so
       // stale transforms and orphan summary documents become diagnosable.
       // SDH #6202.
-      this.logger.error(
+      this.logger.warn(
         `Failed to clean up resources for previous revision of SLO ` +
           `[id=${slo.id}, revision=${slo.revision}]. ` +
-          `Old transforms may continue producing stale summary documents ` +
-          `until the ${ORPHAN_CLEANUP_TASK_TYPE} task runs. ${err}`
+          `Old resources may continue producing data. ${err}`
       );
     }
   }

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -31,6 +31,7 @@ import { retryTransientEsErrors } from '../utils/retry';
 import type { SLODefinitionRepository } from './slo_definition_repository';
 import { createTempSummaryDocument } from './summary_transform_generator/helpers/create_temp_summary';
 import type { TransformManager } from './transform_manager';
+import { TYPE as ORPHAN_CLEANUP_TASK_TYPE } from './tasks/orphan_summary_cleanup_task/orphan_summary_cleanup_task';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
 
 export class UpdateSLO {
@@ -208,8 +209,15 @@ export class UpdateSLO {
 
       await Promise.all([this.deleteRollupData(slo), this.deleteSummaryData(slo)]);
     } catch (err) {
-      // Any errors here should not prevent moving forward.
-      // Worst case we keep rolling up data for the previous revision number.
+      // Don't block the update on cleanup failures, but surface them in logs so
+      // stale transforms and orphan summary documents become diagnosable.
+      // SDH #6202.
+      this.logger.error(
+        `Failed to clean up resources for previous revision of SLO ` +
+          `[id=${slo.id}, revision=${slo.revision}]. ` +
+          `Old transforms may continue producing stale summary documents ` +
+          `until the ${ORPHAN_CLEANUP_TASK_TYPE} task runs. ${err}`
+      );
     }
   }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -31,7 +31,6 @@ import { retryTransientEsErrors } from '../utils/retry';
 import type { SLODefinitionRepository } from './slo_definition_repository';
 import { createTempSummaryDocument } from './summary_transform_generator/helpers/create_temp_summary';
 import type { TransformManager } from './transform_manager';
-import { TYPE as ORPHAN_CLEANUP_TASK_TYPE } from './tasks/orphan_summary_cleanup_task/orphan_summary_cleanup_task';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
 
 export class UpdateSLO {


### PR DESCRIPTION
### Summary

When the `.slo-observability.summary-v3*` index contains summary documents whose `slo.id` no longer maps to any SLO saved object ("orphans"), `GET /api/observability/slos` reports a `total` that includes those rows even though `mergeSloWithSummary` filters them out of `results`. The list page header then reads "Showing 1-N of M" with `M > N`, and the missing rows appear to "disappear" from the UI on refresh. A customer hit this on 8.18.x with a mix of `sli.metric.timeslice` and custom-KQL SLOs.

This PR makes two changes:

1. **`find_slo.ts`** — decrement `total` by the number of rows dropped by `mergeSloWithSummary` on the current page so the response is internally consistent.
2. **`update_slo.ts deleteOriginalSLO`** — replace the silent `catch` with `logger.error`. Failures to clean up previous-revision rollup or summary transforms are otherwise invisible and produce stale summary documents faster than `orphan_summary_cleanup_task` can remove them.

### How to test
 **Unit tests**

```bash
node scripts/jest x-pack/solutions/observability/plugins/slo/server/services/find_slo.test.ts
node scripts/jest x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
```

**End-to-end (against a local dev cluster)**

1. Create a handful of SLOs (any indicator type — five `sli.metric.timeslice` SLOs grouped by a keyword field reproduce the customer's setup).
2. Hit `GET /api/observability/slos?perPage=100`. Confirm `total === results.length`.
3. Inject a fake summary document with a `slo.id` that doesn't exist as a saved object:

   ```
   POST .slo-observability.summary-v3.6/_doc?refresh=true
   {
     "spaceId": "default",
     "isTempDoc": false,
     "slo": {
       "id": "orphan-abc",
       "revision": 1,
       "instanceId": "*"
     },
     "summary": {
       "status": "HEALTHY"
     }
   }
   ```

4. Re-hit `GET /api/observability/slos?perPage=100`.
   - **With this PR:** `total === results.length` (the orphan is filtered out of both).
   - **On `main` before this PR:** `total === results.length + 1`.
5. Refresh the SLO list page. Header should still read "Showing 1-N of N".


<!--ONMERGE {"backportTargets":["8.18","8.19","9.3","9.4"]} ONMERGE-->