### PR TITLE
[Unified Search] Fix inconsistent filter-editor discard prompt

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/with_close_confirm_modal.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/with_close_confirm_modal.test.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Filter } from '@kbn/es-query';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { withCloseFilterEditorConfirmModal } from './with_close_confirm_modal';
+import type { WithCloseFilterEditorConfirmModalProps } from './with_close_confirm_modal';
+
+const phraseFilter = (value: string): Filter =>
+  ({
+    meta: {
+      index: 'my-index',
+      type: 'phrase',
+      key: 'host',
+      params: { query: value },
+      negate: false,
+      disabled: false,
+      alias: null,
+    },
+    query: { match_phrase: { host: value } },
+  } as Filter);
+
+// Approximates a FilterItem / AddFilterPopover consumer:
+//   - mounts the "editor" (renders `.filterEditor__hiddenItem`, the selector
+//     `reArmFocusTrap` uses to locate the popover's focus trap)
+//   - simulates an outside click via `pendingClickOutside`
+//   - simulates an edit via `shouldEdit`
+interface HarnessProps extends WithCloseFilterEditorConfirmModalProps {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  initialFilter: Filter;
+  editedFilter: Filter;
+  pendingClickOutside: boolean;
+  onClickOutsideHandled: () => void;
+  shouldEdit: boolean;
+  onEditHandled: () => void;
+}
+
+const Harness: React.FC<HarnessProps> = ({
+  isOpen,
+  setIsOpen,
+  initialFilter,
+  editedFilter,
+  onCloseFilterPopover,
+  onLocalFilterCreate,
+  onLocalFilterUpdate,
+  pendingClickOutside,
+  onClickOutsideHandled,
+  shouldEdit,
+  onEditHandled,
+}) => {
+  useEffect(() => {
+    if (!isOpen) return;
+    onLocalFilterCreate({
+      filter: initialFilter,
+      queryDslFilter: { queryDsl: '{}', customLabel: null },
+    });
+    onLocalFilterUpdate(initialFilter);
+  }, [isOpen, initialFilter, onLocalFilterCreate, onLocalFilterUpdate]);
+
+  useEffect(() => {
+    if (!shouldEdit) return;
+    onLocalFilterUpdate(editedFilter);
+    onEditHandled();
+  }, [shouldEdit, editedFilter, onLocalFilterUpdate, onEditHandled]);
+
+  useEffect(() => {
+    if (!pendingClickOutside) return;
+    onCloseFilterPopover([() => setIsOpen(false)]);
+    onClickOutsideHandled();
+  }, [pendingClickOutside, onCloseFilterPopover, setIsOpen, onClickOutsideHandled]);
+
+  return isOpen ? <div className="filterEditor__hiddenItem" data-test-subj="editor-open" /> : null;
+};
+
+const WrappedHarness = withCloseFilterEditorConfirmModal(Harness);
+
+interface DriverProps {
+  filter: Filter;
+  editedFilter: Filter;
+}
+
+const Driver: React.FC<DriverProps> = ({ filter, editedFilter }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [shouldEdit, setShouldEdit] = React.useState(false);
+  const [pendingClickOutside, setPendingClickOutside] = React.useState(false);
+
+  return (
+    <div>
+      <button data-test-subj="open" onClick={() => setIsOpen(true)} type="button">
+        open
+      </button>
+      <button data-test-subj="edit" onClick={() => setShouldEdit(true)} type="button">
+        edit
+      </button>
+      <button
+        data-test-subj="click-outside"
+        onClick={() => setPendingClickOutside(true)}
+        type="button"
+      >
+        click outside
+      </button>
+      <WrappedHarness
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        initialFilter={filter}
+        editedFilter={editedFilter}
+        pendingClickOutside={pendingClickOutside}
+        onClickOutsideHandled={() => setPendingClickOutside(false)}
+        shouldEdit={shouldEdit}
+        onEditHandled={() => setShouldEdit(false)}
+      />
+    </div>
+  );
+};
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe('withCloseFilterEditorConfirmModal', () => {
+  const original = phraseFilter('host-1');
+  const edited = phraseFilter('host-2');
+  const CONFIRM_MODAL = 'close-filter-editor-confirm-modal';
+
+  it('closes the popover silently when the user clicks outside without editing', async () => {
+    render(<Driver filter={original} editedFilter={edited} />);
+
+    fireEvent.click(screen.getByTestId('open'));
+    await flush();
+    fireEvent.click(screen.getByTestId('click-outside'));
+    await flush();
+
+    expect(screen.queryByTestId('editor-open')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(CONFIRM_MODAL)).not.toBeInTheDocument();
+  });
+
+  it('keeps the popover open and shows the discard-changes modal when the user edits and clicks outside', async () => {
+    render(<Driver filter={original} editedFilter={edited} />);
+
+    fireEvent.click(screen.getByTestId('open'));
+    await flush();
+    fireEvent.click(screen.getByTestId('edit'));
+    await flush();
+    fireEvent.click(screen.getByTestId('click-outside'));
+    await flush();
+
+    expect(screen.getByTestId('editor-open')).toBeInTheDocument();
+    expect(screen.getByTestId(CONFIRM_MODAL)).toBeInTheDocument();
+  });
+
+  it('dismisses the modal on "Keep editing" and leaves the popover open', async () => {
+    render(<Driver filter={original} editedFilter={edited} />);
+
+    fireEvent.click(screen.getByTestId('open'));
+    await flush();
+    fireEvent.click(screen.getByTestId('edit'));
+    await flush();
+    fireEvent.click(screen.getByTestId('click-outside'));
+    await flush();
+    fireEvent.click(screen.getByTestId('confirmModalCancelButton'));
+    await flush();
+
+    expect(screen.queryByTestId(CONFIRM_MODAL)).not.toBeInTheDocument();
+    expect(screen.getByTestId('editor-open')).toBeInTheDocument();
+  });
+
+  it('closes the popover on "Discard"', async () => {
+    render(<Driver filter={original} editedFilter={edited} />);
+
+    fireEvent.click(screen.getByTestId('open'));
+    await flush();
+    fireEvent.click(screen.getByTestId('edit'));
+    await flush();
+    fireEvent.click(screen.getByTestId('click-outside'));
+    await flush();
+    fireEvent.click(screen.getByTestId('confirmModalConfirmButton'));
+    await flush();
+
+    expect(screen.queryByTestId(CONFIRM_MODAL)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('editor-open')).not.toBeInTheDocument();
+  });
+
+  // Regression guard for the trap-stuck bug — without `reArmFocusTrap`,
+  // `onCloseFilterPopover` was never invoked on the second click because
+  // EuiPopover's focus trap had latched after the first one.
+  it('re-shows the modal on subsequent outside clicks after "Keep editing"', async () => {
+    render(<Driver filter={original} editedFilter={edited} />);
+
+    fireEvent.click(screen.getByTestId('open'));
+    await flush();
+    fireEvent.click(screen.getByTestId('edit'));
+    await flush();
+    fireEvent.click(screen.getByTestId('click-outside'));
+    await flush();
+    fireEvent.click(screen.getByTestId('confirmModalCancelButton'));
+    await flush();
+
+    fireEvent.click(screen.getByTestId('click-outside'));
+    await flush();
+
+    expect(screen.getByTestId(CONFIRM_MODAL)).toBeInTheDocument();
+  });
+});

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/with_close_confirm_modal.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/with_close_confirm_modal.test.tsx
@@ -190,9 +190,27 @@ describe('withCloseFilterEditorConfirmModal', () => {
     expect(screen.queryByTestId('editor-open')).not.toBeInTheDocument();
   });
 
-  // Regression guard for the trap-stuck bug — without `reArmFocusTrap`,
-  // `onCloseFilterPopover` was never invoked on the second click because
-  // EuiPopover's focus trap had latched after the first one.
+  // Regression guard: only `meta.negate` changes between original and edited
+  // filter (e.g. `exists` → `does not exist`, `is X` → `is not X`). The
+  // comparator must include `negate: true` to detect this.
+  it('shows the modal when only meta.negate is toggled', async () => {
+    const negated: Filter = {
+      ...original,
+      meta: { ...original.meta, negate: true },
+    };
+    render(<Driver filter={original} editedFilter={negated} />);
+
+    fireEvent.click(screen.getByTestId('open'));
+    await flush();
+    fireEvent.click(screen.getByTestId('edit'));
+    await flush();
+    fireEvent.click(screen.getByTestId('click-outside'));
+    await flush();
+
+    expect(screen.getByTestId(CONFIRM_MODAL)).toBeInTheDocument();
+    expect(screen.getByTestId('editor-open')).toBeInTheDocument();
+  });
+
   it('re-shows the modal on subsequent outside clicks after "Keep editing"', async () => {
     render(<Driver filter={original} editedFilter={edited} />);
 

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/with_close_confirm_modal.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/with_close_confirm_modal.tsx
@@ -51,12 +51,12 @@ export function withCloseFilterEditorConfirmModal<
 
     const onCancelModal = useCallback(() => {
       setShowConfirmModal(false);
-    }, [setShowConfirmModal]);
+    }, []);
 
     const onConfirmModal = useCallback(() => {
       setShowConfirmModal(false);
       actionsOnClose?.map((action) => action());
-    }, [actionsOnClose, setShowConfirmModal]);
+    }, [actionsOnClose]);
 
     const onCloseFilterPopover = useCallback(
       (actions?: Action[]) => {
@@ -77,7 +77,7 @@ export function withCloseFilterEditorConfirmModal<
           actions?.map((action) => action());
         }
       },
-      [originalFilter, updatedFilter, setShowConfirmModal, setActionsOnClose]
+      [originalFilter, updatedFilter]
     );
 
     return (

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/with_close_confirm_modal.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/with_close_confirm_modal.tsx
@@ -68,6 +68,7 @@ export function withCloseFilterEditorConfirmModal<
             (!isQueryDslFilter(updatedFilter) &&
               !compareFilters(originalFilter.filter, updatedFilter, {
                 index: true,
+                negate: true,
                 alias: true,
               })));
         if (filtersAreNotEqual) {

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_item/filter_item.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_item/filter_item.tsx
@@ -335,6 +335,7 @@ function FilterItemComponent(props: FilterItemProps) {
     panelProps: {
       css: styles.popoverDragAndDrop,
     },
+    focusTrapProps: { clickOutsideDisables: false },
   };
 
   return readOnly ? (

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/add_filter_popover.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/add_filter_popover.tsx
@@ -94,6 +94,7 @@ const AddFilterPopoverComponent = React.memo(function AddFilterPopover({
         ownFocus
         repositionOnScroll
         aria-label={strings.getAddFilterButtonLabel()}
+        focusTrapProps={{ clickOutsideDisables: false }}
       >
         <FilterEditorWrapper
           indexPatterns={indexPatterns}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -269,6 +269,9 @@ function QueryBarMenuComponent({
       aria-label={i18n.translate('unifiedSearch.queryBarMenu.popoverAriaLabel', {
         defaultMessage: 'Query bar menu',
       })}
+      focusTrapProps={
+        renderedComponent === 'addFilter' ? { clickOutsideDisables: false } : undefined
+      }
     >
       {renderComponent()}
     </EuiPopover>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/268712.

Two independent bugs made the filter editor's "discard or keep changes" prompt inconsistent. Both are fixed here.

- **Confirm modal only fired on the first outside click / Esc.** `EuiPopover` hardcodes `clickOutsideDisables: true` on its internal `EuiFocusTrap`, which latches the trap disabled on the first outside click and only resets on unmount. Since the discard-changes modal keeps the popover open, subsequent outside clicks were silently swallowed. Pass `focusTrapProps={{ clickOutsideDisables: false }}` to the three popovers that host a `FilterEditor` — `EuiPopover` spreads `focusTrapProps` after its hardcoded defaults, so this overrides via a public API (already used in markdown editor, controls display, and processor form popovers).
- **Negate-only toggles slipped past the change check.** `compareFilters` defaults `negate` to excluded, so switching `is X` ↔ `is not X` or `exists` ↔ `does not exist` looked equal to the original filter and the editor closed silently, dropping the in-progress edit. Add `negate: true` to the comparator options in `withCloseFilterEditorConfirmModal`.

Regression tests added in `with_close_confirm_modal.test.tsx` for both cases.

### Video

https://github.com/user-attachments/assets/f4c076a9-7636-4b7d-b632-31a101d5c92e

### How to test

1. Open a filter chip → **Edit filter**, change a value, click outside → modal appears. Pick **Keep editing**. Click outside again → modal appears again.
2. Same flow but press **Esc** instead of clicking outside.
3. Open a filter chip → **Edit filter**, toggle `exists` ↔ `does not exist` (or `is X` ↔ `is not X`), click outside → modal appears.
4. Repeat both flows from the top-level **Add filter** button and from the **Query menu → Add filter** panel.
5. Smoke in Graph Visualization (outside click on the graph canvas) — the surface where the trap-latch case was first reported.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Risk of breaking confirmation in all places that use KQL & DSL filters search bar.