### PR TITLE
[CI] Skip flaky scout 2026 05 12

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/home_page.spec.ts
+++ b/x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/home_page.spec.ts
@@ -11,7 +11,8 @@ import { test } from '../fixtures';
 
 const testIndexName = `index-test-${Math.random()}`;
 
-test.describe('Home page', { tag: tags.stateful.classic }, () => {
+// Failing: See https://github.com/elastic/kibana/issues/267414
+test.describe.skip('Home page', { tag: tags.stateful.classic }, () => {
   test.beforeEach(async ({ pageObjects, browserAuth }) => {
     await browserAuth.loginAsIndexManagementUser();
     await pageObjects.indexManagement.goto();

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/landing.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/landing.spec.ts
@@ -16,7 +16,8 @@ import {
 } from '../fixtures/generators';
 import { BIGGER_TIMEOUT, SHORTER_TIMEOUT } from '../fixtures/constants';
 
-test.describe(
+// Failing: See https://github.com/elastic/kibana/issues/267146
+test.describe.skip(
   'Observability Landing Page',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/esql_landing.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/esql_landing.spec.ts
@@ -24,7 +24,8 @@ import { test } from '../fixtures';
 import { generateLogsData, TEST_START_DATE, TEST_END_DATE } from '../fixtures/generators';
 import { BIGGER_TIMEOUT } from '../fixtures/constants';
 
-test.describe(
+// Failing: See https://github.com/elastic/kibana/issues/268022
+test.describe.skip(
   'Observability Landing Page (discover.isEsqlDefault enabled)',
   { tag: [...tags.stateful.classic] },
   () => {

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
@@ -11,7 +11,8 @@ import type { RoleApiCredentials } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
-apiTest.describe(
+// Failing: See https://github.com/elastic/kibana/issues/253221
+apiTest.describe.skip(
   'APM integration not installed but setup completed',
   { tag: tags.stateful.classic },
   () => {


### PR DESCRIPTION
## Summary
This pull request temporarily disables several failing test suites by marking them as skipped and adding references to related GitHub issues for tracking. This helps prevent test failures from blocking other development work while the underlying problems are being addressed. *These tests are consistently failing when ran together with other tests, passing when reran alone*.

Test suite skips (with issue references):

* UI test suites:
  - Skipped the `Home page` test suite in `home_page.spec.ts` due to a known failure (see issue #267414).
  - Skipped the `Observability Landing Page` test suite in `landing.spec.ts` due to a known failure (see issue #267146).
  - Skipped the `Observability Landing Page (discover.isEsqlDefault enabled)` test suite in `esql_landing.spec.ts` due to a known failure (see issue #268022).

* API test suite:
  - Skipped the `APM integration not installed but setup completed` API test suite in `has_setup_apm_not_installed.spec.ts` due to a known failure (see issue #253221).