### PR TITLE
[9.4] [scout] move configs split out of discovery (#266661)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -18,6 +18,7 @@ import type { BuildkiteStep } from '../buildkite';
 import { BuildkiteClient } from '../buildkite';
 import type { TestGroupRunOrderResponse } from './client';
 import { CiStatsClient } from './client';
+import { getTrackedBranch } from '../utils';
 
 import DISABLED_JEST_CONFIGS from '../../disabled_jest_configs.json';
 import SHARDED_JEST_CONFIGS from '../../sharded_jest_configs.json';
@@ -571,23 +572,6 @@ function getRunGroup(bk: BuildkiteClient, allTypes: RunGroup[], typeName: string
     throw new Error(`expected to find exactly 1 "${typeName}" run group`);
   }
   return groups[0];
-}
-
-function getTrackedBranch(): string {
-  let pkg;
-  try {
-    pkg = JSON.parse(Fs.readFileSync('package.json', 'utf8'));
-  } catch (_) {
-    const error = _ instanceof Error ? _ : new Error(`${_} thrown`);
-    throw new Error(`unable to read kibana's package.json file: ${error.message}`);
-  }
-
-  const branch = pkg.branch;
-  if (typeof branch !== 'string') {
-    throw new Error('missing `branch` field from package.json file');
-  }
-
-  return branch;
 }
 
 function isObj(x: unknown): x is Record<string, unknown> {

--- a/.buildkite/pipeline-utils/scout/pick_scout_flaky_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_flaky_run_order.ts
@@ -97,18 +97,7 @@ const buildSteps = (
       );
     }
 
-    // Dedupe modes in case the manifest contains duplicate (arch, domain) entries, and
-    // log a warning so the upstream issue is visible.
-    const modes = [...new Set(entry.serverRunFlags)];
-    if (modes.length !== entry.serverRunFlags.length) {
-      console.warn(
-        `⚠️ scoutConfig '${normalized}' had duplicate serverRunFlags in the manifest ` +
-          `(${entry.serverRunFlags.length} entries, ${modes.length} unique). ` +
-          `Deduping for step generation; consider fixing the discovery output.`
-      );
-    }
-
-    for (const mode of modes) {
+    for (const mode of entry.serverRunFlags) {
       scoutJobs += req.count;
       if (reservedJobs + scoutJobs > MAX_JOBS) {
         throw new Error(

--- a/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
@@ -8,10 +8,11 @@
  */
 
 import Fs from 'fs';
+import path from 'path';
 import { expandAgentQueue } from '../agent_images';
 import { BuildkiteClient, type BuildkiteStep } from '../buildkite';
 import { collectEnvFromLabels } from '../pr_labels';
-import { getRequiredEnv } from '#pipeline-utils';
+import { getKibanaDir, getRequiredEnv } from '#pipeline-utils';
 
 export interface ModuleDiscoveryInfo {
   name: string;
@@ -27,19 +28,83 @@ export interface ModuleDiscoveryInfo {
   }[];
 }
 
-// Collect environment variables to pass through to test execution steps
-const scoutExtraEnv: Record<string, string> = {};
-if (process.env.SERVERLESS_TESTS_ONLY) {
-  scoutExtraEnv.SERVERLESS_TESTS_ONLY = process.env.SERVERLESS_TESTS_ONLY;
-}
+// Buildkite step-level env does not propagate to dynamically uploaded child steps, so
+// we explicitly forward an allow-list of env vars from the generator step's environment
+// (set on the parent "Scout Test Run Builder" step in the consuming pipeline YAMLs)
+// into each generated Scout Configs step's env. Allow-list (vs. spreading process.env)
+// avoids leaking secrets and agent-internal vars into child steps.
+const PASSTHROUGH_ENV_KEYS = [
+  'SERVERLESS_TESTS_ONLY',
+  'UIAM_DOCKER_IMAGE',
+  'UIAM_COSMOSDB_DOCKER_IMAGE',
+] as const;
 
-if (process.env.UIAM_DOCKER_IMAGE) {
-  scoutExtraEnv.UIAM_DOCKER_IMAGE = process.env.UIAM_DOCKER_IMAGE;
-}
+const scoutExtraEnv: Record<string, string> = Object.fromEntries(
+  PASSTHROUGH_ENV_KEYS.flatMap((key) => {
+    const value = process.env[key];
+    return value ? [[key, value]] : [];
+  })
+);
 
-if (process.env.UIAM_COSMOSDB_DOCKER_IMAGE) {
-  scoutExtraEnv.UIAM_COSMOSDB_DOCKER_IMAGE = process.env.UIAM_COSMOSDB_DOCKER_IMAGE;
-}
+// Buildkite artifact name for the post-split ("scheduled") manifest produced by this
+// scheduler. Distinct from the canonical `scout_playwright_configs.json` that discovery
+// uploads so the two coexist without overwriting. `configs.sh` downloads this file when
+// resolving `SCOUT_CONFIG_GROUP_KEY` for child steps.
+const SCHEDULED_MANIFEST_FILENAME = 'scout_playwright_configs_scheduled.json';
+
+// Heavy-suite modules whose test runs are too slow to share a single Buildkite step
+// across every (arch, domain) mode. Substring match (e.g. `streams_app_api` is also
+// covered) keeps the rule permissive without per-module bookkeeping.
+const HEAVY_MODULE_NAME_FRAGMENTS = ['streams_app', 'dashboard'] as const;
+
+const isHeavyModule = (moduleName: string): boolean =>
+  HEAVY_MODULE_NAME_FRAGMENTS.some((fragment) => moduleName.includes(fragment));
+
+const buildModeSuffix = (flag: string): string => {
+  // "--arch <arch> --domain <domain>" -> "<arch>-<domain>"
+  const archDomainMatch = flag.match(/--arch\s+(\S+)\s+--domain\s+(\S+)/);
+  if (archDomainMatch) {
+    return `${archDomainMatch[1]}-${archDomainMatch[2]}`;
+  }
+  return flag.replace(/^--/g, '').replace(/\s*--/g, '-').replace(/=/g, '-').replace(/\s+/g, '-');
+};
+
+/**
+ * Splits heavy modules (per `HEAVY_MODULE_NAME_FRAGMENTS`) into one virtual module per
+ * `(arch, domain)`, renamed `<original>-<arch>-<domain>` and narrowed to the configs
+ * and single `serverRunFlag` that match. Non-matching modules pass through.
+ * Pure: no I/O, no mutation.
+ */
+const splitHeavyModulesByServerRunFlags = (modules: ModuleDiscoveryInfo[]): ModuleDiscoveryInfo[] =>
+  modules.flatMap((module) => {
+    if (!isHeavyModule(module.name)) {
+      return [module];
+    }
+
+    const allServerRunFlags = new Set<string>();
+    for (const config of module.configs) {
+      for (const flag of config.serverRunFlags) {
+        allServerRunFlags.add(flag);
+      }
+    }
+
+    if (allServerRunFlags.size === 0) {
+      // Nothing to split on; emit the module unchanged so the caller can still produce
+      // a step (or filter it out via its own checks).
+      return [module];
+    }
+
+    return Array.from(allServerRunFlags).map((flag) => ({
+      ...module,
+      name: `${module.name}-${buildModeSuffix(flag)}`,
+      configs: module.configs
+        .filter((config) => config.serverRunFlags.includes(flag))
+        .map((config) => ({
+          ...config,
+          serverRunFlags: [flag],
+        })),
+    }));
+  });
 
 export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
   const bk = new BuildkiteClient();
@@ -65,8 +130,18 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
           .filter(Boolean)
       : ['build_scout_tests', 'build'];
 
-  const scoutCiRunGroups = modulesWithTests.map((module) => {
-    // Check if any config in this module uses parallel workers
+  // Apply the heavy-suite split here, at scheduling time, so each (arch, domain) mode
+  // for module gets its own Buildkite step. The scheduled (post-split)
+  // manifest is uploaded as its own artifact (separate from the canonical one written
+  // by discovery) so child steps can resolve their `SCOUT_CONFIG_GROUP_KEY` against
+  // the same names emitted in the BK steps below.
+  const scheduledModules = splitHeavyModulesByServerRunFlags(modulesWithTests);
+
+  const scheduledManifestPath = path.join(getKibanaDir(), SCHEDULED_MANIFEST_FILENAME);
+  Fs.writeFileSync(scheduledManifestPath, JSON.stringify(scheduledModules), 'utf-8');
+  bk.uploadArtifacts(SCHEDULED_MANIFEST_FILENAME);
+
+  const scoutCiRunGroups = scheduledModules.map((module) => {
     const usesParallelWorkers = module.configs.some((config) => config.usesParallelWorkers);
     const affectedPrefix = module.isAffected ? 'affected ' : '';
 

--- a/.buildkite/pipeline-utils/utils.ts
+++ b/.buildkite/pipeline-utils/utils.ts
@@ -71,6 +71,22 @@ const getRequiredEnv = (name: string) => {
   return value;
 };
 
+const getTrackedBranch = (): string => {
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(path.join(getKibanaDir(), 'package.json'), 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`unable to read kibana's package.json file: ${message}`);
+  }
+
+  if (typeof pkg.branch !== 'string') {
+    throw new Error('missing `branch` field from package.json file');
+  }
+
+  return pkg.branch;
+};
+
 function runBatchedPromises<T>(
   promiseCreators: Array<() => Promise<T>>,
   maxParallel: number
@@ -94,4 +110,4 @@ function runBatchedPromises<T>(
   return Promise.all(tasks).then(() => results);
 }
 
-export { getKibanaDir, getVersionsFile, getRequiredEnv, runBatchedPromises };
+export { getKibanaDir, getVersionsFile, getRequiredEnv, getTrackedBranch, runBatchedPromises };

--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -10,7 +10,7 @@
 import { groups } from './groups.json';
 import { TestSuiteType } from './constants';
 import type { BuildkiteStep } from '#pipeline-utils';
-import { expandAgentQueue, collectEnvFromLabels } from '#pipeline-utils';
+import { expandAgentQueue, collectEnvFromLabels, getTrackedBranch } from '#pipeline-utils';
 
 const configJson = process.env.KIBANA_FLAKY_TEST_RUNNER_CONFIG;
 if (!configJson) {
@@ -39,6 +39,10 @@ const MAX_JOBS = 500;
 // total job budget under control and to give users a clear, fast failure when
 // they request too many repetitions for a single config.
 const MAX_SCOUT_COUNT_PER_CONFIG = 50;
+
+// Scout discovery target for the flaky-setup step. We read the branch name
+// from `package.json` (set when forking a release branch).
+const scoutDiscoveryTarget = getTrackedBranch() === 'main' ? 'local' : 'local-stateful-only';
 
 function getTestSuitesFromJson(json: string) {
   const fail = (errorMsg: string) => {
@@ -192,6 +196,7 @@ if (hasScoutSuites) {
       SCOUT_FLAKY_CONCURRENCY: String(concurrency),
       SCOUT_FLAKY_CONCURRENCY_GROUP: process.env.UUID ?? '',
       SCOUT_FLAKY_RESERVED_JOBS: String(reservedJobsForPlanner),
+      SCOUT_DISCOVERY_TARGET: scoutDiscoveryTarget,
     },
     retry: {
       automatic: [{ exit_status: '-1', limit: 3 }],

--- a/.buildkite/scripts/steps/test/scout/configs.sh
+++ b/.buildkite/scripts/steps/test/scout/configs.sh
@@ -50,17 +50,21 @@ fi
 
 
 module_data=""
-# Download module_data if SCOUT_CONFIG_GROUP_KEY is set (needed for serverRunFlags)
-# This is required even when retrying, as we need module_data to get serverRunFlags for each config
+# Download module_data if SCOUT_CONFIG_GROUP_KEY is set (needed for serverRunFlags).
+# Resolve names against the SCHEDULED manifest (post-split) produced by
+# pickScoutTestGroupRunOrder, not the canonical discovery output — heavy-suite modules
+# (streams_app, dashboard) only exist under their split names (e.g. `dashboard-stateful-classic`)
+# in the scheduled manifest.
+SCHEDULED_MANIFEST="scout_playwright_configs_scheduled.json"
 if [ "$SCOUT_CONFIG_GROUP_KEY" != "" ]; then
   echo "--- Downloading Scout Test Configuration"
-  download_artifact scout_playwright_configs.json .
+  download_artifact "$SCHEDULED_MANIFEST" .
 
   # Extract module and its configs
-  module_data=$(jq -c ".[] | select(.name == env.SCOUT_CONFIG_GROUP_KEY)" scout_playwright_configs.json)
+  module_data=$(jq -c ".[] | select(.name == env.SCOUT_CONFIG_GROUP_KEY)" "$SCHEDULED_MANIFEST")
 
   if [[ -z "$module_data" ]]; then
-    echo "Module '${SCOUT_CONFIG_GROUP_KEY}' not found in scout_playwright_configs.json"
+    echo "Module '${SCOUT_CONFIG_GROUP_KEY}' not found in ${SCHEDULED_MANIFEST}"
     exit 1
   fi
 
@@ -76,12 +80,14 @@ if [ -z "$configs" ]; then
   exit 1
 fi
 
-# If we have module_data, we can process configs with their serverRunFlags directly
-# Otherwise, we need to handle the case where SCOUT_CONFIG is set directly
-if [[ -z "${module_data:-}" && -n "$SCOUT_CONFIG" ]]; then
-  echo "⚠️ Warning: SCOUT_CONFIG is set but module_data is not available. Server run flags cannot be determined from tags."
-  echo "   As a result, tests may not run in the expected modes or with the correct configuration, which could lead to unexpected failures or incomplete test coverage."
-  echo "   Execution will proceed, but it is strongly recommended to use SCOUT_CONFIG_GROUP_KEY instead to ensure serverRunFlags are set from the JSON file."
+# Warn only when neither the manifest nor an explicit SCOUT_SERVER_RUN_FLAGS value is
+# available — that's the only case where serverRunFlags truly cannot be determined.
+# The flaky-test runner sets SCOUT_CONFIG + SCOUT_SERVER_RUN_FLAGS directly, which is
+# fully supported below.
+if [[ -z "${module_data:-}" && -n "$SCOUT_CONFIG" && -z "${SCOUT_SERVER_RUN_FLAGS:-}" ]]; then
+  echo "⚠️ Warning: SCOUT_CONFIG is set but neither module_data nor SCOUT_SERVER_RUN_FLAGS is available."
+  echo "   Server run flags cannot be determined from tags; tests may not run in the expected modes."
+  echo "   Use SCOUT_CONFIG_GROUP_KEY (manifest lookup) or pass SCOUT_SERVER_RUN_FLAGS explicitly."
 fi
 
 results=()

--- a/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
@@ -17,11 +17,17 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
+# `SCOUT_DISCOVERY_TARGET` is computed at pipeline-generation time from the
+# `branch` field in package.json in .buildkite/pipelines/flaky_tests/pipeline.ts
+# and injected as step-level env. Hard-require it here so a missing value fails
+# loudly instead of silently defaulting to a wrong target.
+: "${SCOUT_DISCOVERY_TARGET:?SCOUT_DISCOVERY_TARGET must be set by the flaky pipeline generator}"
+
 echo '--- Update Scout Test Config Manifests'
 node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
 
-echo '--- Discover Playwright Configs'
-node scripts/scout discover-playwright-configs --include-custom-servers --save
+echo "--- Discover Playwright Configs (target=$SCOUT_DISCOVERY_TARGET)"
+node scripts/scout discover-playwright-configs --include-custom-servers --target "$SCOUT_DISCOVERY_TARGET" --save
 cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
 buildkite-agent artifact upload "scout_playwright_configs.json"
 

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
@@ -176,47 +176,6 @@ const handleFlattenedOutput = (
   logFlattenedConfigs(flattenedConfigs, log);
 };
 
-// Splits 'streams_app' module by 'serverRunFlags' so CI can run each arch/domain as a
-// separate job (e.g. streams_app-stateful-classic, streams_app-serverless-search).
-const splitStreamsTestsByServerRunFlags = (
-  modules: ModuleDiscoveryInfo[]
-): ModuleDiscoveryInfo[] => {
-  return modules.flatMap((module) => {
-    // It is a temp workaround. Only split modules that include 'streams_app', 'dashboard'  in their name
-    if (!module.name.includes('streams_app') && !module.name.includes('dashboard')) {
-      return [module];
-    }
-
-    const allServerRunFlags = new Set<string>();
-    module.configs.forEach((config) => {
-      config.serverRunFlags.forEach((flag) => allServerRunFlags.add(flag));
-    });
-
-    return Array.from(allServerRunFlags).map((flag) => {
-      // transform: "--arch <arch> --domain <domain>" -> "<arch>-<domain>"
-      const archDomainMatch = flag.match(/--arch\s+(\S+)\s+--domain\s+(\S+)/);
-      const flagSuffix = archDomainMatch
-        ? `${archDomainMatch[1]}-${archDomainMatch[2]}`
-        : flag.replace(/^--/g, '').replace(/\s*--/g, '-').replace(/=/g, '-').replace(/\s+/g, '-');
-      const newModuleName = `${module.name}-${flagSuffix}`;
-
-      const filteredConfigs = module.configs
-        .filter((config) => config.serverRunFlags.includes(flag))
-        .map((config) => ({
-          ...config,
-          // Keep only the matching 'serverRunFlag' for this split module
-          serverRunFlags: [flag],
-        }));
-
-      return {
-        ...module,
-        name: newModuleName,
-        configs: filteredConfigs,
-      };
-    });
-  });
-};
-
 const handleNonFlattenedOutput = (
   filteredModules: ModuleDiscoveryInfo[],
   flagsReader: FlagsReader,
@@ -225,12 +184,10 @@ const handleNonFlattenedOutput = (
 ): void => {
   if (flagsReader.boolean('save')) {
     const filteredForCiModules = filterModulesByScoutCiConfig(log, filteredModules);
-    // 'streams_app' tests are quite time consuming, let's split run by 'serverRunFlags' before saving
-    const splitModules = splitStreamsTestsByServerRunFlags(filteredForCiModules);
-    saveModuleDiscoveryInfo(splitModules, log);
+    saveModuleDiscoveryInfo(filteredForCiModules, log);
 
     const { plugins: savedPluginCount, packages: savedPackageCount } =
-      countModulesByType(splitModules);
+      countModulesByType(filteredForCiModules);
 
     const runScope = selectiveTesting ? 'selective' : 'full suite';
     log.info(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[scout] move configs split out of discovery (#266661)](https://github.com/elastic/kibana/pull/266661)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-05-05T12:01:04Z","message":"[scout] move configs split out of discovery (#266661)\n\n## Summary\n\nCurrently we run all the module tests in a single BK worker, and for few\nlong running ones we explicitly split them into smaller groups with\n`splitStreamsTestsByServerRunFlags`. This change was a workaround and we\nare moving to lanes distribution soon 🚀 It means we can move it away\nfrom configs discovery to have the unified logic for regular and\nflaky-test-runner scout logic.\n\n\nThis PR moves \"split\" into\n`.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts`\nthat we eventually will deprecate in favor of lanes distribution.","sha":"c869642d52ecba74f5aa3694f4fd7b1258b08eaf","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.5.0"],"title":"[scout] move configs split out of discovery","number":266661,"url":"https://github.com/elastic/kibana/pull/266661","mergeCommit":{"message":"[scout] move configs split out of discovery (#266661)\n\n## Summary\n\nCurrently we run all the module tests in a single BK worker, and for few\nlong running ones we explicitly split them into smaller groups with\n`splitStreamsTestsByServerRunFlags`. This change was a workaround and we\nare moving to lanes distribution soon 🚀 It means we can move it away\nfrom configs discovery to have the unified logic for regular and\nflaky-test-runner scout logic.\n\n\nThis PR moves \"split\" into\n`.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts`\nthat we eventually will deprecate in favor of lanes distribution.","sha":"c869642d52ecba74f5aa3694f4fd7b1258b08eaf"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266661","number":266661,"mergeCommit":{"message":"[scout] move configs split out of discovery (#266661)\n\n## Summary\n\nCurrently we run all the module tests in a single BK worker, and for few\nlong running ones we explicitly split them into smaller groups with\n`splitStreamsTestsByServerRunFlags`. This change was a workaround and we\nare moving to lanes distribution soon 🚀 It means we can move it away\nfrom configs discovery to have the unified logic for regular and\nflaky-test-runner scout logic.\n\n\nThis PR moves \"split\" into\n`.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts`\nthat we eventually will deprecate in favor of lanes distribution.","sha":"c869642d52ecba74f5aa3694f4fd7b1258b08eaf"}}]}] BACKPORT-->