### PR TITLE
[ES|QL] Uses @kbn/code-editor

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/moon.yml
+++ b/src/platform/packages/private/kbn-esql-editor/moon.yml
@@ -18,7 +18,6 @@ project:
   sourceRoot: src/platform/packages/private/kbn-esql-editor
 dependsOn:
   - '@kbn/i18n'
-  - '@kbn/monaco'
   - '@kbn/es-query'
   - '@kbn/core'
   - '@kbn/kibana-react-plugin'

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/code-editor';
 import { ESQL_APPLY_TEXT_REPLACEMENT_COMMAND } from '@kbn/esql-language';
 import { coreMock } from '@kbn/core/public/mocks';
 import { uiActionsPluginMock } from '@kbn/ui-actions-plugin/public/mocks';

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/code-editor';
 import { ESQL_APPLY_TEXT_REPLACEMENT_COMMAND } from '@kbn/esql-language';
 import {
   ESQLVariableType,

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
@@ -22,7 +22,7 @@ import { css as classNameCss } from '@emotion/css';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useMemo } from 'react';
-import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
+import type { MonacoMessage } from '@kbn/code-editor';
 import { filterDataErrors } from '../helpers';
 import type { DataErrorsControl } from '../types';
 import { DataErrorsSwitch } from './data_errors_switch';

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
@@ -17,7 +17,7 @@ import {
   LanguageDocumentationInline,
 } from '@kbn/language-documentation';
 import React, { memo, useCallback, useState } from 'react';
-import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
+import type { MonacoMessage } from '@kbn/code-editor';
 import type { QuerySource } from '@kbn/esql-types/src/esql_telemetry_types';
 import type { ESQLQueryStats as QueryStats } from '@kbn/esql-types';
 import type { DataErrorsControl, ESQLEditorDeps } from '../types';

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.test.tsx
@@ -24,10 +24,10 @@ import { ESQLEditor } from './esql_editor';
 import type { ESQLEditorProps } from './types';
 
 const mockValidate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
-jest.mock('@kbn/monaco', () => ({
-  ...jest.requireActual('@kbn/monaco'),
+jest.mock('@kbn/code-editor', () => ({
+  ...jest.requireActual('@kbn/code-editor'),
   ESQLLang: {
-    ...jest.requireActual('@kbn/monaco').ESQLLang,
+    ...jest.requireActual('@kbn/code-editor').ESQLLang,
     getEsqlLanguage: jest.fn(() => ({
       id: 'esql',
       name: 'ESQL',

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -27,7 +27,7 @@ import type { ESQLTelemetryCallbacks, ESQLRegistrySolutionId } from '@kbn/esql-t
 import { ESQL_CLASSIC_SOLUTION_ID } from '@kbn/esql-types';
 import { FavoritesClient } from '@kbn/content-management-favorites-public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { ESQL_LANG_ID, monaco } from '@kbn/monaco';
+import { ESQL_LANG_ID, monaco } from '@kbn/code-editor';
 import { DataSourceBrowser } from '@kbn/esql-resource-browser';
 import { FieldsBrowser } from '@kbn/esql-resource-browser';
 import { useStableCallback } from '@kbn/react-hooks';

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -16,7 +16,7 @@ import {
   filterDuplicatedWarnings,
   shouldAutoTriggerSuggestions,
 } from './helpers';
-import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
+import type { MonacoMessage } from '@kbn/code-editor';
 
 describe('helpers', function () {
   describe('parseErrors', function () {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -11,11 +11,10 @@ import type { UseEuiTheme } from '@elastic/eui';
 import { euiShadow } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { monaco } from '@kbn/monaco';
+import { monaco, type MonacoMessage } from '@kbn/code-editor';
 import { uniqBy, type MapCache } from 'lodash';
 import { useRef } from 'react';
 import useDebounce from 'react-use/lib/useDebounce';
-import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
 import {
   EDITOR_MAX_HEIGHT,
   EDITOR_MIN_HEIGHT,

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_editor_config.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_editor_config.ts
@@ -9,10 +9,13 @@
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ESQLCallbacks, ESQLTelemetryCallbacks } from '@kbn/esql-types';
-import type { monaco } from '@kbn/monaco';
-import { ESQLLang, ESQL_LANG_ID } from '@kbn/monaco';
-import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
-import type { CodeEditorProps } from '@kbn/code-editor';
+import {
+  ESQLLang,
+  ESQL_LANG_ID,
+  type CodeEditorProps,
+  type MonacoMessage,
+  type monaco,
+} from '@kbn/code-editor';
 import type { EsqlLanguageDeps } from '../types';
 
 // Module-level singleton: maps each Monaco model URI to its ES|QL language

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_query_actions.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_query_actions.test.ts
@@ -9,7 +9,7 @@
 
 import { renderHook, act } from '@testing-library/react';
 import { QuerySource } from '@kbn/esql-types';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 import { useQueryActions } from './use_query_actions';
 import type { ESQLEditorTelemetryService } from '../telemetry/telemetry_service';
 import type { ESQLEditorProps } from '../types';

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_query_actions.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_query_actions.ts
@@ -12,7 +12,7 @@ import { i18n } from '@kbn/i18n';
 import type { AggregateQuery } from '@kbn/es-query';
 import { QuerySource, type TelemetryQuerySubmittedProps } from '@kbn/esql-types';
 import { prettifyQuery } from '@kbn/esql-utils';
-import { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/code-editor';
 import type { ESQLEditorTelemetryService } from '../telemetry/telemetry_service';
 import { getToggleCommentLines } from '../helpers';
 import type { ESQLEditorProps } from '../types';

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_query_validation.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_query_validation.ts
@@ -9,8 +9,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ESQLCallbacks } from '@kbn/esql-types';
-import { ESQLLang, monaco } from '@kbn/monaco';
-import type { MonacoMessage } from '@kbn/monaco/src/languages/esql/language';
+import { ESQLLang, monaco, type MonacoMessage } from '@kbn/code-editor';
 import type { MapCache } from 'lodash';
 import {
   filterDataErrors,

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_time_picker_popover.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_time_picker_popover.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { renderHook, act } from '@testing-library/react';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 import { useTimePickerPopover } from './use_time_picker_popover';
 
 describe('useTimePickerPopover', () => {

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_time_picker_popover.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_time_picker_popover.ts
@@ -9,7 +9,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import moment, { type Moment } from 'moment';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 
 const DATEPICKER_WIDTH = 373;
 

--- a/src/platform/packages/private/kbn-esql-editor/src/lookup_join/append_index_to_join_command.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/lookup_join/append_index_to_join_command.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 import {
   appendIndexToJoinCommandByName,
   appendIndexToJoinCommandByPosition,

--- a/src/platform/packages/private/kbn-esql-editor/src/lookup_join/append_index_to_join_command.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/lookup_join/append_index_to_join_command.ts
@@ -15,7 +15,7 @@ import type {
   ESQLSingleAstItem,
   ESQLSource,
 } from '@elastic/esql/types';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 
 interface SelectedJoin {
   joinCmd: ESQLAstJoinCommand;

--- a/src/platform/packages/private/kbn-esql-editor/src/lookup_join/use_lookup_index_editor.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/lookup_join/use_lookup_index_editor.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { renderHook } from '@testing-library/react';
-import { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/code-editor';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { of } from 'rxjs';
 import {

--- a/src/platform/packages/private/kbn-esql-editor/src/lookup_join/use_lookup_index_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/lookup_join/use_lookup_index_editor.tsx
@@ -15,7 +15,7 @@ import { getLookupIndicesFromQuery } from '@kbn/esql-utils';
 import { i18n } from '@kbn/i18n';
 import type { EditLookupIndexContentContext } from '@kbn/index-editor';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/code-editor';
 import { useDebounceFn } from '@kbn/react-hooks';
 import { isEqual } from 'lodash';
 import type React from 'react';

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_data_source_browser.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_data_source_browser.ts
@@ -13,7 +13,7 @@ import type {
   IndicesAutocompleteResult,
   IndexAutocompleteItem,
 } from '@kbn/esql-types';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 import { BROWSER_POPOVER_WIDTH, DataSourceSelectionChange } from '@kbn/esql-resource-browser';
 import {
   computeInsertionText,

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_fields_browser.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_fields_browser.ts
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useRef, useState, type MutableRefObject } from 'react';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 import { BROWSER_POPOVER_WIDTH, DataSourceSelectionChange } from '@kbn/esql-resource-browser';
 import {
   getLocatedSourceItemsFromQuery,

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/code-editor';
 import { useSourcesBadge } from './use_resource_browser_badge';
 import { IndicesBrowserOpenMode } from './types';
 

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.tsx
@@ -9,7 +9,7 @@
 
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
-import { monaco } from '@kbn/monaco';
+import { monaco } from '@kbn/code-editor';
 import { useCallback, useRef } from 'react';
 import type { MutableRefObject } from 'react';
 import { getSupportedCommand } from './utils';

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/utils.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/utils.ts
@@ -8,7 +8,7 @@
  */
 
 import { Parser, isSource } from '@elastic/esql';
-import type { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/code-editor';
 import type { CommandRange, SourceCommandContext, LocatedSourceItem } from './types';
 import { IndicesBrowserOpenMode } from './types';
 import { SUPPORTED_COMMANDS } from './constants';

--- a/src/platform/packages/private/kbn-esql-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/types.ts
@@ -25,7 +25,7 @@ import type {
   ESQLTelemetryCallbacks,
   ESQLSourceResult,
 } from '@kbn/esql-types';
-import type { ESQLDependencies } from '@kbn/monaco/src/languages/esql/language';
+import type { ESQLDependencies } from '@kbn/code-editor';
 
 export interface DataErrorsControl {
   enabled: boolean;

--- a/src/platform/packages/private/kbn-esql-editor/tsconfig.json
+++ b/src/platform/packages/private/kbn-esql-editor/tsconfig.json
@@ -14,7 +14,6 @@
   ],
   "kbn_references": [
     "@kbn/i18n",
-    "@kbn/monaco",
     "@kbn/es-query",
     "@kbn/core",
     "@kbn/kibana-react-plugin",

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/dynamic_rule_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/dynamic_rule_form.test.tsx
@@ -19,6 +19,7 @@ jest.mock('@kbn/yaml-rule-editor', () => ({
 
 // Mock the code-editor to avoid monaco editor setup
 jest.mock('@kbn/code-editor', () => ({
+  ...jest.requireActual('@kbn/code-editor'),
   CodeEditor: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
     <textarea
       data-test-subj="codeEditorMock"
@@ -26,7 +27,6 @@ jest.mock('@kbn/code-editor', () => ({
       onChange={(e) => onChange(e.target.value)}
     />
   ),
-  ESQL_LANG_ID: 'esql',
 }));
 
 // Mock the ES|QL utils to avoid complex setup

--- a/x-pack/platform/plugins/shared/stack_connectors/__mocks__/@kbn/code-editor/index.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/__mocks__/@kbn/code-editor/index.tsx
@@ -5,4 +5,12 @@
  * 2.0.
  */
 
-export { MockedCodeEditor as CodeEditor } from '@kbn/code-editor-mock';
+import { MockedCodeEditor } from '@kbn/code-editor-mock';
+
+type AnyRecord = Record<string, unknown>;
+const actual = jest.requireActual('@kbn/code-editor') as AnyRecord;
+
+module.exports = {
+  ...actual,
+  CodeEditor: MockedCodeEditor,
+};

--- a/x-pack/solutions/observability/plugins/synthetics/__mocks__/@kbn/code-editor/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/__mocks__/@kbn/code-editor/index.ts
@@ -5,4 +5,12 @@
  * 2.0.
  */
 
-export { MockedCodeEditor as CodeEditor } from '@kbn/code-editor-mock';
+import { MockedCodeEditor } from '@kbn/code-editor-mock';
+
+type AnyRecord = Record<string, unknown>;
+const actual = jest.requireActual('@kbn/code-editor') as AnyRecord;
+
+module.exports = {
+  ...actual,
+  CodeEditor: MockedCodeEditor,
+};


### PR DESCRIPTION
## Summary

Imports from @kbn/code-editor instead of @kbn-monaco
