### PR TITLE
[Discover] Better support for computed fields in cascaded documents

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import type { AggregateQuery } from '@kbn/es-query';
 import { BehaviorSubject } from 'rxjs';
 import { renderWithI18n } from '@kbn/test-jest-helpers';
-import type { DataTableRecord } from '@kbn/discover-utils';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { esHitsMock } from '@kbn/discover-utils/src/__mocks__';
 import {
@@ -46,6 +46,11 @@ const expandedDoc = buildDataTableRecord(esHitsMock[0], dataViewWithTimefieldMoc
 const nextExpandedDoc = buildDataTableRecord(esHitsMock[1], dataViewWithTimefieldMock);
 const cellData = [expandedDoc, nextExpandedDoc];
 const cellId = 'leaf-1';
+const cascadedColumnsMeta: DataTableColumnsMeta = {
+  category: {
+    type: 'string',
+  },
+};
 
 const createVirtualizerController = () =>
   createChildVirtualizerController({ getRootVirtualizer: () => undefined });
@@ -54,7 +59,9 @@ const createCascadedDocumentsFetcher = (services: DiscoverServices) => {
   const stateManager: CascadedDocumentsStateManager = {
     getIsActiveInstance: jest.fn(() => true),
     getCascadedDocuments: jest.fn(() => undefined),
+    getColumnsMeta: jest.fn(() => ({})),
     setCascadedDocuments: jest.fn(),
+    setColumnsMeta: jest.fn(),
   };
   const scopedProfilesManager = services.profilesManager.createScopedProfilesManager({
     scopedEbtManager: services.ebtManager.createScopedEBTManager(),
@@ -128,6 +135,7 @@ const createContextValue = ({
     availableCascadeGroups: ['category'],
     selectedCascadeGroups: ['category'],
     cascadedDocumentsFetcher: createCascadedDocumentsFetcher(services),
+    cascadedColumnsMeta,
     esqlQuery,
     esqlVariables: undefined,
     timeRange: undefined,
@@ -176,6 +184,7 @@ describe('ESQLDataCascadeLeafCell', () => {
     expect(getExpandedDocSetter).toHaveBeenCalledWith(cellId);
     expect(getRenderDocumentViewMetaSetter).toHaveBeenCalledWith(cellId);
     expect(unifiedDataTableProps.rows).toEqual(cellData);
+    expect(unifiedDataTableProps.columnsMeta).toEqual(cascadedColumnsMeta);
     expect(unifiedDataTableProps.renderDocumentView).toBe('external');
     expect(unifiedDataTableProps.expandedDoc).toEqual(expandedDoc);
     expect(unifiedDataTableProps.setExpandedDoc).toBe(ownerBoundSetExpandedDoc);
@@ -200,6 +209,7 @@ describe('ESQLDataCascadeLeafCell', () => {
     );
 
     let unifiedDataTableProps = unifiedDataTableMock.mock.lastCall?.[0]!;
+    expect(unifiedDataTableProps.columnsMeta).toEqual(cascadedColumnsMeta);
     expect(unifiedDataTableProps.expandedDoc).toBeUndefined();
     expect(unifiedDataTableProps.setExpandedDoc).toBe(ownerBoundSetExpandedDoc);
     expect(unifiedDataTableProps.setRenderDocumentViewMeta).toBeUndefined();

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/blocks/cascade_leaf_component.tsx
@@ -162,7 +162,6 @@ export const ESQLDataCascadeLeafCell = React.memo(
     dataGridDensityState,
     showTimeCol,
     dataView,
-    showKeyboardShortcuts,
     externalCustomRenderers,
     virtualizerController,
     rowIndex,
@@ -170,6 +169,7 @@ export const ESQLDataCascadeLeafCell = React.memo(
   }: ESQLDataCascadeLeafCellProps) => {
     const services = useDiscoverServices();
     const {
+      cascadedColumnsMeta,
       expandedDoc$,
       expandedDocOwner$,
       getExpandedDocSetter,
@@ -266,7 +266,6 @@ export const ESQLDataCascadeLeafCell = React.memo(
       ),
       [virtualizerController, isCellInFullScreenMode, cellId, cellData, rowIndex]
     );
-
     return (
       <UnifiedDataTable
         isPlainRecord
@@ -281,6 +280,7 @@ export const ESQLDataCascadeLeafCell = React.memo(
         rows={cellData}
         loadingState={DataLoadingState.loaded}
         columns={selectedColumns}
+        columnsMeta={cascadedColumnsMeta}
         onSetColumns={setSelectedColumns}
         renderCustomToolbar={renderCustomToolbarWithElements}
         expandedDoc={expandedDocOwner === cellId ? expandedDoc : undefined}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_document_layout.test.tsx
@@ -120,6 +120,7 @@ const createWrapper = async (overrides?: Partial<CascadedDocumentsContext>) => {
     availableCascadeGroups: ['category'],
     selectedCascadeGroups: ['category'],
     cascadedDocumentsFetcher: createMockFetcher(),
+    cascadedColumnsMeta: {},
     esqlQuery,
     esqlVariables: undefined,
     timeRange: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx
@@ -13,7 +13,7 @@ import type { ReactElement } from 'react';
 import { createContext, useContext } from 'react';
 import type { BehaviorSubject } from 'rxjs';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
-import type { DataTableRecord } from '@kbn/discover-utils';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
 import type { DataCascadeRestorableState } from '@kbn/shared-ux-document-data-cascade';
 import type { UnifiedDataTableRestorableState } from '@kbn/unified-data-table';
 import type {
@@ -32,6 +32,7 @@ export type CascadedDocumentsDataGridUiStateMap = Record<
 export interface CascadedDocumentsContext
   extends Pick<CascadedDocumentsState, 'availableCascadeGroups' | 'selectedCascadeGroups'> {
   cascadedDocumentsFetcher: CascadedDocumentsFetcher;
+  cascadedColumnsMeta: DataTableColumnsMeta;
   esqlQuery: AggregateQuery;
   esqlVariables: ESQLControlVariable[] | undefined;
   timeRange: TimeRange | undefined;

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/hooks/data_fetching.test.ts
@@ -224,6 +224,7 @@ describe('data_fetching related hooks', () => {
         availableCascadeGroups: ['category'],
         selectedCascadeGroups: ['category'],
         cascadedDocumentsFetcher: createMockFetcher(),
+        cascadedColumnsMeta: {},
         esqlQuery,
         esqlVariables: undefined,
         timeRange: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
@@ -15,7 +15,7 @@ import { createDiscoverServicesMock } from '../../../../__mocks__/services';
 import { FetchStatus } from '../../../types';
 import { DiscoverDocuments, onResize } from './discover_documents';
 import { dataViewMock, esHitsMock } from '@kbn/discover-utils/src/__mocks__';
-import { buildDataTableRecord } from '@kbn/discover-utils';
+import { buildDataTableRecord, type DataTableColumnsMeta } from '@kbn/discover-utils';
 import type { EsHitRecord } from '@kbn/discover-utils/types';
 import type { InternalStateMockToolkit } from '../../../../__mocks__/discover_state.mock';
 import { getDiscoverInternalStateMock } from '../../../../__mocks__/discover_state.mock';
@@ -40,6 +40,11 @@ jest.mock('../../../../components/discover_grid_flyout', () => ({
 const discoverGridMock = jest.mocked(DiscoverGrid);
 const discoverGridFlyoutMock = jest.mocked(DiscoverGridFlyout);
 const singleEsHit = esHitsMock.slice(0, 1);
+const cascadedColumnsMeta: DataTableColumnsMeta = {
+  bytes: {
+    type: 'number',
+  },
+};
 
 const setup = async ({ services }: { services?: DiscoverServices } = {}) => {
   const toolkit = getDiscoverInternalStateMock({ services });
@@ -286,6 +291,16 @@ describe('Discover documents layout', () => {
         })
       );
 
+      toolkit.internalState.dispatch(
+        internalStateActions.setCascadedDocumentsState({
+          tabId,
+          cascadedDocumentsState: {
+            ...toolkit.getCurrentTab().cascadedDocumentsState,
+            columnsMeta: cascadedColumnsMeta,
+          },
+        })
+      );
+
       await mountComponent({
         fetchStatus: FetchStatus.COMPLETE,
         hits: esHitsMock,
@@ -320,6 +335,7 @@ describe('Discover documents layout', () => {
       expect(flyoutProps.hit).toEqual(expandedDoc);
       expect(flyoutProps.hits).toEqual([expandedDoc, nextExpandedDoc]);
       expect(flyoutProps.columns).toEqual(['bytes']);
+      expect(flyoutProps.columnsMeta).toEqual(cascadedColumnsMeta);
       expect(flyoutProps.docViewerExtensionActions?.refreshData).toEqual(expect.any(Function));
 
       act(() => {

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -491,9 +491,11 @@ function DiscoverDocumentsComponent({
   const latestCascadedDocumentsDataGridsUiState = useLatest(
     useCurrentTabSelector((tab) => tab.uiState.cascadedDocumentsDataGridMap)
   );
-  const { availableCascadeGroups, selectedCascadeGroups } = useCurrentTabSelector(
-    (tab) => tab.cascadedDocumentsState
-  );
+  const {
+    availableCascadeGroups,
+    selectedCascadeGroups,
+    columnsMeta: cascadedColumnsMeta,
+  } = useCurrentTabSelector((tab) => tab.cascadedDocumentsState);
   const setSelectedCascadeGroups = useCurrentTabAction(
     internalStateActions.setSelectedCascadeGroups
   );
@@ -514,6 +516,7 @@ function DiscoverDocumentsComponent({
       cascadedDocumentsFetcher,
       availableCascadeGroups,
       selectedCascadeGroups,
+      cascadedColumnsMeta,
       esqlQuery: query,
       esqlVariables,
       timeRange: requestParams.timeRangeAbsolute,
@@ -537,6 +540,7 @@ function DiscoverDocumentsComponent({
   }, [
     availableCascadeGroups,
     cascadedDocumentsFetcher,
+    cascadedColumnsMeta,
     dispatch,
     esqlVariables,
     expandedDoc$,
@@ -554,6 +558,13 @@ function DiscoverDocumentsComponent({
     setSelectedCascadeGroups,
     viewModeToggle,
   ]);
+
+  const flyoutColumnsMeta = useMemo(() => {
+    if (!expandedDocOwner || expandedDocOwner === DEFAULT_EXPANDED_DOC_OWNER) {
+      return columnsMeta;
+    }
+    return cascadedColumnsMeta;
+  }, [expandedDocOwner, columnsMeta, cascadedColumnsMeta]);
 
   if (isDataViewLoading || (isEmptyDataResult && isDataLoading)) {
     return (
@@ -650,7 +661,7 @@ function DiscoverDocumentsComponent({
           hits={renderDocumentViewMeta.displayedRows}
           // if default columns are used, don't make them part of the URL - the context state handling will take care to restore them
           columns={renderDocumentViewMeta.displayedColumns}
-          columnsMeta={columnsMeta}
+          columnsMeta={flyoutColumnsMeta}
           savedSearchId={persistedDiscoverSession?.id!}
           query={query}
           initialTabId={initialDocViewerTabId}

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.test.ts
@@ -7,7 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { buildDataTableRecord, type DataTableRecord } from '@kbn/discover-utils';
+import {
+  buildDataTableRecord,
+  type DataTableColumnsMeta,
+  type DataTableRecord,
+} from '@kbn/discover-utils';
 import type { AggregateQuery } from '@kbn/es-query';
 import { constructCascadeQuery } from '@kbn/esql-utils';
 import { apm } from '@elastic/apm-rum';
@@ -42,24 +46,36 @@ jest.mock('@elastic/apm-rum', () => ({
 const mockFetchEsql = jest.mocked(fetchEsql);
 const mockConstructCascadeQuery = jest.mocked(constructCascadeQuery);
 const mockApmCaptureError = jest.mocked(apm.captureError);
+const columnsMeta: DataTableColumnsMeta = {
+  extension: {
+    type: 'string',
+  },
+};
 
-const createStateManager = (): CascadedDocumentsStateManager => {
+const createStateManager = (
+  initialColumnsMeta: DataTableColumnsMeta = {}
+): CascadedDocumentsStateManager => {
   const recordsById = new Map<string, DataTableRecord[]>();
+  let currentColumnsMeta = initialColumnsMeta;
   return {
     getIsActiveInstance: jest.fn(() => true),
     getCascadedDocuments: jest.fn((nodeId: string) => recordsById.get(nodeId)),
+    getColumnsMeta: jest.fn(() => currentColumnsMeta),
     setCascadedDocuments: jest.fn((nodeId: string, records: DataTableRecord[]) => {
       recordsById.set(nodeId, records);
+    }),
+    setColumnsMeta: jest.fn((nextColumnsMeta: DataTableColumnsMeta) => {
+      currentColumnsMeta = nextColumnsMeta;
     }),
   };
 };
 
-const createFetcher = () => {
+const createFetcher = (initialColumnsMeta?: DataTableColumnsMeta) => {
   const discoverServices = createDiscoverServicesMock();
   const scopedProfilesManager = discoverServices.profilesManager.createScopedProfilesManager({
     scopedEbtManager: discoverServices.ebtManager.createScopedEBTManager(),
   });
-  const stateManager = createStateManager();
+  const stateManager = createStateManager(initialColumnsMeta);
 
   return {
     stateManager,
@@ -101,6 +117,7 @@ describe('CascadedDocumentsFetcher', () => {
     expect(result).toBe(cached);
     expect(mockFetchEsql).not.toHaveBeenCalled();
     expect(mockConstructCascadeQuery).not.toHaveBeenCalled();
+    expect(stateManager.setColumnsMeta).not.toHaveBeenCalled();
   });
 
   it('constructs a cascade query, fetches records, and caches them', async () => {
@@ -109,7 +126,10 @@ describe('CascadedDocumentsFetcher', () => {
     const cascadeQuery: AggregateQuery = { esql: 'from logs' };
 
     mockConstructCascadeQuery.mockReturnValueOnce(cascadeQuery);
-    mockFetchEsql.mockResolvedValue({ records });
+    mockFetchEsql.mockResolvedValue({
+      records,
+      esqlQueryColumns: [{ id: 'extension', name: 'extension', meta: columnsMeta.extension }],
+    });
 
     const params = createFetchParams({ nodeId: 'node-2' });
     const result = await fetcher.fetchCascadedDocuments(params);
@@ -142,7 +162,26 @@ describe('CascadedDocumentsFetcher', () => {
         },
       })
     );
+    expect(stateManager.setColumnsMeta).toHaveBeenCalledWith(columnsMeta);
     expect(stateManager.setCascadedDocuments).toHaveBeenCalledWith(params.nodeId, records);
+  });
+
+  it('skips updating columns meta when the fetched value is unchanged', async () => {
+    const { stateManager, fetcher } = createFetcher(columnsMeta);
+    const records = [buildDataTableRecord({ _id: '1', _index: 'logs' }, dataViewWithTimefieldMock)];
+    const cascadeQuery: AggregateQuery = { esql: 'from logs' };
+
+    mockConstructCascadeQuery.mockReturnValueOnce(cascadeQuery);
+    mockFetchEsql.mockResolvedValue({
+      records,
+      esqlQueryColumns: [{ id: 'extension', name: 'extension', meta: columnsMeta.extension }],
+    });
+
+    await fetcher.fetchCascadedDocuments(createFetchParams({ nodeId: 'node-same-meta' }));
+
+    expect(stateManager.getColumnsMeta).toHaveBeenCalled();
+    expect(stateManager.setColumnsMeta).not.toHaveBeenCalled();
+    expect(stateManager.setCascadedDocuments).toHaveBeenCalledWith('node-same-meta', records);
   });
 
   it('captures an error when the cascade query cannot be constructed', async () => {
@@ -154,6 +193,7 @@ describe('CascadedDocumentsFetcher', () => {
 
     expect(result).toEqual([]);
     expect(mockFetchEsql).not.toHaveBeenCalled();
+    expect(stateManager.setColumnsMeta).not.toHaveBeenCalled();
     expect(stateManager.setCascadedDocuments).not.toHaveBeenCalled();
     expect(mockApmCaptureError).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'Failed to construct cascade query' })

--- a/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/data_fetching/cascaded_documents_fetcher.ts
@@ -12,8 +12,10 @@ import type { TimeRange } from '@kbn/es-query';
 import type { CascadeQueryArgs } from '@kbn/esql-utils/src/utils/cascaded_documents_helpers';
 import { apm } from '@elastic/apm-rum';
 import { i18n } from '@kbn/i18n';
-import type { DataTableRecord } from '@kbn/discover-utils';
+import { isEqual } from 'lodash';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
 import { RequestAdapter } from '@kbn/inspector-plugin/public';
+import { getTextBasedColumnsMeta } from '@kbn/unified-data-table';
 import type { DiscoverServices } from '../../../build_services';
 import { fetchEsql } from './fetch_esql';
 import type { ScopedProfilesManager } from '../../../context_awareness';
@@ -26,7 +28,9 @@ export interface FetchCascadedDocumentsParams extends CascadeQueryArgs {
 export interface CascadedDocumentsStateManager {
   getIsActiveInstance(): boolean;
   getCascadedDocuments(nodeId: string): DataTableRecord[] | undefined;
+  getColumnsMeta(): DataTableColumnsMeta;
   setCascadedDocuments(nodeId: string, records: DataTableRecord[]): void;
+  setColumnsMeta(columnsMeta: DataTableColumnsMeta): void;
 }
 
 export class CascadedDocumentsFetcher {
@@ -83,7 +87,7 @@ export class CascadedDocumentsFetcher {
         return [];
       }
 
-      ({ records } = await fetchEsql({
+      const { esqlQueryColumns, records: fetchedRecords } = await fetchEsql({
         query: cascadeQuery,
         esqlVariables,
         dataView,
@@ -102,9 +106,16 @@ export class CascadedDocumentsFetcher {
               'This request queries Elasticsearch to fetch the documents matching the value of the expanded cascade row.',
           }),
         },
-      }));
+      });
 
+      records = fetchedRecords;
       this.stateManager.setCascadedDocuments(nodeId, records);
+
+      const columnsMeta = esqlQueryColumns ? getTextBasedColumnsMeta(esqlQueryColumns) : {};
+      const previousColumnsMeta = this.stateManager.getColumnsMeta();
+      if (!isEqual(previousColumnsMeta, columnsMeta)) {
+        this.stateManager.setColumnsMeta(columnsMeta);
+      }
     } finally {
       this.abortControllers.delete(nodeId);
     }

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -363,6 +363,7 @@ export function getDataStateContainer({
             injectCurrentTab(internalStateActions.setCascadedDocumentsState)({
               cascadedDocumentsState: {
                 ...getCurrentTab().cascadedDocumentsState,
+                columnsMeta: {},
                 cascadedDocumentsMap: {},
               },
             })

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/cascaded_documents_state_manager.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/cascaded_documents_state_manager.ts
@@ -26,6 +26,10 @@ export const createCascadedDocumentsStateManager = ({
     const currentTab = selectTab(internalState.getState(), tabId);
     return currentTab.cascadedDocumentsState.cascadedDocumentsMap[nodeId];
   },
+  getColumnsMeta() {
+    const currentTab = selectTab(internalState.getState(), tabId);
+    return currentTab.cascadedDocumentsState.columnsMeta;
+  },
   setCascadedDocuments(nodeId, records) {
     const currentTab = selectTab(internalState.getState(), tabId);
     const cascadedDocumentsState = currentTab.cascadedDocumentsState;
@@ -38,6 +42,19 @@ export const createCascadedDocumentsStateManager = ({
             ...cascadedDocumentsState.cascadedDocumentsMap,
             [nodeId]: records,
           },
+        },
+      })
+    );
+  },
+  setColumnsMeta(columnsMeta) {
+    const currentTab = selectTab(internalState.getState(), tabId);
+    const cascadedDocumentsState = currentTab.cascadedDocumentsState;
+    internalState.dispatch(
+      internalStateSlice.actions.setCascadedDocumentsState({
+        tabId,
+        cascadedDocumentsState: {
+          ...cascadedDocumentsState,
+          columnsMeta,
         },
       })
     );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -34,6 +34,7 @@ export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
   cascadedDocumentsState: {
     availableCascadeGroups: [],
     selectedCascadeGroups: [],
+    columnsMeta: {},
     cascadedDocumentsMap: {},
   },
   esqlVariables: [],

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
@@ -108,6 +108,7 @@ describe('tab mapping utils', () => {
           "cascadedDocumentsState": Object {
             "availableCascadeGroups": Array [],
             "cascadedDocumentsMap": Object {},
+            "columnsMeta": Object {},
             "selectedCascadeGroups": Array [],
           },
           "dataRequestParams": Object {
@@ -202,6 +203,7 @@ describe('tab mapping utils', () => {
           "cascadedDocumentsState": Object {
             "availableCascadeGroups": Array [],
             "cascadedDocumentsMap": Object {},
+            "columnsMeta": Object {},
             "selectedCascadeGroups": Array [],
           },
           "dataRequestParams": Object {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -10,7 +10,7 @@
 import type { ControlPanelsState } from '@kbn/control-group-renderer';
 import type { RefreshInterval, SerializedSearchSourceFields } from '@kbn/data-plugin/common';
 import type { DataViewListItem } from '@kbn/data-views-plugin/public';
-import type { DataTableRecord } from '@kbn/discover-utils';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
 import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
 import type { ESQLEditorRestorableState } from '@kbn/esql-editor';
 import type { ESQLControlVariable } from '@kbn/esql-types';
@@ -129,6 +129,7 @@ export interface DiscoverAppState {
 export interface CascadedDocumentsState {
   availableCascadeGroups: string[];
   selectedCascadeGroups: string[];
+  columnsMeta: DataTableColumnsMeta;
   cascadedDocumentsMap: Record<string, DataTableRecord[] | undefined>;
 }
 


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/268814
## Summary
Cascaded documents (group by) were not using `columnsMeta`, producing some miss behaviours when dealing with computed fields.
* Types not shown in the Doc Viewer.
* Time column not shown in the Datatable.
* Field formatting skipped on the Summary column.

Note that `columnsMeta` belonging to the top query can't be used for the cascaded docs, as it will only contain the fiels after the `STATS` command.
We need to build a `columnsMeta` from the result of the query ran on the expanded docs. I'm persisting only one result and not one per node as it should be the same one for every group. 

`showTimeCol` flag was not working due to missing `columnsMeta` . I think it makes sense to show the time column respecting the `DOC_HIDE_TIME_COLUMN_SETTING` setting, but we can hardcode it on false to hide it if needed.

### Before 
<img width="1722" height="428" alt="image" src="https://github.com/user-attachments/assets/678ee12b-f470-4e2c-9323-fbe8070319f3" />

### After
<img width="1727" height="408" alt="image" src="https://github.com/user-attachments/assets/3a2cd534-c477-4925-9141-8018d36f918f" />

### Before
<img width="634" height="161" alt="image" src="https://github.com/user-attachments/assets/fe19684b-1a34-4c41-9d9b-c3370cd98fd4" />

### After
<img width="634" height="138" alt="image" src="https://github.com/user-attachments/assets/3d891c12-eb1a-4638-bfa0-19ce2bb9cc6a" />

### Before
<img width="1725" height="740" alt="image" src="https://github.com/user-attachments/assets/b3ba1655-554e-42eb-bfae-d4e85fa95747" />


### After
<img width="1727" height="599" alt="image" src="https://github.com/user-attachments/assets/bc27533f-ece6-4ebd-b5e8-e8846caa46e2" />
### Checklist

Check the PR satisfies following conditions. 
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




