### PR TITLE
[Scout] Only calculate stats for parsable modes

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/stats/test_config.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/stats/test_config.ts
@@ -15,6 +15,7 @@ import {
   SCOUT_TEST_EVENTS_INDEX_PATTERN,
   ScoutTestTarget,
   ScoutTestTargetSchema,
+  testTargets,
 } from '@kbn/scout-info';
 
 export const ScoutTestConfigStatsEntrySchema = z.object({
@@ -87,11 +88,22 @@ export class ScoutTestConfigStats {
       };
     }
   ): Promise<ScoutTestConfigStats> {
+    const parsableModes: Set<String> = new Set(
+      testTargets.all.map((target) => `${target.arch}-${target.domain}`)
+    );
+
     // Build ES query filters
     const whereClauses = [
       `@timestamp >= NOW() - ${options.lookbackDays}day`,
       'event.action == "run-end"',
-      'test_run.target.mode != "unknown"',
+
+      // The remote could have records of domains that this branch has no idea about,
+      // and we need to make sure that those won't make it in the query results
+      `test_run.target.mode IN (${parsableModes
+        .values()
+        .map((mode) => `"${mode}"`)
+        .toArray()
+        .join(', ')})`,
     ];
 
     if (options.configPaths.length > 0) {


### PR DESCRIPTION
When calculating stats using information from a remote cluster, the returned documents could include domain values that are unknown to the particular commit level.

This applies a filter to the ES query that ensures we don't receive any documents with a domain that cannot be parsed.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->