### PR TITLE
Fix flaky test: dashboard migrations missing resources

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/dashboard_migrations/resources/missing.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/dashboard_migrations/resources/missing.ts
@@ -63,7 +63,7 @@ export default ({ getService }: FtrProviderContext) => {
         migrationId,
       });
 
-      expect(missingResourcesResponse.body).toMatchObject([
+      const expectedMissingResources = [
         { name: 'system_metric_search', type: 'macro' },
         { name: 'macro_one(2)', type: 'macro' },
         { name: 'macro_two(1)', type: 'macro' },
@@ -71,7 +71,17 @@ export default ({ getService }: FtrProviderContext) => {
         { name: 'my_lookup_table', type: 'lookup' },
         { name: 'other_lookup_list', type: 'lookup' },
         { name: 'third', type: 'lookup' },
-      ]);
+      ];
+
+      // The endpoint does not guarantee a stable order, so verify set
+      // membership and exact cardinality independently rather than relying
+      // on positional matching.
+      expect(missingResourcesResponse.body).toEqual(
+        expect.arrayContaining(
+          expectedMissingResources.map((resource) => expect.objectContaining(resource))
+        )
+      );
+      expect(missingResourcesResponse.body).toHaveLength(expectedMissingResources.length);
     });
   });
 };


### PR DESCRIPTION
## Summary

### 🛑 Problem

The dashboard migrations `missing.ts` API integration test was flaky because it used `toMatchObject` against a fixed array, which asserts positional matching. The endpoint returning missing resources does not guarantee a stable order, so the test failed intermittently whenever the response came back in a different sequence.

### 💡 Solution

Switched the assertion to verify set membership (`expect.arrayContaining` + `expect.objectContaining`) and cardinality (`toHaveLength`) independently, so the test no longer depends on response order. Added an inline comment so future readers understand why we don't rely on positional matching here.