### PR TITLE
[9.4] [Security Solution] fix wrong banner shown in Discover document flyout because of missing services (#268249)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
@@ -245,6 +245,24 @@ describe('AlertFlyoutHeader', () => {
     );
   });
 
+  it('renders nothing while services or store are not yet resolved', () => {
+    const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
+    const history = createMemoryHistory({ initialEntries: ['/discover'] });
+
+    const { container } = render(
+      <Router history={history}>
+        <AlertFlyoutHeader
+          hit={hit}
+          servicesPromise={new Promise(() => {})}
+          storePromise={new Promise(() => {})}
+          onAlertUpdated={jest.fn()}
+        />
+      </Router>
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('shows a callout when _id or _index are missing from hit.raw', async () => {
     const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
     const store = createStore(() => ({}));
@@ -294,6 +312,39 @@ describe('AlertFlyoutHeader', () => {
       expect(
         screen.getByText(
           'This event originates from a remote cluster. Some features may not be available.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows linked project callout text for remote docs in serverless', async () => {
+    const hit = {
+      id: '1',
+      raw: { _id: '1', _index: 'remote-cluster:logs-system-default' },
+      flattened: {},
+    } as unknown as DataTableRecord;
+    const store = createStore(() => ({}));
+    const history = createMemoryHistory({ initialEntries: ['/discover'] });
+    const serverlessServicesMock = {
+      ...servicesMock,
+      cloud: { isServerlessEnabled: true },
+    } as unknown as StartServices;
+
+    render(
+      <Router history={history}>
+        <AlertFlyoutHeader
+          hit={hit}
+          servicesPromise={Promise.resolve(serverlessServicesMock)}
+          storePromise={Promise.resolve(store as never)}
+          onAlertUpdated={jest.fn()}
+        />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'This event originates from a linked project. Some features may not be available.'
         )
       ).toBeInTheDocument();
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
@@ -104,43 +104,35 @@ export const AlertFlyoutHeader = ({
     };
   }, [servicesPromise, storePromise]);
 
-  const isMissingMetadata = !hit.raw._id || !hit.raw._index;
-
-  const metadataCallout = isMissingMetadata ? (
-    <>
-      <EuiCallOut announceOnMount size="s" title={MISSING_METADATA_CALLOUT} />
-      <EuiSpacer size="s" />
-    </>
-  ) : null;
-  const remoteDocumentCallout = (
-    <RemoteDocumentCallout hit={hit}>
-      <EuiSpacer size="s" />
-    </RemoteDocumentCallout>
-  );
-
   if (!services || !store) {
-    return (
-      <>
-        {metadataCallout}
-        {remoteDocumentCallout}
-      </>
-    );
+    return null;
   }
+
+  const isMissingMetadata = !hit.raw._id || !hit.raw._index;
 
   return (
     <>
-      {metadataCallout}
-      {remoteDocumentCallout}
+      {isMissingMetadata ? (
+        <>
+          <EuiCallOut announceOnMount size="s" title={MISSING_METADATA_CALLOUT} />
+          <EuiSpacer size="s" />
+        </>
+      ) : null}
       {flyoutProviders({
         services,
         store,
         children: (
-          <Header
-            hit={hit}
-            renderCellActions={noopCellActionRenderer}
-            onAlertUpdated={onAlertUpdated}
-            onShowNotes={openNotesFlyout}
-          />
+          <>
+            <RemoteDocumentCallout hit={hit}>
+              <EuiSpacer size="s" />
+            </RemoteDocumentCallout>
+            <Header
+              hit={hit}
+              renderCellActions={noopCellActionRenderer}
+              onAlertUpdated={onAlertUpdated}
+              onShowNotes={openNotesFlyout}
+            />
+          </>
         ),
       })}
     </>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution] fix wrong banner shown in Discover document flyout because of missing services (#268249)](https://github.com/elastic/kibana/pull/268249)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-05-08T22:46:54Z","message":"[Security Solution] fix wrong banner shown in Discover document flyout because of missing services (#268249)\n\n## Summary\n\nThis PR makes a super small couple of changes:\n\n#### Fix wrong banner message\n\nMove the `RemoteDocumentCallout` inside the `flyoutProviders` to ensure\nthat the `services` are setup correctly. There was an inconsistency when\nopening the flyout in Discover (which was showing `This attack\noriginates from a linked project. Some features may not be available.`)\nand opening the same flyout in a Dashboard where Discover is embedded\n(which was showing `This attack originates from a remote cluster. Some\nfeatures may not be available.`).\n\n#### Remove the `metadataCallout`\n\nRemove the `EuiCallOut` for missing metadata when the `services` or\n`store` aren't defined. This is for better consistency with the header\nand footer sections of the flyout, which are currently both returning\n`null`.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e46572362f52cd7769e787eeafce1e2b3abc06e9","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","backport:version","v9.5.0","v9.4.1"],"title":"[Security Solution] fix wrong banner shown in Discover document flyout because of missing services","number":268249,"url":"https://github.com/elastic/kibana/pull/268249","mergeCommit":{"message":"[Security Solution] fix wrong banner shown in Discover document flyout because of missing services (#268249)\n\n## Summary\n\nThis PR makes a super small couple of changes:\n\n#### Fix wrong banner message\n\nMove the `RemoteDocumentCallout` inside the `flyoutProviders` to ensure\nthat the `services` are setup correctly. There was an inconsistency when\nopening the flyout in Discover (which was showing `This attack\noriginates from a linked project. Some features may not be available.`)\nand opening the same flyout in a Dashboard where Discover is embedded\n(which was showing `This attack originates from a remote cluster. Some\nfeatures may not be available.`).\n\n#### Remove the `metadataCallout`\n\nRemove the `EuiCallOut` for missing metadata when the `services` or\n`store` aren't defined. This is for better consistency with the header\nand footer sections of the flyout, which are currently both returning\n`null`.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e46572362f52cd7769e787eeafce1e2b3abc06e9"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/268249","number":268249,"mergeCommit":{"message":"[Security Solution] fix wrong banner shown in Discover document flyout because of missing services (#268249)\n\n## Summary\n\nThis PR makes a super small couple of changes:\n\n#### Fix wrong banner message\n\nMove the `RemoteDocumentCallout` inside the `flyoutProviders` to ensure\nthat the `services` are setup correctly. There was an inconsistency when\nopening the flyout in Discover (which was showing `This attack\noriginates from a linked project. Some features may not be available.`)\nand opening the same flyout in a Dashboard where Discover is embedded\n(which was showing `This attack originates from a remote cluster. Some\nfeatures may not be available.`).\n\n#### Remove the `metadataCallout`\n\nRemove the `EuiCallOut` for missing metadata when the `services` or\n`store` aren't defined. This is for better consistency with the header\nand footer sections of the flyout, which are currently both returning\n`null`.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e46572362f52cd7769e787eeafce1e2b3abc06e9"}},{"branch":"9.4","label":"v9.4.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->