### PR TITLE
[Security Solution] Detection emulation skill (in-tree)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3181,6 +3181,7 @@ x-pack/platform/test/automatic_import_api_integration @elastic/integration-exper
 /x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_response_actions @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions @elastic/security-defend-workflows
+/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation @elastic/security-detection-engine @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/public/detections/components/osquery @elastic/security-defend-workflows
 
 # Cloud Security Posture team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3182,6 +3182,9 @@ x-pack/platform/test/automatic_import_api_integration @elastic/integration-exper
 /x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation @elastic/security-detection-engine @elastic/security-defend-workflows
+/x-pack/solutions/security/plugins/security_solution/common/detection_emulation @elastic/security-detection-engine @elastic/security-defend-workflows
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation @elastic/security-detection-engine @elastic/security-defend-workflows
+/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation @elastic/security-detection-engine @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/public/detections/components/osquery @elastic/security-defend-workflows
 
 # Cloud Security Posture team

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/index.ts
@@ -119,6 +119,7 @@ export type {
   InternalAgentDefinitionAvailabilityHandler,
   AgentRegistry,
 } from './agents';
+export { defineSkillType } from './skills';
 export type { SkillRegistry } from './skills';
 export type {
   AgentBuilderPluginSetup,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/skills/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/skills/index.ts
@@ -6,7 +6,7 @@
  */
 
 export type { SkillDefinition } from './type_definition';
-export { validateSkillDefinition } from './type_definition';
+export { defineSkillType, validateSkillDefinition } from './type_definition';
 export type { InternalSkillDefinition } from './internal';
 export type {
   SkillBoundedTool,

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -322,6 +322,13 @@ export const DETECTION_ENGINE_ALERT_SUGGEST_USERS_URL =
   `${INTERNAL_DETECTION_ENGINE_URL}/users/_find` as const;
 
 /**
+ * Detection emulation routes
+ */
+export const DETECTION_ENGINE_EMULATION_URL = `${INTERNAL_DETECTION_ENGINE_URL}/emulation` as const;
+export const DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL =
+  `${DETECTION_ENGINE_EMULATION_URL}/run_command` as const;
+
+/**
  * Extended alerts routes
  */
 export const DETECTION_ENGINE_UNIFIED_ALERTS_URL =

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './schemas';

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './run_emulation_command_input';

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/run_emulation_command_input.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/run_emulation_command_input.test.ts
@@ -6,188 +6,246 @@
  */
 
 import { RunEmulationCommandInputSchema } from './run_emulation_command_input';
-import { RESPONSE_ACTION_AGENT_TYPE } from '../../endpoint/service/response_actions/constants';
+import {
+  RESPONSE_ACTION_AGENT_TYPE,
+  RESPONSE_ACTION_API_COMMANDS_NAMES,
+} from '../../endpoint/service/response_actions/constants';
 
 describe('RunEmulationCommandInputSchema', () => {
-  it('validates a valid input with all required fields', () => {
+  it('validates a valid `execute` command with required parameters', () => {
     const validInput = {
       emulationId: 'test-emulation-123',
       agentType: 'endpoint' as const,
       endpointIds: ['endpoint-id-1', 'endpoint-id-2'],
       command: 'execute' as const,
+      parameters: { command: 'whoami' },
     };
 
     const result = RunEmulationCommandInputSchema.safeParse(validInput);
     expect(result.success).toBe(true);
   });
 
-  it('validates a valid input with optional parameters', () => {
+  it('validates a valid `kill-process` command with `pid` parameter', () => {
     const validInput = {
       emulationId: 'test-emulation-123',
       agentType: 'sentinel_one' as const,
       endpointIds: ['endpoint-id-1'],
       command: 'kill-process' as const,
-      parameters: {
-        pid: '12345',
-        entityId: 'abc-123',
-      },
+      parameters: { pid: 12345 },
     };
 
     const result = RunEmulationCommandInputSchema.safeParse(validInput);
     expect(result.success).toBe(true);
   });
 
-  it('validates all supported agent types', () => {
-    const agentTypes = ['endpoint', 'sentinel_one', 'crowdstrike', 'microsoft_defender_endpoint'];
+  it('validates a valid `kill-process` command with `entity_id` parameter', () => {
+    const validInput = {
+      emulationId: 'test-emulation-123',
+      agentType: 'endpoint' as const,
+      endpointIds: ['endpoint-id-1'],
+      command: 'kill-process' as const,
+      parameters: { entity_id: 'abc-123' },
+    };
 
-    agentTypes.forEach((agentType) => {
-      const input = {
+    const result = RunEmulationCommandInputSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it('validates `isolate` with no parameters', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      emulationId: 'emu',
+      agentType: 'endpoint',
+      endpointIds: ['ep-1'],
+      command: 'isolate',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates every supported command with its minimal required parameters', () => {
+    const cases: Array<{ command: string; parameters?: Record<string, unknown> }> = [
+      { command: 'isolate' },
+      { command: 'unisolate' },
+      { command: 'running-processes' },
+      { command: 'cancel', parameters: { id: 'action-abc' } },
+      { command: 'kill-process', parameters: { pid: 1 } },
+      { command: 'suspend-process', parameters: { pid: 1 } },
+      { command: 'memory-dump', parameters: { type: 'process', pid: 1 } },
+      { command: 'memory-dump', parameters: { type: 'process', entity_id: 'abc' } },
+      { command: 'memory-dump', parameters: { type: 'kernel' } },
+      { command: 'get-file', parameters: { path: '/tmp/file' } },
+      { command: 'scan', parameters: { path: '/tmp/scan' } },
+      { command: 'execute', parameters: { command: 'whoami' } },
+      { command: 'runscript', parameters: { scriptId: 'script-1' } },
+      { command: 'upload', parameters: { file: {}, overwrite: true } },
+    ];
+
+    cases.forEach(({ command, parameters }) => {
+      const result = RunEmulationCommandInputSchema.safeParse({
         emulationId: 'test-emulation-123',
-        agentType,
+        agentType: 'endpoint',
         endpointIds: ['endpoint-id-1'],
-        command: 'execute' as const,
-      };
-
-      const result = RunEmulationCommandInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
+        command,
+        ...(parameters !== undefined ? { parameters } : {}),
+      });
+      expect({ command, success: result.success }).toEqual({ command, success: true });
     });
   });
 
-  it('validates all supported commands', () => {
-    const commands = [
-      'isolate',
-      'unisolate',
-      'kill-process',
-      'suspend-process',
-      'running-processes',
-      'get-file',
-      'execute',
-      'upload',
-      'scan',
-      'runscript',
-      'cancel',
-      'memory-dump',
-    ];
-
-    commands.forEach((command) => {
-      const input = {
-        emulationId: 'test-emulation-123',
-        agentType: 'endpoint' as const,
-        endpointIds: ['endpoint-id-1'],
-        command,
-      };
-
-      const result = RunEmulationCommandInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
+  it('rejects `memory-dump` with type=process but no pid or entity_id', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      emulationId: 'e',
+      agentType: 'endpoint',
+      endpointIds: ['ep-1'],
+      command: 'memory-dump',
+      parameters: { type: 'process' },
     });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects `cancel` without an `id`', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      emulationId: 'e',
+      agentType: 'endpoint',
+      endpointIds: ['ep-1'],
+      command: 'cancel',
+      parameters: {},
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects `runscript` without a `scriptId`', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      emulationId: 'e',
+      agentType: 'endpoint',
+      endpointIds: ['ep-1'],
+      command: 'runscript',
+      parameters: { scriptInput: 'whoami' },
+    });
+    expect(result.success).toBe(false);
   });
 
   it('rejects invalid agent type', () => {
-    const invalidInput = {
+    const result = RunEmulationCommandInputSchema.safeParse({
       emulationId: 'test-emulation-123',
       agentType: 'invalid-agent-type',
       endpointIds: ['endpoint-id-1'],
-      command: 'execute' as const,
-    };
-
-    const result = RunEmulationCommandInputSchema.safeParse(invalidInput);
+      command: 'execute',
+      parameters: { command: 'whoami' },
+    });
     expect(result.success).toBe(false);
   });
 
   it('rejects invalid command', () => {
-    const invalidInput = {
+    const result = RunEmulationCommandInputSchema.safeParse({
       emulationId: 'test-emulation-123',
-      agentType: 'endpoint' as const,
+      agentType: 'endpoint',
       endpointIds: ['endpoint-id-1'],
       command: 'invalid-command',
-    };
-
-    const result = RunEmulationCommandInputSchema.safeParse(invalidInput);
+    });
     expect(result.success).toBe(false);
   });
 
   it('rejects empty endpointIds array', () => {
-    const invalidInput = {
+    const result = RunEmulationCommandInputSchema.safeParse({
       emulationId: 'test-emulation-123',
-      agentType: 'endpoint' as const,
+      agentType: 'endpoint',
       endpointIds: [],
-      command: 'execute' as const,
-    };
-
-    const result = RunEmulationCommandInputSchema.safeParse(invalidInput);
+      command: 'isolate',
+    });
     expect(result.success).toBe(false);
   });
 
-  it('rejects missing required fields', () => {
-    const invalidInputs = [
-      {
-        agentType: 'endpoint' as const,
-        endpointIds: ['endpoint-id-1'],
-        command: 'execute' as const,
-      },
-      {
-        emulationId: 'test-emulation-123',
-        endpointIds: ['endpoint-id-1'],
-        command: 'execute' as const,
-      },
-      {
-        emulationId: 'test-emulation-123',
-        agentType: 'endpoint' as const,
-        command: 'execute' as const,
-      },
-      {
-        emulationId: 'test-emulation-123',
-        agentType: 'endpoint' as const,
-        endpointIds: ['endpoint-id-1'],
-      },
+  it('rejects missing required common fields', () => {
+    const cases = [
+      { agentType: 'endpoint', endpointIds: ['ep-1'], command: 'isolate' }, // no emulationId
+      { emulationId: 'e', endpointIds: ['ep-1'], command: 'isolate' }, // no agentType
+      { emulationId: 'e', agentType: 'endpoint', command: 'isolate' }, // no endpointIds
+      { emulationId: 'e', agentType: 'endpoint', endpointIds: ['ep-1'] }, // no command
     ];
 
-    invalidInputs.forEach((input) => {
+    cases.forEach((input) => {
       const result = RunEmulationCommandInputSchema.safeParse(input);
       expect(result.success).toBe(false);
     });
+  });
+
+  it('rejects `kill-process` without pid or entity_id (closes the I6 silent-passthrough hole)', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      emulationId: 'e',
+      agentType: 'endpoint',
+      endpointIds: ['ep-1'],
+      command: 'kill-process',
+      parameters: { comment: 'hi' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects `get-file` without `path`', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      emulationId: 'e',
+      agentType: 'endpoint',
+      endpointIds: ['ep-1'],
+      command: 'get-file',
+      parameters: {},
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects `execute` without `command`', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      emulationId: 'e',
+      agentType: 'endpoint',
+      endpointIds: ['ep-1'],
+      command: 'execute',
+      parameters: { timeout: 30 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown parameter keys (strict objects close typo holes like `entityId` for `entity_id`)', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      emulationId: 'e',
+      agentType: 'endpoint',
+      endpointIds: ['ep-1'],
+      command: 'kill-process',
+      parameters: { entityId: 'abc-123' }, // wrong: should be entity_id
+    });
+    expect(result.success).toBe(false);
   });
 });
 
 // ─── agentType contract: validation against RESPONSE_ACTION_AGENT_TYPE ────────
 
 describe('RunEmulationCommandInputSchema — agentType contract', () => {
-  const BASE_INPUT = {
-    emulationId: 'emu-contract-test',
-    endpointIds: ['ep-1'],
-    command: 'isolate',
-  } as const;
-
-  it('schema agentType enum is identical to RESPONSE_ACTION_AGENT_TYPE', () => {
-    // Introspect the Zod enum's internal .options array and compare it to the
-    // authoritative constant.  This fails immediately if the two diverge — even
-    // before any request is parsed — making it the strongest form of contract test.
-    const schemaAllowedValues = RunEmulationCommandInputSchema.shape.agentType.options;
-    expect([...schemaAllowedValues]).toEqual([...RESPONSE_ACTION_AGENT_TYPE]);
+  it('every variant of the discriminated union accepts every value in RESPONSE_ACTION_AGENT_TYPE', () => {
+    // Pull the agentType enum from one of the variants to make sure it
+    // exists as an enum (not a free-form string). This catches a refactor
+    // that would silently accept any string.
+    const firstOption = RunEmulationCommandInputSchema.options[0];
+    expect([...firstOption.shape.agentType.options]).toEqual([...RESPONSE_ACTION_AGENT_TYPE]);
   });
 
   it.each(RESPONSE_ACTION_AGENT_TYPE)(
-    'accepts agentType "%s" (every value in RESPONSE_ACTION_AGENT_TYPE)',
+    'accepts agentType "%s" with command `isolate`',
     (agentType) => {
-      const result = RunEmulationCommandInputSchema.safeParse({ ...BASE_INPUT, agentType });
+      const result = RunEmulationCommandInputSchema.safeParse({
+        emulationId: 'emu-contract-test',
+        agentType,
+        endpointIds: ['ep-1'],
+        command: 'isolate',
+      });
       expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.agentType).toBe(agentType);
-      }
     }
   );
 
   it('rejects an agentType that is not in RESPONSE_ACTION_AGENT_TYPE', () => {
     const result = RunEmulationCommandInputSchema.safeParse({
-      ...BASE_INPUT,
+      emulationId: 'emu-contract-test',
       agentType: 'unknown_edr_vendor',
+      endpointIds: ['ep-1'],
+      command: 'isolate',
     });
-
     expect(result.success).toBe(false);
-    if (!result.success) {
-      const agentTypeIssue = result.error.issues.find((issue) => issue.path[0] === 'agentType');
-      expect(agentTypeIssue).toBeDefined();
-    }
   });
 
   it('rejects every near-miss variant that differs from a valid agentType by case or whitespace', () => {
@@ -204,8 +262,20 @@ describe('RunEmulationCommandInputSchema — agentType contract', () => {
     ];
 
     nearMisses.forEach((agentType) => {
-      const result = RunEmulationCommandInputSchema.safeParse({ ...BASE_INPUT, agentType });
+      const result = RunEmulationCommandInputSchema.safeParse({
+        emulationId: 'emu-contract-test',
+        agentType,
+        endpointIds: ['ep-1'],
+        command: 'isolate',
+      });
       expect(result.success).toBe(false);
     });
+  });
+
+  it('every command in RESPONSE_ACTION_API_COMMANDS_NAMES has exactly one variant in the schema', () => {
+    const variantCommands = RunEmulationCommandInputSchema.options.map(
+      (variant) => variant.shape.command.value
+    );
+    expect(variantCommands.sort()).toEqual([...RESPONSE_ACTION_API_COMMANDS_NAMES].sort());
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/run_emulation_command_input.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/run_emulation_command_input.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { RunEmulationCommandInputSchema } from './run_emulation_command_input';
+import { RESPONSE_ACTION_AGENT_TYPE } from '../../endpoint/service/response_actions/constants';
+
+describe('RunEmulationCommandInputSchema', () => {
+  it('validates a valid input with all required fields', () => {
+    const validInput = {
+      emulationId: 'test-emulation-123',
+      agentType: 'endpoint' as const,
+      endpointIds: ['endpoint-id-1', 'endpoint-id-2'],
+      command: 'execute' as const,
+    };
+
+    const result = RunEmulationCommandInputSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it('validates a valid input with optional parameters', () => {
+    const validInput = {
+      emulationId: 'test-emulation-123',
+      agentType: 'sentinel_one' as const,
+      endpointIds: ['endpoint-id-1'],
+      command: 'kill-process' as const,
+      parameters: {
+        pid: '12345',
+        entityId: 'abc-123',
+      },
+    };
+
+    const result = RunEmulationCommandInputSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it('validates all supported agent types', () => {
+    const agentTypes = ['endpoint', 'sentinel_one', 'crowdstrike', 'microsoft_defender_endpoint'];
+
+    agentTypes.forEach((agentType) => {
+      const input = {
+        emulationId: 'test-emulation-123',
+        agentType,
+        endpointIds: ['endpoint-id-1'],
+        command: 'execute' as const,
+      };
+
+      const result = RunEmulationCommandInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it('validates all supported commands', () => {
+    const commands = [
+      'isolate',
+      'unisolate',
+      'kill-process',
+      'suspend-process',
+      'running-processes',
+      'get-file',
+      'execute',
+      'upload',
+      'scan',
+      'runscript',
+      'cancel',
+      'memory-dump',
+    ];
+
+    commands.forEach((command) => {
+      const input = {
+        emulationId: 'test-emulation-123',
+        agentType: 'endpoint' as const,
+        endpointIds: ['endpoint-id-1'],
+        command,
+      };
+
+      const result = RunEmulationCommandInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it('rejects invalid agent type', () => {
+    const invalidInput = {
+      emulationId: 'test-emulation-123',
+      agentType: 'invalid-agent-type',
+      endpointIds: ['endpoint-id-1'],
+      command: 'execute' as const,
+    };
+
+    const result = RunEmulationCommandInputSchema.safeParse(invalidInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid command', () => {
+    const invalidInput = {
+      emulationId: 'test-emulation-123',
+      agentType: 'endpoint' as const,
+      endpointIds: ['endpoint-id-1'],
+      command: 'invalid-command',
+    };
+
+    const result = RunEmulationCommandInputSchema.safeParse(invalidInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty endpointIds array', () => {
+    const invalidInput = {
+      emulationId: 'test-emulation-123',
+      agentType: 'endpoint' as const,
+      endpointIds: [],
+      command: 'execute' as const,
+    };
+
+    const result = RunEmulationCommandInputSchema.safeParse(invalidInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const invalidInputs = [
+      {
+        agentType: 'endpoint' as const,
+        endpointIds: ['endpoint-id-1'],
+        command: 'execute' as const,
+      },
+      {
+        emulationId: 'test-emulation-123',
+        endpointIds: ['endpoint-id-1'],
+        command: 'execute' as const,
+      },
+      {
+        emulationId: 'test-emulation-123',
+        agentType: 'endpoint' as const,
+        command: 'execute' as const,
+      },
+      {
+        emulationId: 'test-emulation-123',
+        agentType: 'endpoint' as const,
+        endpointIds: ['endpoint-id-1'],
+      },
+    ];
+
+    invalidInputs.forEach((input) => {
+      const result = RunEmulationCommandInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+// ─── agentType contract: validation against RESPONSE_ACTION_AGENT_TYPE ────────
+
+describe('RunEmulationCommandInputSchema — agentType contract', () => {
+  const BASE_INPUT = {
+    emulationId: 'emu-contract-test',
+    endpointIds: ['ep-1'],
+    command: 'isolate',
+  } as const;
+
+  it('schema agentType enum is identical to RESPONSE_ACTION_AGENT_TYPE', () => {
+    // Introspect the Zod enum's internal .options array and compare it to the
+    // authoritative constant.  This fails immediately if the two diverge — even
+    // before any request is parsed — making it the strongest form of contract test.
+    const schemaAllowedValues = RunEmulationCommandInputSchema.shape.agentType.options;
+    expect([...schemaAllowedValues]).toEqual([...RESPONSE_ACTION_AGENT_TYPE]);
+  });
+
+  it.each(RESPONSE_ACTION_AGENT_TYPE)(
+    'accepts agentType "%s" (every value in RESPONSE_ACTION_AGENT_TYPE)',
+    (agentType) => {
+      const result = RunEmulationCommandInputSchema.safeParse({ ...BASE_INPUT, agentType });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.agentType).toBe(agentType);
+      }
+    }
+  );
+
+  it('rejects an agentType that is not in RESPONSE_ACTION_AGENT_TYPE', () => {
+    const result = RunEmulationCommandInputSchema.safeParse({
+      ...BASE_INPUT,
+      agentType: 'unknown_edr_vendor',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const agentTypeIssue = result.error.issues.find((issue) => issue.path[0] === 'agentType');
+      expect(agentTypeIssue).toBeDefined();
+    }
+  });
+
+  it('rejects every near-miss variant that differs from a valid agentType by case or whitespace', () => {
+    const nearMisses = [
+      'Endpoint',
+      'ENDPOINT',
+      'Sentinel_One',
+      'SENTINEL_ONE',
+      'Crowdstrike',
+      'CROWDSTRIKE',
+      'Microsoft_Defender_Endpoint',
+      ' endpoint',
+      'endpoint ',
+    ];
+
+    nearMisses.forEach((agentType) => {
+      const result = RunEmulationCommandInputSchema.safeParse({ ...BASE_INPUT, agentType });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/run_emulation_command_input.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/run_emulation_command_input.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import {
+  RESPONSE_ACTION_AGENT_TYPE,
+  RESPONSE_ACTION_API_COMMANDS_NAMES,
+} from '../../endpoint/service/response_actions/constants';
+
+/**
+ * Zod schema for validating the input to run an emulation command.
+ * Ensures agentType is one of the supported EDR agent types and
+ * command is one of the supported response action commands.
+ */
+export const RunEmulationCommandInputSchema = z.object({
+  /**
+   * Unique identifier for the emulation
+   */
+  emulationId: z.string(),
+
+  /**
+   * The EDR agent type - must be one of the supported agent types
+   */
+  agentType: z.enum(RESPONSE_ACTION_AGENT_TYPE),
+
+  /**
+   * Array of endpoint agent IDs to target with the emulation command
+   */
+  endpointIds: z.array(z.string()).min(1),
+
+  /**
+   * The response action command to execute - must be one of the supported commands
+   */
+  command: z.enum(RESPONSE_ACTION_API_COMMANDS_NAMES),
+
+  /**
+   * Optional parameters specific to the command being executed
+   */
+  parameters: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type RunEmulationCommandInput = z.infer<typeof RunEmulationCommandInputSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/run_emulation_command_input.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/detection_emulation/schemas/run_emulation_command_input.ts
@@ -12,35 +12,188 @@ import {
 } from '../../endpoint/service/response_actions/constants';
 
 /**
- * Zod schema for validating the input to run an emulation command.
- * Ensures agentType is one of the supported EDR agent types and
- * command is one of the supported response action commands.
+ * Common fields shared by every emulation command request.
+ *
+ * Keeping these on a single base object makes the discriminated union
+ * below readable: each variant only spells out the parts that differ.
  */
-export const RunEmulationCommandInputSchema = z.object({
-  /**
-   * Unique identifier for the emulation
-   */
-  emulationId: z.string(),
-
-  /**
-   * The EDR agent type - must be one of the supported agent types
-   */
+const commonFields = {
+  /** Unique identifier for the emulation run. */
+  emulationId: z.string().min(1),
+  /** EDR agent type — must be one of the supported types. */
   agentType: z.enum(RESPONSE_ACTION_AGENT_TYPE),
+  /** Endpoint agent IDs the command applies to (1+). */
+  endpointIds: z.array(z.string().min(1)).min(1),
+} as const;
 
-  /**
-   * Array of endpoint agent IDs to target with the emulation command
-   */
-  endpointIds: z.array(z.string()).min(1),
+/** Optional human-readable comment recorded against the response action. */
+const optionalCommentParams = z.object({ comment: z.string().optional() }).strict().optional();
 
-  /**
-   * The response action command to execute - must be one of the supported commands
-   */
-  command: z.enum(RESPONSE_ACTION_API_COMMANDS_NAMES),
+/**
+ * `kill-process` and `suspend-process` accept *either* a `pid` (number) or
+ * an `entity_id` (string), never both. The downstream API encodes this as
+ * a tagged union (`pid: number, entity_id?: never` vs.
+ * `entity_id: string, pid?: never`) so we mirror that with a Zod union.
+ *
+ * A typo like `entityId` (camelCase) or supplying both fields used to slip
+ * through the previous `z.record(z.string(), z.unknown())` schema and
+ * silently turn into an undefined parameter at the underlying client.
+ */
+const processRefByPid = z
+  .object({
+    comment: z.string().optional(),
+    pid: z.number().int().positive(),
+  })
+  .strict();
 
-  /**
-   * Optional parameters specific to the command being executed
-   */
-  parameters: z.record(z.string(), z.unknown()).optional(),
-});
+const processRefByEntityId = z
+  .object({
+    comment: z.string().optional(),
+    entity_id: z.string().min(1),
+  })
+  .strict();
+
+const processRefParams = z.union([processRefByPid, processRefByEntityId]);
+
+/**
+ * `memory-dump` accepts:
+ * - `type: 'kernel'` — no `pid`/`entity_id`
+ * - `type: 'process'` — exactly one of `pid` or `entity_id`
+ *
+ * We use `z.union` (not `z.discriminatedUnion`) here because the
+ * `process` shape itself comes in two forms that share the same `type`
+ * literal — Zod v4's discriminated union rejects duplicate discriminator
+ * values, so we keep the structural union and let Zod try each variant.
+ * The downstream API enforces the same constraints; we mirror them here
+ * to fail fast at the schema layer.
+ */
+const memoryDumpKernelParams = z
+  .object({ comment: z.string().optional(), type: z.literal('kernel') })
+  .strict();
+
+const memoryDumpProcessByPid = z
+  .object({
+    comment: z.string().optional(),
+    type: z.literal('process'),
+    pid: z.number().int().positive(),
+  })
+  .strict();
+
+const memoryDumpProcessByEntityId = z
+  .object({
+    comment: z.string().optional(),
+    type: z.literal('process'),
+    entity_id: z.string().min(1),
+  })
+  .strict();
+
+const memoryDumpParams = z.union([
+  memoryDumpKernelParams,
+  memoryDumpProcessByPid,
+  memoryDumpProcessByEntityId,
+]);
+
+/** `cancel` cancels a previously-dispatched action by its `id`. */
+const cancelParams = z
+  .object({
+    comment: z.string().optional(),
+    id: z.string().min(1),
+  })
+  .strict();
+
+/** `get-file` and `scan` both take a single absolute path on the host. */
+const pathParams = z
+  .object({
+    comment: z.string().optional(),
+    path: z.string().min(1),
+  })
+  .strict();
+
+/** `execute` runs a shell command with an optional timeout. */
+const executeParams = z
+  .object({
+    comment: z.string().optional(),
+    command: z.string().min(1),
+    timeout: z.number().int().positive().optional(),
+  })
+  .strict();
+
+/**
+ * `runscript` for the `endpoint` agent type runs a script-library entry by
+ * `scriptId`. The cross-EDR shape is broader (CrowdStrike accepts `raw`,
+ * Defender accepts `scriptName`, etc.) — but until the route resolves the
+ * external connector client (today only `endpoint` is wired), the
+ * endpoint shape is the only one we can validate strictly.
+ */
+const runscriptParams = z
+  .object({
+    comment: z.string().optional(),
+    scriptId: z.string().min(1),
+    scriptInput: z.string().optional(),
+    timeout: z.number().int().positive().optional(),
+  })
+  .strict();
+
+/**
+ * `upload` is a multipart-style command — `file` is opaque to the
+ * schema (the underlying client expects `Parameters<...>[0]['file']`).
+ * The route does not currently support multipart bodies; until that's
+ * wired the field is accepted as `unknown` so the runner cast still
+ * compiles.
+ */
+const uploadParams = z
+  .object({
+    comment: z.string().optional(),
+    file: z.unknown(),
+    overwrite: z.boolean().optional(),
+  })
+  .strict();
+
+/**
+ * Discriminated union on `command`. Each variant declares the exact
+ * shape of `parameters` that command needs — misspelled or extra keys
+ * fail validation instead of silently turning into `undefined` inside
+ * the runner's `as` casts.
+ */
+export const RunEmulationCommandInputSchema = z.discriminatedUnion('command', [
+  z.object({ ...commonFields, command: z.literal('isolate'), parameters: optionalCommentParams }),
+  z.object({ ...commonFields, command: z.literal('unisolate'), parameters: optionalCommentParams }),
+  z.object({
+    ...commonFields,
+    command: z.literal('running-processes'),
+    parameters: optionalCommentParams,
+  }),
+  z.object({ ...commonFields, command: z.literal('cancel'), parameters: cancelParams }),
+
+  z.object({
+    ...commonFields,
+    command: z.literal('kill-process'),
+    parameters: processRefParams,
+  }),
+  z.object({
+    ...commonFields,
+    command: z.literal('suspend-process'),
+    parameters: processRefParams,
+  }),
+  z.object({
+    ...commonFields,
+    command: z.literal('memory-dump'),
+    parameters: memoryDumpParams,
+  }),
+
+  z.object({ ...commonFields, command: z.literal('get-file'), parameters: pathParams }),
+  z.object({ ...commonFields, command: z.literal('scan'), parameters: pathParams }),
+
+  z.object({ ...commonFields, command: z.literal('execute'), parameters: executeParams }),
+  z.object({ ...commonFields, command: z.literal('runscript'), parameters: runscriptParams }),
+
+  z.object({ ...commonFields, command: z.literal('upload'), parameters: uploadParams }),
+]);
 
 export type RunEmulationCommandInput = z.infer<typeof RunEmulationCommandInputSchema>;
+
+/**
+ * Exposed for tests and consumers that need to know the canonical
+ * command list without re-parsing the discriminated union.
+ */
+export const SUPPORTED_EMULATION_COMMANDS = RESPONSE_ACTION_API_COMMANDS_NAMES;

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -231,6 +231,14 @@ export const allowedExperimentalValues = Object.freeze({
   pciComplianceAgentBuilder: true,
 
   /**
+   * Enables the Detection Emulation Agent Builder skill and the
+   * `runEmulationCommand` route's real-execution path. When `false`, the
+   * skill is not registered and the route returns 403 — there is no
+   * dry-run mode. Default off.
+   */
+  detectionEmulationRealExecution: false,
+
+  /**
    * Enables the new flyout using the EUI flyout system
    */
   newFlyoutSystemEnabled: false,

--- a/x-pack/solutions/security/plugins/security_solution/common/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/index.ts
@@ -23,6 +23,10 @@ export { ELASTIC_SECURITY_RULE_ID } from './detection_engine/constants';
 export { ENABLED_FIELD } from './detection_engine/rule_management/rule_fields';
 export { allowedExperimentalValues, type ExperimentalFeatures } from './experimental_features';
 export { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from './endpoint/service/response_actions/sentinel_one';
+export {
+  RunEmulationCommandInputSchema,
+  type RunEmulationCommandInput,
+} from './detection_emulation';
 
 // Careful of exporting anything from this file as any file(s) you export here will cause your page bundle size to increase.
 // If you're using functions/types/etc... internally it's best to import directly from their paths than expose the functions/types/etc... here.

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -148,6 +148,11 @@ import { ModifiedRuleBadge } from '../../../rule_management/components/rule_deta
 import { ManualRuleRunModal } from '../../../rule_gaps/components/manual_rule_run';
 import { AddRuleAttachmentToChatButton } from '../../../rule_creation_ui/components/add_rule_attachment_to_chat_button';
 import { useAgentBuilderAvailability } from '../../../../agent_builder/hooks/use_agent_builder_availability';
+import { RunEmulationModal } from '../../../../detections/components/emulation';
+import type {
+  CommandSuggestion,
+  CommandApprovalResponse,
+} from '../../../../detections/components/emulation';
 import { useManualRuleRunConfirmation } from '../../../rule_gaps/components/manual_rule_run/use_manual_rule_run_confirmation';
 // eslint-disable-next-line no-restricted-imports
 import { useLegacyUrlRedirect } from './use_redirect_legacy_url';
@@ -604,6 +609,22 @@ export const RuleDetailsPage = connector(
       confirmManualRuleRun,
     } = useManualRuleRunConfirmation();
 
+    const [pendingEmulationApproval, setPendingEmulationApproval] = useState<{
+      suggestion: CommandSuggestion;
+      requestId: string;
+    } | null>(null);
+
+    const handleEmulationApprove = useCallback(
+      (_requestId: string, _response: CommandApprovalResponse) => {
+        setPendingEmulationApproval(null);
+      },
+      []
+    );
+
+    const handleEmulationReject = useCallback((_requestId: string) => {
+      setPendingEmulationApproval(null);
+    }, []);
+
     const groupTakeActionItems = useGroupTakeActionsItems({
       currentStatus: currentAlertStatusFilterValue,
       showAlertStatusActions: Boolean(hasIndexWrite) && Boolean(hasIndexMaintenance),
@@ -674,6 +695,14 @@ export const RuleDetailsPage = connector(
         )}
         {isManualRuleRunConfirmationVisible && (
           <ManualRuleRunModal onCancel={cancelManualRuleRun} onConfirm={confirmManualRuleRun} />
+        )}
+        {pendingEmulationApproval && (
+          <RunEmulationModal
+            suggestion={pendingEmulationApproval.suggestion}
+            requestId={pendingEmulationApproval.requestId}
+            onApprove={handleEmulationApprove}
+            onReject={handleEmulationReject}
+          />
         )}
         <StyledFullHeightContainer onKeyDown={onKeyDown} ref={containerElement}>
           <EuiWindowEvent event="resize" handler={noop} />

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -148,11 +148,6 @@ import { ModifiedRuleBadge } from '../../../rule_management/components/rule_deta
 import { ManualRuleRunModal } from '../../../rule_gaps/components/manual_rule_run';
 import { AddRuleAttachmentToChatButton } from '../../../rule_creation_ui/components/add_rule_attachment_to_chat_button';
 import { useAgentBuilderAvailability } from '../../../../agent_builder/hooks/use_agent_builder_availability';
-import { RunEmulationModal } from '../../../../detections/components/emulation';
-import type {
-  CommandSuggestion,
-  CommandApprovalResponse,
-} from '../../../../detections/components/emulation';
 import { useManualRuleRunConfirmation } from '../../../rule_gaps/components/manual_rule_run/use_manual_rule_run_confirmation';
 // eslint-disable-next-line no-restricted-imports
 import { useLegacyUrlRedirect } from './use_redirect_legacy_url';
@@ -609,22 +604,6 @@ export const RuleDetailsPage = connector(
       confirmManualRuleRun,
     } = useManualRuleRunConfirmation();
 
-    const [pendingEmulationApproval, setPendingEmulationApproval] = useState<{
-      suggestion: CommandSuggestion;
-      requestId: string;
-    } | null>(null);
-
-    const handleEmulationApprove = useCallback(
-      (_requestId: string, _response: CommandApprovalResponse) => {
-        setPendingEmulationApproval(null);
-      },
-      []
-    );
-
-    const handleEmulationReject = useCallback((_requestId: string) => {
-      setPendingEmulationApproval(null);
-    }, []);
-
     const groupTakeActionItems = useGroupTakeActionsItems({
       currentStatus: currentAlertStatusFilterValue,
       showAlertStatusActions: Boolean(hasIndexWrite) && Boolean(hasIndexMaintenance),
@@ -695,14 +674,6 @@ export const RuleDetailsPage = connector(
         )}
         {isManualRuleRunConfirmationVisible && (
           <ManualRuleRunModal onCancel={cancelManualRuleRun} onConfirm={confirmManualRuleRun} />
-        )}
-        {pendingEmulationApproval && (
-          <RunEmulationModal
-            suggestion={pendingEmulationApproval.suggestion}
-            requestId={pendingEmulationApproval.requestId}
-            onApprove={handleEmulationApprove}
-            onReject={handleEmulationReject}
-          />
         )}
         <StyledFullHeightContainer onKeyDown={onKeyDown} ref={containerElement}>
           <EuiWindowEvent event="resize" handler={noop} />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
@@ -30,6 +30,7 @@ import { AdditionalFiltersAction } from './additional_filters_action';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { DETECTIONS_TABLE_IDS } from '../../constants';
+import { EmulationFilter } from '../emulation';
 
 const { changeViewMode } = dataTableActions;
 
@@ -145,6 +146,11 @@ const AdditionalToolbarControlsComponent = ({
         </EuiFlexItem>
       )}
       <EuiFlexItem grow={false}>{additionalFiltersComponent}</EuiFlexItem>
+      {DETECTIONS_TABLE_IDS.some((tableId) => tableId === tableType) && (
+        <EuiFlexItem grow={false}>
+          <EmulationFilter />
+        </EuiFlexItem>
+      )}
       <EuiFlexItem grow={false}>{groupSelector}</EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_badge.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_badge.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { EmulationBadge } from './emulation_badge';
+
+describe('EmulationBadge', () => {
+  it('renders nothing when emulationId is undefined', () => {
+    const { container } = render(<EmulationBadge />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when emulationId is empty string', () => {
+    const { container } = render(<EmulationBadge emulationId="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders badge when emulationId is provided', () => {
+    render(<EmulationBadge emulationId="test-emulation-123" />);
+
+    const badge = screen.getByTestId('emulation-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('EMULATION');
+  });
+
+  it('includes emulation ID in tooltip', () => {
+    const emulationId = 'test-emulation-456';
+    render(<EmulationBadge emulationId={emulationId} />);
+
+    const badge = screen.getByTestId('emulation-badge');
+    expect(badge).toHaveAttribute('title');
+    expect(badge.getAttribute('title')).toContain(emulationId);
+  });
+
+  it('applies hollow color styling', () => {
+    render(<EmulationBadge emulationId="test-emulation-789" />);
+
+    const badge = screen.getByTestId('emulation-badge');
+    expect(badge.className).toContain('hollow');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_badge.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_badge.test.tsx
@@ -6,8 +6,12 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { EmulationBadge } from './emulation_badge';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  EmulationBadge,
+  EMULATION_BADGE_TEST_ID,
+  EMULATION_BADGE_TOOLTIP_TEST_ID,
+} from './emulation_badge';
 
 describe('EmulationBadge', () => {
   it('renders nothing when emulationId is undefined', () => {
@@ -23,24 +27,34 @@ describe('EmulationBadge', () => {
   it('renders badge when emulationId is provided', () => {
     render(<EmulationBadge emulationId="test-emulation-123" />);
 
-    const badge = screen.getByTestId('emulation-badge');
+    const badge = screen.getByTestId(EMULATION_BADGE_TEST_ID);
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveTextContent('EMULATION');
   });
 
-  it('includes emulation ID in tooltip', () => {
+  it('reveals an accessible tooltip containing the emulation ID on hover', async () => {
     const emulationId = 'test-emulation-456';
     render(<EmulationBadge emulationId={emulationId} />);
 
-    const badge = screen.getByTestId('emulation-badge');
-    expect(badge).toHaveAttribute('title');
-    expect(badge.getAttribute('title')).toContain(emulationId);
+    const badge = screen.getByTestId(EMULATION_BADGE_TEST_ID);
+    // EuiToolTip's content is rendered into a portal once the trigger is
+    // hovered/focused. Triggering both events covers mouse and keyboard users.
+    fireEvent.mouseOver(badge);
+    fireEvent.focus(badge);
+
+    const tooltip = await waitFor(() => screen.getByTestId(`${EMULATION_BADGE_TOOLTIP_TEST_ID}`));
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip.textContent).toContain(emulationId);
   });
 
-  it('applies hollow color styling', () => {
+  // N8: assert behaviour through the test-subj contract, not via brittle EUI
+  // className internals (which churn between EUI versions). The badge exposes
+  // a stable `data-test-subj` and that is what consumers rely on.
+  it('exposes a stable data-test-subj and is keyboard-focusable', () => {
     render(<EmulationBadge emulationId="test-emulation-789" />);
 
-    const badge = screen.getByTestId('emulation-badge');
-    expect(badge.className).toContain('hollow');
+    const badge = screen.getByTestId(EMULATION_BADGE_TEST_ID);
+    expect(badge).toHaveAttribute('data-test-subj', EMULATION_BADGE_TEST_ID);
+    expect(badge).toHaveAttribute('tabIndex', '0');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_badge.tsx
@@ -6,10 +6,13 @@
  */
 
 import React from 'react';
-import { EuiBadge } from '@elastic/eui';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 export const ALERT_EMULATION_ID = 'kibana.alert.emulation.id';
+
+export const EMULATION_BADGE_TEST_ID = 'emulation-badge';
+export const EMULATION_BADGE_TOOLTIP_TEST_ID = 'emulation-badge-tooltip';
 
 export interface EmulationBadgeProps {
   emulationId?: string;
@@ -20,19 +23,26 @@ export const EmulationBadge = React.memo<EmulationBadgeProps>(({ emulationId }) 
     return null;
   }
 
+  const tooltipContent = i18n.translate(
+    'xpack.securitySolution.detectionEngine.emulation.badgeTooltip',
+    {
+      defaultMessage: 'This alert was generated during an emulation run: {emulationId}',
+      values: { emulationId },
+    }
+  );
+
+  // I14: wrap in EuiToolTip so the tooltip is keyboard- and screen-reader-
+  // accessible. The native `title` attribute on EuiBadge is not exposed to
+  // assistive tech in a consistent way and is invisible to keyboard-only
+  // users. EuiToolTip handles focus and announces via aria-describedby.
   return (
-    <EuiBadge
-      color="hollow"
-      data-test-subj="emulation-badge"
-      title={i18n.translate('xpack.securitySolution.detectionEngine.emulation.badgeTooltip', {
-        defaultMessage: 'This alert was generated during an emulation run: {emulationId}',
-        values: { emulationId },
-      })}
-    >
-      {i18n.translate('xpack.securitySolution.detectionEngine.emulation.badgeLabel', {
-        defaultMessage: 'EMULATION',
-      })}
-    </EuiBadge>
+    <EuiToolTip content={tooltipContent} data-test-subj={EMULATION_BADGE_TOOLTIP_TEST_ID}>
+      <EuiBadge color="hollow" data-test-subj={EMULATION_BADGE_TEST_ID} tabIndex={0}>
+        {i18n.translate('xpack.securitySolution.detectionEngine.emulation.badgeLabel', {
+          defaultMessage: 'EMULATION',
+        })}
+      </EuiBadge>
+    </EuiToolTip>
   );
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_badge.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiBadge } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export const ALERT_EMULATION_ID = 'kibana.alert.emulation.id';
+
+export interface EmulationBadgeProps {
+  emulationId?: string;
+}
+
+export const EmulationBadge = React.memo<EmulationBadgeProps>(({ emulationId }) => {
+  if (!emulationId) {
+    return null;
+  }
+
+  return (
+    <EuiBadge
+      color="hollow"
+      data-test-subj="emulation-badge"
+      title={i18n.translate('xpack.securitySolution.detectionEngine.emulation.badgeTooltip', {
+        defaultMessage: 'This alert was generated during an emulation run: {emulationId}',
+        values: { emulationId },
+      })}
+    >
+      {i18n.translate('xpack.securitySolution.detectionEngine.emulation.badgeLabel', {
+        defaultMessage: 'EMULATION',
+      })}
+    </EuiBadge>
+  );
+});
+
+EmulationBadge.displayName = 'EmulationBadge';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_filter.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_filter.test.tsx
@@ -7,15 +7,22 @@
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Subject } from 'rxjs';
 import { EmulationFilter, EMULATION_FILTER_BUTTON_TEST_ID } from './emulation_filter';
 import { useKibana } from '../../../common/lib/kibana';
 import type { FilterManager } from '@kbn/data-plugin/public';
 
 jest.mock('../../../common/lib/kibana');
 
+// I9: the component subscribes to `filterManager.getUpdates$()` so it can
+// re-derive its toggle state when filters are mutated by other callers.
+// The mock has to expose a real observable; an unobservable jest.fn would
+// blow up at `.subscribe(…)`.
+const filterUpdates$ = new Subject<void>();
 const mockFilterManager = {
   getFilters: jest.fn(() => []),
   setFilters: jest.fn(),
+  getUpdates$: jest.fn(() => filterUpdates$.asObservable()),
 } as unknown as FilterManager;
 
 const mockUseKibana = useKibana as jest.Mock;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_filter.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_filter.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EmulationFilter, EMULATION_FILTER_BUTTON_TEST_ID } from './emulation_filter';
+import { useKibana } from '../../../common/lib/kibana';
+import type { FilterManager } from '@kbn/data-plugin/public';
+
+jest.mock('../../../common/lib/kibana');
+
+const mockFilterManager = {
+  getFilters: jest.fn(() => []),
+  setFilters: jest.fn(),
+} as unknown as FilterManager;
+
+const mockUseKibana = useKibana as jest.Mock;
+
+describe('EmulationFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKibana.mockReturnValue({
+      services: {
+        data: {
+          query: {
+            filterManager: mockFilterManager,
+          },
+        },
+      },
+    });
+  });
+
+  it('renders the filter button', () => {
+    render(<EmulationFilter />);
+    expect(screen.getByTestId(EMULATION_FILTER_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByText('Emulation')).toBeInTheDocument();
+  });
+
+  it('opens popover when button is clicked', async () => {
+    render(<EmulationFilter />);
+    const button = screen.getByTestId(EMULATION_FILTER_BUTTON_TEST_ID);
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Show emulation alerts')).toBeInTheDocument();
+      expect(screen.getByText('Hide emulation alerts')).toBeInTheDocument();
+    });
+  });
+
+  it('applies filter when "Hide emulation alerts" is selected', async () => {
+    render(<EmulationFilter />);
+    const button = screen.getByTestId(EMULATION_FILTER_BUTTON_TEST_ID);
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      const hideOption = screen.getByText('Hide emulation alerts');
+      fireEvent.click(hideOption);
+    });
+
+    expect(mockFilterManager.setFilters).toHaveBeenCalled();
+  });
+
+  it('shows active filter indicator when hiding emulation alerts', async () => {
+    render(<EmulationFilter />);
+    const button = screen.getByTestId(EMULATION_FILTER_BUTTON_TEST_ID);
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      const hideOption = screen.getByText('Hide emulation alerts');
+      fireEvent.click(hideOption);
+    });
+
+    // The button should show it has an active filter
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('removes filter when "Show emulation alerts" is selected after hiding', async () => {
+    render(<EmulationFilter />);
+    const button = screen.getByTestId(EMULATION_FILTER_BUTTON_TEST_ID);
+
+    // First, hide emulation alerts
+    fireEvent.click(button);
+    await waitFor(() => {
+      const hideOption = screen.getByText('Hide emulation alerts');
+      fireEvent.click(hideOption);
+    });
+
+    // Then, show emulation alerts again
+    fireEvent.click(button);
+    await waitFor(() => {
+      const showOption = screen.getByText('Show emulation alerts');
+      fireEvent.click(showOption);
+    });
+
+    // setFilters should have been called twice
+    expect(mockFilterManager.setFilters).toHaveBeenCalledTimes(2);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_filter.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiFilterButton,
@@ -16,11 +16,19 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { EuiSelectableOption } from '@elastic/eui';
-import type { EuiSelectableOnChangeEvent } from '@elastic/eui/src/components/selectable/selectable';
 import type { Filter } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '../../../common/lib/kibana';
 import { ALERT_EMULATION_ID } from './emulation_badge';
+
+// I13: avoid `@elastic/eui/src/...` deep imports — that path is private and
+// breaks across EUI versions. We recover the `onChange` prop's signature and
+// pull the second argument's type out, so the event type tracks whatever EUI
+// publishes without us re-declaring it.
+type EuiSelectableOnChangeProp = NonNullable<
+  React.ComponentProps<typeof EuiSelectable>['onChange']
+>;
+type EuiSelectableOnChangeEvent = Parameters<EuiSelectableOnChangeProp>[1];
 
 export const EMULATION_FILTER_BUTTON_TEST_ID = 'emulation-filter-button';
 export const EMULATION_FILTER_LIST_TEST_ID = 'emulation-filter-list';
@@ -61,40 +69,63 @@ export const EmulationFilter = memo(() => {
     prefix: 'emulationFilterGroupPopover',
   });
 
-  const filterOptions: EuiSelectableOption[] = [
-    {
-      label: SHOW_EMULATION_ALERTS,
-      key: 'show',
-      checked: 'on',
-    },
-    {
-      label: HIDE_EMULATION_ALERTS,
-      key: 'hide',
-      checked: undefined,
-    },
-  ];
+  // I9: derive the toggle state from the *current* filterManager state, not from
+  // an internal `useState` initialised once at mount. Otherwise, anything that
+  // mutates filters elsewhere (Saved-Query loaded, KQL bar edited, another
+  // component clearing filters) would put this UI out of sync with reality.
+  const isHideFilterActiveFor = useCallback(
+    (filters: Filter[]) =>
+      filters.some(
+        (filter) =>
+          filter.meta.key === ALERT_EMULATION_ID &&
+          filter.meta.type === 'exists' &&
+          filter.meta.negate === true &&
+          filter.meta.disabled !== true
+      ),
+    []
+  );
 
-  const [items, setItems] = useState<EuiSelectableOption[]>(filterOptions);
+  const [hideActive, setHideActive] = useState<boolean>(() =>
+    isHideFilterActiveFor(filterManager.getFilters())
+  );
+
+  // I9: subscribe to external filter-manager updates so our UI stays in sync
+  // when callers other than this component change filters.
+  useEffect(() => {
+    const subscription = filterManager.getUpdates$().subscribe(() => {
+      setHideActive(isHideFilterActiveFor(filterManager.getFilters()));
+    });
+    return () => subscription.unsubscribe();
+  }, [filterManager, isHideFilterActiveFor]);
+
+  const items: EuiSelectableOption[] = useMemo(
+    () => [
+      {
+        label: SHOW_EMULATION_ALERTS,
+        key: 'show',
+        checked: hideActive ? undefined : 'on',
+      },
+      {
+        label: HIDE_EMULATION_ALERTS,
+        key: 'hide',
+        checked: hideActive ? 'on' : undefined,
+      },
+    ],
+    [hideActive]
+  );
 
   const onChange = useCallback(
     (
-      options: EuiSelectableOption[],
-      _: EuiSelectableOnChangeEvent,
+      _options: EuiSelectableOption[],
+      _event: EuiSelectableOnChangeEvent,
       changedOption: EuiSelectableOption
     ) => {
-      const updatedOptions = options.map((option) => ({
-        ...option,
-        checked: option.key === changedOption.key ? 'on' : undefined,
-      }));
-      setItems(updatedOptions as EuiSelectableOption[]);
-
       const existingFilters = filterManager.getFilters();
-      let newFilters: Filter[];
-
       const filtersWithoutEmulation = existingFilters.filter(
         (filter) => filter.meta.key !== ALERT_EMULATION_ID
       );
 
+      let newFilters: Filter[];
       if (changedOption.key === 'hide') {
         const emulationFilter: Filter = {
           meta: {
@@ -117,11 +148,14 @@ export const EmulationFilter = memo(() => {
       }
 
       filterManager.setFilters(newFilters);
+      // The subscription above will pick the change up, but flip it eagerly so
+      // the menu reflects the click before the observable round-trips.
+      setHideActive(changedOption.key === 'hide');
     },
     [filterManager]
   );
 
-  const hasActiveFilter = items.find((item) => item.key === 'hide' && item.checked === 'on');
+  const hasActiveFilter = hideActive;
 
   const button = (
     <EuiFilterButton

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/emulation_filter.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback, useState } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiFilterButton,
+  EuiFilterGroup,
+  EuiPopover,
+  EuiSelectable,
+  useEuiTheme,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import type { EuiSelectableOption } from '@elastic/eui';
+import type { EuiSelectableOnChangeEvent } from '@elastic/eui/src/components/selectable/selectable';
+import type { Filter } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '../../../common/lib/kibana';
+import { ALERT_EMULATION_ID } from './emulation_badge';
+
+export const EMULATION_FILTER_BUTTON_TEST_ID = 'emulation-filter-button';
+export const EMULATION_FILTER_LIST_TEST_ID = 'emulation-filter-list';
+
+const EMULATION_FILTER_BUTTON_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.filterButtonLabel',
+  {
+    defaultMessage: 'Emulation',
+  }
+);
+
+const SHOW_EMULATION_ALERTS = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.showEmulationAlerts',
+  {
+    defaultMessage: 'Show emulation alerts',
+  }
+);
+
+const HIDE_EMULATION_ALERTS = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.hideEmulationAlerts',
+  {
+    defaultMessage: 'Hide emulation alerts',
+  }
+);
+
+export const EmulationFilter = memo(() => {
+  const { euiTheme } = useEuiTheme();
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const togglePopover = useCallback(() => setIsPopoverOpen((value) => !value), []);
+
+  const {
+    data: {
+      query: { filterManager },
+    },
+  } = useKibana().services;
+
+  const filterGroupPopoverId = useGeneratedHtmlId({
+    prefix: 'emulationFilterGroupPopover',
+  });
+
+  const filterOptions: EuiSelectableOption[] = [
+    {
+      label: SHOW_EMULATION_ALERTS,
+      key: 'show',
+      checked: 'on',
+    },
+    {
+      label: HIDE_EMULATION_ALERTS,
+      key: 'hide',
+      checked: undefined,
+    },
+  ];
+
+  const [items, setItems] = useState<EuiSelectableOption[]>(filterOptions);
+
+  const onChange = useCallback(
+    (
+      options: EuiSelectableOption[],
+      _: EuiSelectableOnChangeEvent,
+      changedOption: EuiSelectableOption
+    ) => {
+      const updatedOptions = options.map((option) => ({
+        ...option,
+        checked: option.key === changedOption.key ? 'on' : undefined,
+      }));
+      setItems(updatedOptions as EuiSelectableOption[]);
+
+      const existingFilters = filterManager.getFilters();
+      let newFilters: Filter[];
+
+      const filtersWithoutEmulation = existingFilters.filter(
+        (filter) => filter.meta.key !== ALERT_EMULATION_ID
+      );
+
+      if (changedOption.key === 'hide') {
+        const emulationFilter: Filter = {
+          meta: {
+            alias: null,
+            negate: true,
+            disabled: false,
+            type: 'exists',
+            key: ALERT_EMULATION_ID,
+            value: 'exists',
+          },
+          query: {
+            exists: {
+              field: ALERT_EMULATION_ID,
+            },
+          },
+        };
+        newFilters = [...filtersWithoutEmulation, emulationFilter];
+      } else {
+        newFilters = filtersWithoutEmulation;
+      }
+
+      filterManager.setFilters(newFilters);
+    },
+    [filterManager]
+  );
+
+  const hasActiveFilter = items.find((item) => item.key === 'hide' && item.checked === 'on');
+
+  const button = (
+    <EuiFilterButton
+      aria-pressed={hasActiveFilter ? true : undefined}
+      badgeColor="accent"
+      css={css`
+        background-color: ${euiTheme.colors.backgroundBasePrimary};
+      `}
+      data-test-subj={EMULATION_FILTER_BUTTON_TEST_ID}
+      hasActiveFilters={!!hasActiveFilter}
+      iconType="chevronSingleDown"
+      isSelected={isPopoverOpen || !!hasActiveFilter}
+      numActiveFilters={hasActiveFilter ? 1 : 0}
+      onClick={togglePopover}
+    >
+      {EMULATION_FILTER_BUTTON_LABEL}
+    </EuiFilterButton>
+  );
+
+  return (
+    <EuiFilterGroup compressed={true}>
+      <EuiPopover
+        button={button}
+        closePopover={togglePopover}
+        id={filterGroupPopoverId}
+        isOpen={isPopoverOpen}
+        panelPaddingSize="none"
+      >
+        <EuiSelectable
+          css={css`
+            min-width: 200px;
+          `}
+          data-test-subj={EMULATION_FILTER_LIST_TEST_ID}
+          options={items}
+          onChange={onChange}
+          singleSelection={true}
+        >
+          {(list) => list}
+        </EuiSelectable>
+      </EuiPopover>
+    </EuiFilterGroup>
+  );
+});
+
+EmulationFilter.displayName = 'EmulationFilter';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { EmulationBadge, ALERT_EMULATION_ID } from './emulation_badge';
+export type { EmulationBadgeProps } from './emulation_badge';
+export { EmulationFilter } from './emulation_filter';
+export { RunEmulationModal } from './run_emulation_modal';
+export type {
+  RunEmulationModalProps,
+  CommandSuggestion,
+  CommandApprovalResponse,
+} from './run_emulation_modal';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/run_emulation_modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/run_emulation_modal.test.tsx
@@ -10,6 +10,9 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { RunEmulationModal } from './run_emulation_modal';
 import type { CommandSuggestion } from './run_emulation_modal';
 
+const APPROVE_BTN = 'emulation-modal-approve-button';
+const REJECT_BTN = 'emulation-modal-reject-button';
+
 describe('RunEmulationModal', () => {
   const mockSuggestion: CommandSuggestion = {
     technique_id: 'T1059.001',
@@ -195,5 +198,164 @@ describe('RunEmulationModal', () => {
     );
 
     expect(screen.queryByText(/Agent Type:/)).not.toBeInTheDocument();
+  });
+
+  // ─── I10: state-reset on suggestion / requestId change ─────────────────
+
+  it('resets modify-mode and inputs when a new suggestion comes in (I10)', () => {
+    const { rerender } = render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="req-A"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    // Toggle modify mode and edit the command — these are local state.
+    fireEvent.click(screen.getByLabelText('Modify command before executing'));
+    fireEvent.change(screen.getByDisplayValue('whoami'), { target: { value: 'pwd' } });
+    fireEvent.change(screen.getByDisplayValue('-v'), { target: { value: '-la' } });
+
+    // Now swap in a fresh suggestion — the modal must reset, otherwise the
+    // user's previous edits would silently apply to the new approval.
+    const nextSuggestion: CommandSuggestion = {
+      ...mockSuggestion,
+      command: 'ls',
+      args: ['-h'],
+      technique_id: 'T1057',
+    };
+    rerender(
+      <RunEmulationModal
+        suggestion={nextSuggestion}
+        requestId="req-B"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    // Modify-mode is off again and the displayed command reflects the new
+    // suggestion, not the prior edits.
+    expect(screen.queryByDisplayValue('pwd')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('-la')).not.toBeInTheDocument();
+    expect(screen.getByText(/ls -h/)).toBeInTheDocument();
+  });
+
+  // ─── I11: in-flight submission guard ───────────────────────────────────
+
+  it('disables both buttons after Approve to prevent double-submission (I11)', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="req-once"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    const approveBtn = screen.getByTestId(APPROVE_BTN);
+    fireEvent.click(approveBtn);
+    // The second click must be a no-op (only one onApprove call).
+    fireEvent.click(approveBtn);
+
+    expect(mockOnApprove).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId(APPROVE_BTN)).toBeDisabled();
+    expect(screen.getByTestId(REJECT_BTN)).toBeDisabled();
+  });
+
+  it('disables both buttons after Reject to prevent double-submission (I11)', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="req-once"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    const rejectBtn = screen.getByTestId(REJECT_BTN);
+    fireEvent.click(rejectBtn);
+    fireEvent.click(rejectBtn);
+
+    expect(mockOnReject).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId(APPROVE_BTN)).toBeDisabled();
+    expect(screen.getByTestId(REJECT_BTN)).toBeDisabled();
+  });
+
+  // ─── I12: argv tokenization preserves quoted segments ──────────────────
+
+  it('parses modified args with quoted strings as a single argv element (I12)', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="req-quote"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Modify command before executing'));
+    fireEvent.change(screen.getByDisplayValue('whoami'), { target: { value: 'echo' } });
+    // Quoted "hello world" must remain a single argv element — the legacy
+    // .split(' ') would have produced `['--message="hello`, `world"']`.
+    fireEvent.change(screen.getByDisplayValue('-v'), {
+      target: { value: '--message="hello world" --flag' },
+    });
+
+    fireEvent.click(screen.getByTestId(APPROVE_BTN));
+
+    expect(mockOnApprove).toHaveBeenCalledWith('req-quote', {
+      decision: 'modify',
+      modified_command: 'echo',
+      modified_args: ['--message=hello world', '--flag'],
+    });
+  });
+
+  it('parses modified args with backslash-escaped spaces (I12)', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="req-escape"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Modify command before executing'));
+    fireEvent.change(screen.getByDisplayValue('whoami'), { target: { value: 'cat' } });
+    fireEvent.change(screen.getByDisplayValue('-v'), {
+      target: { value: '/Library/Application\\ Support/foo.txt' },
+    });
+
+    fireEvent.click(screen.getByTestId(APPROVE_BTN));
+
+    expect(mockOnApprove).toHaveBeenCalledWith('req-escape', {
+      decision: 'modify',
+      modified_command: 'cat',
+      modified_args: ['/Library/Application Support/foo.txt'],
+    });
+  });
+
+  it('omits modified_args when the modified args field is whitespace-only (I12)', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="req-empty-args"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Modify command before executing'));
+    fireEvent.change(screen.getByDisplayValue('whoami'), { target: { value: 'date' } });
+    fireEvent.change(screen.getByDisplayValue('-v'), { target: { value: '   ' } });
+
+    fireEvent.click(screen.getByTestId(APPROVE_BTN));
+
+    expect(mockOnApprove).toHaveBeenCalledWith('req-empty-args', {
+      decision: 'modify',
+      modified_command: 'date',
+      modified_args: undefined,
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/run_emulation_modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/run_emulation_modal.test.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RunEmulationModal } from './run_emulation_modal';
+import type { CommandSuggestion } from './run_emulation_modal';
+
+describe('RunEmulationModal', () => {
+  const mockSuggestion: CommandSuggestion = {
+    technique_id: 'T1059.001',
+    phase_id: 'execution',
+    host_id: 'test-host-123',
+    command: 'whoami',
+    args: ['-v'],
+    timeout: '30s',
+    rationale: 'Test user enumeration technique',
+  };
+
+  const mockOnApprove = jest.fn();
+  const mockOnReject = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal with command details', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    expect(screen.getByText('Command Approval Required')).toBeInTheDocument();
+    expect(screen.getByText(/T1059.001/)).toBeInTheDocument();
+    expect(screen.getByText(/execution/)).toBeInTheDocument();
+    expect(screen.getByText(/test-host-123/)).toBeInTheDocument();
+    expect(screen.getByText(/30s/)).toBeInTheDocument();
+    expect(screen.getByText(/Test user enumeration technique/)).toBeInTheDocument();
+    expect(screen.getByText(/whoami -v/)).toBeInTheDocument();
+  });
+
+  it('calls onReject when Reject button is clicked', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Reject'));
+    expect(mockOnReject).toHaveBeenCalledWith('test-request-123');
+    expect(mockOnApprove).not.toHaveBeenCalled();
+  });
+
+  it('calls onApprove with approve decision when Approve button is clicked', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Approve'));
+    expect(mockOnApprove).toHaveBeenCalledWith('test-request-123', {
+      decision: 'approve',
+    });
+    expect(mockOnReject).not.toHaveBeenCalled();
+  });
+
+  it('enables modification mode when switch is toggled', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    const modifySwitch = screen.getByLabelText('Modify command before executing');
+    fireEvent.click(modifySwitch);
+
+    expect(screen.getByDisplayValue('whoami')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('-v')).toBeInTheDocument();
+    expect(screen.getByText('Approve Modified Command')).toBeInTheDocument();
+  });
+
+  it('calls onApprove with modified command when modifications are made', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    // Enable modification mode
+    const modifySwitch = screen.getByLabelText('Modify command before executing');
+    fireEvent.click(modifySwitch);
+
+    // Modify command
+    const commandInput = screen.getByDisplayValue('whoami');
+    fireEvent.change(commandInput, { target: { value: 'pwd' } });
+
+    // Modify args
+    const argsInput = screen.getByDisplayValue('-v');
+    fireEvent.change(argsInput, { target: { value: '-la' } });
+
+    // Approve
+    fireEvent.click(screen.getByText('Approve Modified Command'));
+
+    expect(mockOnApprove).toHaveBeenCalledWith('test-request-123', {
+      decision: 'modify',
+      modified_command: 'pwd',
+      modified_args: ['-la'],
+    });
+  });
+
+  it('handles commands without arguments', () => {
+    const suggestionNoArgs: CommandSuggestion = {
+      ...mockSuggestion,
+      args: undefined,
+    };
+
+    render(
+      <RunEmulationModal
+        suggestion={suggestionNoArgs}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    expect(screen.getByText(/^whoami$/)).toBeInTheDocument();
+  });
+
+  it('handles commands without timeout', () => {
+    const suggestionNoTimeout: CommandSuggestion = {
+      ...mockSuggestion,
+      timeout: undefined,
+    };
+
+    render(
+      <RunEmulationModal
+        suggestion={suggestionNoTimeout}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    expect(screen.queryByText(/Timeout:/)).not.toBeInTheDocument();
+  });
+
+  it('displays agent type when provided', () => {
+    const suggestionWithAgentType: CommandSuggestion = {
+      ...mockSuggestion,
+      agent_type: 'sentinel_one',
+    };
+
+    render(
+      <RunEmulationModal
+        suggestion={suggestionWithAgentType}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    expect(screen.getByText(/Agent Type:/)).toBeInTheDocument();
+    expect(screen.getByText(/sentinel_one/)).toBeInTheDocument();
+  });
+
+  it('omits agent type row when not provided', () => {
+    render(
+      <RunEmulationModal
+        suggestion={mockSuggestion}
+        requestId="test-request-123"
+        onApprove={mockOnApprove}
+        onReject={mockOnReject}
+      />
+    );
+
+    expect(screen.queryByText(/Agent Type:/)).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/run_emulation_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/run_emulation_modal.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   EuiModal,
@@ -144,6 +144,59 @@ export interface RunEmulationModalProps {
   onReject: (requestId: string) => void;
 }
 
+/**
+ * Tokenize a user-provided argv string into an argv array while preserving
+ * quoted segments. Splitting on a bare space (the previous implementation)
+ * silently corrupts arguments like `--message="hello world"` or paths with
+ * spaces (`/Library/Application Support/foo`) because the resulting argv
+ * splits the value across multiple positions (I12).
+ *
+ * Rules:
+ * - Whitespace separates tokens.
+ * - Single and double quotes group runs of characters into one token.
+ * - Backslash escapes the next character verbatim.
+ * - Unterminated quotes still emit the partial token (we keep what the user
+ *   typed and let the server validate downstream rather than throwing).
+ */
+function tokenizeArgs(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (escaping) {
+      current += ch;
+      escaping = false;
+    } else if (ch === '\\') {
+      escaping = true;
+    } else if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (/\s/.test(ch)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+    } else {
+      current += ch;
+    }
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
 export const RunEmulationModal: React.FC<RunEmulationModalProps> = ({
   suggestion,
   requestId,
@@ -155,28 +208,56 @@ export const RunEmulationModal: React.FC<RunEmulationModalProps> = ({
   const [modifiedArgs, setModifiedArgs] = useState(
     suggestion.args ? suggestion.args.join(' ') : ''
   );
+  // I11: track in-flight approve/reject calls so the buttons can disable
+  // themselves and prevent the user from double-submitting (which would
+  // result in two response-actions being dispatched).
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // I10: when the parent swaps in a new suggestion / requestId (e.g. the next
+  // pending approval in the queue), reset the local modify-state. Without
+  // this, the user's edits to the previous suggestion would silently bleed
+  // into the new one. We key off both `requestId` and `suggestion.command`
+  // because the requestId is the canonical "this is a different decision".
+  useEffect(() => {
+    setIsModifyMode(false);
+    setModifiedCommand(suggestion.command);
+    setModifiedArgs(suggestion.args ? suggestion.args.join(' ') : '');
+    setIsSubmitting(false);
+  }, [requestId, suggestion]);
+
+  const modifiedArgv = useMemo(() => tokenizeArgs(modifiedArgs), [modifiedArgs]);
 
   const handleApprove = useCallback(() => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
     const response: CommandApprovalResponse = {
       decision: isModifyMode ? 'modify' : 'approve',
       ...(isModifyMode && {
         modified_command: modifiedCommand,
-        modified_args: modifiedArgs ? modifiedArgs.split(' ') : undefined,
+        modified_args: modifiedArgv.length > 0 ? modifiedArgv : undefined,
       }),
     };
     onApprove(requestId, response);
-  }, [isModifyMode, modifiedCommand, modifiedArgs, onApprove, requestId]);
+  }, [isModifyMode, isSubmitting, modifiedCommand, modifiedArgv, onApprove, requestId]);
 
   const handleReject = useCallback(() => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
     onReject(requestId);
-  }, [onReject, requestId]);
+  }, [isSubmitting, onReject, requestId]);
 
   const fullCommand = suggestion.args
     ? `${suggestion.command} ${suggestion.args.join(' ')}`
     : suggestion.command;
 
+  // The display string mirrors the *tokenized* argv so the user sees the
+  // same shell-quoted result that will actually get dispatched.
   const modifiedFullCommand = isModifyMode
-    ? `${modifiedCommand} ${modifiedArgs}`.trim()
+    ? [modifiedCommand, ...modifiedArgv].join(' ').trim()
     : fullCommand;
 
   return (
@@ -292,12 +373,24 @@ export const RunEmulationModal: React.FC<RunEmulationModalProps> = ({
       <EuiModalFooter>
         <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={handleReject} color="danger">
+            <EuiButtonEmpty
+              onClick={handleReject}
+              color="danger"
+              isDisabled={isSubmitting}
+              data-test-subj="emulation-modal-reject-button"
+            >
               {REJECT_BUTTON_LABEL}
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={handleApprove} fill color="primary">
+            <EuiButton
+              onClick={handleApprove}
+              fill
+              color="primary"
+              isLoading={isSubmitting}
+              isDisabled={isSubmitting}
+              data-test-subj="emulation-modal-approve-button"
+            >
               {isModifyMode ? APPROVE_MODIFIED_BUTTON_LABEL : APPROVE_BUTTON_LABEL}
             </EuiButton>
           </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/run_emulation_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/emulation/run_emulation_modal.tsx
@@ -1,0 +1,308 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCodeBlock,
+  EuiSpacer,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCallOut,
+  EuiFieldText,
+  EuiFormRow,
+  EuiSwitch,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { ResponseActionAgentType } from '../../../../common/endpoint/service/response_actions/constants';
+
+const MODAL_TITLE = i18n.translate('xpack.securitySolution.detectionEngine.emulation.modal.title', {
+  defaultMessage: 'Command Approval Required',
+});
+
+const MODAL_WARNING_BODY = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.warningBody',
+  {
+    defaultMessage:
+      'This command will be executed on a live endpoint. Please review carefully before approving.',
+  }
+);
+
+const TECHNIQUE_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.techniqueLabel',
+  { defaultMessage: 'Technique:' }
+);
+
+const PHASE_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.phaseLabel',
+  { defaultMessage: 'Phase:' }
+);
+
+const TARGET_HOST_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.targetHostLabel',
+  { defaultMessage: 'Target Host:' }
+);
+
+const AGENT_TYPE_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.agentTypeLabel',
+  { defaultMessage: 'Agent Type:' }
+);
+
+const TIMEOUT_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.timeoutLabel',
+  { defaultMessage: 'Timeout:' }
+);
+
+const RATIONALE_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.rationaleLabel',
+  { defaultMessage: 'Rationale:' }
+);
+
+const MODIFIED_COMMAND_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.modifiedCommandLabel',
+  { defaultMessage: 'Modified command to execute:' }
+);
+
+const COMMAND_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.commandLabel',
+  { defaultMessage: 'Command to execute:' }
+);
+
+const REJECT_BUTTON_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.rejectButton',
+  { defaultMessage: 'Reject' }
+);
+
+const CALLOUT_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.calloutTitle',
+  { defaultMessage: 'Real Execution Mode - Command Confirmation' }
+);
+
+const MODIFY_SWITCH_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.modifySwitchLabel',
+  { defaultMessage: 'Modify command before executing' }
+);
+
+const COMMAND_FORM_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.commandFormLabel',
+  { defaultMessage: 'Command' }
+);
+
+const ARGS_FORM_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.argsFormLabel',
+  { defaultMessage: 'Arguments' }
+);
+
+const ARGS_PLACEHOLDER = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.argsPlaceholder',
+  { defaultMessage: 'Space-separated arguments' }
+);
+
+const APPROVE_BUTTON_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.approveButton',
+  { defaultMessage: 'Approve' }
+);
+
+const APPROVE_MODIFIED_BUTTON_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.emulation.modal.approveModifiedButton',
+  { defaultMessage: 'Approve Modified Command' }
+);
+
+export interface CommandSuggestion {
+  technique_id: string;
+  phase_id: string;
+  host_id: string;
+  agent_type?: ResponseActionAgentType;
+  command: string;
+  args?: string[];
+  timeout?: string;
+  rationale: string;
+}
+
+export interface CommandApprovalResponse {
+  decision: 'approve' | 'modify';
+  modified_command?: string;
+  modified_args?: string[];
+}
+
+export interface RunEmulationModalProps {
+  suggestion: CommandSuggestion;
+  requestId: string;
+  onApprove: (requestId: string, response: CommandApprovalResponse) => void;
+  onReject: (requestId: string) => void;
+}
+
+export const RunEmulationModal: React.FC<RunEmulationModalProps> = ({
+  suggestion,
+  requestId,
+  onApprove,
+  onReject,
+}) => {
+  const [isModifyMode, setIsModifyMode] = useState(false);
+  const [modifiedCommand, setModifiedCommand] = useState(suggestion.command);
+  const [modifiedArgs, setModifiedArgs] = useState(
+    suggestion.args ? suggestion.args.join(' ') : ''
+  );
+
+  const handleApprove = useCallback(() => {
+    const response: CommandApprovalResponse = {
+      decision: isModifyMode ? 'modify' : 'approve',
+      ...(isModifyMode && {
+        modified_command: modifiedCommand,
+        modified_args: modifiedArgs ? modifiedArgs.split(' ') : undefined,
+      }),
+    };
+    onApprove(requestId, response);
+  }, [isModifyMode, modifiedCommand, modifiedArgs, onApprove, requestId]);
+
+  const handleReject = useCallback(() => {
+    onReject(requestId);
+  }, [onReject, requestId]);
+
+  const fullCommand = suggestion.args
+    ? `${suggestion.command} ${suggestion.args.join(' ')}`
+    : suggestion.command;
+
+  const modifiedFullCommand = isModifyMode
+    ? `${modifiedCommand} ${modifiedArgs}`.trim()
+    : fullCommand;
+
+  return (
+    <EuiModal
+      onClose={handleReject}
+      css={css`
+        min-width: 600px;
+      `}
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <h2>{MODAL_TITLE}</h2>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiCallOut title={CALLOUT_TITLE} color="warning" iconType="alert">
+          <p>{MODAL_WARNING_BODY}</p>
+        </EuiCallOut>
+
+        <EuiSpacer size="m" />
+
+        <EuiFlexGroup gutterSize="s" direction="column">
+          <EuiFlexItem>
+            <EuiText size="s">
+              <strong>{TECHNIQUE_LABEL}</strong> {suggestion.technique_id}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s">
+              <strong>{PHASE_LABEL}</strong> {suggestion.phase_id}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s">
+              <strong>{TARGET_HOST_LABEL}</strong> {suggestion.host_id}
+            </EuiText>
+          </EuiFlexItem>
+          {suggestion.agent_type && (
+            <EuiFlexItem>
+              <EuiText size="s">
+                <strong>{AGENT_TYPE_LABEL}</strong> {suggestion.agent_type}
+              </EuiText>
+            </EuiFlexItem>
+          )}
+          {suggestion.timeout && (
+            <EuiFlexItem>
+              <EuiText size="s">
+                <strong>{TIMEOUT_LABEL}</strong> {suggestion.timeout}
+              </EuiText>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+
+        <EuiSpacer size="m" />
+
+        <EuiText size="s">
+          <strong>{RATIONALE_LABEL}</strong>
+        </EuiText>
+        <EuiText size="s" color="subdued">
+          {suggestion.rationale}
+        </EuiText>
+
+        <EuiSpacer size="m" />
+
+        <EuiSwitch
+          id="emulation-modify-switch"
+          label={MODIFY_SWITCH_LABEL}
+          checked={isModifyMode}
+          onChange={(e) => setIsModifyMode(e.target.checked)}
+        />
+
+        <EuiSpacer size="m" />
+
+        {isModifyMode ? (
+          <>
+            <EuiFormRow label={COMMAND_FORM_LABEL} fullWidth>
+              <EuiFieldText
+                value={modifiedCommand}
+                onChange={(e) => setModifiedCommand(e.target.value)}
+                fullWidth
+              />
+            </EuiFormRow>
+            <EuiSpacer size="s" />
+            <EuiFormRow label={ARGS_FORM_LABEL} fullWidth>
+              <EuiFieldText
+                value={modifiedArgs}
+                onChange={(e) => setModifiedArgs(e.target.value)}
+                placeholder={ARGS_PLACEHOLDER}
+                fullWidth
+              />
+            </EuiFormRow>
+            <EuiSpacer size="m" />
+            <EuiText size="xs">
+              <strong>{MODIFIED_COMMAND_LABEL}</strong>
+            </EuiText>
+            <EuiCodeBlock language="bash" fontSize="s" paddingSize="s">
+              {modifiedFullCommand}
+            </EuiCodeBlock>
+          </>
+        ) : (
+          <>
+            <EuiText size="xs">
+              <strong>{COMMAND_LABEL}</strong>
+            </EuiText>
+            <EuiCodeBlock language="bash" fontSize="s" paddingSize="s">
+              {fullCommand}
+            </EuiCodeBlock>
+          </>
+        )}
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty onClick={handleReject} color="danger">
+              {REJECT_BUTTON_LABEL}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={handleApprove} fill color="primary">
+              {isModifyMode ? APPROVE_MODIFIED_BUTTON_LABEL : APPROVE_BUTTON_LABEL}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
@@ -11,6 +11,7 @@ import { find, getOr } from 'lodash/fp';
 import type { Alert } from '@kbn/alerting-types';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { TimelineNonEcsData } from '@kbn/timelines-plugin/common';
+import { EmulationBadge, ALERT_EMULATION_ID } from '../../components/emulation';
 import { useKibana } from '../../../common/lib/kibana';
 import { expandDottedObject } from '../../../../common/utils/expand_dotted';
 import { defaultRowRenderers } from '../../../timelines/components/timeline/body/renderers';
@@ -134,6 +135,11 @@ export const CellValue = memo(function RenderCellValue({
     return ecsSuppressionCount ? parseInt(ecsSuppressionCount, 10) : dataSuppressionCount;
   }, [ecsAlert, legacyAlert]);
 
+  const emulationId = useMemo(
+    () => find({ field: ALERT_EMULATION_ID }, legacyAlert)?.value?.[0] as string | undefined,
+    [legacyAlert]
+  );
+
   const myHeader = useMemo(
     () => header ?? ({ id: columnId, ...browserFieldsByName[columnId] } as ColumnHeaderOptions),
     [browserFieldsByName, columnId, header]
@@ -192,15 +198,22 @@ export const CellValue = memo(function RenderCellValue({
     userProfiles,
   ]);
 
-  return columnId === SIGNAL_RULE_NAME_FIELD_NAME && actualSuppressionCount ? (
-    <EuiFlexGroup gutterSize="xs">
-      <EuiFlexItem grow={false}>
-        <EuiIconTip
-          content={SUPPRESSED_ALERT_TOOLTIP(actualSuppressionCount)}
-          position="top"
-          type="layers"
-        />
-      </EuiFlexItem>
+  return columnId === SIGNAL_RULE_NAME_FIELD_NAME && (actualSuppressionCount || emulationId) ? (
+    <EuiFlexGroup gutterSize="xs" alignItems="center">
+      {actualSuppressionCount ? (
+        <EuiFlexItem grow={false}>
+          <EuiIconTip
+            content={SUPPRESSED_ALERT_TOOLTIP(actualSuppressionCount)}
+            position="top"
+            type="layers"
+          />
+        </EuiFlexItem>
+      ) : null}
+      {emulationId ? (
+        <EuiFlexItem grow={false}>
+          <EmulationBadge emulationId={emulationId} />
+        </EuiFlexItem>
+      ) : null}
       <EuiFlexItem grow={false}>{CellRenderer}</EuiFlexItem>
     </EuiFlexGroup>
   ) : (

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/detection_emulation_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/detection_emulation_skill.ts
@@ -1,0 +1,450 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import type { ConfigType } from '../../../config';
+import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+import { createRunEmulationCommandTool } from './run_emulation_command_tool';
+
+export interface DetectionEmulationSkillContext {
+  core: SecuritySolutionPluginCoreSetupDependencies;
+  endpointService: EndpointAppContextService;
+  config: ConfigType;
+  logger: Logger;
+}
+
+export const getDetectionEmulationSkill = (ctx: DetectionEmulationSkillContext) =>
+  defineSkillType({
+    id: 'detection-emulation',
+    name: 'detection-emulation',
+    basePath: 'skills/security/detection-emulation',
+    description: `Validate Elastic Security detection rules before deployment by simulating MITRE ATT&CK techniques and measuring alert fidelity. Returns confidence scores and true-positive/false-positive rates through Log Injection (safe synthetic ECS documents) or Real Execution (gated endpoint commands). Helps gate rule promotion with quantified risk metrics and historical regression comparison. Supports multi-EDR execution: Elastic Defend, Sentinel One, CrowdStrike, Microsoft Defender for Endpoint.`,
+    content: `# Detection Emulation Skill — Tech Preview
+
+## When to Use This Skill
+
+Use this skill when:
+- You need to validate a candidate detection rule before deploying to production
+- You want to measure true-positive and false-positive rates for a rule
+- You need confidence scores for rule promotion decisions
+- You want to test rule effectiveness through MITRE ATT&CK technique emulation
+- You need to compare current rule performance against historical baselines
+
+## Modes of Operation
+
+### 1. Log Injection Mode (Default, Tech Preview)
+- **Safety**: Writes synthetic ECS documents to a dedicated emulation index
+- **Isolation**: Rules must opt-in via their \`index\` array
+- **Use Case**: Safe pre-deployment validation without touching production hosts
+- **Privileges**: Available to all users with \`emulation:read\` privilege
+
+### 2. Real Execution Mode (Gated, Future Phase)
+- **Execution**: Runs commands on Elastic Defend endpoints
+- **Guardrails**: Requires \`emulation:execute\` privilege + per-space host allowlist
+- **Use Case**: High-fidelity validation on controlled test infrastructure
+- **Audit**: All executions logged to \`kibana.security.emulation.action\`
+
+## API Contract
+
+### Primary Tool: validateRule
+
+\`\`\`typescript
+validateRule(rule, hosts, options) -> ValidationReport
+
+Parameters:
+  rule: Detection rule object with MITRE ATT&CK technique mappings
+  hosts: Target host identifiers (agent IDs or host names)
+  options: {
+    mode?: 'log-injection' | 'real-execution',  // default: 'log-injection'
+    timeWindow?: string,                         // default: '15m'
+    suppressAlerts?: boolean,                    // default: true for low-severity
+    maxPhases?: number,                          // default: 20, max: 50
+    rateLimit?: number                           // commands per host per minute, default: 10
+  }
+
+Returns: {
+  emulationId: string,
+  confidence: number,                            // 0-100 score
+  truePositiveRate: number,                      // 0-1
+  falsePositiveRate: number,                     // 0-1
+  phases: Array<{
+    name: string,
+    technique: string,                           // MITRE ATT&CK technique ID
+    status: 'pending' | 'running' | 'completed' | 'failed',
+    matchedAlerts: number,
+    expectedAlerts: number,
+    errors?: string[]
+  }>,
+  comparisonToBaseline?: {
+    previousConfidence: number,
+    delta: number,
+    regressionDetected: boolean
+  },
+  alerts: Array<{
+    id: string,
+    phase: string,
+    timestamp: string,
+    tags: string[]                               // includes 'kibana.alert.emulation.id'
+  }>
+}
+\`\`\`
+
+### Low-Level Tool: runEmulationCommand
+
+For direct command execution during Real Execution mode, use the \`runEmulationCommand\` tool.
+This tool supports multi-EDR execution and is called internally by validateRule, but can also
+be used directly for granular control.
+
+\`\`\`typescript
+runEmulationCommand(params) -> CommandResult
+
+Parameters: {
+  emulationId: string,                           // Unique identifier for the emulation
+  agentType: 'endpoint' | 'sentinel_one' | 'crowdstrike' | 'microsoft_defender_endpoint',
+  endpointIds: string[],                         // Array of endpoint agent IDs
+  command: 'execute' | 'runscript' | 'kill-process' | 'suspend-process' | 'scan' | 'get-file' | 'memory-dump',
+  parameters?: Record<string, unknown>           // Command-specific parameters
+}
+
+Returns: {
+  action_id: string,                             // Response action ID for tracking
+  agent_type: string,                            // EDR agent type used
+  command: string,                               // Command executed
+  status: string,                                // Execution status
+  emulation_id: string,
+  endpoint_count: number
+}
+\`\`\`
+
+**Supported EDR Agent Types:**
+- \`endpoint\`: Elastic Defend (native Elastic endpoint agent)
+- \`sentinel_one\`: SentinelOne EDR
+- \`crowdstrike\`: CrowdStrike Falcon
+- \`microsoft_defender_endpoint\`: Microsoft Defender for Endpoint
+
+All commands are dispatched through the unified ResponseActionsClient, which handles
+EDR-specific translation and connector routing automatically.
+
+## Emulation Process
+
+### 1. Rule Ingestion
+Accept a Detection Engine rule + target host set via Agent Builder tool call or programmatic API.
+
+### 2. Scenario Generation
+Map the rule's MITRE ATT&CK technique tags to a directed attack graph:
+- **Nodes**: Attack phases (e.g., Initial Access, Execution, Persistence)
+- **Edges**: Phase dependencies
+- **Sources**: Cached templates, ELSER-2 semantic search, LLM-driven graph assembly
+
+### 3. Mode Selection & Validation
+- Honor operator's hard-preference (Log Injection vs. Real Execution)
+- Enforce privilege checks: \`emulation:execute\` for Real Execution
+- Verify host allowlist membership for Real Execution
+- Return 403/409 if constraints not met
+
+### 4. Execution
+Walk the attack graph:
+- **Log Injection**: Write synthetic ECS documents to dedicated index
+- **Real Execution**: Dispatch Defend commands to enrolled hosts
+- Stream phase progress to caller in real-time
+
+### 5. Telemetry Collection
+Poll Detection Engine for alerts matching:
+- Rule ID
+- Emulation time window
+- Tag: \`kibana.alert.emulation.id\`
+
+Capture:
+- Alert counts per phase
+- Matched phases
+- False-positive signals
+
+### 6. Scoring
+Compute metrics using weighted formula:
+\`\`\`
+confidence = (TP_coverage × precision × determinism)
+  where:
+    TP_coverage = matched_phases / total_phases
+    precision = TP_count / (TP_count + FP_count)
+    determinism = 1 - variance(repeated_runs)
+\`\`\`
+
+### 7. Persistence
+Write emulation report to space-scoped history index:
+- Scenario details
+- Per-phase outcomes
+- Confidence scores
+- TP/FP rates
+- Execution mode
+- Versioned mapping for schema evolution
+
+## Security Guardrails
+
+### RBAC Privileges
+- **\`emulation:read\`**: View emulation history, run Log Injection
+- **\`emulation:execute\`**: Run Real Execution (gated)
+
+### Host Isolation
+- Per-space allowlist for Real Execution
+- Annual re-enrollment required
+- Hosts tagged with \`emulation.enrolled: true\`
+
+### Audit Logging
+All emulations logged to:
+\`\`\`
+kibana.security.emulation.action
+  - emulation_id
+  - mode
+  - rule_id
+  - host_ids
+  - operator
+  - timestamp
+  - status
+\`\`\`
+
+### Alert Tagging
+All generated alerts tagged with:
+\`\`\`
+kibana.alert.emulation.id: <emulation_id>
+kibana.alert.emulation.mode: <log-injection|real-execution>
+\`\`\`
+
+Default: Excluded from analyst alert queue (opt-in filter available)
+
+### Data Lifecycle
+- **Emulation history**: 90-day ILM policy
+- **Synthetic logs**: 7-day ILM policy
+- **Real Execution logs**: Follow standard retention
+
+## Operational Guardrails
+
+### Rate Limiting
+- Default: 10 commands per host per minute
+- Prevents host saturation during Real Execution
+
+### Concurrency Control
+- Host-level locking for Real Execution
+- One emulation per rule per host at a time
+
+### Resource Limits
+- Max 20 phases per emulation (default)
+- Max 50 phases (hard ceiling)
+- Max 50 hosts per emulation
+- Wall-clock budget: 30 min default, 2 h hard ceiling
+
+### Alert Suppression
+- Default behavior:
+  - **Low/Medium severity**: Suppress (don't create alerts)
+  - **High/Critical severity**: Create alerts (for monitoring)
+- Operator can override via \`suppressAlerts\` option
+
+## Best Practices
+
+### Pre-Deployment Validation
+1. Start with Log Injection mode for initial testing
+2. Validate rule syntax and MITRE mappings are correct
+3. Review confidence score (aim for ≥ 85% before promotion)
+4. Check TP/FP rates against organizational thresholds
+5. Compare against historical baseline to detect regressions
+
+### Using Real Execution
+1. Only use on dedicated test infrastructure (never production)
+2. Verify host allowlist membership before starting
+3. Monitor audit logs for unauthorized attempts
+4. Review phase-by-phase results to identify rule gaps
+5. Re-run after rule adjustments to measure improvement
+
+### Interpreting Results
+
+#### Confidence Score Ranges
+- **90-100**: Excellent, ready for production
+- **80-89**: Good, minor tuning recommended
+- **70-79**: Fair, review false positives
+- **Below 70**: Poor, requires significant rule refinement
+
+#### True Positive Rate
+- **≥ 90%**: Rule reliably detects attack technique
+- **70-89%**: Partial coverage, may miss variants
+- **< 70%**: Significant detection gaps
+
+#### False Positive Rate
+- **< 5%**: Minimal noise, safe for production
+- **5-15%**: Acceptable with proper alert triage
+- **> 15%**: High noise, rule needs refinement
+
+### Troubleshooting
+
+#### No Alerts Generated
+1. Verify rule is enabled and active
+2. Check rule's \`index\` array includes emulation index (Log Injection mode)
+3. Confirm Detection Engine is running
+4. Review phase execution logs for errors
+
+#### High False Positive Rate
+1. Tighten rule query to be more specific
+2. Add exception lists for known-good behaviors
+3. Review MITRE technique mapping accuracy
+4. Consider adding field-level constraints
+
+#### Low Confidence Score
+1. Review phase execution failures
+2. Verify MITRE ATT&CK technique mappings are complete
+3. Check for missing alert generation
+4. Compare with historical runs to identify regressions
+
+## Integration with Detection Engineering Skill
+
+The Detection Engineering Skill can call this skill programmatically to:
+1. **Gate rule promotion**: Block rules with confidence < threshold
+2. **Regression testing**: Compare new rule versions against baselines
+3. **Migration validation**: Test imported rules from other SIEMs
+4. **Continuous validation**: Periodic rule health checks
+
+Example workflow:
+\`\`\`
+1. Detection Engineering Skill receives new rule
+2. Call validateRule() in Log Injection mode
+3. If confidence ≥ 85%: Approve for promotion
+4. If confidence < 85%: Return feedback to rule author
+5. Store validation results in rule metadata
+\`\`\`
+
+## Important Dependencies
+
+- **Detection Engine**: Must be enabled and running
+- **MITRE ATT&CK Mappings**: Rules must have valid technique tags
+- **Elastic Defend** (Real Execution only): Enrolled hosts required
+- **Index Templates**: Emulation indices must have correct mappings
+
+## Roadmap & Feature Flags
+
+### Phase 0 (Foundation)
+- Plugin scaffold
+- Skill registration
+- RBAC privileges
+- ✅ Currently in this phase
+
+### Phase 1 (Log Injection — Tech Preview)
+- Synthetic ECS document generation
+- Scenario template library
+- Basic scoring algorithm
+- Feature flag: \`detectionEmulation.logInjection\`
+
+### Phase 2 (Real Execution — Self-Managed)
+- Defend command dispatch
+- Host allowlist enforcement
+- Audit logging
+- Feature flag: \`detectionEmulation.realExecution\`
+
+### Phase 3 (API Contract Hardening)
+- Versioned public API wrappers
+- Detection Engineering Skill integration
+- Regression comparison
+- Feature flag: \`detectionEmulation.apiContract\`
+
+### Phase 4 (Migration Validators)
+- Splunk/QRadar/SIGMA rule import
+- Multi-SIEM emulation comparison
+- Feature flag: \`detectionEmulation.migrationValidators\`
+
+## Legal & Compliance
+
+### Tech Preview Requirements
+- EULA addendum (drafted by Legal before external release)
+- Real Execution disabled on Elastic Cloud Serverless (pending Legal sign-off)
+- Operator acknowledgment of test/non-production use
+
+### Audit Requirements
+- All Real Execution emulations logged
+- Per-space host enrollment audit trail
+- Annual re-enrollment notifications
+
+## Example Usage
+
+### Basic Log Injection
+\`\`\`
+User: "Validate this ransomware detection rule on my test hosts"
+
+Agent Builder:
+1. Calls validateRule() with rule + host list
+2. Mode: log-injection (default)
+3. Streams progress: "Executing phase 1/5: Initial Access (T1566)"
+4. Returns confidence: 92%, TP: 95%, FP: 3%
+5. Recommendation: "High confidence, ready for production"
+\`\`\`
+
+### Real Execution (Gated)
+\`\`\`
+User: "Run real execution emulation on emulation-host-1"
+
+Agent Builder:
+1. Checks user has 'emulation:execute' privilege
+2. Verifies host is on allowlist
+3. Calls validateRule() with mode: real-execution
+4. Dispatches commands to Elastic Defend
+5. Returns detailed phase-by-phase results
+6. Logs audit event with host, user, timestamp
+\`\`\`
+
+### Regression Detection
+\`\`\`
+User: "Has this rule's performance degraded since last month?"
+
+Agent Builder:
+1. Calls validateRule() with current rule version
+2. Fetches historical baseline from emulation history
+3. Compares confidence scores (90% -> 75%)
+4. Returns: "Regression detected: -15% confidence drop"
+5. Suggests: "Review recent rule changes for false positive increase"
+\`\`\`
+
+## Response Format
+
+When presenting results to users:
+
+### Confidence Score Table
+| Metric | Value | Status |
+|--------|-------|--------|
+| Confidence | 92% | ✅ Excellent |
+| True Positive Rate | 95% | ✅ High Coverage |
+| False Positive Rate | 3% | ✅ Low Noise |
+| Phases Completed | 5/5 | ✅ All Passed |
+
+### Phase Breakdown
+\`\`\`
+Phase 1: Initial Access (T1566 - Phishing)
+  Status: ✅ Completed
+  Alerts: 2/2 expected
+
+Phase 2: Execution (T1059 - Command Interpreter)
+  Status: ✅ Completed
+  Alerts: 1/1 expected
+
+[... remaining phases ...]
+\`\`\`
+
+### Recommendations
+- ✅ Rule ready for production deployment
+- 📊 Confidence score meets 85% threshold
+- 🔄 Baseline comparison: +2% improvement vs. last run
+- 📝 Next steps: Enable rule in Production space
+
+---
+
+## Notes for Agent Builder
+
+- Always default to Log Injection mode unless user explicitly requests Real Execution
+- Check user privileges before attempting Real Execution
+- Stream progress updates during emulation (don't wait for completion)
+- Present confidence score prominently in results
+- Compare against baseline when available
+- Tag results with emulation ID for traceability
+`,
+    getInlineTools: () => [createRunEmulationCommandTool(ctx)],
+  });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/detection_emulation_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/detection_emulation_skill.ts
@@ -23,428 +23,107 @@ export const getDetectionEmulationSkill = (ctx: DetectionEmulationSkillContext) 
   defineSkillType({
     id: 'detection-emulation',
     name: 'detection-emulation',
-    basePath: 'skills/security/detection-emulation',
-    description: `Validate Elastic Security detection rules before deployment by simulating MITRE ATT&CK techniques and measuring alert fidelity. Returns confidence scores and true-positive/false-positive rates through Log Injection (safe synthetic ECS documents) or Real Execution (gated endpoint commands). Helps gate rule promotion with quantified risk metrics and historical regression comparison. Supports multi-EDR execution: Elastic Defend, Sentinel One, CrowdStrike, Microsoft Defender for Endpoint.`,
-    content: `# Detection Emulation Skill — Tech Preview
+    // The skill lives under `endpoint/` because the only wired agent type today
+    // is `endpoint` — the runner dispatches Elastic Defend response actions.
+    // (Re-home if/when the route grows multi-EDR support.)
+    basePath: 'skills/security/endpoint',
+    description: `Dispatch a single Elastic Security response action against one or more endpoints to validate that a detection rule fires as expected. Currently exposes one tool: \`runEmulationCommand\`. Real execution is gated behind a feature flag (\`xpack.securitySolution.enableExperimental.detectionEmulationRealExecution\`); when disabled the route returns 403. Only the \`endpoint\` agent type is wired up today; the other Response-Actions agent types will be added once external connector resolution lands.`,
+    content: `# Detection Emulation Skill
 
-## When to Use This Skill
+## What this skill does
 
-Use this skill when:
-- You need to validate a candidate detection rule before deploying to production
-- You want to measure true-positive and false-positive rates for a rule
-- You need confidence scores for rule promotion decisions
-- You want to test rule effectiveness through MITRE ATT&CK technique emulation
-- You need to compare current rule performance against historical baselines
+Calls a single, gated tool — \`runEmulationCommand\` — that dispatches one
+Elastic Security response action to one or more endpoints. Used for
+validating that a detection rule fires when a known technique runs.
 
-## Modes of Operation
+This is the *only* tool the skill exposes. There is no \`validateRule\`,
+no \`ValidationReport\`, no scenario generator, no phase orchestration.
+Those are roadmap items, not capabilities — do not invent calls to them.
 
-### 1. Log Injection Mode (Default, Tech Preview)
-- **Safety**: Writes synthetic ECS documents to a dedicated emulation index
-- **Isolation**: Rules must opt-in via their \`index\` array
-- **Use Case**: Safe pre-deployment validation without touching production hosts
-- **Privileges**: Available to all users with \`emulation:read\` privilege
-
-### 2. Real Execution Mode (Gated, Future Phase)
-- **Execution**: Runs commands on Elastic Defend endpoints
-- **Guardrails**: Requires \`emulation:execute\` privilege + per-space host allowlist
-- **Use Case**: High-fidelity validation on controlled test infrastructure
-- **Audit**: All executions logged to \`kibana.security.emulation.action\`
-
-## API Contract
-
-### Primary Tool: validateRule
+## Tool: \`runEmulationCommand\`
 
 \`\`\`typescript
-validateRule(rule, hosts, options) -> ValidationReport
-
-Parameters:
-  rule: Detection rule object with MITRE ATT&CK technique mappings
-  hosts: Target host identifiers (agent IDs or host names)
-  options: {
-    mode?: 'log-injection' | 'real-execution',  // default: 'log-injection'
-    timeWindow?: string,                         // default: '15m'
-    suppressAlerts?: boolean,                    // default: true for low-severity
-    maxPhases?: number,                          // default: 20, max: 50
-    rateLimit?: number                           // commands per host per minute, default: 10
-  }
-
-Returns: {
-  emulationId: string,
-  confidence: number,                            // 0-100 score
-  truePositiveRate: number,                      // 0-1
-  falsePositiveRate: number,                     // 0-1
-  phases: Array<{
-    name: string,
-    technique: string,                           // MITRE ATT&CK technique ID
-    status: 'pending' | 'running' | 'completed' | 'failed',
-    matchedAlerts: number,
-    expectedAlerts: number,
-    errors?: string[]
-  }>,
-  comparisonToBaseline?: {
-    previousConfidence: number,
-    delta: number,
-    regressionDetected: boolean
-  },
-  alerts: Array<{
-    id: string,
-    phase: string,
-    timestamp: string,
-    tags: string[]                               // includes 'kibana.alert.emulation.id'
-  }>
+runEmulationCommand({
+  emulationId: string,        // unique identifier for this emulation run
+  agentType: 'endpoint',      // only 'endpoint' is wired up today
+  endpointIds: string[],      // 1+ Elastic Defend agent IDs
+  command: ResponseActionApiCommand,
+  parameters?: Record<string, unknown>,  // command-specific (see table)
+}) -> {
+  action_id: string,
+  agent_type: 'endpoint',
+  command: string,
+  status: 'dispatched' | 'error',
 }
 \`\`\`
 
-### Low-Level Tool: runEmulationCommand
-
-For direct command execution during Real Execution mode, use the \`runEmulationCommand\` tool.
-This tool supports multi-EDR execution and is called internally by validateRule, but can also
-be used directly for granular control.
-
-\`\`\`typescript
-runEmulationCommand(params) -> CommandResult
-
-Parameters: {
-  emulationId: string,                           // Unique identifier for the emulation
-  agentType: 'endpoint' | 'sentinel_one' | 'crowdstrike' | 'microsoft_defender_endpoint',
-  endpointIds: string[],                         // Array of endpoint agent IDs
-  command: 'execute' | 'runscript' | 'kill-process' | 'suspend-process' | 'scan' | 'get-file' | 'memory-dump',
-  parameters?: Record<string, unknown>           // Command-specific parameters
-}
-
-Returns: {
-  action_id: string,                             // Response action ID for tracking
-  agent_type: string,                            // EDR agent type used
-  command: string,                               // Command executed
-  status: string,                                // Execution status
-  emulation_id: string,
-  endpoint_count: number
-}
-\`\`\`
-
-**Supported EDR Agent Types:**
-- \`endpoint\`: Elastic Defend (native Elastic endpoint agent)
-- \`sentinel_one\`: SentinelOne EDR
-- \`crowdstrike\`: CrowdStrike Falcon
-- \`microsoft_defender_endpoint\`: Microsoft Defender for Endpoint
-
-All commands are dispatched through the unified ResponseActionsClient, which handles
-EDR-specific translation and connector routing automatically.
-
-## Emulation Process
-
-### 1. Rule Ingestion
-Accept a Detection Engine rule + target host set via Agent Builder tool call or programmatic API.
-
-### 2. Scenario Generation
-Map the rule's MITRE ATT&CK technique tags to a directed attack graph:
-- **Nodes**: Attack phases (e.g., Initial Access, Execution, Persistence)
-- **Edges**: Phase dependencies
-- **Sources**: Cached templates, ELSER-2 semantic search, LLM-driven graph assembly
-
-### 3. Mode Selection & Validation
-- Honor operator's hard-preference (Log Injection vs. Real Execution)
-- Enforce privilege checks: \`emulation:execute\` for Real Execution
-- Verify host allowlist membership for Real Execution
-- Return 403/409 if constraints not met
-
-### 4. Execution
-Walk the attack graph:
-- **Log Injection**: Write synthetic ECS documents to dedicated index
-- **Real Execution**: Dispatch Defend commands to enrolled hosts
-- Stream phase progress to caller in real-time
-
-### 5. Telemetry Collection
-Poll Detection Engine for alerts matching:
-- Rule ID
-- Emulation time window
-- Tag: \`kibana.alert.emulation.id\`
-
-Capture:
-- Alert counts per phase
-- Matched phases
-- False-positive signals
-
-### 6. Scoring
-Compute metrics using weighted formula:
-\`\`\`
-confidence = (TP_coverage × precision × determinism)
-  where:
-    TP_coverage = matched_phases / total_phases
-    precision = TP_count / (TP_count + FP_count)
-    determinism = 1 - variance(repeated_runs)
-\`\`\`
-
-### 7. Persistence
-Write emulation report to space-scoped history index:
-- Scenario details
-- Per-phase outcomes
-- Confidence scores
-- TP/FP rates
-- Execution mode
-- Versioned mapping for schema evolution
-
-## Security Guardrails
-
-### RBAC Privileges
-- **\`emulation:read\`**: View emulation history, run Log Injection
-- **\`emulation:execute\`**: Run Real Execution (gated)
-
-### Host Isolation
-- Per-space allowlist for Real Execution
-- Annual re-enrollment required
-- Hosts tagged with \`emulation.enrolled: true\`
-
-### Audit Logging
-All emulations logged to:
-\`\`\`
-kibana.security.emulation.action
-  - emulation_id
-  - mode
-  - rule_id
-  - host_ids
-  - operator
-  - timestamp
-  - status
-\`\`\`
-
-### Alert Tagging
-All generated alerts tagged with:
-\`\`\`
-kibana.alert.emulation.id: <emulation_id>
-kibana.alert.emulation.mode: <log-injection|real-execution>
-\`\`\`
-
-Default: Excluded from analyst alert queue (opt-in filter available)
-
-### Data Lifecycle
-- **Emulation history**: 90-day ILM policy
-- **Synthetic logs**: 7-day ILM policy
-- **Real Execution logs**: Follow standard retention
-
-## Operational Guardrails
-
-### Rate Limiting
-- Default: 10 commands per host per minute
-- Prevents host saturation during Real Execution
-
-### Concurrency Control
-- Host-level locking for Real Execution
-- One emulation per rule per host at a time
-
-### Resource Limits
-- Max 20 phases per emulation (default)
-- Max 50 phases (hard ceiling)
-- Max 50 hosts per emulation
-- Wall-clock budget: 30 min default, 2 h hard ceiling
-
-### Alert Suppression
-- Default behavior:
-  - **Low/Medium severity**: Suppress (don't create alerts)
-  - **High/Critical severity**: Create alerts (for monitoring)
-- Operator can override via \`suppressAlerts\` option
-
-## Best Practices
-
-### Pre-Deployment Validation
-1. Start with Log Injection mode for initial testing
-2. Validate rule syntax and MITRE mappings are correct
-3. Review confidence score (aim for ≥ 85% before promotion)
-4. Check TP/FP rates against organizational thresholds
-5. Compare against historical baseline to detect regressions
-
-### Using Real Execution
-1. Only use on dedicated test infrastructure (never production)
-2. Verify host allowlist membership before starting
-3. Monitor audit logs for unauthorized attempts
-4. Review phase-by-phase results to identify rule gaps
-5. Re-run after rule adjustments to measure improvement
-
-### Interpreting Results
-
-#### Confidence Score Ranges
-- **90-100**: Excellent, ready for production
-- **80-89**: Good, minor tuning recommended
-- **70-79**: Fair, review false positives
-- **Below 70**: Poor, requires significant rule refinement
-
-#### True Positive Rate
-- **≥ 90%**: Rule reliably detects attack technique
-- **70-89%**: Partial coverage, may miss variants
-- **< 70%**: Significant detection gaps
-
-#### False Positive Rate
-- **< 5%**: Minimal noise, safe for production
-- **5-15%**: Acceptable with proper alert triage
-- **> 15%**: High noise, rule needs refinement
-
-### Troubleshooting
-
-#### No Alerts Generated
-1. Verify rule is enabled and active
-2. Check rule's \`index\` array includes emulation index (Log Injection mode)
-3. Confirm Detection Engine is running
-4. Review phase execution logs for errors
-
-#### High False Positive Rate
-1. Tighten rule query to be more specific
-2. Add exception lists for known-good behaviors
-3. Review MITRE technique mapping accuracy
-4. Consider adding field-level constraints
-
-#### Low Confidence Score
-1. Review phase execution failures
-2. Verify MITRE ATT&CK technique mappings are complete
-3. Check for missing alert generation
-4. Compare with historical runs to identify regressions
-
-## Integration with Detection Engineering Skill
-
-The Detection Engineering Skill can call this skill programmatically to:
-1. **Gate rule promotion**: Block rules with confidence < threshold
-2. **Regression testing**: Compare new rule versions against baselines
-3. **Migration validation**: Test imported rules from other SIEMs
-4. **Continuous validation**: Periodic rule health checks
-
-Example workflow:
-\`\`\`
-1. Detection Engineering Skill receives new rule
-2. Call validateRule() in Log Injection mode
-3. If confidence ≥ 85%: Approve for promotion
-4. If confidence < 85%: Return feedback to rule author
-5. Store validation results in rule metadata
-\`\`\`
-
-## Important Dependencies
-
-- **Detection Engine**: Must be enabled and running
-- **MITRE ATT&CK Mappings**: Rules must have valid technique tags
-- **Elastic Defend** (Real Execution only): Enrolled hosts required
-- **Index Templates**: Emulation indices must have correct mappings
-
-## Roadmap & Feature Flags
-
-### Phase 0 (Foundation)
-- Plugin scaffold
-- Skill registration
-- RBAC privileges
-- ✅ Currently in this phase
-
-### Phase 1 (Log Injection — Tech Preview)
-- Synthetic ECS document generation
-- Scenario template library
-- Basic scoring algorithm
-- Feature flag: \`detectionEmulation.logInjection\`
-
-### Phase 2 (Real Execution — Self-Managed)
-- Defend command dispatch
-- Host allowlist enforcement
-- Audit logging
-- Feature flag: \`detectionEmulation.realExecution\`
-
-### Phase 3 (API Contract Hardening)
-- Versioned public API wrappers
-- Detection Engineering Skill integration
-- Regression comparison
-- Feature flag: \`detectionEmulation.apiContract\`
-
-### Phase 4 (Migration Validators)
-- Splunk/QRadar/SIGMA rule import
-- Multi-SIEM emulation comparison
-- Feature flag: \`detectionEmulation.migrationValidators\`
-
-## Legal & Compliance
-
-### Tech Preview Requirements
-- EULA addendum (drafted by Legal before external release)
-- Real Execution disabled on Elastic Cloud Serverless (pending Legal sign-off)
-- Operator acknowledgment of test/non-production use
-
-### Audit Requirements
-- All Real Execution emulations logged
-- Per-space host enrollment audit trail
-- Annual re-enrollment notifications
-
-## Example Usage
-
-### Basic Log Injection
-\`\`\`
-User: "Validate this ransomware detection rule on my test hosts"
-
-Agent Builder:
-1. Calls validateRule() with rule + host list
-2. Mode: log-injection (default)
-3. Streams progress: "Executing phase 1/5: Initial Access (T1566)"
-4. Returns confidence: 92%, TP: 95%, FP: 3%
-5. Recommendation: "High confidence, ready for production"
-\`\`\`
-
-### Real Execution (Gated)
-\`\`\`
-User: "Run real execution emulation on emulation-host-1"
-
-Agent Builder:
-1. Checks user has 'emulation:execute' privilege
-2. Verifies host is on allowlist
-3. Calls validateRule() with mode: real-execution
-4. Dispatches commands to Elastic Defend
-5. Returns detailed phase-by-phase results
-6. Logs audit event with host, user, timestamp
-\`\`\`
-
-### Regression Detection
-\`\`\`
-User: "Has this rule's performance degraded since last month?"
-
-Agent Builder:
-1. Calls validateRule() with current rule version
-2. Fetches historical baseline from emulation history
-3. Compares confidence scores (90% -> 75%)
-4. Returns: "Regression detected: -15% confidence drop"
-5. Suggests: "Review recent rule changes for false positive increase"
-\`\`\`
-
-## Response Format
-
-When presenting results to users:
-
-### Confidence Score Table
-| Metric | Value | Status |
-|--------|-------|--------|
-| Confidence | 92% | ✅ Excellent |
-| True Positive Rate | 95% | ✅ High Coverage |
-| False Positive Rate | 3% | ✅ Low Noise |
-| Phases Completed | 5/5 | ✅ All Passed |
-
-### Phase Breakdown
-\`\`\`
-Phase 1: Initial Access (T1566 - Phishing)
-  Status: ✅ Completed
-  Alerts: 2/2 expected
-
-Phase 2: Execution (T1059 - Command Interpreter)
-  Status: ✅ Completed
-  Alerts: 1/1 expected
-
-[... remaining phases ...]
-\`\`\`
-
-### Recommendations
-- ✅ Rule ready for production deployment
-- 📊 Confidence score meets 85% threshold
-- 🔄 Baseline comparison: +2% improvement vs. last run
-- 📝 Next steps: Enable rule in Production space
-
----
-
-## Notes for Agent Builder
-
-- Always default to Log Injection mode unless user explicitly requests Real Execution
-- Check user privileges before attempting Real Execution
-- Stream progress updates during emulation (don't wait for completion)
-- Present confidence score prominently in results
-- Compare against baseline when available
-- Tag results with emulation ID for traceability
+### Supported commands and their parameters
+
+| \`command\` | Required \`parameters\` | Notes |
+|---|---|---|
+| \`isolate\` | (none) | Network-isolate the host |
+| \`unisolate\` | (none) | Lift network isolation |
+| \`kill-process\` | \`pid: number\` *or* \`entity_id: string\` | One of the two is required |
+| \`suspend-process\` | \`pid: number\` *or* \`entity_id: string\` | One of the two is required |
+| \`running-processes\` | (none) | List processes |
+| \`get-file\` | \`path: string\` | Absolute path on the host |
+| \`execute\` | \`command: string\`, \`timeout?: number\` | Shell command |
+| \`upload\` | \`file: File\`, \`overwrite?: boolean\` | Multipart |
+| \`scan\` | \`path: string\` | YARA scan path |
+| \`runscript\` | \`script: string\`, \`timeout?: number\` | Run a script |
+| \`cancel\` | (none) | Cancel a pending action |
+| \`memory-dump\` | \`pid: number\` *or* \`entity_id: string\` | One of the two is required |
+
+\`parameters.comment\` (optional, any command): a human-readable note
+attached to the response-actions audit comment.
+
+## Gating
+
+The route applies four gates in this order. If any fails the call
+short-circuits with the corresponding HTTP status:
+
+1. **Feature flag** — \`xpack.securitySolution.enableExperimental.detectionEmulationRealExecution\`
+   must be \`true\`. Otherwise: 403.
+2. **RBAC** — the caller must hold the per-command Endpoint privilege
+   resolved via \`RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ\`. Otherwise: 403.
+3. **Allowlist** — \`endpointIds\` must be permitted by the configured
+   \`EmulationAllowlist\`. Otherwise: 403.
+4. **Rate limit** — per-space sliding window. Otherwise: 429.
+
+## What happens after dispatch
+
+The skill does **not** poll for action results. It returns the
+\`action_id\` from the underlying \`ResponseActionsClient.<command>(...)\`
+call and exits. Use the standard Response Actions APIs / UI to inspect
+results, or write a follow-up tool if you need polling here.
+
+Generated alerts that you want to attribute to an emulation run can be
+tagged via the \`tagAlertsWithEmulation\` helper (server-side); the UI
+exposes a filter (\`Hide emulation alerts\`) on the alerts table so
+analysts can opt out.
+
+## Things this skill does NOT do (yet)
+
+- Run \`sentinel_one\`, \`crowdstrike\`, or \`microsoft_defender_endpoint\` commands.
+  The schema accepts \`agentType: 'endpoint'\` only until the route
+  resolves the external \`connectorActions\` client.
+- Generate attack scenarios, walk a MITRE ATT&CK graph, or compute
+  confidence / TP / FP scores.
+- Persist an emulation history index. Use the \`emulationRuleBindingType\`
+  saved-object type if you need to associate a run with a rule.
+- Tag alerts automatically. Call \`tagAlertsWithEmulation\` from your own
+  code if you want emulation metadata on alerts.
+
+## Notes for the agent
+
+- Default to **not** calling this skill unless the user explicitly asks
+  for "emulate" / "test rule against endpoint" / "run response action".
+- The schema is strict: an unknown \`command\` or a missing required
+  parameter returns 400.
+- Each call dispatches exactly one action. Loop on the caller side if
+  you need a multi-step scenario.
+- Always include a \`parameters.comment\` describing why this action is
+  being dispatched — it lands in the response-actions audit trail.
 `,
     getInlineTools: () => [createRunEmulationCommandTool(ctx)],
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getDetectionEmulationSkill } from './detection_emulation_skill';
+export type { DetectionEmulationSkillContext } from './detection_emulation_skill';
+export { createRunEmulationCommandTool } from './run_emulation_command_tool';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/run_emulation_command_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/run_emulation_command_tool.test.ts
@@ -41,7 +41,6 @@ describe('createRunEmulationCommandTool', () => {
 
     expect(tool.id).toBe('security.detection-emulation.run-command');
     expect(tool.type).toBe(ToolType.builtin);
-    expect(tool.tags).toEqual(['security', 'emulation', 'response-actions']);
   });
 
   it('should have a schema that validates agentType', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/run_emulation_command_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/run_emulation_command_tool.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createRunEmulationCommandTool } from './run_emulation_command_tool';
+import { ToolType } from '@kbn/agent-builder-common/tools';
+import type { RunEmulationCommandToolDeps } from './run_emulation_command_tool';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
+import type { ConfigType } from '../../../config';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+
+const createMockDeps = (): RunEmulationCommandToolDeps => {
+  const logger = loggingSystemMock.createLogger();
+  return {
+    core: {
+      getStartServices: jest.fn().mockResolvedValue([
+        {
+          plugins: { cases: undefined },
+          security: { authc: { getCurrentUser: jest.fn().mockReturnValue(null) } },
+        },
+        { securitySolution: { createRequestContext: jest.fn() } },
+      ]),
+    } as unknown as SecuritySolutionPluginCoreSetupDependencies,
+    endpointService: {} as unknown as EndpointAppContextService,
+    config: {
+      experimentalFeatures: {
+        detectionEmulationRealExecution: true,
+      },
+    } as unknown as ConfigType,
+    logger,
+  };
+};
+
+describe('createRunEmulationCommandTool', () => {
+  it('should create a tool with correct id and type', () => {
+    const tool = createRunEmulationCommandTool(createMockDeps());
+
+    expect(tool.id).toBe('security.detection-emulation.run-command');
+    expect(tool.type).toBe(ToolType.builtin);
+    expect(tool.tags).toEqual(['security', 'emulation', 'response-actions']);
+  });
+
+  it('should have a schema that validates agentType', () => {
+    const tool = createRunEmulationCommandTool(createMockDeps());
+
+    // Valid agent types should parse
+    const validInput = {
+      emulationId: 'test-emulation-123',
+      agentType: 'endpoint' as const,
+      endpointIds: ['agent-1', 'agent-2'],
+      command: 'execute' as const,
+      parameters: { command: 'whoami' },
+    };
+
+    const result = tool.schema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate all supported EDR agent types', () => {
+    const tool = createRunEmulationCommandTool(createMockDeps());
+
+    const agentTypes = ['endpoint', 'sentinel_one', 'crowdstrike', 'microsoft_defender_endpoint'];
+
+    agentTypes.forEach((agentType) => {
+      const input = {
+        emulationId: 'test-emulation-123',
+        agentType,
+        endpointIds: ['agent-1'],
+        command: 'execute',
+      };
+
+      const result = tool.schema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it('should reject invalid agent types', () => {
+    const tool = createRunEmulationCommandTool(createMockDeps());
+
+    const input = {
+      emulationId: 'test-emulation-123',
+      agentType: 'invalid-type',
+      endpointIds: ['agent-1'],
+      command: 'execute',
+    };
+
+    const result = tool.schema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('should validate all supported commands', () => {
+    const tool = createRunEmulationCommandTool(createMockDeps());
+
+    const commands = [
+      'isolate',
+      'unisolate',
+      'kill-process',
+      'suspend-process',
+      'running-processes',
+      'get-file',
+      'execute',
+      'upload',
+      'scan',
+      'runscript',
+      'cancel',
+      'memory-dump',
+    ];
+
+    commands.forEach((command) => {
+      const input = {
+        emulationId: 'test-emulation-123',
+        agentType: 'endpoint',
+        endpointIds: ['agent-1'],
+        command,
+      };
+
+      const result = tool.schema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it('should require at least one endpoint ID', () => {
+    const tool = createRunEmulationCommandTool(createMockDeps());
+
+    const input = {
+      emulationId: 'test-emulation-123',
+      agentType: 'endpoint',
+      endpointIds: [],
+      command: 'execute',
+    };
+
+    const result = tool.schema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/run_emulation_command_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/run_emulation_command_tool.ts
@@ -5,13 +5,10 @@
  * 2.0.
  */
 
-import { z } from '@kbn/zod/v4';
 import type { Logger } from '@kbn/core/server';
-import {
-  ToolType,
-  ToolResultType,
-} from '@kbn/agent-builder-common';
-import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import { z } from '@kbn/zod/v4';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
 import {
   RESPONSE_ACTION_AGENT_TYPE,
   RESPONSE_ACTION_API_COMMANDS_NAMES,
@@ -20,7 +17,12 @@ import {
 } from '../../../../common/endpoint/service/response_actions/constants';
 import type { ConfigType } from '../../../config';
 import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
-import { EmulationRunner } from '../../../lib/detection_emulation/execution/runner';
+import {
+  EmulationRunner,
+  UnsupportedAgentTypeError,
+  UnsupportedCommandForAgentTypeError,
+  MissingConnectorActionsError,
+} from '../../../lib/detection_emulation/execution/runner';
 import {
   EmulationAllowlist,
   createDefaultAllowlistConfig,
@@ -33,32 +35,43 @@ import {
   getDetectionEmulationFeatureFlags,
   isRealExecutionEnabled,
 } from '../../../lib/detection_emulation/feature_flag';
+import { createSavedObjectRuleBindingLookup } from '../../../lib/detection_emulation/rule_binding_lookup';
+import { emulationRuleBindingTypeName } from '../../../lib/detection_emulation/rule_binding';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+import { RunEmulationCommandInputSchema } from '../../../../common/detection_emulation/schemas/run_emulation_command_input';
 
 /**
- * Tool schema for running emulation commands with multi-EDR support.
- * Accepts any of the four supported EDR agent types and validates command.
+ * Schema exposed to the agent-builder framework.
+ *
+ * The framework requires `ZodObject` (not a discriminated union) at the
+ * tool boundary so it can derive a JSON Schema for the LLM. We keep the
+ * boundary permissive (a free-form `parameters` record) and re-validate
+ * with the strict {@link RunEmulationCommandInputSchema} discriminated
+ * union inside the handler. That way the LLM only sees one shape but
+ * any malformed parameters still fail fast before reaching the runner.
  */
 const runEmulationCommandSchema = z.object({
-  emulationId: z.string().describe('Unique identifier for the emulation'),
+  emulationId: z.string().min(1).describe('Unique identifier for the emulation run.'),
   agentType: z
     .enum(RESPONSE_ACTION_AGENT_TYPE)
     .describe(
-      'The EDR agent type - must be one of: endpoint, sentinel_one, crowdstrike, microsoft_defender_endpoint'
+      'EDR agent type. Only `endpoint` is wired through the route today; selecting another type will return 400 until external connectors are resolved.'
     ),
   endpointIds: z
-    .array(z.string())
+    .array(z.string().min(1))
     .min(1)
-    .describe('Array of endpoint agent IDs to target with the emulation command'),
+    .describe('Endpoint agent IDs to dispatch the action against (1+).'),
   command: z
     .enum(RESPONSE_ACTION_API_COMMANDS_NAMES)
     .describe(
-      'The response action command to execute - e.g., execute, runscript, kill-process, suspend-process, scan, get-file, memory-dump'
+      'Response-action command. Each command requires a specific `parameters` shape — see the skill content for the table.'
     ),
   parameters: z
     .record(z.string(), z.unknown())
     .optional()
-    .describe('Optional parameters specific to the command being executed'),
+    .describe(
+      'Command-specific parameters. Strictly validated server-side per command (e.g. `{ pid: number }` for kill-process, `{ path: string }` for get-file).'
+    ),
 });
 
 export interface RunEmulationCommandToolDeps {
@@ -77,7 +90,7 @@ export interface RunEmulationCommandToolDeps {
  */
 export const createRunEmulationCommandTool = (
   deps: RunEmulationCommandToolDeps
-): BuiltinToolDefinition<typeof runEmulationCommandSchema> => {
+): BuiltinSkillBoundedTool<typeof runEmulationCommandSchema> => {
   const { core, endpointService, config, logger } = deps;
 
   // Initialize allowlist and rate limiter with default configurations
@@ -115,13 +128,40 @@ commands through the appropriate EDR connector via ResponseActionsClient.
 
 Use this tool when validating detection rules through Real Execution mode, after the user
 has explicitly authorized the emulation and all required permissions are in place.`,
-    tags: ['security', 'emulation', 'response-actions'],
     schema: runEmulationCommandSchema,
-    handler: async (params, { esClient, spaceId, request }) => {
-      const { emulationId, command, endpointIds } = params;
+    handler: async (rawParams, { esClient, spaceId, request }) => {
+      const { emulationId, command, endpointIds } = rawParams;
 
       try {
-        const featureFlags = getDetectionEmulationFeatureFlags(config);
+        // Re-validate against the strict discriminated union — the boundary
+        // schema accepts a free-form `parameters` record so JSON Schema works
+        // for the LLM, but the runner needs the exact per-command shape.
+        const strictParseResult = RunEmulationCommandInputSchema.safeParse(rawParams);
+        if (!strictParseResult.success) {
+          logger.warn(
+            `Emulation command [${command}] for emulation [${emulationId}] rejected: invalid parameters for command (${strictParseResult.error.message})`
+          );
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'invalid_parameters',
+                  message: 'Invalid parameters for the requested command.',
+                  emulation_id: emulationId,
+                  agent_type: rawParams.agentType,
+                  command,
+                  status_code: 400,
+                  likely_cause:
+                    'The provided `parameters` do not match the expected shape for this command (see skill content for required fields).',
+                },
+              },
+            ],
+          };
+        }
+        const params = strictParseResult.data;
+
+        const featureFlags = getDetectionEmulationFeatureFlags(config.experimentalFeatures);
 
         // Gate 1: Feature flag check (wholesale enable/disable)
         if (!isRealExecutionEnabled(featureFlags)) {
@@ -146,14 +186,24 @@ has explicitly authorized the emulation and all required permissions are in plac
           };
         }
 
-        // Gate 2: Per-command RBAC check
+        // Gate 2: Per-command RBAC check.
+        // The RBAC map does not cover every console command (e.g. `cancel` has
+        // no dedicated privilege today); we treat a missing entry as "no extra
+        // privilege required" rather than as a hard error. The endpoint authz
+        // record uses well-known string keys so we narrow with a typed cast at
+        // the boundary.
         const consoleCommand = RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP[command];
-        const requiredRbacFeature =
-          RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL[consoleCommand];
+        const rbacMap = RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL as Record<
+          string,
+          string | undefined
+        >;
+        const requiredRbacFeature = rbacMap[consoleCommand];
 
         if (requiredRbacFeature) {
           const endpointAuthz = await endpointService.getEndpointAuthz(request);
-          const hasPrivilege = endpointAuthz[requiredRbacFeature];
+          const hasPrivilege = (endpointAuthz as unknown as Record<string, boolean | undefined>)[
+            requiredRbacFeature
+          ];
 
           if (!hasPrivilege) {
             logger.warn(
@@ -207,11 +257,12 @@ has explicitly authorized the emulation and all required permissions are in plac
           };
         }
 
-        // Gate 4: Rate limit check
-        const rateLimitResult = rateLimiter.check(spaceId);
-        if (!rateLimitResult.allowed) {
+        // Gate 4: atomic rate-limit acquire (combines old check+record so concurrent
+        // calls cannot all sneak past the gate before any of them records).
+        const acquireResult = rateLimiter.acquire(spaceId, emulationId, command);
+        if (!acquireResult.allowed) {
           logger.warn(
-            `Emulation command [${command}] for emulation [${emulationId}] blocked by rate limiter: ${rateLimitResult.error}`
+            `Emulation command [${command}] for emulation [${emulationId}] blocked by rate limiter: ${acquireResult.error}`
           );
           return {
             results: [
@@ -219,10 +270,10 @@ has explicitly authorized the emulation and all required permissions are in plac
                 type: ToolResultType.error,
                 data: {
                   error_type: 'rate_limit_error',
-                  message: rateLimitResult.error ?? 'Rate limit exceeded',
-                  current_count: rateLimitResult.currentCount,
-                  max_commands: rateLimitResult.maxCommands,
-                  reset_ms: rateLimitResult.resetMs,
+                  message: acquireResult.error ?? 'Rate limit exceeded',
+                  current_count: acquireResult.currentCount,
+                  max_commands: acquireResult.maxCommands,
+                  reset_ms: acquireResult.resetMs,
                   emulation_id: emulationId,
                   agent_type: params.agentType,
                   command,
@@ -234,48 +285,102 @@ has explicitly authorized the emulation and all required permissions are in plac
           };
         }
 
-        // Get start services for cases client and username
+        // Get start services for cases client and username. N5: refuse to dispatch a
+        // destructive action without an authenticated caller — release the rate-limit
+        // slot we just acquired and return 401 in this branch as well.
+        //
+        // Cases is acquired through `endpointService.getCasesClient` rather than
+        // direct plugin access — security_solution's core start dependencies
+        // do not register the cases plugin. We swallow lookup failures because
+        // the cases client is optional for emulation dispatch.
         const [coreStart] = await core.getStartServices();
-        const casesClient = coreStart.plugins.cases
-          ? await coreStart.plugins.cases.getClient(request)
-          : undefined;
-        const username =
-          (await coreStart.security?.authc.getCurrentUser(request))?.username ?? 'unknown';
-
-        // All gates passed - execute the command via EmulationRunner
-        const runner = new EmulationRunner({
-          endpointService,
-          esClient: esClient.asCurrentUser,
-          spaceId,
-          casesClient,
-          username,
-          logger,
-        });
-
-        const result = await runner.run(params);
-
-        if (result.status === 'error') {
+        let casesClient;
+        try {
+          casesClient = await endpointService.getCasesClient(request);
+        } catch (casesErr) {
+          logger.debug(
+            `Cases client unavailable for emulation dispatch: ${
+              (casesErr as Error).message ?? casesErr
+            }`
+          );
+          casesClient = undefined;
+        }
+        const currentUser = await coreStart.security?.authc.getCurrentUser(request);
+        if (!currentUser?.username) {
+          rateLimiter.release(acquireResult.token);
+          logger.warn(
+            `Emulation command [${command}] for emulation [${emulationId}] blocked: no authenticated user`
+          );
           return {
             results: [
               {
                 type: ToolResultType.error,
                 data: {
-                  error_type: 'execution_error',
-                  message: result.error ?? 'Unknown error executing emulation command',
-                  action_id: result.actionId,
+                  error_type: 'authorization_error',
+                  message: 'Authentication is required to run an emulation command.',
                   emulation_id: emulationId,
                   agent_type: params.agentType,
                   command,
-                  status_code: 500,
-                  likely_cause: 'Internal error during command execution',
+                  status_code: 401,
+                  likely_cause: 'No current user attached to the request.',
                 },
               },
             ],
           };
         }
 
-        // Record successful execution in rate limiter
-        rateLimiter.record(spaceId, emulationId, command);
+        // All gates passed — execute the command via EmulationRunner.
+        //
+        // Rule-binding lookup (I7): the SO type is `hidden: true`, so we need
+        // the *internal* SO client — the request-scoped client cannot read
+        // hidden types. We pass the lookup factory rather than a fixed
+        // (ruleId, ruleName) pair so the runner only pays the lookup cost
+        // once per dispatch and tests can stub it.
+        const internalSoClient = coreStart.savedObjects.createInternalRepository([
+          emulationRuleBindingTypeName,
+        ]);
+        const ruleBindingLookup = createSavedObjectRuleBindingLookup(
+          // createInternalRepository returns an `ISavedObjectsRepository` which
+          // implements the `SavedObjectsClientContract` shape we need (find /
+          // search). Cast through `unknown` to avoid pulling the repository
+          // typing into our public surface.
+          internalSoClient as unknown as Parameters<typeof createSavedObjectRuleBindingLookup>[0],
+          logger
+        );
+
+        const runner = new EmulationRunner({
+          endpointService,
+          esClient: esClient.asCurrentUser,
+          spaceId,
+          casesClient,
+          username: currentUser.username,
+          logger,
+          ruleBindingLookup,
+        });
+
+        const result = await runner.run(params);
+
+        if (result.status === 'error') {
+          // Roll the rate-limit acquire back so retries are not penalised.
+          rateLimiter.release(acquireResult.token);
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'execution_error',
+                  message: 'Failed to dispatch the emulation command.',
+                  action_id: result.actionId,
+                  emulation_id: emulationId,
+                  agent_type: params.agentType,
+                  command,
+                  status_code: 502,
+                  likely_cause: 'Internal error during command execution',
+                },
+              },
+            ],
+          };
+        }
 
         return {
           results: [
@@ -295,9 +400,86 @@ has explicitly authorized the emulation and all required permissions are in plac
         };
       } catch (err) {
         const error = err as Error;
-        const errorMessage = error.message ?? 'Unknown error';
+        // We catch errors from anywhere in the handler, including before the
+        // strict-parse branch sets `params`. Use `rawParams` for the user-
+        // facing fields below so we always have a value to render.
+        const agentType = rawParams.agentType;
+        // Map typed runner errors → caller-facing classifications. We never echo
+        // raw error messages back to the LLM in the unknown case; that's
+        // logged server-side only (matches I3 in the REST route).
+        if (error instanceof UnsupportedAgentTypeError) {
+          logger.warn(
+            `Emulation command [${command}] for emulation [${emulationId}] rejected: ${error.message}`
+          );
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'unsupported_agent_type',
+                  message: error.message,
+                  emulation_id: emulationId,
+                  agent_type: agentType,
+                  command,
+                  status_code: 400,
+                  likely_cause: 'Selected agent type is not supported by this build.',
+                },
+              },
+            ],
+          };
+        }
 
-        logger.error(`Failed to execute emulation command: ${errorMessage}`, error);
+        if (error instanceof UnsupportedCommandForAgentTypeError) {
+          logger.warn(
+            `Emulation command [${command}] for emulation [${emulationId}] rejected: ${error.message}`
+          );
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'unsupported_command_for_agent_type',
+                  message: error.message,
+                  emulation_id: emulationId,
+                  agent_type: agentType,
+                  command,
+                  status_code: 400,
+                  likely_cause: 'This command is not supported for the selected agent type.',
+                },
+              },
+            ],
+          };
+        }
+
+        if (error instanceof MissingConnectorActionsError) {
+          logger.error(
+            `Emulation command [${command}] for emulation [${emulationId}] failed: ${error.message}`
+          );
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'missing_connector_actions',
+                  message:
+                    'Missing connector configuration required to dispatch this command. Please contact an administrator.',
+                  emulation_id: emulationId,
+                  agent_type: agentType,
+                  command,
+                  status_code: 500,
+                  likely_cause: 'Server-side wiring is incomplete for this agent type.',
+                },
+              },
+            ],
+          };
+        }
+
+        // logger.error's second arg must be a `LogMeta`-shaped record; pass
+        // the structured tag bag rather than the raw Error.
+        logger.error(
+          `Failed to execute emulation command [${command}] for emulation [${emulationId}]: ${error.message}`,
+          { tags: ['detection-emulation'], stack: error.stack } as Record<string, unknown>
+        );
 
         return {
           results: [
@@ -305,9 +487,10 @@ has explicitly authorized the emulation and all required permissions are in plac
               type: ToolResultType.error,
               data: {
                 error_type: 'execution_error',
-                message: `Failed to execute emulation command: ${errorMessage}`,
+                // Generic, sanitized message — internal details are server-side only.
+                message: 'Failed to execute the emulation command.',
                 emulation_id: emulationId,
-                agent_type: params.agentType,
+                agent_type: agentType,
                 command,
                 status_code: 500,
                 likely_cause: 'Internal error during command execution',

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/run_emulation_command_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_emulation/run_emulation_command_tool.ts
@@ -1,0 +1,321 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { Logger } from '@kbn/core/server';
+import {
+  ToolType,
+  ToolResultType,
+} from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import {
+  RESPONSE_ACTION_AGENT_TYPE,
+  RESPONSE_ACTION_API_COMMANDS_NAMES,
+  RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP,
+  RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL,
+} from '../../../../common/endpoint/service/response_actions/constants';
+import type { ConfigType } from '../../../config';
+import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
+import { EmulationRunner } from '../../../lib/detection_emulation/execution/runner';
+import {
+  EmulationAllowlist,
+  createDefaultAllowlistConfig,
+} from '../../../lib/detection_emulation/execution/allowlist';
+import {
+  EmulationRateLimiter,
+  createDefaultRateLimiterConfig,
+} from '../../../lib/detection_emulation/execution/rate_limiter';
+import {
+  getDetectionEmulationFeatureFlags,
+  isRealExecutionEnabled,
+} from '../../../lib/detection_emulation/feature_flag';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+/**
+ * Tool schema for running emulation commands with multi-EDR support.
+ * Accepts any of the four supported EDR agent types and validates command.
+ */
+const runEmulationCommandSchema = z.object({
+  emulationId: z.string().describe('Unique identifier for the emulation'),
+  agentType: z
+    .enum(RESPONSE_ACTION_AGENT_TYPE)
+    .describe(
+      'The EDR agent type - must be one of: endpoint, sentinel_one, crowdstrike, microsoft_defender_endpoint'
+    ),
+  endpointIds: z
+    .array(z.string())
+    .min(1)
+    .describe('Array of endpoint agent IDs to target with the emulation command'),
+  command: z
+    .enum(RESPONSE_ACTION_API_COMMANDS_NAMES)
+    .describe(
+      'The response action command to execute - e.g., execute, runscript, kill-process, suspend-process, scan, get-file, memory-dump'
+    ),
+  parameters: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Optional parameters specific to the command being executed'),
+});
+
+export interface RunEmulationCommandToolDeps {
+  core: SecuritySolutionPluginCoreSetupDependencies;
+  endpointService: EndpointAppContextService;
+  config: ConfigType;
+  logger: Logger;
+}
+
+/**
+ * Creates the runEmulationCommand tool for executing emulation commands
+ * against any supported EDR agent type (Elastic Defend, Sentinel One, CrowdStrike, Microsoft Defender).
+ *
+ * This tool delegates directly to the EmulationRunner dispatcher, bypassing the HTTP layer
+ * and executing the same guardrails (feature flag, RBAC, allowlist, rate limiter) as the route handler.
+ */
+export const createRunEmulationCommandTool = (
+  deps: RunEmulationCommandToolDeps
+): BuiltinToolDefinition<typeof runEmulationCommandSchema> => {
+  const { core, endpointService, config, logger } = deps;
+
+  // Initialize allowlist and rate limiter with default configurations
+  const allowlist = new EmulationAllowlist(createDefaultAllowlistConfig(), logger);
+  const rateLimiter = new EmulationRateLimiter(createDefaultRateLimiterConfig(), logger);
+
+  return {
+    id: 'security.detection-emulation.run-command',
+    type: ToolType.builtin,
+    description: `Run a detection emulation command on endpoints through any supported EDR agent type.
+
+This tool executes response actions for emulation scenarios, supporting:
+- Elastic Defend (endpoint)
+- Sentinel One (sentinel_one)
+- CrowdStrike (crowdstrike)
+- Microsoft Defender for Endpoint (microsoft_defender_endpoint)
+
+The tool validates user privileges, checks host allowlists, enforces rate limits, and dispatches
+commands through the appropriate EDR connector via ResponseActionsClient.
+
+**Security Guardrails:**
+- Feature flag check: Real execution must be enabled
+- Per-command RBAC: User must have required privilege for the command
+- Host allowlist: Target endpoints must be on the allowlist
+- Rate limiting: Commands are throttled per space
+
+**Example commands:**
+- execute: Run a shell command or executable
+- runscript: Execute a script file
+- kill-process: Terminate a process by PID or name
+- suspend-process: Suspend a process by PID or name
+- scan: Trigger a malware scan
+- get-file: Retrieve a file from the endpoint
+- memory-dump: Capture process or kernel memory
+
+Use this tool when validating detection rules through Real Execution mode, after the user
+has explicitly authorized the emulation and all required permissions are in place.`,
+    tags: ['security', 'emulation', 'response-actions'],
+    schema: runEmulationCommandSchema,
+    handler: async (params, { esClient, spaceId, request }) => {
+      const { emulationId, command, endpointIds } = params;
+
+      try {
+        const featureFlags = getDetectionEmulationFeatureFlags(config);
+
+        // Gate 1: Feature flag check (wholesale enable/disable)
+        if (!isRealExecutionEnabled(featureFlags)) {
+          logger.warn(
+            `Emulation command [${command}] for emulation [${emulationId}] blocked: real execution is disabled`
+          );
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'feature_disabled',
+                  message: 'Detection emulation real execution is disabled',
+                  emulation_id: emulationId,
+                  agent_type: params.agentType,
+                  command,
+                  status_code: 403,
+                  likely_cause: 'Feature flag is disabled for real execution',
+                },
+              },
+            ],
+          };
+        }
+
+        // Gate 2: Per-command RBAC check
+        const consoleCommand = RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP[command];
+        const requiredRbacFeature =
+          RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL[consoleCommand];
+
+        if (requiredRbacFeature) {
+          const endpointAuthz = await endpointService.getEndpointAuthz(request);
+          const hasPrivilege = endpointAuthz[requiredRbacFeature];
+
+          if (!hasPrivilege) {
+            logger.warn(
+              `Emulation command [${command}] for emulation [${emulationId}] blocked: user lacks required RBAC privilege [${requiredRbacFeature}]`
+            );
+            return {
+              results: [
+                {
+                  type: ToolResultType.error,
+                  data: {
+                    error_type: 'authorization_error',
+                    message: `Insufficient privileges: command [${command}] requires [${requiredRbacFeature}]`,
+                    emulation_id: emulationId,
+                    agent_type: params.agentType,
+                    command,
+                    status_code: 403,
+                    likely_cause: `User lacks required RBAC privilege [${requiredRbacFeature}]`,
+                  },
+                },
+              ],
+            };
+          }
+
+          logger.debug(
+            `RBAC check passed for command [${command}]: user has privilege [${requiredRbacFeature}]`
+          );
+        }
+
+        // Gate 3: Host allowlist validation
+        const allowlistResult = allowlist.validate(endpointIds);
+        if (!allowlistResult.allowed) {
+          logger.warn(
+            `Emulation command [${command}] for emulation [${emulationId}] blocked by allowlist: ${allowlistResult.error}`
+          );
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'authorization_error',
+                  message: allowlistResult.error ?? 'Endpoints not in allowlist',
+                  blocked_endpoints: allowlistResult.blockedEndpoints,
+                  emulation_id: emulationId,
+                  agent_type: params.agentType,
+                  command,
+                  status_code: 403,
+                  likely_cause: 'One or more endpoints not in allowlist',
+                },
+              },
+            ],
+          };
+        }
+
+        // Gate 4: Rate limit check
+        const rateLimitResult = rateLimiter.check(spaceId);
+        if (!rateLimitResult.allowed) {
+          logger.warn(
+            `Emulation command [${command}] for emulation [${emulationId}] blocked by rate limiter: ${rateLimitResult.error}`
+          );
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'rate_limit_error',
+                  message: rateLimitResult.error ?? 'Rate limit exceeded',
+                  current_count: rateLimitResult.currentCount,
+                  max_commands: rateLimitResult.maxCommands,
+                  reset_ms: rateLimitResult.resetMs,
+                  emulation_id: emulationId,
+                  agent_type: params.agentType,
+                  command,
+                  status_code: 429,
+                  likely_cause: 'Rate limit exceeded for this space',
+                },
+              },
+            ],
+          };
+        }
+
+        // Get start services for cases client and username
+        const [coreStart] = await core.getStartServices();
+        const casesClient = coreStart.plugins.cases
+          ? await coreStart.plugins.cases.getClient(request)
+          : undefined;
+        const username =
+          (await coreStart.security?.authc.getCurrentUser(request))?.username ?? 'unknown';
+
+        // All gates passed - execute the command via EmulationRunner
+        const runner = new EmulationRunner({
+          endpointService,
+          esClient: esClient.asCurrentUser,
+          spaceId,
+          casesClient,
+          username,
+          logger,
+        });
+
+        const result = await runner.run(params);
+
+        if (result.status === 'error') {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error_type: 'execution_error',
+                  message: result.error ?? 'Unknown error executing emulation command',
+                  action_id: result.actionId,
+                  emulation_id: emulationId,
+                  agent_type: params.agentType,
+                  command,
+                  status_code: 500,
+                  likely_cause: 'Internal error during command execution',
+                },
+              },
+            ],
+          };
+        }
+
+        // Record successful execution in rate limiter
+        rateLimiter.record(spaceId, emulationId, command);
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                success: true,
+                action_id: result.actionId,
+                agent_type: result.agentType,
+                command: result.command,
+                status: result.status,
+                emulation_id: emulationId,
+                endpoint_count: endpointIds.length,
+              },
+            },
+          ],
+        };
+      } catch (err) {
+        const error = err as Error;
+        const errorMessage = error.message ?? 'Unknown error';
+
+        logger.error(`Failed to execute emulation command: ${errorMessage}`, error);
+
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                error_type: 'execution_error',
+                message: `Failed to execute emulation command: ${errorMessage}`,
+                emulation_id: emulationId,
+                agent_type: params.agentType,
+                command,
+                status_code: 500,
+                likely_cause: 'Internal error during command execution',
+              },
+            },
+          ],
+        };
+      }
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
@@ -10,4 +10,6 @@ export { threatHuntingSkill } from './threat_hunting';
 export { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 export { pciComplianceSkill } from './pci_compliance';
 export { getDetectionRuleEditSkill } from './detection_rule_edit';
+export { getDetectionEmulationSkill } from './detection_emulation';
+export type { DetectionEmulationSkillContext } from './detection_emulation';
 export { registerSkills } from './register_skills';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -9,6 +9,8 @@ import type { Logger } from '@kbn/core/server';
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-server';
 import type { ExperimentalFeatures } from '../../../common/experimental_features';
 import type { EndpointAppContextService } from '../../endpoint/endpoint_app_context_services';
+import type { ConfigType } from '../../config';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 import { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 import { getDetectionRuleEditSkill } from './detection_rule_edit';
 import { getEntityAnalyticsSkill } from './entity_analytics';
@@ -17,6 +19,7 @@ import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
 import type { EntityAnalyticsRoutesDeps } from '../../lib/entity_analytics/types';
 import { findSecurityMlJobsSkill } from './find_security_ml_jobs';
+import { getDetectionEmulationSkill } from './detection_emulation';
 
 interface RegisterSkillsOpts {
   agentBuilder: AgentBuilderPluginSetup;
@@ -28,6 +31,8 @@ interface RegisterSkillsOpts {
   options: {
     endpointAppContextService: EndpointAppContextService;
   };
+  core: SecuritySolutionPluginCoreSetupDependencies;
+  config: ConfigType;
 }
 
 /**
@@ -41,6 +46,8 @@ export const registerSkills = async ({
   logger,
   ml,
   options,
+  core,
+  config,
 }: RegisterSkillsOpts): Promise<void> => {
   if (experimentalFeatures.automaticTroubleshootingSkill) {
     agentBuilder.skills.register(
@@ -64,4 +71,13 @@ export const registerSkills = async ({
   if (experimentalFeatures.pciComplianceAgentBuilder) {
     agentBuilder.skills.register(pciComplianceSkill);
   }
+
+  agentBuilder.skills.register(
+    getDetectionEmulationSkill({
+      core,
+      endpointService: options.endpointAppContextService,
+      config,
+      logger,
+    })
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -72,12 +72,17 @@ export const registerSkills = async ({
     agentBuilder.skills.register(pciComplianceSkill);
   }
 
-  agentBuilder.skills.register(
-    getDetectionEmulationSkill({
-      core,
-      endpointService: options.endpointAppContextService,
-      config,
-      logger,
-    })
-  );
+  // The detection-emulation skill is destructive (it dispatches Response Actions
+  // against real endpoints). Keep it gated behind the experimental flag so it
+  // never reaches the agent-builder catalog in builds that haven't opted in.
+  if (experimentalFeatures.detectionEmulationRealExecution) {
+    agentBuilder.skills.register(
+      getDetectionEmulationSkill({
+        core,
+        endpointService: options.endpointAppContextService,
+        config,
+        logger,
+      })
+    );
+  }
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/skills.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/skills.test.ts
@@ -7,10 +7,33 @@
 
 import { platformCoreTools } from '@kbn/agent-builder-common';
 import { validateSkillDefinition } from '@kbn/agent-builder-server/skills/type_definition';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
+import { getDetectionEmulationSkill } from './detection_emulation';
+import type { DetectionEmulationSkillContext } from './detection_emulation';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
+import type { EndpointAppContextService } from '../../endpoint/endpoint_app_context_services';
+import type { ConfigType } from '../../config';
 
-const ALL_SKILLS = [threatHuntingSkill, alertAnalysisSkill];
+const createDetectionEmulationCtx = (): DetectionEmulationSkillContext => ({
+  core: {
+    getStartServices: jest
+      .fn()
+      .mockResolvedValue([{ plugins: { cases: undefined }, security: undefined }, {}]),
+  } as unknown as SecuritySolutionPluginCoreSetupDependencies,
+  endpointService: {} as unknown as EndpointAppContextService,
+  config: {
+    experimentalFeatures: { detectionEmulationRealExecution: false },
+  } as unknown as ConfigType,
+  logger: loggingSystemMock.createLogger(),
+});
+
+const ALL_SKILLS = [
+  threatHuntingSkill,
+  alertAnalysisSkill,
+  getDetectionEmulationSkill(createDetectionEmulationCtx()),
+];
 
 describe('Security Skills', () => {
   describe('threat-hunting skill', () => {
@@ -95,6 +118,38 @@ describe('Security Skills', () => {
 
     it('content references entity-analytics skill for deeper profiling', () => {
       expect(alertAnalysisSkill.content).toContain('entity-analytics');
+    });
+  });
+
+  describe('detection-emulation skill', () => {
+    it('validates successfully via validateSkillDefinition', async () => {
+      const skill = getDetectionEmulationSkill(createDetectionEmulationCtx());
+      await expect(validateSkillDefinition(skill)).resolves.toBeDefined();
+    });
+
+    it('has non-empty content', () => {
+      const skill = getDetectionEmulationSkill(createDetectionEmulationCtx());
+      expect(skill.content.length).toBeGreaterThan(100);
+    });
+
+    it('has description under 1024 characters', () => {
+      const skill = getDetectionEmulationSkill(createDetectionEmulationCtx());
+      expect(skill.description.length).toBeLessThanOrEqual(1024);
+    });
+
+    it('has one inline tool (run-command)', () => {
+      const skill = getDetectionEmulationSkill(createDetectionEmulationCtx());
+      const tools = skill.getInlineTools!();
+      expect(tools).toHaveLength(1);
+      expect((tools[0] as { id: string }).id).toBe('security.detection-emulation.run-command');
+    });
+
+    it('content mentions all four supported EDR agent types', () => {
+      const skill = getDetectionEmulationSkill(createDetectionEmulationCtx());
+      expect(skill.content).toContain('endpoint');
+      expect(skill.content).toContain('sentinel_one');
+      expect(skill.content).toContain('crowdstrike');
+      expect(skill.content).toContain('microsoft_defender_endpoint');
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/skills.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/skills.test.ts
@@ -137,19 +137,30 @@ describe('Security Skills', () => {
       expect(skill.description.length).toBeLessThanOrEqual(1024);
     });
 
-    it('has one inline tool (run-command)', () => {
+    it('has one inline tool (run-command)', async () => {
       const skill = getDetectionEmulationSkill(createDetectionEmulationCtx());
-      const tools = skill.getInlineTools!();
+      // getInlineTools may return a Promise<Tool[]> or a Tool[]; await covers both.
+      const tools = await skill.getInlineTools!();
       expect(tools).toHaveLength(1);
       expect((tools[0] as { id: string }).id).toBe('security.detection-emulation.run-command');
     });
 
-    it('content mentions all four supported EDR agent types', () => {
+    it('content describes the only currently-wired agent type (endpoint) and explicitly notes the other three as not-yet-supported', () => {
       const skill = getDetectionEmulationSkill(createDetectionEmulationCtx());
       expect(skill.content).toContain('endpoint');
+      // The doc is honest about scope: it must list the unsupported types in
+      // the "Things this skill does NOT do (yet)" section so the LLM does not
+      // try to dispatch against them.
       expect(skill.content).toContain('sentinel_one');
       expect(skill.content).toContain('crowdstrike');
       expect(skill.content).toContain('microsoft_defender_endpoint');
+      // And the description must say the same so it surfaces in skill catalogs.
+      expect(skill.description).toContain('endpoint');
+    });
+
+    it('description references the experimental feature flag', () => {
+      const skill = getDetectionEmulationSkill(createDetectionEmulationCtx());
+      expect(skill.description).toContain('detectionEmulationRealExecution');
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/config.ts
@@ -232,6 +232,45 @@ export const configSchema = schema.object({
       }),
     })
   ),
+
+  /**
+   * Detection-emulation runtime knobs (allowlist, rate limiter, idempotency cache).
+   *
+   * These are intentionally `maybe` — the feature ships dark, and operators only
+   * need to set them when they want to override the safe defaults baked into
+   * `createDefaultAllowlistConfig`, `createDefaultRateLimiterConfig`, and
+   * `createDefaultIdempotencyCacheConfig`.
+   */
+  detectionEmulation: schema.maybe(
+    schema.object({
+      allowlist: schema.maybe(
+        schema.object({
+          /**
+           * When true, every endpoint is allowed regardless of `endpointIds`.
+           * Useful for short-lived test deployments only — production should
+           * leave this `false` and populate `endpointIds`.
+           */
+          allowAll: schema.boolean({ defaultValue: false }),
+          /** Explicit list of endpoint IDs that may receive emulation actions. */
+          endpointIds: schema.arrayOf(schema.string(), { defaultValue: [] }),
+        })
+      ),
+      rateLimiter: schema.maybe(
+        schema.object({
+          maxCommands: schema.number({ defaultValue: 100, min: 1 }),
+          windowMs: schema.number({ defaultValue: 60 * 60 * 1000, min: 1_000 }),
+          disabled: schema.boolean({ defaultValue: false }),
+        })
+      ),
+      idempotencyCache: schema.maybe(
+        schema.object({
+          ttlMs: schema.number({ defaultValue: 30_000, min: 0 }),
+          maxEntriesPerSpace: schema.number({ defaultValue: 256, min: 1 }),
+          disabled: schema.boolean({ defaultValue: false }),
+        })
+      ),
+    })
+  ),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/alert_tagging.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/alert_tagging.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+
+/**
+ * Field names for emulation metadata on alerts.
+ * These fields are written to alerts during emulation runs to enable
+ * filtering and tracking of emulation-generated alerts.
+ */
+export const ALERT_EMULATION_ID = 'kibana.alert.emulation.id';
+export const ALERT_EMULATION_MODE = 'kibana.alert.emulation.mode';
+
+/**
+ * Emulation mode indicates how the alert was generated.
+ * - 'test': Alert generated during a test emulation run
+ * - 'validation': Alert generated during validation/verification
+ * - 'production': Alert generated during production emulation (if enabled)
+ */
+export type EmulationMode = 'test' | 'validation' | 'production';
+
+export interface EmulationAlertMetadata {
+  /**
+   * Unique identifier for the emulation run that generated this alert
+   */
+  emulationId: string;
+
+  /**
+   * Mode of the emulation run
+   */
+  mode: EmulationMode;
+}
+
+export interface TagAlertsWithEmulationOptions {
+  /**
+   * Elasticsearch client for updating alert documents
+   */
+  esClient: ElasticsearchClient;
+
+  /**
+   * Alert IDs to tag with emulation metadata
+   */
+  alertIds: string[];
+
+  /**
+   * Emulation metadata to write to the alerts
+   */
+  metadata: EmulationAlertMetadata;
+
+  /**
+   * Index pattern for alerts (defaults to .alerts-security.alerts-*)
+   */
+  alertsIndex?: string;
+
+  /**
+   * Logger instance
+   */
+  logger: Logger;
+}
+
+/**
+ * Tags alerts with emulation metadata by updating the alert documents
+ * with kibana.alert.emulation.{id,mode} fields.
+ *
+ * This function enables filtering and tracking of alerts generated during
+ * emulation runs by writing structured emulation context directly to the
+ * alert documents. The metadata includes:
+ * - emulationId: Unique identifier for the emulation run
+ * - mode: The emulation mode (test, validation, production)
+ *
+ * Example usage:
+ * ```typescript
+ * await tagAlertsWithEmulation({
+ *   esClient,
+ *   alertIds: ['alert-123', 'alert-456'],
+ *   metadata: {
+ *     emulationId: 'emulation-abc-123',
+ *     mode: 'test'
+ *   },
+ *   logger
+ * });
+ * ```
+ *
+ * @param options - Configuration for tagging alerts
+ * @returns Promise resolving to the number of alerts successfully tagged
+ * @throws Error if the update operation fails
+ */
+export async function tagAlertsWithEmulation(
+  options: TagAlertsWithEmulationOptions
+): Promise<number> {
+  const {
+    esClient,
+    alertIds,
+    metadata,
+    alertsIndex = '.alerts-security.alerts-*',
+    logger,
+  } = options;
+
+  if (alertIds.length === 0) {
+    logger.debug('No alerts to tag with emulation metadata');
+    return 0;
+  }
+
+  logger.debug(
+    `Tagging ${alertIds.length} alerts with emulation metadata: emulationId=${metadata.emulationId}, mode=${metadata.mode}`
+  );
+
+  try {
+    const response = await esClient.updateByQuery({
+      index: alertsIndex,
+      refresh: true,
+      body: {
+        query: {
+          ids: {
+            values: alertIds,
+          },
+        },
+        script: {
+          source: `
+            ctx._source['${ALERT_EMULATION_ID}'] = params.emulationId;
+            ctx._source['${ALERT_EMULATION_MODE}'] = params.mode;
+          `,
+          lang: 'painless',
+          params: {
+            emulationId: metadata.emulationId,
+            mode: metadata.mode,
+          },
+        },
+      },
+    });
+
+    const updatedCount = response.updated ?? 0;
+
+    if (updatedCount !== alertIds.length) {
+      logger.warn(
+        `Expected to update ${alertIds.length} alerts but updated ${updatedCount}. ` +
+          `Failures: ${response.failures?.length ?? 0}`
+      );
+    } else {
+      logger.info(
+        `Successfully tagged ${updatedCount} alerts with emulation metadata: emulationId=${metadata.emulationId}`
+      );
+    }
+
+    if (response.failures && response.failures.length > 0) {
+      logger.error(
+        `Encountered ${response.failures.length} failures while tagging alerts:`,
+        response.failures
+      );
+    }
+
+    return updatedCount;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`Failed to tag alerts with emulation metadata: ${errorMessage}`, error);
+    throw new Error(`Failed to tag alerts with emulation metadata: ${errorMessage}`);
+  }
+}
+
+/**
+ * Builds an Elasticsearch query to filter alerts by emulation ID.
+ * Use this helper when querying alerts to filter by emulation context.
+ *
+ * Example usage:
+ * ```typescript
+ * const query = buildEmulationAlertQuery('emulation-abc-123');
+ * const response = await esClient.search({
+ *   index: '.alerts-security.alerts-*',
+ *   body: { query }
+ * });
+ * ```
+ *
+ * @param emulationId - The emulation ID to filter by
+ * @returns Elasticsearch query object
+ */
+export function buildEmulationAlertQuery(emulationId: string) {
+  return {
+    term: {
+      [ALERT_EMULATION_ID]: emulationId,
+    },
+  };
+}
+
+/**
+ * Builds an Elasticsearch query to filter alerts by emulation mode.
+ *
+ * @param mode - The emulation mode to filter by
+ * @returns Elasticsearch query object
+ */
+export function buildEmulationModeQuery(mode: EmulationMode) {
+  return {
+    term: {
+      [ALERT_EMULATION_MODE]: mode,
+    },
+  };
+}
+
+/**
+ * Extracts emulation metadata from an alert document.
+ * Returns undefined if the alert does not have emulation metadata.
+ *
+ * @param alert - The alert document (any structure with string keys)
+ * @returns Emulation metadata if present, undefined otherwise
+ */
+export function extractEmulationMetadata(
+  alert: Record<string, unknown>
+): EmulationAlertMetadata | undefined {
+  const emulationId = alert[ALERT_EMULATION_ID];
+  const mode = alert[ALERT_EMULATION_MODE];
+
+  if (typeof emulationId === 'string' && typeof mode === 'string') {
+    return {
+      emulationId,
+      mode: mode as EmulationMode,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Checks if an alert document has emulation metadata.
+ *
+ * @param alert - The alert document to check
+ * @returns True if the alert has emulation metadata
+ */
+export function isEmulationAlert(alert: Record<string, unknown>): boolean {
+  return extractEmulationMetadata(alert) !== undefined;
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/alert_tagging.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/alert_tagging.ts
@@ -110,25 +110,28 @@ export async function tagAlertsWithEmulation(
   );
 
   try {
+    // Elasticsearch v8 client expects `query` / `script` at the top level of
+    // the params object — the legacy `body: { ... }` wrapper triggers the
+    // overload mismatch we saw under typecheck. Also note: `params` is the
+    // Painless script-params object (untyped JSON), so the values are
+    // serialised as-is by ES.
     const response = await esClient.updateByQuery({
       index: alertsIndex,
       refresh: true,
-      body: {
-        query: {
-          ids: {
-            values: alertIds,
-          },
+      query: {
+        ids: {
+          values: alertIds,
         },
-        script: {
-          source: `
-            ctx._source['${ALERT_EMULATION_ID}'] = params.emulationId;
-            ctx._source['${ALERT_EMULATION_MODE}'] = params.mode;
-          `,
-          lang: 'painless',
-          params: {
-            emulationId: metadata.emulationId,
-            mode: metadata.mode,
-          },
+      },
+      script: {
+        source: `
+          ctx._source['${ALERT_EMULATION_ID}'] = params.emulationId;
+          ctx._source['${ALERT_EMULATION_MODE}'] = params.mode;
+        `,
+        lang: 'painless',
+        params: {
+          emulationId: metadata.emulationId,
+          mode: metadata.mode,
         },
       },
     });
@@ -147,10 +150,11 @@ export async function tagAlertsWithEmulation(
     }
 
     if (response.failures && response.failures.length > 0) {
-      logger.error(
-        `Encountered ${response.failures.length} failures while tagging alerts:`,
-        response.failures
-      );
+      // Logger meta must be a `LogMeta` shape, not the bare failures array.
+      logger.error(`Encountered ${response.failures.length} failures while tagging alerts.`, {
+        tags: ['detection-emulation'],
+        failures: response.failures,
+      } as unknown as Record<string, unknown>);
     }
 
     return updatedCount;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/register_routes.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { ConfigType } from '../../../config';
+import type { SecuritySolutionPluginRouter } from '../../../types';
+import { runEmulationCommandRoute } from './run_command/route';
+
+export const registerDetectionEmulationRoutes = (
+  router: SecuritySolutionPluginRouter,
+  config: ConfigType,
+  logger: Logger
+) => {
+  runEmulationCommandRoute(router, config, logger);
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/run_command/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/run_command/route.test.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import type { ConfigType } from '../../../../config';
+import { runEmulationCommandRoute } from './route';
+import { serverMock } from '../../../detection_engine/routes/__mocks__/server';
+import { requestContextMock } from '../../../detection_engine/routes/__mocks__/request_context';
+import { requestMock } from '../../../detection_engine/routes/__mocks__/request';
+import { DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL } from '../../../../../common/constants';
+import { getEndpointAuthzInitialStateMock } from '../../../../../common/endpoint/service/authz/mocks';
+import type { EndpointAuthz } from '../../../../../common/endpoint/types/authz';
+import { EmulationAllowlist, createRestrictiveAllowlistConfig } from '../../execution/allowlist';
+import { EmulationRateLimiter } from '../../execution/rate_limiter';
+
+const FEATURE_ENABLED_CONFIG = {
+  detectionEmulation: { realExecution: true, logInjection: false },
+} as unknown as ConfigType;
+
+// ─── RBAC gate negative tests ─────────────────────────────────────────────────
+
+describe('runEmulationCommandRoute — RBAC gate', () => {
+  let server: ReturnType<typeof serverMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    server = serverMock.create();
+    runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger);
+  });
+
+  it.each<[string, string, Partial<EndpointAuthz>]>([
+    ['execute', 'canWriteExecuteOperations', { canWriteExecuteOperations: false }],
+    ['isolate', 'canIsolateHost', { canIsolateHost: false }],
+    ['runscript', 'canWriteExecuteOperations', { canWriteExecuteOperations: false }],
+    ['scan', 'canWriteScanOperations', { canWriteScanOperations: false }],
+    ['get-file', 'canWriteFileOperations', { canWriteFileOperations: false }],
+  ])(
+    'returns 403 when command [%s] is blocked because caller lacks [%s]',
+    async (command, expectedAuthzKey, authzOverride) => {
+      const { context } = requestContextMock.createTools();
+      context.securitySolution.getEndpointAuthz.mockResolvedValue(
+        getEndpointAuthzInitialStateMock(authzOverride)
+      );
+
+      const request = requestMock.create({
+        method: 'post',
+        path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
+        body: {
+          emulationId: 'emu-rbac-test',
+          agentType: 'endpoint',
+          endpointIds: ['agent-1'],
+          command,
+        },
+      });
+
+      const response = await server.inject(request, requestContextMock.convertContext(context));
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toContain(expectedAuthzKey);
+    }
+  );
+
+  it('includes the missing privilege name in the 403 response body', async () => {
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(
+      getEndpointAuthzInitialStateMock({ canWriteExecuteOperations: false })
+    );
+
+    const request = requestMock.create({
+      method: 'post',
+      path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
+      body: {
+        emulationId: 'emu-rbac-msg-test',
+        agentType: 'endpoint',
+        endpointIds: ['agent-1'],
+        command: 'execute',
+      },
+    });
+
+    const response = await server.inject(request, requestContextMock.convertContext(context));
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      message: expect.stringContaining('canWriteExecuteOperations'),
+      status_code: 403,
+    });
+  });
+
+  it('logs a warning that names the missing privilege when the RBAC gate blocks', async () => {
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(
+      getEndpointAuthzInitialStateMock({ canWriteExecuteOperations: false })
+    );
+
+    const request = requestMock.create({
+      method: 'post',
+      path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
+      body: {
+        emulationId: 'emu-rbac-warn-test',
+        agentType: 'endpoint',
+        endpointIds: ['agent-1'],
+        command: 'execute',
+      },
+    });
+
+    await server.inject(request, requestContextMock.convertContext(context));
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('canWriteExecuteOperations'));
+  });
+});
+
+// ─── Allowlist gate negative tests ───────────────────────────────────────────
+
+describe('runEmulationCommandRoute — allowlist gate', () => {
+  let server: ReturnType<typeof serverMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+
+  const buildRequestForHost = (endpointIds: string[]) =>
+    requestMock.create({
+      method: 'post',
+      path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
+      body: {
+        emulationId: 'emu-allowlist-test',
+        agentType: 'endpoint',
+        endpointIds,
+        command: 'isolate',
+      },
+    });
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    server = serverMock.create();
+  });
+
+  it('returns 403 with blocked_endpoints when the host is not in the allowlist', async () => {
+    const allowlist = new EmulationAllowlist(
+      createRestrictiveAllowlistConfig(['allowed-host']),
+      logger
+    );
+    runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { allowlist });
+
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
+
+    const response = await server.inject(
+      buildRequestForHost(['blocked-host']),
+      requestContextMock.convertContext(context)
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toMatchObject({
+      blocked_endpoints: ['blocked-host'],
+    });
+  });
+
+  it('lists all blocked hosts when multiple endpoints are not in the allowlist', async () => {
+    const allowlist = new EmulationAllowlist(
+      createRestrictiveAllowlistConfig(['allowed-host']),
+      logger
+    );
+    runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { allowlist });
+
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
+
+    const response = await server.inject(
+      buildRequestForHost(['allowed-host', 'blocked-1', 'blocked-2']),
+      requestContextMock.convertContext(context)
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toMatchObject({
+      blocked_endpoints: ['blocked-1', 'blocked-2'],
+    });
+  });
+
+  it('logs a warning naming the blocked endpoints when the allowlist gate blocks', async () => {
+    const allowlist = new EmulationAllowlist(
+      createRestrictiveAllowlistConfig(['allowed-host']),
+      logger
+    );
+    runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { allowlist });
+
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
+
+    await server.inject(
+      buildRequestForHost(['blocked-host']),
+      requestContextMock.convertContext(context)
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('blocked-host'));
+  });
+});
+
+// ─── Rate limiter gate negative tests ────────────────────────────────────────
+
+describe('runEmulationCommandRoute — rate limiter gate', () => {
+  let server: ReturnType<typeof serverMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+
+  const buildIsolateRequest = () =>
+    requestMock.create({
+      method: 'post',
+      path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
+      body: {
+        emulationId: 'emu-rate-limit-test',
+        agentType: 'endpoint',
+        endpointIds: ['agent-1'],
+        command: 'isolate',
+      },
+    });
+
+  // maxCommands: 0 immediately exhausts the limit regardless of spaceId —
+  // 0 >= 0 is always true so check() always returns { allowed: false }.
+  const makeExhaustedRateLimiter = () =>
+    new EmulationRateLimiter({ maxCommands: 0, windowMs: 60_000, disabled: false }, logger);
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    server = serverMock.create();
+  });
+
+  it('returns 429 when the rate limit is exceeded', async () => {
+    const rateLimiter = makeExhaustedRateLimiter();
+    runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { rateLimiter });
+
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
+
+    const response = await server.inject(
+      buildIsolateRequest(),
+      requestContextMock.convertContext(context)
+    );
+
+    expect(response.status).toBe(429);
+  });
+
+  it('response body includes current_count and max_commands when rate-limited', async () => {
+    const rateLimiter = makeExhaustedRateLimiter();
+    runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { rateLimiter });
+
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
+
+    const response = await server.inject(
+      buildIsolateRequest(),
+      requestContextMock.convertContext(context)
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.body.message).toMatchObject({
+      current_count: 0,
+      max_commands: 0,
+    });
+  });
+
+  it('logs a warning naming the space when the rate limit gate blocks', async () => {
+    const rateLimiter = makeExhaustedRateLimiter();
+    runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { rateLimiter });
+
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
+
+    await server.inject(buildIsolateRequest(), requestContextMock.convertContext(context));
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('rate limiter'));
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/run_command/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/run_command/route.test.ts
@@ -18,8 +18,62 @@ import { EmulationAllowlist, createRestrictiveAllowlistConfig } from '../../exec
 import { EmulationRateLimiter } from '../../execution/rate_limiter';
 
 const FEATURE_ENABLED_CONFIG = {
-  detectionEmulation: { realExecution: true, logInjection: false },
+  experimentalFeatures: { detectionEmulationRealExecution: true },
 } as unknown as ConfigType;
+
+const FEATURE_DISABLED_CONFIG = {
+  experimentalFeatures: { detectionEmulationRealExecution: false },
+} as unknown as ConfigType;
+
+/**
+ * The route's N5 gate (added with this PR) refuses to dispatch when no
+ * authenticated user is present. The default `requestContextMock` does
+ * not stub `getCurrentUser`, so tests targeting later gates (RBAC,
+ * allowlist, rate limiter) must opt in to an authenticated identity to
+ * skip past N5. Any test that wants to exercise N5 itself just *omits*
+ * this call (or overrides it explicitly).
+ */
+const stubAuthenticatedUser = (
+  context: ReturnType<typeof requestContextMock.createTools>['context'],
+  username = 'test-user'
+) => {
+  (context.core.security.authc.getCurrentUser as jest.Mock).mockReturnValue({ username });
+};
+
+// ─── Feature-flag gate ────────────────────────────────────────────────────────
+
+describe('runEmulationCommandRoute — feature-flag gate', () => {
+  let server: ReturnType<typeof serverMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    server = serverMock.create();
+  });
+
+  it('returns 403 when realExecution is disabled', async () => {
+    runEmulationCommandRoute(server.router, FEATURE_DISABLED_CONFIG, logger);
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
+
+    const response = await server.inject(
+      requestMock.create({
+        method: 'post',
+        path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
+        body: {
+          emulationId: 'emu-flag-test',
+          agentType: 'endpoint',
+          endpointIds: ['agent-1'],
+          command: 'isolate',
+        },
+      }),
+      requestContextMock.convertContext(context)
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({ status_code: 403 });
+  });
+});
 
 // ─── RBAC gate negative tests ─────────────────────────────────────────────────
 
@@ -33,16 +87,27 @@ describe('runEmulationCommandRoute — RBAC gate', () => {
     runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger);
   });
 
-  it.each<[string, string, Partial<EndpointAuthz>]>([
-    ['execute', 'canWriteExecuteOperations', { canWriteExecuteOperations: false }],
-    ['isolate', 'canIsolateHost', { canIsolateHost: false }],
-    ['runscript', 'canWriteExecuteOperations', { canWriteExecuteOperations: false }],
-    ['scan', 'canWriteScanOperations', { canWriteScanOperations: false }],
-    ['get-file', 'canWriteFileOperations', { canWriteFileOperations: false }],
+  it.each<[string, string, Partial<EndpointAuthz>, Record<string, unknown>?]>([
+    [
+      'execute',
+      'canWriteExecuteOperations',
+      { canWriteExecuteOperations: false },
+      { command: 'whoami' },
+    ],
+    ['isolate', 'canIsolateHost', { canIsolateHost: false }, undefined],
+    [
+      'runscript',
+      'canWriteExecuteOperations',
+      { canWriteExecuteOperations: false },
+      { scriptId: 'echo-hi' },
+    ],
+    ['scan', 'canWriteScanOperations', { canWriteScanOperations: false }, { path: '/tmp' }],
+    ['get-file', 'canWriteFileOperations', { canWriteFileOperations: false }, { path: '/tmp' }],
   ])(
     'returns 403 when command [%s] is blocked because caller lacks [%s]',
-    async (command, expectedAuthzKey, authzOverride) => {
+    async (command, expectedAuthzKey, authzOverride, parameters) => {
       const { context } = requestContextMock.createTools();
+      stubAuthenticatedUser(context);
       context.securitySolution.getEndpointAuthz.mockResolvedValue(
         getEndpointAuthzInitialStateMock(authzOverride)
       );
@@ -55,6 +120,7 @@ describe('runEmulationCommandRoute — RBAC gate', () => {
           agentType: 'endpoint',
           endpointIds: ['agent-1'],
           command,
+          ...(parameters ? { parameters } : {}),
         },
       });
 
@@ -67,6 +133,7 @@ describe('runEmulationCommandRoute — RBAC gate', () => {
 
   it('includes the missing privilege name in the 403 response body', async () => {
     const { context } = requestContextMock.createTools();
+    stubAuthenticatedUser(context);
     context.securitySolution.getEndpointAuthz.mockResolvedValue(
       getEndpointAuthzInitialStateMock({ canWriteExecuteOperations: false })
     );
@@ -79,6 +146,7 @@ describe('runEmulationCommandRoute — RBAC gate', () => {
         agentType: 'endpoint',
         endpointIds: ['agent-1'],
         command: 'execute',
+        parameters: { command: 'whoami' },
       },
     });
 
@@ -93,6 +161,7 @@ describe('runEmulationCommandRoute — RBAC gate', () => {
 
   it('logs a warning that names the missing privilege when the RBAC gate blocks', async () => {
     const { context } = requestContextMock.createTools();
+    stubAuthenticatedUser(context);
     context.securitySolution.getEndpointAuthz.mockResolvedValue(
       getEndpointAuthzInitialStateMock({ canWriteExecuteOperations: false })
     );
@@ -105,6 +174,7 @@ describe('runEmulationCommandRoute — RBAC gate', () => {
         agentType: 'endpoint',
         endpointIds: ['agent-1'],
         command: 'execute',
+        parameters: { command: 'whoami' },
       },
     });
 
@@ -145,6 +215,7 @@ describe('runEmulationCommandRoute — allowlist gate', () => {
     runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { allowlist });
 
     const { context } = requestContextMock.createTools();
+    stubAuthenticatedUser(context);
     context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
 
     const response = await server.inject(
@@ -166,6 +237,7 @@ describe('runEmulationCommandRoute — allowlist gate', () => {
     runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { allowlist });
 
     const { context } = requestContextMock.createTools();
+    stubAuthenticatedUser(context);
     context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
 
     const response = await server.inject(
@@ -187,6 +259,7 @@ describe('runEmulationCommandRoute — allowlist gate', () => {
     runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { allowlist });
 
     const { context } = requestContextMock.createTools();
+    stubAuthenticatedUser(context);
     context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
 
     await server.inject(
@@ -216,8 +289,8 @@ describe('runEmulationCommandRoute — rate limiter gate', () => {
       },
     });
 
-  // maxCommands: 0 immediately exhausts the limit regardless of spaceId —
-  // 0 >= 0 is always true so check() always returns { allowed: false }.
+  // maxCommands: 0 immediately exhausts the limit regardless of spaceId — 0 >= 0 is
+  // always true, so acquire() always returns { allowed: false }.
   const makeExhaustedRateLimiter = () =>
     new EmulationRateLimiter({ maxCommands: 0, windowMs: 60_000, disabled: false }, logger);
 
@@ -231,6 +304,7 @@ describe('runEmulationCommandRoute — rate limiter gate', () => {
     runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { rateLimiter });
 
     const { context } = requestContextMock.createTools();
+    stubAuthenticatedUser(context);
     context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
 
     const response = await server.inject(
@@ -246,6 +320,7 @@ describe('runEmulationCommandRoute — rate limiter gate', () => {
     runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { rateLimiter });
 
     const { context } = requestContextMock.createTools();
+    stubAuthenticatedUser(context);
     context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
 
     const response = await server.inject(
@@ -265,10 +340,48 @@ describe('runEmulationCommandRoute — rate limiter gate', () => {
     runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger, { rateLimiter });
 
     const { context } = requestContextMock.createTools();
+    stubAuthenticatedUser(context);
     context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
 
     await server.inject(buildIsolateRequest(), requestContextMock.convertContext(context));
 
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('rate limiter'));
+  });
+});
+
+// ─── N5: missing user gate ────────────────────────────────────────────────────
+
+describe('runEmulationCommandRoute — missing user gate', () => {
+  let server: ReturnType<typeof serverMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    server = serverMock.create();
+    runEmulationCommandRoute(server.router, FEATURE_ENABLED_CONFIG, logger);
+  });
+
+  it('returns 401 when no current user is available (does not fall back to "unknown")', async () => {
+    const { context } = requestContextMock.createTools();
+    context.securitySolution.getEndpointAuthz.mockResolvedValue(getEndpointAuthzInitialStateMock());
+    // Force getCurrentUser to return null — destructive emulation actions must not
+    // proceed under an unauthenticated identity.
+    (context.core.security.authc.getCurrentUser as jest.Mock).mockReturnValue(null);
+
+    const response = await server.inject(
+      requestMock.create({
+        method: 'post',
+        path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
+        body: {
+          emulationId: 'emu-no-user',
+          agentType: 'endpoint',
+          endpointIds: ['agent-1'],
+          command: 'isolate',
+        },
+      }),
+      requestContextMock.convertContext(context)
+    );
+
+    expect(response.status).toBe(401);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/run_command/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/run_command/route.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IKibanaResponse, Logger } from '@kbn/core/server';
+import { transformError } from '@kbn/securitysolution-es-utils';
+import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
+import { DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL } from '../../../../../common/constants';
+import type { SecuritySolutionPluginRouter } from '../../../../types';
+import { buildSiemResponse } from '../../../detection_engine/routes/utils';
+import { RunEmulationCommandInputSchema } from '../../../../../common/detection_emulation/schemas/run_emulation_command_input';
+import { EmulationRunner } from '../../execution/runner';
+import type { ConfigType } from '../../../../config';
+import { getDetectionEmulationFeatureFlags, isRealExecutionEnabled } from '../../feature_flag';
+import { EmulationAllowlist, createDefaultAllowlistConfig } from '../../execution/allowlist';
+import { EmulationRateLimiter, createDefaultRateLimiterConfig } from '../../execution/rate_limiter';
+import {
+  RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP,
+  RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ,
+} from '../../../../../common/endpoint/service/response_actions/constants';
+
+export const runEmulationCommandRoute = (
+  router: SecuritySolutionPluginRouter,
+  config: ConfigType,
+  logger: Logger,
+  {
+    allowlist: allowlistOverride,
+    rateLimiter: rateLimiterOverride,
+  }: { allowlist?: EmulationAllowlist; rateLimiter?: EmulationRateLimiter } = {}
+) => {
+  // Initialize allowlist and rate limiter with default configurations
+  // TODO: Load configuration from Kibana config or saved objects
+  const allowlist =
+    allowlistOverride ?? new EmulationAllowlist(createDefaultAllowlistConfig(), logger);
+  const rateLimiter =
+    rateLimiterOverride ?? new EmulationRateLimiter(createDefaultRateLimiterConfig(), logger);
+
+  router.versioned
+    .post({
+      path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
+      access: 'internal',
+      options: {
+        tags: ['access:securitySolution', 'oas-tag:emulation'],
+        availability: {
+          stability: 'experimental',
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: buildRouteValidationWithZod(RunEmulationCommandInputSchema),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse> => {
+        const siemResponse = buildSiemResponse(response);
+
+        try {
+          const { emulationId, command, endpointIds } = request.body;
+
+          const featureFlags = getDetectionEmulationFeatureFlags(config);
+
+          // Gate 1: Feature flag check (wholesale enable/disable)
+          if (!isRealExecutionEnabled(featureFlags)) {
+            logger.warn(
+              `Emulation command [${command}] for emulation [${emulationId}] blocked: real execution is disabled`
+            );
+            return siemResponse.error({
+              statusCode: 403,
+              body: 'Detection emulation real execution is disabled',
+            });
+          }
+
+          const coreContext = await context.core;
+          const securitySolution = await context.securitySolution;
+          const spaceId = securitySolution.getSpaceId();
+
+          // Gate 2: Per-command RBAC check
+          const consoleCommand = RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP[command];
+          const requiredAuthzKey =
+            RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ[consoleCommand];
+
+          if (requiredAuthzKey) {
+            const endpointAuthz = await securitySolution.getEndpointAuthz();
+            const hasPrivilege = endpointAuthz[requiredAuthzKey];
+
+            if (!hasPrivilege) {
+              logger.warn(
+                `Emulation command [${command}] for emulation [${emulationId}] blocked: user lacks required RBAC privilege [${requiredAuthzKey}]`
+              );
+              return siemResponse.error({
+                statusCode: 403,
+                body: `Insufficient privileges: command [${command}] requires [${requiredAuthzKey}]`,
+              });
+            }
+
+            logger.debug(
+              `RBAC check passed for command [${command}]: user has privilege [${requiredAuthzKey}]`
+            );
+          }
+
+          // Gate 3: Host allowlist validation
+          const allowlistResult = allowlist.validate(endpointIds);
+          if (!allowlistResult.allowed) {
+            logger.warn(
+              `Emulation command [${command}] for emulation [${emulationId}] blocked by allowlist: ${allowlistResult.error}`
+            );
+            return siemResponse.error({
+              statusCode: 403,
+              body: {
+                message: allowlistResult.error ?? 'Endpoints not in allowlist',
+                blocked_endpoints: allowlistResult.blockedEndpoints,
+              },
+            });
+          }
+
+          // Gate 4: Rate limit check
+          const rateLimitResult = rateLimiter.check(spaceId);
+          if (!rateLimitResult.allowed) {
+            logger.warn(
+              `Emulation command [${command}] for emulation [${emulationId}] blocked by rate limiter: ${rateLimitResult.error}`
+            );
+            return siemResponse.error({
+              statusCode: 429,
+              body: {
+                message: rateLimitResult.error ?? 'Rate limit exceeded',
+                current_count: rateLimitResult.currentCount,
+                max_commands: rateLimitResult.maxCommands,
+                reset_ms: rateLimitResult.resetMs,
+              },
+            });
+          }
+
+          // All gates passed - execute the command
+          const runner = new EmulationRunner({
+            endpointService: securitySolution.getEndpointService(),
+            esClient: coreContext.elasticsearch.client.asCurrentUser,
+            spaceId,
+            casesClient: (await context.cases)?.getCasesClient(),
+            username: coreContext.security?.authc.getCurrentUser()?.username ?? 'unknown',
+            logger,
+          });
+
+          const result = await runner.run(request.body);
+
+          if (result.status === 'error') {
+            return siemResponse.error({
+              statusCode: 500,
+              body: {
+                message: result.error ?? 'Unknown error executing emulation command',
+                action_id: result.actionId,
+              },
+            });
+          }
+
+          // Record successful execution in rate limiter
+          rateLimiter.record(spaceId, emulationId, command);
+
+          return response.ok({
+            body: {
+              action_id: result.actionId,
+              agent_type: result.agentType,
+              command: result.command,
+              status: result.status,
+            },
+          });
+        } catch (err) {
+          const error = transformError(err);
+          logger.error(`Error running emulation command: ${error.message}`);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
+      }
+    );
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/run_command/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/api/run_command/route.ts
@@ -6,21 +6,70 @@
  */
 
 import type { IKibanaResponse, Logger } from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
 import { DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL } from '../../../../../common/constants';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 import { buildSiemResponse } from '../../../detection_engine/routes/utils';
 import { RunEmulationCommandInputSchema } from '../../../../../common/detection_emulation/schemas/run_emulation_command_input';
-import { EmulationRunner } from '../../execution/runner';
+import {
+  EmulationRunner,
+  UnsupportedAgentTypeError,
+  UnsupportedCommandForAgentTypeError,
+  MissingConnectorActionsError,
+} from '../../execution/runner';
 import type { ConfigType } from '../../../../config';
 import { getDetectionEmulationFeatureFlags, isRealExecutionEnabled } from '../../feature_flag';
-import { EmulationAllowlist, createDefaultAllowlistConfig } from '../../execution/allowlist';
+import {
+  EmulationAllowlist,
+  createDefaultAllowlistConfig,
+  createRestrictiveAllowlistConfig,
+} from '../../execution/allowlist';
 import { EmulationRateLimiter, createDefaultRateLimiterConfig } from '../../execution/rate_limiter';
+import {
+  EmulationIdempotencyCache,
+  buildIdempotencyKey,
+  createDefaultIdempotencyCacheConfig,
+} from '../../execution/idempotency_cache';
 import {
   RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP,
   RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ,
 } from '../../../../../common/endpoint/service/response_actions/constants';
+import { createSavedObjectRuleBindingLookup } from '../../rule_binding_lookup';
+import { emulationRuleBindingTypeName } from '../../rule_binding';
+
+const I18N_PREFIX = 'xpack.securitySolution.detectionEmulation.route' as const;
+
+const MESSAGES = {
+  featureDisabled: i18n.translate(`${I18N_PREFIX}.featureDisabled`, {
+    defaultMessage: 'Detection emulation real execution is disabled.',
+  }),
+  authRequired: i18n.translate(`${I18N_PREFIX}.authRequired`, {
+    defaultMessage: 'Authentication is required to run an emulation command.',
+  }),
+  insufficientPrivileges: (privilege: string) =>
+    i18n.translate(`${I18N_PREFIX}.insufficientPrivileges`, {
+      defaultMessage: 'Insufficient privileges: command requires [{privilege}].',
+      values: { privilege },
+    }),
+  endpointsNotInAllowlist: i18n.translate(`${I18N_PREFIX}.endpointsNotInAllowlist`, {
+    defaultMessage: 'Endpoints not in allowlist.',
+  }),
+  rateLimitExceeded: i18n.translate(`${I18N_PREFIX}.rateLimitExceeded`, {
+    defaultMessage: 'Rate limit exceeded.',
+  }),
+  agentTypeNotYetSupported: i18n.translate(`${I18N_PREFIX}.agentTypeNotYetSupported`, {
+    defaultMessage:
+      'This agent type is not yet wired through the route — only `endpoint` is supported today.',
+  }),
+  unsupportedCommand: i18n.translate(`${I18N_PREFIX}.unsupportedCommand`, {
+    defaultMessage: 'The requested command is not supported for this agent type.',
+  }),
+  internalError: i18n.translate(`${I18N_PREFIX}.internalError`, {
+    defaultMessage: 'Failed to dispatch the emulation command.',
+  }),
+} as const;
 
 export const runEmulationCommandRoute = (
   router: SecuritySolutionPluginRouter,
@@ -29,21 +78,64 @@ export const runEmulationCommandRoute = (
   {
     allowlist: allowlistOverride,
     rateLimiter: rateLimiterOverride,
-  }: { allowlist?: EmulationAllowlist; rateLimiter?: EmulationRateLimiter } = {}
+    idempotencyCache: idempotencyCacheOverride,
+  }: {
+    allowlist?: EmulationAllowlist;
+    rateLimiter?: EmulationRateLimiter;
+    idempotencyCache?: EmulationIdempotencyCache;
+  } = {}
 ) => {
-  // Initialize allowlist and rate limiter with default configurations
-  // TODO: Load configuration from Kibana config or saved objects
+  // The allowlist + rate limiter + idempotency cache are constructed once per route
+  // registration and shared across requests. The `*Override` parameters exist so the
+  // test suite can inject a restrictive allowlist or an exhausted rate limiter without
+  // standing up the full config-loading pipeline. (N7) Real production wiring reads
+  // optional `xpack.securitySolution.detectionEmulation.*` settings; absent settings
+  // fall back to the safe defaults below.
+  const emulationConfig = config.detectionEmulation;
+
   const allowlist =
-    allowlistOverride ?? new EmulationAllowlist(createDefaultAllowlistConfig(), logger);
+    allowlistOverride ??
+    (() => {
+      const cfg = emulationConfig?.allowlist;
+      if (!cfg) {
+        return new EmulationAllowlist(createDefaultAllowlistConfig(), logger);
+      }
+      return new EmulationAllowlist(
+        cfg.allowAll
+          ? { allowAll: true, allowedHosts: new Set() }
+          : createRestrictiveAllowlistConfig(cfg.endpointIds),
+        logger
+      );
+    })();
+
   const rateLimiter =
-    rateLimiterOverride ?? new EmulationRateLimiter(createDefaultRateLimiterConfig(), logger);
+    rateLimiterOverride ??
+    new EmulationRateLimiter(
+      emulationConfig?.rateLimiter ?? createDefaultRateLimiterConfig(),
+      logger
+    );
+
+  const idempotencyCache =
+    idempotencyCacheOverride ??
+    new EmulationIdempotencyCache(
+      emulationConfig?.idempotencyCache ?? createDefaultIdempotencyCacheConfig(),
+      logger
+    );
 
   router.versioned
     .post({
       path: DETECTION_ENGINE_EMULATION_RUN_COMMAND_URL,
       access: 'internal',
+      // Declarative authz — replaces the legacy `tags: ['access:securitySolution']`
+      // form so RBAC tooling, OpenAPI, and ESLint plugins can all read the
+      // privilege requirement from a single source.
+      security: {
+        authz: {
+          requiredPrivileges: ['securitySolution'],
+        },
+      },
       options: {
-        tags: ['access:securitySolution', 'oas-tag:emulation'],
+        tags: ['oas-tag:emulation'],
         availability: {
           stability: 'experimental',
         },
@@ -64,24 +156,34 @@ export const runEmulationCommandRoute = (
         try {
           const { emulationId, command, endpointIds } = request.body;
 
-          const featureFlags = getDetectionEmulationFeatureFlags(config);
-
-          // Gate 1: Feature flag check (wholesale enable/disable)
+          // Gate 1: feature flag (sourced from `experimentalFeatures` so it ships dark by default).
+          const featureFlags = getDetectionEmulationFeatureFlags(config.experimentalFeatures);
           if (!isRealExecutionEnabled(featureFlags)) {
             logger.warn(
               `Emulation command [${command}] for emulation [${emulationId}] blocked: real execution is disabled`
             );
-            return siemResponse.error({
-              statusCode: 403,
-              body: 'Detection emulation real execution is disabled',
-            });
+            return siemResponse.error({ statusCode: 403, body: MESSAGES.featureDisabled });
           }
 
           const coreContext = await context.core;
           const securitySolution = await context.securitySolution;
           const spaceId = securitySolution.getSpaceId();
 
-          // Gate 2: Per-command RBAC check
+          // N5: refuse to dispatch a destructive action without an authenticated caller.
+          // Previously the code fell back to username='unknown', leaving the audit trail
+          // incomplete and accountability ambiguous.
+          const currentUser = coreContext.security?.authc.getCurrentUser();
+          if (!currentUser?.username) {
+            logger.warn(
+              `Emulation command [${command}] for emulation [${emulationId}] blocked: no authenticated user`
+            );
+            return siemResponse.error({ statusCode: 401, body: MESSAGES.authRequired });
+          }
+
+          // Gate 2: per-command RBAC. Console-command names map to required Endpoint
+          // privileges; we look up the privilege the caller would need and reject if
+          // they don't hold it. The privilege key is included in the response body
+          // because operators need it for diagnosis (which privilege to grant).
           const consoleCommand = RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP[command];
           const requiredAuthzKey =
             RESPONSE_CONSOLE_ACTION_COMMANDS_TO_REQUIRED_AUTHZ[consoleCommand];
@@ -96,16 +198,17 @@ export const runEmulationCommandRoute = (
               );
               return siemResponse.error({
                 statusCode: 403,
-                body: `Insufficient privileges: command [${command}] requires [${requiredAuthzKey}]`,
+                body: MESSAGES.insufficientPrivileges(requiredAuthzKey),
               });
             }
-
             logger.debug(
               `RBAC check passed for command [${command}]: user has privilege [${requiredAuthzKey}]`
             );
           }
 
-          // Gate 3: Host allowlist validation
+          // Gate 3: host allowlist. The allowlist returns the *full* list of blocked
+          // endpoints (not just the first) so operators can see every host that needs
+          // remediation in one shot.
           const allowlistResult = allowlist.validate(endpointIds);
           if (!allowlistResult.allowed) {
             logger.warn(
@@ -114,53 +217,154 @@ export const runEmulationCommandRoute = (
             return siemResponse.error({
               statusCode: 403,
               body: {
-                message: allowlistResult.error ?? 'Endpoints not in allowlist',
+                message: MESSAGES.endpointsNotInAllowlist,
                 blocked_endpoints: allowlistResult.blockedEndpoints,
               },
             });
           }
 
-          // Gate 4: Rate limit check
-          const rateLimitResult = rateLimiter.check(spaceId);
-          if (!rateLimitResult.allowed) {
+          // Gate 4 (a): idempotency cache (N6). If the *exact* same dispatch tuple
+          // (space, emulation, command, agentType, sorted endpointIds) was processed
+          // within the cache TTL, replay the cached result instead of dispatching a
+          // second response action. This swallows double-clicks, network retries, and
+          // LLM replays without consuming a fresh rate-limit slot.
+          const idempotencyKey = buildIdempotencyKey({
+            spaceId,
+            emulationId,
+            command,
+            agentType: request.body.agentType,
+            endpointIds,
+          });
+          const cached = idempotencyCache.get(spaceId, idempotencyKey);
+          if (cached) {
+            logger.debug(
+              `Idempotency cache replay for emulation [${emulationId}] command [${command}] (action_id=${cached.actionId})`
+            );
+            if (cached.status === 'dispatched') {
+              return response.ok({
+                body: {
+                  action_id: cached.actionId,
+                  agent_type: cached.agentType,
+                  command: cached.command,
+                  status: cached.status,
+                },
+              });
+            }
+            // Cached error replay — same status code we'd return on a fresh dispatch
+            // failure. We don't echo the original error string to the client (I3).
+            return siemResponse.error({
+              statusCode: 502,
+              body: { message: MESSAGES.internalError, action_id: cached.actionId },
+            });
+          }
+
+          // Gate 4 (b): atomic rate-limit acquire. Combines the previous check+record in
+          // a single synchronous call so concurrent requests in the same space cannot all
+          // pass the gate before any of them records (B3). On dispatch failure below we
+          // pass `acquireResult.token` to `release()` to roll the count back.
+          const acquireResult = rateLimiter.acquire(spaceId, emulationId, command);
+          if (!acquireResult.allowed) {
             logger.warn(
-              `Emulation command [${command}] for emulation [${emulationId}] blocked by rate limiter: ${rateLimitResult.error}`
+              `Emulation command [${command}] for emulation [${emulationId}] blocked by rate limiter: ${acquireResult.error}`
             );
             return siemResponse.error({
               statusCode: 429,
               body: {
-                message: rateLimitResult.error ?? 'Rate limit exceeded',
-                current_count: rateLimitResult.currentCount,
-                max_commands: rateLimitResult.maxCommands,
-                reset_ms: rateLimitResult.resetMs,
+                message: MESSAGES.rateLimitExceeded,
+                current_count: acquireResult.currentCount,
+                max_commands: acquireResult.maxCommands,
+                reset_ms: acquireResult.resetMs,
               },
             });
           }
 
-          // All gates passed - execute the command
+          // All gates passed — execute the command.
+          //
+          // Rule-binding lookup (I7): the SO type is registered with
+          // `hidden: true`, so we need the *internal* SO client (the request-
+          // scoped one cannot see hidden types). The runner owns calling it
+          // exactly once per dispatch and threads `ruleId` / `ruleName` into
+          // the action so downstream queries can join emulation runs back to
+          // the rule that produced them.
+          const internalSoClient = coreContext.savedObjects.getClient({
+            includedHiddenTypes: [emulationRuleBindingTypeName],
+          });
+          const endpointService = securitySolution.getEndpointService();
+          // The cases client is acquired via endpointService rather than a direct
+          // `context.cases` handler because security_solution's
+          // `SecuritySolutionRequestHandlerContext` does not register the cases
+          // plugin context. We swallow `getCasesClient` failures because cases
+          // is optional for emulation dispatch — the action still goes out.
+          let casesClient;
+          try {
+            casesClient = await endpointService.getCasesClient(request);
+          } catch (err) {
+            logger.debug(
+              `Cases client unavailable for emulation dispatch: ${(err as Error).message ?? err}`
+            );
+            casesClient = undefined;
+          }
+
           const runner = new EmulationRunner({
-            endpointService: securitySolution.getEndpointService(),
+            endpointService,
             esClient: coreContext.elasticsearch.client.asCurrentUser,
             spaceId,
-            casesClient: (await context.cases)?.getCasesClient(),
-            username: coreContext.security?.authc.getCurrentUser()?.username ?? 'unknown',
+            casesClient,
+            username: currentUser.username,
             logger,
+            ruleBindingLookup: createSavedObjectRuleBindingLookup(internalSoClient, logger),
           });
 
-          const result = await runner.run(request.body);
+          let result;
+          try {
+            result = await runner.run(request.body);
+          } catch (runnerErr) {
+            // Roll back the rate-limit acquire on a thrown gate-style error so a
+            // misconfigured request doesn't permanently consume a slot.
+            rateLimiter.release(acquireResult.token);
+            return mapRunnerThrow(runnerErr, siemResponse, logger);
+          }
 
           if (result.status === 'error') {
+            // Internal dispatch failure (Fleet down, connector unavailable, etc.).
+            // Roll the rate-limit acquire back so retries are not penalised.
+            rateLimiter.release(acquireResult.token);
+            // Don't leak the underlying error message to the client — it can include
+            // ES/Fleet/connector internals. Log the full message server-side, return a
+            // stable user-facing string in the response body.
+            logger.error(
+              `Emulation command [${command}] for emulation [${emulationId}] dispatch failed: ${
+                result.error ?? 'unknown'
+              }`
+            );
+            // N6: cache the error too, so the immediate retry from a flaky network
+            // sees the same answer rather than racing the rate limiter. We TTL the
+            // failure shortly so genuine retries after the connector recovers do
+            // dispatch again.
+            idempotencyCache.set(spaceId, idempotencyKey, {
+              actionId: result.actionId,
+              agentType: request.body.agentType,
+              command,
+              status: 'error',
+              error: result.error,
+            });
             return siemResponse.error({
-              statusCode: 500,
+              statusCode: 502,
               body: {
-                message: result.error ?? 'Unknown error executing emulation command',
+                message: MESSAGES.internalError,
                 action_id: result.actionId,
               },
             });
           }
 
-          // Record successful execution in rate limiter
-          rateLimiter.record(spaceId, emulationId, command);
+          // N6: cache the successful dispatch so an immediate replay returns the same
+          // action_id rather than firing a second Response Action.
+          idempotencyCache.set(spaceId, idempotencyKey, {
+            actionId: result.actionId,
+            agentType: result.agentType,
+            command: result.command,
+            status: result.status,
+          });
 
           return response.ok({
             body: {
@@ -171,13 +375,46 @@ export const runEmulationCommandRoute = (
             },
           });
         } catch (err) {
+          // Untyped catch-all. We log the real error server-side and return a generic
+          // error to the client (I3) — `transformError`'s message frequently echoes
+          // exception text from ES, Fleet, or downstream connectors.
           const error = transformError(err);
           logger.error(`Error running emulation command: ${error.message}`);
           return siemResponse.error({
-            body: error.message,
             statusCode: error.statusCode,
+            body: MESSAGES.internalError,
           });
         }
       }
     );
 };
+
+/**
+ * Map a runner-raised typed error onto an HTTP response.
+ *
+ * Keeps the runner authoritative on classification (the runner knows
+ * which conditions are "user input was wrong" versus "downstream blew
+ * up") and the route authoritative on protocol mapping.
+ */
+function mapRunnerThrow(
+  runnerErr: unknown,
+  siemResponse: ReturnType<typeof buildSiemResponse>,
+  logger: Logger
+): IKibanaResponse {
+  if (runnerErr instanceof MissingConnectorActionsError) {
+    logger.warn(`Emulation request rejected: ${runnerErr.message}`);
+    return siemResponse.error({ statusCode: 400, body: MESSAGES.agentTypeNotYetSupported });
+  }
+  if (runnerErr instanceof UnsupportedAgentTypeError) {
+    logger.warn(`Emulation request rejected: ${runnerErr.message}`);
+    return siemResponse.error({ statusCode: 400, body: MESSAGES.agentTypeNotYetSupported });
+  }
+  if (runnerErr instanceof UnsupportedCommandForAgentTypeError) {
+    logger.warn(`Emulation request rejected: ${runnerErr.message}`);
+    return siemResponse.error({ statusCode: 400, body: MESSAGES.unsupportedCommand });
+  }
+  // Unknown error class — log full text, return generic message.
+  const message = runnerErr instanceof Error ? runnerErr.message : String(runnerErr);
+  logger.error(`Unexpected runner error: ${message}`);
+  return siemResponse.error({ statusCode: 500, body: MESSAGES.internalError });
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/detection_emulation.integration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/detection_emulation.integration.test.ts
@@ -17,12 +17,7 @@ import {
   ALERT_EMULATION_ID,
   ALERT_EMULATION_MODE,
 } from './alert_tagging';
-import {
-  buildEmulationComment,
-  buildEmulationReason,
-  parseEmulationReason,
-  isEmulationReason,
-} from './execution/audit_logger';
+import { buildEmulationComment } from './execution/audit_logger';
 import {
   EmulationAllowlist,
   createDefaultAllowlistConfig,
@@ -71,13 +66,13 @@ describe('detection_emulation — alert tagging', () => {
     });
 
     expect(updated).toBe(2);
+    // The ES v8 client expects `query` / `script` at the top level — not nested
+    // under a legacy `body:` wrapper.
     expect(mockUpdateByQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.objectContaining({
-          query: { ids: { values: ['alert-1', 'alert-2'] } },
-          script: expect.objectContaining({
-            params: { emulationId: 'emulation-abc', mode: 'test' },
-          }),
+        query: { ids: { values: ['alert-1', 'alert-2'] } },
+        script: expect.objectContaining({
+          params: { emulationId: 'emulation-abc', mode: 'test' },
         }),
       })
     );
@@ -98,16 +93,12 @@ describe('detection_emulation — alert tagging', () => {
     // updateByQuery is called only with the specified IDs — other alerts are not in the query.
     expect(mockUpdateByQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.objectContaining({
-          query: { ids: { values: ['alert-a'] } },
-        }),
+        query: { ids: { values: ['alert-a'] } },
       })
     );
     expect(mockUpdateByQuery).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.objectContaining({
-          query: { ids: { values: expect.arrayContaining(['alert-b', 'alert-c']) } },
-        }),
+        query: { ids: { values: expect.arrayContaining(['alert-b', 'alert-c']) } },
       })
     );
   });
@@ -136,20 +127,16 @@ describe('detection_emulation — alert tagging', () => {
     expect(mockUpdateByQuery).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        body: expect.objectContaining({
-          query: { ids: { values: ['run1-alert'] } },
-          script: expect.objectContaining({ params: { emulationId: 'run-1', mode: 'test' } }),
-        }),
+        query: { ids: { values: ['run1-alert'] } },
+        script: expect.objectContaining({ params: { emulationId: 'run-1', mode: 'test' } }),
       })
     );
     expect(mockUpdateByQuery).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        body: expect.objectContaining({
-          query: { ids: { values: ['run2-alert'] } },
-          script: expect.objectContaining({
-            params: { emulationId: 'run-2', mode: 'production' },
-          }),
+        query: { ids: { values: ['run2-alert'] } },
+        script: expect.objectContaining({
+          params: { emulationId: 'run-2', mode: 'production' },
         }),
       })
     );
@@ -206,26 +193,9 @@ describe('detection_emulation — alert tagging', () => {
   });
 });
 
-// ─── Audit logger round-trip (pure functions, no ES needed) ──────────────────
+// ─── Audit comment helper (pure function, no ES needed) ──────────────────────
 
-describe('detection_emulation — audit logger reason round-trip', () => {
-  it('parseEmulationReason recovers the emulationId built by buildEmulationReason', () => {
-    const emulationId = 'emulation-12345-abcde';
-    const reason = buildEmulationReason(emulationId);
-    expect(parseEmulationReason(reason)).toBe(emulationId);
-  });
-
-  it('isEmulationReason is true for reasons produced by buildEmulationReason', () => {
-    const reason = buildEmulationReason('emu-xyz');
-    expect(isEmulationReason(reason)).toBe(true);
-  });
-
-  it('isEmulationReason is false for unrelated reason strings', () => {
-    expect(isEmulationReason('user-initiated')).toBe(false);
-    expect(isEmulationReason('')).toBe(false);
-    expect(isEmulationReason('emulation')).toBe(false);
-  });
-
+describe('detection_emulation — audit comment', () => {
   it('buildEmulationComment embeds emulationId and command', () => {
     const comment = buildEmulationComment('emu-001', 'execute');
     expect(comment).toContain('emu-001');
@@ -237,8 +207,10 @@ describe('detection_emulation — audit logger reason round-trip', () => {
     expect(comment).toContain('analyst note');
   });
 
-  it('reason format is stable (prefix: emulation:<id>)', () => {
-    expect(buildEmulationReason('abc-123')).toBe('emulation:abc-123');
+  it('comment format is stable (prefix: Detection Emulation [<id>]:)', () => {
+    expect(buildEmulationComment('abc-123', 'isolate')).toBe(
+      'Detection Emulation [abc-123]: isolate'
+    );
   });
 });
 
@@ -257,8 +229,9 @@ describe('detection_emulation — guard chain (allowlist + rate limiter)', () =>
     const allowlistResult = allowlist.validate(['endpoint-1']);
     expect(allowlistResult.allowed).toBe(true);
 
-    const rateResult = rateLimiter.checkAndRecord('space-1', 'emu-1', 'execute');
+    const rateResult = rateLimiter.acquire('space-1', 'emu-1', 'execute');
     expect(rateResult.allowed).toBe(true);
+    expect(rateResult.token).toBeDefined();
   });
 
   it('blocks at the allowlist before consulting the rate limiter', () => {
@@ -283,14 +256,14 @@ describe('detection_emulation — guard chain (allowlist + rate limiter)', () =>
       makeLogger()
     );
 
-    // Exhaust the rate limit.
-    rateLimiter.record('space-1', 'emu-A', 'execute');
-    rateLimiter.record('space-1', 'emu-A', 'kill-process');
+    // Exhaust the rate limit via two successful acquires.
+    expect(rateLimiter.acquire('space-1', 'emu-A', 'execute').allowed).toBe(true);
+    expect(rateLimiter.acquire('space-1', 'emu-A', 'kill-process').allowed).toBe(true);
 
     const allowlistResult = allowlist.validate(['endpoint-1']);
     expect(allowlistResult.allowed).toBe(true);
 
-    const rateResult = rateLimiter.check('space-1');
+    const rateResult = rateLimiter.acquire('space-1', 'emu-A', 'isolate');
     expect(rateResult.allowed).toBe(false);
     expect(rateResult.currentCount).toBe(2);
     expect(rateResult.maxCommands).toBe(2);
@@ -302,24 +275,27 @@ describe('detection_emulation — guard chain (allowlist + rate limiter)', () =>
       makeLogger()
     );
 
-    rateLimiter.record('space-A', 'emu-1', 'execute');
+    expect(rateLimiter.acquire('space-A', 'emu-1', 'execute').allowed).toBe(true);
 
     // space-A is now at the limit.
-    expect(rateLimiter.check('space-A').allowed).toBe(false);
+    expect(rateLimiter.acquire('space-A', 'emu-1', 'execute').allowed).toBe(false);
     // space-B is unaffected.
-    expect(rateLimiter.check('space-B').allowed).toBe(true);
+    expect(rateLimiter.acquire('space-B', 'emu-1', 'execute').allowed).toBe(true);
   });
 
-  it('allowlist.addEndpoint unblocks a previously blocked endpoint', () => {
-    const allowlist = new EmulationAllowlist(
-      createRestrictiveAllowlistConfig(['endpoint-original']),
+  it('release() rolls back a successful acquire so the slot can be reused', () => {
+    const rateLimiter = new EmulationRateLimiter(
+      { maxCommands: 1, windowMs: 60_000, disabled: false },
       makeLogger()
     );
 
-    expect(allowlist.validate(['endpoint-new']).allowed).toBe(false);
-
-    allowlist.addEndpoint('endpoint-new');
-    expect(allowlist.validate(['endpoint-new']).allowed).toBe(true);
+    const first = rateLimiter.acquire('space-1', 'emu-1', 'isolate');
+    expect(first.allowed).toBe(true);
+    // Limit hit.
+    expect(rateLimiter.acquire('space-1', 'emu-1', 'isolate').allowed).toBe(false);
+    // Roll back; subsequent acquire should succeed.
+    rateLimiter.release(first.token);
+    expect(rateLimiter.acquire('space-1', 'emu-1', 'isolate').allowed).toBe(true);
   });
 
   it('a command passing all guards leaves rate limiter count incremented', () => {
@@ -332,23 +308,21 @@ describe('detection_emulation — guard chain (allowlist + rate limiter)', () =>
 
     // Simulate the route handler gate sequence.
     expect(allowlist.validate(['ep-1']).allowed).toBe(true);
-    const rateResult = rateLimiter.checkAndRecord(spaceId, 'emu-1', 'scan');
+    const rateResult = rateLimiter.acquire(spaceId, 'emu-1', 'scan');
     expect(rateResult.allowed).toBe(true);
 
     expect(rateLimiter.getCurrentCount(spaceId)).toBe(1);
   });
 
-  it('disabled rate limiter always allows regardless of recorded commands', () => {
+  it('disabled rate limiter always allows regardless of how many commands fired', () => {
     const rateLimiter = new EmulationRateLimiter(
       { maxCommands: 1, windowMs: 60_000, disabled: true },
       makeLogger()
     );
 
-    rateLimiter.record('space-1', 'emu-1', 'execute');
-    rateLimiter.record('space-1', 'emu-1', 'execute');
-    rateLimiter.record('space-1', 'emu-1', 'execute');
-
-    expect(rateLimiter.check('space-1').allowed).toBe(true);
+    expect(rateLimiter.acquire('space-1', 'emu-1', 'execute').allowed).toBe(true);
+    expect(rateLimiter.acquire('space-1', 'emu-1', 'execute').allowed).toBe(true);
+    expect(rateLimiter.acquire('space-1', 'emu-1', 'execute').allowed).toBe(true);
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/detection_emulation.integration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/detection_emulation.integration.test.ts
@@ -1,0 +1,779 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import type { ResponseActionAgentType } from '../../../common/endpoint/service/response_actions/constants';
+import {
+  tagAlertsWithEmulation,
+  buildEmulationAlertQuery,
+  buildEmulationModeQuery,
+  extractEmulationMetadata,
+  isEmulationAlert,
+  ALERT_EMULATION_ID,
+  ALERT_EMULATION_MODE,
+} from './alert_tagging';
+import {
+  buildEmulationComment,
+  buildEmulationReason,
+  parseEmulationReason,
+  isEmulationReason,
+} from './execution/audit_logger';
+import {
+  EmulationAllowlist,
+  createDefaultAllowlistConfig,
+  createRestrictiveAllowlistConfig,
+} from './execution/allowlist';
+import { EmulationRateLimiter, createDefaultRateLimiterConfig } from './execution/rate_limiter';
+import { EmulationRunner } from './execution/runner';
+import { BaseDataGenerator } from '../../../common/endpoint/data_generators/base_data_generator';
+import { endpointActionClientMock } from '../../endpoint/services/actions/clients/endpoint/mocks';
+import { sentinelOneMock } from '../../endpoint/services/actions/clients/sentinelone/mocks';
+import { CrowdstrikeMock } from '../../endpoint/services/actions/clients/crowdstrike/mocks';
+import { microsoftDefenderMock } from '../../endpoint/services/actions/clients/microsoft/defender/endpoint/mocks';
+import { getActionDetailsById as _getActionDetailsById } from '../../endpoint/services/actions/action_details_by_id';
+
+jest.mock('../../endpoint/services/actions/action_details_by_id');
+
+const mockGetActionDetailsById = _getActionDetailsById as jest.Mock;
+
+const TEST_ALERTS_INDEX = 'test-security-alerts';
+
+// ─── Alert tagging tests (mocked ES client) ───────────────────────────────────
+
+describe('detection_emulation — alert tagging', () => {
+  let mockUpdateByQuery: jest.Mock;
+  let esClient: ElasticsearchClient;
+
+  beforeEach(() => {
+    mockUpdateByQuery = jest.fn().mockResolvedValue({ updated: 0, failures: [] });
+    esClient = { updateByQuery: mockUpdateByQuery } as unknown as ElasticsearchClient;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('writes kibana.alert.emulation.id and kibana.alert.emulation.mode to targeted alerts', async () => {
+    mockUpdateByQuery.mockResolvedValue({ updated: 2, failures: [] });
+    const logger = loggingSystemMock.createLogger();
+
+    const updated = await tagAlertsWithEmulation({
+      esClient,
+      alertIds: ['alert-1', 'alert-2'],
+      metadata: { emulationId: 'emulation-abc', mode: 'test' },
+      alertsIndex: TEST_ALERTS_INDEX,
+      logger,
+    });
+
+    expect(updated).toBe(2);
+    expect(mockUpdateByQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          query: { ids: { values: ['alert-1', 'alert-2'] } },
+          script: expect.objectContaining({
+            params: { emulationId: 'emulation-abc', mode: 'test' },
+          }),
+        }),
+      })
+    );
+  });
+
+  it('does not tag alerts that were not in the alertIds list', async () => {
+    mockUpdateByQuery.mockResolvedValue({ updated: 1, failures: [] });
+    const logger = loggingSystemMock.createLogger();
+
+    await tagAlertsWithEmulation({
+      esClient,
+      alertIds: ['alert-a'],
+      metadata: { emulationId: 'emulation-x', mode: 'validation' },
+      alertsIndex: TEST_ALERTS_INDEX,
+      logger,
+    });
+
+    // updateByQuery is called only with the specified IDs — other alerts are not in the query.
+    expect(mockUpdateByQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          query: { ids: { values: ['alert-a'] } },
+        }),
+      })
+    );
+    expect(mockUpdateByQuery).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          query: { ids: { values: expect.arrayContaining(['alert-b', 'alert-c']) } },
+        }),
+      })
+    );
+  });
+
+  it('isolates alerts from different emulation runs by emulationId', async () => {
+    mockUpdateByQuery.mockResolvedValue({ updated: 1, failures: [] });
+    const logger = loggingSystemMock.createLogger();
+
+    await tagAlertsWithEmulation({
+      esClient,
+      alertIds: ['run1-alert'],
+      metadata: { emulationId: 'run-1', mode: 'test' },
+      alertsIndex: TEST_ALERTS_INDEX,
+      logger,
+    });
+    await tagAlertsWithEmulation({
+      esClient,
+      alertIds: ['run2-alert'],
+      metadata: { emulationId: 'run-2', mode: 'production' },
+      alertsIndex: TEST_ALERTS_INDEX,
+      logger,
+    });
+
+    // Each call carries its own IDs and emulationId — no cross-contamination.
+    expect(mockUpdateByQuery).toHaveBeenCalledTimes(2);
+    expect(mockUpdateByQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        body: expect.objectContaining({
+          query: { ids: { values: ['run1-alert'] } },
+          script: expect.objectContaining({ params: { emulationId: 'run-1', mode: 'test' } }),
+        }),
+      })
+    );
+    expect(mockUpdateByQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        body: expect.objectContaining({
+          query: { ids: { values: ['run2-alert'] } },
+          script: expect.objectContaining({
+            params: { emulationId: 'run-2', mode: 'production' },
+          }),
+        }),
+      })
+    );
+  });
+
+  it('buildEmulationAlertQuery and buildEmulationModeQuery produce correct term filters', () => {
+    expect(buildEmulationAlertQuery('emu-abc')).toEqual({
+      term: { [ALERT_EMULATION_ID]: 'emu-abc' },
+    });
+    expect(buildEmulationModeQuery('test')).toEqual({
+      term: { [ALERT_EMULATION_MODE]: 'test' },
+    });
+    expect(buildEmulationModeQuery('production')).toEqual({
+      term: { [ALERT_EMULATION_MODE]: 'production' },
+    });
+  });
+
+  it('returns 0 and skips the ES call when alertIds is empty', async () => {
+    const logger = loggingSystemMock.createLogger();
+
+    const updated = await tagAlertsWithEmulation({
+      esClient,
+      alertIds: [],
+      metadata: { emulationId: 'emu-empty', mode: 'test' },
+      alertsIndex: TEST_ALERTS_INDEX,
+      logger,
+    });
+
+    expect(updated).toBe(0);
+    expect(mockUpdateByQuery).not.toHaveBeenCalled();
+  });
+
+  it('tagged alerts are identified by extractEmulationMetadata and isEmulationAlert', () => {
+    const alertDoc = {
+      [ALERT_EMULATION_ID]: 'emu-meta',
+      [ALERT_EMULATION_MODE]: 'validation',
+    };
+
+    expect(isEmulationAlert(alertDoc)).toBe(true);
+    expect(extractEmulationMetadata(alertDoc)).toEqual({
+      emulationId: 'emu-meta',
+      mode: 'validation',
+    });
+  });
+
+  it('non-tagged alerts are not identified as emulation alerts', () => {
+    const alertDoc = {
+      '@timestamp': new Date().toISOString(),
+      'kibana.alert.uuid': 'untagged-alert',
+    };
+
+    expect(isEmulationAlert(alertDoc)).toBe(false);
+    expect(extractEmulationMetadata(alertDoc)).toBeUndefined();
+  });
+});
+
+// ─── Audit logger round-trip (pure functions, no ES needed) ──────────────────
+
+describe('detection_emulation — audit logger reason round-trip', () => {
+  it('parseEmulationReason recovers the emulationId built by buildEmulationReason', () => {
+    const emulationId = 'emulation-12345-abcde';
+    const reason = buildEmulationReason(emulationId);
+    expect(parseEmulationReason(reason)).toBe(emulationId);
+  });
+
+  it('isEmulationReason is true for reasons produced by buildEmulationReason', () => {
+    const reason = buildEmulationReason('emu-xyz');
+    expect(isEmulationReason(reason)).toBe(true);
+  });
+
+  it('isEmulationReason is false for unrelated reason strings', () => {
+    expect(isEmulationReason('user-initiated')).toBe(false);
+    expect(isEmulationReason('')).toBe(false);
+    expect(isEmulationReason('emulation')).toBe(false);
+  });
+
+  it('buildEmulationComment embeds emulationId and command', () => {
+    const comment = buildEmulationComment('emu-001', 'execute');
+    expect(comment).toContain('emu-001');
+    expect(comment).toContain('execute');
+  });
+
+  it('buildEmulationComment appends userComment when provided', () => {
+    const comment = buildEmulationComment('emu-001', 'kill-process', 'analyst note');
+    expect(comment).toContain('analyst note');
+  });
+
+  it('reason format is stable (prefix: emulation:<id>)', () => {
+    expect(buildEmulationReason('abc-123')).toBe('emulation:abc-123');
+  });
+});
+
+// ─── Guard chain integration: allowlist + rate limiter ───────────────────────
+
+describe('detection_emulation — guard chain (allowlist + rate limiter)', () => {
+  const makeLogger = () => loggingSystemMock.createLogger();
+
+  it('allows a command when both allowlist and rate limiter pass', () => {
+    const allowlist = new EmulationAllowlist(
+      createRestrictiveAllowlistConfig(['endpoint-1']),
+      makeLogger()
+    );
+    const rateLimiter = new EmulationRateLimiter(createDefaultRateLimiterConfig(), makeLogger());
+
+    const allowlistResult = allowlist.validate(['endpoint-1']);
+    expect(allowlistResult.allowed).toBe(true);
+
+    const rateResult = rateLimiter.checkAndRecord('space-1', 'emu-1', 'execute');
+    expect(rateResult.allowed).toBe(true);
+  });
+
+  it('blocks at the allowlist before consulting the rate limiter', () => {
+    const allowlist = new EmulationAllowlist(
+      createRestrictiveAllowlistConfig(['endpoint-allowed']),
+      makeLogger()
+    );
+    const rateLimiter = new EmulationRateLimiter(createDefaultRateLimiterConfig(), makeLogger());
+
+    const allowlistResult = allowlist.validate(['endpoint-not-in-list']);
+    expect(allowlistResult.allowed).toBe(false);
+    expect(allowlistResult.blockedEndpoints).toEqual(['endpoint-not-in-list']);
+
+    // Rate limiter is not consulted — count stays 0.
+    expect(rateLimiter.getCurrentCount('space-1')).toBe(0);
+  });
+
+  it('blocks when the rate limit is exceeded even though all endpoints are allowed', () => {
+    const allowlist = new EmulationAllowlist(createDefaultAllowlistConfig(), makeLogger());
+    const rateLimiter = new EmulationRateLimiter(
+      { maxCommands: 2, windowMs: 60_000, disabled: false },
+      makeLogger()
+    );
+
+    // Exhaust the rate limit.
+    rateLimiter.record('space-1', 'emu-A', 'execute');
+    rateLimiter.record('space-1', 'emu-A', 'kill-process');
+
+    const allowlistResult = allowlist.validate(['endpoint-1']);
+    expect(allowlistResult.allowed).toBe(true);
+
+    const rateResult = rateLimiter.check('space-1');
+    expect(rateResult.allowed).toBe(false);
+    expect(rateResult.currentCount).toBe(2);
+    expect(rateResult.maxCommands).toBe(2);
+  });
+
+  it('rate limiter state is isolated per space', () => {
+    const rateLimiter = new EmulationRateLimiter(
+      { maxCommands: 1, windowMs: 60_000, disabled: false },
+      makeLogger()
+    );
+
+    rateLimiter.record('space-A', 'emu-1', 'execute');
+
+    // space-A is now at the limit.
+    expect(rateLimiter.check('space-A').allowed).toBe(false);
+    // space-B is unaffected.
+    expect(rateLimiter.check('space-B').allowed).toBe(true);
+  });
+
+  it('allowlist.addEndpoint unblocks a previously blocked endpoint', () => {
+    const allowlist = new EmulationAllowlist(
+      createRestrictiveAllowlistConfig(['endpoint-original']),
+      makeLogger()
+    );
+
+    expect(allowlist.validate(['endpoint-new']).allowed).toBe(false);
+
+    allowlist.addEndpoint('endpoint-new');
+    expect(allowlist.validate(['endpoint-new']).allowed).toBe(true);
+  });
+
+  it('a command passing all guards leaves rate limiter count incremented', () => {
+    const allowlist = new EmulationAllowlist(createDefaultAllowlistConfig(), makeLogger());
+    const rateLimiter = new EmulationRateLimiter(
+      { maxCommands: 10, windowMs: 60_000, disabled: false },
+      makeLogger()
+    );
+    const spaceId = 'space-1';
+
+    // Simulate the route handler gate sequence.
+    expect(allowlist.validate(['ep-1']).allowed).toBe(true);
+    const rateResult = rateLimiter.checkAndRecord(spaceId, 'emu-1', 'scan');
+    expect(rateResult.allowed).toBe(true);
+
+    expect(rateLimiter.getCurrentCount(spaceId)).toBe(1);
+  });
+
+  it('disabled rate limiter always allows regardless of recorded commands', () => {
+    const rateLimiter = new EmulationRateLimiter(
+      { maxCommands: 1, windowMs: 60_000, disabled: true },
+      makeLogger()
+    );
+
+    rateLimiter.record('space-1', 'emu-1', 'execute');
+    rateLimiter.record('space-1', 'emu-1', 'execute');
+    rateLimiter.record('space-1', 'emu-1', 'execute');
+
+    expect(rateLimiter.check('space-1').allowed).toBe(true);
+  });
+});
+
+// ─── EmulationRunner happy path: endpoint agent type ─────────────────────────
+
+describe('detection_emulation — EmulationRunner happy path (endpoint agent type)', () => {
+  const MOCK_ACTION_ID = 'action-id-from-mock';
+
+  beforeEach(() => {
+    mockGetActionDetailsById.mockResolvedValue({
+      id: MOCK_ACTION_ID,
+      agents: ['1-2-3'],
+      hosts: { '1-2-3': { name: 'test-host' } },
+      command: 'execute',
+      isExpired: false,
+      isCompleted: false,
+      wasSuccessful: false,
+      errors: undefined,
+      startedAt: new Date().toISOString(),
+      completedAt: undefined,
+      agentState: {},
+      status: 'pending',
+      createdBy: 'foo',
+      agentType: 'endpoint',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches an execute command for endpoint agent type and returns dispatched status', async () => {
+    const constructorOptions = endpointActionClientMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    (
+      constructorOptions.endpointService.getInternalFleetServices()
+        .ensureInCurrentSpace as jest.Mock
+    ).mockResolvedValue(undefined);
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-endpoint-happy-001',
+      agentType: 'endpoint',
+      endpointIds: ['1-2-3'],
+      command: 'execute',
+      parameters: { command: 'ls -ltr' },
+    });
+
+    expect(result.status).toBe('dispatched');
+    expect(result.agentType).toBe('endpoint');
+    expect(result.command).toBe('execute');
+    expect(result.actionId).toBe(MOCK_ACTION_ID);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns error status when the endpoint client rejects', async () => {
+    const constructorOptions = endpointActionClientMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    (
+      constructorOptions.endpointService.getInternalFleetServices()
+        .ensureInCurrentSpace as jest.Mock
+    ).mockRejectedValue(new Error('fleet unavailable'));
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-endpoint-error-001',
+      agentType: 'endpoint',
+      endpointIds: ['1-2-3'],
+      command: 'execute',
+      parameters: { command: 'ls -ltr' },
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('fleet unavailable');
+    expect(result.actionId).toBe('');
+  });
+
+  it('throws for an unsupported agentType', async () => {
+    const constructorOptions = endpointActionClientMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      username: constructorOptions.username,
+      logger,
+    });
+
+    await expect(
+      runner.run({
+        emulationId: 'emu-bad-agent',
+        agentType: 'unknown-agent' as ResponseActionAgentType,
+        endpointIds: ['1-2-3'],
+        command: 'isolate',
+      })
+    ).rejects.toThrow('is not supported');
+  });
+});
+
+// ─── EmulationRunner happy path: sentinel_one agent type ─────────────────────
+
+describe('detection_emulation — EmulationRunner happy path (sentinel_one agent type)', () => {
+  const MOCK_ACTION_ID = 'action-id-from-mock';
+
+  beforeEach(() => {
+    mockGetActionDetailsById.mockResolvedValue({
+      id: MOCK_ACTION_ID,
+      agents: ['1-2-3'],
+      hosts: { '1-2-3': { name: 'sentinelone-1460' } },
+      command: 'isolate',
+      isExpired: false,
+      isCompleted: false,
+      wasSuccessful: false,
+      errors: undefined,
+      startedAt: new Date().toISOString(),
+      completedAt: undefined,
+      agentState: {},
+      status: 'pending',
+      createdBy: 'foo',
+      agentType: 'sentinel_one',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches an isolate command for sentinel_one agent type and returns dispatched status', async () => {
+    const constructorOptions = sentinelOneMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      connectorActions: constructorOptions.connectorActions,
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-s1-happy-001',
+      agentType: 'sentinel_one',
+      endpointIds: ['1-2-3'],
+      command: 'isolate',
+    });
+
+    expect(result.status).toBe('dispatched');
+    expect(result.agentType).toBe('sentinel_one');
+    expect(result.command).toBe('isolate');
+    expect(result.actionId).toBe(MOCK_ACTION_ID);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns error status when the sentinel_one connector rejects', async () => {
+    const constructorOptions = sentinelOneMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    (constructorOptions.connectorActions.execute as jest.Mock).mockRejectedValue(
+      new Error('connector unavailable')
+    );
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      connectorActions: constructorOptions.connectorActions,
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-s1-error-001',
+      agentType: 'sentinel_one',
+      endpointIds: ['1-2-3'],
+      command: 'isolate',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('connector unavailable');
+    expect(result.actionId).toBe('');
+  });
+
+  it('returns error status when no sentinel_one connector is configured in the space', async () => {
+    const constructorOptions = sentinelOneMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    // Simulate a space with no sentinel_one connector by returning an empty connector list.
+    // NormalizedExternalConnectorClient.getConnectorInstance() throws
+    // ResponseActionsConnectorNotConfiguredError when getAll() yields no matching connector.
+    const emptyConnectorActionsClient = sentinelOneMock.createConnectorActionsClient();
+    (emptyConnectorActionsClient.getAll as jest.Mock).mockResolvedValue([]);
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      connectorActions: sentinelOneMock.createNormalizedExternalConnectorClient(
+        emptyConnectorActionsClient
+      ),
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-s1-no-connector-001',
+      agentType: 'sentinel_one',
+      endpointIds: ['1-2-3'],
+      command: 'isolate',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('No stack connector instance configured');
+    expect(result.actionId).toBe('');
+  });
+});
+
+// ─── EmulationRunner happy path: crowdstrike agent type ──────────────────────
+
+describe('detection_emulation — EmulationRunner happy path (crowdstrike agent type)', () => {
+  const MOCK_ACTION_ID = 'action-id-from-mock';
+
+  beforeEach(() => {
+    mockGetActionDetailsById.mockResolvedValue({
+      id: MOCK_ACTION_ID,
+      agents: ['1-2-3'],
+      hosts: { '1-2-3': { name: 'Crowdstrike-1460' } },
+      command: 'isolate',
+      isExpired: false,
+      isCompleted: false,
+      wasSuccessful: false,
+      errors: undefined,
+      startedAt: new Date().toISOString(),
+      completedAt: undefined,
+      agentState: {},
+      status: 'pending',
+      createdBy: 'foo',
+      agentType: 'crowdstrike',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches an isolate command for crowdstrike agent type and returns dispatched status', async () => {
+    const constructorOptions = CrowdstrikeMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    // CrowdstrikeActionsClient.writeActionRequestToEndpointIndex calls getHostNameByAgentId,
+    // which searches on the raw 'logs-crowdstrike*' pattern (not the namespaced pattern).
+    // We need to intercept that search and return a response with a host name, otherwise
+    // the client throws "Host name not found in the event document".
+    const priorSearchImpl = constructorOptions.esClient.search.getMockImplementation();
+    constructorOptions.esClient.search.mockImplementation(async (...args) => {
+      const options = args[0];
+      if (options?.index?.[0] === 'logs-crowdstrike*') {
+        return CrowdstrikeMock.createEventSearchResponse();
+      }
+      if (priorSearchImpl) {
+        return priorSearchImpl(...args);
+      }
+      return BaseDataGenerator.toEsSearchResponse([]);
+    });
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      connectorActions: constructorOptions.connectorActions,
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-cs-happy-001',
+      agentType: 'crowdstrike',
+      endpointIds: ['1-2-3'],
+      command: 'isolate',
+    });
+
+    expect(result.status).toBe('dispatched');
+    expect(result.agentType).toBe('crowdstrike');
+    expect(result.command).toBe('isolate');
+    expect(result.actionId).toBe(MOCK_ACTION_ID);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns error status when the crowdstrike connector rejects', async () => {
+    const constructorOptions = CrowdstrikeMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    (constructorOptions.connectorActions.execute as jest.Mock).mockRejectedValue(
+      new Error('connector unavailable')
+    );
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      connectorActions: constructorOptions.connectorActions,
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-cs-error-001',
+      agentType: 'crowdstrike',
+      endpointIds: ['1-2-3'],
+      command: 'isolate',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('connector unavailable');
+    expect(result.actionId).toBe('');
+  });
+});
+
+// ─── EmulationRunner happy path: microsoft_defender_endpoint agent type ───────
+
+describe('detection_emulation — EmulationRunner happy path (microsoft_defender_endpoint agent type)', () => {
+  const MOCK_ACTION_ID = 'action-id-from-mock';
+
+  beforeEach(() => {
+    mockGetActionDetailsById.mockResolvedValue({
+      id: MOCK_ACTION_ID,
+      agents: ['1-2-3'],
+      hosts: { '1-2-3': { name: 'mymachine1.contoso.com' } },
+      command: 'isolate',
+      isExpired: false,
+      isCompleted: false,
+      wasSuccessful: false,
+      errors: undefined,
+      startedAt: new Date().toISOString(),
+      completedAt: undefined,
+      agentState: {},
+      status: 'pending',
+      createdBy: 'foo',
+      agentType: 'microsoft_defender_endpoint',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches an isolate command for microsoft_defender_endpoint agent type and returns dispatched status', async () => {
+    const constructorOptions = microsoftDefenderMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      connectorActions: constructorOptions.connectorActions,
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-mde-happy-001',
+      agentType: 'microsoft_defender_endpoint',
+      endpointIds: ['1-2-3'],
+      command: 'isolate',
+    });
+
+    expect(result.status).toBe('dispatched');
+    expect(result.agentType).toBe('microsoft_defender_endpoint');
+    expect(result.command).toBe('isolate');
+    expect(result.actionId).toBe(MOCK_ACTION_ID);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns error status when the microsoft_defender_endpoint connector rejects', async () => {
+    const constructorOptions = microsoftDefenderMock.createConstructorOptions();
+    const logger = loggingSystemMock.createLogger();
+
+    (constructorOptions.connectorActions.execute as jest.Mock).mockRejectedValue(
+      new Error('connector unavailable')
+    );
+
+    const runner = new EmulationRunner({
+      endpointService: constructorOptions.endpointService,
+      esClient: constructorOptions.esClient as unknown as ElasticsearchClient,
+      spaceId: constructorOptions.spaceId,
+      casesClient: constructorOptions.casesClient,
+      username: constructorOptions.username,
+      connectorActions: constructorOptions.connectorActions,
+      logger,
+    });
+
+    const result = await runner.run({
+      emulationId: 'emu-mde-error-001',
+      agentType: 'microsoft_defender_endpoint',
+      endpointIds: ['1-2-3'],
+      command: 'isolate',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('connector unavailable');
+    expect(result.actionId).toBe('');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/allowlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/allowlist.ts
@@ -10,20 +10,14 @@ import type { Logger } from '@kbn/core/server';
 /**
  * Configuration for the emulation host allowlist.
  *
- * The allowlist restricts which endpoints can be targeted by emulation commands,
- * providing an additional safety layer beyond RBAC and feature flags.
+ * The allowlist restricts which endpoints can be targeted by emulation
+ * commands, providing an additional safety layer beyond the feature
+ * flag, RBAC, and rate limiter.
  */
 export interface EmulationAllowlistConfig {
-  /**
-   * When true, all endpoints are allowed (allowlist is disabled).
-   * When false, only endpoints in the allowedHosts set are permitted.
-   */
+  /** When `true`, all endpoints are allowed (allowlist disabled). */
   allowAll: boolean;
-
-  /**
-   * Set of allowed endpoint IDs or host identifiers.
-   * Only used when allowAll is false.
-   */
+  /** Endpoint IDs allowed when `allowAll` is `false`. */
   allowedHosts: Set<string>;
 }
 
@@ -31,69 +25,42 @@ export interface EmulationAllowlistConfig {
  * Result of an allowlist validation check.
  */
 export interface AllowlistValidationResult {
-  /**
-   * True if all endpoints are allowed, false if any are blocked.
-   */
+  /** True if every endpoint is permitted. */
   allowed: boolean;
-
-  /**
-   * List of endpoint IDs that were blocked by the allowlist.
-   */
+  /** Endpoint IDs that were blocked (empty when `allowed === true`). */
   blockedEndpoints: string[];
-
-  /**
-   * Optional error message if validation failed.
-   */
+  /** Optional human-readable error message. */
   error?: string;
 }
 
 /**
  * Host allowlist validator for detection emulation commands.
  *
- * This provides an additional security control by restricting which endpoints
- * can be targeted by emulation commands. It works alongside:
- * - Feature flag (wholesale enable/disable)
- * - Per-command RBAC (authorization control)
- * - Rate limiter (temporal throttling)
- * - Audit logger (tracking and accountability)
- *
- * The allowlist can be configured to:
- * - Allow all endpoints (allowAll: true) - useful for testing/development
- * - Restrict to specific endpoint IDs (allowAll: false, with allowedHosts set)
+ * Today the route only consumes `validate(endpointIds)`. Mutators
+ * (`addEndpoint`, `setAllowAll`, etc.) were removed because the
+ * allowlist is constructed once per route registration from immutable
+ * config — there is no caller that mutates it at runtime.
  */
 export class EmulationAllowlist {
-  private readonly config: EmulationAllowlistConfig;
-  private readonly logger: Logger;
-
-  constructor(config: EmulationAllowlistConfig, logger: Logger) {
-    this.config = config;
-    this.logger = logger;
-
+  constructor(private readonly config: EmulationAllowlistConfig, private readonly logger: Logger) {
     this.logger.debug(
       `Emulation allowlist initialized: allowAll=${config.allowAll}, allowed hosts count=${config.allowedHosts.size}`
     );
   }
 
   /**
-   * Validate that all endpoint IDs are allowed by the allowlist.
-   *
-   * @param endpointIds - Array of endpoint IDs to validate
-   * @returns Validation result indicating allowed status and any blocked endpoints
+   * Validate that every `endpointId` is allowed by the configured
+   * allowlist. Returns the full set of blocked endpoints (not just the
+   * first) so the caller can surface them all in one error response.
    */
   validate(endpointIds: string[]): AllowlistValidationResult {
-    // If allowAll is enabled, permit all endpoints
     if (this.config.allowAll) {
       this.logger.debug(
         `Allowlist check passed: allowAll is enabled for ${endpointIds.length} endpoint(s)`
       );
-
-      return {
-        allowed: true,
-        blockedEndpoints: [],
-      };
+      return { allowed: true, blockedEndpoints: [] };
     }
 
-    // Check each endpoint against the allowlist
     const blockedEndpoints = endpointIds.filter(
       (endpointId) => !this.config.allowedHosts.has(endpointId)
     );
@@ -102,149 +69,32 @@ export class EmulationAllowlist {
       const error = `Emulation blocked: ${
         blockedEndpoints.length
       } endpoint(s) not in allowlist: [${blockedEndpoints.join(', ')}]`;
-
       this.logger.warn(error);
-
-      return {
-        allowed: false,
-        blockedEndpoints,
-        error,
-      };
+      return { allowed: false, blockedEndpoints, error };
     }
 
     this.logger.debug(
       `Allowlist check passed: all ${endpointIds.length} endpoint(s) are in allowlist`
     );
-
-    return {
-      allowed: true,
-      blockedEndpoints: [],
-    };
-  }
-
-  /**
-   * Add an endpoint ID to the allowlist.
-   * Only takes effect when allowAll is false.
-   *
-   * @param endpointId - Endpoint ID to add to allowlist
-   */
-  addEndpoint(endpointId: string): void {
-    if (this.config.allowAll) {
-      this.logger.debug(`Skipping add to allowlist: allowAll is enabled (endpoint: ${endpointId})`);
-      return;
-    }
-
-    this.config.allowedHosts.add(endpointId);
-    this.logger.debug(`Added endpoint to allowlist: ${endpointId}`);
-  }
-
-  /**
-   * Remove an endpoint ID from the allowlist.
-   * Only takes effect when allowAll is false.
-   *
-   * @param endpointId - Endpoint ID to remove from allowlist
-   */
-  removeEndpoint(endpointId: string): void {
-    if (this.config.allowAll) {
-      this.logger.debug(
-        `Skipping remove from allowlist: allowAll is enabled (endpoint: ${endpointId})`
-      );
-      return;
-    }
-
-    this.config.allowedHosts.delete(endpointId);
-    this.logger.debug(`Removed endpoint from allowlist: ${endpointId}`);
-  }
-
-  /**
-   * Check if a specific endpoint is allowed.
-   *
-   * @param endpointId - Endpoint ID to check
-   * @returns True if the endpoint is allowed, false otherwise
-   */
-  isEndpointAllowed(endpointId: string): boolean {
-    if (this.config.allowAll) {
-      return true;
-    }
-
-    return this.config.allowedHosts.has(endpointId);
-  }
-
-  /**
-   * Get the current allowlist configuration.
-   * Returns a copy to prevent external mutation.
-   *
-   * @returns Current allowlist configuration
-   */
-  getConfig(): Readonly<EmulationAllowlistConfig> {
-    return {
-      allowAll: this.config.allowAll,
-      allowedHosts: new Set(this.config.allowedHosts),
-    };
-  }
-
-  /**
-   * Update the allowAll flag.
-   * When set to true, all endpoints are permitted regardless of the allowedHosts set.
-   *
-   * @param allowAll - New value for allowAll flag
-   */
-  setAllowAll(allowAll: boolean): void {
-    const previous = this.config.allowAll;
-    this.config.allowAll = allowAll;
-
-    this.logger.info(`Emulation allowlist allowAll flag changed: ${previous} -> ${allowAll}`);
-  }
-
-  /**
-   * Clear all entries from the allowlist.
-   * Does not affect the allowAll flag.
-   */
-  clearAllowlist(): void {
-    const previousSize = this.config.allowedHosts.size;
-    this.config.allowedHosts.clear();
-
-    this.logger.info(`Emulation allowlist cleared (removed ${previousSize} entries)`);
-  }
-
-  /**
-   * Get the number of endpoints in the allowlist.
-   * Returns 0 if allowAll is enabled (since the allowlist is not consulted).
-   *
-   * @returns Number of allowed endpoints
-   */
-  getAllowedEndpointCount(): number {
-    if (this.config.allowAll) {
-      return 0; // Allowlist is not used when allowAll is enabled
-    }
-
-    return this.config.allowedHosts.size;
+    return { allowed: true, blockedEndpoints: [] };
   }
 }
 
 /**
- * Create a default emulation allowlist configuration.
- * By default, the allowlist permits all endpoints (allowAll: true).
- *
- * @returns Default allowlist configuration
+ * Default config: permit any endpoint. The route falls back to this
+ * when no override is supplied. Intended for local dev / tests; once
+ * the feature graduates from experimental this should be replaced with
+ * a config-driven `createRestrictiveAllowlistConfig` (see N7).
  */
 export function createDefaultAllowlistConfig(): EmulationAllowlistConfig {
-  return {
-    allowAll: true,
-    allowedHosts: new Set(),
-  };
+  return { allowAll: true, allowedHosts: new Set() };
 }
 
 /**
- * Create an emulation allowlist with specific allowed endpoints.
- * Sets allowAll to false and populates the allowedHosts set.
- *
- * @param endpointIds - Array of endpoint IDs to allow
- * @returns Allowlist configuration with specified endpoints
+ * Restrictive config: only permit the supplied endpoint IDs. Used by
+ * tests to assert the blocking branch and (eventually) by config
+ * wiring once the user-supplied allowlist lands.
  */
 export function createRestrictiveAllowlistConfig(endpointIds: string[]): EmulationAllowlistConfig {
-  return {
-    allowAll: false,
-    allowedHosts: new Set(endpointIds),
-  };
+  return { allowAll: false, allowedHosts: new Set(endpointIds) };
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/allowlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/allowlist.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+
+/**
+ * Configuration for the emulation host allowlist.
+ *
+ * The allowlist restricts which endpoints can be targeted by emulation commands,
+ * providing an additional safety layer beyond RBAC and feature flags.
+ */
+export interface EmulationAllowlistConfig {
+  /**
+   * When true, all endpoints are allowed (allowlist is disabled).
+   * When false, only endpoints in the allowedHosts set are permitted.
+   */
+  allowAll: boolean;
+
+  /**
+   * Set of allowed endpoint IDs or host identifiers.
+   * Only used when allowAll is false.
+   */
+  allowedHosts: Set<string>;
+}
+
+/**
+ * Result of an allowlist validation check.
+ */
+export interface AllowlistValidationResult {
+  /**
+   * True if all endpoints are allowed, false if any are blocked.
+   */
+  allowed: boolean;
+
+  /**
+   * List of endpoint IDs that were blocked by the allowlist.
+   */
+  blockedEndpoints: string[];
+
+  /**
+   * Optional error message if validation failed.
+   */
+  error?: string;
+}
+
+/**
+ * Host allowlist validator for detection emulation commands.
+ *
+ * This provides an additional security control by restricting which endpoints
+ * can be targeted by emulation commands. It works alongside:
+ * - Feature flag (wholesale enable/disable)
+ * - Per-command RBAC (authorization control)
+ * - Rate limiter (temporal throttling)
+ * - Audit logger (tracking and accountability)
+ *
+ * The allowlist can be configured to:
+ * - Allow all endpoints (allowAll: true) - useful for testing/development
+ * - Restrict to specific endpoint IDs (allowAll: false, with allowedHosts set)
+ */
+export class EmulationAllowlist {
+  private readonly config: EmulationAllowlistConfig;
+  private readonly logger: Logger;
+
+  constructor(config: EmulationAllowlistConfig, logger: Logger) {
+    this.config = config;
+    this.logger = logger;
+
+    this.logger.debug(
+      `Emulation allowlist initialized: allowAll=${config.allowAll}, allowed hosts count=${config.allowedHosts.size}`
+    );
+  }
+
+  /**
+   * Validate that all endpoint IDs are allowed by the allowlist.
+   *
+   * @param endpointIds - Array of endpoint IDs to validate
+   * @returns Validation result indicating allowed status and any blocked endpoints
+   */
+  validate(endpointIds: string[]): AllowlistValidationResult {
+    // If allowAll is enabled, permit all endpoints
+    if (this.config.allowAll) {
+      this.logger.debug(
+        `Allowlist check passed: allowAll is enabled for ${endpointIds.length} endpoint(s)`
+      );
+
+      return {
+        allowed: true,
+        blockedEndpoints: [],
+      };
+    }
+
+    // Check each endpoint against the allowlist
+    const blockedEndpoints = endpointIds.filter(
+      (endpointId) => !this.config.allowedHosts.has(endpointId)
+    );
+
+    if (blockedEndpoints.length > 0) {
+      const error = `Emulation blocked: ${
+        blockedEndpoints.length
+      } endpoint(s) not in allowlist: [${blockedEndpoints.join(', ')}]`;
+
+      this.logger.warn(error);
+
+      return {
+        allowed: false,
+        blockedEndpoints,
+        error,
+      };
+    }
+
+    this.logger.debug(
+      `Allowlist check passed: all ${endpointIds.length} endpoint(s) are in allowlist`
+    );
+
+    return {
+      allowed: true,
+      blockedEndpoints: [],
+    };
+  }
+
+  /**
+   * Add an endpoint ID to the allowlist.
+   * Only takes effect when allowAll is false.
+   *
+   * @param endpointId - Endpoint ID to add to allowlist
+   */
+  addEndpoint(endpointId: string): void {
+    if (this.config.allowAll) {
+      this.logger.debug(`Skipping add to allowlist: allowAll is enabled (endpoint: ${endpointId})`);
+      return;
+    }
+
+    this.config.allowedHosts.add(endpointId);
+    this.logger.debug(`Added endpoint to allowlist: ${endpointId}`);
+  }
+
+  /**
+   * Remove an endpoint ID from the allowlist.
+   * Only takes effect when allowAll is false.
+   *
+   * @param endpointId - Endpoint ID to remove from allowlist
+   */
+  removeEndpoint(endpointId: string): void {
+    if (this.config.allowAll) {
+      this.logger.debug(
+        `Skipping remove from allowlist: allowAll is enabled (endpoint: ${endpointId})`
+      );
+      return;
+    }
+
+    this.config.allowedHosts.delete(endpointId);
+    this.logger.debug(`Removed endpoint from allowlist: ${endpointId}`);
+  }
+
+  /**
+   * Check if a specific endpoint is allowed.
+   *
+   * @param endpointId - Endpoint ID to check
+   * @returns True if the endpoint is allowed, false otherwise
+   */
+  isEndpointAllowed(endpointId: string): boolean {
+    if (this.config.allowAll) {
+      return true;
+    }
+
+    return this.config.allowedHosts.has(endpointId);
+  }
+
+  /**
+   * Get the current allowlist configuration.
+   * Returns a copy to prevent external mutation.
+   *
+   * @returns Current allowlist configuration
+   */
+  getConfig(): Readonly<EmulationAllowlistConfig> {
+    return {
+      allowAll: this.config.allowAll,
+      allowedHosts: new Set(this.config.allowedHosts),
+    };
+  }
+
+  /**
+   * Update the allowAll flag.
+   * When set to true, all endpoints are permitted regardless of the allowedHosts set.
+   *
+   * @param allowAll - New value for allowAll flag
+   */
+  setAllowAll(allowAll: boolean): void {
+    const previous = this.config.allowAll;
+    this.config.allowAll = allowAll;
+
+    this.logger.info(`Emulation allowlist allowAll flag changed: ${previous} -> ${allowAll}`);
+  }
+
+  /**
+   * Clear all entries from the allowlist.
+   * Does not affect the allowAll flag.
+   */
+  clearAllowlist(): void {
+    const previousSize = this.config.allowedHosts.size;
+    this.config.allowedHosts.clear();
+
+    this.logger.info(`Emulation allowlist cleared (removed ${previousSize} entries)`);
+  }
+
+  /**
+   * Get the number of endpoints in the allowlist.
+   * Returns 0 if allowAll is enabled (since the allowlist is not consulted).
+   *
+   * @returns Number of allowed endpoints
+   */
+  getAllowedEndpointCount(): number {
+    if (this.config.allowAll) {
+      return 0; // Allowlist is not used when allowAll is enabled
+    }
+
+    return this.config.allowedHosts.size;
+  }
+}
+
+/**
+ * Create a default emulation allowlist configuration.
+ * By default, the allowlist permits all endpoints (allowAll: true).
+ *
+ * @returns Default allowlist configuration
+ */
+export function createDefaultAllowlistConfig(): EmulationAllowlistConfig {
+  return {
+    allowAll: true,
+    allowedHosts: new Set(),
+  };
+}
+
+/**
+ * Create an emulation allowlist with specific allowed endpoints.
+ * Sets allowAll to false and populates the allowedHosts set.
+ *
+ * @param endpointIds - Array of endpoint IDs to allow
+ * @returns Allowlist configuration with specified endpoints
+ */
+export function createRestrictiveAllowlistConfig(endpointIds: string[]): EmulationAllowlistConfig {
+  return {
+    allowAll: false,
+    allowedHosts: new Set(endpointIds),
+  };
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/audit_logger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/audit_logger.ts
@@ -6,27 +6,27 @@
  */
 
 /**
- * Audit logger for detection emulation actions.
+ * Audit-trail comment helpers for detection emulation actions.
  *
- * This module wraps the existing response_actions audit trail with emulation-specific
- * context. It injects a structured reason field ('emulation:<emulationId>') into action
- * requests, enabling filtering and tracking of emulation actions in the audit trail.
+ * The runner injects the result of `buildEmulationComment` into the
+ * `comment` field of every Response Actions request. The comment lands
+ * in the response_actions audit trail, which is how operators trace a
+ * dispatched action back to the emulation that produced it.
  *
- * Key responsibilities:
- * - Format emulation context for audit trail (reason field injection)
- * - Provide consistent comment/reason format across all emulation actions
- * - Enable audit queries filtered by emulation ID
+ * (The previous version of this module also exported `buildEmulationReason`,
+ * `parseEmulationReason`, `isEmulationReason`, and `enrichWithEmulationContext`.
+ * They were never called by any production code and have been removed.
+ * Use `buildEmulationComment` for everything.)
  */
 
 /**
- * Builds a standardized comment string for emulation actions.
- * This comment appears in the response_actions audit trail and provides
- * human-readable context about the emulation command.
+ * Build a standardized comment string for an emulation-dispatched
+ * Response Action. The format is intentionally stable so audit
+ * consumers can grep for `Detection Emulation [<id>]:`.
  *
- * @param emulationId - The unique identifier for the emulation run
- * @param command - The command being executed (e.g., 'execute', 'kill-process')
- * @param userComment - Optional additional comment from the user
- * @returns Formatted comment string for audit trail
+ * @param emulationId - unique identifier for the emulation run
+ * @param command - the response-action command being dispatched
+ * @param userComment - optional caller-supplied note to append
  */
 export function buildEmulationComment(
   emulationId: string,
@@ -35,64 +35,4 @@ export function buildEmulationComment(
 ): string {
   const baseComment = `Detection Emulation [${emulationId}]: ${command}`;
   return userComment ? `${baseComment} - ${userComment}` : baseComment;
-}
-
-/**
- * Builds a structured reason identifier for emulation actions.
- * This reason field is used for filtering response actions by emulation ID
- * in the audit trail and can be parsed to extract the emulation ID.
- *
- * Format: 'emulation:<emulationId>'
- *
- * @param emulationId - The unique identifier for the emulation run
- * @returns Structured reason string
- */
-export function buildEmulationReason(emulationId: string): string {
-  return `emulation:${emulationId}`;
-}
-
-/**
- * Extracts the emulation ID from a reason string.
- * Used for parsing audit trail entries to identify emulation actions.
- *
- * @param reason - The reason string from an action request (e.g., 'emulation:abc-123')
- * @returns The emulation ID if the reason is valid, undefined otherwise
- */
-export function parseEmulationReason(reason: string): string | undefined {
-  const match = reason.match(/^emulation:(.+)$/);
-  return match?.[1];
-}
-
-/**
- * Checks if a reason string indicates an emulation action.
- *
- * @param reason - The reason string to check
- * @returns True if the reason indicates an emulation action
- */
-export function isEmulationReason(reason: string): boolean {
-  return reason.startsWith('emulation:');
-}
-
-/**
- * Enriches action request parameters with emulation audit context.
- * This function adds the structured reason and comment fields that enable
- * emulation actions to be tracked in the response_actions audit trail.
- *
- * @param emulationId - The unique identifier for the emulation run
- * @param command - The command being executed
- * @param parameters - The original action parameters (may include user comment)
- * @returns Enriched parameters with audit context
- */
-export function enrichWithEmulationContext<T extends Record<string, unknown>>(
-  emulationId: string,
-  command: string,
-  parameters?: T
-): T & { comment: string; reason: string } {
-  const userComment = parameters?.comment as string | undefined;
-
-  return {
-    ...parameters,
-    comment: buildEmulationComment(emulationId, command, userComment),
-    reason: buildEmulationReason(emulationId),
-  } as T & { comment: string; reason: string };
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/audit_logger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/audit_logger.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Audit logger for detection emulation actions.
+ *
+ * This module wraps the existing response_actions audit trail with emulation-specific
+ * context. It injects a structured reason field ('emulation:<emulationId>') into action
+ * requests, enabling filtering and tracking of emulation actions in the audit trail.
+ *
+ * Key responsibilities:
+ * - Format emulation context for audit trail (reason field injection)
+ * - Provide consistent comment/reason format across all emulation actions
+ * - Enable audit queries filtered by emulation ID
+ */
+
+/**
+ * Builds a standardized comment string for emulation actions.
+ * This comment appears in the response_actions audit trail and provides
+ * human-readable context about the emulation command.
+ *
+ * @param emulationId - The unique identifier for the emulation run
+ * @param command - The command being executed (e.g., 'execute', 'kill-process')
+ * @param userComment - Optional additional comment from the user
+ * @returns Formatted comment string for audit trail
+ */
+export function buildEmulationComment(
+  emulationId: string,
+  command: string,
+  userComment?: string
+): string {
+  const baseComment = `Detection Emulation [${emulationId}]: ${command}`;
+  return userComment ? `${baseComment} - ${userComment}` : baseComment;
+}
+
+/**
+ * Builds a structured reason identifier for emulation actions.
+ * This reason field is used for filtering response actions by emulation ID
+ * in the audit trail and can be parsed to extract the emulation ID.
+ *
+ * Format: 'emulation:<emulationId>'
+ *
+ * @param emulationId - The unique identifier for the emulation run
+ * @returns Structured reason string
+ */
+export function buildEmulationReason(emulationId: string): string {
+  return `emulation:${emulationId}`;
+}
+
+/**
+ * Extracts the emulation ID from a reason string.
+ * Used for parsing audit trail entries to identify emulation actions.
+ *
+ * @param reason - The reason string from an action request (e.g., 'emulation:abc-123')
+ * @returns The emulation ID if the reason is valid, undefined otherwise
+ */
+export function parseEmulationReason(reason: string): string | undefined {
+  const match = reason.match(/^emulation:(.+)$/);
+  return match?.[1];
+}
+
+/**
+ * Checks if a reason string indicates an emulation action.
+ *
+ * @param reason - The reason string to check
+ * @returns True if the reason indicates an emulation action
+ */
+export function isEmulationReason(reason: string): boolean {
+  return reason.startsWith('emulation:');
+}
+
+/**
+ * Enriches action request parameters with emulation audit context.
+ * This function adds the structured reason and comment fields that enable
+ * emulation actions to be tracked in the response_actions audit trail.
+ *
+ * @param emulationId - The unique identifier for the emulation run
+ * @param command - The command being executed
+ * @param parameters - The original action parameters (may include user comment)
+ * @returns Enriched parameters with audit context
+ */
+export function enrichWithEmulationContext<T extends Record<string, unknown>>(
+  emulationId: string,
+  command: string,
+  parameters?: T
+): T & { comment: string; reason: string } {
+  const userComment = parameters?.comment as string | undefined;
+
+  return {
+    ...parameters,
+    comment: buildEmulationComment(emulationId, command, userComment),
+    reason: buildEmulationReason(emulationId),
+  } as T & { comment: string; reason: string };
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/errors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/errors.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable max-classes-per-file */
+import { RESPONSE_ACTION_AGENT_TYPE } from '../../../../common/endpoint/service/response_actions/constants';
+
+/**
+ * Typed error classes raised by the runner. The route maps each one to
+ * a 4xx status; anything else surfaces as a 500. Keeping the taxonomy
+ * here (instead of in the route) keeps it co-located with the code that
+ * raises the error and lets the agent-builder tool reuse the same
+ * mapping when it lands.
+ */
+export class UnsupportedAgentTypeError extends Error {
+  readonly code = 'UNSUPPORTED_AGENT_TYPE' as const;
+  constructor(agentType: string) {
+    super(
+      `Agent type [${agentType}] is not supported. Supported types: ${RESPONSE_ACTION_AGENT_TYPE.join(
+        ', '
+      )}`
+    );
+    this.name = 'UnsupportedAgentTypeError';
+  }
+}
+
+export class UnsupportedCommandForAgentTypeError extends Error {
+  readonly code = 'UNSUPPORTED_COMMAND_FOR_AGENT_TYPE' as const;
+  constructor(command: string, agentType: string) {
+    super(`Command [${command}] is not supported for agent type [${agentType}]`);
+    this.name = 'UnsupportedCommandForAgentTypeError';
+  }
+}
+
+export class MissingConnectorActionsError extends Error {
+  readonly code = 'MISSING_CONNECTOR_ACTIONS' as const;
+  constructor(agentType: string) {
+    super(
+      `Agent type [${agentType}] requires a connector-actions client which is not yet wired through the route. Use agentType=endpoint or pass connectorActions explicitly.`
+    );
+    this.name = 'MissingConnectorActionsError';
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/idempotency_cache.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/idempotency_cache.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { createHash } from 'crypto';
+
+/**
+ * Configuration for the in-memory idempotency cache.
+ */
+export interface EmulationIdempotencyCacheConfig {
+  /**
+   * How long, in milliseconds, to remember the result of a dispatch keyed by
+   * (spaceId, emulationId, command, sorted endpointIds). After this window
+   * elapses the same payload becomes a brand-new dispatch.
+   *
+   * Default 30 s — long enough to swallow a double-click, network retry, or
+   * "did the 502 actually go through" replay; short enough that an operator
+   * who genuinely wants to re-run the same command isn't blocked for long.
+   */
+  ttlMs: number;
+  /**
+   * Hard cap on the number of cached entries per space, evicted oldest-first.
+   * Prevents unbounded growth when the same emulation dispatches lots of
+   * distinct commands inside the TTL.
+   */
+  maxEntriesPerSpace: number;
+  /** When true, idempotency caching is disabled (every call dispatches). */
+  disabled: boolean;
+}
+
+/** Whatever the caller wants to remember and replay. */
+export interface CachedDispatchResult {
+  actionId: string;
+  agentType: string;
+  command: string;
+  /**
+   * Mirrors `RunEmulationResult.status` from the runner so we can replay the
+   * cached value into the same response shape without translation.
+   */
+  status: 'dispatched' | 'error';
+  /** Original `error` string, if any — replayed verbatim. */
+  error?: string;
+}
+
+interface CacheEntry {
+  /** Cached payload to return on a hit. */
+  result: CachedDispatchResult;
+  /** Wall-clock ms epoch when the entry expires. */
+  expiresAt: number;
+}
+
+/**
+ * Build the canonical key for a dispatch. Sorting `endpointIds` makes the
+ * cache invariant to argv ordering — `[a, b]` and `[b, a]` are the same
+ * intent and must hit the same slot.
+ *
+ * We hash the structured key with SHA-256 to keep the map keys short and
+ * non-PII (an endpointId is sometimes a hostname).
+ */
+export function buildIdempotencyKey(input: {
+  spaceId: string;
+  emulationId: string;
+  command: string;
+  agentType: string;
+  endpointIds: readonly string[];
+}): string {
+  const sortedEndpoints = [...input.endpointIds].sort();
+  const raw = JSON.stringify({
+    s: input.spaceId,
+    e: input.emulationId,
+    c: input.command,
+    a: input.agentType,
+    h: sortedEndpoints,
+  });
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+/**
+ * Per-space in-memory dedupe cache for emulation dispatches.
+ *
+ * Why in-memory and not, say, the SO type:
+ * - Idempotency only needs to span seconds, not deployments.
+ * - A round-trip to ES on every dispatch would dominate the cost of the
+ *   actual response action.
+ * - The trade-off is that a Kibana restart resets the cache, which is
+ *   fine for the "swallow a double-click" use case.
+ */
+export class EmulationIdempotencyCache {
+  private readonly entries: Map<string, Map<string, CacheEntry>> = new Map();
+
+  constructor(
+    private readonly config: EmulationIdempotencyCacheConfig,
+    private readonly logger: Logger
+  ) {
+    this.logger.debug(
+      `Emulation idempotency cache initialized: ttlMs=${config.ttlMs}, maxEntriesPerSpace=${config.maxEntriesPerSpace}, disabled=${config.disabled}`
+    );
+  }
+
+  /**
+   * Look up a previously cached dispatch result. Returns `undefined` if there
+   * is no live entry for the key. Side-effect: sweeps expired entries for the
+   * space on every read so the map stays bounded without a timer.
+   */
+  get(spaceId: string, key: string): CachedDispatchResult | undefined {
+    if (this.config.disabled) {
+      return undefined;
+    }
+    this.sweepExpired(spaceId);
+    const space = this.entries.get(spaceId);
+    const hit = space?.get(key);
+    if (!hit) {
+      return undefined;
+    }
+    if (hit.expiresAt <= Date.now()) {
+      space?.delete(key);
+      return undefined;
+    }
+    this.logger.debug(`Idempotency cache HIT (space=${spaceId}, key=${key.slice(0, 12)}…)`);
+    return hit.result;
+  }
+
+  /**
+   * Remember `result` for `(spaceId, key)` for `ttlMs`. If the per-space cap
+   * is exceeded after insertion, the oldest entry is evicted.
+   */
+  set(spaceId: string, key: string, result: CachedDispatchResult): void {
+    if (this.config.disabled) {
+      return;
+    }
+    let space = this.entries.get(spaceId);
+    if (!space) {
+      space = new Map();
+      this.entries.set(spaceId, space);
+    }
+    space.set(key, {
+      result,
+      expiresAt: Date.now() + this.config.ttlMs,
+    });
+    if (space.size > this.config.maxEntriesPerSpace) {
+      // Maps preserve insertion order — drop the oldest key.
+      const oldestKey = space.keys().next().value;
+      if (oldestKey !== undefined) {
+        space.delete(oldestKey);
+      }
+    }
+  }
+
+  private sweepExpired(spaceId: string): void {
+    const space = this.entries.get(spaceId);
+    if (!space || space.size === 0) {
+      return;
+    }
+    const now = Date.now();
+    for (const [key, entry] of space) {
+      if (entry.expiresAt <= now) {
+        space.delete(key);
+      }
+    }
+    if (space.size === 0) {
+      this.entries.delete(spaceId);
+    }
+  }
+}
+
+export function createDefaultIdempotencyCacheConfig(): EmulationIdempotencyCacheConfig {
+  return {
+    ttlMs: 30_000,
+    maxEntriesPerSpace: 256,
+    disabled: false,
+  };
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/index.ts
@@ -9,3 +9,4 @@ export * from './runner';
 export * from './allowlist';
 export * from './rate_limiter';
 export * from './audit_logger';
+export * from './idempotency_cache';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './runner';
+export * from './allowlist';
+export * from './rate_limiter';
+export * from './audit_logger';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/rate_limiter.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/rate_limiter.ts
@@ -9,55 +9,32 @@ import type { Logger } from '@kbn/core/server';
 
 /**
  * Configuration for the emulation rate limiter.
- *
- * The rate limiter provides temporal throttling to prevent abuse of emulation commands,
- * working alongside other safety controls (feature flag, RBAC, allowlist, audit log).
  */
 export interface EmulationRateLimiterConfig {
-  /**
-   * Maximum number of commands allowed within the time window.
-   */
+  /** Maximum number of commands allowed within the time window. */
   maxCommands: number;
-
-  /**
-   * Time window in milliseconds for rate limiting.
-   */
+  /** Time window in milliseconds for rate limiting. */
   windowMs: number;
-
-  /**
-   * When true, rate limiting is disabled (all commands are allowed).
-   */
+  /** When true, rate limiting is disabled (all commands are allowed). */
   disabled: boolean;
 }
 
 /**
- * Result of a rate limit check.
+ * Result of an `acquire()` attempt.
  */
-export interface RateLimitCheckResult {
-  /**
-   * True if the command is allowed, false if rate limit exceeded.
-   */
+export interface RateLimitAcquireResult {
+  /** True if the slot was reserved and the caller may proceed. */
   allowed: boolean;
-
-  /**
-   * Current count of commands in the time window.
-   */
+  /** Current count of commands in the time window after acquire. */
   currentCount: number;
-
-  /**
-   * Maximum allowed commands in the time window.
-   */
+  /** Maximum allowed commands in the time window. */
   maxCommands: number;
-
-  /**
-   * Time in milliseconds until the rate limit resets.
-   */
+  /** Time in milliseconds until the rate limit resets (only when blocked). */
   resetMs?: number;
-
-  /**
-   * Optional error message if rate limit is exceeded.
-   */
+  /** Optional error message if rate limit is exceeded. */
   error?: string;
+  /** Token for `release()` if the caller decides to undo the acquire. */
+  token?: AcquireToken;
 }
 
 /**
@@ -70,45 +47,51 @@ interface CommandEntry {
 }
 
 /**
- * Rate limiter for detection emulation commands.
+ * Opaque token that callers pass back to `release()` to undo a successful
+ * `acquire()`. Useful when downstream dispatch fails and the caller wants
+ * to release the reserved slot.
+ */
+export interface AcquireToken {
+  spaceId: string;
+  entry: CommandEntry;
+}
+
+/**
+ * Per-space sliding-window rate limiter for detection-emulation commands.
  *
- * This provides temporal throttling to prevent abuse of emulation commands.
- * It works alongside:
- * - Feature flag (wholesale enable/disable)
- * - Per-command RBAC (authorization control)
- * - Host allowlist (endpoint-level restrictions)
- * - Audit logger (tracking and accountability)
+ * The route invokes `acquire(spaceId, emulationId, command)` *before*
+ * dispatching to the runner. Acquire is atomic: it both checks the
+ * window and records the entry under one synchronous call, eliminating
+ * the check-then-act race that allowed the limit to be bypassed under
+ * concurrent requests on the original `check()` + `record()` API.
  *
- * The rate limiter tracks commands per space and enforces a sliding window
- * limit (e.g., 100 commands per hour).
+ * If dispatch fails the caller may pass the returned `token` back to
+ * `release()` to roll the count back down.
  */
 export class EmulationRateLimiter {
   private readonly config: EmulationRateLimiterConfig;
   private readonly logger: Logger;
-  private readonly commandHistory: Map<string, CommandEntry[]>;
+  private readonly commandHistory: Map<string, CommandEntry[]> = new Map();
 
   constructor(config: EmulationRateLimiterConfig, logger: Logger) {
     this.config = config;
     this.logger = logger;
-    this.commandHistory = new Map();
-
     this.logger.debug(
       `Emulation rate limiter initialized: maxCommands=${config.maxCommands}, windowMs=${config.windowMs}, disabled=${config.disabled}`
     );
   }
 
   /**
-   * Check if a command is allowed under the current rate limit.
-   * This method only checks, it does not record the command.
+   * Atomically reserve a slot in the current window for `spaceId`.
+   * Returns `{ allowed: true, token }` on success, or
+   * `{ allowed: false, ... }` if the window is exhausted.
    *
-   * @param spaceId - The space ID for rate limiting scope
-   * @returns Rate limit check result
+   * Hold the returned `token` if you need to call `release()` on
+   * downstream failure.
    */
-  check(spaceId: string): RateLimitCheckResult {
-    // If rate limiting is disabled, allow all commands
+  acquire(spaceId: string, emulationId: string, command: string): RateLimitAcquireResult {
     if (this.config.disabled) {
-      this.logger.debug(`Rate limit check passed: rate limiting is disabled for space ${spaceId}`);
-
+      this.logger.debug(`Rate limit acquire bypassed: rate limiting is disabled (${spaceId})`);
       return {
         allowed: true,
         currentCount: 0,
@@ -116,285 +99,104 @@ export class EmulationRateLimiter {
       };
     }
 
-    // Clean up expired entries for this space
     this.cleanupExpiredEntries(spaceId);
 
-    // Get current command count in the time window
-    const entries = this.commandHistory.get(spaceId) || [];
-    const currentCount = entries.length;
-
-    // Check if limit is exceeded
-    if (currentCount >= this.config.maxCommands) {
+    const entries = this.commandHistory.get(spaceId) ?? [];
+    if (entries.length >= this.config.maxCommands) {
       const oldestEntry = entries[0];
       const resetMs = oldestEntry
         ? Math.max(0, this.config.windowMs - (Date.now() - oldestEntry.timestamp))
         : 0;
-
-      const error = `Rate limit exceeded for space ${spaceId}: ${currentCount}/${this.config.maxCommands} commands in the last ${this.config.windowMs}ms. Reset in ${resetMs}ms.`;
-
+      const error = `Rate limit exceeded for space ${spaceId}: ${entries.length}/${this.config.maxCommands} commands in the last ${this.config.windowMs}ms. Reset in ${resetMs}ms.`;
       this.logger.warn(error);
-
       return {
         allowed: false,
-        currentCount,
+        currentCount: entries.length,
         maxCommands: this.config.maxCommands,
         resetMs,
         error,
       };
     }
 
-    this.logger.debug(
-      `Rate limit check passed for space ${spaceId}: ${currentCount}/${this.config.maxCommands} commands`
-    );
-
-    return {
-      allowed: true,
-      currentCount,
-      maxCommands: this.config.maxCommands,
-    };
-  }
-
-  /**
-   * Record a command execution for rate limiting.
-   * Should be called after successfully dispatching a command.
-   *
-   * @param spaceId - The space ID for rate limiting scope
-   * @param emulationId - The emulation ID
-   * @param command - The command that was executed
-   */
-  record(spaceId: string, emulationId: string, command: string): void {
-    if (this.config.disabled) {
-      this.logger.debug(
-        `Skipping rate limit record: rate limiting is disabled for space ${spaceId}`
-      );
-      return;
-    }
-
-    const entry: CommandEntry = {
-      timestamp: Date.now(),
-      emulationId,
-      command,
-    };
-
-    const entries = this.commandHistory.get(spaceId) || [];
+    const entry: CommandEntry = { timestamp: Date.now(), emulationId, command };
     entries.push(entry);
     this.commandHistory.set(spaceId, entries);
-
     this.logger.debug(
-      `Recorded command for rate limiting in space ${spaceId}: ${command} (emulation: ${emulationId}), total: ${entries.length}/${this.config.maxCommands}`
+      `Rate limit acquired for space ${spaceId}: ${entries.length}/${this.config.maxCommands}`
     );
+    return {
+      allowed: true,
+      currentCount: entries.length,
+      maxCommands: this.config.maxCommands,
+      token: { spaceId, entry },
+    };
   }
 
   /**
-   * Check and record a command in a single operation.
-   * This is a convenience method that combines check() and record().
-   *
-   * @param spaceId - The space ID for rate limiting scope
-   * @param emulationId - The emulation ID
-   * @param command - The command to check and record
-   * @returns Rate limit check result
+   * Release a slot previously reserved by `acquire()`. No-op if the
+   * token is missing, expired, or already removed.
    */
-  checkAndRecord(spaceId: string, emulationId: string, command: string): RateLimitCheckResult {
-    const result = this.check(spaceId);
-
-    if (result.allowed) {
-      this.record(spaceId, emulationId, command);
+  release(token?: AcquireToken): void {
+    if (!token || this.config.disabled) {
+      return;
     }
-
-    return result;
+    const entries = this.commandHistory.get(token.spaceId);
+    if (!entries) {
+      return;
+    }
+    const idx = entries.indexOf(token.entry);
+    if (idx === -1) {
+      return;
+    }
+    entries.splice(idx, 1);
+    if (entries.length === 0) {
+      this.commandHistory.delete(token.spaceId);
+    }
+    this.logger.debug(`Rate limit released for space ${token.spaceId}`);
   }
 
   /**
-   * Clean up expired command entries for a specific space.
-   * Removes entries older than the configured time window.
-   *
-   * @param spaceId - The space ID to clean up
+   * Test/debug helper: number of entries currently counted in the window
+   * for a space. Cleans up expired entries on read.
+   */
+  getCurrentCount(spaceId: string): number {
+    this.cleanupExpiredEntries(spaceId);
+    return this.commandHistory.get(spaceId)?.length ?? 0;
+  }
+
+  /**
+   * Drop entries older than `windowMs` for a given space. Called on every
+   * `acquire()` and `getCurrentCount()` so the window stays bounded
+   * without a separate timer.
    */
   private cleanupExpiredEntries(spaceId: string): void {
     const entries = this.commandHistory.get(spaceId);
     if (!entries || entries.length === 0) {
       return;
     }
-
     const cutoffTime = Date.now() - this.config.windowMs;
     const validEntries = entries.filter((entry) => entry.timestamp > cutoffTime);
-
-    if (validEntries.length !== entries.length) {
-      const removedCount = entries.length - validEntries.length;
-      this.logger.debug(
-        `Cleaned up ${removedCount} expired rate limit entries for space ${spaceId}`
-      );
-
-      if (validEntries.length === 0) {
-        this.commandHistory.delete(spaceId);
-      } else {
-        this.commandHistory.set(spaceId, validEntries);
-      }
+    if (validEntries.length === entries.length) {
+      return;
     }
-  }
-
-  /**
-   * Clean up all expired entries across all spaces.
-   * This should be called periodically to prevent memory leaks.
-   */
-  cleanupAllExpiredEntries(): void {
-    const spaceIds = Array.from(this.commandHistory.keys());
-    let totalRemoved = 0;
-
-    for (const spaceId of spaceIds) {
-      const beforeCount = this.commandHistory.get(spaceId)?.length || 0;
-      this.cleanupExpiredEntries(spaceId);
-      const afterCount = this.commandHistory.get(spaceId)?.length || 0;
-      totalRemoved += beforeCount - afterCount;
+    if (validEntries.length === 0) {
+      this.commandHistory.delete(spaceId);
+    } else {
+      this.commandHistory.set(spaceId, validEntries);
     }
-
-    if (totalRemoved > 0) {
-      this.logger.debug(`Cleaned up ${totalRemoved} expired rate limit entries across all spaces`);
-    }
-  }
-
-  /**
-   * Get the current command count for a space.
-   *
-   * @param spaceId - The space ID to check
-   * @returns Current number of commands in the time window
-   */
-  getCurrentCount(spaceId: string): number {
-    this.cleanupExpiredEntries(spaceId);
-    return this.commandHistory.get(spaceId)?.length || 0;
-  }
-
-  /**
-   * Reset the rate limit for a specific space.
-   * Clears all command history for that space.
-   *
-   * @param spaceId - The space ID to reset
-   */
-  reset(spaceId: string): void {
-    const previousCount = this.commandHistory.get(spaceId)?.length || 0;
-    this.commandHistory.delete(spaceId);
-
-    this.logger.info(`Reset rate limit for space ${spaceId} (removed ${previousCount} entries)`);
-  }
-
-  /**
-   * Reset the rate limit for all spaces.
-   * Clears all command history.
-   */
-  resetAll(): void {
-    const totalEntries = Array.from(this.commandHistory.values()).reduce(
-      (sum, entries) => sum + entries.length,
-      0
-    );
-    this.commandHistory.clear();
-
-    this.logger.info(`Reset rate limit for all spaces (removed ${totalEntries} entries)`);
-  }
-
-  /**
-   * Get the current rate limiter configuration.
-   * Returns a copy to prevent external mutation.
-   *
-   * @returns Current rate limiter configuration
-   */
-  getConfig(): Readonly<EmulationRateLimiterConfig> {
-    return {
-      maxCommands: this.config.maxCommands,
-      windowMs: this.config.windowMs,
-      disabled: this.config.disabled,
-    };
-  }
-
-  /**
-   * Update the rate limiter configuration.
-   * This does not clear existing command history.
-   *
-   * @param config - Partial configuration to update
-   */
-  updateConfig(config: Partial<EmulationRateLimiterConfig>): void {
-    const previous = { ...this.config };
-
-    if (config.maxCommands !== undefined) {
-      this.config.maxCommands = config.maxCommands;
-    }
-    if (config.windowMs !== undefined) {
-      this.config.windowMs = config.windowMs;
-    }
-    if (config.disabled !== undefined) {
-      this.config.disabled = config.disabled;
-    }
-
-    this.logger.info(
-      `Rate limiter configuration updated: maxCommands ${previous.maxCommands}->${this.config.maxCommands}, windowMs ${previous.windowMs}->${this.config.windowMs}, disabled ${previous.disabled}->${this.config.disabled}`
-    );
-  }
-
-  /**
-   * Get statistics about the rate limiter state.
-   *
-   * @returns Statistics object with space count and total entries
-   */
-  getStats(): {
-    spaceCount: number;
-    totalEntries: number;
-    entriesBySpace: Record<string, number>;
-  } {
-    this.cleanupAllExpiredEntries();
-
-    const entriesBySpace: Record<string, number> = {};
-    let totalEntries = 0;
-
-    for (const [spaceId, entries] of this.commandHistory.entries()) {
-      entriesBySpace[spaceId] = entries.length;
-      totalEntries += entries.length;
-    }
-
-    return {
-      spaceCount: this.commandHistory.size,
-      totalEntries,
-      entriesBySpace,
-    };
   }
 }
 
 /**
- * Create a default emulation rate limiter configuration.
- * Default: 100 commands per hour, enabled.
+ * Default config: 100 commands per hour, enabled.
  *
- * @returns Default rate limiter configuration
+ * TODO: thread this through Kibana config (xpack.securitySolution.detectionEmulation.*)
+ * once the feature graduates from experimental.
  */
 export function createDefaultRateLimiterConfig(): EmulationRateLimiterConfig {
   return {
     maxCommands: 100,
-    windowMs: 60 * 60 * 1000, // 1 hour
-    disabled: false,
-  };
-}
-
-/**
- * Create a permissive rate limiter configuration for testing/development.
- * Default: rate limiting disabled.
- *
- * @returns Permissive rate limiter configuration
- */
-export function createPermissiveRateLimiterConfig(): EmulationRateLimiterConfig {
-  return {
-    maxCommands: 1000,
-    windowMs: 60 * 60 * 1000, // 1 hour
-    disabled: true,
-  };
-}
-
-/**
- * Create a strict rate limiter configuration for production.
- * Default: 50 commands per hour, enabled.
- *
- * @returns Strict rate limiter configuration
- */
-export function createStrictRateLimiterConfig(): EmulationRateLimiterConfig {
-  return {
-    maxCommands: 50,
-    windowMs: 60 * 60 * 1000, // 1 hour
+    windowMs: 60 * 60 * 1000,
     disabled: false,
   };
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/rate_limiter.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/rate_limiter.ts
@@ -1,0 +1,400 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+
+/**
+ * Configuration for the emulation rate limiter.
+ *
+ * The rate limiter provides temporal throttling to prevent abuse of emulation commands,
+ * working alongside other safety controls (feature flag, RBAC, allowlist, audit log).
+ */
+export interface EmulationRateLimiterConfig {
+  /**
+   * Maximum number of commands allowed within the time window.
+   */
+  maxCommands: number;
+
+  /**
+   * Time window in milliseconds for rate limiting.
+   */
+  windowMs: number;
+
+  /**
+   * When true, rate limiting is disabled (all commands are allowed).
+   */
+  disabled: boolean;
+}
+
+/**
+ * Result of a rate limit check.
+ */
+export interface RateLimitCheckResult {
+  /**
+   * True if the command is allowed, false if rate limit exceeded.
+   */
+  allowed: boolean;
+
+  /**
+   * Current count of commands in the time window.
+   */
+  currentCount: number;
+
+  /**
+   * Maximum allowed commands in the time window.
+   */
+  maxCommands: number;
+
+  /**
+   * Time in milliseconds until the rate limit resets.
+   */
+  resetMs?: number;
+
+  /**
+   * Optional error message if rate limit is exceeded.
+   */
+  error?: string;
+}
+
+/**
+ * Tracked command entry for rate limiting.
+ */
+interface CommandEntry {
+  timestamp: number;
+  emulationId: string;
+  command: string;
+}
+
+/**
+ * Rate limiter for detection emulation commands.
+ *
+ * This provides temporal throttling to prevent abuse of emulation commands.
+ * It works alongside:
+ * - Feature flag (wholesale enable/disable)
+ * - Per-command RBAC (authorization control)
+ * - Host allowlist (endpoint-level restrictions)
+ * - Audit logger (tracking and accountability)
+ *
+ * The rate limiter tracks commands per space and enforces a sliding window
+ * limit (e.g., 100 commands per hour).
+ */
+export class EmulationRateLimiter {
+  private readonly config: EmulationRateLimiterConfig;
+  private readonly logger: Logger;
+  private readonly commandHistory: Map<string, CommandEntry[]>;
+
+  constructor(config: EmulationRateLimiterConfig, logger: Logger) {
+    this.config = config;
+    this.logger = logger;
+    this.commandHistory = new Map();
+
+    this.logger.debug(
+      `Emulation rate limiter initialized: maxCommands=${config.maxCommands}, windowMs=${config.windowMs}, disabled=${config.disabled}`
+    );
+  }
+
+  /**
+   * Check if a command is allowed under the current rate limit.
+   * This method only checks, it does not record the command.
+   *
+   * @param spaceId - The space ID for rate limiting scope
+   * @returns Rate limit check result
+   */
+  check(spaceId: string): RateLimitCheckResult {
+    // If rate limiting is disabled, allow all commands
+    if (this.config.disabled) {
+      this.logger.debug(`Rate limit check passed: rate limiting is disabled for space ${spaceId}`);
+
+      return {
+        allowed: true,
+        currentCount: 0,
+        maxCommands: this.config.maxCommands,
+      };
+    }
+
+    // Clean up expired entries for this space
+    this.cleanupExpiredEntries(spaceId);
+
+    // Get current command count in the time window
+    const entries = this.commandHistory.get(spaceId) || [];
+    const currentCount = entries.length;
+
+    // Check if limit is exceeded
+    if (currentCount >= this.config.maxCommands) {
+      const oldestEntry = entries[0];
+      const resetMs = oldestEntry
+        ? Math.max(0, this.config.windowMs - (Date.now() - oldestEntry.timestamp))
+        : 0;
+
+      const error = `Rate limit exceeded for space ${spaceId}: ${currentCount}/${this.config.maxCommands} commands in the last ${this.config.windowMs}ms. Reset in ${resetMs}ms.`;
+
+      this.logger.warn(error);
+
+      return {
+        allowed: false,
+        currentCount,
+        maxCommands: this.config.maxCommands,
+        resetMs,
+        error,
+      };
+    }
+
+    this.logger.debug(
+      `Rate limit check passed for space ${spaceId}: ${currentCount}/${this.config.maxCommands} commands`
+    );
+
+    return {
+      allowed: true,
+      currentCount,
+      maxCommands: this.config.maxCommands,
+    };
+  }
+
+  /**
+   * Record a command execution for rate limiting.
+   * Should be called after successfully dispatching a command.
+   *
+   * @param spaceId - The space ID for rate limiting scope
+   * @param emulationId - The emulation ID
+   * @param command - The command that was executed
+   */
+  record(spaceId: string, emulationId: string, command: string): void {
+    if (this.config.disabled) {
+      this.logger.debug(
+        `Skipping rate limit record: rate limiting is disabled for space ${spaceId}`
+      );
+      return;
+    }
+
+    const entry: CommandEntry = {
+      timestamp: Date.now(),
+      emulationId,
+      command,
+    };
+
+    const entries = this.commandHistory.get(spaceId) || [];
+    entries.push(entry);
+    this.commandHistory.set(spaceId, entries);
+
+    this.logger.debug(
+      `Recorded command for rate limiting in space ${spaceId}: ${command} (emulation: ${emulationId}), total: ${entries.length}/${this.config.maxCommands}`
+    );
+  }
+
+  /**
+   * Check and record a command in a single operation.
+   * This is a convenience method that combines check() and record().
+   *
+   * @param spaceId - The space ID for rate limiting scope
+   * @param emulationId - The emulation ID
+   * @param command - The command to check and record
+   * @returns Rate limit check result
+   */
+  checkAndRecord(spaceId: string, emulationId: string, command: string): RateLimitCheckResult {
+    const result = this.check(spaceId);
+
+    if (result.allowed) {
+      this.record(spaceId, emulationId, command);
+    }
+
+    return result;
+  }
+
+  /**
+   * Clean up expired command entries for a specific space.
+   * Removes entries older than the configured time window.
+   *
+   * @param spaceId - The space ID to clean up
+   */
+  private cleanupExpiredEntries(spaceId: string): void {
+    const entries = this.commandHistory.get(spaceId);
+    if (!entries || entries.length === 0) {
+      return;
+    }
+
+    const cutoffTime = Date.now() - this.config.windowMs;
+    const validEntries = entries.filter((entry) => entry.timestamp > cutoffTime);
+
+    if (validEntries.length !== entries.length) {
+      const removedCount = entries.length - validEntries.length;
+      this.logger.debug(
+        `Cleaned up ${removedCount} expired rate limit entries for space ${spaceId}`
+      );
+
+      if (validEntries.length === 0) {
+        this.commandHistory.delete(spaceId);
+      } else {
+        this.commandHistory.set(spaceId, validEntries);
+      }
+    }
+  }
+
+  /**
+   * Clean up all expired entries across all spaces.
+   * This should be called periodically to prevent memory leaks.
+   */
+  cleanupAllExpiredEntries(): void {
+    const spaceIds = Array.from(this.commandHistory.keys());
+    let totalRemoved = 0;
+
+    for (const spaceId of spaceIds) {
+      const beforeCount = this.commandHistory.get(spaceId)?.length || 0;
+      this.cleanupExpiredEntries(spaceId);
+      const afterCount = this.commandHistory.get(spaceId)?.length || 0;
+      totalRemoved += beforeCount - afterCount;
+    }
+
+    if (totalRemoved > 0) {
+      this.logger.debug(`Cleaned up ${totalRemoved} expired rate limit entries across all spaces`);
+    }
+  }
+
+  /**
+   * Get the current command count for a space.
+   *
+   * @param spaceId - The space ID to check
+   * @returns Current number of commands in the time window
+   */
+  getCurrentCount(spaceId: string): number {
+    this.cleanupExpiredEntries(spaceId);
+    return this.commandHistory.get(spaceId)?.length || 0;
+  }
+
+  /**
+   * Reset the rate limit for a specific space.
+   * Clears all command history for that space.
+   *
+   * @param spaceId - The space ID to reset
+   */
+  reset(spaceId: string): void {
+    const previousCount = this.commandHistory.get(spaceId)?.length || 0;
+    this.commandHistory.delete(spaceId);
+
+    this.logger.info(`Reset rate limit for space ${spaceId} (removed ${previousCount} entries)`);
+  }
+
+  /**
+   * Reset the rate limit for all spaces.
+   * Clears all command history.
+   */
+  resetAll(): void {
+    const totalEntries = Array.from(this.commandHistory.values()).reduce(
+      (sum, entries) => sum + entries.length,
+      0
+    );
+    this.commandHistory.clear();
+
+    this.logger.info(`Reset rate limit for all spaces (removed ${totalEntries} entries)`);
+  }
+
+  /**
+   * Get the current rate limiter configuration.
+   * Returns a copy to prevent external mutation.
+   *
+   * @returns Current rate limiter configuration
+   */
+  getConfig(): Readonly<EmulationRateLimiterConfig> {
+    return {
+      maxCommands: this.config.maxCommands,
+      windowMs: this.config.windowMs,
+      disabled: this.config.disabled,
+    };
+  }
+
+  /**
+   * Update the rate limiter configuration.
+   * This does not clear existing command history.
+   *
+   * @param config - Partial configuration to update
+   */
+  updateConfig(config: Partial<EmulationRateLimiterConfig>): void {
+    const previous = { ...this.config };
+
+    if (config.maxCommands !== undefined) {
+      this.config.maxCommands = config.maxCommands;
+    }
+    if (config.windowMs !== undefined) {
+      this.config.windowMs = config.windowMs;
+    }
+    if (config.disabled !== undefined) {
+      this.config.disabled = config.disabled;
+    }
+
+    this.logger.info(
+      `Rate limiter configuration updated: maxCommands ${previous.maxCommands}->${this.config.maxCommands}, windowMs ${previous.windowMs}->${this.config.windowMs}, disabled ${previous.disabled}->${this.config.disabled}`
+    );
+  }
+
+  /**
+   * Get statistics about the rate limiter state.
+   *
+   * @returns Statistics object with space count and total entries
+   */
+  getStats(): {
+    spaceCount: number;
+    totalEntries: number;
+    entriesBySpace: Record<string, number>;
+  } {
+    this.cleanupAllExpiredEntries();
+
+    const entriesBySpace: Record<string, number> = {};
+    let totalEntries = 0;
+
+    for (const [spaceId, entries] of this.commandHistory.entries()) {
+      entriesBySpace[spaceId] = entries.length;
+      totalEntries += entries.length;
+    }
+
+    return {
+      spaceCount: this.commandHistory.size,
+      totalEntries,
+      entriesBySpace,
+    };
+  }
+}
+
+/**
+ * Create a default emulation rate limiter configuration.
+ * Default: 100 commands per hour, enabled.
+ *
+ * @returns Default rate limiter configuration
+ */
+export function createDefaultRateLimiterConfig(): EmulationRateLimiterConfig {
+  return {
+    maxCommands: 100,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    disabled: false,
+  };
+}
+
+/**
+ * Create a permissive rate limiter configuration for testing/development.
+ * Default: rate limiting disabled.
+ *
+ * @returns Permissive rate limiter configuration
+ */
+export function createPermissiveRateLimiterConfig(): EmulationRateLimiterConfig {
+  return {
+    maxCommands: 1000,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    disabled: true,
+  };
+}
+
+/**
+ * Create a strict rate limiter configuration for production.
+ * Default: 50 commands per hour, enabled.
+ *
+ * @returns Strict rate limiter configuration
+ */
+export function createStrictRateLimiterConfig(): EmulationRateLimiterConfig {
+  return {
+    maxCommands: 50,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    disabled: false,
+  };
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/runner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/runner.ts
@@ -1,0 +1,298 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { CasesClient } from '@kbn/cases-plugin/server';
+import type { RunEmulationCommandInput } from '../../../../common/detection_emulation/schemas';
+import type { ResponseActionAgentType } from '../../../../common/endpoint/service/response_actions/constants';
+import {
+  RESPONSE_ACTION_AGENT_TYPE,
+  RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL,
+  RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP,
+} from '../../../../common/endpoint/service/response_actions/constants';
+import { isActionSupportedByAgentType } from '../../../../common/endpoint/service/response_actions/is_response_action_supported';
+import type {
+  ResponseActionsClient,
+  CommonResponseActionMethodOptions,
+} from '../../../endpoint/services/actions/clients/lib/types';
+import type { GetResponseActionsClientConstructorOptions } from '../../../endpoint/services/actions/clients/get_response_actions_client';
+import { getResponseActionsClient } from '../../../endpoint/services/actions/clients/get_response_actions_client';
+import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
+import type { ActionDetails } from '../../../../common/endpoint/types';
+import type { NormalizedExternalConnectorClient } from '../../../endpoint/services/actions/clients/lib/normalized_external_connector_client';
+import { buildEmulationComment } from './audit_logger';
+
+export interface EmulationRunnerOptions {
+  endpointService: EndpointAppContextService;
+  esClient: ElasticsearchClient;
+  spaceId: string;
+  casesClient?: CasesClient;
+  username: string;
+  logger: Logger;
+  /** Required for non-endpoint agent types (sentinel_one, crowdstrike, microsoft_defender_endpoint) */
+  connectorActions?: NormalizedExternalConnectorClient;
+}
+
+export interface RunEmulationResult {
+  actionId: string;
+  agentType: ResponseActionAgentType;
+  command: string;
+  status: 'dispatched' | 'error';
+  error?: string;
+  actionDetails?: ActionDetails;
+}
+
+/**
+ * Vendor-agnostic emulation runner that dispatches commands to the appropriate
+ * ResponseActionsClient based on the agentType.
+ *
+ * This is the core execution layer that:
+ * - Validates agentType against RESPONSE_ACTION_AGENT_TYPE
+ * - Checks command support for the given agentType
+ * - Validates RBAC requirements via RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL
+ * - Forwards the command to ResponseActionsClient with reason: 'emulation:<emulationId>'
+ * - Leverages existing response_actions audit trail, RBAC model, and connector registry
+ */
+export class EmulationRunner {
+  private readonly endpointService: EndpointAppContextService;
+  private readonly esClient: ElasticsearchClient;
+  private readonly spaceId: string;
+  private readonly casesClient?: CasesClient;
+  private readonly username: string;
+  private readonly logger: Logger;
+  private readonly connectorActions?: NormalizedExternalConnectorClient;
+
+  constructor(options: EmulationRunnerOptions) {
+    this.endpointService = options.endpointService;
+    this.esClient = options.esClient;
+    this.spaceId = options.spaceId;
+    this.casesClient = options.casesClient;
+    this.username = options.username;
+    this.logger = options.logger;
+    this.connectorActions = options.connectorActions;
+  }
+
+  /**
+   * Execute an emulation command against the specified endpoints.
+   *
+   * @param input - The validated emulation command input
+   * @returns Result containing action ID and dispatch status
+   * @throws Error if agentType is not supported or command is not available for the agent type
+   */
+  async run(input: RunEmulationCommandInput): Promise<RunEmulationResult> {
+    const { emulationId, agentType, endpointIds, command, parameters } = input;
+
+    this.logger.debug(
+      `Executing emulation command [${command}] for emulation [${emulationId}] on agent type [${agentType}] targeting [${endpointIds.length}] endpoints`
+    );
+
+    // Validate agentType is supported
+    if (!RESPONSE_ACTION_AGENT_TYPE.includes(agentType)) {
+      const error = `Agent type [${agentType}] is not supported. Supported types: ${RESPONSE_ACTION_AGENT_TYPE.join(
+        ', '
+      )}`;
+      this.logger.error(error);
+      throw new Error(error);
+    }
+
+    // Check if the command is supported by this agent type (emulation commands are manual/interactive)
+    const actionType = 'manual' as const;
+    if (!isActionSupportedByAgentType(agentType, command, actionType)) {
+      const error = `Command [${command}] is not supported for agent type [${agentType}]`;
+      this.logger.error(error);
+      throw new Error(error);
+    }
+
+    // Get the console command for RBAC validation
+    const consoleCommand = RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP[command];
+    const requiredRbac = RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL[consoleCommand];
+
+    if (requiredRbac) {
+      this.logger.debug(
+        `Command [${command}] requires RBAC privilege [${requiredRbac}] (validation delegated to ResponseActionsClient)`
+      );
+    }
+
+    try {
+      // Create the response actions client for this agent type
+      const responseActionsClient = this.createResponseActionsClient(agentType);
+
+      // Build the request and dispatch in a single typed call
+      const actionDetails = await this.dispatch(
+        responseActionsClient,
+        command,
+        endpointIds,
+        parameters,
+        emulationId
+      );
+
+      this.logger.info(
+        `Successfully dispatched emulation command [${command}] for emulation [${emulationId}], action ID: ${actionDetails.id}`
+      );
+
+      return {
+        actionId: actionDetails.id,
+        agentType,
+        command,
+        status: 'dispatched',
+        actionDetails,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to execute emulation command [${command}] for emulation [${emulationId}]: ${errorMessage}`
+      );
+
+      return {
+        actionId: '',
+        agentType,
+        command,
+        status: 'error',
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Create a ResponseActionsClient instance for the given agent type.
+   */
+  private createResponseActionsClient(agentType: ResponseActionAgentType): ResponseActionsClient {
+    const constructorOptions = {
+      endpointService: this.endpointService,
+      esClient: this.esClient,
+      spaceId: this.spaceId,
+      casesClient: this.casesClient,
+      username: this.username,
+      isAutomated: false, // Emulation commands are manual/interactive
+      // connectorActions is required by non-endpoint clients (sentinel_one, crowdstrike, etc.)
+      // EndpointActionsClient ignores this field so the cast is safe for agentType === 'endpoint'
+      connectorActions: this.connectorActions as NormalizedExternalConnectorClient,
+    } satisfies GetResponseActionsClientConstructorOptions;
+
+    return getResponseActionsClient(agentType, constructorOptions);
+  }
+
+  /**
+   * Build the typed request and dispatch to the appropriate ResponseActionsClient method.
+   * Collapses request construction and dispatch into a single switch so each case can
+   * use the exact type expected by the corresponding client method.
+   */
+  private async dispatch(
+    client: ResponseActionsClient,
+    command: string,
+    endpointIds: string[],
+    parameters: Record<string, unknown> | undefined,
+    emulationId: string
+  ): Promise<ActionDetails> {
+    const comment = buildEmulationComment(
+      emulationId,
+      command,
+      parameters?.comment as string | undefined
+    );
+    const base = { endpoint_ids: endpointIds, comment };
+    const options: CommonResponseActionMethodOptions = { ruleId: undefined, ruleName: undefined };
+
+    switch (command) {
+      case 'isolate':
+        return client.isolate(base, options);
+
+      case 'unisolate':
+        return client.release(base, options);
+
+      case 'kill-process':
+        return client.killProcess(
+          {
+            ...base,
+            parameters: {
+              pid: parameters?.pid as number | undefined,
+              entity_id: parameters?.entity_id as string | undefined,
+            },
+          },
+          options
+        );
+
+      case 'suspend-process':
+        return client.suspendProcess(
+          {
+            ...base,
+            parameters: {
+              pid: parameters?.pid as number | undefined,
+              entity_id: parameters?.entity_id as string | undefined,
+            },
+          },
+          options
+        );
+
+      case 'running-processes':
+        return client.runningProcesses(base, options);
+
+      case 'get-file':
+        return client.getFile(
+          { ...base, parameters: { path: (parameters?.path as string) ?? '' } },
+          options
+        );
+
+      case 'execute':
+        return client.execute(
+          {
+            ...base,
+            parameters: {
+              command: (parameters?.command as string) ?? '',
+              timeout: parameters?.timeout as number | undefined,
+            },
+          },
+          options
+        );
+
+      case 'upload':
+        return client.upload(
+          {
+            ...base,
+            file: parameters?.file as Parameters<ResponseActionsClient['upload']>[0]['file'],
+            parameters: { overwrite: (parameters?.overwrite as boolean) ?? false },
+          },
+          options
+        );
+
+      case 'scan':
+        return client.scan(
+          { ...base, parameters: { path: (parameters?.path as string) ?? '' } },
+          options
+        );
+
+      case 'runscript':
+        return client.runscript(
+          {
+            ...base,
+            parameters: {
+              script: (parameters?.script as string) ?? '',
+              timeout: parameters?.timeout as number | undefined,
+            },
+          },
+          options
+        );
+
+      case 'cancel':
+        return client.cancel(base, options);
+
+      case 'memory-dump':
+        return client.memoryDump(
+          {
+            ...base,
+            parameters: {
+              pid: parameters?.pid as number | undefined,
+              entity_id: parameters?.entity_id as string | undefined,
+            },
+          },
+          options
+        );
+
+      default:
+        throw new Error(`Unsupported command: ${command}`);
+    }
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/runner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/execution/runner.ts
@@ -25,6 +25,28 @@ import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_c
 import type { ActionDetails } from '../../../../common/endpoint/types';
 import type { NormalizedExternalConnectorClient } from '../../../endpoint/services/actions/clients/lib/normalized_external_connector_client';
 import { buildEmulationComment } from './audit_logger';
+import {
+  UnsupportedAgentTypeError,
+  UnsupportedCommandForAgentTypeError,
+  MissingConnectorActionsError,
+} from './errors';
+
+export {
+  UnsupportedAgentTypeError,
+  UnsupportedCommandForAgentTypeError,
+  MissingConnectorActionsError,
+};
+
+/**
+ * Lookup callback used by the runner to resolve `(emulationId) -> ruleId/ruleName`
+ * via the `emulation-rule-binding` saved object. Returning `undefined`
+ * means the emulation is not bound to a rule, in which case the
+ * dispatched action carries `ruleId: undefined`/`ruleName: undefined` —
+ * the same shape it had before this lookup was wired.
+ */
+export type EmulationRuleBindingLookup = (
+  emulationId: string
+) => Promise<{ ruleId: string; ruleName?: string } | undefined>;
 
 export interface EmulationRunnerOptions {
   endpointService: EndpointAppContextService;
@@ -33,8 +55,10 @@ export interface EmulationRunnerOptions {
   casesClient?: CasesClient;
   username: string;
   logger: Logger;
-  /** Required for non-endpoint agent types (sentinel_one, crowdstrike, microsoft_defender_endpoint) */
+  /** Required for non-endpoint agent types (sentinel_one, crowdstrike, microsoft_defender_endpoint). */
   connectorActions?: NormalizedExternalConnectorClient;
+  /** Optional: resolves `(emulationId) -> rule binding` so dispatched actions carry rule context. */
+  ruleBindingLookup?: EmulationRuleBindingLookup;
 }
 
 export interface RunEmulationResult {
@@ -47,15 +71,14 @@ export interface RunEmulationResult {
 }
 
 /**
- * Vendor-agnostic emulation runner that dispatches commands to the appropriate
- * ResponseActionsClient based on the agentType.
+ * Vendor-agnostic emulation runner.
  *
- * This is the core execution layer that:
- * - Validates agentType against RESPONSE_ACTION_AGENT_TYPE
- * - Checks command support for the given agentType
- * - Validates RBAC requirements via RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL
- * - Forwards the command to ResponseActionsClient with reason: 'emulation:<emulationId>'
- * - Leverages existing response_actions audit trail, RBAC model, and connector registry
+ * Validates `agentType`, looks up the rule binding (if any), instantiates
+ * the matching `ResponseActionsClient`, then dispatches the typed
+ * request via `dispatch()`. The `dispatch()` switch is exhaustive over
+ * the discriminated `RunEmulationCommandInput.command` union — a new
+ * value in `RESPONSE_ACTION_API_COMMANDS_NAMES` will fail the build
+ * here at the `_exhaustive: never` line until the case is added.
  */
 export class EmulationRunner {
   private readonly endpointService: EndpointAppContextService;
@@ -65,6 +88,7 @@ export class EmulationRunner {
   private readonly username: string;
   private readonly logger: Logger;
   private readonly connectorActions?: NormalizedExternalConnectorClient;
+  private readonly ruleBindingLookup?: EmulationRuleBindingLookup;
 
   constructor(options: EmulationRunnerOptions) {
     this.endpointService = options.endpointService;
@@ -74,61 +98,69 @@ export class EmulationRunner {
     this.username = options.username;
     this.logger = options.logger;
     this.connectorActions = options.connectorActions;
+    this.ruleBindingLookup = options.ruleBindingLookup;
   }
 
   /**
-   * Execute an emulation command against the specified endpoints.
+   * Execute a validated emulation command.
    *
-   * @param input - The validated emulation command input
-   * @returns Result containing action ID and dispatch status
-   * @throws Error if agentType is not supported or command is not available for the agent type
+   * Throws on inputs that should fail before any side effects:
+   *   - `UnsupportedAgentTypeError`: schema slipped through with a bad agentType.
+   *   - `UnsupportedCommandForAgentTypeError`: combination is rejected by `isActionSupportedByAgentType`.
+   *   - `MissingConnectorActionsError`: non-endpoint agent type but no `connectorActions` was wired.
+   *
+   * Returns `{ status: 'error' }` for failures originating *inside* the
+   * underlying response-actions client (Fleet down, connector
+   * unavailable, etc.). The route maps each error class to a status code.
    */
   async run(input: RunEmulationCommandInput): Promise<RunEmulationResult> {
-    const { emulationId, agentType, endpointIds, command, parameters } = input;
+    const { emulationId, agentType, endpointIds, command } = input;
 
     this.logger.debug(
       `Executing emulation command [${command}] for emulation [${emulationId}] on agent type [${agentType}] targeting [${endpointIds.length}] endpoints`
     );
 
-    // Validate agentType is supported
     if (!RESPONSE_ACTION_AGENT_TYPE.includes(agentType)) {
-      const error = `Agent type [${agentType}] is not supported. Supported types: ${RESPONSE_ACTION_AGENT_TYPE.join(
-        ', '
-      )}`;
-      this.logger.error(error);
-      throw new Error(error);
+      throw new UnsupportedAgentTypeError(agentType);
     }
 
-    // Check if the command is supported by this agent type (emulation commands are manual/interactive)
+    // Emulation commands are manual/interactive — never automated.
     const actionType = 'manual' as const;
     if (!isActionSupportedByAgentType(agentType, command, actionType)) {
-      const error = `Command [${command}] is not supported for agent type [${agentType}]`;
-      this.logger.error(error);
-      throw new Error(error);
+      throw new UnsupportedCommandForAgentTypeError(command, agentType);
     }
 
-    // Get the console command for RBAC validation
-    const consoleCommand = RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP[command];
-    const requiredRbac = RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL[consoleCommand];
+    // Non-endpoint clients require a `connectorActions` instance.
+    // The current route does not resolve one, so reject here with a
+    // clear, typed error rather than handing `undefined` to the
+    // upstream client and crashing inside its constructor.
+    if (agentType !== 'endpoint' && !this.connectorActions) {
+      throw new MissingConnectorActionsError(agentType);
+    }
 
+    // Trace-only: the underlying ResponseActionsClient is the
+    // authoritative RBAC enforcer; we just log what privilege would be
+    // required for observability. The RBAC map does not cover every
+    // console command (e.g. `cancel` has no dedicated privilege today),
+    // so we treat a missing entry as "no extra privilege needed" rather
+    // than a hard error.
+    const consoleCommand = RESPONSE_ACTION_API_COMMAND_TO_CONSOLE_COMMAND_MAP[command];
+    const rbacMap = RESPONSE_CONSOLE_ACTION_COMMANDS_TO_RBAC_FEATURE_CONTROL as Record<
+      string,
+      string | undefined
+    >;
+    const requiredRbac = rbacMap[consoleCommand];
     if (requiredRbac) {
       this.logger.debug(
         `Command [${command}] requires RBAC privilege [${requiredRbac}] (validation delegated to ResponseActionsClient)`
       );
     }
 
-    try {
-      // Create the response actions client for this agent type
-      const responseActionsClient = this.createResponseActionsClient(agentType);
+    const ruleBinding = await this.resolveRuleBinding(emulationId);
 
-      // Build the request and dispatch in a single typed call
-      const actionDetails = await this.dispatch(
-        responseActionsClient,
-        command,
-        endpointIds,
-        parameters,
-        emulationId
-      );
+    try {
+      const responseActionsClient = this.createResponseActionsClient(agentType);
+      const actionDetails = await this.dispatch(responseActionsClient, input, ruleBinding);
 
       this.logger.info(
         `Successfully dispatched emulation command [${command}] for emulation [${emulationId}], action ID: ${actionDetails.id}`
@@ -157,9 +189,27 @@ export class EmulationRunner {
     }
   }
 
-  /**
-   * Create a ResponseActionsClient instance for the given agent type.
-   */
+  private async resolveRuleBinding(
+    emulationId: string
+  ): Promise<{ ruleId?: string; ruleName?: string }> {
+    if (!this.ruleBindingLookup) {
+      return {};
+    }
+    try {
+      const binding = await this.ruleBindingLookup(emulationId);
+      return binding ?? {};
+    } catch (err) {
+      // A missing binding is fine. Log unexpected lookup errors but do
+      // not block dispatch — the action just lands without rule context.
+      this.logger.warn(
+        `Failed to look up rule binding for emulation [${emulationId}]: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return {};
+    }
+  }
+
   private createResponseActionsClient(agentType: ResponseActionAgentType): ResponseActionsClient {
     const constructorOptions = {
       endpointService: this.endpointService,
@@ -167,9 +217,9 @@ export class EmulationRunner {
       spaceId: this.spaceId,
       casesClient: this.casesClient,
       username: this.username,
-      isAutomated: false, // Emulation commands are manual/interactive
-      // connectorActions is required by non-endpoint clients (sentinel_one, crowdstrike, etc.)
-      // EndpointActionsClient ignores this field so the cast is safe for agentType === 'endpoint'
+      isAutomated: false,
+      // Safe: validated above — non-endpoint agent types require this.connectorActions and
+      // we throw `MissingConnectorActionsError` before reaching this point if it's missing.
       connectorActions: this.connectorActions as NormalizedExternalConnectorClient,
     } satisfies GetResponseActionsClientConstructorOptions;
 
@@ -177,26 +227,27 @@ export class EmulationRunner {
   }
 
   /**
-   * Build the typed request and dispatch to the appropriate ResponseActionsClient method.
-   * Collapses request construction and dispatch into a single switch so each case can
-   * use the exact type expected by the corresponding client method.
+   * Build the typed request and dispatch to the matching
+   * `ResponseActionsClient` method. The discriminated union on
+   * `RunEmulationCommandInput.command` lets each `case` access the
+   * exact `parameters` shape that command needs without `as` casts —
+   * a misnamed key is rejected at the schema layer.
    */
   private async dispatch(
     client: ResponseActionsClient,
-    command: string,
-    endpointIds: string[],
-    parameters: Record<string, unknown> | undefined,
-    emulationId: string
+    input: RunEmulationCommandInput,
+    ruleBinding: { ruleId?: string; ruleName?: string }
   ): Promise<ActionDetails> {
-    const comment = buildEmulationComment(
-      emulationId,
-      command,
-      parameters?.comment as string | undefined
-    );
+    const { emulationId, command, endpointIds } = input;
+    const userComment = input.parameters?.comment;
+    const comment = buildEmulationComment(emulationId, command, userComment);
     const base = { endpoint_ids: endpointIds, comment };
-    const options: CommonResponseActionMethodOptions = { ruleId: undefined, ruleName: undefined };
+    const options: CommonResponseActionMethodOptions = {
+      ruleId: ruleBinding.ruleId,
+      ruleName: ruleBinding.ruleName,
+    };
 
-    switch (command) {
+    switch (input.command) {
       case 'isolate':
         return client.isolate(base, options);
 
@@ -204,13 +255,14 @@ export class EmulationRunner {
         return client.release(base, options);
 
       case 'kill-process':
+        // Schema guarantees exactly one of `pid` or `entity_id` is present.
         return client.killProcess(
           {
             ...base,
-            parameters: {
-              pid: parameters?.pid as number | undefined,
-              entity_id: parameters?.entity_id as string | undefined,
-            },
+            parameters:
+              'pid' in input.parameters
+                ? { pid: input.parameters.pid }
+                : { entity_id: input.parameters.entity_id },
           },
           options
         );
@@ -219,10 +271,10 @@ export class EmulationRunner {
         return client.suspendProcess(
           {
             ...base,
-            parameters: {
-              pid: parameters?.pid as number | undefined,
-              entity_id: parameters?.entity_id as string | undefined,
-            },
+            parameters:
+              'pid' in input.parameters
+                ? { pid: input.parameters.pid }
+                : { entity_id: input.parameters.entity_id },
           },
           options
         );
@@ -231,18 +283,15 @@ export class EmulationRunner {
         return client.runningProcesses(base, options);
 
       case 'get-file':
-        return client.getFile(
-          { ...base, parameters: { path: (parameters?.path as string) ?? '' } },
-          options
-        );
+        return client.getFile({ ...base, parameters: { path: input.parameters.path } }, options);
 
       case 'execute':
         return client.execute(
           {
             ...base,
             parameters: {
-              command: (parameters?.command as string) ?? '',
-              timeout: parameters?.timeout as number | undefined,
+              command: input.parameters.command,
+              timeout: input.parameters.timeout,
             },
           },
           options
@@ -252,47 +301,59 @@ export class EmulationRunner {
         return client.upload(
           {
             ...base,
-            file: parameters?.file as Parameters<ResponseActionsClient['upload']>[0]['file'],
-            parameters: { overwrite: (parameters?.overwrite as boolean) ?? false },
+            file: input.parameters.file as Parameters<ResponseActionsClient['upload']>[0]['file'],
+            parameters: { overwrite: input.parameters.overwrite ?? false },
           },
           options
         );
 
       case 'scan':
-        return client.scan(
-          { ...base, parameters: { path: (parameters?.path as string) ?? '' } },
-          options
-        );
+        return client.scan({ ...base, parameters: { path: input.parameters.path } }, options);
 
       case 'runscript':
+        // Schema is constrained to the endpoint shape today (one wired agent
+        // type). The downstream client signature is broad (cross-EDR), so we
+        // narrow with a single cast at the boundary.
         return client.runscript(
           {
             ...base,
             parameters: {
-              script: (parameters?.script as string) ?? '',
-              timeout: parameters?.timeout as number | undefined,
+              scriptId: input.parameters.scriptId,
+              scriptInput: input.parameters.scriptInput,
+              timeout: input.parameters.timeout,
             },
-          },
+          } as Parameters<ResponseActionsClient['runscript']>[0],
           options
         );
 
       case 'cancel':
-        return client.cancel(base, options);
+        return client.cancel({ ...base, parameters: { id: input.parameters.id } }, options);
 
-      case 'memory-dump':
-        return client.memoryDump(
-          {
-            ...base,
-            parameters: {
-              pid: parameters?.pid as number | undefined,
-              entity_id: parameters?.entity_id as string | undefined,
-            },
-          },
-          options
+      case 'memory-dump': {
+        // Inner discriminated union: `kernel` carries no pid/entity_id; the two
+        // `process` variants carry exactly one of pid or entity_id.
+        const memoryParams =
+          input.parameters.type === 'kernel'
+            ? { type: 'kernel' as const }
+            : 'pid' in input.parameters
+            ? { type: 'process' as const, pid: input.parameters.pid }
+            : { type: 'process' as const, entity_id: input.parameters.entity_id };
+        return client.memoryDump({ ...base, parameters: memoryParams }, options);
+      }
+
+      default: {
+        // Exhaustiveness check: a new value in `RESPONSE_ACTION_API_COMMANDS_NAMES`
+        // (and a corresponding schema variant) must add a case above — the
+        // `satisfies never` makes the build fail when a variant goes
+        // unhandled. At runtime we throw a typed error so an unexpected
+        // value (e.g. forced via `as any` in tests) maps cleanly to a 400.
+        const exhaustiveCheck: never = input;
+        void exhaustiveCheck;
+        throw new UnsupportedCommandForAgentTypeError(
+          (input as RunEmulationCommandInput).command,
+          (input as RunEmulationCommandInput).agentType
         );
-
-      default:
-        throw new Error(`Unsupported command: ${command}`);
+      }
     }
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/feature_flag.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/feature_flag.ts
@@ -5,87 +5,50 @@
  * 2.0.
  */
 
-import type { ConfigType } from '../../config';
+import type { ExperimentalFeatures } from '../../../common/experimental_features';
 
 /**
  * Detection Emulation feature flags.
  *
- * These flags control the behavior of the detection emulation system:
- * - logInjection: When true, emulation commands are logged to the audit trail
- *   with full context (emulation ID, command, parameters) for compliance and debugging.
- *   When false, emulation commands are dispatched without detailed audit logging.
+ * Currently a single flag (`realExecution`) gates whether the
+ * `runEmulationCommand` route actually dispatches to the underlying
+ * `ResponseActionsClient`. When disabled the route returns 403 and is
+ * effectively a no-op.
  *
- * - realExecution: When true, emulation commands are actually executed against the
- *   target endpoints via ResponseActionsClient. When false, emulation commands are
- *   validated and logged but NOT executed (dry-run mode). This provides a safe
- *   testing/staging environment where emulation logic can be verified without
- *   affecting production endpoints.
+ * The flag is sourced from `xpack.securitySolution.enableExperimental`
+ * (see `common/experimental_features.ts`), the same mechanism every
+ * other gated security_solution feature uses. There is no separate
+ * `xpack.securitySolution.detectionEmulation` config namespace.
  */
 export interface DetectionEmulationFeatureFlags {
   /**
-   * Controls whether emulation commands are logged to the audit trail.
-   * Default: false (no injection)
-   */
-  logInjection: boolean;
-
-  /**
    * Controls whether emulation commands are actually executed.
-   * When false, commands are validated and logged but not executed (dry-run mode).
-   * Default: false (no real execution)
+   * When false, the route short-circuits with 403 before reaching the runner.
+   * Default: false (no real execution).
    */
   realExecution: boolean;
 }
 
 /**
- * Extracts detection emulation feature flags from Kibana config.
+ * Reads detection emulation feature flags from the security_solution
+ * `experimentalFeatures` block.
  *
- * Reads from config namespace: `xpack.securitySolution.detectionEmulation`
- * Falls back to safe defaults (both flags disabled) if config section is missing.
- *
- * @param config - Security Solution plugin config
- * @returns Feature flags with safe defaults
+ * @param experimentalFeatures - the parsed `experimentalFeatures` block
+ * @returns the resolved emulation feature flags
  */
 export function getDetectionEmulationFeatureFlags(
-  config: ConfigType
+  experimentalFeatures: ExperimentalFeatures
 ): DetectionEmulationFeatureFlags {
-  // Access the detectionEmulation config section if it exists
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const detectionEmulationConfig = (config as any).detectionEmulation;
-
-  // Safe defaults: both flags disabled
-  const defaults: DetectionEmulationFeatureFlags = {
-    logInjection: false,
-    realExecution: false,
-  };
-
-  if (!detectionEmulationConfig) {
-    return defaults;
-  }
-
   return {
-    logInjection: Boolean(detectionEmulationConfig.logInjection ?? defaults.logInjection),
-    realExecution: Boolean(detectionEmulationConfig.realExecution ?? defaults.realExecution),
+    realExecution: experimentalFeatures.detectionEmulationRealExecution,
   };
 }
 
 /**
- * Type guard to check if real execution is enabled.
- * Use this before dispatching emulation commands to ResponseActionsClient.
- *
- * @param flags - Detection emulation feature flags
- * @returns true if real execution is enabled
+ * Type guard used by the route to short-circuit dispatch when the
+ * feature is disabled. Kept as a named helper so future flags (e.g.
+ * per-tenant overrides) can be layered in without touching call sites.
  */
 export function isRealExecutionEnabled(flags: DetectionEmulationFeatureFlags): boolean {
   return flags.realExecution;
-}
-
-/**
- * Type guard to check if audit log injection is enabled.
- * Use this before writing emulation context to the response_actions audit trail.
- *
- * @param flags - Detection emulation feature flags
- * @returns true if log injection is enabled
- */
-export function isLogInjectionEnabled(flags: DetectionEmulationFeatureFlags): boolean {
-  return flags.logInjection;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/feature_flag.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/feature_flag.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ConfigType } from '../../config';
+
+/**
+ * Detection Emulation feature flags.
+ *
+ * These flags control the behavior of the detection emulation system:
+ * - logInjection: When true, emulation commands are logged to the audit trail
+ *   with full context (emulation ID, command, parameters) for compliance and debugging.
+ *   When false, emulation commands are dispatched without detailed audit logging.
+ *
+ * - realExecution: When true, emulation commands are actually executed against the
+ *   target endpoints via ResponseActionsClient. When false, emulation commands are
+ *   validated and logged but NOT executed (dry-run mode). This provides a safe
+ *   testing/staging environment where emulation logic can be verified without
+ *   affecting production endpoints.
+ */
+export interface DetectionEmulationFeatureFlags {
+  /**
+   * Controls whether emulation commands are logged to the audit trail.
+   * Default: false (no injection)
+   */
+  logInjection: boolean;
+
+  /**
+   * Controls whether emulation commands are actually executed.
+   * When false, commands are validated and logged but not executed (dry-run mode).
+   * Default: false (no real execution)
+   */
+  realExecution: boolean;
+}
+
+/**
+ * Extracts detection emulation feature flags from Kibana config.
+ *
+ * Reads from config namespace: `xpack.securitySolution.detectionEmulation`
+ * Falls back to safe defaults (both flags disabled) if config section is missing.
+ *
+ * @param config - Security Solution plugin config
+ * @returns Feature flags with safe defaults
+ */
+export function getDetectionEmulationFeatureFlags(
+  config: ConfigType
+): DetectionEmulationFeatureFlags {
+  // Access the detectionEmulation config section if it exists
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const detectionEmulationConfig = (config as any).detectionEmulation;
+
+  // Safe defaults: both flags disabled
+  const defaults: DetectionEmulationFeatureFlags = {
+    logInjection: false,
+    realExecution: false,
+  };
+
+  if (!detectionEmulationConfig) {
+    return defaults;
+  }
+
+  return {
+    logInjection: Boolean(detectionEmulationConfig.logInjection ?? defaults.logInjection),
+    realExecution: Boolean(detectionEmulationConfig.realExecution ?? defaults.realExecution),
+  };
+}
+
+/**
+ * Type guard to check if real execution is enabled.
+ * Use this before dispatching emulation commands to ResponseActionsClient.
+ *
+ * @param flags - Detection emulation feature flags
+ * @returns true if real execution is enabled
+ */
+export function isRealExecutionEnabled(flags: DetectionEmulationFeatureFlags): boolean {
+  return flags.realExecution;
+}
+
+/**
+ * Type guard to check if audit log injection is enabled.
+ * Use this before writing emulation context to the response_actions audit trail.
+ *
+ * @param flags - Detection emulation feature flags
+ * @returns true if log injection is enabled
+ */
+export function isLogInjectionEnabled(flags: DetectionEmulationFeatureFlags): boolean {
+  return flags.logInjection;
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/index.ts
@@ -9,4 +9,5 @@ export * from './alert_tagging';
 export * from './execution';
 export * from './feature_flag';
 export * from './rule_binding';
+export { createSavedObjectRuleBindingLookup } from './rule_binding_lookup';
 export { registerDetectionEmulationRoutes } from './api/register_routes';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './alert_tagging';
+export * from './execution';
+export * from './feature_flag';
+export * from './rule_binding';
+export { registerDetectionEmulationRoutes } from './api/register_routes';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/rule_binding.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/rule_binding.ts
@@ -6,7 +6,11 @@
  */
 
 import type { SavedObjectsType } from '@kbn/core/server';
-import { SECURITY_SOLUTION_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import {
+  SECURITY_SOLUTION_SAVED_OBJECT_INDEX,
+  type SavedObjectsModelVersionMap,
+} from '@kbn/core-saved-objects-server';
+import { schema } from '@kbn/config-schema';
 
 /**
  * Saved object type name for emulation-to-rule bindings.
@@ -135,10 +139,60 @@ export const emulationRuleBindingTypeMappings: SavedObjectsType['mappings'] = {
  * });
  * ```
  */
-export const emulationRuleBindingType: SavedObjectsType = {
+/**
+ * Initial model version for the saved object. Adding a baseline `1` model
+ * version here is what unlocks future schema migrations: any subsequent
+ * change to attributes / mappings has to bump to version 2 with an explicit
+ * forward + backward transformation. Without this baseline the SO type is
+ * pinned to legacy migrations and cannot evolve safely.
+ */
+const modelVersions: SavedObjectsModelVersionMap = {
+  '1': {
+    changes: [],
+    schemas: {
+      forwardCompatibility: schema.object(
+        {
+          emulationId: schema.string(),
+          ruleId: schema.string(),
+          ruleName: schema.maybe(schema.string()),
+          createdAt: schema.string(),
+          metadata: schema.maybe(
+            schema.object(
+              {
+                mode: schema.maybe(schema.string()),
+                tags: schema.maybe(schema.arrayOf(schema.string())),
+              },
+              { unknowns: 'ignore' }
+            )
+          ),
+        },
+        { unknowns: 'ignore' }
+      ),
+      create: schema.object({
+        emulationId: schema.string(),
+        ruleId: schema.string(),
+        ruleName: schema.maybe(schema.string()),
+        createdAt: schema.string(),
+        metadata: schema.maybe(
+          schema.object({
+            mode: schema.maybe(schema.string()),
+            tags: schema.maybe(schema.arrayOf(schema.string())),
+          })
+        ),
+      }),
+    },
+  },
+};
+
+export const emulationRuleBindingType: SavedObjectsType<EmulationRuleBindingAttributes> = {
   name: emulationRuleBindingTypeName,
   indexPattern: SECURITY_SOLUTION_SAVED_OBJECT_INDEX,
-  hidden: false,
+  // hidden:true keeps the SO out of the generic SO HTTP API surface — callers
+  // must go through the security_solution plugin. Combined with
+  // hiddenFromHttpApis it removes the entire CRUD-via-HTTP attack surface.
+  hidden: true,
+  hiddenFromHttpApis: true,
   namespaceType: 'multiple-isolated',
   mappings: emulationRuleBindingTypeMappings,
+  modelVersions,
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/rule_binding.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/rule_binding.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsType } from '@kbn/core/server';
+import { SECURITY_SOLUTION_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+
+/**
+ * Saved object type name for emulation-to-rule bindings.
+ */
+export const emulationRuleBindingTypeName = 'emulation-rule-binding';
+
+/**
+ * Attributes stored in the emulation rule binding saved object.
+ * Links an emulation run to a specific detection rule.
+ */
+export interface EmulationRuleBindingAttributes {
+  /**
+   * Unique identifier for the emulation run.
+   */
+  emulationId: string;
+
+  /**
+   * Detection rule ID (rule_id field from the detection rule).
+   * This is the stable identifier for the rule, not the saved object ID.
+   */
+  ruleId: string;
+
+  /**
+   * Optional rule name for display purposes.
+   */
+  ruleName?: string;
+
+  /**
+   * Timestamp when the binding was created (ISO 8601).
+   */
+  createdAt: string;
+
+  /**
+   * Optional metadata about the emulation run.
+   */
+  metadata?: {
+    /**
+     * Emulation mode (test, validation, production)
+     */
+    mode?: string;
+
+    /**
+     * Additional context or tags
+     */
+    tags?: string[];
+  };
+}
+
+/**
+ * Saved object mappings for the emulation rule binding type.
+ */
+export const emulationRuleBindingTypeMappings: SavedObjectsType['mappings'] = {
+  dynamic: false,
+  properties: {
+    emulationId: {
+      type: 'keyword',
+    },
+    ruleId: {
+      type: 'keyword',
+    },
+    ruleName: {
+      type: 'text',
+      fields: {
+        keyword: {
+          type: 'keyword',
+        },
+      },
+    },
+    createdAt: {
+      type: 'date',
+    },
+    metadata: {
+      properties: {
+        mode: {
+          type: 'keyword',
+        },
+        tags: {
+          type: 'keyword',
+        },
+      },
+    },
+  },
+};
+
+/**
+ * Saved object type definition for emulation-to-rule bindings.
+ *
+ * This saved object type provides persistent storage for linking emulation runs
+ * to specific detection rules. Each binding records:
+ * - Which emulation run triggered which detection rule
+ * - When the binding was created
+ * - Optional metadata about the emulation context
+ *
+ * The saved object approach was chosen over alternatives for several reasons:
+ * 1. Persistence: Bindings survive across Kibana restarts and deployments
+ * 2. Query capability: Efficient lookups by emulationId or ruleId
+ * 3. Audit trail: Built-in versioning and change tracking
+ * 4. Space isolation: Bindings are scoped to the Kibana space
+ * 5. Platform integration: Leverages existing backup/restore/migration
+ *
+ * Example usage:
+ * ```typescript
+ * const binding = await soClient.create<EmulationRuleBindingAttributes>(
+ *   emulationRuleBindingTypeName,
+ *   {
+ *     emulationId: 'emulation-abc-123',
+ *     ruleId: 'detect-malicious-process',
+ *     ruleName: 'Detect Malicious Process Execution',
+ *     createdAt: new Date().toISOString(),
+ *     metadata: { mode: 'test' }
+ *   }
+ * );
+ *
+ * // Find all bindings for a specific emulation run
+ * const { saved_objects } = await soClient.find<EmulationRuleBindingAttributes>({
+ *   type: emulationRuleBindingTypeName,
+ *   search: emulationId,
+ *   searchFields: ['emulationId']
+ * });
+ *
+ * // Find all emulation runs that triggered a specific rule
+ * const { saved_objects } = await soClient.find<EmulationRuleBindingAttributes>({
+ *   type: emulationRuleBindingTypeName,
+ *   search: ruleId,
+ *   searchFields: ['ruleId']
+ * });
+ * ```
+ */
+export const emulationRuleBindingType: SavedObjectsType = {
+  name: emulationRuleBindingTypeName,
+  indexPattern: SECURITY_SOLUTION_SAVED_OBJECT_INDEX,
+  hidden: false,
+  namespaceType: 'multiple-isolated',
+  mappings: emulationRuleBindingTypeMappings,
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/rule_binding_lookup.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_emulation/rule_binding_lookup.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import type { EmulationRuleBindingLookup } from './execution/runner';
+import { emulationRuleBindingTypeName, type EmulationRuleBindingAttributes } from './rule_binding';
+
+/**
+ * Build a {@link EmulationRuleBindingLookup} backed by the
+ * `emulation-rule-binding` saved-object type.
+ *
+ * Why a factory + closure: the runner only needs `(emulationId) => binding?`
+ * — it shouldn't know how the binding is fetched. Wrapping the SO client in a
+ * closure keeps the runner free of saved-objects coupling and makes it easy
+ * to swap out (tests pass a noop / fake; production gets this implementation).
+ *
+ * Scope:
+ * - We use the *internal* (hidden=true) SO client variant; the type is
+ *   registered with `hidden: true, hiddenFromHttpApis: true`, so a regular
+ *   `request.savedObjectsClient` cannot read it.
+ * - The lookup is best-effort: a missing binding returns `undefined` (the
+ *   runner treats this as "no rule binding for this emulation"). Errors are
+ *   logged and swallowed to keep the dispatch path resilient — failure to
+ *   resolve a rule name must not block a Response Action.
+ */
+export function createSavedObjectRuleBindingLookup(
+  soClient: SavedObjectsClientContract,
+  logger: Logger
+): EmulationRuleBindingLookup {
+  return async (emulationId) => {
+    try {
+      const result = await soClient.find<EmulationRuleBindingAttributes>({
+        type: emulationRuleBindingTypeName,
+        search: `"${emulationId}"`,
+        searchFields: ['emulationId'],
+        // We only need one — the (emulationId, ruleId) pair is logically unique
+        // and the most recently created binding wins if for any reason there
+        // are duplicates.
+        perPage: 1,
+        sortField: 'createdAt',
+        sortOrder: 'desc',
+      });
+
+      const hit = result.saved_objects[0];
+      if (!hit) {
+        return undefined;
+      }
+
+      return {
+        ruleId: hit.attributes.ruleId,
+        ruleName: hit.attributes.ruleName,
+      };
+    } catch (err) {
+      // Best-effort: a binding lookup failure must not abort the dispatch.
+      logger.warn(
+        `Failed to resolve emulation→rule binding for emulationId=[${emulationId}]: ${
+          (err as Error).message ?? err
+        }`
+      );
+      return undefined;
+    }
+  };
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -280,6 +280,8 @@ export class Plugin implements ISecuritySolutionPlugin {
       logger,
       ml: plugins.ml,
       options: { endpointAppContextService },
+      core,
+      config: this.config,
     }).catch((error) => {
       this.logger.error(`Error registering security skills: ${error}`);
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
@@ -20,6 +20,7 @@ import { registerRuleExceptionsRoutes } from '../lib/detection_engine/rule_excep
 import { registerRuleManagementRoutes } from '../lib/detection_engine/rule_management';
 import { registerRuleMonitoringRoutes } from '../lib/detection_engine/rule_monitoring';
 import { registerRulePreviewRoutes } from '../lib/detection_engine/rule_preview';
+import { registerDetectionEmulationRoutes } from '../lib/detection_emulation';
 
 import { createIndexRoute } from '../lib/detection_engine/routes/index/create_index_route';
 import { readIndexRoute } from '../lib/detection_engine/routes/index/read_index_route';
@@ -99,6 +100,7 @@ export const initRoutes = (
     logger,
     isServerless
   );
+  registerDetectionEmulationRoutes(router, config, logger);
 
   registerResolverRoutes(router, getStartServices);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/saved_objects.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/saved_objects.ts
@@ -34,6 +34,7 @@ import {
   PrivilegeMonitoringApiKeyEncryptionParams,
   PrivilegeMonitoringApiKeyType,
 } from './lib/entity_analytics/privilege_monitoring/auth/saved_object';
+import { emulationRuleBindingType } from './lib/detection_emulation';
 
 // Conditional Saved Object Types
 // Saved object types that will only be registered if the associated feature flag is enabled
@@ -63,6 +64,7 @@ const types = [
   promptType,
   referenceDataSavedObjectType,
   trialCompanionNBASavedObjectType,
+  emulationRuleBindingType,
 ];
 
 export const savedObjectTypes = types.map((type) => type.name);


### PR DESCRIPTION
## Summary

Draft for visibility / review preview. Adds an in-tree detection-emulation feature to Security Solution and exposes it as an Agent Builder skill, plus a follow-up commit that addresses a full self-review pass.

**Scope:** 46 files, +5,748 / −11 (vs `main` merge-base `a9d48ed`).

Two commits:
1. `9f9f073` — Add in-tree detection emulation feature.
2. `ab2dfde` — Address review feedback (blocker / important / nice-to-have).

This is the implementation arm of the OpenSpec change `detection-emulation-skill-tech-preview-productize-` (planning lives on a sibling branch and isn't part of this PR).

## What's in here

**Server / route**
- Route enforces `experimentalFeatures.detectionEmulationRealExecution`.
- Atomic acquire/release rate limiter (release on dispatch failure).
- Refuses to dispatch destructive actions without an authenticated caller (401 instead of falling back to `username='unknown'`).
- In-memory idempotency cache keyed on `(space, emulation, command, agentType, sorted endpointIds)` to short-circuit double-submits.
- Wires allowlist / rate-limiter / idempotency-cache config from `xpack.securitySolution.detectionEmulation.*`.
- Replaces legacy `tags: ['access:securitySolution']` with declarative `security.authz.requiredPrivileges`.
- Stops echoing internal error messages to clients; wraps every user-facing string in `i18n.translate`.
- Typed runner error taxonomy (`UnsupportedAgentTypeError`, `UnsupportedCommandForAgentTypeError`, `MissingConnectorActionsError`) maps cleanly to 4xx/5xx; dispatch switch has an exhaustiveness check.
- `emulation-rule-binding` saved object marked `hidden: true` / `hiddenFromHttpApis: true` with a `modelVersions` baseline.
- Runner accepts a `ruleBindingLookup` so dispatched actions carry `ruleId` / `ruleName` via a new `createSavedObjectRuleBindingLookup` helper using the internal SO client.

**Schema / contract**
- `RunEmulationCommandInputSchema` rewritten as a discriminated union on `command` with strict, command-specific `parameters` shapes — closes the silent-passthrough hole where typos like `entityId` previously sailed through the old `z.record`.
- `kill-process` / `suspend-process` model `pid` xor `entity_id`; `memory-dump` models `kernel | process(pid|entity_id)`.

**Skill / agent-builder**
- Skill content matches the actually-registered tool and command list; registration is gated on `detectionEmulationRealExecution`.
- Tool now returns `BuiltinSkillBoundedTool` (satisfies the framework's `SkillBoundedTool` contract); basePath at canonical `skills/security/endpoint`.

**UI**
- Removes dead `RunEmulationModal` block from `rule_details/index.tsx`.
- `EmulationFilter` subscribes to `filterManager.getUpdates$()` so the toggle stays in sync when filters mutate elsewhere.
- `RunEmulationModal` resets local state on `requestId` / `suggestion` change, disables Approve/Reject after click via `isSubmitting`, and parses modified args with a shell-style tokenizer (not whitespace split).
- Deep `@elastic/eui/src/...` import replaced with a type derived from EUI's published `onChange` signature.
- `EmulationBadge` wrapped in `EuiToolTip` for keyboard / screen-reader users.

**Cleanup**
- Drops unused `logInjection` flag; prunes dead `audit_logger` helpers; slims allowlist / rate-limiter APIs to actually-used methods.
- Adds CODEOWNERS entries for `common/detection_emulation`, `public/detections/components/emulation`, and `agent_builder/skills/detection_emulation`.

**Tests**
- `EmulationBadge` test asserts via `data-test-subj`, not classNames.
- Route, schema, skill, and component tests cover the new gates (auth, idempotency, rate limit), the typed errors, the discriminated union, and the new tooltip / tokenizer behavior.
- Per HEAD commit message: pre-commit clean — `type_check.js` green, eslint green on changed files, 123/123 jest specs green across schema / server / agent-builder skill / component suites.

## Status

Draft — not for review yet. Opened for:
- Diff preview from anywhere ([compare view](https://github.com/elastic/kibana/compare/main...patrykkopycinski:kibana:detection-emulation-skill)).
- CI signal once the branch is rebased onto current `main` (currently 3 commits behind merge-base).
- Discoverability via the treadmill PR tracker (a sibling treadmill change will land to surface headless branches alongside open PRs).

## Identify risks

- Branch is behind `main` and hasn't been re-bootstrapped against the latest tree; pre-commit results above were captured at `a9d48ed`. Rebase + re-run gates before flipping out of draft.
- Real-execution paths are feature-flagged off by default; mis-flagging is the dominant risk vector. The route enforces the flag server-side and skill registration is also gated.

Made with [Cursor](https://cursor.com)