### PR TITLE
Fix flaky test: IntegrationFilterButton

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/integrations_filter_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/integrations_filter_button.test.tsx
@@ -39,16 +39,22 @@ describe('<IntegrationFilterButton />', () => {
       services: { data: { query: { filterManager: jest.fn() } } },
     });
 
-    const { getByTestId } = render(<IntegrationFilterButton integrations={integrations} />);
+    const { getByTestId, findByTestId } = render(
+      <IntegrationFilterButton integrations={integrations} />
+    );
 
     const button = getByTestId(INTEGRATION_BUTTON_TEST_ID);
     expect(button).toBeInTheDocument();
     await userEvent.click(button);
 
-    expect(getByTestId(INTEGRATIONS_LIST_TEST_ID)).toBeInTheDocument();
+    // The popover and its EuiSelectable mount asynchronously after the click,
+    // so wait for the list (and its options) to appear before asserting on them.
+    expect(await findByTestId(INTEGRATIONS_LIST_TEST_ID)).toBeInTheDocument();
 
-    expect(getByTestId('first')).toHaveTextContent('firstLabel');
-    expect(getByTestId('second')).toHaveTextContent('secondLabel');
+    await waitFor(() => {
+      expect(getByTestId('first')).toHaveTextContent('firstLabel');
+      expect(getByTestId('second')).toHaveTextContent('secondLabel');
+    });
   });
 
   it('should add a negated filter to filterManager', async () => {


### PR DESCRIPTION
## Summary

### 🛑 Problem

The `<IntegrationFilterButton />` unit test was flaky: after clicking the button to open the popover, it asserted synchronously on the integrations list and its options, but the popover and its `EuiSelectable` mount asynchronously, so the assertions occasionally ran before the elements were in the DOM.

### 💡 Solution

Switched the post-click assertions to async equivalents — `findByTestId` for the integrations list, and a `waitFor` around the option label assertions — so the test waits for the popover content to mount before asserting. Added a comment explaining the async mount so this doesn't get "simplified" back to the flaky version.