### PR TITLE
[Dashboard Agent] Scope Agent Builder event subscriptions by conversation

### DIFF
--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_integration/agent_live_updates_subscription.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_integration/agent_live_updates_subscription.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { filter, type Subscription } from 'rxjs';
+import { EMPTY, filter, switchMap, type Subscription } from 'rxjs';
 import { isRoundCompleteEvent } from '@kbn/agent-builder-common';
 import { ATTACHMENT_REF_OPERATION, getLatestVersion } from '@kbn/agent-builder-common/attachments';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
@@ -28,53 +28,60 @@ export const createAgentLiveUpdatesSubscription = ({
   api,
   setAttachments,
 }: AgentLiveUpdatesSubscriptionParams): Subscription =>
-  agentBuilder.events.chat$.pipe(filter(isRoundCompleteEvent)).subscribe((event) => {
-    const dashboardAttachments = event.data.attachments?.filter(isDashboardAttachment) ?? [];
-    const incomingAttachments = dashboardAttachments.filter((attachment) => {
-      return (
-        event.data.round.input.attachment_refs?.some(
-          (ref) =>
-            ref.attachment_id === attachment.id &&
-            (ref.operation === ATTACHMENT_REF_OPERATION.updated ||
-              ref.operation === ATTACHMENT_REF_OPERATION.created)
-        ) === true
+  agentBuilder.events.ui.activeConversation$
+    .pipe(
+      switchMap((conversation) =>
+        conversation?.id ? agentBuilder.events.getChatEvents$(conversation.id) : EMPTY
+      ),
+      filter(isRoundCompleteEvent)
+    )
+    .subscribe((event) => {
+      const dashboardAttachments = event.data.attachments?.filter(isDashboardAttachment) ?? [];
+      const incomingAttachments = dashboardAttachments.filter((attachment) => {
+        return (
+          event.data.round.input.attachment_refs?.some(
+            (ref) =>
+              ref.attachment_id === attachment.id &&
+              (ref.operation === ATTACHMENT_REF_OPERATION.updated ||
+                ref.operation === ATTACHMENT_REF_OPERATION.created)
+          ) === true
+        );
+      });
+
+      setAttachments(
+        dashboardAttachments
+          .map((attachment): DashboardAttachment | undefined => {
+            const latestVersionData = getLatestVersion(attachment)?.data;
+            return latestVersionData
+              ? {
+                  id: attachment.id,
+                  type: attachment.type,
+                  data: latestVersionData,
+                  origin: attachment.origin,
+                }
+              : undefined;
+          })
+          .filter((attachment): attachment is DashboardAttachment => attachment !== undefined)
       );
+
+      // TODO: we're assuming only one attachment is coming in at a time
+      const incomingAttachment = incomingAttachments?.at(0);
+      if (!incomingAttachment) {
+        return;
+      }
+
+      const currentSavedObjectId = api.savedObjectId$.getValue();
+
+      // Skip if viewing a saved dashboard that differs from the attachment's linked dashboard
+      if (currentSavedObjectId && incomingAttachment.origin !== currentSavedObjectId) {
+        return;
+      }
+
+      const latestVersionData = getLatestVersion(incomingAttachment)?.data;
+
+      if (!latestVersionData) {
+        return;
+      }
+
+      api.setState(attachmentDataToDashboardState(latestVersionData));
     });
-
-    setAttachments(
-      dashboardAttachments
-        .map((attachment): DashboardAttachment | undefined => {
-          const latestVersionData = getLatestVersion(attachment)?.data;
-          return latestVersionData
-            ? {
-                id: attachment.id,
-                type: attachment.type,
-                data: latestVersionData,
-                origin: attachment.origin,
-              }
-            : undefined;
-        })
-        .filter((attachment): attachment is DashboardAttachment => attachment !== undefined)
-    );
-
-    // TODO: we're assuming only one attachment is coming in at a time
-    const incomingAttachment = incomingAttachments?.at(0);
-    if (!incomingAttachment) {
-      return;
-    }
-
-    const currentSavedObjectId = api.savedObjectId$.getValue();
-
-    // Skip if viewing a saved dashboard that differs from the attachment's linked dashboard
-    if (currentSavedObjectId && incomingAttachment.origin !== currentSavedObjectId) {
-      return;
-    }
-
-    const latestVersionData = getLatestVersion(incomingAttachment)?.data;
-
-    if (!latestVersionData) {
-      return;
-    }
-
-    api.setState(attachmentDataToDashboardState(latestVersionData));
-  });

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_integration/dashboard_app_integration.test.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_integration/dashboard_app_integration.test.ts
@@ -188,7 +188,7 @@ const createActiveConversation = ({
 
 describe('registerDashboardAppIntegration', () => {
   let mockApi: MockDashboardApi;
-  let chat$: Subject<ChatEvent>;
+  let chatEventsByConversationId: Map<string, Subject<ChatEvent>>;
   let addAttachment: jest.Mock;
   let updateAttachmentOrigin: jest.Mock;
   let getUpdateOrigin: jest.Mock;
@@ -203,7 +203,7 @@ describe('registerDashboardAppIntegration', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockApi = createMockDashboardApi();
-    chat$ = new Subject<ChatEvent>();
+    chatEventsByConversationId = new Map();
     addAttachment = jest.fn();
     updateAttachmentOrigin = jest.fn().mockResolvedValue(undefined);
     getUpdateOrigin = jest.fn(
@@ -223,6 +223,10 @@ describe('registerDashboardAppIntegration', () => {
     };
   });
 
+  const emitChatEvent = (conversationId: string, event: ChatEvent) => {
+    chatEventsByConversationId.get(conversationId)?.next(event);
+  };
+
   afterEach(() => {
     cleanup?.();
     jest.useRealTimers();
@@ -234,7 +238,16 @@ describe('registerDashboardAppIntegration', () => {
       addAttachment,
       updateAttachmentOrigin,
       events: {
-        chat$,
+        getChatEvents$: jest.fn((conversationId: string) => {
+          let chatEvents$ = chatEventsByConversationId.get(conversationId);
+
+          if (!chatEvents$) {
+            chatEvents$ = new Subject<ChatEvent>();
+            chatEventsByConversationId.set(conversationId, chatEvents$);
+          }
+
+          return chatEvents$.asObservable();
+        }),
         ui: { activeConversation$: activeConversation$.asObservable() },
       },
     } as unknown as AgentBuilderPluginStart;
@@ -459,7 +472,9 @@ describe('registerDashboardAppIntegration', () => {
     );
 
     addAttachment.mockClear();
-    chat$.next(
+    emitConversationChange({ id: 'conversation-1', attachments: [] });
+    emitChatEvent(
+      'conversation-1',
       createMockRoundCompleteEvent(
         [createVersionedAttachment(createDashboardAttachment({ id: firstDraftAttachment.id }))],
         [{ attachment_id: firstDraftAttachment.id, operation: ATTACHMENT_REF_OPERATION.created }]

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_integration/new_attachment_id_regeneration_subscription.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_integration/new_attachment_id_regeneration_subscription.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { filter, type Subscription } from 'rxjs';
+import { EMPTY, filter, switchMap, type Subscription } from 'rxjs';
 import { isRoundCompleteEvent } from '@kbn/agent-builder-common';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type { IdGenerator } from '..';
@@ -21,8 +21,15 @@ export const createNewAttachmentIdRegenerationSubscription = ({
   agentBuilder,
   draftAttachmentId,
 }: NewAttachmentIdRegenerationSubscriptionParams): Subscription =>
-  agentBuilder.events.chat$.pipe(filter(isRoundCompleteEvent)).subscribe((event) => {
-    if (event.data.attachments?.some(({ id }) => id === draftAttachmentId.current)) {
-      draftAttachmentId.next();
-    }
-  });
+  agentBuilder.events.ui.activeConversation$
+    .pipe(
+      switchMap((conversation) =>
+        conversation?.id ? agentBuilder.events.getChatEvents$(conversation.id) : EMPTY
+      ),
+      filter(isRoundCompleteEvent)
+    )
+    .subscribe((event) => {
+      if (event.data.attachments?.some(({ id }) => id === draftAttachmentId.current)) {
+        draftAttachmentId.next();
+      }
+    });

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
@@ -193,12 +193,21 @@ describe('registerDashboardAttachmentUiDefinition', () => {
   let deps: ReturnType<typeof createMockDeps>;
   let uiDefinition: AttachmentUIDefinition<DashboardAttachment>;
   let unregister: () => void;
-  let chat$: Subject<ChatEvent>;
   let currentAppId$: BehaviorSubject<string | null>;
 
   const createMockDeps = () => {
-    chat$ = new Subject<ChatEvent>();
     currentAppId$ = new BehaviorSubject<string | null>('agentBuilder');
+    const chatEventsByConversationId = new Map<string, Subject<ChatEvent>>();
+    const getChatEvents = (conversationId: string) => {
+      let chatEvents$ = chatEventsByConversationId.get(conversationId);
+
+      if (!chatEvents$) {
+        chatEvents$ = new Subject<ChatEvent>();
+        chatEventsByConversationId.set(conversationId, chatEvents$);
+      }
+
+      return chatEvents$;
+    };
     const dashboardAppClientApi$ = new Subject<DashboardApi | undefined>();
     const addAttachmentType = jest.fn();
     const updateAttachmentOrigin = jest.fn().mockResolvedValue(undefined);
@@ -216,7 +225,9 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       addAttachment: mockAddAttachment,
       updateAttachmentOrigin,
       events: {
-        chat$,
+        getChatEvents$: jest.fn((conversationId: string) =>
+          getChatEvents(conversationId).asObservable()
+        ),
         ui: { activeConversation$: activeConversation$.asObservable() },
       },
     } as unknown as AgentBuilderPluginStart;
@@ -252,7 +263,9 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       updateAttachmentOrigin,
       findDashboardsService,
       emitConversationChange,
-      chat$,
+      emitChatEvent: (conversationId: string, event: ChatEvent) => {
+        getChatEvents(conversationId).next(event);
+      },
       currentAppId$,
     };
   };
@@ -329,7 +342,7 @@ describe('registerDashboardAttachmentUiDefinition', () => {
         addAttachment: jest.fn(),
         updateAttachmentOrigin: jest.fn().mockResolvedValue(undefined),
         events: {
-          chat$: new Subject<ChatEvent>(),
+          getChatEvents$: jest.fn(() => new Subject<ChatEvent>().asObservable()),
           ui: {
             activeConversation$: new BehaviorSubject<ActiveConversation | null>(
               null
@@ -555,7 +568,7 @@ describe('registerDashboardAttachmentUiDefinition', () => {
     });
   });
 
-  describe('dashboard app integration - live changes from chat$', () => {
+  describe('dashboard app integration - live changes from Agent Builder events', () => {
     beforeEach(() => {
       jest.useFakeTimers();
     });
@@ -575,7 +588,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
 
       // Updated operation triggers state update
       const versionedAttachment = createMockVersionedAttachment('attachment-1');
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [versionedAttachment],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.updated }]
@@ -589,7 +603,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
 
       // Created operation also triggers
       mockApi.setState.mockClear();
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [versionedAttachment],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.created }]
@@ -597,6 +612,28 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       );
       expect(mockApi.setState).toHaveBeenCalled();
 
+      cleanup?.();
+    });
+
+    it('ignores roundComplete events from other conversations', async () => {
+      const { getAttachment } = createMockAttachment('attachment-1');
+      const mockApi = createMockDashboardApi();
+
+      const cleanup = await mountAttachment({
+        getAttachment,
+        api: mockApi as unknown as DashboardApi,
+        conversationId: 'conversation-1',
+      });
+
+      deps.emitChatEvent(
+        'conversation-2',
+        createMockRoundCompleteEvent(
+          [createMockVersionedAttachment('attachment-1')],
+          [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.updated }]
+        )
+      );
+
+      expect(mockApi.setState).not.toHaveBeenCalled();
       cleanup?.();
     });
 
@@ -610,7 +647,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       });
 
       // Read operation - no update
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [createMockVersionedAttachment('attachment-1')],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.read }]
@@ -619,7 +657,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       expect(mockApi.setState).not.toHaveBeenCalled();
 
       // No attachment in event - no update
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.updated }]
@@ -628,7 +667,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       expect(mockApi.setState).not.toHaveBeenCalled();
 
       // Attachment without versions - no update
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [createMockVersionedAttachment('attachment-1', undefined, false)],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.updated }]
@@ -652,7 +692,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
         api: mockApi1 as unknown as DashboardApi,
       });
 
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [createMockVersionedAttachment('attachment-1', 'original-dashboard-id')],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.updated }]
@@ -678,7 +719,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
         api: mockApi2 as unknown as DashboardApi,
       });
 
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [createMockVersionedAttachment('attachment-1', 'same-dashboard-id')],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.updated }]
@@ -688,7 +730,7 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       cleanup2?.();
     });
 
-    it('cleans up chat$ subscription on cleanup or API unavailable', async () => {
+    it('cleans up Agent Builder events subscription on cleanup or API unavailable', async () => {
       const { getAttachment } = createMockAttachment('attachment-1');
       const mockApi = createMockDashboardApi();
 
@@ -699,7 +741,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
 
       // API becomes unavailable
       deps.dashboardAppClientApi$.next(undefined);
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [createMockVersionedAttachment('attachment-1')],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.updated }]
@@ -710,7 +753,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       // After cleanup
       deps.dashboardAppClientApi$.next(mockApi as unknown as DashboardApi);
       cleanup?.();
-      chat$.next(
+      deps.emitChatEvent(
+        'conversation-1',
         createMockRoundCompleteEvent(
           [createMockVersionedAttachment('attachment-1')],
           [{ attachment_id: 'attachment-1', operation: ATTACHMENT_REF_OPERATION.updated }]


### PR DESCRIPTION
## Summary

Rewrite after merging https://github.com/elastic/kibana/pull/268440

Migrates Dashboard Agent off the deprecated shared `agentBuilder.events.chat$` stream and onto the new per-conversation `agentBuilder.events.getChatEvents$(conversationId)` API.

This prevents dashboard live updates from reacting to events emitted by other concurrent Agent Builder conversations and adjusts our code to the new api.
