### PR TITLE
[Fleet] Use specific index pattern for OTel component metrics

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/use_component_metrics.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/use_component_metrics.ts
@@ -29,7 +29,7 @@ interface UseComponentMetricsResult {
   error?: Error;
 }
 
-const METRICS_INDEX = 'metrics-*';
+const METRICS_INDEX = 'metrics-collectortelemetry.otel-*';
 
 interface MetricDefinition {
   field: string;


### PR DESCRIPTION
## Summary
- Narrow the OTel component metrics query index from `metrics-*` to `metrics-collectortelemetry.otel-*` to avoid matching unrelated metric indices, consistent with the server-side agent metrics query.

## Test plan
- [ ] Open the OTel collector component details in Fleet UI and verify metrics charts still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)