### PR TITLE
[Discover][Logs] Fix "Explain this log entry" AI insight resetting on auto-refresh

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/insights/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/insights/index.tsx
@@ -74,19 +74,18 @@ export function createLogAIInsight(
   core: CoreStart,
   plugins: ObservabilityAgentBuilderPluginStartDependencies
 ) {
-  return (props: LogAiInsightProps) => {
-    const { Provider: KibanaReactContextProvider } = createKibanaReactContext({
-      ...core,
-      ...plugins,
-    });
-    return (
-      <QueryClientProvider client={queryClient}>
-        <KibanaReactContextProvider>
-          <LogAiInsightLazy {...props} />
-        </KibanaReactContextProvider>
-      </QueryClientProvider>
-    );
-  };
+  const { Provider: KibanaReactContextProvider } = createKibanaReactContext({
+    ...core,
+    ...plugins,
+  });
+
+  return (props: LogAiInsightProps) => (
+    <QueryClientProvider client={queryClient}>
+      <KibanaReactContextProvider>
+        <LogAiInsightLazy {...props} />
+      </KibanaReactContextProvider>
+    </QueryClientProvider>
+  );
 }
 
 export const createLogsAIInsightRenderer =


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/268105

The "Explain this log entry" AI insight in the logs flyout was resetting its state (collapsing, losing any in-progress or completed summary) on every auto-refresh. 

<img width="769" height="98" alt="Screenshot 2026-05-12 at 15 06 44" src="https://github.com/user-attachments/assets/fd0a72aa-4425-40e9-9359-e369adf46df6" />


The root cause was that `createKibanaReactContext` was called inside the component function returned by `createLogAIInsight`. `createKibanaReactContext` produces a new component type on every call, so each re-render of the flyout created a new `KibanaReactContextProvider` type, causing React to unmount and remount the entire subtree including `LogAiInsightLazy` and resetting all state. 

The fix moves `createKibanaReactContext` outside the returned component so the provider type is stable across re-renders, matching the pattern already used by `createAlertAIInsight` and `createErrorSampleAIInsight` in the same file.

### Classic mode 

|Before|After|
|-|-|
|<img alt="logs_ai_insight_classic_before" src="https://github.com/user-attachments/assets/5c8034e4-e9fc-4761-918a-c7583defe35c" />|<img alt="logs_ai_insight_classic_after" src="https://github.com/user-attachments/assets/52edd0f0-504e-40bf-b019-2f25133ae6e4" />|

### ES|QL mode

> [!NOTE]
> This should also resolve the reset in ES|QL mode. 
> However, in ES|QL, the flyout does not yet pin the document across auto-refresh, meaning the AI insight may end up associated with a different document after the data refreshes. Once https://github.com/elastic/kibana/pull/268328 is merged, the flyout will pin the originally opened document, and the AI insight will behave correctly end-to-end in ES|QL mode too.

|Before|After|
|-|-|
|<img alt="logs_ai_insight_esql_before" src="https://github.com/user-attachments/assets/881dbf0a-9772-40ed-bc19-d3bf81e1dc28" />|<img alt="logs_ai_insight_esql_after" src="https://github.com/user-attachments/assets/37707c64-072c-41ab-bdc8-efb7158f58fd" />|



### How to test

- Open Discover and switch to a data view that has log documents (e.g. `logs-*`).
- Open the flyout for any log document and expand the "Explain this log entry" section. Wait for the AI summary to start generating or complete.
- Enable auto-refresh (e.g. every 1 seconds) and let it trigger one or more refreshes.
- Verify the AI insight section does not collapse or reset its state.
- Navigate to a different log document via the flyout pagination arrows and verify the AI insight resets for the new document.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->