### PR TITLE
[Security Solution] Add ILM policy for the change history index

### DIFF
--- a/x-pack/platform/packages/shared/kbn-change-history/README.md
+++ b/x-pack/platform/packages/shared/kbn-change-history/README.md
@@ -123,6 +123,23 @@ The data stream uses `dynamic: false` and the following index mapping (defined b
 
 Variable-shape field `object.snapshot` is stored but unmapped; `metadata` uses the `flattened` type so arbitrary keys can be stored and indexed without dynamic mapping.
 
+### Index Lifecycle Management (ILM)
+
+The data stream is linked to a managed ILM policy named:
+
+```
+.kibana-change-history-ilm-policy
+```
+
+The default policy ships with a single `hot` phase and no actions — change history documents are kept indefinitely with no automatic rollover or deletion. The policy is installed only when it does not already exist, so cluster admins can customize it in place without their changes being overwritten on the next Kibana startup.
+
+To adjust retention or add a rollover strategy, edit the policy via:
+
+- the Kibana UI: **Stack Management → Index Lifecycle Policies → `.kibana-change-history-ilm-policy`**, or
+- the Elasticsearch API: `PUT _ilm/policy/.kibana-change-history-ilm-policy`.
+
+Edits take effect on existing backing indices on the next ILM poll.
+
 ### Dependencies
 
 See [tsconfig.json](tsconfig.json) for internal kibana references.

--- a/x-pack/platform/packages/shared/kbn-change-history/index.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/index.ts
@@ -7,6 +7,7 @@
 
 export type * from './src/types';
 export * from './src/client';
+export { ILM_POLICY_NAME } from './src/constants';
 /**
  * @internal exported for test use only — do NOT use in production code,
  * this could cause the index to be created before the feature is ready for GA

--- a/x-pack/platform/packages/shared/kbn-change-history/integration_tests/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/integration_tests/client.test.ts
@@ -11,7 +11,7 @@ import { ToolingLog } from '@kbn/tooling-log';
 import type { EsTestCluster } from '@kbn/test';
 import { createTestEsCluster } from '@kbn/test';
 import { FLAGS } from '../src/constants';
-import { ChangeHistoryClient } from '..';
+import { ChangeHistoryClient, ILM_POLICY_NAME } from '..';
 import { DATA_STREAM_NAME } from '../src/client';
 import type { ObjectChange } from '..';
 import { sha256 } from '../src/utils';
@@ -43,6 +43,7 @@ describe('ChangeHistoryClient', () => {
     const client = esServer.getClient();
     await client.indices.deleteDataStream({ name: DATA_STREAM_NAME }).catch(() => {});
     await client.indices.deleteIndexTemplate({ name: DATA_STREAM_NAME }).catch(() => {});
+    await client.ilm.deleteLifecycle({ name: ILM_POLICY_NAME }).catch(() => {});
   };
 
   beforeAll(async () => {
@@ -93,6 +94,71 @@ describe('ChangeHistoryClient', () => {
       const result = await client.getHistory(KIBANA_SPACE, 'rule', 'any-id');
       expect(result.total).toBe(0);
       expect(result.items).toEqual([]);
+    });
+
+    describe('ILM policy', () => {
+      const getInstalledPolicy = async () => {
+        const res = await esServer.getClient().ilm.getLifecycle({ name: ILM_POLICY_NAME });
+        return res[ILM_POLICY_NAME]?.policy;
+      };
+      const getBackingIndexLifecycleName = async () => {
+        const settings = await esServer
+          .getClient()
+          .indices.getSettings({ index: DATA_STREAM_NAME, expand_wildcards: ['hidden', 'open'] });
+        const [first] = Object.values(settings);
+        return first?.settings?.index?.lifecycle?.name;
+      };
+
+      it('installs the ILM policy and points the index template at it', async () => {
+        const esClient = esServer.getClient();
+        await expect(esClient.ilm.getLifecycle({ name: ILM_POLICY_NAME })).rejects.toMatchObject({
+          meta: { statusCode: 404 },
+        });
+
+        const client = new ChangeHistoryClient(defaultCostructorOpts);
+        await client.initialize(esClient);
+
+        const policy = await getInstalledPolicy();
+        expect(policy).toEqual({
+          _meta: { managed: true },
+          phases: { hot: { min_age: '0ms', actions: {} } },
+        });
+
+        const template = await esClient.indices.getIndexTemplate({ name: DATA_STREAM_NAME });
+        expect(
+          template.index_templates[0]?.index_template?.template?.settings?.index?.lifecycle?.name
+        ).toBe(ILM_POLICY_NAME);
+
+        expect(await getBackingIndexLifecycleName()).toBe(ILM_POLICY_NAME);
+      });
+
+      it('does not overwrite an admin-modified ILM policy on re-initialize', async () => {
+        const esClient = esServer.getClient();
+
+        const customPolicy = {
+          _meta: { managed: false, modified_by: 'admin' },
+          phases: {
+            hot: {
+              actions: {
+                rollover: { max_age: '7d', max_primary_shard_size: '25gb' },
+              },
+            },
+            delete: { min_age: '90d', actions: { delete: {} } },
+          },
+        };
+        await esClient.ilm.putLifecycle({ name: ILM_POLICY_NAME, policy: customPolicy });
+
+        const client = new ChangeHistoryClient(defaultCostructorOpts);
+        await client.initialize(esClient);
+
+        const policy = await getInstalledPolicy();
+        expect(policy?._meta).toEqual({ managed: false, modified_by: 'admin' });
+        expect(policy?.phases?.hot?.actions?.rollover).toEqual({
+          max_age: '7d',
+          max_primary_shard_size: '25gb',
+        });
+        expect(policy?.phases?.delete).toBeDefined();
+      });
     });
   });
 

--- a/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/client.ts
@@ -19,10 +19,12 @@ import { changeHistoryMappings } from './mappings';
 import {
   FLAGS,
   DATA_STREAM_NAME,
+  ILM_POLICY_NAME,
   SEPARATOR_CHAR,
   ECS_VERSION,
   DEFAULT_RESULT_SIZE,
 } from './constants';
+import { ensureIlmPolicy } from './ilm_policy';
 import type {
   ChangeHistoryDocument,
   GetHistoryResult,
@@ -106,8 +108,22 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
       this.logger.error(error);
       throw error;
     }
-    // Step 1: Create data stream definition
-    // TODO: What about ILM policy (defaults to none = keep forever)
+    // Step 1: Ensure the ILM policy exists. Installed only when missing so
+    // cluster admins can customize the policy in place without Kibana
+    // overwriting their changes on the next startup.
+    try {
+      await ensureIlmPolicy(elasticsearchClient, this.logger);
+    } catch (error) {
+      const err = new Error(
+        `Unable to install change history ILM policy [${ILM_POLICY_NAME}]: ${error}`,
+        { cause: error }
+      );
+      this.logger.error(err);
+      throw err;
+    }
+
+    // Step 2: Create data stream definition. The `index.lifecycle.name` setting
+    // points backing indices at the policy installed above.
     const definition: DataStreamDefinition<typeof changeHistoryMappings.v1, ChangeHistoryDocument> =
       {
         name: DATA_STREAM_NAME,
@@ -116,10 +132,13 @@ export class ChangeHistoryClient implements IChangeHistoryClient {
         template: {
           priority: 100,
           mappings: changeHistoryMappings.v1,
+          settings: {
+            'index.lifecycle.name': ILM_POLICY_NAME,
+          },
         },
       };
 
-    // Step 2: Initialize data stream
+    // Step 3: Initialize data stream
     try {
       this.client = await DataStreamClient.initialize({
         dataStream: definition,

--- a/x-pack/platform/packages/shared/kbn-change-history/src/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/constants.ts
@@ -10,6 +10,12 @@
  */
 export const DATA_STREAM_NAME = '.kibana_change_history';
 /**
+ * Name of the ILM policy applied to the change history data stream.
+ * Documented in the package README so cluster admins can edit it via the
+ * Kibana Index Lifecycle Management UI / Elasticsearch ILM API.
+ */
+export const ILM_POLICY_NAME = '.kibana-change-history-ilm-policy';
+/**
  * Separator char. Used for scoping.
  */
 export const SEPARATOR_CHAR = '|';

--- a/x-pack/platform/packages/shared/kbn-change-history/src/ilm_policy.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/ilm_policy.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IlmPolicy } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import { ILM_POLICY_NAME } from './constants';
+
+/**
+ * Default ILM policy for `.kibana_change_history`.
+ *
+ * Indefinite retention: a single `hot` phase with no actions (no rollover, no
+ * delete). The policy exists as an edit point so cluster admins can introduce
+ * rollover / retention through the Kibana ILM UI or the Elasticsearch ILM API
+ * without Kibana having to redeploy.
+ */
+export const ILM_POLICY: IlmPolicy = {
+  _meta: { managed: true },
+  phases: {
+    hot: {
+      actions: {},
+    },
+  },
+};
+
+/**
+ * Install the change history ILM policy iff it does not already exist.
+ *
+ * Calling `putLifecycle` unconditionally would silently overwrite any admin
+ * customization on every Kibana startup, which contradicts the "admins can
+ * edit the policy in place" guarantee documented in the package README.
+ */
+export async function ensureIlmPolicy(
+  elasticsearchClient: ElasticsearchClient,
+  logger: Logger
+): Promise<void> {
+  if (await ilmPolicyExists(elasticsearchClient)) {
+    logger.debug(`ILM policy ${ILM_POLICY_NAME} already exists; leaving it as-is.`);
+    return;
+  }
+  logger.debug(`Installing ILM policy ${ILM_POLICY_NAME} for change history data stream.`);
+  await elasticsearchClient.ilm.putLifecycle({
+    name: ILM_POLICY_NAME,
+    policy: ILM_POLICY,
+  });
+}
+
+async function ilmPolicyExists(elasticsearchClient: ElasticsearchClient): Promise<boolean> {
+  try {
+    await elasticsearchClient.ilm.getLifecycle({ name: ILM_POLICY_NAME });
+    return true;
+  } catch (error) {
+    if (error?.meta?.statusCode === 404) {
+      return false;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
**Resolves: https://github.com/elastic/security-team/issues/17280** (internal)
**Epic: https://github.com/elastic/security-team/issues/12367** (internal)

## Summary

Adds an Index Lifecycle Management (ILM) policy for the hidden `.kibana_change_history` data stream used by `@kbn/change-history`. This is the last `@kbn/change-history` follow-up that needed to land before the MVP can be released in 9.5. The change-history feature itself remains behind `FLAGS.FEATURE_ENABLED`, so this PR has no user-visible effect yet.

Without an ILM policy, the change history index grows unbounded for every cluster that has the feature enabled. The new policy gives cluster admins a single, well-known edit point for retention and rollover, and Kibana never overwrites their customizations.

## Details

- **New ILM policy** `.kibana-change-history-ilm-policy`. Default body has a single `hot` phase with no actions (no rollover, no delete) — indefinite retention. The policy is intentionally minimal so it acts as an edit point: admins add rollover/retention via the Kibana ILM UI or `PUT _ilm/policy/...`.
- **Idempotent install**: `ChangeHistoryClient.initialize()` calls `ilm.getLifecycle()` first and only `ilm.putLifecycle()` when the policy is missing. Admin edits survive subsequent Kibana restarts.
- **Template link**: the data stream's index template now sets `index.lifecycle.name` so newly created backing indices pick up the policy automatically.
- **Docs**: a new "Index Lifecycle Management (ILM)" section in the `kbn-change-history` README explains the policy name and how to edit it.

No `kibana.yml` knob for 9.5 — editing the policy in place via Kibana's ILM UI is sufficient per the ticket scope; a config knob can be added later if there's demand.

## How to test

Automated coverage is in `x-pack/platform/packages/shared/kbn-change-history/integration_tests/client.test.ts` under the new `ILM policy` describe:

- `installs the ILM policy and points the index template at it` — verifies the policy exists after `initialize()`, the index template's `index.lifecycle.name` is set, and the backing index inherits it.
- `does not overwrite an admin-modified ILM policy on re-initialize` — pre-installs a custom policy (different `_meta`, rollover + delete actions) and asserts the client leaves it untouched.

To run locally:

```bash
yarn test:jest_integration --config=x-pack/platform/packages/shared/kbn-change-history/jest.integration.config.js
```

## Release note

skip

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

- The change is gated by `FLAGS.FEATURE_ENABLED` (currently `false` in `main`) and the change-history feature isn't shipped yet — no production behavior change in 9.5 ahead of MVP enablement.
- Policy installation is idempotent and only-if-missing, so admin customizations made via the ILM UI / ES API are preserved across Kibana restarts.