### PR TITLE
fix: normalize headers in repository_with_proxy test before forwarding

### DIFF
--- a/src/core/server/integration_tests/saved_objects/service/lib/repository_with_proxy.test.ts
+++ b/src/core/server/integration_tests/saved_objects/service/lib/repository_with_proxy.test.ts
@@ -75,8 +75,7 @@ const registerSOTypes = (setup: InternalCoreSetup) => {
   });
 };
 
-// Failing: See https://github.com/elastic/kibana/issues/141398
-describe.skip('404s from proxies', () => {
+describe('404s from proxies', () => {
   let root: Root;
   let start: InternalCoreStart;
 

--- a/src/core/server/integration_tests/saved_objects/service/lib/repository_with_proxy_utils.ts
+++ b/src/core/server/integration_tests/saved_objects/service/lib/repository_with_proxy_utils.ts
@@ -24,6 +24,24 @@ const defaultProxyOptions = (hostname: string, port: string) => ({
   passThrough: true,
 });
 
+// Netty 4.1.133+ strictly rejects HTTP/1.1 requests carrying both `Content-Length`
+// and `Transfer-Encoding` per RFC 9112 (CVE-2026-42585). Two sources combine to
+// produce such requests through the h2o2 proxy:
+//   1. `passThrough: true` forwards any inbound `Transfer-Encoding: chunked` header,
+//      while Wreck also adds `Content-Length` based on the buffered payload.
+//   2. h2o2 unconditionally adds `Transfer-Encoding: chunked` for DELETE requests
+//      whenever `request.payload` is truthy (the empty Buffer Hapi produces for a
+//      bodyless DELETE counts), then Wreck adds `Content-Length: 0`.
+// Normalize before proxying: drop any inbound `Transfer-Encoding` and clear empty
+// buffered payloads so h2o2 does not synthesize a chunked encoding.
+// See https://github.com/elastic/kibana/issues/141398.
+const normalizeRequestForProxy = (request: Hapi.Request) => {
+  delete request.headers['transfer-encoding'];
+  if (Buffer.isBuffer(request.payload) && request.payload.length === 0) {
+    (request as { payload: unknown }).payload = null;
+  }
+};
+
 let proxyInterrupt: string | null | undefined = null;
 
 export const setProxyInterrupt = (
@@ -41,11 +59,23 @@ export const setProxyInterrupt = (
 ) => (proxyInterrupt = testArg);
 
 // passes the req/response directly as is
-const relayHandler = (h: Hapi.ResponseToolkit, hostname: string, port: string) => {
+const relayHandler = (
+  request: Hapi.Request,
+  h: Hapi.ResponseToolkit,
+  hostname: string,
+  port: string
+) => {
+  normalizeRequestForProxy(request);
   return h.proxy(defaultProxyOptions(hostname, port));
 };
 
-const proxyResponseHandler = (h: Hapi.ResponseToolkit, hostname: string, port: string) => {
+const proxyResponseHandler = (
+  request: Hapi.Request,
+  h: Hapi.ResponseToolkit,
+  hostname: string,
+  port: string
+) => {
+  normalizeRequestForProxy(request);
   return h.proxy({
     ...defaultProxyOptions(hostname, port),
     // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -78,9 +108,9 @@ export const declareGetRoute = (
           req.params.type === 'my_type:myType_123' ||
           proxyInterrupt === 'updatePreflight'
         ) {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -102,9 +132,9 @@ export const declareDeleteRoute = (
       },
       handler: (req, h) => {
         if (req.params._id === 'my_type:myTypeId1') {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -122,9 +152,9 @@ export const declarePostBulkRoute = (hapiServer: Hapi.Server, hostname: string, 
       },
       handler: (req, h) => {
         if (proxyInterrupt === 'bulkCreate') {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -146,9 +176,9 @@ export const declarePostMgetRoute = (hapiServer: Hapi.Server, hostname: string, 
           proxyInterrupt === 'internalBulkResolve' ||
           proxyInterrupt === 'bulkDeleteMyDocs'
         ) {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -167,9 +197,9 @@ export const declareGetSearchRoute = (
       handler: (req, h) => {
         const payload = req.payload;
         if (!payload) {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -191,9 +221,9 @@ export const declarePostSearchRoute = (
       },
       handler: (req, h) => {
         if (proxyInterrupt === 'find') {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -215,9 +245,9 @@ export const declarePostUpdateRoute = (
       },
       handler: (req, h) => {
         if (req.params._id === 'my_type:myTypeToUpdate') {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -239,9 +269,9 @@ export const declarePostPitRoute = (
       },
       handler: (req, h) => {
         if (proxyInterrupt === 'openPit') {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -263,9 +293,9 @@ export const declarePostUpdateByQueryRoute = (
       },
       handler: (req, h) => {
         if (proxyInterrupt === 'deleteByNamespace') {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -288,9 +318,9 @@ export const declareIndexRoute = (
       },
       handler: (req, h) => {
         if (proxyInterrupt === 'update') {
-          return proxyResponseHandler(h, hostname, port);
+          return proxyResponseHandler(req, h, hostname, port);
         } else {
-          return relayHandler(h, hostname, port);
+          return relayHandler(req, h, hostname, port);
         }
       },
     },
@@ -307,7 +337,7 @@ export const declarePassthroughRoute = (hapiServer: Hapi.Server, hostname: strin
         parse: false,
       },
       handler: (req, h) => {
-        return relayHandler(h, hostname, port);
+        return relayHandler(req, h, hostname, port);
       },
     },
   });


### PR DESCRIPTION
## Summary

### Problem

`repository_with_proxy.test.ts` is failing on `kibana-es-forward-compatibility-testing-9-dot-3` since 2026-05-08 (see #141398) with:

```
ResponseError: Content-Length are not allowed in HTTP/1.1 messages that contains a Transfer-Encoding header.: content_length_not_allowed_exception
```

[elastic/elasticsearch#148394](https://github.com/elastic/elasticsearch/pull/148394) bumped Netty from `4.1.132.Final` to `4.1.133.Final`, which contains the [CVE-2026-42585](https://github.com/netty/netty/releases/tag/netty-4.1.133.Final) request-smuggling fix that strictly rejects HTTP/1.1 requests carrying both `Content-Length` and `Transfer-Encoding` (RFC 9112 §6.1). The bump was auto-backported to `8.19.16`, `9.3.5`, `9.4.1`, and `9.5.0`.

The test's `@hapi/h2o2` proxy (`passThrough: true`) was producing exactly such a request shape:

1. `passThrough: true` forwards any inbound `Transfer-Encoding: chunked` header verbatim, while Wreck adds `Content-Length` based on the buffered payload.
2. h2o2 unconditionally sets `Transfer-Encoding: chunked` for `DELETE` requests when `request.payload` is truthy. Hapi's `payload: { output: 'data', parse: false }` produces an *empty* `Buffer` for a body-less `DELETE`, which counts as truthy. Wreck then adds `Content-Length: 0`. The `DELETE` test was the only consistently failing case because `DELETE` is the only method in h2o2's `CHUNKABLE` list.

### Solution

Normalize the inbound Hapi request before forwarding via `h.proxy(...)`:

- Drop `Transfer-Encoding` from inbound headers so `passThrough` cannot reintroduce it.
- Clear empty buffered payloads so h2o2 does not synthesize a chunked encoding for `DELETE`.

Also re-enables the suite that was skipped in `3f51f9651ff6` as the workaround.

### Verification

```
node scripts/jest_integration src/core/server/integration_tests/saved_objects/service/lib/repository_with_proxy.test.ts
```

All 25 cases pass against ES `9.5.0-SNAPSHOT` (Netty 4.1.133), including the previously-failing `handles \`delete\` requests that are successful`.

## Checklist

- [x] Test changes only; no production code touched.
- [x] Re-enables the previously-skipped suite.
- [x] Backport labels added for `8.19`, `9.3`, `9.4`, `9.5`. The `9.3`/`9.4` backports will conflict on the un-skip line because they still carry `describe.skip` from `be3e30a63417` / `634a2540bad7`; resolve by keeping the un-skip.

Closes #141398

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->