### PR TITLE
[Security Solution][Graph] Polish label node popover title and abbreviate badge counts

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node.test.tsx
@@ -22,15 +22,6 @@ import {
   TEST_SUBJ_TOOLTIP,
 } from './label_node';
 
-jest.mock('./label_node_badges', () => {
-  // Use the actual exports, except override LIMIT
-  const actual = jest.requireActual('./label_node_badges');
-  return {
-    ...actual,
-    LIMIT: 2,
-  };
-});
-
 describe('LabelNode', () => {
   const baseProps: NodeProps = {
     id: 'test-label-node',

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.test.tsx
@@ -92,18 +92,18 @@ describe('LabelNodeBadges', () => {
     );
   });
 
-  test('renders event badge with limited counter and alert badge with icon and limited counter for multiple events and alerts', () => {
-    const countOverLimit = 120;
+  test('renders event badge with abbreviated counter and alert badge with icon and abbreviated counter for very large numbers of events and alerts', () => {
+    const largeCount = 1_200_000;
     const analysis = analyzeDocuments({
-      uniqueEventsCount: countOverLimit,
-      uniqueAlertsCount: countOverLimit,
+      uniqueEventsCount: largeCount,
+      uniqueAlertsCount: largeCount,
     });
 
     render(<LabelNodeBadges analysis={analysis} />);
 
-    expect(screen.getByTestId(TEST_SUBJ_EVENT_COUNT)).toHaveTextContent('+99');
+    expect(screen.getByTestId(TEST_SUBJ_EVENT_COUNT)).toHaveTextContent('1.2m');
     expect(screen.queryByTestId(TEST_SUBJ_ALERT_ICON)).toBeInTheDocument();
-    expect(screen.getByTestId(TEST_SUBJ_ALERT_COUNT)).toHaveTextContent('+99');
+    expect(screen.getByTestId(TEST_SUBJ_ALERT_COUNT)).toHaveTextContent('1.2m');
   });
 
   describe('Popover', () => {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_badges.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { EuiIcon, EuiText, EuiButtonEmpty, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
 import { RoundedBadge } from '../styles';
 import type { DocumentAnalysisOutput } from './analyze_documents';
 
@@ -17,9 +18,6 @@ export const TEST_SUBJ_ALERT_COUNT = 'label-node-alert-count';
 export const TEST_SUBJ_ALERT_COUNT_BUTTON = 'label-node-alert-count-button';
 export const TEST_SUBJ_EVENT_COUNT = 'label-node-event-count';
 export const TEST_SUBJ_EVENT_COUNT_BUTTON = 'label-node-event-count-button';
-
-export const LIMIT = 99;
-export const displayCount = (count: number) => (count > LIMIT ? `+${LIMIT}` : count);
 
 const POPOVER_EVENT_ARIA_LABEL = i18n.translate(
   'securitySolutionPackages.csp.graph.labelBadges.eventAriaLabel',
@@ -87,11 +85,11 @@ const EventBadge: React.FC<{
             color: ${euiTheme.colors.textHeading};
           `}
         >
-          {displayCount(count)}
+          {getAbbreviatedNumber(count)}
         </EuiButtonEmpty>
       ) : (
         <CountText testSubj={TEST_SUBJ_EVENT_COUNT} color={euiTheme.colors.textHeading}>
-          {displayCount(count)}
+          {getAbbreviatedNumber(count)}
         </CountText>
       )}
     </RoundedBadge>
@@ -127,11 +125,11 @@ const AlertCountBadge: React.FC<{
             color: ${textColor};
           `}
         >
-          {displayCount(count)}
+          {getAbbreviatedNumber(count)}
         </EuiButtonEmpty>
       ) : (
         <CountText testSubj={TEST_SUBJ_ALERT_COUNT} color={textColor}>
-          {displayCount(count)}
+          {getAbbreviatedNumber(count)}
         </CountText>
       )}
     </RoundedBadge>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_popover.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_popover.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { LabelNodePopoverContent } from './label_node_popover';
+import { LabelNodePopoverContent, TEST_SUBJ_TITLE } from './label_node_popover';
 import { analyzeDocuments } from './analyze_documents';
 
 const TEST_SUBJ_ALERT_SECTION = 'label-node-tooltip-alert-section';
@@ -120,5 +120,44 @@ describe('LabelNodePopoverContent', () => {
 
     // Check that the event count is present for multiple events
     expect(screen.getByTestId(TEST_SUBJ_EVENT_COUNT)).toHaveTextContent('1.2m');
+  });
+
+  describe('title', () => {
+    test('does not render the title when text prop is omitted', () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 2, uniqueAlertsCount: 0 });
+
+      render(<LabelNodePopoverContent analysis={analysis} />);
+
+      expect(screen.queryByTestId(TEST_SUBJ_TITLE)).not.toBeInTheDocument();
+    });
+
+    test('does not render the title when text prop is an empty string', () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 2, uniqueAlertsCount: 0 });
+
+      render(<LabelNodePopoverContent analysis={analysis} text="" />);
+
+      expect(screen.queryByTestId(TEST_SUBJ_TITLE)).not.toBeInTheDocument();
+    });
+
+    test('renders the full title when text prop is provided', () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 2, uniqueAlertsCount: 0 });
+      const text = 'Short title';
+
+      render(<LabelNodePopoverContent analysis={analysis} text={text} />);
+
+      const title = screen.getByTestId(TEST_SUBJ_TITLE);
+      expect(title).toHaveTextContent(text);
+    });
+
+    test('renders the title even when there are no counters', () => {
+      const analysis = analyzeDocuments({ uniqueEventsCount: 0, uniqueAlertsCount: 0 });
+      const text = 'Title without counters';
+
+      render(<LabelNodePopoverContent analysis={analysis} text={text} />);
+
+      expect(screen.getByTestId(TEST_SUBJ_TITLE)).toHaveTextContent(text);
+      expect(screen.queryByTestId(TEST_SUBJ_ALERT_SECTION)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(TEST_SUBJ_EVENT_SECTION)).not.toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/label_node/label_node_popover.tsx
@@ -6,13 +6,17 @@
  */
 
 import React from 'react';
-import { EuiText, EuiIcon, useEuiTheme } from '@elastic/eui';
+import { EuiText, EuiIcon, EuiHorizontalRule, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
 import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
 import { RoundedBadge } from '../styles';
 import type { DocumentAnalysisOutput } from './analyze_documents';
+
+export const TEST_SUBJ_TITLE = 'label-node-tooltip-title';
+
+const POPOVER_TITLE_MAX_WIDTH = 320;
 
 const alertedEventsText = i18n.translate(
   'securitySolutionPackages.csp.graph.labelNode.tooltip.alertedEvents',
@@ -30,6 +34,7 @@ const defaultEventsText = i18n.translate(
 
 interface LabelNodePopoverProps {
   analysis: DocumentAnalysisOutput;
+  text?: string;
 }
 
 const CountText: React.FC<{ testSubj: string; children: React.ReactNode }> = ({
@@ -100,8 +105,11 @@ const EventBadge: React.FC<{ count: number }> = ({ count }) => (
   </RoundedBadge>
 );
 
-export const LabelNodePopoverContent = ({ analysis }: LabelNodePopoverProps) => {
+export const LabelNodePopoverContent = ({ analysis, text }: LabelNodePopoverProps) => {
   const { euiTheme } = useEuiTheme();
+  const hasTitle = Boolean(text);
+  const hasCounters = analysis.uniqueAlertsCount > 0 || analysis.uniqueEventsCount > 0;
+
   return (
     <div
       css={css`
@@ -110,6 +118,30 @@ export const LabelNodePopoverContent = ({ analysis }: LabelNodePopoverProps) => 
         gap: ${euiTheme.size.s};
       `}
     >
+      {hasTitle && (
+        <EuiText
+          data-test-subj={TEST_SUBJ_TITLE}
+          size="s"
+          css={css`
+            font-weight: ${euiTheme.font.weight.bold};
+            max-width: ${POPOVER_TITLE_MAX_WIDTH}px;
+            word-break: break-word;
+            overflow-wrap: anywhere;
+          `}
+        >
+          {text}
+        </EuiText>
+      )}
+      {hasTitle && hasCounters && (
+        <EuiHorizontalRule
+          margin="none"
+          size="full"
+          css={css`
+            width: calc(100% + ${euiTheme.size.xl});
+            margin-left: -${euiTheme.size.base};
+          `}
+        />
+      )}
       {analysis.uniqueAlertsCount > 0 && (
         <Section
           testSubj="label-node-tooltip-alert-section"

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/details/use_event_details_popover.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/details/use_event_details_popover.tsx
@@ -6,8 +6,6 @@
  */
 
 import React, { memo, useMemo, useCallback } from 'react';
-import { EuiHorizontalRule, EuiTextTruncate, useEuiTheme } from '@elastic/eui';
-import { css } from '@emotion/react';
 import type { PopoverActions, PopoverState } from '../primitives/use_graph_popover_state';
 import { useGraphPopoverState } from '../primitives/use_graph_popover_state';
 import { GraphPopover } from '../primitives/graph_popover';
@@ -47,7 +45,6 @@ export const useEventDetailsPopover = (
   text: string
 ): UseEventDetailsPopoverReturn => {
   const { id, state, actions } = useGraphPopoverState('events-popover');
-  const { euiTheme } = useEuiTheme();
 
   // eslint-disable-next-line react/display-name
   const PopoverComponent = memo(() => (
@@ -59,26 +56,7 @@ export const useEventDetailsPopover = (
       closePopover={actions.closePopover}
       data-test-subj={GRAPH_EVENTS_POPOVER_ID}
     >
-      {text && (
-        <>
-          <EuiTextTruncate
-            css={css`
-              font-weight: ${euiTheme.font.weight.bold};
-            `}
-            truncation="end"
-            text={text}
-          />
-          <EuiHorizontalRule
-            margin="m"
-            size="full"
-            css={css`
-              width: calc(100% + ${euiTheme.size.xl});
-              margin-left: -${euiTheme.size.base};
-            `}
-          />
-        </>
-      )}
-      {analysis && <LabelNodePopoverContent analysis={analysis} />}
+      {analysis && <LabelNodePopoverContent analysis={analysis} text={text} />}
     </GraphPopover>
   ));
 


### PR DESCRIPTION
## Summary

Closes elastic/security-team#17263.

Two small UX polish fixes for the Graph label nodes:

- **Popover title**: render the full event/alert title inside the label node popover. Long IDs now **wrap** instead of being truncated with `…`, and the native browser `title` tooltip on hover is gone. The divider is only drawn when both a title and counters are present.
- **Badge counts**: replace the `+99` cap on the on-graph event/alert badges with `getAbbreviatedNumber`, so analysts see real magnitudes (e.g. `1k`, `1.2m`) without opening the popover.

### Screenshots

| Before | After |
|--------|--------|
| <img width="388" height="409" alt="Screenshot 2026-06-18 at 10 20 02" src="https://github.com/user-attachments/assets/b1769e5d-936d-4254-a5e6-d74fa76adfc9" /> | <img width="412" height="466" alt="Screenshot 2026-06-18 at 10 07 52" src="https://github.com/user-attachments/assets/81930389-ec90-477c-bc48-1be205121910" /> |

### How to test

1. Open Storybook and check the Graph Components > Label Node > Badges story.
2. Check the counts are abbreviated i.e. (`1k`, `1.2m`, …) vs. previous i.e. `+99`.
3. Check popover title is not truncated when too long.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
