### PR TITLE
[Streams] Fix data quality badges on listing (bulk failure doc counts)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_streams_doc_counts_fetch.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_streams_doc_counts_fetch.ts
@@ -28,7 +28,8 @@ export interface StreamDocCountsFetch {
 
 interface UseDocCountFetchProps {
   groupTotalCountByTimestamp: boolean;
-  getCanReadFailureStore: (streamName: string) => boolean;
+  /** When `streamName` is omitted (streams listing), this decides whether to fetch failed-doc counts for all streams. */
+  getCanReadFailureStore: (streamName?: string) => boolean;
   numDataPoints: number;
 }
 
@@ -111,8 +112,7 @@ export function useStreamDocCountsFetch({
           : {}),
       });
 
-      // Check per-stream privilege
-      const canReadFailureStore = streamName ? getCanReadFailureStore(streamName) : false;
+      const canReadFailureStore = getCanReadFailureStore(streamName);
 
       const failedCountPromise = canReadFailureStore
         ? streamsRepositoryClient.fetch('GET /internal/streams/doc_counts/failed', {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/268805

The streams listing calls `getStreamDocCounts()` without a `stream` filter. After per-stream failure-store privileges landed in https://github.com/elastic/kibana/pull/264087, the hook set `canReadFailureStore` to `false` whenever `streamName` was omitted, so failed-doc counts were never fetched for the table. Rows then fell back to `qualityByStream[name] ?? 'good'`, while stream detail correctly included failures.

## Fix

Use `getCanReadFailureStore(streamName)` for bulk requests too. `StreamsTreeTable` already passes `undefined` through to `hasFailureStoreAccess` (any listed stream may read the failure store).

## Testing

- `node scripts/eslint` on the touched file.

Made with [Cursor](https://cursor.com)