### PR TITLE
Fix flaky test: alert_context_menu

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -140,6 +140,26 @@ const alertWorkflowPanelContent = 'alert-workflow-panel-content';
 const runDocumentWorkflowActionButton = 'run-document-workflow-action';
 const documentWorkflowPanelContent = 'document-workflow-panel-content';
 
+// `alert_context_menu.tsx` eagerly imports four flyout components that are
+// never opened by any test in this file. Their transitive module graphs add a
+// large one-time cost to the first render through `<TestProviders>` +
+// `<AlertContextMenu>`, which under CI load was pushing the first `Case
+// actions` test past Jest's default 5s test timeout (flake on
+// kibana-on-merge build 96698). Replacing the flyouts with no-op components
+// removes the cost at its source.
+jest.mock(
+  '../../../../management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout',
+  () => ({ EndpointExceptionsFlyout: () => null })
+);
+jest.mock('../../osquery/osquery_flyout', () => ({ OsqueryFlyout: () => null }));
+jest.mock('../../../../detection_engine/rule_exceptions/components/add_exception_flyout', () => ({
+  AddExceptionFlyout: () => null,
+}));
+jest.mock(
+  '../../../../management/pages/event_filters/view/components/event_filters_flyout',
+  () => ({ EventFiltersFlyout: () => null })
+);
+
 describe('Alert table context menu', () => {
   describe('Case actions', () => {
     test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', async () => {
@@ -257,6 +277,12 @@ describe('Alert table context menu', () => {
     });
 
     test('it shows the workflow panel when run workflow action is clicked', async () => {
+      // EuiPopover applies `pointer-events: none` on the panel until its mount
+      // transition completes. user-event v14 throws synchronously when it
+      // encounters that style, which made this click flaky. Disabling the
+      // pointer-events check here mirrors the sibling Document workflow test
+      // below and is the same fix the user-event docs recommend for popovers.
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
       mockUseRunAlertWorkflowPanel.mockReturnValue({
         runWorkflowMenuItem: mockRunWorkflowMenuItem,
         runAlertWorkflowPanel: mockRunAlertWorkflowPanel,
@@ -268,8 +294,8 @@ describe('Alert table context menu', () => {
         </TestProviders>
       );
 
-      await userEvent.click(wrapper.getByTestId(actionMenuButton));
-      await userEvent.click(wrapper.getByTestId(runWorkflowActionButton));
+      await user.click(wrapper.getByTestId(actionMenuButton));
+      await user.click(wrapper.getByTestId(runWorkflowActionButton));
 
       await waitFor(() => {
         expect(wrapper.getByTestId(alertWorkflowPanelContent)).toBeInTheDocument();


### PR DESCRIPTION
## Summary

### 🛑 Problem

The `alert_context_menu.test.tsx` suite has been flaky on CI. Two distinct issues were causing it:

1. The first `Case actions` test was occasionally exceeding Jest's default 5s timeout (seen on kibana-on-merge build 96698). `alert_context_menu.tsx` eagerly imports four flyout components whose transitive module graphs add a large one-time cost to the first render through `<TestProviders>` + `<AlertContextMenu>`, and under CI load that cost was enough to tip the first test over the limit.
2. The `it shows the workflow panel when run workflow action is clicked` test was intermittently failing because `EuiPopover` sets `pointer-events: none` on the panel until its mount transition completes, and `user-event` v14 throws synchronously when it hits that style.

### 💡 Solution

1. Mock the four unused flyout components (`EndpointExceptionsFlyout`, `OsqueryFlyout`, `AddExceptionFlyout`, `EventFiltersFlyout`) with no-op components. None of the tests in this file open these flyouts, so removing their module-graph cost at the source is safe and fixes the timeout root cause rather than just bumping the timeout.
2. Set up a local `userEvent` instance with `pointerEventsCheck: 0` for the affected test. This mirrors the sibling Document workflow test below and matches the `user-event` docs' recommended fix for popovers.