### PR TITLE
[9.4] [Entity Analytics] Keep agent open when navigating to EA homepage (#266779)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
@@ -6,15 +6,23 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
+import type { UnknownAttachment } from '@kbn/agent-builder-common/attachments';
 import { CanvasFlyout } from './canvas_flyout';
 
 const mockCloseCanvas = jest.fn();
-let mockConversationId = 'conversation-1';
+const mockOpenSidebarConversation = jest.fn();
+let mockConversationId: string | undefined = 'conversation-1';
+let mockCanvasState: {
+  attachment: UnknownAttachment;
+  isSidebar: boolean;
+  version?: number;
+} | null = null;
 
 jest.mock('./canvas_context', () => ({
   useCanvasContext: () => ({
-    canvasState: null,
+    canvasState: mockCanvasState,
     closeCanvas: mockCloseCanvas,
     setCanvasAttachmentOrigin: jest.fn(),
     updateCanvasAttachment: jest.fn(),
@@ -39,13 +47,7 @@ jest.mock('../../../../../hooks/use_conversation', () => ({
 
 jest.mock('../../../../../hooks/use_agent_builder_service', () => ({
   useAgentBuilderServices: () => ({
-    openSidebarConversation: jest.fn(),
-  }),
-}));
-
-jest.mock('../../../../../hooks/use_persisted_conversation_id', () => ({
-  usePersistedConversationId: () => ({
-    updatePersistedConversationId: jest.fn(),
+    openSidebarConversation: mockOpenSidebarConversation,
   }),
 }));
 
@@ -58,6 +60,7 @@ describe('CanvasFlyout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockConversationId = 'conversation-1';
+    mockCanvasState = null;
   });
 
   it('closes canvas when conversation ID changes', () => {
@@ -78,5 +81,47 @@ describe('CanvasFlyout', () => {
     rerender(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
 
     expect(mockCloseCanvas).not.toHaveBeenCalled();
+  });
+
+  describe('openSidebarConversation prop forwarded to canvas content', () => {
+    // Fake canvas content with a button wired to `props.openSidebarConversation`. Clicking
+    // the button stands in for any real attachment-content control that wants to open the
+    // sidebar — letting the test assert what the closure does on invocation.
+    const TRIGGER_LABEL = 'fake-open-sidebar';
+
+    const renderWithFakeCanvas = ({ isSidebar = false }: { isSidebar?: boolean } = {}) => {
+      mockAttachmentsService.getAttachmentUiDefinition.mockReturnValue({
+        getLabel: () => 'Test attachment',
+        renderCanvasContent: (props: AttachmentRenderProps<UnknownAttachment>) => (
+          <button type="button" onClick={props.openSidebarConversation}>
+            {TRIGGER_LABEL}
+          </button>
+        ),
+      });
+      mockCanvasState = {
+        attachment: { id: 'attachment-1', type: 'test', data: {} },
+        isSidebar,
+      };
+      return render(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+    };
+
+    it('invokes openSidebarConversationInternal with the active conversationId when triggered from canvas content', () => {
+      renderWithFakeCanvas({ isSidebar: false });
+
+      fireEvent.click(screen.getByRole('button', { name: TRIGGER_LABEL }));
+
+      expect(mockOpenSidebarConversation).toHaveBeenCalledTimes(1);
+      expect(mockOpenSidebarConversation).toHaveBeenCalledWith({
+        conversationId: 'conversation-1',
+      });
+    });
+
+    it('does not invoke openSidebarConversationInternal when rendered inside the sidebar', () => {
+      renderWithFakeCanvas({ isSidebar: true });
+
+      fireEvent.click(screen.getByRole('button', { name: TRIGGER_LABEL }));
+
+      expect(mockOpenSidebarConversation).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -13,7 +13,6 @@ import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
 import { useConversationId } from '../../../../../context/conversation/use_conversation_id';
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
-import { usePersistedConversationId } from '../../../../../hooks/use_persisted_conversation_id';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
 import { AttachmentHeader } from './attachment_header';
 import { useCanvasContext } from './canvas_context';
@@ -40,15 +39,11 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
   const conversationId = useConversationId();
   const { conversationActions } = useConversationContext();
   const { openSidebarConversation: openSidebarConversationInternal } = useAgentBuilderServices();
-  const { updatePersistedConversationId } = usePersistedConversationId({});
   const isNarrowViewport = useIsWithinBreakpoints(['xs', 's', 'm']);
 
   const openSidebarConversation = useCallback(() => {
-    if (conversationId) {
-      updatePersistedConversationId(conversationId);
-    }
-    openSidebarConversationInternal();
-  }, [conversationId, updatePersistedConversationId, openSidebarConversationInternal]);
+    openSidebarConversationInternal({ conversationId });
+  }, [conversationId, openSidebarConversationInternal]);
 
   // Track previous conversation ID to detect changes
   const prevConversationIdRef = useRef(conversationId);

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -15,7 +15,6 @@ import { EuiSplitPanel } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
-import { usePersistedConversationId } from '../../../../../hooks/use_persisted_conversation_id';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
 import { AttachmentHeader } from './attachment_header';
 import { getAttachmentPreviewKey, useCanvasContext } from './canvas_context';
@@ -53,7 +52,6 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   } = useCanvasContext();
   const { conversationActions } = useConversationContext();
   const { openSidebarConversation: openSidebarConversationInternal } = useAgentBuilderServices();
-  const { updatePersistedConversationId } = usePersistedConversationId({});
 
   const openCanvas = useCallback(() => {
     openCanvasContext(attachment, isSidebar, version);
@@ -69,11 +67,8 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   );
 
   const openSidebarConversation = useCallback(() => {
-    if (conversationId) {
-      updatePersistedConversationId(conversationId);
-    }
-    openSidebarConversationInternal();
-  }, [conversationId, updatePersistedConversationId, openSidebarConversationInternal]);
+    openSidebarConversationInternal({ conversationId });
+  }, [conversationId, openSidebarConversationInternal]);
 
   const uiDefinition = attachmentsService.getAttachmentUiDefinition(attachment.type);
   const attachmentPreviewKey = getAttachmentPreviewKey(attachment.id, version);

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -58,13 +58,14 @@ import type {
   ConversationSidebarRef,
 } from './types';
 import type { EmbeddableConversationProps } from './embeddable/types';
-import type { OpenConversationSidebarOptions } from './sidebar/types';
+import type { OpenConversationSidebarOptions, OpenSidebarInternalOptions } from './sidebar/types';
 import {
   setSidebarServices,
   setSidebarRuntimeContext,
   clearSidebarRuntimeContext,
 } from './sidebar';
 import { createVisualizationAttachmentDefinition } from './application/components/attachments/visualization_attachment';
+import { storageKeys } from './application/storage_keys';
 
 export class AgentBuilderPlugin
   implements
@@ -169,8 +170,15 @@ export class AgentBuilderPlugin
     const hasAgentBuilder = core.application.capabilities.agentBuilder?.show === true;
     const sidebar = core.chrome.sidebar.getApp('agentBuilder');
 
-    const openSidebarInternal = (options?: OpenConversationSidebarOptions) => {
-      const config = options ?? this.conversationActiveConfig;
+    const openSidebarInternal = (options?: OpenSidebarInternalOptions) => {
+      const { conversationId, ...openOptions } = options ?? {};
+      const config =
+        Object.keys(openOptions).length > 0 ? openOptions : this.conversationActiveConfig;
+
+      if (conversationId) {
+        const storageKey = storageKeys.getLastConversationKey(config.sessionTag, config.agentId);
+        window?.localStorage?.setItem(storageKey, JSON.stringify(conversationId));
+      }
 
       // If already open, update props instead of creating new
       if (this.activeSidebarRef && this.sidebarCallbacks) {
@@ -222,7 +230,7 @@ export class AgentBuilderPlugin
       accessChecker,
       eventsService,
       isEarsEnabled: this.isEarsEnabled,
-      openSidebarConversation: (options?: OpenConversationSidebarOptions) => {
+      openSidebarConversation: (options?: OpenSidebarInternalOptions) => {
         return openSidebarInternal(options);
       },
     };

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
@@ -8,7 +8,7 @@
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import type { AgentBuilderAccessChecker } from './access/access';
 import type { AgentBuilderStartDependencies, OpenConversationSidebarReturn } from '../types';
-import type { OpenConversationSidebarOptions } from '../sidebar/types';
+import type { OpenSidebarInternalOptions } from '../sidebar/types';
 import type { AgentService } from './agents';
 import type { AttachmentsService } from './attachments';
 import type { ChatService } from './chat';
@@ -37,7 +37,5 @@ export interface AgentBuilderInternalService {
   accessChecker: AgentBuilderAccessChecker;
   eventsService: EventsService;
   isEarsEnabled: boolean;
-  openSidebarConversation: (
-    options?: OpenConversationSidebarOptions
-  ) => OpenConversationSidebarReturn;
+  openSidebarConversation: (options?: OpenSidebarInternalOptions) => OpenConversationSidebarReturn;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/public/sidebar/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/sidebar/types.ts
@@ -10,3 +10,11 @@ import type { EmbeddableConversationProps } from '../embeddable/types';
 export interface OpenConversationSidebarOptions extends EmbeddableConversationProps {
   onClose?: () => void;
 }
+
+export interface OpenSidebarInternalOptions extends OpenConversationSidebarOptions {
+  /**
+   * Conversation id to restore on open. The plugin persists it under the storage key
+   * derived from the resolved sidebar config (`sessionTag`/`agentId`)
+   */
+  conversationId?: string;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_agent_navigation_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_agent_navigation_context.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useCallback, useContext, useMemo } from 'react';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { APP_UI_ID } from '../../../common';
+import type {
+  SecurityAgentBuilderChrome,
+  EntityFlyoutRightPanel,
+} from './entity_explore_navigation';
+import {
+  navigateToEntityAnalyticsWithFlyoutInApp,
+  navigateToEntityAnalyticsHomePageInApp,
+} from './entity_explore_navigation';
+
+interface EntityAnalyticsAgentNavigationContextValue {
+  application?: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  searchSession?: ISessionService;
+}
+
+const EntityAnalyticsAgentNavigationContext =
+  createContext<EntityAnalyticsAgentNavigationContextValue>({});
+
+export const EntityAnalyticsAgentNavigationProvider: React.FC<
+  React.PropsWithChildren<EntityAnalyticsAgentNavigationContextValue>
+> = ({ application, agentBuilder, chrome, openSidebarConversation, searchSession, children }) => {
+  const value = useMemo<EntityAnalyticsAgentNavigationContextValue>(
+    () => ({ application, agentBuilder, chrome, openSidebarConversation, searchSession }),
+    [application, agentBuilder, chrome, openSidebarConversation, searchSession]
+  );
+  return (
+    <EntityAnalyticsAgentNavigationContext.Provider value={value}>
+      {children}
+    </EntityAnalyticsAgentNavigationContext.Provider>
+  );
+};
+
+interface EntityAnalyticsAgentNavigation {
+  canNavigate: boolean;
+  navigateWithFlyout: (flyout: { preview: unknown[]; right: EntityFlyoutRightPanel }) => void;
+  navigateToHome: (opts?: { watchlistId?: string; watchlistName?: string }) => void;
+}
+
+export const useEntityAnalyticsAgentNavigation = (): EntityAnalyticsAgentNavigation => {
+  const { application, agentBuilder, chrome, openSidebarConversation, searchSession } = useContext(
+    EntityAnalyticsAgentNavigationContext
+  );
+
+  const canNavigate = application != null;
+
+  const navigateWithFlyout = useCallback(
+    (flyout: { preview: unknown[]; right: EntityFlyoutRightPanel }) => {
+      if (!application) return;
+      navigateToEntityAnalyticsWithFlyoutInApp({
+        application,
+        appId: APP_UI_ID,
+        flyout,
+        agentBuilder,
+        chrome,
+        openSidebarConversation,
+        searchSession,
+      });
+    },
+    [application, agentBuilder, chrome, openSidebarConversation, searchSession]
+  );
+
+  const navigateToHome = useCallback(
+    (opts?: { watchlistId?: string; watchlistName?: string }) => {
+      if (!application) return;
+      navigateToEntityAnalyticsHomePageInApp({
+        application,
+        appId: APP_UI_ID,
+        agentBuilder,
+        chrome,
+        openSidebarConversation,
+        searchSession,
+        ...opts,
+      });
+    },
+    [application, agentBuilder, chrome, openSidebarConversation, searchSession]
+  );
+
+  return { canNavigate, navigateWithFlyout, navigateToHome };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.tsx
@@ -42,6 +42,7 @@ import {
   navigateToEntityAnalyticsHomePageInApp,
   type SecurityAgentBuilderChrome,
 } from './entity_explore_navigation';
+import { EntityAnalyticsAgentNavigationProvider } from './entity_analytics_agent_navigation_context';
 
 export type EntityAnalyticsDashboardAttachment = Attachment<
   typeof SecurityAgentBuilderAttachments.entityAnalyticsDashboard,
@@ -473,12 +474,7 @@ const EntityAnalyticsDashboardCanvasContent: React.FC<
           </EuiTitle>
           <EuiSpacer size="m" />
           {data.entities.length ? (
-            <EntityListTable
-              entities={data.entities}
-              application={application}
-              searchSession={searchSession}
-              closeCanvas={closeCanvas}
-            />
+            <EntityListTable entities={data.entities} closeCanvas={closeCanvas} />
           ) : (
             <EuiText size="s" color="subdued">
               {i18n.translate(
@@ -529,66 +525,76 @@ export const createEntityAnalyticsDashboardAttachmentDefinition = ({
   agentBuilder?: AgentBuilderPluginStart;
   chrome?: SecurityAgentBuilderChrome;
   searchSession?: ISessionService;
-}): AttachmentUIDefinition<EntityAnalyticsDashboardAttachment> => ({
-  getLabel: (attachment) =>
-    attachment.data.attachmentLabel ??
-    i18n.translate('xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.pillLabel', {
-      defaultMessage: 'Entity Analytics dashboard',
-    }),
-  getIcon: () => 'dashboardApp',
-  canvasWidth: EA_DASHBOARD_CANVAS_WIDTH,
-  renderInlineContent: (props) => <EntityAnalyticsDashboardInlineContent {...props} />,
-  renderCanvasContent: (props, { closeCanvas }) => (
-    <EntityAnalyticsDashboardCanvasContent
-      {...props}
-      application={application}
-      searchSession={searchSession}
-      closeCanvas={closeCanvas}
-    />
-  ),
-  getActionButtons: ({ attachment, openCanvas, isCanvas, openSidebarConversation }) => {
-    if (isCanvas) {
-      const data = attachment.data;
+}): AttachmentUIDefinition<EntityAnalyticsDashboardAttachment> => {
+  return {
+    getLabel: (attachment) =>
+      attachment.data.attachmentLabel ??
+      i18n.translate('xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.pillLabel', {
+        defaultMessage: 'Entity Analytics dashboard',
+      }),
+    getIcon: () => 'dashboardApp',
+    canvasWidth: EA_DASHBOARD_CANVAS_WIDTH,
+    renderInlineContent: (props) => <EntityAnalyticsDashboardInlineContent {...props} />,
+    renderCanvasContent: (props, { closeCanvas }) => (
+      <EntityAnalyticsAgentNavigationProvider
+        application={application}
+        agentBuilder={agentBuilder}
+        chrome={chrome}
+        openSidebarConversation={props.openSidebarConversation}
+        searchSession={searchSession}
+      >
+        <EntityAnalyticsDashboardCanvasContent
+          {...props}
+          application={application}
+          searchSession={searchSession}
+          closeCanvas={closeCanvas}
+        />
+      </EntityAnalyticsAgentNavigationProvider>
+    ),
+    getActionButtons: ({ attachment, openCanvas, isCanvas, openSidebarConversation }) => {
+      if (isCanvas) {
+        const data = attachment.data;
+        return [
+          {
+            label: i18n.translate(
+              'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.openInSecurity',
+              {
+                defaultMessage: 'Open Entity Analytics in Security',
+              }
+            ),
+            icon: 'popout',
+            type: ActionButtonType.SECONDARY,
+            handler: () => {
+              navigateToEntityAnalyticsHomePageInApp({
+                application,
+                appId: APP_UI_ID,
+                agentBuilder,
+                chrome,
+                openSidebarConversation,
+                watchlistId: data.watchlist_id,
+                watchlistName: data.watchlist_name,
+                searchSession,
+              });
+            },
+          },
+        ];
+      }
+      if (!openCanvas) {
+        return [];
+      }
       return [
         {
           label: i18n.translate(
-            'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.openInSecurity',
+            'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.preview',
             {
-              defaultMessage: 'Open Entity Analytics in Security',
+              defaultMessage: 'Preview',
             }
           ),
-          icon: 'popout',
+          icon: 'eye',
           type: ActionButtonType.SECONDARY,
-          handler: () => {
-            navigateToEntityAnalyticsHomePageInApp({
-              application,
-              appId: APP_UI_ID,
-              agentBuilder,
-              chrome,
-              openSidebarConversation,
-              watchlistId: data.watchlist_id,
-              watchlistName: data.watchlist_name,
-              searchSession,
-            });
-          },
+          handler: openCanvas,
         },
       ];
-    }
-    if (!openCanvas) {
-      return [];
-    }
-    return [
-      {
-        label: i18n.translate(
-          'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.preview',
-          {
-            defaultMessage: 'Preview',
-          }
-        ),
-        icon: 'eye',
-        type: ActionButtonType.SECONDARY,
-        handler: openCanvas,
-      },
-    ];
-  },
-});
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.test.tsx
@@ -259,25 +259,23 @@ describe('createEntityAttachmentDefinition', () => {
       const searchSession = { clear: jest.fn() } as unknown as ISessionService;
       const def = buildDefinition({ searchSession });
 
-      const suspenseElement = def.renderCanvasContent!(
+      const providerElement = def.renderCanvasContent!(
         renderProps,
         renderCallbacks
-      ) as ReactElement<{
-        children: ReactElement<{ searchSession?: ISessionService }>;
-      }>;
+      ) as ReactElement<{ searchSession?: ISessionService }>;
 
-      expect(suspenseElement.props.children.props.searchSession).toBe(searchSession);
+      expect(providerElement.props.searchSession).toBe(searchSession);
     });
 
     it('forwards searchSession into the inline content element', () => {
       const searchSession = { clear: jest.fn() } as unknown as ISessionService;
       const def = buildDefinition({ searchSession });
 
-      const suspenseElement = def.renderInlineContent!(renderProps) as ReactElement<{
-        children: ReactElement<{ searchSession?: ISessionService }>;
+      const providerElement = def.renderInlineContent!(renderProps) as ReactElement<{
+        searchSession?: ISessionService;
       }>;
 
-      expect(suspenseElement.props.children.props.searchSession).toBe(searchSession);
+      expect(providerElement.props.searchSession).toBe(searchSession);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.tsx
@@ -17,7 +17,6 @@ import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import type { ISessionService } from '@kbn/data-plugin/public';
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiSkeletonText } from '@elastic/eui';
 import type { ExperimentalFeatures } from '../../../../common/experimental_features';
-import { APP_UI_ID } from '../../../../common/constants';
 import type { EntityAttachment } from './types';
 import { isFlyoutCapableIdentifierType } from './types';
 import { normaliseEntityAttachment } from './payload';
@@ -28,6 +27,8 @@ import {
   navigateToEntityAnalyticsWithFlyoutInApp,
   type SecurityAgentBuilderChrome,
 } from '../entity_explore_navigation';
+import { EntityAnalyticsAgentNavigationProvider } from '../entity_analytics_agent_navigation_context';
+import { APP_UI_ID } from '../../../../common/constants';
 
 const DEFAULT_LABEL = i18n.translate(
   'xpack.securitySolution.agentBuilder.attachments.entity.label',
@@ -117,14 +118,20 @@ export const createEntityAttachmentDefinition = ({
     },
     getIcon: () => 'user',
     renderInlineContent: (props) => (
-      <React.Suspense fallback={<EuiSkeletonText lines={4} />}>
-        <LazyEntityAttachmentInlineContent
-          {...props}
-          experimentalFeatures={experimentalFeatures}
-          application={application}
-          searchSession={searchSession}
-        />
-      </React.Suspense>
+      <EntityAnalyticsAgentNavigationProvider
+        application={application}
+        agentBuilder={agentBuilder}
+        chrome={chrome}
+        openSidebarConversation={props.openSidebarConversation}
+        searchSession={searchSession}
+      >
+        <React.Suspense fallback={<EuiSkeletonText lines={4} />}>
+          <LazyEntityAttachmentInlineContent
+            {...props}
+            experimentalFeatures={experimentalFeatures}
+          />
+        </React.Suspense>
+      </EntityAnalyticsAgentNavigationProvider>
     ),
   };
 
@@ -139,25 +146,33 @@ export const createEntityAttachmentDefinition = ({
     ...baseDefinition,
     canvasWidth: ENTITY_CANVAS_WIDTH,
     renderCanvasContent: (props: AttachmentRenderProps<EntityAttachment>) => (
-      <React.Suspense
-        fallback={
-          <EuiFlexGroup alignItems="center" justifyContent="center" css={{ minHeight: 200 }}>
-            <EuiFlexItem grow={false}>
-              <EuiLoadingSpinner size="l" />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        }
+      <EntityAnalyticsAgentNavigationProvider
+        application={resolvedApplication}
+        agentBuilder={agentBuilder}
+        chrome={chrome}
+        openSidebarConversation={props.openSidebarConversation}
+        searchSession={searchSession}
       >
-        <LazyEntityAttachmentCanvasContent
-          {...props}
-          experimentalFeatures={experimentalFeatures}
-          application={resolvedApplication}
-          agentBuilder={agentBuilder}
-          chrome={chrome}
-          resolveSecurityCanvasContext={resolvedResolveCanvasContext}
-          searchSession={searchSession}
-        />
-      </React.Suspense>
+        <React.Suspense
+          fallback={
+            <EuiFlexGroup alignItems="center" justifyContent="center" css={{ minHeight: 200 }}>
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner size="l" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          }
+        >
+          <LazyEntityAttachmentCanvasContent
+            {...props}
+            experimentalFeatures={experimentalFeatures}
+            application={resolvedApplication}
+            agentBuilder={agentBuilder}
+            chrome={chrome}
+            resolveSecurityCanvasContext={resolvedResolveCanvasContext}
+            searchSession={searchSession}
+          />
+        </React.Suspense>
+      </EntityAnalyticsAgentNavigationProvider>
     ),
     getActionButtons: ({ attachment, isCanvas, openCanvas, openSidebarConversation }) => {
       const parsed = normaliseEntityAttachment(attachment);

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_inline_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_inline_content.tsx
@@ -11,8 +11,6 @@ import { EuiCallOut, EuiPanel, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { QueryClientProvider } from '@kbn/react-query';
 import type { AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
-import type { ApplicationStart } from '@kbn/core-application-browser';
-import type { ISessionService } from '@kbn/data-plugin/public';
 import type { ExperimentalFeatures } from '../../../../common/experimental_features';
 import { normaliseEntityAttachment } from './payload';
 import type { EntityAttachment } from './types';
@@ -23,13 +21,6 @@ import { entityAttachmentQueryClient } from './query_client';
 export interface EntityAttachmentInlineContentProps
   extends AttachmentRenderProps<EntityAttachment> {
   experimentalFeatures: ExperimentalFeatures;
-  /**
-   * Optional navigation context. When provided, `EntityTable` adds per-row Explore icons that
-   * deep-link into the Security Solution Hosts/Users/Services pages (mirrors the dashboard's
-   * `EntityListTable`). Without them the table renders without per-row navigation.
-   */
-  application?: ApplicationStart;
-  searchSession?: ISessionService;
 }
 
 /**
@@ -48,8 +39,6 @@ export const ENTITY_ATTACHMENT_ROOT_CLASS = 'securitySolutionEntityAttachment__r
 export const EntityAttachmentInlineContent: React.FC<EntityAttachmentInlineContentProps> = ({
   attachment,
   experimentalFeatures,
-  application,
-  searchSession,
 }) => {
   const parsed = normaliseEntityAttachment(attachment);
   const { euiTheme } = useEuiTheme();
@@ -124,15 +113,9 @@ export const EntityAttachmentInlineContent: React.FC<EntityAttachmentInlineConte
               resolutionRiskStats={parsed.resolutionRiskStats}
               watchlistsEnabled={watchlistsEnabled}
               privmonModifierEnabled={privmonModifierEnabled}
-              application={application}
-              searchSession={searchSession}
             />
           ) : (
-            <EntityTable
-              entities={parsed.entities}
-              application={application}
-              searchSession={searchSession}
-            />
+            <EntityTable entities={parsed.entities} />
           )}
         </QueryClientProvider>
       </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card.test.tsx
@@ -10,16 +10,15 @@ import { render, screen } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { EntityType } from '../../../../../common/entity_analytics/types';
 import { useEntityForAttachment, type EntityForAttachment } from '../use_entity_for_attachment';
+import { useEntityAnalyticsAgentNavigation } from '../../entity_analytics_agent_navigation_context';
 import { EntityCard } from './entity_card';
 
 jest.mock('../use_entity_for_attachment', () => ({
   useEntityForAttachment: jest.fn(),
 }));
 
-jest.mock('@kbn/kibana-react-plugin/public', () => ({
-  useKibana: () => ({
-    services: { application: { navigateToApp: jest.fn() } },
-  }),
+jest.mock('../../entity_analytics_agent_navigation_context', () => ({
+  useEntityAnalyticsAgentNavigation: jest.fn(),
 }));
 
 jest.mock('./resolution_mini', () => ({
@@ -62,6 +61,7 @@ jest.mock('./risk_summary_mini', () => ({
 }));
 
 const mockedUseEntityForAttachment = useEntityForAttachment as jest.Mock;
+const mockedUseEntityAnalyticsAgentNavigation = useEntityAnalyticsAgentNavigation as jest.Mock;
 
 const baseEntity = (override: Partial<EntityForAttachment> = {}): EntityForAttachment => ({
   entityType: EntityType.user,
@@ -110,6 +110,11 @@ const renderCard = (props: Partial<React.ComponentProps<typeof EntityCard>> = {}
 describe('EntityCard', () => {
   beforeEach(() => {
     mockedUseEntityForAttachment.mockReset();
+    mockedUseEntityAnalyticsAgentNavigation.mockReturnValue({
+      canNavigate: true,
+      navigateWithFlyout: jest.fn(),
+      navigateToHome: jest.fn(),
+    });
   });
 
   it('renders a skeleton while loading', () => {
@@ -127,6 +132,22 @@ describe('EntityCard', () => {
     renderCard();
     expect(screen.getByTestId('entityAttachmentCardError')).toBeInTheDocument();
     expect(screen.getByTestId('entityAttachmentCardActions')).toBeInTheDocument();
+  });
+
+  it('omits the actions button in the error case when navigation is not available', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      isLoading: false,
+      error: new Error('boom'),
+      data: undefined,
+    });
+    mockedUseEntityAnalyticsAgentNavigation.mockReturnValueOnce({
+      canNavigate: false,
+      navigateWithFlyout: jest.fn(),
+      navigateToHome: jest.fn(),
+    });
+    renderCard();
+    expect(screen.getByTestId('entityAttachmentCardError')).toBeInTheDocument();
+    expect(screen.queryByTestId('entityAttachmentCardActions')).not.toBeInTheDocument();
   });
 
   it('renders the rich layout for an entity that is in the store', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card.tsx
@@ -8,12 +8,11 @@
 import React, { useMemo } from 'react';
 import { EuiCallOut, EuiPanel, EuiSkeletonText, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { ApplicationStart } from '@kbn/core-application-browser';
-import type { ISessionService } from '@kbn/data-plugin/public';
 import type { RiskSeverity, RiskStats } from '../../../../../common/search_strategy';
 import { EntityType } from '../../../../../common/entity_analytics/types';
 import { useEntityForAttachment } from '../use_entity_for_attachment';
 import type { EntityAttachmentIdentifier, EntityAttachmentRiskStats } from '../types';
+import { useEntityAnalyticsAgentNavigation } from '../../entity_analytics_agent_navigation_context';
 import { IdentityHeader } from './identity_header';
 import { EntitySummaryGridMini } from './entity_summary_grid';
 import { RiskSummaryMini } from './risk_summary_mini';
@@ -37,17 +36,6 @@ interface EntityCardProps {
   resolutionRiskStats?: EntityAttachmentRiskStats;
   watchlistsEnabled: boolean;
   privmonModifierEnabled: boolean;
-  /**
-   * Optional core `ApplicationStart`. Forwarded to `EntityCardActions` so "Open in Entity
-   * Analytics" goes through the shared `navigateTo…InApp` helpers (which clear the search
-   * session before cross-app navigation) instead of a raw `navigateToApp` call.
-   */
-  application?: ApplicationStart;
-  /**
-   * Optional search session service. Forwarded to `EntityCardActions` to enable the
-   * session-clearing hook in the shared `navigateTo…InApp` helpers.
-   */
-  searchSession?: ISessionService;
 }
 
 /**
@@ -96,10 +84,9 @@ export const EntityCard: React.FC<EntityCardProps> = ({
   resolutionRiskStats: attachmentResolutionRiskStats,
   watchlistsEnabled,
   privmonModifierEnabled,
-  application,
-  searchSession,
 }) => {
   const { isLoading, error, data } = useEntityForAttachment(identifier);
+  const { canNavigate } = useEntityAnalyticsAgentNavigation();
 
   // Prefer attachment-supplied risk stats (full breakdown from the risk
   // index) over the entity-store-derived stats (score/level only). Falls
@@ -171,11 +158,7 @@ export const EntityCard: React.FC<EntityCardProps> = ({
           isEntityInStore={false}
           hasLastSeenDate={false}
         />
-        <EntityCardActions
-          identifier={identifier}
-          application={application}
-          searchSession={searchSession}
-        />
+        {canNavigate && <EntityCardActions identifier={identifier} />}
       </EuiPanel>
     );
   }
@@ -251,11 +234,7 @@ export const EntityCard: React.FC<EntityCardProps> = ({
           )}
         </>
       )}
-      <EntityCardActions
-        identifier={identifier}
-        application={application}
-        searchSession={searchSession}
-      />
+      <EntityCardActions identifier={identifier} />
     </EuiPanel>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.test.tsx
@@ -9,12 +9,14 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
 import { APP_UI_ID } from '../../../../../common/constants';
 import type { EntityAttachmentIdentifier } from '../types';
 import {
   navigateToEntityAnalyticsHomePageInApp,
   navigateToEntityAnalyticsWithFlyoutInApp,
 } from '../../entity_explore_navigation';
+import { EntityAnalyticsAgentNavigationProvider } from '../../entity_analytics_agent_navigation_context';
 import { EntityCardActions } from './entity_card_actions';
 
 jest.mock('../../entity_explore_navigation', () => {
@@ -26,12 +28,6 @@ jest.mock('../../entity_explore_navigation', () => {
   };
 });
 
-jest.mock('@kbn/kibana-react-plugin/public', () => ({
-  useKibana: () => ({
-    services: { application: { navigateToApp: jest.fn() } },
-  }),
-}));
-
 const mockedNavigateToHome = navigateToEntityAnalyticsHomePageInApp as jest.Mock;
 const mockedNavigateToFlyout = navigateToEntityAnalyticsWithFlyoutInApp as jest.Mock;
 
@@ -40,12 +36,17 @@ const buildApplicationMock = (): ApplicationStart =>
 
 const renderActions = (
   identifier: EntityAttachmentIdentifier,
-  extraProps: Partial<React.ComponentProps<typeof EntityCardActions>> = {}
+  providerProps: { application?: ApplicationStart; searchSession?: ISessionService } = {}
 ) => {
-  const application = extraProps.application ?? buildApplicationMock();
+  const application = providerProps.application ?? buildApplicationMock();
   const utils = render(
     <I18nProvider>
-      <EntityCardActions identifier={identifier} application={application} {...extraProps} />
+      <EntityAnalyticsAgentNavigationProvider
+        application={application}
+        searchSession={providerProps.searchSession}
+      >
+        <EntityCardActions identifier={identifier} />
+      </EntityAnalyticsAgentNavigationProvider>
     </I18nProvider>
   );
   return { ...utils, application };

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.tsx
@@ -8,33 +8,12 @@
 import React, { useCallback, useMemo } from 'react';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
-import type { ApplicationStart } from '@kbn/core-application-browser';
-import type { ISessionService } from '@kbn/data-plugin/public';
-import { APP_UI_ID } from '../../../../../common/constants';
 import type { EntityAttachmentIdentifier } from '../types';
-import {
-  buildEntityRightPanel,
-  navigateToEntityAnalyticsHomePageInApp,
-  navigateToEntityAnalyticsWithFlyoutInApp,
-} from '../../entity_explore_navigation';
+import { buildEntityRightPanel } from '../../entity_explore_navigation';
+import { useEntityAnalyticsAgentNavigation } from '../../entity_analytics_agent_navigation_context';
 
 interface EntityCardActionsProps {
   identifier: EntityAttachmentIdentifier;
-  /**
-   * Optional core `ApplicationStart`. When provided, the "Open in Entity Analytics" button
-   * routes through the shared `navigateTo…InApp` helpers, which clear any active
-   * Agent Builder-tagged search session before the cross-app jump. When omitted, falls back
-   * to `useKibana()` so existing call sites / tests without an explicit `application` prop
-   * keep working.
-   */
-  application?: ApplicationStart;
-  /**
-   * Optional search session service. Forwarded to the shared `navigateTo…InApp` helpers
-   * so the active search session tagged with `appName: 'agent_builder'` is cleared before
-   * the legitimate cross-app navigation to `securitySolutionUI`.
-   */
-  searchSession?: ISessionService;
 }
 
 const OPEN_IN_ENTITY_ANALYTICS_LABEL = i18n.translate(
@@ -56,37 +35,23 @@ const OPEN_ENTITY_ANALYTICS_LABEL = i18n.translate(
  * the label from "Open in Entity Analytics" to "Open Entity Analytics" so
  * the copy matches the navigation target.
  */
-export const EntityCardActions: React.FC<EntityCardActionsProps> = ({
-  identifier,
-  application,
-  searchSession,
-}) => {
-  const { services } = useKibana<{ application: ApplicationStart }>();
-  const effectiveApplication = application ?? services.application;
+export const EntityCardActions: React.FC<EntityCardActionsProps> = ({ identifier }) => {
+  const { canNavigate, navigateWithFlyout, navigateToHome } = useEntityAnalyticsAgentNavigation();
 
   const rightPanel = useMemo(() => buildEntityRightPanel(identifier), [identifier]);
-
   const label = rightPanel ? OPEN_IN_ENTITY_ANALYTICS_LABEL : OPEN_ENTITY_ANALYTICS_LABEL;
 
   const handleOpenEntityAnalytics = useCallback(() => {
-    if (!effectiveApplication) {
-      return;
+    if (!canNavigate) {
+      return null;
     }
+
     if (rightPanel) {
-      navigateToEntityAnalyticsWithFlyoutInApp({
-        application: effectiveApplication,
-        appId: APP_UI_ID,
-        searchSession,
-        flyout: { preview: [], right: rightPanel },
-      });
-      return;
+      navigateWithFlyout({ preview: [], right: rightPanel });
+    } else {
+      navigateToHome();
     }
-    navigateToEntityAnalyticsHomePageInApp({
-      application: effectiveApplication,
-      appId: APP_UI_ID,
-      searchSession,
-    });
-  }, [effectiveApplication, rightPanel, searchSession]);
+  }, [canNavigate, navigateWithFlyout, navigateToHome, rightPanel]);
 
   return (
     <div data-test-subj="entityAttachmentCardActions">

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.test.tsx
@@ -10,7 +10,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { EntityType } from '../../../../../common/entity_analytics/types';
 import type { EntityForAttachment } from '../use_entity_for_attachment';
 import { useEntityForAttachment } from '../use_entity_for_attachment';
@@ -18,14 +17,11 @@ import {
   navigateToEntityAnalyticsHomePageInApp,
   navigateToEntityAnalyticsWithFlyoutInApp,
 } from '../../entity_explore_navigation';
+import { EntityAnalyticsAgentNavigationProvider } from '../../entity_analytics_agent_navigation_context';
 import { EntityTable } from './entity_table';
 
 jest.mock('../use_entity_for_attachment', () => ({
   useEntityForAttachment: jest.fn(),
-}));
-
-jest.mock('@kbn/kibana-react-plugin/public', () => ({
-  useKibana: jest.fn(),
 }));
 
 jest.mock('../../entity_explore_navigation', () => {
@@ -38,7 +34,6 @@ jest.mock('../../entity_explore_navigation', () => {
 });
 
 const mockedUseEntityForAttachment = useEntityForAttachment as jest.Mock;
-const mockedUseKibana = useKibana as jest.Mock;
 const mockedNavigateToFlyout = navigateToEntityAnalyticsWithFlyoutInApp as jest.Mock;
 const mockedNavigateToHome = navigateToEntityAnalyticsHomePageInApp as jest.Mock;
 
@@ -57,25 +52,34 @@ const baseEntityData = (override: Partial<EntityForAttachment> = {}): EntityForA
   ...override,
 });
 
-const renderTable = (props: Partial<React.ComponentProps<typeof EntityTable>> = {}) =>
-  render(
+const renderTable = (
+  props: Partial<React.ComponentProps<typeof EntityTable>> & {
+    application?: ApplicationStart;
+    searchSession?: ISessionService;
+  } = {}
+) => {
+  const { application, searchSession, ...tableProps } = props;
+  return render(
     <I18nProvider>
-      <EntityTable
-        entities={[
-          { identifierType: 'host', identifier: 'host-1' },
-          { identifierType: 'user', identifier: 'bob' },
-        ]}
-        {...props}
-      />
+      <EntityAnalyticsAgentNavigationProvider
+        application={application}
+        searchSession={searchSession}
+      >
+        <EntityTable
+          entities={[
+            { identifierType: 'host', identifier: 'host-1' },
+            { identifierType: 'user', identifier: 'bob' },
+          ]}
+          {...tableProps}
+        />
+      </EntityAnalyticsAgentNavigationProvider>
     </I18nProvider>
   );
+};
 
 describe('EntityTable', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseKibana.mockReturnValue({
-      services: { application: { navigateToApp: jest.fn() } },
-    });
     mockedUseEntityForAttachment.mockReturnValue({
       data: baseEntityData(),
       isLoading: false,
@@ -97,16 +101,12 @@ describe('EntityTable', () => {
   });
 
   describe('per-row Explore button', () => {
-    it('does not render when no application prop or kibana.services.application is available', () => {
-      // Simulates the embedding environment where the attachment is rendered outside
-      // `KibanaContextProvider`: `useKibana().services.application` is undefined and no
-      // `application` prop is passed, so per-row Explore must be hidden.
-      mockedUseKibana.mockReturnValue({ services: {} });
+    it('does not render when no application is provided to the navigation provider', () => {
       renderTable({ entities: [{ identifierType: 'host', identifier: 'host-1' }] });
       expect(screen.queryAllByTestId('entityAttachmentTableOpenEntity')).toHaveLength(0);
     });
 
-    it('renders when application is passed explicitly', () => {
+    it('renders when application is provided to the navigation provider', () => {
       const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
       renderTable({ application });
       const buttons = screen.getAllByTestId('entityAttachmentTableOpenEntity');

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.tsx
@@ -21,10 +21,6 @@ import {
 import type { Criteria, EuiBasicTableColumn } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
-import type { ApplicationStart } from '@kbn/core-application-browser';
-import type { ISessionService } from '@kbn/data-plugin/public';
-import { APP_UI_ID, ENTITY_ANALYTICS_PATH } from '../../../../../common/constants';
 import { EntityType } from '../../../../../common/entity_analytics/types';
 import { AssetCriticalityBadge } from '../../../../entity_analytics/components/asset_criticality/asset_criticality_badge';
 import { RiskScoreCell } from '../../../../entity_analytics/components/home/entities_table/risk_score_cell';
@@ -36,26 +32,11 @@ import { useEntityForAttachment } from '../use_entity_for_attachment';
 import type { EntityForAttachment } from '../use_entity_for_attachment';
 import type { EntityAttachmentIdentifier } from '../types';
 import { formatEntitySource } from './entity_data_source_utils';
-import {
-  buildEntityRightPanel,
-  navigateToEntityAnalyticsHomePageInApp,
-  navigateToEntityAnalyticsWithFlyoutInApp,
-} from '../../entity_explore_navigation';
+import { buildEntityRightPanel } from '../../entity_explore_navigation';
+import { useEntityAnalyticsAgentNavigation } from '../../entity_analytics_agent_navigation_context';
 
 export interface EntityTableProps {
   entities: EntityAttachmentIdentifier[];
-  /**
-   * When provided, the Name column renders a per-row Explore icon that deep-links into the
-   * Security Solution Hosts/Users/Services page for that entity (mirrors the dashboard
-   * `EntityListTable`). Omit in tests or environments without Kibana routing.
-   */
-  application?: ApplicationStart;
-  /**
-   * Optional search session service. Forwarded to the shared `navigateTo…InApp` helpers so the
-   * active Agent Builder-tagged search session is cleared before the cross-app jump into the
-   * Entity Analytics flyout.
-   */
-  searchSession?: ISessionService;
 }
 
 interface EntityRow {
@@ -253,14 +234,8 @@ const EntityDataSourceBadges: React.FC<{
   );
 };
 
-export const EntityTable: React.FC<EntityTableProps> = ({
-  entities,
-  application,
-  searchSession,
-}) => {
-  const { services } = useKibana<{ application: ApplicationStart }>();
-  const exploreApplication = application ?? services.application;
-  const canExplorePerRow = exploreApplication != null;
+export const EntityTable: React.FC<EntityTableProps> = ({ entities }) => {
+  const { canNavigate, navigateWithFlyout, navigateToHome } = useEntityAnalyticsAgentNavigation();
   const [pageIndex, setPageIndex] = useState(0);
   const [rowsByKey, setRowsByKey] = useState<Record<string, EntityRow>>({});
 
@@ -312,14 +287,15 @@ export const EntityTable: React.FC<EntityTableProps> = ({
   );
 
   const handleOpenEntityAnalytics = useCallback(() => {
-    services.application?.navigateToApp(APP_UI_ID, { path: ENTITY_ANALYTICS_PATH });
-  }, [services.application]);
+    navigateToHome();
+  }, [navigateToHome]);
 
   const handleOpenEntity = useCallback(
     (row: EntityRow) => {
-      if (!exploreApplication) {
+      if (!canNavigate) {
         return;
       }
+
       const entityStoreId = row.data?.entityId ?? row.identifier.entityStoreId;
       const displayName = row.data?.displayName ?? row.identifier.identifier;
       const rightPanel = buildEntityRightPanel({
@@ -328,21 +304,12 @@ export const EntityTable: React.FC<EntityTableProps> = ({
         entityStoreId,
       });
       if (rightPanel) {
-        navigateToEntityAnalyticsWithFlyoutInApp({
-          application: exploreApplication,
-          appId: APP_UI_ID,
-          flyout: { preview: [], right: rightPanel },
-          searchSession,
-        });
-        return;
+        navigateWithFlyout({ preview: [], right: rightPanel });
+      } else {
+        navigateToHome();
       }
-      navigateToEntityAnalyticsHomePageInApp({
-        application: exploreApplication,
-        appId: APP_UI_ID,
-        searchSession,
-      });
     },
-    [exploreApplication, searchSession]
+    [canNavigate, navigateWithFlyout, navigateToHome]
   );
 
   const columns = useMemo<Array<EuiBasicTableColumn<EntityRow>>>(
@@ -359,7 +326,7 @@ export const EntityTable: React.FC<EntityTableProps> = ({
             ] ?? 'globe';
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-              {canExplorePerRow && (
+              {canNavigate && (
                 <EuiFlexItem grow={false}>
                   <EuiButtonIcon
                     iconType={icon}
@@ -447,7 +414,7 @@ export const EntityTable: React.FC<EntityTableProps> = ({
         width: '140px',
       },
     ],
-    [canExplorePerRow, handleOpenEntity]
+    [canNavigate, handleOpenEntity]
   );
 
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
@@ -161,7 +162,10 @@ describe('entity_explore_navigation', () => {
     });
   });
 
-  describe('search session clearing on cross-app navigation', () => {
+  describe('navigation helpers', () => {
+    const EA_HOME_PATH = '/app/security/entity_analytics_home_page';
+    const OTHER_PATH = '/app/security/alerts';
+
     const buildApplicationMock = (): jest.Mocked<ApplicationStart> =>
       ({
         navigateToApp: jest.fn(),
@@ -169,6 +173,23 @@ describe('entity_explore_navigation', () => {
 
     const buildSearchSessionMock = (): jest.Mocked<Pick<ISessionService, 'clear'>> => ({
       clear: jest.fn(),
+    });
+
+    const buildChromeMock = (sidebarAppId: string | null = 'agentBuilder') =>
+      ({
+        sidebar: { getCurrentAppId: () => sidebarAppId },
+      } as never);
+
+    const buildAgentBuilderNavigationMock = (): jest.Mocked<
+      Pick<AgentBuilderPluginStart, 'toggleChat' | 'openChat'>
+    > => ({
+      toggleChat: jest.fn(),
+      openChat: jest.fn(),
+    });
+
+    beforeEach(() => {
+      // Reset to a non-EA path so tests that set their own pathname don't bleed into each other.
+      window.history.replaceState({}, '', OTHER_PATH);
     });
 
     describe('navigateToEntityAnalyticsWithFlyoutInApp', () => {
@@ -179,7 +200,7 @@ describe('entity_explore_navigation', () => {
         window.history.replaceState(
           {},
           '',
-          `/app/security/entity_analytics_home_page?cspq=${encodeURIComponent(
+          `${EA_HOME_PATH}?cspq=${encodeURIComponent(
             risonQuery
           )}&watchlistId=wl-123&watchlistName=VIPs&groupBy=resolution`
         );
@@ -202,7 +223,7 @@ describe('entity_explore_navigation', () => {
         expect(params.get('flyout')).toContain('right');
       });
 
-      it('clears the search session before navigateToApp is called', () => {
+      it('clears the search session before navigateToApp is called (cross-app)', () => {
         const application = buildApplicationMock();
         const searchSession = buildSearchSessionMock();
 
@@ -232,10 +253,57 @@ describe('entity_explore_navigation', () => {
         ).not.toThrow();
         expect(application.navigateToApp).toHaveBeenCalledTimes(1);
       });
+
+      describe('when already on the EA home page', () => {
+        beforeEach(() => {
+          window.history.replaceState({}, '', EA_HOME_PATH);
+        });
+
+        it('still navigates to update the flyout URL param', () => {
+          const application = buildApplicationMock();
+
+          navigateToEntityAnalyticsWithFlyoutInApp({
+            application,
+            appId: 'securitySolutionUI',
+            flyout: { right: { id: 'host-panel', params: { hostName: 'web-01' } } },
+          });
+
+          expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not close the sidebar', () => {
+          const application = buildApplicationMock();
+          const agentBuilder = buildAgentBuilderNavigationMock();
+
+          navigateToEntityAnalyticsWithFlyoutInApp({
+            application,
+            appId: 'securitySolutionUI',
+            flyout: { right: { id: 'host-panel', params: { hostName: 'web-01' } } },
+            agentBuilder: agentBuilder as unknown as AgentBuilderPluginStart,
+            chrome: buildChromeMock(),
+          });
+
+          expect(agentBuilder.toggleChat).not.toHaveBeenCalled();
+        });
+
+        it('does not clear the search session', () => {
+          const application = buildApplicationMock();
+          const searchSession = buildSearchSessionMock();
+
+          navigateToEntityAnalyticsWithFlyoutInApp({
+            application,
+            appId: 'securitySolutionUI',
+            flyout: { right: { id: 'host-panel', params: { hostName: 'web-01' } } },
+            searchSession: searchSession as unknown as ISessionService,
+          });
+
+          expect(searchSession.clear).not.toHaveBeenCalled();
+        });
+      });
     });
 
     describe('navigateToEntityAnalyticsHomePageInApp', () => {
-      it('clears the search session before navigateToApp is called', () => {
+      it('clears the search session before navigateToApp is called (cross-app)', () => {
         const application = buildApplicationMock();
         const searchSession = buildSearchSessionMock();
 
@@ -262,6 +330,102 @@ describe('entity_explore_navigation', () => {
           })
         ).not.toThrow();
         expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+      });
+
+      describe('fallback when openSidebarConversation is not provided', () => {
+        const AGENT_BUILDER_AGENT_ID_KEY = 'agentBuilder.agentId';
+
+        beforeEach(() => {
+          window.localStorage.removeItem(AGENT_BUILDER_AGENT_ID_KEY);
+        });
+
+        afterEach(() => {
+          jest.useRealTimers();
+        });
+
+        it('opens chat via agentBuilder.openChat with sessionTag: security and the stored agentId', () => {
+          jest.useFakeTimers();
+          const application = buildApplicationMock();
+          const agentBuilder = buildAgentBuilderNavigationMock();
+          const storedAgentId = 'my-agent';
+          window.localStorage.setItem(AGENT_BUILDER_AGENT_ID_KEY, JSON.stringify(storedAgentId));
+
+          navigateToEntityAnalyticsHomePageInApp({
+            application,
+            appId: 'securitySolutionUI',
+            agentBuilder: agentBuilder as unknown as AgentBuilderPluginStart,
+          });
+
+          jest.runAllTimers();
+
+          expect(agentBuilder.openChat).toHaveBeenCalledTimes(1);
+          expect(agentBuilder.openChat).toHaveBeenCalledWith({
+            sessionTag: 'security',
+            newConversation: false,
+            agentId: storedAgentId,
+          });
+        });
+      });
+
+      describe('when already on the EA home page', () => {
+        beforeEach(() => {
+          window.history.replaceState({}, '', EA_HOME_PATH);
+        });
+
+        it('skips navigation entirely when no watchlist params are needed', () => {
+          const application = buildApplicationMock();
+
+          navigateToEntityAnalyticsHomePageInApp({
+            application,
+            appId: 'securitySolutionUI',
+          });
+
+          expect(application.navigateToApp).not.toHaveBeenCalled();
+        });
+
+        it('does not close the sidebar when no watchlist params are needed', () => {
+          const application = buildApplicationMock();
+          const agentBuilder = buildAgentBuilderNavigationMock();
+
+          navigateToEntityAnalyticsHomePageInApp({
+            application,
+            appId: 'securitySolutionUI',
+            agentBuilder: agentBuilder as unknown as AgentBuilderPluginStart,
+            chrome: buildChromeMock(),
+          });
+
+          expect(agentBuilder.toggleChat).not.toHaveBeenCalled();
+        });
+
+        it('still navigates when watchlist params are provided', () => {
+          const application = buildApplicationMock();
+
+          navigateToEntityAnalyticsHomePageInApp({
+            application,
+            appId: 'securitySolutionUI',
+            watchlistId: 'wl-1',
+            watchlistName: 'VIPs',
+          });
+
+          expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+          const [, options] = application.navigateToApp.mock.calls[0];
+          expect((options as { path?: string }).path).toContain('watchlistId=wl-1');
+        });
+
+        it('does not close the sidebar even when navigating for watchlist params', () => {
+          const application = buildApplicationMock();
+          const agentBuilder = buildAgentBuilderNavigationMock();
+
+          navigateToEntityAnalyticsHomePageInApp({
+            application,
+            appId: 'securitySolutionUI',
+            watchlistId: 'wl-1',
+            agentBuilder: agentBuilder as unknown as AgentBuilderPluginStart,
+            chrome: buildChromeMock(),
+          });
+
+          expect(agentBuilder.toggleChat).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.ts
@@ -15,7 +15,7 @@ import {
   readLastAgentBuilderAgentIdForSecuritySession,
 } from '../../../common/agent_builder_navigation_gate';
 
-import { SecurityPageName } from '../../../common/constants';
+import { SecurityPageName, ENTITY_ANALYTICS_HOME_PAGE_PATH } from '../../../common/constants';
 import {
   HostPanelKey,
   ServicePanelKey,
@@ -30,10 +30,9 @@ const INVALID_PLACEHOLDER_ENTITY_NAME = 'name';
 const USER_EUID_PREFIX = 'user:';
 
 const AGENT_BUILDER_SIDEBAR_APP_ID = 'agentBuilder' as const;
-const ENTITY_ANALYTICS_HOME_PATH = '/entity_analytics_home_page';
 
 const getEntityAnalyticsStateSearchParams = (): URLSearchParams => {
-  if (!window.location.pathname.includes(ENTITY_ANALYTICS_HOME_PATH)) {
+  if (!window.location.pathname.includes(ENTITY_ANALYTICS_HOME_PAGE_PATH)) {
     return new URLSearchParams();
   }
 
@@ -291,17 +290,26 @@ export const navigateToEntityAnalyticsWithFlyoutInApp = ({
     return;
   }
 
-  markPreserveAgentBuilderSessionDuringNextSecurityNavigation();
-  if (isAgentBuilderSidebarOpen(chrome) && agentBuilder?.toggleChat) {
-    agentBuilder.toggleChat();
+  // When already on the EA page we're doing an in-app URL update (same app,
+  // no remount), so the sidebar does not need to close and reopen.
+  const alreadyOnEaHomePage = window.location.pathname.includes(ENTITY_ANALYTICS_HOME_PAGE_PATH);
+  if (!alreadyOnEaHomePage) {
+    markPreserveAgentBuilderSessionDuringNextSecurityNavigation();
+    if (isAgentBuilderSidebarOpen(chrome) && agentBuilder?.toggleChat) {
+      agentBuilder.toggleChat();
+    }
+    clearSearchSessionBeforeSecurityNavigation(searchSession);
   }
-  clearSearchSessionBeforeSecurityNavigation(searchSession);
+
   application.navigateToApp(appId, {
     deepLinkId: SecurityPageName.entityAnalyticsHomePage,
     path,
     replace: true,
   });
-  scheduleReopenAgentBuilderAfterSecurityNavigation({ agentBuilder, openSidebarConversation });
+
+  if (!alreadyOnEaHomePage) {
+    scheduleReopenAgentBuilderAfterSecurityNavigation({ agentBuilder, openSidebarConversation });
+  }
 };
 
 export const navigateToEntityAnalyticsHomePageInApp = ({
@@ -337,17 +345,31 @@ export const navigateToEntityAnalyticsHomePageInApp = ({
   const query = params.toString();
   const path = query === '' ? undefined : `?${query}`;
 
-  markPreserveAgentBuilderSessionDuringNextSecurityNavigation();
-  if (isAgentBuilderSidebarOpen(chrome) && agentBuilder?.toggleChat) {
-    agentBuilder.toggleChat();
+  // Already on EA home page with no URL changes needed — nothing to do.
+  const alreadyOnEaHomePage = window.location.pathname.includes(ENTITY_ANALYTICS_HOME_PAGE_PATH);
+  if (alreadyOnEaHomePage && !path) {
+    return;
   }
-  clearSearchSessionBeforeSecurityNavigation(searchSession);
+
+  // When already on the EA page we're doing an in-app URL update (same app,
+  // no remount), so the sidebar does not need to close and reopen.
+  if (!alreadyOnEaHomePage) {
+    markPreserveAgentBuilderSessionDuringNextSecurityNavigation();
+    if (isAgentBuilderSidebarOpen(chrome) && agentBuilder?.toggleChat) {
+      agentBuilder.toggleChat();
+    }
+    clearSearchSessionBeforeSecurityNavigation(searchSession);
+  }
+
   application.navigateToApp(appId, {
     deepLinkId: SecurityPageName.entityAnalyticsHomePage,
     path,
     replace: true,
   });
-  scheduleReopenAgentBuilderAfterSecurityNavigation({ agentBuilder, openSidebarConversation });
+
+  if (!alreadyOnEaHomePage) {
+    scheduleReopenAgentBuilderAfterSecurityNavigation({ agentBuilder, openSidebarConversation });
+  }
 };
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.test.tsx
@@ -14,6 +14,7 @@ import {
   navigateToEntityAnalyticsHomePageInApp,
   navigateToEntityAnalyticsWithFlyoutInApp,
 } from './entity_explore_navigation';
+import { EntityAnalyticsAgentNavigationProvider } from './entity_analytics_agent_navigation_context';
 import { EntityListTable, type EntityListRow } from './entity_list_table';
 
 jest.mock('./entity_explore_navigation', () => {
@@ -50,13 +51,19 @@ const buildApplication = (): ApplicationStart =>
   ({ navigateToApp: jest.fn() } as unknown as ApplicationStart);
 
 const renderTable = (
-  row: EntityListRow,
-  extraProps: Partial<React.ComponentProps<typeof EntityListTable>> = {}
+  rows: EntityListRow[],
+  extraProps: { searchSession?: ISessionService; closeCanvas?: () => void } = {}
 ) => {
   const application = buildApplication();
+  const { searchSession, closeCanvas } = extraProps;
   render(
     <I18nProvider>
-      <EntityListTable entities={[row]} application={application} {...extraProps} />
+      <EntityAnalyticsAgentNavigationProvider
+        application={application}
+        searchSession={searchSession}
+      >
+        <EntityListTable entities={rows} closeCanvas={closeCanvas} />
+      </EntityAnalyticsAgentNavigationProvider>
     </I18nProvider>
   );
   return { application };
@@ -68,17 +75,10 @@ describe('EntityListTable', () => {
   });
 
   it('renders one row per entity with its display name', () => {
-    render(
-      <I18nProvider>
-        <EntityListTable
-          entities={[
-            { entity_type: 'host', entity_id: 'host:web-01@default', entity_name: 'web-01' },
-            { entity_type: 'user', entity_id: 'user:bob@default', entity_name: 'bob' },
-          ]}
-          application={buildApplication()}
-        />
-      </I18nProvider>
-    );
+    renderTable([
+      { entity_type: 'host', entity_id: 'host:web-01@default', entity_name: 'web-01' },
+      { entity_type: 'user', entity_id: 'user:bob@default', entity_name: 'bob' },
+    ]);
 
     expect(screen.getByText('web-01')).toBeInTheDocument();
     expect(screen.getByText('bob')).toBeInTheDocument();
@@ -86,11 +86,13 @@ describe('EntityListTable', () => {
 
   describe('Name-column Open entity in Entity Analytics button', () => {
     it('opens the flyout with the HostPanelKey payload for host rows with an entity id', () => {
-      const { application } = renderTable({
-        entity_type: 'host',
-        entity_id: 'host:web-01@default',
-        entity_name: 'web-01',
-      });
+      const { application } = renderTable([
+        {
+          entity_type: 'host',
+          entity_id: 'host:web-01@default',
+          entity_name: 'web-01',
+        },
+      ]);
 
       fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
 
@@ -113,11 +115,13 @@ describe('EntityListTable', () => {
     });
 
     it('opens the flyout with the UserPanelKey payload for user rows with an entity id', () => {
-      renderTable({
-        entity_type: 'user',
-        entity_id: 'user:bob@default',
-        entity_name: 'bob',
-      });
+      renderTable([
+        {
+          entity_type: 'user',
+          entity_id: 'user:bob@default',
+          entity_name: 'bob',
+        },
+      ]);
 
       fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
 
@@ -135,11 +139,13 @@ describe('EntityListTable', () => {
     });
 
     it('opens the flyout with the ServicePanelKey payload for service rows with an entity id', () => {
-      renderTable({
-        entity_type: 'service',
-        entity_id: 'service:auth-svc@default',
-        entity_name: 'auth-svc',
-      });
+      renderTable([
+        {
+          entity_type: 'service',
+          entity_id: 'service:auth-svc@default',
+          entity_name: 'auth-svc',
+        },
+      ]);
 
       fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
 
@@ -156,10 +162,12 @@ describe('EntityListTable', () => {
     });
 
     it('falls back to the entity_id for the display name when entity_name is missing', () => {
-      renderTable({
-        entity_type: 'host',
-        entity_id: 'host:no-name@default',
-      });
+      renderTable([
+        {
+          entity_type: 'host',
+          entity_id: 'host:no-name@default',
+        },
+      ]);
 
       fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
 
@@ -171,11 +179,13 @@ describe('EntityListTable', () => {
     });
 
     it('falls back to the unfiltered Entity Analytics home for generic entities (no dedicated flyout)', () => {
-      const { application } = renderTable({
-        entity_type: 'generic',
-        entity_id: 'generic:some-id@default',
-        entity_name: 'some-id',
-      });
+      const { application } = renderTable([
+        {
+          entity_type: 'generic',
+          entity_id: 'generic:some-id@default',
+          entity_name: 'some-id',
+        },
+      ]);
 
       fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
 
@@ -188,11 +198,13 @@ describe('EntityListTable', () => {
       const searchSession = { clear: jest.fn() } as unknown as ISessionService;
 
       renderTable(
-        {
-          entity_type: 'host',
-          entity_id: 'host:web-01@default',
-          entity_name: 'web-01',
-        },
+        [
+          {
+            entity_type: 'host',
+            entity_id: 'host:web-01@default',
+            entity_name: 'web-01',
+          },
+        ],
         { searchSession }
       );
 
@@ -206,11 +218,13 @@ describe('EntityListTable', () => {
       const searchSession = { clear: jest.fn() } as unknown as ISessionService;
 
       renderTable(
-        {
-          entity_type: 'generic',
-          entity_id: 'generic:some-id@default',
-          entity_name: 'some-id',
-        },
+        [
+          {
+            entity_type: 'generic',
+            entity_id: 'generic:some-id@default',
+            entity_name: 'some-id',
+          },
+        ],
         { searchSession }
       );
 
@@ -228,11 +242,13 @@ describe('EntityListTable', () => {
       });
 
       renderTable(
-        {
-          entity_type: 'host',
-          entity_id: 'host:web-01@default',
-          entity_name: 'web-01',
-        },
+        [
+          {
+            entity_type: 'host',
+            entity_id: 'host:web-01@default',
+            entity_name: 'web-01',
+          },
+        ],
         { closeCanvas }
       );
 
@@ -250,11 +266,13 @@ describe('EntityListTable', () => {
       const closeCanvas = jest.fn();
 
       renderTable(
-        {
-          entity_type: 'generic',
-          entity_id: 'generic:some-id@default',
-          entity_name: 'some-id',
-        },
+        [
+          {
+            entity_type: 'generic',
+            entity_id: 'generic:some-id@default',
+            entity_name: 'some-id',
+          },
+        ],
         { closeCanvas }
       );
 
@@ -268,11 +286,13 @@ describe('EntityListTable', () => {
     });
 
     it('is a no-op when closeCanvas is not provided (inline table usage)', () => {
-      renderTable({
-        entity_type: 'host',
-        entity_id: 'host:web-01@default',
-        entity_name: 'web-01',
-      });
+      renderTable([
+        {
+          entity_type: 'host',
+          entity_id: 'host:web-01@default',
+          entity_name: 'web-01',
+        },
+      ]);
 
       expect(() => {
         fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.tsx
@@ -17,19 +17,13 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { ApplicationStart } from '@kbn/core-application-browser';
-import type { ISessionService } from '@kbn/data-plugin/public';
 import type { CriticalityLevelWithUnassigned } from '../../../common/entity_analytics/asset_criticality/types';
 import type { EntityType } from '../../../common/entity_analytics/types';
 import { RiskSeverity } from '../../../common/search_strategy';
-import { APP_UI_ID } from '../../../common/constants';
 import { FormattedRelativePreferenceDate } from '../../common/components/formatted_date';
 import { getEmptyTagValue } from '../../common/components/empty_value';
-import {
-  buildEntityRightPanel,
-  navigateToEntityAnalyticsHomePageInApp,
-  navigateToEntityAnalyticsWithFlyoutInApp,
-} from './entity_explore_navigation';
+import { buildEntityRightPanel } from './entity_explore_navigation';
+import { useEntityAnalyticsAgentNavigation } from './entity_analytics_agent_navigation_context';
 import { formatRiskScore } from '../../entity_analytics/common';
 import { CRITICALITY_LEVEL_TITLE } from '../../entity_analytics/components/asset_criticality/translations';
 import { RiskScoreLevel } from '../../entity_analytics/components/severity/common';
@@ -175,8 +169,6 @@ const tableScrollStyles = css`
 
 export const EntityListTable: React.FC<{
   entities: EntityListRow[];
-  application: ApplicationStart;
-  searchSession?: ISessionService;
   /**
    * Dismisses the Agent Builder canvas flyout. When present, the Name-column
    * "open entity" button closes the canvas before navigating to Entity
@@ -184,8 +176,9 @@ export const EntityListTable: React.FC<{
    * underneath the canvas overlay.
    */
   closeCanvas?: () => void;
-}> = ({ entities, application, searchSession, closeCanvas }) => {
+}> = ({ entities, closeCanvas }) => {
   const { euiTheme } = useEuiTheme();
+  const { navigateWithFlyout, navigateToHome } = useEntityAnalyticsAgentNavigation();
 
   const columns: Array<EuiBasicTableColumn<EntityListRow>> = useMemo(
     () => [
@@ -218,19 +211,10 @@ export const EntityListTable: React.FC<{
                     // expandable flyout that the URL change is about to open.
                     closeCanvas?.();
                     if (rightPanel) {
-                      navigateToEntityAnalyticsWithFlyoutInApp({
-                        application,
-                        appId: APP_UI_ID,
-                        flyout: { preview: [], right: rightPanel },
-                        searchSession,
-                      });
-                      return;
+                      navigateWithFlyout({ preview: [], right: rightPanel });
+                    } else {
+                      navigateToHome();
                     }
-                    navigateToEntityAnalyticsHomePageInApp({
-                      application,
-                      appId: APP_UI_ID,
-                      searchSession,
-                    });
                   }}
                 />
               </EuiFlexItem>
@@ -367,7 +351,7 @@ export const EntityListTable: React.FC<{
         ),
       },
     ],
-    [application, closeCanvas, euiTheme.font.familyCode, searchSession]
+    [navigateWithFlyout, navigateToHome, closeCanvas, euiTheme.font.familyCode]
   );
 
   return (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Analytics] Keep agent open when navigating to EA homepage (#266779)](https://github.com/elastic/kibana/pull/266779)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"tcalopes","email":"tatiana.lopes@elastic.co"},"sourceCommit":{"committedDate":"2026-05-11T14:38:03Z","message":"[Entity Analytics] Keep agent open when navigating to EA homepage (#266779)\n\n## Summary\n\nOpen agent sidebar when navigating from the Agent Builder chat to the\nEntity Analytics page.\n\n- Added `EntityAnalyticsAgentNavigationContext` to centralise navigation\ndependencies, avoiding prop drilling across attachment components\n- Added an in-page navigation guard that detects when the user is\nalready on the EA home page and skips the sidebar close/reopen cycle, so\nonly the URL is updated.\n\n> [!IMPORTANT]\n> ### Updates\n> As @jonwalstedt noted below the redirect the sidebar would sometimes\nshow a blank conversation instead of the active one. The root cause is\nin the agent_builder plugin: the `openSidebarConversation` callback was\nsaving the conversation id under the \"default\" storage key (it called\n`usePersistedConversationId({})`), while the sidebar reads from a key\nderived from the active config (e.g. { sessionTag: 'security', agentId\n}). That was causing the mismatch.\n> #### Changes\n>\n>**`agent_builder` plugin**:\n>- `OpenConversationSidebarOptions` now accepts an optional\n`conversationId`. When provided, `openSidebarInternal` persists it under\nthe storage key derived from the resolved sidebar config\n(`storageKeys.getLastConversationKey(sessionTag, agentId)`)\n>- `CanvasFlyout` and `InlineAttachmentWithActions` no longer write to\nlocalStorage directly. Their closures forward `{ conversationId }` to\nthe plugin, where the persistence happens with full knowledge of the\nresolved config\n>- Bumped the agentBuilder page-load bundle limit by 1KB to accommodate\nthe new storage_keys import in `plugin.tsx`\n\n## How to test\n\n1. Start Elasticsearch with EIS (to use AI chat)\n2. Start Kibana locally\n      <details>\n        <summary>feature flags</summary>\n   \n        uiSettings:\n          overrides:\n            agentBuilder:experimentalFeatures: true\n            securitySolution:entityStoreEnableV2: true\n        \n        xpack.securitySolution.enableExperimental:\n          - entityAnalyticsEntityStoreV2\n          - entityAnalyticsNewHomePageEnabled\n        \n        feature_flags.overrides:\n          aiAssistant.aiAgents.enabled: true\n\n      </details>\n3. Load some EA data\n    <details>\n<summary>Script used to load data (see instruction at the top about base\npath; uses\nhttps://github.com/elastic/security-documents-generator)</summary>\n\n          #!/bin/bash\n          # Usage: ./populate_entity_store\n# remember to add your base path to the KIBANA_URL if you are using a\nbase path\n          KIBANA_URL='https://elastic:changeme@localhost:5601/'\n          \nH=(-H 'Content-Type: application/json' -H 'x-elastic-internal-origin:\nKibana' -H 'kbn-xsrf: true')\n          \n          printf \"\\nEnabling entity store v2\\n\"\ncurl -k -X POST \"${H[@]}\"\n\"${KIBANA_URL}/api/security/entity_store/install?apiVersion=2023-10-31\"\n-d '{}'\n          \n          # Initialize maintainers (this triggers the setup phase)\n          printf \"\\nInitializing entity maintainers\\n\"\ncurl -k -X POST \"${H[@]}\"\n\"${KIBANA_URL}/internal/security/entity_store/entity_maintainers/init?apiVersion=2\"\n\\\n            -d '{}'\n          \n          printf \"\\nAdding organization data\\n\"\n          yarn start organization-quick\n          \n          printf \"\\nWaiting 1 minute so entity store can run\\n\"\n          sleep 60\n          \n          printf \"\\nEnriching entity store data\\n\"\n          yarn start generate-entity-maintainers-data --quick\n          \n          printf \"\\nDone 🚀\\n\"\n      </details>\n4. Start chat conversations that trigger the Entity table, Entity Card\nand EA overview to show up\n      <details>\n        <summary>prompts used</summary>\n     \n        Entity table -> list the top 5 entities to pay attention to\n        Entity card -> give more information about <entity_name> entity\nEA overview -> give me an overview of the findings on Entity Analytics\n\n      </details>\n5. For each scenario\n- From the Agent Builder page, click the navigation button that\nredirects to the Entity Analytics page (see video below for reference).\n- Verify that after the redirect, the agent sidebar is opened on the\ncorresponding chat conversation.\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/97b00256-8560-4714-bcde-c0dd7cbd83a4\n\n### After\n\n\nhttps://github.com/user-attachments/assets/b41d75fa-25e6-42aa-af45-8a4b2db2dc4f\n\n\nhttps://github.com/user-attachments/assets/02069d00-d07e-4b3e-ab5e-1f02f99a3d98","sha":"37ba4b7c2af3c92149cb2e146a34ba8a6e0eea54","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Entity Analytics","backport:version","v9.4.0","v9.5.0"],"title":"[Entity Analytics] Keep agent open when navigating to EA homepage","number":266779,"url":"https://github.com/elastic/kibana/pull/266779","mergeCommit":{"message":"[Entity Analytics] Keep agent open when navigating to EA homepage (#266779)\n\n## Summary\n\nOpen agent sidebar when navigating from the Agent Builder chat to the\nEntity Analytics page.\n\n- Added `EntityAnalyticsAgentNavigationContext` to centralise navigation\ndependencies, avoiding prop drilling across attachment components\n- Added an in-page navigation guard that detects when the user is\nalready on the EA home page and skips the sidebar close/reopen cycle, so\nonly the URL is updated.\n\n> [!IMPORTANT]\n> ### Updates\n> As @jonwalstedt noted below the redirect the sidebar would sometimes\nshow a blank conversation instead of the active one. The root cause is\nin the agent_builder plugin: the `openSidebarConversation` callback was\nsaving the conversation id under the \"default\" storage key (it called\n`usePersistedConversationId({})`), while the sidebar reads from a key\nderived from the active config (e.g. { sessionTag: 'security', agentId\n}). That was causing the mismatch.\n> #### Changes\n>\n>**`agent_builder` plugin**:\n>- `OpenConversationSidebarOptions` now accepts an optional\n`conversationId`. When provided, `openSidebarInternal` persists it under\nthe storage key derived from the resolved sidebar config\n(`storageKeys.getLastConversationKey(sessionTag, agentId)`)\n>- `CanvasFlyout` and `InlineAttachmentWithActions` no longer write to\nlocalStorage directly. Their closures forward `{ conversationId }` to\nthe plugin, where the persistence happens with full knowledge of the\nresolved config\n>- Bumped the agentBuilder page-load bundle limit by 1KB to accommodate\nthe new storage_keys import in `plugin.tsx`\n\n## How to test\n\n1. Start Elasticsearch with EIS (to use AI chat)\n2. Start Kibana locally\n      <details>\n        <summary>feature flags</summary>\n   \n        uiSettings:\n          overrides:\n            agentBuilder:experimentalFeatures: true\n            securitySolution:entityStoreEnableV2: true\n        \n        xpack.securitySolution.enableExperimental:\n          - entityAnalyticsEntityStoreV2\n          - entityAnalyticsNewHomePageEnabled\n        \n        feature_flags.overrides:\n          aiAssistant.aiAgents.enabled: true\n\n      </details>\n3. Load some EA data\n    <details>\n<summary>Script used to load data (see instruction at the top about base\npath; uses\nhttps://github.com/elastic/security-documents-generator)</summary>\n\n          #!/bin/bash\n          # Usage: ./populate_entity_store\n# remember to add your base path to the KIBANA_URL if you are using a\nbase path\n          KIBANA_URL='https://elastic:changeme@localhost:5601/'\n          \nH=(-H 'Content-Type: application/json' -H 'x-elastic-internal-origin:\nKibana' -H 'kbn-xsrf: true')\n          \n          printf \"\\nEnabling entity store v2\\n\"\ncurl -k -X POST \"${H[@]}\"\n\"${KIBANA_URL}/api/security/entity_store/install?apiVersion=2023-10-31\"\n-d '{}'\n          \n          # Initialize maintainers (this triggers the setup phase)\n          printf \"\\nInitializing entity maintainers\\n\"\ncurl -k -X POST \"${H[@]}\"\n\"${KIBANA_URL}/internal/security/entity_store/entity_maintainers/init?apiVersion=2\"\n\\\n            -d '{}'\n          \n          printf \"\\nAdding organization data\\n\"\n          yarn start organization-quick\n          \n          printf \"\\nWaiting 1 minute so entity store can run\\n\"\n          sleep 60\n          \n          printf \"\\nEnriching entity store data\\n\"\n          yarn start generate-entity-maintainers-data --quick\n          \n          printf \"\\nDone 🚀\\n\"\n      </details>\n4. Start chat conversations that trigger the Entity table, Entity Card\nand EA overview to show up\n      <details>\n        <summary>prompts used</summary>\n     \n        Entity table -> list the top 5 entities to pay attention to\n        Entity card -> give more information about <entity_name> entity\nEA overview -> give me an overview of the findings on Entity Analytics\n\n      </details>\n5. For each scenario\n- From the Agent Builder page, click the navigation button that\nredirects to the Entity Analytics page (see video below for reference).\n- Verify that after the redirect, the agent sidebar is opened on the\ncorresponding chat conversation.\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/97b00256-8560-4714-bcde-c0dd7cbd83a4\n\n### After\n\n\nhttps://github.com/user-attachments/assets/b41d75fa-25e6-42aa-af45-8a4b2db2dc4f\n\n\nhttps://github.com/user-attachments/assets/02069d00-d07e-4b3e-ab5e-1f02f99a3d98","sha":"37ba4b7c2af3c92149cb2e146a34ba8a6e0eea54"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266779","number":266779,"mergeCommit":{"message":"[Entity Analytics] Keep agent open when navigating to EA homepage (#266779)\n\n## Summary\n\nOpen agent sidebar when navigating from the Agent Builder chat to the\nEntity Analytics page.\n\n- Added `EntityAnalyticsAgentNavigationContext` to centralise navigation\ndependencies, avoiding prop drilling across attachment components\n- Added an in-page navigation guard that detects when the user is\nalready on the EA home page and skips the sidebar close/reopen cycle, so\nonly the URL is updated.\n\n> [!IMPORTANT]\n> ### Updates\n> As @jonwalstedt noted below the redirect the sidebar would sometimes\nshow a blank conversation instead of the active one. The root cause is\nin the agent_builder plugin: the `openSidebarConversation` callback was\nsaving the conversation id under the \"default\" storage key (it called\n`usePersistedConversationId({})`), while the sidebar reads from a key\nderived from the active config (e.g. { sessionTag: 'security', agentId\n}). That was causing the mismatch.\n> #### Changes\n>\n>**`agent_builder` plugin**:\n>- `OpenConversationSidebarOptions` now accepts an optional\n`conversationId`. When provided, `openSidebarInternal` persists it under\nthe storage key derived from the resolved sidebar config\n(`storageKeys.getLastConversationKey(sessionTag, agentId)`)\n>- `CanvasFlyout` and `InlineAttachmentWithActions` no longer write to\nlocalStorage directly. Their closures forward `{ conversationId }` to\nthe plugin, where the persistence happens with full knowledge of the\nresolved config\n>- Bumped the agentBuilder page-load bundle limit by 1KB to accommodate\nthe new storage_keys import in `plugin.tsx`\n\n## How to test\n\n1. Start Elasticsearch with EIS (to use AI chat)\n2. Start Kibana locally\n      <details>\n        <summary>feature flags</summary>\n   \n        uiSettings:\n          overrides:\n            agentBuilder:experimentalFeatures: true\n            securitySolution:entityStoreEnableV2: true\n        \n        xpack.securitySolution.enableExperimental:\n          - entityAnalyticsEntityStoreV2\n          - entityAnalyticsNewHomePageEnabled\n        \n        feature_flags.overrides:\n          aiAssistant.aiAgents.enabled: true\n\n      </details>\n3. Load some EA data\n    <details>\n<summary>Script used to load data (see instruction at the top about base\npath; uses\nhttps://github.com/elastic/security-documents-generator)</summary>\n\n          #!/bin/bash\n          # Usage: ./populate_entity_store\n# remember to add your base path to the KIBANA_URL if you are using a\nbase path\n          KIBANA_URL='https://elastic:changeme@localhost:5601/'\n          \nH=(-H 'Content-Type: application/json' -H 'x-elastic-internal-origin:\nKibana' -H 'kbn-xsrf: true')\n          \n          printf \"\\nEnabling entity store v2\\n\"\ncurl -k -X POST \"${H[@]}\"\n\"${KIBANA_URL}/api/security/entity_store/install?apiVersion=2023-10-31\"\n-d '{}'\n          \n          # Initialize maintainers (this triggers the setup phase)\n          printf \"\\nInitializing entity maintainers\\n\"\ncurl -k -X POST \"${H[@]}\"\n\"${KIBANA_URL}/internal/security/entity_store/entity_maintainers/init?apiVersion=2\"\n\\\n            -d '{}'\n          \n          printf \"\\nAdding organization data\\n\"\n          yarn start organization-quick\n          \n          printf \"\\nWaiting 1 minute so entity store can run\\n\"\n          sleep 60\n          \n          printf \"\\nEnriching entity store data\\n\"\n          yarn start generate-entity-maintainers-data --quick\n          \n          printf \"\\nDone 🚀\\n\"\n      </details>\n4. Start chat conversations that trigger the Entity table, Entity Card\nand EA overview to show up\n      <details>\n        <summary>prompts used</summary>\n     \n        Entity table -> list the top 5 entities to pay attention to\n        Entity card -> give more information about <entity_name> entity\nEA overview -> give me an overview of the findings on Entity Analytics\n\n      </details>\n5. For each scenario\n- From the Agent Builder page, click the navigation button that\nredirects to the Entity Analytics page (see video below for reference).\n- Verify that after the redirect, the agent sidebar is opened on the\ncorresponding chat conversation.\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/97b00256-8560-4714-bcde-c0dd7cbd83a4\n\n### After\n\n\nhttps://github.com/user-attachments/assets/b41d75fa-25e6-42aa-af45-8a4b2db2dc4f\n\n\nhttps://github.com/user-attachments/assets/02069d00-d07e-4b3e-ab5e-1f02f99a3d98","sha":"37ba4b7c2af3c92149cb2e146a34ba8a6e0eea54"}}]}] BACKPORT-->