### PR TITLE
[9.3] Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/kibana-management` files (#268614)

### DIFF
--- a/src/platform/packages/shared/kbn-management/cards_navigation/src/cards_navigation.tsx
+++ b/src/platform/packages/shared/kbn-management/cards_navigation/src/cards_navigation.tsx
@@ -192,7 +192,7 @@ export const CardsNavigation = ({
                 <EuiCard
                   data-test-subj={`app-card-${app.id}`}
                   layout="horizontal"
-                  icon={<EuiIcon type={app.icon} size="l" color="text" />}
+                  icon={<EuiIcon type={app.icon} size="l" color="text" aria-hidden={true} />}
                   titleSize="xs"
                   title={app.title}
                   description={app.description}

--- a/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/__stories__/use_array_reorder.tsx
+++ b/src/platform/plugins/shared/es_ui_shared/static/forms/hook_form_lib/components/__stories__/use_array_reorder.tsx
@@ -90,7 +90,7 @@ export function Reorder() {
                                     css={{ marginTop: '20px' }}
                                     aria-label="Change row order"
                                   >
-                                    <EuiIcon type="grab" />
+                                    <EuiIcon type="grab" aria-hidden={true} />
                                   </div>
                                 </EuiFlexItem>
                                 <EuiFlexItem>
@@ -217,7 +217,7 @@ const MyFormComponent = () => {
                                   css={{ marginTop: '20px' }}
                                   aria-label="Change row order"
                                 >
-                                  <EuiIcon type="grab" />
+                                  <EuiIcon type="grab" aria-hidden={true} />
                                 </div>
                               </EuiFlexItem>
                               <EuiFlexItem>

--- a/src/platform/plugins/shared/management/public/components/management_sidebar_nav/management_sidebar_nav.tsx
+++ b/src/platform/plugins/shared/management/public/components/management_sidebar_nav/management_sidebar_nav.tsx
@@ -85,7 +85,7 @@ export const managementSidebarNav = ({
       id: item.id,
       name: item.tip ? <HeaderWrapper text={item.title} tip={item.tip} /> : item.title,
       isSelected: item.id === selectedId,
-      icon: iconType ? <EuiIcon type={iconType} size="m" /> : undefined,
+      icon: iconType ? <EuiIcon type={iconType} size="m" aria-hidden={true} /> : undefined,
       'data-test-subj': item.id,
       ...customParams,
     };

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/select_template/error_state.tsx
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/select_template/error_state.tsx
@@ -24,7 +24,7 @@ export const ErrorState = ({ onRetryLoadTemplates }: { onRetryLoadTemplates: () 
       })}
     >
       <EuiEmptyPrompt
-        icon={<EuiIcon type="warning" color="warning" size="l" />}
+        icon={<EuiIcon type="warning" color="warning" size="l" aria-hidden={true} />}
         color="warning"
         data-test-subj="errorLoadingTemplates"
         title={

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/components/auto_follow_pattern_action_menu/auto_follow_pattern_action_menu.tsx
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/components/auto_follow_pattern_action_menu/auto_follow_pattern_action_menu.tsx
@@ -73,7 +73,7 @@ const AutoFollowPatternActionMenuUI: FunctionComponent<Props> = ({
               defaultMessage: 'Pause {total, plural, one {replication} other {replications}}',
               values: { total: patterns.length },
             }),
-            icon: <EuiIcon type="pause" />,
+            icon: <EuiIcon type="pause" aria-hidden={true} />,
             onClick: () => {
               pauseAutoFollowPattern(patterns.map(({ name }) => name));
               closePopoverViaAction();
@@ -84,7 +84,7 @@ const AutoFollowPatternActionMenuUI: FunctionComponent<Props> = ({
               defaultMessage: 'Resume {total, plural, one {replication} other {replications}}',
               values: { total: patterns.length },
             }),
-            icon: <EuiIcon type="play" />,
+            icon: <EuiIcon type="play" aria-hidden={true} />,
             onClick: () => {
               resumeAutoFollowPattern(patterns.map(({ name }) => name));
               closePopoverViaAction();
@@ -99,7 +99,7 @@ const AutoFollowPatternActionMenuUI: FunctionComponent<Props> = ({
           name: i18n.translate('xpack.crossClusterReplication.editAutoFollowPatternButtonLabel', {
             defaultMessage: 'Edit pattern',
           }),
-          icon: <EuiIcon type="pencil" />,
+          icon: <EuiIcon type="pencil" aria-hidden={true} />,
           onClick: () => {
             routing.navigate(routing.getAutoFollowPatternPath(patterns[0].name));
           },
@@ -115,7 +115,7 @@ const AutoFollowPatternActionMenuUI: FunctionComponent<Props> = ({
           total: patterns.length,
         },
       }),
-      icon: <EuiIcon type="trash" />,
+      icon: <EuiIcon type="trash" aria-hidden={true} />,
       onClick: () => {
         deleteAutoFollowPattern(patterns.map(({ name }) => name));
         closePopoverViaAction();

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/auto_follow_pattern_list/components/detail_panel/detail_panel.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/auto_follow_pattern_list/components/detail_panel/detail_panel.js
@@ -211,7 +211,7 @@ export class DetailPanel extends Component {
       <EuiFlyoutBody>
         <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon size="m" type="warning" color="danger" />
+            <EuiIcon size="m" type="warning" color="danger" aria-hidden={true} />
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
@@ -238,7 +238,7 @@ export class DetailPanel extends Component {
       <section data-test-subj="errors">
         <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warning" color="danger" />
+            <EuiIcon type="warning" color="danger" aria-hidden={true} />
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/detail_panel/detail_panel.tsx
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/detail_panel/detail_panel.tsx
@@ -507,7 +507,7 @@ export const DetailPanel = ({
         <EuiFlyoutBody>
           <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon size="m" type="warning" color="danger" />
+              <EuiIcon size="m" type="warning" color="danger" aria-hidden={true} />
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/policy_list/policy_flyout/view_policy_flyout.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/policy_list/policy_flyout/view_policy_flyout.tsx
@@ -61,7 +61,7 @@ export const ViewPolicyFlyout = ({ policy }: { policy: PolicyFromES }) => {
       name: i18n.translate('xpack.indexLifecycleMgmt.policyFlyout.editActionLabel', {
         defaultMessage: 'Edit',
       }),
-      icon: <EuiIcon type="pencil" />,
+      icon: <EuiIcon type="pencil" aria-hidden={true} />,
       onClick: () => onEdit(policy.name),
     },
     /**
@@ -71,7 +71,7 @@ export const ViewPolicyFlyout = ({ policy }: { policy: PolicyFromES }) => {
       name: i18n.translate('xpack.indexLifecycleMgmt.policyFlyout.addToIndexTemplate', {
         defaultMessage: 'Add to index template',
       }),
-      icon: <EuiIcon type="plusInCircle" />,
+      icon: <EuiIcon type="plusInCircle" aria-hidden={true} />,
       onClick: () => setListAction({ selectedPolicy: policy, actionType: 'addIndexTemplate' }),
     },
   ];
@@ -83,7 +83,7 @@ export const ViewPolicyFlyout = ({ policy }: { policy: PolicyFromES }) => {
       name: i18n.translate('xpack.indexLifecycleMgmt.policyFlyout.deleteActionLabel', {
         defaultMessage: 'Delete',
       }),
-      icon: <EuiIcon type="trash" />,
+      icon: <EuiIcon type="trash" aria-hidden={true} />,
       onClick: () => {
         setShowPopover(false);
         setListAction({ selectedPolicy: policy, actionType: 'deletePolicy' });

--- a/x-pack/platform/plugins/private/painless_lab/public/application/components/output_pane/context_tab.tsx
+++ b/x-pack/platform/plugins/private/painless_lab/public/application/components/output_pane/context_tab.tsx
@@ -48,7 +48,7 @@ export const ContextTab: FunctionComponent = () => {
                 id="xpack.painlessLab.contextFieldLabel"
                 defaultMessage="Execution context"
               />{' '}
-              <EuiIcon type="question" color="subdued" />
+              <EuiIcon type="question" color="subdued" aria-hidden={true} />
             </span>
           </EuiToolTip>
         }
@@ -87,7 +87,7 @@ export const ContextTab: FunctionComponent = () => {
                   id="xpack.painlessLab.indexFieldLabel"
                   defaultMessage="Index name"
                 />{' '}
-                <EuiIcon type="question" color="subdued" />
+                <EuiIcon type="question" color="subdued" aria-hidden={true} />
               </span>
             </EuiToolTip>
           }
@@ -126,7 +126,7 @@ export const ContextTab: FunctionComponent = () => {
             >
               <span tabIndex={0}>
                 <FormattedMessage id="xpack.painlessLab.queryFieldLabel" defaultMessage="Query" />{' '}
-                <EuiIcon type="question" color="subdued" />
+                <EuiIcon type="question" color="subdued" aria-hidden={true} />
               </span>
             </EuiToolTip>
           }
@@ -172,7 +172,7 @@ export const ContextTab: FunctionComponent = () => {
                   id="xpack.painlessLab.documentFieldLabel"
                   defaultMessage="Sample document (JSON)"
                 />{' '}
-                <EuiIcon type="question" color="subdued" />
+                <EuiIcon type="question" color="subdued" aria-hidden={true} />
               </span>
             </EuiToolTip>
           }

--- a/x-pack/platform/plugins/private/painless_lab/public/application/components/output_pane/output_pane.tsx
+++ b/x-pack/platform/plugins/private/painless_lab/public/application/components/output_pane/output_pane.tsx
@@ -57,9 +57,9 @@ export const OutputPane: FunctionComponent<Props> = ({ isLoading, response }) =>
         {isLoading ? (
           <EuiLoadingSpinner size="m" />
         ) : response && response.error ? (
-          <EuiIcon type="warning" color="danger" />
+          <EuiIcon type="warning" color="danger" aria-hidden={true} />
         ) : (
-          <EuiIcon type="check" color="success" />
+          <EuiIcon type="check" color="success" aria-hidden={true} />
         )}
       </EuiFlexItem>
 

--- a/x-pack/platform/plugins/private/painless_lab/public/application/components/output_pane/parameters_tab.tsx
+++ b/x-pack/platform/plugins/private/painless_lab/public/application/components/output_pane/parameters_tab.tsx
@@ -36,7 +36,7 @@ export const ParametersTab: FunctionComponent = () => {
                 id="xpack.painlessLab.parametersFieldLabel"
                 defaultMessage="Parameters (JSON)"
               />{' '}
-              <EuiIcon type="question" color="subdued" />
+              <EuiIcon type="question" color="subdued" aria-hidden={true} />
             </span>
           </EuiToolTip>
         }

--- a/x-pack/platform/plugins/private/remote_clusters/public/application/sections/remote_cluster_list/detail_panel/detail_panel.js
+++ b/x-pack/platform/plugins/private/remote_clusters/public/application/sections/remote_cluster_list/detail_panel/detail_panel.js
@@ -83,7 +83,7 @@ export class DetailPanel extends Component {
         data-test-subj="remoteClusterDetailClusterNotFound"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon size="m" type="warning" color="danger" />
+          <EuiIcon size="m" type="warning" color="danger" aria-hidden={true} />
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/private/rollup/public/crud_app/sections/components/job_action_menu/job_action_menu.js
+++ b/x-pack/platform/plugins/private/rollup/public/crud_app/sections/components/job_action_menu/job_action_menu.js
@@ -67,7 +67,7 @@ export class JobActionMenuUi extends Component {
           defaultMessage: 'Start {isSingleSelection, plural, one {job} other {jobs}}',
           values: { isSingleSelection },
         }),
-        icon: <EuiIcon type="play" />,
+        icon: <EuiIcon type="play" aria-hidden={true} />,
         onClick: () => {
           this.closePopover();
           startJobs();
@@ -81,7 +81,7 @@ export class JobActionMenuUi extends Component {
           defaultMessage: 'Stop {isSingleSelection, plural, one {job} other {jobs}}',
           values: { isSingleSelection },
         }),
-        icon: <EuiIcon type="stop" />,
+        icon: <EuiIcon type="stop" aria-hidden={true} />,
         onClick: () => {
           this.closePopover();
           stopJobs();
@@ -94,7 +94,7 @@ export class JobActionMenuUi extends Component {
         name: i18n.translate('xpack.rollupJobs.jobActionMenu.cloneJobLabel', {
           defaultMessage: 'Clone job',
         }),
-        icon: <EuiIcon data-test-subj="jobCloneActionContextMenu" type="copy" />,
+        icon: <EuiIcon data-test-subj="jobCloneActionContextMenu" type="copy" aria-hidden={true} />,
         onClick: () => {
           this.closePopover();
           const { jobs } = this.props;
@@ -111,7 +111,7 @@ export class JobActionMenuUi extends Component {
             isSingleSelection,
           },
         }),
-        icon: <EuiIcon type="trash" />,
+        icon: <EuiIcon type="trash" aria-hidden={true} />,
         onClick: () => {
           this.closePopover();
           this.openDeleteConfirmationModal();

--- a/x-pack/platform/plugins/private/rollup/public/crud_app/sections/job_list/detail_panel/detail_panel.js
+++ b/x-pack/platform/plugins/private/rollup/public/crud_app/sections/job_list/detail_panel/detail_panel.js
@@ -210,7 +210,7 @@ export class DetailPanel extends Component {
         <EuiFlyoutBody data-test-subj="rollupJobDetailJobNotFound">
           <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon size="m" type="warning" color="danger" />
+              <EuiIcon size="m" type="warning" color="danger" aria-hidden={true} />
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_data_streams_list.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_data_streams_list.tsx
@@ -57,10 +57,7 @@ export const CollapsibleDataStreamsList: React.FunctionComponent<Props> = ({ dat
                 values={{ count: hiddenItemsCount }}
               />
             )}{' '}
-            <EuiIcon
-              type={isShowingFullList ? 'arrowUp' : 'arrowDown'}
-              aria-hidden={true}
-            />
+            <EuiIcon type={isShowingFullList ? 'arrowUp' : 'arrowDown'} aria-hidden={true} />
           </EuiLink>
         </>
       ) : null}

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_data_streams_list.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_data_streams_list.tsx
@@ -57,7 +57,10 @@ export const CollapsibleDataStreamsList: React.FunctionComponent<Props> = ({ dat
                 values={{ count: hiddenItemsCount }}
               />
             )}{' '}
-            <EuiIcon type={isShowingFullList ? 'arrowUp' : 'arrowDown'} />
+            <EuiIcon
+              type={isShowingFullList ? 'arrowUp' : 'arrowDown'}
+              aria-hidden={true}
+            />
           </EuiLink>
         </>
       ) : null}

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_feature_states.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_feature_states.tsx
@@ -71,7 +71,10 @@ export const CollapsibleFeatureStatesList: React.FunctionComponent<Props> = ({ f
                 values={{ count: hiddenItemsCount }}
               />
             )}{' '}
-            <EuiIcon type={isShowingFullList ? 'arrowUp' : 'arrowDown'} />
+            <EuiIcon
+              type={isShowingFullList ? 'arrowUp' : 'arrowDown'}
+              aria-hidden={true}
+            />
           </EuiLink>
         </>
       ) : null}

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_feature_states.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_feature_states.tsx
@@ -71,10 +71,7 @@ export const CollapsibleFeatureStatesList: React.FunctionComponent<Props> = ({ f
                 values={{ count: hiddenItemsCount }}
               />
             )}{' '}
-            <EuiIcon
-              type={isShowingFullList ? 'arrowUp' : 'arrowDown'}
-              aria-hidden={true}
-            />
+            <EuiIcon type={isShowingFullList ? 'arrowUp' : 'arrowDown'} aria-hidden={true} />
           </EuiLink>
         </>
       ) : null}

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_indices_list.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_indices_list.tsx
@@ -59,6 +59,7 @@ export const CollapsibleIndicesList: React.FunctionComponent<Props> = ({ indices
             <EuiIcon
               type={isShowingFullList ? 'arrowUp' : 'arrowDown'}
               data-test-subj="collapsibleIndicesArrow"
+              aria-hidden={true}
             />
           </EuiLink>
         </>

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_review.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_review.tsx
@@ -65,7 +65,7 @@ export const RestoreSnapshotStepReview: React.FunctionComponent<StepProps> = ({
             }
           >
             <EuiLink onClick={() => updateCurrentStep(1)}>
-              <EuiIcon type="pencil" />
+              <EuiIcon type="pencil" aria-hidden={true} />
             </EuiLink>
           </EuiToolTip>
         </h3>
@@ -208,7 +208,7 @@ export const RestoreSnapshotStepReview: React.FunctionComponent<StepProps> = ({
             }
           >
             <EuiLink onClick={() => updateCurrentStep(2)}>
-              <EuiIcon type="pencil" />
+              <EuiIcon type="pencil" aria-hidden={true} />
             </EuiLink>
           </EuiToolTip>
         </h3>

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/snapshot_list/components/snapshot_empty_prompt.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/snapshot_list/components/snapshot_empty_prompt.tsx
@@ -102,7 +102,7 @@ export const SnapshotEmptyPrompt: React.FunctionComponent<{ policiesCount: numbe
                       id="xpack.snapshotRestore.emptyPrompt.noSnapshotsDocLinkText"
                       defaultMessage="Learn how to create a snapshot"
                     />{' '}
-                    <EuiIcon type="link" />
+                    <EuiIcon type="link" aria-hidden={true} />
                   </EuiLink>
                 </p>
               </Fragment>

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/snapshot_list/snapshot_details/tabs/snapshot_state.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/snapshot_list/snapshot_details/tabs/snapshot_state.tsx
@@ -57,7 +57,7 @@ export const SnapshotState: React.FC<Props> = ({ state, displayTooltipIcon }) =>
 
   const { color, label, tip } = stateMap[state];
 
-  const iconTip = displayTooltipIcon && tip && <EuiIcon type="question" />;
+  const iconTip = displayTooltipIcon && tip && <EuiIcon type="question" aria-hidden={true} />;
 
   return (
     <EuiToolTip position="top" content={tip}>

--- a/x-pack/platform/plugins/private/transform/public/app/components/job_icon.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/components/job_icon.tsx
@@ -8,6 +8,7 @@
 import React, { type FC } from 'react';
 
 import { EuiIcon, EuiIconTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { AuditMessageBase } from '../../../common/types/messages';
 
 interface Props {
@@ -36,6 +37,15 @@ export const JobIcon: FC<Props> = ({ message, showTooltip = false }) => {
   if (showTooltip) {
     return <EuiIconTip position="bottom" content={message.text} type={icon} color={color} />;
   } else {
-    return <EuiIcon type={icon} color={color} />;
+    return (
+      <EuiIcon
+        type={icon}
+        color={color}
+        aria-label={i18n.translate('xpack.transform.jobIcon.ariaLabel', {
+          defaultMessage: 'Transform job status: {level}',
+          values: { level: message.level },
+        })}
+      />
+    );
   }
 };

--- a/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
@@ -384,7 +384,7 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
               <EuiFlexGroup gutterSize="l">
                 <EuiFlexItem style={PANEL_ITEM_STYLE} grow={false}>
                   <EuiCard
-                    icon={<EuiIcon size="xxl" type="list" />}
+                    icon={<EuiIcon size="xxl" type="list" aria-hidden={true} />}
                     title={i18n.translate('xpack.transform.stepCreateForm.transformListCardTitle', {
                       defaultMessage: 'Transforms',
                     })}
@@ -418,7 +418,7 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
                 {isDiscoverAvailable && discoverLink !== undefined && (
                   <EuiFlexItem style={PANEL_ITEM_STYLE} grow={false}>
                     <EuiCard
-                      icon={<EuiIcon size="xxl" type="discoverApp" />}
+                      icon={<EuiIcon size="xxl" type="discoverApp" aria-hidden={true} />}
                       title={i18n.translate('xpack.transform.stepCreateForm.discoverCardTitle', {
                         defaultMessage: 'Discover',
                       })}

--- a/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/step_define/transform_function_selector.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/step_define/transform_function_selector.tsx
@@ -50,7 +50,7 @@ export const TransformFunctionSelector: FC<TransformFunctionSelectorProps> = ({
         {transformFunctions.map(({ helpText, icon, name, title }) => (
           <EuiFlexItem key={name} style={{ width: 320 }} grow={false}>
             <EuiCard
-              icon={<EuiIcon size="xl" type={icon} />}
+              icon={<EuiIcon size="xl" type={icon} aria-hidden={true} />}
               title={title}
               description={helpText}
               data-test-subj={`transformCreation-${name}-option${

--- a/x-pack/platform/plugins/private/transform/public/app/sections/edit_transform/components/edit_transform_flyout_callout.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/edit_transform/components/edit_transform_flyout_callout.tsx
@@ -26,7 +26,7 @@ export const EditTransformFlyoutCallout: FC = () => {
     <EuiCallOut>
       <EuiFlexGroup>
         <EuiFlexItem grow={false}>
-          <EuiIcon type="question" />
+          <EuiIcon type="question" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiTextColor color="subdued">

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/common/initializing_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/common/initializing_step.tsx
@@ -46,7 +46,7 @@ export const InitializingStep: React.FunctionComponent<InitializingStepProps> = 
       <EuiFlexGroup direction="column" alignItems="center" justifyContent="center">
         <EuiFlexItem>
           {hasInitializingError ? (
-            <EuiIcon type="alert" size="xl" color="danger" />
+            <EuiIcon type="alert" size="xl" color="danger" aria-hidden={true} />
           ) : (
             <EuiLoadingSpinner size="xl" />
           )}

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/common/step_progress.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/common/step_progress.tsx
@@ -66,22 +66,22 @@ const StepStatus: React.FunctionComponent<{ status: STATUS; idx: number }> = ({ 
     inProgress: <EuiLoadingSpinner size="m" css={statusStyles.info} />,
     complete: (
       <span css={statusStyles.success}>
-        <EuiIcon type="check" size="s" />
+        <EuiIcon type="check" size="s" aria-hidden={true} />
       </span>
     ),
     paused: (
       <span css={statusStyles.warning}>
-        <EuiIcon type="pause" size="s" />
+        <EuiIcon type="pause" size="s" aria-hidden={true} />
       </span>
     ),
     cancelled: (
       <span css={statusStyles.warning}>
-        <EuiIcon type="cross" size="s" />
+        <EuiIcon type="cross" size="s" aria-hidden={true} />
       </span>
     ),
     failed: (
       <span css={statusStyles.danger}>
-        <EuiIcon type="cross" size="s" />
+        <EuiIcon type="cross" size="s" aria-hidden={true} />
       </span>
     ),
   };

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/actions_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/actions_table_cell.tsx
@@ -40,7 +40,7 @@ export const ClusterSettingsActionsCell: React.FunctionComponent<Props> = ({ ope
           data-test-subj="clusterSettingsResolutionStatusCell"
         >
           <EuiFlexItem grow={false}>
-            <EuiIcon type="indexSettings" />
+            <EuiIcon type="indexSettings" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.resolutionText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/resolution_table_cell.tsx
@@ -65,7 +65,7 @@ export const ClusterSettingsResolutionCell: React.FunctionComponent<Props> = ({ 
         data-test-subj="clusterSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="checkInCircleFilled" color="success" />
+          <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteCompleteText}</EuiText>
@@ -82,7 +82,7 @@ export const ClusterSettingsResolutionCell: React.FunctionComponent<Props> = ({ 
         data-test-subj="clusterSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="warningFilled" color="danger" />
+          <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteFailedText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
@@ -154,7 +154,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="checkInCircleFilled" color="success" />
+            <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.resolutionCompleteText}</EuiText>
@@ -165,7 +165,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warningFilled" color="danger" />
+            <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.resolutionFailedText}</EuiText>
@@ -176,7 +176,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warningFilled" color="danger" />
+            <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.resolutionFetchFailedText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/default/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/default/table_row.tsx
@@ -71,7 +71,7 @@ export const DefaultTableRow: React.FunctionComponent<Props> = ({
               deprecation={deprecation}
               actionsTableCell={
                 <EuiLink onClick={() => setShowFlyout(true)} data-test-subj="deprecation-default">
-                  <EuiIcon type="gear" />
+                  <EuiIcon type="gear" aria-hidden={true} />
                 </EuiLink>
               }
             />

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/health_indicator/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/health_indicator/table_row.tsx
@@ -70,7 +70,7 @@ export const HealthIndicatorTableRow: React.FunctionComponent<Props> = ({
               deprecation={deprecation}
               actionsTableCell={
                 <EuiLink onClick={() => setShowFlyout(true)} data-test-subj="deprecation-default">
-                  <EuiIcon type="gear" />
+                  <EuiIcon type="gear" aria-hidden={true} />
                 </EuiLink>
               }
             />

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/actions_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/actions_table_cell.tsx
@@ -42,7 +42,7 @@ export const IndexSettingsActionsCell: React.FunctionComponent<Props> = ({ openF
       <EuiLink onClick={openFlyout} data-test-subj={'deprecation-indexSetting'}>
         <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="indexSettingsActionsCell">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="indexSettings" />
+            <EuiIcon type="indexSettings" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.resolutionText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/resolution_table_cell.tsx
@@ -80,7 +80,7 @@ export const IndexSettingsResolutionCell: React.FunctionComponent<Props> = ({ st
         data-test-subj="indexSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="checkInCircleFilled" color="success" />
+          <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteCompleteText}</EuiText>
@@ -97,7 +97,7 @@ export const IndexSettingsResolutionCell: React.FunctionComponent<Props> = ({ st
         data-test-subj="indexSettingsResolutionStatusCell"
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="warningFilled" color="danger" />
+          <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">{i18nTexts.deleteFailedText}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/resolution_table_cell.tsx
@@ -301,7 +301,7 @@ export const ReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="checkInCircleFilled" color="success" />
+            <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexCompleteText}</EuiText>
@@ -313,7 +313,7 @@ export const ReindexResolutionCell: React.FunctionComponent<{
         return (
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="warningFilled" color="danger" />
+              <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiText size="s">{i18nTexts.reindexFailedText}</EuiText>
@@ -326,7 +326,7 @@ export const ReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warningFilled" color="danger" />
+            <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexFetchFailedText}</EuiText>
@@ -337,7 +337,7 @@ export const ReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="warningFilled" color="danger" />
+            <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts.reindexPausedText}</EuiText>
@@ -364,7 +364,7 @@ export const ReindexResolutionCell: React.FunctionComponent<{
       return (
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="checkInCircleFilled" color="success" />
+            <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{i18nTexts[`${updateAction}CompleteText`]}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/resolution_table_cell.tsx
@@ -75,7 +75,7 @@ export const MlSnapshotsResolutionCell: React.FunctionComponent = () => {
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="mlActionResolutionCell">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="checkInCircleFilled" color="success" />
+          <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">
@@ -92,7 +92,7 @@ export const MlSnapshotsResolutionCell: React.FunctionComponent = () => {
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="mlActionResolutionCell">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="warningFilled" color="danger" />
+          <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s">

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/kibana_deprecations/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/kibana_deprecations/resolution_table_cell.tsx
@@ -136,7 +136,7 @@ export const ResolutionTableCell: React.FunctionComponent<Props> = ({
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="resolutionStatusCell">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="warningFilled" color="danger" />
+                <EuiIcon type="warningFilled" color="danger" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiText size="s">{resolutionI18nTexts.resolutionFailedCellLabel}</EuiText>
@@ -148,7 +148,7 @@ export const ResolutionTableCell: React.FunctionComponent<Props> = ({
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="resolutionStatusCell">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="checkInCircleFilled" color="success" />
+                <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiText size="s">{resolutionI18nTexts.resolutionCompleteCellLabel}</EuiText>
@@ -167,7 +167,7 @@ export const ResolutionTableCell: React.FunctionComponent<Props> = ({
           data-test-subj="resolutionStatusCell"
         >
           <EuiFlexItem grow={false}>
-            <EuiIcon type={euiIconType} />
+            <EuiIcon type={euiIconType} aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">{resolutionI18nTexts.resolutionTypeCellLabel}</EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/backup_step/cloud_backup.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/backup_step/cloud_backup.tsx
@@ -99,7 +99,7 @@ export const CloudBackup: React.FunctionComponent<Props> = ({
   const statusMessage = data!.isBackedUp ? (
     <EuiFlexGroup alignItems="center" gutterSize="s" data-test-subj="dataBackedUpStatus">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="check" color="success" />
+        <EuiIcon type="check" color="success" aria-hidden={true} />
       </EuiFlexItem>
 
       <EuiFlexItem>
@@ -129,7 +129,7 @@ export const CloudBackup: React.FunctionComponent<Props> = ({
   ) : (
     <EuiFlexGroup alignItems="center" gutterSize="s" data-test-subj="dataNotBackedUpStatus">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="warning" color="danger" />
+        <EuiIcon type="warning" color="danger" aria-hidden={true} />
       </EuiFlexItem>
 
       <EuiFlexItem>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/fix_issues_step/components/deprecation_issues.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/fix_issues_step/components/deprecation_issues.tsx
@@ -21,7 +21,7 @@ export const DeprecationIssue = (props: Props) => {
       <EuiText color={color}>
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <EuiIcon type={iconType} />
+            <EuiIcon type={iconType} aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false} alignItems="center">
             <EuiFlexGroup gutterSize="s" alignItems="center">

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/fix_issues_step/components/loading_issues_error.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/fix_issues_step/components/loading_issues_error.tsx
@@ -13,7 +13,7 @@ export const LoadingIssuesError: FC<PropsWithChildren<unknown>> = ({ children })
   <EuiText color="subdued" data-test-subj="loadingIssuesError">
     <EuiFlexGroup gutterSize="s" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="warning" color="danger" />
+        <EuiIcon type="warning" color="danger" aria-hidden={true} />
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>{children}</EuiFlexItem>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/fix_issues_step/components/no_deprecation_issues.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/fix_issues_step/components/no_deprecation_issues.tsx
@@ -25,7 +25,7 @@ export const NoDeprecationIssues: FunctionComponent<Props> = (props) => {
     <EuiText color="success">
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="checkInCircleFilled" />
+          <EuiIcon type="checkInCircleFilled" aria-hidden={true} />
         </EuiFlexItem>
 
         <EuiFlexItem grow={false} data-test-subj={props['data-test-subj']}>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/migrate_system_indices/flyout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/migrate_system_indices/flyout.tsx
@@ -133,7 +133,7 @@ const renderMigrationStatus = (status: MIGRATION_STATUS) => {
     return (
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="checkInCircleFilled" color="success" />
+          <EuiIcon type="checkInCircleFilled" color="success" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText color="green" size="s" data-test-subj="featureNoUpgradeNeeded">
@@ -171,7 +171,7 @@ const renderMigrationStatus = (status: MIGRATION_STATUS) => {
     return (
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="warning" color="danger" />
+          <EuiIcon type="warning" color="danger" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText color="danger" size="s" data-test-subj="featureError">

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/migrate_system_indices/migrate_system_indices.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/migrate_system_indices/migrate_system_indices.tsx
@@ -186,7 +186,7 @@ const MigrateSystemIndicesStep: FunctionComponent<Props> = ({ setIsComplete }) =
     return (
       <EuiFlexGroup alignItems="center" gutterSize="s" data-test-subj="noMigrationNeededSection">
         <EuiFlexItem grow={false}>
-          <EuiIcon type="check" color="success" />
+          <EuiIcon type="check" color="success" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText color="success">

--- a/x-pack/platform/plugins/private/watcher/public/application/components/action_state_badge.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/components/action_state_badge.tsx
@@ -28,7 +28,7 @@ export const ActionStateBadge = ({ state, size = 's' }: Props) => {
   return (
     <EuiFlexGroup gutterSize="xs" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="dot" color={stateToColorMap[state]} />
+        <EuiIcon type="dot" color={stateToColorMap[state]} aria-hidden={true} />
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/private/watcher/public/application/components/watch_state_badge.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/components/watch_state_badge.tsx
@@ -26,7 +26,7 @@ export const WatchStateBadge = ({ state, size = 's' }: Props) => {
   return (
     <EuiFlexGroup gutterSize="xs" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="dot" color={stateToColorMap[state]} />
+        <EuiIcon type="dot" color={stateToColorMap[state]} aria-hidden={true} />
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/json_watch_edit/simulate_watch_results_flyout.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/json_watch_edit/simulate_watch_results_flyout.tsx
@@ -207,7 +207,7 @@ export const SimulateWatchResultsFlyout = ({
 
   const conditionMetStatus = (details?.result?.condition?.met && (
     <>
-      <EuiIcon color="green" type="check" data-test-subj="conditionMetStatus" />{' '}
+      <EuiIcon color="green" type="check" data-test-subj="conditionMetStatus" aria-hidden={true} />{' '}
       <FormattedMessage
         id="xpack.watcher.sections.watchEdit.simulateResults.conditionMetStatus"
         defaultMessage="Condition met"
@@ -215,7 +215,12 @@ export const SimulateWatchResultsFlyout = ({
     </>
   )) || (
     <>
-      <EuiIcon color="subdued" type="cross" data-test-subj="conditionNotMetStatus" />{' '}
+      <EuiIcon
+        color="subdued"
+        type="cross"
+        data-test-subj="conditionNotMetStatus"
+        aria-hidden={true}
+      />{' '}
       <FormattedMessage
         id="xpack.watcher.sections.watchEdit.simulateResults.conditionNotMetStatus"
         defaultMessage="Condition not met"

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_action_accordion.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_action_accordion.tsx
@@ -132,7 +132,7 @@ export const WatchActionsAccordion: React.FunctionComponent<Props> = ({
           buttonContent={
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={false}>
-                <EuiIcon type={action.iconClass} size="m" />
+                <EuiIcon type={action.iconClass} size="m" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiTitle size="s">

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_action_dropdown.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_action_dropdown.tsx
@@ -114,7 +114,7 @@ export const WatchActionsDropdown: React.FunctionComponent<Props> = ({ settings,
             >
               <EuiFlexGroup responsive={false}>
                 <EuiFlexItem grow={false} css={styles.watcherTresholdActionContextMenuItem}>
-                  <EuiIcon type={action.iconClass} />
+                  <EuiIcon type={action.iconClass} aria-hidden={true} />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <strong>{action.typeName}</strong>

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_list_page/watch_list_page.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_list_page/watch_list_page.tsx
@@ -60,7 +60,13 @@ const stateColumnHeader = (
       {i18n.translate('xpack.watcher.sections.watchList.watchTable.stateHeader', {
         defaultMessage: 'State',
       })}{' '}
-      <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+      <EuiIcon
+        size="s"
+        color="subdued"
+        type="question"
+        className="eui-alignTop"
+        aria-hidden={true}
+      />
     </span>
   </EuiToolTip>
 );
@@ -78,7 +84,13 @@ const conditionLastMetHeader = (
       {i18n.translate('xpack.watcher.sections.watchList.watchTable.lastFiredHeader', {
         defaultMessage: 'Condition last met',
       })}{' '}
-      <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+      <EuiIcon
+        size="s"
+        color="subdued"
+        type="question"
+        className="eui-alignTop"
+        aria-hidden={true}
+      />
     </span>
   </EuiToolTip>
 );
@@ -96,7 +108,13 @@ const lastCheckedHeader = (
       {i18n.translate('xpack.watcher.sections.watchList.watchTable.lastTriggeredHeader', {
         defaultMessage: 'Last checked',
       })}{' '}
-      <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+      <EuiIcon
+        size="s"
+        color="subdued"
+        type="question"
+        className="eui-alignTop"
+        aria-hidden={true}
+      />
     </span>
   </EuiToolTip>
 );
@@ -115,7 +133,13 @@ const commentHeader = (
       {i18n.translate('xpack.watcher.sections.watchList.watchTable.commentHeader', {
         defaultMessage: 'Comment',
       })}{' '}
-      <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+      <EuiIcon
+        size="s"
+        color="subdued"
+        type="question"
+        className="eui-alignTop"
+        aria-hidden={true}
+      />
     </span>
   </EuiToolTip>
 );

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_status_page/components/action_statuses_panel.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_status_page/components/action_statuses_panel.tsx
@@ -91,7 +91,13 @@ export const ActionStatusesPanel = () => {
             {i18n.translate('xpack.watcher.sections.watchDetail.watchTable.stateHeader', {
               defaultMessage: 'State',
             })}{' '}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </span>
         </EuiToolTip>
       ),
@@ -117,7 +123,13 @@ export const ActionStatusesPanel = () => {
                 defaultMessage: 'Last executed',
               }
             )}{' '}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </span>
         </EuiToolTip>
       ),

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_status_page/components/execution_history_panel.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_status_page/components/execution_history_panel.tsx
@@ -156,7 +156,13 @@ export const ExecutionHistoryPanel = () => {
             {i18n.translate('xpack.watcher.sections.watchHistory.watchTable.stateHeader', {
               defaultMessage: 'State',
             })}{' '}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </span>
         </EuiToolTip>
       ),
@@ -179,7 +185,13 @@ export const ExecutionHistoryPanel = () => {
             {i18n.translate('xpack.watcher.sections.watchHistory.watchTable.metConditionHeader', {
               defaultMessage: 'Condition met',
             })}{' '}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </span>
         </EuiToolTip>
       ),
@@ -192,7 +204,16 @@ export const ExecutionHistoryPanel = () => {
         } = item;
 
         if (startTime.isSame(lastExecution)) {
-          return <EuiIcon color="green" type="check" />;
+          return (
+            <EuiIcon
+              color="green"
+              type="check"
+              aria-label={i18n.translate(
+                'xpack.watcher.sections.watchHistory.watchTable.conditionMetAriaLabel',
+                { defaultMessage: 'Condition met' }
+              )}
+            />
+          );
         }
       },
     },
@@ -212,7 +233,13 @@ export const ExecutionHistoryPanel = () => {
             {i18n.translate('xpack.watcher.sections.watchHistory.watchTable.commentHeader', {
               defaultMessage: 'Comment',
             })}{' '}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </span>
         </EuiToolTip>
       ),
@@ -291,7 +318,13 @@ export const ExecutionHistoryPanel = () => {
                     defaultMessage: 'State',
                   }
                 )}{' '}
-                <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+                <EuiIcon
+                  size="s"
+                  color="subdued"
+                  type="question"
+                  className="eui-alignTop"
+                  aria-hidden={true}
+                />
               </span>
             </EuiToolTip>
           ),

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/disconnect_cluster_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/disconnect_cluster_modal/index.tsx
@@ -87,8 +87,14 @@ export const DisconnectClusterModal: React.FC<DisconnectClusterModalProps> = ({
                         copyToClipboard(clusterName);
                       }}
                       data-test-subj="disconnectClusterNameLink"
+                      aria-label={i18n.translate(
+                        'xpack.cloudConnect.connectedServices.disconnect.clusterNameLinkAriaLabel',
+                        {
+                          defaultMessage: 'Copy cluster name to clipboard',
+                        }
+                      )}
                     >
-                      {clusterName} <EuiIcon type="copy" />
+                      {clusterName} <EuiIcon type="copy" aria-hidden={true} />
                     </EuiLink>
                   ),
                 }}

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/common/integration_icon.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/common/integration_icon.tsx
@@ -7,6 +7,7 @@
 
 import { EuiIcon } from '@elastic/eui';
 import { PackageIcon } from '@kbn/fleet-plugin/public';
+import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { NONE } from '../../../common/constants';
 import type { Integration } from '../../../common/data_streams_stats/integration';
@@ -26,6 +27,12 @@ export const IntegrationIcon = ({ integration }: IntegrationIconProps) => {
       tryApi
     />
   ) : (
-    <EuiIcon type={loggingIcon} size="m" />
+    <EuiIcon
+      type={loggingIcon}
+      size="m"
+      aria-label={i18n.translate('xpack.datasetQuality.weightedIcon.loggingAriaLabel', {
+        defaultMessage: 'Logging',
+      })}
+    />
   );
 };

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/summary/panel.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/summary/panel.tsx
@@ -107,7 +107,13 @@ export function PanelIndicator({
             <EuiToolTip content={tooltip}>
               <EuiText size="xs" color="subdued" tabIndex={0}>
                 {`${label} `}
-                <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+                <EuiIcon
+                  size="s"
+                  color="subdued"
+                  type="question"
+                  className="eui-alignTop"
+                  aria-hidden={true}
+                />
               </EuiText>
             </EuiToolTip>
           ) : (

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/manual/component_template_link.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/possible_mitigations/manual/component_template_link.tsx
@@ -80,7 +80,7 @@ export function CreateEditComponentTemplateLink({
         css={{ width: '100%' }}
       >
         <EuiFlexGroup alignItems="center" gutterSize="s">
-          <EuiIcon type="popout" />
+          <EuiIcon type="popout" aria-hidden={true} />
           {otherMitigationsCustomComponentTemplate}
         </EuiFlexGroup>
       </EuiLink>

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/failed_docs/columns.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/failed_docs/columns.tsx
@@ -50,7 +50,13 @@ export const getFailedDocsErrorsColumns = (): Array<EuiBasicTableColumn<FailedDo
       <EuiToolTip content={typeColumnTooltip}>
         <span tabIndex={0}>
           {`${typeColumnName} `}
-          <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+          <EuiIcon
+            size="s"
+            color="subdued"
+            type="question"
+            className="eui-alignTop"
+            aria-hidden={true}
+          />
         </span>
       </EuiToolTip>
     ),

--- a/x-pack/platform/plugins/shared/dataset_quality/public/rule_types/degraded_docs/rule_form/chart_preview/chart_preview_helper.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/rule_types/degraded_docs/rule_form/chart_preview/chart_preview_helper.tsx
@@ -165,7 +165,13 @@ export function TimeLabelForData({
         <EuiToolTip content={totalGroupsTooltip} position="top">
           <EuiFlexGroup gutterSize="xs">
             {xAxisInfo}
-            <EuiIcon size="s" color="subdued" type="question" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              color="subdued"
+              type="question"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </EuiFlexGroup>
         </EuiToolTip>
       ) : (

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -298,7 +298,10 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
               </EuiPanel>
             </EuiContextMenuPanel>
             <EuiHorizontalRule margin="none" />
-            <EuiContextMenuItem icon={<EuiIcon type="question" color="primary" />} size="m">
+            <EuiContextMenuItem
+              icon={<EuiIcon type="question" color="primary" aria-hidden={true} />}
+              size="m"
+            >
               <EuiLink
                 href={docLinks.links.inferenceManagement.inferenceAPIDocumentation}
                 target="_blank"

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/enrich_policy_create/steps/configuration.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/enrich_policy_create/steps/configuration.tsx
@@ -196,7 +196,7 @@ export const ConfigurationStep = ({ onNext }: Props) => {
                 data-test-subj="typePopoverIcon"
                 onClick={() => setIsPopoverOpen((isOpen) => !isOpen)}
               >
-                <EuiIcon type="question" />
+                <EuiIcon type="question" aria-hidden={true} />
               </EuiLink>
             }
             isOpen={isPopoverOpen}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/kibana-management` files (#268614)](https://github.com/elastic/kibana/pull/268614)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-12T09:58:28Z","message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/kibana-management` files (#268614)\n\nResolves 110+ `@elastic/eui/icon-accessibility-rules` ESLint violations\nacross 59 files owned by `@elastic/kibana-management`.\n\n### Changes\n\n- **Decorative icons** (~107 instances): Added `aria-hidden={true}` to\n`EuiIcon` components where meaning is already conveyed by adjacent text,\nparent buttons/links, tooltips, or context menu labels\n- **Meaningful icons** (2 instances): Added `aria-label` with\n`i18n.translate()` for standalone icons that convey information without\naccompanying text:\n  - `transform/.../job_icon.tsx` — status icon\n  - `dataset_quality/.../integration_icon.tsx` — logging type icon\n\n```tsx\n// Decorative: icon next to text label → aria-hidden\n<EuiIcon type=\"check\" color=\"success\" aria-hidden={true} />\n<span>Completed</span>\n\n// Meaningful: standalone status icon → aria-label with i18n\n<EuiIcon type={icon} color={color} aria-label={i18n.translate('xpack.transform.jobIcon.ariaLabel', {\n  defaultMessage: 'Transform job status: {level}',\n  values: { level: message.level },\n})} />\n```\n\n### Scope\n\nPlugins/packages touched: `kbn-esql-resource-browser`, `kbn-management`,\n`es_ui_shared`, `management`, `kbn-classic-stream-flyout`,\n`cross_cluster_replication`, `index_lifecycle_management`,\n`painless_lab`, `remote_clusters`, `rollup`, `snapshot_restore`,\n`transform`, `upgrade_assistant`, `watcher`, `cloud_connect`,\n`dataset_quality`, `index_management`.\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap\nbash --no\u0004\u0018\n/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indexgit`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js bin/ldd ldd\nb/li\u0004\u0018 nibrowser-gtk/sys/lib/libbrotlienc.so.1.0.7 x /ldd\n/shared/cloud_coldd` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>","sha":"7457f335794a7368e7fed673d44b12957bdd045f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","💝community","backport:version","v9.5.0","v9.3.5","v9.4.1"],"title":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/kibana-management` files","number":268614,"url":"https://github.com/elastic/kibana/pull/268614","mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/kibana-management` files (#268614)\n\nResolves 110+ `@elastic/eui/icon-accessibility-rules` ESLint violations\nacross 59 files owned by `@elastic/kibana-management`.\n\n### Changes\n\n- **Decorative icons** (~107 instances): Added `aria-hidden={true}` to\n`EuiIcon` components where meaning is already conveyed by adjacent text,\nparent buttons/links, tooltips, or context menu labels\n- **Meaningful icons** (2 instances): Added `aria-label` with\n`i18n.translate()` for standalone icons that convey information without\naccompanying text:\n  - `transform/.../job_icon.tsx` — status icon\n  - `dataset_quality/.../integration_icon.tsx` — logging type icon\n\n```tsx\n// Decorative: icon next to text label → aria-hidden\n<EuiIcon type=\"check\" color=\"success\" aria-hidden={true} />\n<span>Completed</span>\n\n// Meaningful: standalone status icon → aria-label with i18n\n<EuiIcon type={icon} color={color} aria-label={i18n.translate('xpack.transform.jobIcon.ariaLabel', {\n  defaultMessage: 'Transform job status: {level}',\n  values: { level: message.level },\n})} />\n```\n\n### Scope\n\nPlugins/packages touched: `kbn-esql-resource-browser`, `kbn-management`,\n`es_ui_shared`, `management`, `kbn-classic-stream-flyout`,\n`cross_cluster_replication`, `index_lifecycle_management`,\n`painless_lab`, `remote_clusters`, `rollup`, `snapshot_restore`,\n`transform`, `upgrade_assistant`, `watcher`, `cloud_connect`,\n`dataset_quality`, `index_management`.\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap\nbash --no\u0004\u0018\n/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indexgit`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js bin/ldd ldd\nb/li\u0004\u0018 nibrowser-gtk/sys/lib/libbrotlienc.so.1.0.7 x /ldd\n/shared/cloud_coldd` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>","sha":"7457f335794a7368e7fed673d44b12957bdd045f"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/268614","number":268614,"mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/kibana-management` files (#268614)\n\nResolves 110+ `@elastic/eui/icon-accessibility-rules` ESLint violations\nacross 59 files owned by `@elastic/kibana-management`.\n\n### Changes\n\n- **Decorative icons** (~107 instances): Added `aria-hidden={true}` to\n`EuiIcon` components where meaning is already conveyed by adjacent text,\nparent buttons/links, tooltips, or context menu labels\n- **Meaningful icons** (2 instances): Added `aria-label` with\n`i18n.translate()` for standalone icons that convey information without\naccompanying text:\n  - `transform/.../job_icon.tsx` — status icon\n  - `dataset_quality/.../integration_icon.tsx` — logging type icon\n\n```tsx\n// Decorative: icon next to text label → aria-hidden\n<EuiIcon type=\"check\" color=\"success\" aria-hidden={true} />\n<span>Completed</span>\n\n// Meaningful: standalone status icon → aria-label with i18n\n<EuiIcon type={icon} color={color} aria-label={i18n.translate('xpack.transform.jobIcon.ariaLabel', {\n  defaultMessage: 'Transform job status: {level}',\n  values: { level: message.level },\n})} />\n```\n\n### Scope\n\nPlugins/packages touched: `kbn-esql-resource-browser`, `kbn-management`,\n`es_ui_shared`, `management`, `kbn-classic-stream-flyout`,\n`cross_cluster_replication`, `index_lifecycle_management`,\n`painless_lab`, `remote_clusters`, `rollup`, `snapshot_restore`,\n`transform`, `upgrade_assistant`, `watcher`, `cloud_connect`,\n`dataset_quality`, `index_management`.\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap\nbash --no\u0004\u0018\n/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indexgit`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js bin/ldd ldd\nb/li\u0004\u0018 nibrowser-gtk/sys/lib/libbrotlienc.so.1.0.7 x /ldd\n/shared/cloud_coldd` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>","sha":"7457f335794a7368e7fed673d44b12957bdd045f"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/268849","number":268849,"state":"OPEN"}]}] BACKPORT-->