### PR TITLE
[ES|QL] Correcty parses error for conflict types

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -79,6 +79,34 @@ describe('helpers', function () {
       ]);
     });
 
+    it('should return one marker per problem when ES reports multiple problems with colon-containing index names', function () {
+      const error = new Error(
+        '[esql] > Unexpected error from Elasticsearch: verification_exception - Found 2 problems\nline 3:19: Cannot use field [fields.varnish_cache_hit_rate] due to ambiguities being mapped as [2] incompatible types: [float] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000716] and [102] other indices, [long] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.04-000720] and [25] other indices\nline 3:64: Cannot use field [fields.varnish_cache_miss_rate] due to ambiguities being mapped as [2] incompatible types: [float] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000716] and [106] other indices, [long] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.06-000730] and [21] other indices'
+      );
+      expect(parseErrors([error], 'FROM smops_tv_bmbg10:tv-poc_metrics_cdn-*')).toEqual([
+        {
+          message:
+            ' Cannot use field [fields.varnish_cache_hit_rate] due to ambiguities being mapped as [2] incompatible types: [float] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000716] and [102] other indices, [long] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.04-000720] and [25] other indices',
+          startColumn: 19,
+          startLineNumber: 3,
+          endColumn: 19 + 'fields.varnish_cache_hit_rate'.length + 1,
+          endLineNumber: 3,
+          severity: 8,
+          code: 'errorFromES',
+        },
+        {
+          message:
+            ' Cannot use field [fields.varnish_cache_miss_rate] due to ambiguities being mapped as [2] incompatible types: [float] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000716] and [106] other indices, [long] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.06-000730] and [21] other indices',
+          startColumn: 64,
+          startLineNumber: 3,
+          endColumn: 64 + 'fields.varnish_cache_miss_rate'.length + 1,
+          endLineNumber: 3,
+          severity: 8,
+          code: 'errorFromES',
+        },
+      ]);
+    });
+
     it('should return the generic error object for an error with unexpected format', function () {
       const error = new Error(
         '[esql] > Unexpected error from Elasticsearch: verification_exception - Found ambiguous reference to [user_id]; matches any of [line 3:15 [user_id], line 4:15 [user_id]]'

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -116,46 +116,63 @@ export const parseWarning = (warning: string): MonacoMessage[] => {
   ];
 };
 
+const ES_PROBLEM_MARKER_REGEX = /line (\d+):(\d+):/g;
+
 export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
-  return errors.map((error) => {
+  return errors.flatMap((error): MonacoMessage[] => {
     try {
       if (
         // Found while testing random commands (as inlinestats)
         !error.message.includes('esql_illegal_argument_exception') &&
         error.message.includes('line')
       ) {
-        const text = error.message.split('line')[1];
-        const [lineNumber, startPosition, errorMessage] = text.split(':');
-        // initialize the length to 10 in case no error word found
-        let errorLength = 10;
-        const [_, wordWithError] = errorMessage.split('[');
-        if (wordWithError) {
-          errorLength = wordWithError.length - 1;
+        const markers: Array<{ line: number; column: number; end: number; start: number }> = [];
+        for (const match of error.message.matchAll(ES_PROBLEM_MARKER_REGEX)) {
+          markers.push({
+            line: Number(match[1]),
+            column: Number(match[2]),
+            start: match.index ?? 0,
+            end: (match.index ?? 0) + match[0].length,
+          });
         }
-        return {
-          message: errorMessage,
-          startColumn: Number(startPosition),
-          startLineNumber: Number(lineNumber),
-          endColumn: Number(startPosition) + errorLength + 1,
-          endLineNumber: Number(lineNumber),
-          severity: monaco.MarkerSeverity.Error,
-          code: 'errorFromES',
-        };
-      } else if (error.message.includes('expression was aborted')) {
-        return {
-          message: i18n.translate('esqlEditor.query.aborted', {
-            defaultMessage: 'Request was aborted',
-          }),
-          startColumn: 1,
-          startLineNumber: 1,
-          endColumn: 10,
-          endLineNumber: 1,
-          severity: monaco.MarkerSeverity.Warning,
-          code: 'abortedRequest',
-        };
-      } else {
-        // unknown error message
-        return {
+
+        if (markers.length > 0) {
+          return markers.map((marker, i) => {
+            const messageEnd = i + 1 < markers.length ? markers[i + 1].start : error.message.length;
+            const message = error.message.slice(marker.end, messageEnd).replace(/\s+$/, '');
+            const bracketed = message.match(/\[([^\]]*)\]/);
+            const errorLength = bracketed ? bracketed[1].length : 10;
+            return {
+              message,
+              startColumn: marker.column,
+              startLineNumber: marker.line,
+              endColumn: marker.column + errorLength + 1,
+              endLineNumber: marker.line,
+              severity: monaco.MarkerSeverity.Error,
+              code: 'errorFromES',
+            };
+          });
+        }
+      }
+
+      if (error.message.includes('expression was aborted')) {
+        return [
+          {
+            message: i18n.translate('esqlEditor.query.aborted', {
+              defaultMessage: 'Request was aborted',
+            }),
+            startColumn: 1,
+            startLineNumber: 1,
+            endColumn: 10,
+            endLineNumber: 1,
+            severity: monaco.MarkerSeverity.Warning,
+            code: 'abortedRequest',
+          },
+        ];
+      }
+
+      return [
+        {
           message: error.message,
           startColumn: 1,
           startLineNumber: 1,
@@ -163,18 +180,20 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
           endLineNumber: 1,
           severity: monaco.MarkerSeverity.Error,
           code: 'unknownError',
-        };
-      }
+        },
+      ];
     } catch (e) {
-      return {
-        message: error.message,
-        startColumn: 1,
-        startLineNumber: 1,
-        endColumn: 10,
-        endLineNumber: 1,
-        severity: monaco.MarkerSeverity.Error,
-        code: 'unknownError',
-      };
+      return [
+        {
+          message: error.message,
+          startColumn: 1,
+          startLineNumber: 1,
+          endColumn: 10,
+          endLineNumber: 1,
+          severity: monaco.MarkerSeverity.Error,
+          code: 'unknownError',
+        },
+      ];
     }
   });
 };


### PR DESCRIPTION
## Summary

Fixes a wrong parsing of the error that comes from ES when we have conflict types such as:


```
"Found 2 problems\nline 3:19: Cannot use field [fields.varnish_cache_hit_rate] due to ambiguities being mapped as [2] incompatible types: [float] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000716, smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000717, smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000718] and [102] other indices, [long] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.04-000720, smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.07-000733, smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.10-000745] and [25] other indices\nline 3:64: Cannot use field [fields.varnish_cache_miss_rate] due to ambiguities being mapped as [2] incompatible types: [float] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000716, smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000717, smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.03-000718] and [106] other indices, [long] in [smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.06-000730, smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.08-000734, smops_tv_bmbg10:tv-poc_metrics_cdn-2026.04.08-000737] and [21] other indices"
```

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



