### PR TITLE
[Unified Search][KQL] Stop Escape propagation when closing autocomplete

### DIFF
--- a/src/platform/plugins/shared/kql/public/components/query_string_input/query_string_input.test.tsx
+++ b/src/platform/plugins/shared/kql/public/components/query_string_input/query_string_input.test.tsx
@@ -15,7 +15,7 @@ import {
 
 import React from 'react';
 import { I18nProvider } from '@kbn/i18n-react';
-import { waitFor, render, screen } from '@testing-library/react';
+import { waitFor, render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { coreMock } from '@kbn/core/public/mocks';
@@ -445,5 +445,52 @@ describe('QueryStringInput', () => {
     await waitFor(() => {
       expect(mockCallback).toHaveBeenCalled();
     });
+  });
+
+  it('Stops Escape propagation while suggestions are visible so parent overlays do not close', async () => {
+    const onParentKeyDown = jest.fn();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <div onKeyDown={onParentKeyDown}>
+        {wrapQueryStringInputInContext({
+          query: { query: '', language: 'kuery' },
+          onSubmit: noop,
+          indexPatterns: [stubIndexPattern],
+          disableAutoFocus: true,
+        })}
+      </div>
+    );
+
+    const textarea = screen.getByRole('textbox');
+    // Typing flips `isSuggestionsVisible` to true synchronously via
+    // `onQueryStringChange`. The typed keydown also reaches the parent, so
+    // we clear the spy before exercising the Escape behavior we care about.
+    await user.type(textarea, 'r');
+    onParentKeyDown.mockClear();
+
+    fireEvent.keyDown(textarea, { key: 'Escape', keyCode: 27 });
+
+    expect(onParentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('Lets Escape propagate when no suggestions are visible so parent Esc-to-close still works', () => {
+    const onParentKeyDown = jest.fn();
+
+    render(
+      <div onKeyDown={onParentKeyDown}>
+        {wrapQueryStringInputInContext({
+          query: kqlQuery,
+          onSubmit: noop,
+          indexPatterns: [stubIndexPattern],
+          disableAutoFocus: true,
+        })}
+      </div>
+    );
+
+    const textarea = screen.getByRole('textbox');
+    fireEvent.keyDown(textarea, { key: 'Escape', keyCode: 27 });
+
+    expect(onParentKeyDown).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/platform/plugins/shared/kql/public/components/query_string_input/query_string_input.tsx
+++ b/src/platform/plugins/shared/kql/public/components/query_string_input/query_string_input.tsx
@@ -452,6 +452,10 @@ export class QueryStringInput extends PureComponent<QueryStringInputProps, State
         case KEY_CODES.ESC:
           if (isSuggestionsVisible) {
             event.preventDefault();
+            // Without this, the Esc keeps bubbling up to ancestor handlers
+            // (e.g. EuiFlyout's Esc-to-close), so closing the autocomplete
+            // would also dismiss the surrounding overlay.
+            event.stopPropagation();
           }
           this.setState({ isSuggestionsVisible: false, index: null });
           break;


### PR DESCRIPTION
## Summary

Partially closes https://github.com/elastic/kibana/issues/264433.
But the fix will affect all places where Unified Search is used within an external overlay such as a flyout or modal.

When the KQL autocomplete suggestions are visible, pressing Escape closes them — but the textarea's `onKeyDown` only calls `event.preventDefault()`, not `event.stopPropagation()`. The keydown keeps bubbling up to ancestor handlers (`EuiFlyout`, modals, anything with its own Esc-to-close), so the user ends up dismissing the surrounding overlay in addition to the autocomplete.

Adds `event.stopPropagation()` alongside `preventDefault()` in `query_string_input.tsx` so Escape is fully consumed once it closes the autocomplete. When no suggestions are visible, Escape continues to propagate, preserving Esc-to-close behavior on the parent overlay.

### Video

https://github.com/user-attachments/assets/881de500-7104-4ea0-af06-d94305ed0f18

### How to test

1. Open Discover, focus the KQL bar, type to trigger suggestions, press Escape — suggestions close, Discover stays put.
2. Open a flyout that contains a KQL bar (e.g. Cloud Security's Graph investigation, alert rule preview), trigger suggestions, press Escape — suggestions close, flyout stays open.
3. In the same flyout, press Escape with no suggestions visible — flyout closes.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Very low risk of breaking Esc key behavior for KQL autocompletion list if not done right