### PR TITLE
[Scout] Enable `lens` plugin in CI config

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -11,6 +11,7 @@ plugins:
     - index_management
     - infra
     - logstash
+    - lens
     - maps
     - observability
     - observability_onboarding


### PR DESCRIPTION
Quick checks are failing because the `lens` plugin is not included in Scout CI config.

Unblocks https://github.com/elastic/kibana/pull/268792