### PR TITLE
[Task Manager] Claim nudge PoC via Fleet global checkpoints

### DIFF
--- a/packages/kbn-check-saved-objects-cli/current_fields.json
+++ b/packages/kbn-check-saved-objects-cli/current_fields.json
@@ -1456,6 +1456,10 @@
     "userScope.apiKeyId",
     "userScope.uiamApiKeyId"
   ],
+  "task_manager_wakeup_signal": [
+    "nonce",
+    "updated_at"
+  ],
   "telemetry": [],
   "threshold-explorer-view": [],
   "trial-companion-nba-milestone": [

--- a/packages/kbn-check-saved-objects-cli/current_mappings.json
+++ b/packages/kbn-check-saved-objects-cli/current_mappings.json
@@ -4836,6 +4836,17 @@
       }
     }
   },
+  "task_manager_wakeup_signal": {
+    "dynamic": false,
+    "properties": {
+      "nonce": {
+        "type": "keyword"
+      },
+      "updated_at": {
+        "type": "date"
+      }
+    }
+  },
   "telemetry": {
     "dynamic": false,
     "properties": {}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
@@ -141,7 +141,7 @@ describe('AgentExecutionService', () => {
           params: { executionId: result.executionId },
           scope: ['agent-builder'],
         }),
-        { request, refresh: true }
+        { request, requestImmediateClaim: true }
       );
     });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
@@ -141,7 +141,7 @@ describe('AgentExecutionService', () => {
           params: { executionId: result.executionId },
           scope: ['agent-builder'],
         }),
-        { request }
+        { request, refresh: true }
       );
     });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -175,7 +175,7 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
         enabled: true,
         state: {},
       },
-      { request }
+      { request, refresh: true }
     );
 
     this.logger.debug(`Scheduled remote agent execution ${executionId} for agent ${agentId}`);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -175,7 +175,7 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
         enabled: true,
         state: {},
       },
-      { request, refresh: true }
+      { request, requestImmediateClaim: true }
     );
 
     this.logger.debug(`Scheduled remote agent execution ${executionId} for agent ${agentId}`);

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.ts
@@ -278,7 +278,11 @@ export class RuleTypeRegistry {
     }
 
     if (ruleType.priority) {
-      if (![TaskPriority.Normal, TaskPriority.NormalLongRunning].includes(ruleType.priority)) {
+      if (
+        ![TaskPriority.Normal, TaskPriority.NormalLongRunning, TaskPriority.High].includes(
+          ruleType.priority
+        )
+      ) {
         throw new Error(
           i18n.translate('xpack.alerting.ruleTypeRegistry.register.invalidPriorityRuleTypeError', {
             defaultMessage: 'Rule type "{id}" has invalid priority: {errorMessage}.',

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -390,7 +390,7 @@ export interface RuleType<
    * Task priority allowing for tasks to be ran at lower priority (NormalLongRunning vs Normal), defaults to
    * normal priority.
    */
-  priority?: TaskPriority.Normal | TaskPriority.NormalLongRunning;
+  priority?: TaskPriority.Normal | TaskPriority.NormalLongRunning | TaskPriority.High;
   /**
    * Indicates that the rule type is managed internally by a Kibana plugin.
    * Alerts of internally managed rule types are not returned by the APIs and thus not shown in the alerts table.

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { loggingSystemMock, savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
+import { TaskManagerClaimNudgeService } from './claim_nudge_service';
+import { TASK_MANAGER_CLAIM_NUDGE_SO_NAME } from '../saved_objects';
+
+describe('TaskManagerClaimNudgeService', () => {
+  it('writes the claim nudge using refresh:true', async () => {
+    const repository = savedObjectsRepositoryMock.create();
+    const esClient = {
+      fleet: {
+        globalCheckpoints: jest.fn(),
+      },
+    } as unknown as ElasticsearchClient;
+
+    const service = new TaskManagerClaimNudgeService({
+      logger: loggingSystemMock.create().get(),
+      esClient,
+      savedObjectsRepository: repository,
+      index: '.kibana_task_manager_claim_nudge',
+    });
+
+    await service.notify();
+
+    expect(repository.create).toHaveBeenCalledWith(
+      TASK_MANAGER_CLAIM_NUDGE_SO_NAME,
+      expect.objectContaining({
+        updated_at: expect.any(String),
+        nonce: expect.any(String),
+      }),
+      {
+        id: 'global',
+        overwrite: true,
+        refresh: true,
+      }
+    );
+  });
+
+  it('emits a claim nudge when checkpoints advance', async () => {
+    const repository = savedObjectsRepositoryMock.create();
+    const esClient = {
+      fleet: {
+        globalCheckpoints: jest.fn(),
+      },
+    } as unknown as ElasticsearchClient;
+
+    const service = new TaskManagerClaimNudgeService({
+      logger: loggingSystemMock.create().get(),
+      esClient,
+      savedObjectsRepository: repository,
+      index: '.kibana_task_manager_claim_nudge',
+    });
+
+    let calls = 0;
+    (esClient.fleet.globalCheckpoints as jest.Mock).mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return { global_checkpoints: [1], timed_out: false };
+      }
+
+      service.stop();
+      return { global_checkpoints: [2], timed_out: false };
+    });
+
+    const nudgeSpy = jest.fn();
+    service.claimNudge$.subscribe(nudgeSpy);
+
+    service.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(nudgeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 } from 'uuid';
+import { Subject } from 'rxjs';
+import type { ElasticsearchClient, ISavedObjectsRepository, Logger } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { TASK_MANAGER_CLAIM_NUDGE_SO_NAME } from '../saved_objects';
+import type { TaskManagerClaimNudge } from '../saved_objects/schemas/task_manager_claim_nudge';
+
+const GLOBAL_CLAIM_NUDGE_ID = 'global';
+const CHECKPOINT_TIMEOUT = '30s';
+const ERROR_RETRY_DELAY_MS = 1_000;
+
+interface GlobalCheckpointsResponse {
+  global_checkpoints: number[];
+  timed_out: boolean;
+}
+
+export interface TaskManagerClaimNudgeServiceOptions {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  savedObjectsRepository: ISavedObjectsRepository;
+  index: string;
+}
+
+export class TaskManagerClaimNudgeService {
+  private readonly logger: Logger;
+  private readonly esClient: ElasticsearchClient;
+  private readonly savedObjectsRepository: ISavedObjectsRepository;
+  private readonly index: string;
+  private readonly claimNudgeSubject = new Subject<void>();
+  private started = false;
+  private abortController: AbortController | undefined;
+  private baselineSet = false;
+
+  constructor({
+    logger,
+    esClient,
+    savedObjectsRepository,
+    index,
+  }: TaskManagerClaimNudgeServiceOptions) {
+    this.logger = logger;
+    this.esClient = esClient;
+    this.savedObjectsRepository = savedObjectsRepository;
+    this.index = index;
+  }
+
+  public get claimNudge$() {
+    return this.claimNudgeSubject.asObservable();
+  }
+
+  public start() {
+    if (this.started) {
+      return;
+    }
+
+    this.started = true;
+    this.baselineSet = false;
+    void this.watchCheckpoints();
+  }
+
+  public stop() {
+    this.started = false;
+    this.abortController?.abort();
+    this.abortController = undefined;
+  }
+
+  public async notify() {
+    const attributes: TaskManagerClaimNudge = {
+      updated_at: new Date().toISOString(),
+      nonce: v4(),
+    };
+
+    await this.savedObjectsRepository.create<TaskManagerClaimNudge>(
+      TASK_MANAGER_CLAIM_NUDGE_SO_NAME,
+      attributes,
+      {
+        id: GLOBAL_CLAIM_NUDGE_ID,
+        overwrite: true,
+        refresh: true,
+      }
+    );
+  }
+
+  private async watchCheckpoints() {
+    let checkpoints: number[] = [];
+
+    while (this.started) {
+      this.abortController = new AbortController();
+
+      try {
+        const response = await this.esClient.fleet.globalCheckpoints(
+          {
+            index: this.index,
+            wait_for_advance: true,
+            wait_for_index: true,
+            checkpoints,
+            timeout: CHECKPOINT_TIMEOUT,
+          },
+          { signal: this.abortController.signal, retryOnTimeout: false }
+        );
+        const { global_checkpoints: nextCheckpoints, timed_out } =
+          response as unknown as GlobalCheckpointsResponse;
+
+        const hasAdvanced =
+          this.baselineSet &&
+          !timed_out &&
+          JSON.stringify(checkpoints) !== JSON.stringify(nextCheckpoints);
+
+        checkpoints = nextCheckpoints;
+        this.baselineSet = true;
+
+        if (hasAdvanced) {
+          this.claimNudgeSubject.next();
+        }
+      } catch (err) {
+        if (!this.started || this.isAbortError(err)) {
+          return;
+        }
+
+        this.logger.debug(
+          `Failed to watch Task Manager claim nudge checkpoints for index ${
+            this.index
+          }: ${this.getErrorMessage(err)}`
+        );
+        await this.delay(ERROR_RETRY_DELAY_MS);
+      } finally {
+        this.abortController = undefined;
+      }
+    }
+  }
+
+  private isAbortError(err: unknown): boolean {
+    if (err instanceof Error) {
+      return (
+        err.name === 'AbortError' ||
+        err.name === 'RequestAbortedError' ||
+        err.message.includes('aborted')
+      );
+    }
+    return false;
+  }
+
+  private getErrorMessage(err: unknown): string {
+    if (SavedObjectsErrorHelpers.isNotFoundError(err)) {
+      return err.message;
+    }
+    if (err instanceof Error) {
+      return err.message;
+    }
+    return String(err);
+  }
+
+  private delay(ms: number) {
+    return new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/constants.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/constants.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 export const TASK_MANAGER_INDEX = '.kibana_task_manager';
+export const TASK_MANAGER_CLAIM_NUDGE_INDEX = '.kibana_task_manager_claim_nudge';
 export const CONCURRENCY_ALLOW_LIST_BY_TASK_TYPE: string[] = [
   // for testing
   'sampleTaskWithSingleConcurrency',

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -41,6 +41,7 @@ import {
   BACKGROUND_TASK_NODE_SO_NAME,
   TASK_SO_NAME,
   INVALIDATE_API_KEY_SO_NAME,
+  TASK_MANAGER_CLAIM_NUDGE_SO_NAME,
 } from './saved_objects';
 import type { TaskDefinitionRegistry } from './task_type_dictionary';
 import { TaskTypeDictionary } from './task_type_dictionary';
@@ -52,7 +53,7 @@ import type { MonitoringStats } from './monitoring';
 import { createMonitoringStats } from './monitoring';
 import type { ConcreteTaskInstance, TaskEventLogger } from './task';
 import { registerTaskManagerUsageCollector } from './usage';
-import { TASK_MANAGER_INDEX } from './constants';
+import { TASK_MANAGER_CLAIM_NUDGE_INDEX, TASK_MANAGER_INDEX } from './constants';
 import { AdHocTaskCounter } from './lib/adhoc_task_counter';
 import { setupIntervalLogging } from './lib/log_health_metrics';
 import type { Metrics } from './metrics';
@@ -76,6 +77,7 @@ import {
   scheduleInvalidateApiKeyTask,
 } from './invalidate_api_keys/invalidate_api_keys_task';
 import { createApiKeyStrategy } from './api_key_strategy';
+import { TaskManagerClaimNudgeService } from './claim_nudge/claim_nudge_service';
 
 export interface TaskManagerSetupContract {
   /**
@@ -160,6 +162,7 @@ export class TaskManagerPlugin
   private invalidateUiamApiKeyFn?: UiamApiKeyInvalidationFn;
   private taskStore?: TaskStore;
   private startContract?: TaskManagerStartContract;
+  private claimNudgeService?: TaskManagerClaimNudgeService;
 
   constructor(private readonly initContext: PluginInitializerContext) {
     this.initContext = initContext;
@@ -302,7 +305,6 @@ export class TaskManagerPlugin
       core.getStartServices,
       this.definitions
     );
-
     if (this.config.unsafe.exclude_task_types.length) {
       this.logger.warn(
         `Excluding task types from execution: ${this.config.unsafe.exclude_task_types.join(', ')}`
@@ -345,7 +347,15 @@ export class TaskManagerPlugin
       TASK_SO_NAME,
       BACKGROUND_TASK_NODE_SO_NAME,
       INVALIDATE_API_KEY_SO_NAME,
+      TASK_MANAGER_CLAIM_NUDGE_SO_NAME,
     ]);
+
+    this.claimNudgeService = new TaskManagerClaimNudgeService({
+      logger: this.logger,
+      esClient: elasticsearch.client.asInternalUser,
+      savedObjectsRepository,
+      index: TASK_MANAGER_CLAIM_NUDGE_INDEX,
+    });
 
     this.kibanaDiscoveryService = new KibanaDiscoveryService({
       savedObjectsRepository,
@@ -442,6 +452,7 @@ export class TaskManagerPlugin
         startingCapacity,
         apiKeyStrategy,
         eventLogger: this.taskEventLogger!,
+        claimNudgeService: this.claimNudgeService,
       });
     }
 
@@ -470,7 +481,12 @@ export class TaskManagerPlugin
       middleware: this.middleware,
       taskManagerId: taskStore.taskManagerId,
       taskPollingLifecycle: this.taskPollingLifecycle,
+      claimNudgeService: this.claimNudgeService,
     });
+
+    if (this.shouldRunBackgroundTasks) {
+      this.claimNudgeService.start();
+    }
 
     scheduleDeleteInactiveNodesTaskDefinition(this.logger, taskScheduling).catch(() => {});
     scheduleInvalidateApiKeyTask(
@@ -528,5 +544,7 @@ export class TaskManagerPlugin
         this.logger.error(`Deleting current node has failed. error: ${e.message}`);
       }
     }
+
+    this.claimNudgeService?.stop();
   }
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -51,7 +51,7 @@ import { TaskScheduling } from './task_scheduling';
 import { backgroundTaskUtilizationRoute, healthRoute, metricsRoute } from './routes';
 import type { MonitoringStats } from './monitoring';
 import { createMonitoringStats } from './monitoring';
-import type { ConcreteTaskInstance, TaskEventLogger } from './task';
+import { TaskPriority, type ConcreteTaskInstance, type TaskEventLogger } from './task';
 import { registerTaskManagerUsageCollector } from './usage';
 import { TASK_MANAGER_CLAIM_NUDGE_INDEX, TASK_MANAGER_INDEX } from './constants';
 import { AdHocTaskCounter } from './lib/adhoc_task_counter';
@@ -126,6 +126,8 @@ export interface TaskManagerPluginsSetup {
 }
 
 const LogHealthForBackgroundTasksOnlyMinutes = 60;
+const TaskManagerLatencyProbeTaskType = 'task_manager:latency_probe';
+const TaskManagerLatencyProbeIntervalMs = 10_000;
 
 export class TaskManagerPlugin
   implements
@@ -163,6 +165,7 @@ export class TaskManagerPlugin
   private taskStore?: TaskStore;
   private startContract?: TaskManagerStartContract;
   private claimNudgeService?: TaskManagerClaimNudgeService;
+  private probeScheduleIntervalId?: NodeJS.Timeout;
 
   constructor(private readonly initContext: PluginInitializerContext) {
     this.initContext = initContext;
@@ -305,6 +308,36 @@ export class TaskManagerPlugin
       core.getStartServices,
       this.definitions
     );
+    this.definitions.registerTaskDefinitions({
+      [TaskManagerLatencyProbeTaskType]: {
+        title: 'Task Manager latency probe',
+        timeout: '5m',
+        priority: TaskPriority.High,
+        createTaskRunner: ({ taskInstance }) => ({
+          run: async () => {
+            const startedAtMs = Date.now();
+            const params = (taskInstance.params ?? {}) as { scheduleRequestedAtMs?: number };
+            const scheduleRequestedAtMs = params.scheduleRequestedAtMs ?? 0;
+            const scheduledAtMs = taskInstance.scheduledAt.valueOf();
+
+            this.logger.info(
+              `[tm_latency_probe] run_started_at=${new Date(
+                startedAtMs
+              ).toISOString()} schedule_requested_at=${new Date(
+                scheduleRequestedAtMs
+              ).toISOString()} task_scheduled_at=${taskInstance.scheduledAt.toISOString()} delta_from_requested_ms=${
+                startedAtMs - scheduleRequestedAtMs
+              } delta_from_scheduled_ms=${startedAtMs - scheduledAtMs}`
+            );
+
+            return {
+              state: {},
+              shouldDeleteTask: true,
+            };
+          },
+        }),
+      },
+    });
     if (this.config.unsafe.exclude_task_types.length) {
       this.logger.warn(
         `Excluding task types from execution: ${this.config.unsafe.exclude_task_types.join(', ')}`
@@ -486,6 +519,50 @@ export class TaskManagerPlugin
 
     if (this.shouldRunBackgroundTasks) {
       this.claimNudgeService.start();
+
+      const scheduleProbeTask = () => {
+        const scheduleRequestedAtMs = Date.now();
+        const probeTaskId = `tm-latency-probe-${this.taskManagerId}-${scheduleRequestedAtMs}`;
+        this.logger.info(
+          `[tm_latency_probe] scheduling_one_time_task id=${probeTaskId} schedule_requested_at=${new Date(
+            scheduleRequestedAtMs
+          ).toISOString()}`
+        );
+
+        taskScheduling
+          .schedule(
+            {
+              id: probeTaskId,
+              taskType: TaskManagerLatencyProbeTaskType,
+              params: { scheduleRequestedAtMs },
+              state: {},
+              enabled: true,
+              priority: TaskPriority.High,
+            },
+            { requestImmediateClaim: true }
+          )
+          .then(() => {
+            const persistedAtMs = Date.now();
+            this.logger.info(
+              `[tm_latency_probe] task_scheduled id=${probeTaskId} persisted_at=${new Date(
+                persistedAtMs
+              ).toISOString()} persistence_delta_ms=${persistedAtMs - scheduleRequestedAtMs}`
+            );
+          })
+          .catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`[tm_latency_probe] failed_scheduling id=${probeTaskId}: ${message}`);
+          });
+      };
+
+      scheduleProbeTask();
+      this.logger.info(
+        `[tm_latency_probe] using setInterval(${TaskManagerLatencyProbeIntervalMs}ms) to schedule one-time probe tasks`
+      );
+      this.probeScheduleIntervalId = setInterval(
+        scheduleProbeTask,
+        TaskManagerLatencyProbeIntervalMs
+      );
     }
 
     scheduleDeleteInactiveNodesTaskDefinition(this.logger, taskScheduling).catch(() => {});
@@ -546,5 +623,10 @@ export class TaskManagerPlugin
     }
 
     this.claimNudgeService?.stop();
+
+    if (this.probeScheduleIntervalId) {
+      clearInterval(this.probeScheduleIntervalId);
+      this.probeScheduleIntervalId = undefined;
+    }
   }
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/polling/task_poller.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling/task_poller.ts
@@ -26,6 +26,7 @@ interface Opts<H> {
   initialPollInterval: number;
   pollInterval$: Observable<number>;
   pollIntervalDelay$?: Observable<number>;
+  claimNudge$?: Observable<void>;
   getCapacity: () => number;
   work: WorkFn<H>;
 }
@@ -52,11 +53,14 @@ export function createTaskPoller<T, H>({
   initialPollInterval,
   pollInterval$,
   pollIntervalDelay$,
+  claimNudge$,
   getCapacity,
   work,
 }: Opts<H>): TaskPoller<T, H> {
   const hasCapacity = () => getCapacity() > 0;
   let running: boolean = false;
+  let isCycleRunning: boolean = false;
+  let nudgeRequested: boolean = false;
   let timeoutId: NodeJS.Timeout | null = null;
   let hasSubscribed: boolean = false;
   let pollInterval = initialPollInterval;
@@ -65,6 +69,7 @@ export function createTaskPoller<T, H>({
 
   async function runCycle() {
     timeoutId = null;
+    isCycleRunning = true;
     const start = Date.now();
     try {
       if (hasCapacity()) {
@@ -75,16 +80,22 @@ export function createTaskPoller<T, H>({
       }
     } catch (e) {
       subject.next(asPollingError<T>(e, PollingErrorType.WorkError));
+    } finally {
+      isCycleRunning = false;
     }
 
     if (running) {
       // Set the next runCycle call
+      const nextDelay = nudgeRequested
+        ? 0
+        : Math.max(pollInterval - (Date.now() - start) + (pollIntervalDelay % pollInterval), 0);
+      nudgeRequested = false;
       timeoutId = setTimeout(
         () =>
           runCycle().catch((e) => {
             subject.next(asPollingError(e, PollingErrorType.PollerError));
           }),
-        Math.max(pollInterval - (Date.now() - start) + (pollIntervalDelay % pollInterval), 0)
+        nextDelay
       );
       // Reset delay, it's designed to shuffle only once
       pollIntervalDelay = 0;
@@ -116,6 +127,27 @@ export function createTaskPoller<T, H>({
       pollIntervalDelay$.subscribe((delay) => {
         pollIntervalDelay = delay;
         logger.debug(`Task poller now delaying emission by ${delay}ms`);
+      });
+    }
+    if (claimNudge$) {
+      claimNudge$.subscribe(() => {
+        if (!running) {
+          return;
+        }
+
+        if (isCycleRunning) {
+          nudgeRequested = true;
+          return;
+        }
+
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+
+        runCycle().catch((e) => {
+          subject.next(asPollingError(e, PollingErrorType.PollerError));
+        });
       });
     }
     hasSubscribed = true;

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -62,6 +62,7 @@ import {
   ADJUST_THROUGHPUT_INTERVAL,
 } from './lib/create_managed_configuration';
 import { createRunningAveragedStat } from './monitoring/task_run_calculators';
+import type { TaskManagerClaimNudgeService } from './claim_nudge/claim_nudge_service';
 
 const MAX_BUFFER_OPERATIONS = 100;
 
@@ -83,6 +84,7 @@ export interface TaskPollingLifecycleOpts {
   startingCapacity: number;
   apiKeyStrategy: ApiKeyStrategy;
   eventLogger: TaskEventLogger;
+  claimNudgeService?: TaskManagerClaimNudgeService;
 }
 
 export type TaskLifecycleEvent =
@@ -148,6 +150,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     startingCapacity,
     apiKeyStrategy,
     eventLogger,
+    claimNudgeService,
   }: TaskPollingLifecycleOpts) {
     this.basePathService = basePathService;
     this.logger = logger;
@@ -224,6 +227,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
       initialPollInterval: pollInterval,
       pollInterval$: this.pollIntervalConfiguration$,
       pollIntervalDelay$,
+      claimNudge$: claimNudgeService?.claimNudge$,
       getCapacity: () => {
         const capacity = this.pool.availableCapacity();
         if (!capacity) {

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/index.ts
@@ -7,14 +7,20 @@
 
 import type { SavedObjectsServiceSetup } from '@kbn/core/server';
 import type { estypes } from '@elastic/elasticsearch';
-import { backgroundTaskNodeMapping, taskMappings, apiKeyToInvalidateMappings } from './mappings';
+import {
+  backgroundTaskNodeMapping,
+  taskMappings,
+  apiKeyToInvalidateMappings,
+  taskManagerClaimNudgeMappings,
+} from './mappings';
 import { getMigrations } from './migrations';
 import { getOldestIdleActionTask } from '../queries/oldest_idle_action_task';
-import { TASK_MANAGER_INDEX } from '../constants';
+import { TASK_MANAGER_CLAIM_NUDGE_INDEX, TASK_MANAGER_INDEX } from '../constants';
 import {
   backgroundTaskNodeModelVersions,
   taskModelVersions,
   apiKeyToInvalidateModelVersions,
+  taskManagerClaimNudgeModelVersions,
 } from './model_versions';
 
 export {
@@ -26,6 +32,7 @@ export {
 export const TASK_SO_NAME = 'task';
 export const BACKGROUND_TASK_NODE_SO_NAME = 'background-task-node';
 export const INVALIDATE_API_KEY_SO_NAME = 'api_key_to_invalidate';
+export const TASK_MANAGER_CLAIM_NUDGE_SO_NAME = 'task_manager_claim_nudge';
 
 export function setupSavedObjects(savedObjects: SavedObjectsServiceSetup) {
   savedObjects.registerType({
@@ -102,5 +109,14 @@ export function setupSavedObjects(savedObjects: SavedObjectsServiceSetup) {
     mappings: apiKeyToInvalidateMappings,
     indexPattern: TASK_MANAGER_INDEX,
     modelVersions: apiKeyToInvalidateModelVersions,
+  });
+
+  savedObjects.registerType({
+    name: TASK_MANAGER_CLAIM_NUDGE_SO_NAME,
+    namespaceType: 'agnostic',
+    hidden: true,
+    mappings: taskManagerClaimNudgeMappings,
+    indexPattern: TASK_MANAGER_CLAIM_NUDGE_INDEX,
+    modelVersions: taskManagerClaimNudgeModelVersions,
   });
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/mappings.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/mappings.ts
@@ -119,3 +119,15 @@ export const apiKeyToInvalidateMappings: SavedObjectsTypeMappingDefinition = {
     },
   },
 };
+
+export const taskManagerClaimNudgeMappings: SavedObjectsTypeMappingDefinition = {
+  dynamic: false,
+  properties: {
+    updated_at: {
+      type: 'date',
+    },
+    nonce: {
+      type: 'keyword',
+    },
+  },
+};

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/index.ts
@@ -8,3 +8,4 @@
 export { taskModelVersions } from './task_model_versions';
 export { backgroundTaskNodeModelVersions } from './background_task_node_model_versions';
 export { apiKeyToInvalidateModelVersions } from './api_key_to_invalidate_model_versions';
+export { taskManagerClaimNudgeModelVersions } from './task_manager_claim_nudge_model_versions';

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/task_manager_claim_nudge_model_versions.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/task_manager_claim_nudge_model_versions.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsModelVersionMap } from '@kbn/core-saved-objects-server';
+import { taskManagerClaimNudgeSchemaV1 } from '../schemas/task_manager_claim_nudge';
+
+export const taskManagerClaimNudgeModelVersions: SavedObjectsModelVersionMap = {
+  '1': {
+    changes: [],
+    schemas: {
+      create: taskManagerClaimNudgeSchemaV1,
+    },
+  },
+};

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/task_manager_claim_nudge.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/task_manager_claim_nudge.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
+
+export const taskManagerClaimNudgeSchemaV1 = schema.object({
+  updated_at: schema.string(),
+  nonce: schema.string(),
+});
+
+export type TaskManagerClaimNudge = TypeOf<typeof taskManagerClaimNudgeSchemaV1>;

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -22,6 +22,7 @@ export enum TaskPriority {
   Low = 1,
   NormalLongRunning = 40,
   Normal = 50,
+  High = 75,
 }
 
 export enum TaskCost {
@@ -570,7 +571,14 @@ export interface ApiKeyOptions {
   regenerateApiKey?: boolean;
 }
 
-export type ScheduleOptions = Record<string, unknown> & ApiKeyOptions;
+export type ScheduleOptions = Record<string, unknown> &
+  ApiKeyOptions & {
+    /**
+     * Controls SO refresh behavior after scheduling. Use `true` only for
+     * latency-sensitive scheduling paths.
+     */
+    refresh?: boolean;
+  };
 
 // Local event log interface to avoid a circular dependency with @kbn/event-log-plugin in .tsconfig
 export interface TaskEventLogger {

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -574,8 +574,13 @@ export interface ApiKeyOptions {
 export type ScheduleOptions = Record<string, unknown> &
   ApiKeyOptions & {
     /**
-     * Controls SO refresh behavior after scheduling. Use `true` only for
-     * latency-sensitive scheduling paths.
+     * Requests immediate claiming behavior for latency-sensitive tasks where a user
+     * is waiting on a result. This maps to refresh + claim nudge internally.
+     */
+    requestImmediateClaim?: boolean;
+    /**
+     * Controls SO refresh behavior after scheduling.
+     * Prefer `requestImmediateClaim` for user-facing latency-sensitive paths.
      */
     refresh?: boolean;
   };

--- a/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.test.ts
@@ -21,6 +21,7 @@ import { omit } from 'lodash';
 import { httpServerMock } from '@kbn/core/server/mocks';
 import { TaskAlreadyRunningError } from './lib/errors';
 import { taskPollingLifecycleMock } from './polling_lifecycle.mock';
+import type { TaskManagerClaimNudgeService } from './claim_nudge/claim_nudge_service';
 
 let fakeTimer: sinon.SinonFakeTimers;
 jest.mock('uuid', () => ({
@@ -63,6 +64,9 @@ describe('TaskScheduling', () => {
   const mockTaskStore = taskStoreMock.create({});
   const definitions = new TaskTypeDictionary(mockLogger());
   const taskPollingLifecycle = taskPollingLifecycleMock.create({});
+  const claimNudgeService = {
+    notify: jest.fn(),
+  } as unknown as jest.Mocked<TaskManagerClaimNudgeService>;
   const taskSchedulingOpts = {
     taskStore: mockTaskStore,
     logger: mockLogger(),
@@ -70,6 +74,7 @@ describe('TaskScheduling', () => {
     definitions,
     taskManagerId: '123',
     taskPollingLifecycle,
+    claimNudgeService,
   };
 
   definitions.registerTaskDefinitions({
@@ -128,8 +133,35 @@ describe('TaskScheduling', () => {
       },
       {
         request: mockRequest,
+        refresh: undefined,
       }
     );
+  });
+
+  test('should call task store with refresh when provided', async () => {
+    const taskScheduling = new TaskScheduling(taskSchedulingOpts);
+    const task = {
+      taskType: 'foo',
+      params: {},
+      state: {},
+    };
+
+    await taskScheduling.schedule(task, { refresh: true });
+
+    expect(mockTaskStore.schedule).toHaveBeenCalledWith(
+      {
+        ...task,
+        id: undefined,
+        schedule: undefined,
+        traceparent: 'parent',
+        enabled: true,
+      },
+      {
+        request: undefined,
+        refresh: true,
+      }
+    );
+    expect(claimNudgeService.notify).toHaveBeenCalledTimes(1);
   });
 
   test('allows scheduling tasks that are disabled', async () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.test.ts
@@ -164,6 +164,32 @@ describe('TaskScheduling', () => {
     expect(claimNudgeService.notify).toHaveBeenCalledTimes(1);
   });
 
+  test('should call task store with refresh and notify when requestImmediateClaim is provided', async () => {
+    const taskScheduling = new TaskScheduling(taskSchedulingOpts);
+    const task = {
+      taskType: 'foo',
+      params: {},
+      state: {},
+    };
+
+    await taskScheduling.schedule(task, { requestImmediateClaim: true });
+
+    expect(mockTaskStore.schedule).toHaveBeenCalledWith(
+      {
+        ...task,
+        id: undefined,
+        schedule: undefined,
+        traceparent: 'parent',
+        enabled: true,
+      },
+      {
+        request: undefined,
+        refresh: true,
+      }
+    );
+    expect(claimNudgeService.notify).toHaveBeenCalledTimes(1);
+  });
+
   test('allows scheduling tasks that are disabled', async () => {
     const taskScheduling = new TaskScheduling(taskSchedulingOpts);
     const task = {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
@@ -30,6 +30,7 @@ import { calculateNextRunAtFromSchedule } from './lib/get_next_run_at';
 import { TaskAlreadyRunningError } from './lib/errors';
 import type { TaskPollingLifecycle } from './polling_lifecycle';
 import { getExecutionId } from './lib/get_execution_id';
+import type { TaskManagerClaimNudgeService } from './claim_nudge/claim_nudge_service';
 
 const VERSION_CONFLICT_STATUS = 409;
 const NOT_FOUND_STATUS = 404;
@@ -40,6 +41,7 @@ export interface TaskSchedulingOpts {
   middleware: Middleware;
   taskManagerId: string;
   taskPollingLifecycle?: TaskPollingLifecycle; // subscribe to task lifecycle events
+  claimNudgeService?: TaskManagerClaimNudgeService;
 }
 
 /**
@@ -71,6 +73,7 @@ export class TaskScheduling {
   private logger: Logger;
   private middleware: Middleware;
   private readonly taskPolling: TaskPollingLifecycle | undefined;
+  private readonly claimNudgeService: TaskManagerClaimNudgeService | undefined;
 
   /**
    * Initializes the task manager, preventing any further addition of middleware,
@@ -82,6 +85,7 @@ export class TaskScheduling {
     this.middleware = opts.middleware;
     this.store = opts.taskStore;
     this.taskPolling = opts.taskPollingLifecycle;
+    this.claimNudgeService = opts.claimNudgeService;
   }
 
   /**
@@ -104,18 +108,30 @@ export class TaskScheduling {
         ? agent.currentTraceparent
         : '';
 
-    return await this.store.schedule(
+    const scheduledTask = await this.store.schedule(
       {
         ...modifiedTask,
         traceparent: traceparent || '',
         enabled: modifiedTask.enabled ?? true,
       },
-      options?.request
+      options?.request || options?.refresh !== undefined
         ? {
             request: options?.request,
+            refresh: options?.refresh,
           }
         : undefined
     );
+
+    if (options?.refresh === true && this.claimNudgeService) {
+      try {
+        await this.claimNudgeService.notify();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`Failed to notify cross-node Task Manager claim nudge: ${message}`);
+      }
+    }
+
+    return scheduledTask;
   }
 
   /**

--- a/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
@@ -98,6 +98,10 @@ export class TaskScheduling {
     taskInstance: TaskInstanceWithDeprecatedFields,
     options?: ScheduleOptions
   ): Promise<ConcreteTaskInstance> {
+    const shouldRequestImmediateClaim =
+      options?.requestImmediateClaim === true || options?.refresh === true;
+    const effectiveRefresh = shouldRequestImmediateClaim ? true : options?.refresh;
+
     const { taskInstance: modifiedTask } = await this.middleware.beforeSave({
       ...omit(options, 'apiKey', 'request'),
       taskInstance: ensureDeprecatedFieldsAreCorrected(taskInstance, this.logger),
@@ -114,15 +118,15 @@ export class TaskScheduling {
         traceparent: traceparent || '',
         enabled: modifiedTask.enabled ?? true,
       },
-      options?.request || options?.refresh !== undefined
+      options?.request || effectiveRefresh !== undefined
         ? {
             request: options?.request,
-            refresh: options?.refresh,
+            refresh: effectiveRefresh,
           }
         : undefined
     );
 
-    if (options?.refresh === true && this.claimNudgeService) {
+    if (shouldRequestImmediateClaim && this.claimNudgeService) {
       try {
         await this.claimNudgeService.notify();
       } catch (err) {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -55,6 +55,7 @@ import type {
   PartialConcreteTaskInstance,
   PartialSerializedConcreteTaskInstance,
   ApiKeyOptions,
+  ScheduleOptions,
 } from './task';
 import { TaskStatus, TaskLifecycleResult } from './task';
 
@@ -441,7 +442,7 @@ export class TaskStore {
    */
   public async schedule(
     taskInstance: TaskInstance,
-    options?: ApiKeyOptions
+    options?: ScheduleOptions
   ): Promise<ConcreteTaskInstance> {
     return this.executionContextRunner.run(() => this._schedule(taskInstance, options), {
       id: 'schedule',
@@ -449,7 +450,7 @@ export class TaskStore {
   }
   private async _schedule(
     taskInstance: TaskInstance,
-    options?: ApiKeyOptions
+    options?: ScheduleOptions
   ): Promise<ConcreteTaskInstance> {
     try {
       this.validateCanEncryptSavedObjects(options?.request);
@@ -478,7 +479,7 @@ export class TaskStore {
           ...apiKeySOFields,
           runAt: getFirstRunAt({ taskInstance: validatedTaskInstance, logger: this.logger }),
         },
-        { id, refresh: false }
+        { id, refresh: options?.refresh ?? false }
       );
       if (
         get(taskInstance, 'schedule.interval', null) == null &&


### PR DESCRIPTION
## Summary
- replace wakeup polling with a renamed claim nudge service that long-polls Fleet global checkpoints
- move claim-nudge signal documents to a dedicated index (`.kibana_task_manager_claim_nudge`) to avoid task index noise
- wire claim nudges through scheduling/poller lifecycle and remove temporary latency probe code from the task manager plugin

## Test plan
- [x] `node scripts/jest x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.test.ts x-pack/platform/plugins/shared/task_manager/server/task_scheduling.test.ts`
- [x] `node scripts/check_changes.ts`

Made with [Cursor](https://cursor.com)