### PR TITLE
[Fleet] Deny output_permissions key in agent policy overrides

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.test.ts
@@ -147,6 +147,32 @@ describe('AgentPolicyBaseSchema', () => {
       }).toThrow();
     });
   });
+
+  describe('overrides validations', () => {
+    it('should throw an error if inputs key is provided', () => {
+      expect(() => {
+        AgentPolicyBaseSchema.overrides.validate({ 'inputs.foo': 'bar' });
+      }).toThrow('inputs overrides is not allowed');
+    });
+
+    it('should throw an error if output_permissions key is provided', () => {
+      expect(() => {
+        AgentPolicyBaseSchema.overrides.validate({ output_permissions: { _fallback: {} } });
+      }).toThrow('output_permissions overrides is not allowed');
+    });
+
+    it('should throw an error if nested output_permissions key is provided', () => {
+      expect(() => {
+        AgentPolicyBaseSchema.overrides.validate({ 'output_permissions.someOutput': {} });
+      }).toThrow('output_permissions overrides is not allowed');
+    });
+
+    it('should not throw for valid overrides keys', () => {
+      expect(() => {
+        AgentPolicyBaseSchema.overrides.validate({ 'agent.monitoring.use_output': 'custom' });
+      }).not.toThrow();
+    });
+  });
 });
 
 describe('FullAgentPolicySchema', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
@@ -115,6 +115,9 @@ export const AgentPolicyBaseSchema = {
           if (Object.keys(val).some((key) => key.match(/^inputs(\.)?/))) {
             return 'inputs overrides is not allowed';
           }
+          if (Object.keys(val).some((key) => key.match(/^output_permissions(\.)?/))) {
+            return 'output_permissions overrides is not allowed';
+          }
         },
         meta: {
           description:


### PR DESCRIPTION
## Summary

- Extends the `overrides` field validator in `AgentPolicyBaseSchema` to reject any key matching `output_permissions` or `output_permissions.*`
- Mirrors the existing guard that already blocks `inputs.*` keys from being overridden via the API
- Adds 4 unit tests covering the new validation

## Test plan

- [x] `node scripts/jest x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.test.ts` passes (all 13 tests green)
- [x] Sending `PUT /api/fleet/agent_policies/{id}` with `overrides: { output_permissions: {...} }` returns a 400 validation error
- [x] Valid overrides keys (e.g. `agent.monitoring.use_output`) are still accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

```
PUT kbn:/api/fleet/agent_policies/6f1f5702-901f-4811-9f00-d008d8988d4d
{
    "name": "Agent policy 2",
    "namespace": "default",
    "overrides": {
      "output_permissions": {
        "default": {
          "_escalated": {
            "indices": [
              {"names": ["*"], "privileges": ["all"]},
              {"names": [".security*"], "privileges": ["all"]}
            ],
            "cluster": ["all", "manage_security", "manage_api_key"]
          }
        }
      }
    }
  }

{
  "statusCode": 400,
  "error": "Bad Request",
  "message": """[request body.overrides]: types that failed validation:
- [request body.overrides.0]: expected value to equal [null]
- [request body.overrides.1]: output_permissions overrides is not allowed"""
}
```

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->