### PR TITLE
[sigevents] Reduce dataset analysis size

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/dataset_analysis.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/dataset_analysis.ts
@@ -29,6 +29,7 @@ This is useful for understanding what fields are available for querying and what
     const formattedAnalysis = formatDocumentAnalysis(analysis, {
       dropEmpty: true,
       dropUnmapped: false,
+      limit: 150,
     });
 
     return {

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/utils.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/utils.ts
@@ -22,6 +22,7 @@ export interface QueryData {
 
 const SAMPLE_EVENTS_COUNT = 5;
 const CURRENT_WINDOW_MINUTES = 15;
+const SAMPLE_EVENT_MAX_CHARS = 2_000;
 
 /**
  * Safely extracts insights from an LLM response.
@@ -107,9 +108,12 @@ export async function collectQueryData({
     return undefined;
   }
 
-  const sampleEvents = currentResponse.hits.hits.map((hit) =>
-    JSON.stringify(omit(hit._source?.original_source ?? {}, '_id'))
-  );
+  const sampleEvents = currentResponse.hits.hits.map((hit) => {
+    const stringified = JSON.stringify(omit(hit._source?.original_source ?? {}, '_id'));
+    return stringified.length > SAMPLE_EVENT_MAX_CHARS
+      ? `${stringified.slice(0, SAMPLE_EVENT_MAX_CHARS)}…(truncated)`
+      : stringified;
+  });
 
   return {
     title: query.query.title,


### PR DESCRIPTION
## Summary

Two small adjustments to reduce context size

- **`dataset_analysis` computed feature**: cap field count via `formatDocumentAnalysis({ limit: 150 })` instead of the default of 500.
- **`collectQueryData` sample events**: hard-cap each stringified `original_source` at 2,000 chars with a `…(truncated)` suffix (new `SAMPLE_EVENT_MAX_CHARS` constant).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->