### PR TITLE
[Cases][workflow] Resolve templates from correct owner

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/create_case_from_template.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/create_case_from_template.test.ts
@@ -62,6 +62,7 @@ describe('createCaseFromTemplateStepDefinition', () => {
     const result = await definition.handler(
       createContext({
         case_template_id: 'triage_template',
+        owner: 'securitySolution',
         overwrites: {
           title: 'Overwrite title',
           status: 'in-progress',
@@ -137,6 +138,7 @@ describe('createCaseFromTemplateStepDefinition', () => {
 
     await definition.handler(
       createContext({
+        owner: 'securitySolution',
         case_template_id: 'triage_template',
       })
     );
@@ -174,6 +176,7 @@ describe('createCaseFromTemplateStepDefinition', () => {
 
     await definition.handler(
       createContext({
+        owner: 'securitySolution',
         case_template_id: 'triage_template',
       })
     );
@@ -203,6 +206,7 @@ describe('createCaseFromTemplateStepDefinition', () => {
 
     const result = await definition.handler(
       createContext({
+        owner: 'securitySolution',
         case_template_id: 'missing_template',
       })
     );
@@ -239,6 +243,7 @@ describe('createCaseFromTemplateStepDefinition', () => {
     await definition.handler(
       createContext(
         {
+          owner: 'securitySolution',
           case_template_id: 'triage_template',
         },
         { 'push-case': true }

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/create_case_from_template.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/create_case_from_template.ts
@@ -25,9 +25,6 @@ import {
   type GetInitialCaseValueArgs,
 } from '../../../common/utils/get_initial_case_value';
 
-// TODO: make dynamic once https://github.com/elastic/security-team/issues/15982 has been resolved
-const WORKFLOW_CASE_OWNER = 'securitySolution' as const;
-
 const findTemplateById = (
   configurations: Configurations,
   templateId: string
@@ -47,21 +44,20 @@ export const createCaseFromTemplateStepDefinition = (
       CreateCaseFromTemplateStepConfig,
       CreateCaseFromTemplateStepOutput['case']
     >(getCasesClient, async (casesClient, input) => {
-      const configurations = await casesClient.configure.get({ owner: WORKFLOW_CASE_OWNER });
-      const template = findTemplateById(configurations, input.case_template_id);
+      const { case_template_id, owner, overwrites } = input;
+      const configurations = await casesClient.configure.get({ owner });
+      const template = findTemplateById(configurations, case_template_id);
 
       if (!template) {
-        throw new Error(
-          `Case template not found for owner "${WORKFLOW_CASE_OWNER}": ${input.case_template_id}`
-        );
+        throw new Error(`Case template not found for owner "${owner}": ${case_template_id}`);
       }
 
-      const normalizedOverwrites = input.overwrites
-        ? normalizeCaseStepUpdatesForBulkPatch(input.overwrites)
+      const normalizedOverwrites = overwrites
+        ? normalizeCaseStepUpdatesForBulkPatch(overwrites)
         : {};
 
       const mergedCreatePayload = getInitialCaseValue({
-        owner: WORKFLOW_CASE_OWNER,
+        owner,
         ...(template.caseFields ?? {}),
         ...normalizedOverwrites,
       } as GetInitialCaseValueArgs);


### PR DESCRIPTION
## Summary

The `cases.createCaseFromTemplate` server-side code is currently only checking against security templates. The const was a leftover from the initial implementation.

### How to test

1. Go to Observability -> Cases
2. Create a template
3. Create a new workflow that uses the template (see below)
4. Make sure the workflow works

```yaml
name: New workflow
enabled: true
description: This is a new workflow
triggers:
  - type: manual
 
steps:
  - name: create
    type: cases.createCaseFromTemplate
    with:
      owner: securitySolution
      case_template_id: YOUR_TEMPLATE_HERE
      overwrites:
        description: Test
        title: test
```

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->