### PR TITLE
[9.4] [scout] add optional globalTeardownHook to Scout (#268489)

### DIFF
--- a/.agents/skills/cypress-to-scout-migration/references/migration-best-practices.md
+++ b/.agents/skills/cypress-to-scout-migration/references/migration-best-practices.md
@@ -105,6 +105,27 @@ spaceTest.afterAll(async ({ apiServices, scoutSpace }) => {
 
 Do not use `esArchiver` to manipulate system indices — use `kbnClient`.
 
+### Suite-wide cleanup with `globalTeardownHook`
+
+For state that's shared **across spec files** (e.g., data ingested in `global.setup.ts`, feature-flag overrides, global `uiSettings`), use the optional `globalTeardownHook` in `parallel_tests/global.teardown.ts`. It runs once after all workers finish, even if tests failed.
+
+```typescript
+import { globalTeardownHook } from '@kbn/scout-security'; // or '@kbn/scout' / '@kbn/scout-oblt'
+
+globalTeardownHook('Reset shared state', async ({ kbnClient, apiServices, log }) => {
+  // Revert global uiSettings or feature flags toggled for the whole suite
+  await kbnClient.uiSettings.unset('my:setting');
+  await apiServices.core.settings({ 'feature_flags.overrides': { 'my.flag': 'false' } });
+});
+```
+
+**Cautions:**
+
+- **`esArchiver` is intentionally not exposed** in `globalTeardownHook`. Scout's `esArchiver` only supports `loadIfNeeded` — archive unloading was never offered because it's slow and unnecessary (leftover indexes in the cluster don't break tests with idempotent `loadIfNeeded`). For state that does need resetting, use `esClient.indices.delete` / `deleteDataStream` / `deleteByQuery`.
+- **Don't load new data here** — teardown is for resetting state. Data loading belongs in `globalSetupHook`.
+- **Per-test/per-suite cleanup still belongs in `afterEach`/`afterAll`** — the global teardown is for state that other configs (running against the same Kibana/ES) would otherwise inherit.
+- Optional and opt-in by file presence: add `parallel_tests/global.teardown.ts` and you're done. `runGlobalSetup: true` already wires the project up.
+
 ## test.step() for Execution Time
 
 Each `test()` block creates a new browser context. Use `test.step()` for multi-step flows to reuse context:

--- a/.agents/skills/scout-best-practices-reviewer/SKILL.md
+++ b/.agents/skills/scout-best-practices-reviewer/SKILL.md
@@ -44,6 +44,7 @@ Important: Do not post GitHub comments unless explicitly stated.
 - **RBAC / realism**: minimal permissions (avoid `admin` unless required); space-aware behavior covered or explicitly out of scope.
 - **Flake traps**: avoid `waitForTimeout()` and time-based assertions/retries; rely on auto-waiting + explicit readiness signals. Some locators are restricted by `@kbn/eslint/scout_no_locators` (e.g. `globalLoadingIndicator`).
 - **Cost**: avoid repeating expensive setup; consider a global setup hook for shared one-time operations.
+- **Global teardown** (when `global.teardown.ts` is present): cleanup must use `esClient`/`kbnClient`/`apiServices`. `esArchiver` isn't on the teardown fixture surface — Scout intentionally never exposed archive-unloading (slow and unnecessary; leftover indexes don't break tests with idempotent `loadIfNeeded`). Flag teardowns that try to use `esArchiver` at all, that **load** new data (teardown is for state reset only), or that duplicate work belonging in `afterAll`/per-test cleanup.
 - **Tags / environment**: validate deployment tags and avoid assumptions that only hold in specific environments.
 
 ### Migration parity analysis (required when migration is detected)

--- a/.agents/skills/scout-create-scaffold/SKILL.md
+++ b/.agents/skills/scout-create-scaffold/SKILL.md
@@ -62,6 +62,7 @@ Notes:
   - `test/<scout-root>/ui/parallel_tests/example_one.spec.ts`
   - `test/<scout-root>/ui/parallel_tests/example_two.spec.ts`
   - `test/<scout-root>/ui/parallel_tests/global.setup.ts`
+  - `test/<scout-root>/ui/parallel_tests/global.teardown.ts` is **not** generated; opt in by adding the file with a `globalTeardownHook(...)` call. See `scout-ui-testing/references/scout-ui-parallelism.md`.
 
 The generator **does not** create **`tsconfig.json`** files. Playwright runs without them, but **`node scripts/type_check`** (CI) must still include Scout specs in a TS project—see **TypeScript layout** below.
 

--- a/.agents/skills/scout-ui-testing/SKILL.md
+++ b/.agents/skills/scout-ui-testing/SKILL.md
@@ -48,6 +48,7 @@ description: Use when creating, updating, debugging, or reviewing Scout UI tests
 - Use `spaceTest` so you can access `scoutSpace` for worker-isolated saved objects + UI settings.
 - Pre-ingest shared ES data in `parallel_tests/global.setup.ts` via `globalSetupHook(...)`.
   - Only **worker** fixtures are available there (no `page`, `browserAuth`, `pageObjects`).
+- Reset Elasticsearch/Kibana state once after the suite via `globalTeardownHook(...)` in `parallel_tests/global.teardown.ts` (optional, opt-in by file presence). For state that does need resetting, use `esClient`/`kbnClient`/`apiServices`. See `references/scout-ui-parallelism.md`.
 - Cleanup space-scoped mutations in `afterAll` (`scoutSpace.savedObjects.cleanStandardList()`, unset UI settings you set).
 
 ## Extending fixtures

--- a/.agents/skills/scout-ui-testing/references/scout-ui-parallelism.md
+++ b/.agents/skills/scout-ui-testing/references/scout-ui-parallelism.md
@@ -14,6 +14,7 @@ Use this when working under `.../test/scout*/ui/parallel_tests/` or a `parallel.
 
 - `ui/parallel.playwright.config.ts`: `testDir: './parallel_tests'`, `workers: 2..3`, optional `runGlobalSetup: true`.
 - `ui/parallel_tests/global.setup.ts`: define `globalSetupHook(...)` (runs once total).
+- `ui/parallel_tests/global.teardown.ts` (optional): define `globalTeardownHook(...)` to reset cluster/Kibana state once after the suite. Picked up automatically when `runGlobalSetup: true`; no extra config flag.
 
 ## Minimal pattern
 
@@ -44,3 +45,38 @@ spaceTest.describe('my feature', { tag: tags.deploymentAgnostic }, () => {
 - Global setup runs once total (executed by the first worker); other workers wait for it to finish.
 - Only worker-scoped fixtures are available (for example `esArchiver`, `apiServices`, `kbnClient`, `esClient`, `log`).
 - No `page`, `browserAuth`, or `pageObjects` in `global.setup.ts`.
+
+## Global teardown hook (optional)
+
+Use `globalTeardownHook` in `parallel_tests/global.teardown.ts` to reset Kibana/cluster state **once** after all workers finish — runs even if tests failed. Same fixture surface as setup, **except `esArchiver` is intentionally not exposed**.
+
+```ts
+import { globalTeardownHook } from '@kbn/scout'; // or '@kbn/scout-oblt' / '@kbn/scout-security'
+
+globalTeardownHook('Reset shared Kibana state', async ({ esClient, kbnClient, apiServices, log }) => {
+  log.info('[teardown] resetting shared state');
+
+  // Drop hand-indexed data ingested by global.setup.ts that affects other Scout configs
+  // sharing this cluster (Scout's esArchiver intentionally has no unload — see cautions)
+  await esClient.indices.delete({ index: 'apm-8.0.0-*', ignore_unavailable: true });
+  await esClient.indices.deleteDataStream({ name: 'logs-my_dataset-*' }).catch(() => {});
+
+  // Revert any uiSettings / advanced settings the suite set globally
+  await kbnClient.uiSettings.unset('discover:searchOnPageLoad');
+  await kbnClient.uiSettings.updateGlobal({ hideAnnouncements: false });
+
+  // Revert feature-flag overrides flipped via apiServices.core.settings(...)
+  await apiServices.core.settings({ 'feature_flags.overrides': { 'discover.isEsqlDefault': 'false' } });
+
+  // Saved-object cleanup the suite created cluster-wide (per-space cleanup belongs in afterAll)
+  await kbnClient.savedObjects.cleanStandardList();
+});
+```
+
+**Cautions:**
+
+- **No `esArchiver` on the teardown surface — by design.** Scout's `esArchiver` fixture only ever exposed `loadIfNeeded`; archive-driven unloading was never supported because it's slow and adds nothing — leftover indexes in the cluster don't break tests when setup uses idempotent `loadIfNeeded`. For state that **does** need resetting, use `esClient.indices.delete` / `deleteDataStream` / `deleteByQuery` directly.
+- **Don't reload data here** — teardown is for resetting state, not for setting up new data. If you need fresh data on every run, do it in `globalSetupHook` (which is idempotent via `esArchiver.loadIfNeeded`).
+- **Per-test/per-suite cleanup still belongs in `afterEach`/`afterAll`** — the global teardown is for state shared across the whole suite (or leaked into the cluster from setup) that other configs running in the same Kibana/ES would otherwise inherit.
+- **Available fixtures**: `log`, `config`, `kbnUrl`, `esClient`, `kbnClient`, `apiServices` (plus the same lazy `samlAuth`/`isSnapshotBuild` from `coreWorkerFixtures`). No `page`/`browserAuth`/`pageObjects` and no `esArchiver`.
+- **Optional, opt-in by file presence**: just add `parallel_tests/global.teardown.ts` calling `globalTeardownHook(...)`. No new config flag — `runGlobalSetup: true` is enough.

--- a/docs/extend/scout/best-practices.md
+++ b/docs/extend/scout/best-practices.md
@@ -99,16 +99,30 @@ test('can see dashboard', async ({ page }) => {
 
 :::::
 
-### Use a global setup hook for one-time setup [move-repeated-one-time-setup-operations-to-a-global-setup-hook]
+### Use the global setup and teardown hooks in parallel test suites [move-repeated-one-time-setup-operations-to-a-global-setup-hook]
 
-If many files share the same “one-time” work (archives, API calls, settings), move it to a [global setup hook](./global-setup-hook.md).
+For parallel suites, move shared “one-time” work (archives, API calls, settings) to a [global setup hook](./global-setup-hook.md), and reset any state that would leak into other Scout configs in a [global teardown hook](./global-setup-hook.md#global-teardown-hook). See [When to use](./global-setup-hook.md#when-to-use) for the full guidance on what belongs here vs. in `beforeAll`/`afterAll`.
 
-:::::{dropdown} Example
+:::::{dropdown} Examples
+
+✔️ **Do:** load shared data once in `global.setup.ts`:
 
 ```ts
 globalSetupHook('Load shared test data (if needed)', async ({ esArchiver, log }) => {
   log.debug('[setup] loading archives (only if indexes do not exist)...');
   await esArchiver.loadIfNeeded(MY_ARCHIVE);
+});
+```
+
+✔️ **Do:** revert suite-wide state in `global.teardown.ts` so it doesn't leak into other configs:
+
+```ts
+globalTeardownHook('Reset shared Kibana state', async ({ kbnClient, apiServices, log }) => {
+  log.debug('[teardown] resetting shared state...');
+  await kbnClient.uiSettings.unset('discover:searchOnPageLoad');
+  await apiServices.core.settings({
+    'feature_flags.overrides': { 'discover.isEsqlDefault': false },
+  });
 });
 ```
 

--- a/docs/extend/scout/feature-flags.md
+++ b/docs/extend/scout/feature-flags.md
@@ -44,6 +44,21 @@ globalSetupHook('Enable feature flags', async ({ apiServices, log }) => {
 });
 ```
 
+Because feature-flag overrides are server-wide, they survive past your suite and would leak into other Scout configs sharing the same Kibana. Pair the setup with a [global teardown hook](./global-setup-hook.md#global-teardown-hook) in `global.teardown.ts` to revert the override after the suite finishes:
+
+```ts
+import { globalTeardownHook } from '@kbn/scout';
+
+globalTeardownHook('Revert feature flags', async ({ apiServices, log }) => {
+  log.info('[teardown] Reverting my-feature-flag...');
+  await apiServices.core.settings({
+    'feature_flags.overrides': {
+      'my-plugin.my-feature-flag': false,
+    },
+  });
+});
+```
+
 ### In a test suite (sequential tests) [scout-feature-flags-test-suite]
 
 For sequential suites you can enable flags in `beforeAll` and reset them in `afterAll`:

--- a/docs/extend/scout/global-setup-hook.md
+++ b/docs/extend/scout/global-setup-hook.md
@@ -1,10 +1,14 @@
 ---
-navigation_title: Global setup hook
+navigation_title: Global setup and teardown
 ---
 
-# Global setup hook [scout-global-setup-hook]
+# Global setup and teardown [scout-global-setup-hook]
 
-Use a global setup hook to run code **once** before any tests start (even with multiple workers). This is most useful for [parallel suites](./parallelism.md), where you want shared data/setup to exist before workers begin. It is also supported by non-parallel test suites.
+Use the global setup and teardown hooks to run code **once** before any tests start and/or after all workers finish — even with multiple workers. They are most useful for [parallel suites](./parallelism.md), where shared data/setup must exist before workers begin and suite-wide state may need to be reset afterwards. Both hooks are also supported by non-parallel test suites.
+
+## Global setup hook [global-setup-hook]
+
+Use `globalSetupHook(...)` in `global.setup.ts` to run code once before any tests start.
 
 **Common uses**:
 
@@ -12,11 +16,9 @@ Use a global setup hook to run code **once** before any tests start (even with m
 - Run one-time API setup with `apiServices`
 - Apply shared Kibana settings via `kbnClient`
 
-::::::{note}
-Scout doesn’t currently have a global teardown hook. Most environments are ephemeral and are shut down after the run.
-::::::
+For **suite-wide** state that's shared across spec files (data ingested in `global.setup.ts`, feature-flag overrides, global UI settings), use the optional [global teardown hook](#global-teardown-hook) instead.
 
-## Enable it [enable-global-setup-hook]
+### Enable it [enable-global-setup-hook]
 
 :::::::::::{stepper}
 
@@ -70,6 +72,71 @@ The global setup hook only has access to **worker-scoped** fixtures. It cannot u
 
 ::::::::::{step} Run tests
 
-Run tests as usual via [Run Scout tests](./run-tests.md). The global setup hook will execute first—check console logs to verify it ran successfully.
+Run tests as usual via [Run Scout tests](./run-tests.md). The global setup hook runs first — check console logs to verify it ran successfully.
 
 ::::::::::::
+
+## Global teardown hook (optional) [global-teardown-hook]
+
+When `runGlobalSetup: true` is set, Scout also wires up an optional `globalTeardownHook` that runs **once after all workers finish**, even when tests fail. Use it to reset shared cluster/Kibana state that would otherwise leak into other Scout configs running against the same Kibana/ES — for example, dropping legacy or hand-indexed data ingested by `global.setup.ts`, reverting feature-flag overrides, or unsetting global UI settings.
+
+### Enable it
+
+Add `global.teardown.ts` next to `global.setup.ts` in your `testDir` and call `globalTeardownHook(...)`. No extra config flag — `runGlobalSetup: true` is already enough. If the file is absent, the project is silently skipped.
+
+```text
+test/scout/ui/
+└── parallel_tests/
+    ├── global.setup.ts
+    ├── global.teardown.ts
+    └── some_suite.spec.ts
+```
+
+### Example: Reset shared state
+
+```ts
+import { globalTeardownHook } from '@kbn/scout';
+
+globalTeardownHook(
+  'Reset shared Kibana state',
+  async ({ esClient, kbnClient, apiServices, log }) => {
+    log.info('[teardown] resetting shared state');
+
+    // Drop legacy or hand-indexed data the suite created.
+    await esClient.indices.delete({ index: 'apm-8.0.0-*', ignore_unavailable: true });
+    await esClient.indices
+      .deleteDataStream({ name: 'logs-my_dataset-*' })
+      .catch(() => undefined); // tolerate missing data stream on a clean cluster
+
+    // Revert any global UI settings / advanced settings the suite set.
+    await kbnClient.uiSettings.unset('discover:searchOnPageLoad');
+    await kbnClient.uiSettings.updateGlobal({ hideAnnouncements: false });
+
+    // Revert feature-flag overrides flipped via apiServices.core.settings(...).
+    await apiServices.core.settings({
+      'feature_flags.overrides': { 'discover.isEsqlDefault': false },
+    });
+  }
+);
+```
+
+### Available fixtures
+
+`globalTeardownHook` exposes a deliberately narrower fixture surface than `globalSetupHook`:
+
+- `log`, `config`, `kbnUrl`
+- `esClient`, `kbnClient`
+- `apiServices` (incl. `apiServices.core.settings(...)` for feature-flag rollbacks)
+
+::::::{warning}
+**`esArchiver` is intentionally not exposed in `globalTeardownHook`.** Scout's `esArchiver` fixture only ever exposed `loadIfNeeded` — by design, there is no archive-driven unload. Removing archives that way is slow and unnecessary: leftover indexes in the cluster don't break Scout tests (setup is idempotent via `loadIfNeeded`), so there's no reason to spend time deleting them at the end of every run.
+
+For state that **does** need resetting (server-wide feature-flag overrides, global UI settings, hand-indexed data that breaks redirect or navigation logic for other configs sharing the cluster), use targeted `esClient.indices.delete`, `esClient.indices.deleteDataStream`, `esClient.deleteByQuery`, `kbnClient.uiSettings.unset`, or `apiServices.core.settings`.
+::::::
+
+### Cautions
+
+- **Don't load new data here.** Teardown is for resetting state, not setting up new data. Data loading belongs in `globalSetupHook` (which is idempotent via `esArchiver.loadIfNeeded`).
+- **Per-test/per-suite cleanup still belongs in `afterEach`/`afterAll`.** The global teardown is for state shared across the whole suite — typically state seeded by `global.setup.ts` itself, or anything that other Scout configs sharing the cluster would inherit.
+- **Same fixture-scope limitation as setup**: only worker-scoped fixtures are available — no `page`, `browserAuth`, or `pageObjects`.
+- **Runs even when tests fail.** Wired via Playwright's per-project `teardown` field, so the hook runs after the setup project AND every project depending on it has finished, including on failure. Use this to your advantage (always-clean cluster) but write the teardown defensively — pass `ignore_unavailable: true` on Elasticsearch deletes and swallow expected `404`s on optional resources — so a partial setup doesn't break cleanup.

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.js
@@ -36,12 +36,13 @@ const hasSpecExtension = (filename) => {
 };
 
 /**
- * Checks if a file is a global setup file
+ * Checks if a file is a global setup or teardown file
  * @param {string} filename
  * @returns {boolean}
  */
-const isGlobalSetupFile = (filename) => {
-  return path.basename(filename) === 'global.setup.ts';
+const isGlobalSetupOrTeardownFile = (filename) => {
+  const basename = path.basename(filename);
+  return basename === 'global.setup.ts' || basename === 'global.teardown.ts';
 };
 
 const ALLOWED_PLAYWRIGHT_CONFIG_NAMES = new Set([
@@ -110,8 +111,8 @@ module.exports = {
 
     // Check if the file is in a Scout test directory
     if (isInScoutTestDirectory(filename)) {
-      // Allow global.setup.ts files
-      if (isGlobalSetupFile(filename)) {
+      // Allow global.setup.ts and global.teardown.ts files
+      if (isGlobalSetupOrTeardownFile(filename)) {
         return {};
       }
 

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_test_file_naming.test.js
@@ -110,6 +110,24 @@ ruleTester.run('@kbn/eslint/scout_test_file_naming', rule, {
       filename:
         'x-pack/solutions/observability/plugins/my_plugin/test/scout/api/tests/global.setup.ts',
     },
+    // Valid: global.teardown.ts in tests directory
+    {
+      code: '',
+      filename:
+        'x-pack/solutions/observability/plugins/my_plugin/test/scout/ui/tests/global.teardown.ts',
+    },
+    // Valid: global.teardown.ts in parallel_tests directory
+    {
+      code: '',
+      filename:
+        'x-pack/solutions/observability/plugins/my_plugin/test/scout/ui/parallel_tests/global.teardown.ts',
+    },
+    // Valid: global.teardown.ts in API tests
+    {
+      code: '',
+      filename:
+        'x-pack/solutions/observability/plugins/my_plugin/test/scout/api/tests/global.teardown.ts',
+    },
   ],
 
   invalid: [

--- a/src/platform/packages/shared/kbn-scout/README.md
+++ b/src/platform/packages/shared/kbn-scout/README.md
@@ -107,6 +107,8 @@ export default createPlaywrightConfig({
 
 Scout relies on configuration to determine the test files and opt-in [parallel test execution](https://playwright.dev/docs/test-parallel) against the single Elastic cluster.
 
+When `runGlobalSetup: true` is set, Scout also auto-discovers an optional `global.teardown.ts` next to `global.setup.ts`. Use `globalTeardownHook(...)` in that file to reset shared cluster/Kibana state once after all workers finish (even on failure) — for example, dropping legacy/hand-indexed data ingested by `global.setup.ts` or reverting feature-flag overrides. The teardown surface intentionally excludes `esArchiver`; use `esClient`/`kbnClient`/`apiServices` instead. See [`docs/extend/scout/global-setup-hook.md`](../../../../docs/extend/scout/global-setup-hook.md#global-teardown-hook) for the contract and examples.
+
 The Playwright configuration should only be created this way to ensure compatibility with Scout functionality. For configuration verification, we use a marker `VALID_CONFIG_MARKER`, and Scout will throw an error if the configuration is invalid.
 
 #### Fixtures

--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -11,7 +11,15 @@
 export * as cli from './src/cli';
 
 // Test framework
-export { test, spaceTest, lighthouseTest, apiTest, globalSetupHook, tags } from './src/playwright';
+export {
+  test,
+  spaceTest,
+  lighthouseTest,
+  apiTest,
+  globalSetupHook,
+  globalTeardownHook,
+  tags,
+} from './src/playwright';
 
 // Fixtures & configuration
 export {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Project } from '@playwright/test';
 import { SCOUT_SERVERS_ROOT } from '@kbn/scout-info';
 import {
   generateTestRunId,
@@ -15,6 +16,10 @@ import {
 } from '@kbn/scout-reporting';
 import { VALID_CONFIG_MARKER } from '../types';
 import { createPlaywrightConfig } from './create_config';
+
+// Playwright's `teardown` is a project-config option (Project<>) but isn't part of the
+// runtime `Project` interface used in expectations; cast to access it in assertions.
+type PlaywrightProject = Project & { teardown?: string };
 
 jest.mock('@kbn/scout-reporting', () => ({
   ...jest.requireActual('@kbn/scout-reporting'),
@@ -117,30 +122,53 @@ describe('createPlaywrightConfig', () => {
     expect(config.projects![2].name).toEqual('mki');
   });
 
-  it('should add global.setup.ts as pre-step when runGlobalSetup is true and apply default timeout', () => {
+  it('should add global.setup.ts and global.teardown.ts projects when runGlobalSetup is true', () => {
     const testDir = './my_tests';
-    const defaultGlobalSetupTimeout = 180000;
+    const defaultGlobalHookTimeout = 180000;
 
     const config = createPlaywrightConfig({ testDir, runGlobalSetup: true });
     expect(config.workers).toBe(1);
 
-    expect(config.projects).toHaveLength(6);
-    expect(config.projects![0].name).toEqual('setup-local');
-    expect(config.projects![0].testMatch).toEqual(/global.setup\.ts/);
-    expect(config.projects![0].timeout).toBe(defaultGlobalSetupTimeout);
-    expect(config.projects![1].name).toEqual('local');
-    expect(config.projects![1]).toHaveProperty('dependencies', ['setup-local']);
-    expect(config.projects![1]).not.toHaveProperty('timeout');
-    expect(config.projects![2].name).toEqual('setup-ech');
-    expect(config.projects![2].timeout).toBe(defaultGlobalSetupTimeout);
-    expect(config.projects![3].name).toEqual('ech');
-    expect(config.projects![3]).toHaveProperty('dependencies', ['setup-ech']);
-    expect(config.projects![3]).not.toHaveProperty('timeout');
-    expect(config.projects![4].name).toEqual('setup-mki');
-    expect(config.projects![4].timeout).toBe(defaultGlobalSetupTimeout);
-    expect(config.projects![5].name).toEqual('mki');
-    expect(config.projects![5]).toHaveProperty('dependencies', ['setup-mki']);
-    expect(config.projects![5]).not.toHaveProperty('timeout');
+    // 3 base projects (local/ech/mki) × 3 hook projects each (setup, main, teardown)
+    expect(config.projects).toHaveLength(9);
+
+    const projectNames = config.projects!.map((p) => p.name);
+    expect(projectNames).toEqual([
+      'setup-local',
+      'local',
+      'teardown-local',
+      'setup-ech',
+      'ech',
+      'teardown-ech',
+      'setup-mki',
+      'mki',
+      'teardown-mki',
+    ]);
+
+    for (const projectName of ['local', 'ech', 'mki']) {
+      const setup = config.projects!.find((p) => p.name === `setup-${projectName}`);
+      const main = config.projects!.find((p) => p.name === projectName);
+      const teardown = config.projects!.find((p) => p.name === `teardown-${projectName}`);
+
+      expect(setup).toBeDefined();
+      expect(setup!.testMatch).toEqual(/global.setup\.ts/);
+      expect(setup!.timeout).toBe(defaultGlobalHookTimeout);
+      // teardown is wired via Playwright's per-project `teardown` field, not `dependencies`,
+      // so it runs after setup AND every project depending on it has finished — even on
+      // test failure. https://playwright.dev/docs/test-projects#teardown
+      expect((setup as PlaywrightProject).teardown).toBe(`teardown-${projectName}`);
+
+      expect(main).toBeDefined();
+      expect(main).toHaveProperty('dependencies', [`setup-${projectName}`]);
+      expect(main).not.toHaveProperty('timeout');
+
+      expect(teardown).toBeDefined();
+      // The teardown project is always emitted; if a plugin doesn't ship `global.teardown.ts`,
+      // the regex matches no files and Playwright silently skips the project — opt-in by file
+      // presence with no extra config flag required.
+      expect(teardown!.testMatch).toEqual(/global.teardown\.ts/);
+      expect(teardown!.timeout).toBe(defaultGlobalHookTimeout);
+    }
   });
 
   it('should generate and cache runId in process.env.TEST_RUN_ID', () => {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -62,16 +62,30 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
    * While Playwright doesn't allow to read 'use' from the parent project, we have to create
    * a setup project with the explicit 'use' object for each parent project.
    * This is a workaround for https://github.com/microsoft/playwright/issues/32547
+   *
+   * The matching teardown project is always emitted: if no `global.teardown.ts` exists in
+   * `testDir`, the project's `testMatch` finds no tests and Playwright silently skips it,
+   * so plugins opt-in to teardown simply by adding the file. Linking it via Playwright's
+   * `teardown` field on the setup project guarantees teardown runs after the setup project
+   * AND every project depending on it has finished — including on test failure.
    */
+  const GLOBAL_HOOK_TIMEOUT_MS = 180000; // 3 minutes
   scoutProjects = options.runGlobalSetup
     ? scoutDefaultProjects.flatMap((project) => [
         {
           name: `setup-${project?.name}`,
           use: project?.use ? { ...project.use } : {},
           testMatch: /global.setup\.ts/,
-          timeout: 180000, // Default to 3 minutes for global setup
+          timeout: GLOBAL_HOOK_TIMEOUT_MS,
+          teardown: `teardown-${project?.name}`,
         },
         { ...project, dependencies: [`setup-${project?.name}`] },
+        {
+          name: `teardown-${project?.name}`,
+          use: project?.use ? { ...project.use } : {},
+          testMatch: /global.teardown\.ts/,
+          timeout: GLOBAL_HOOK_TIMEOUT_MS,
+        },
       ])
     : scoutDefaultProjects;
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
@@ -56,7 +56,7 @@ export type {
 export { tags } from './tags';
 
 // Test entrypoints
-export { test, spaceTest, lighthouseTest, globalSetupHook } from './test/ui';
+export { test, spaceTest, lighthouseTest, globalSetupHook, globalTeardownHook } from './test/ui';
 export { apiTest } from './test/api';
 
 // Test helpers for EUI components

--- a/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/index.ts
@@ -8,7 +8,11 @@
  */
 
 import { scoutFixtures, lighthouseFixtures } from './single_thread_fixtures';
-import { scoutParallelFixtures, globalSetupFixtures } from './parallel_run_fixtures';
+import {
+  scoutParallelFixtures,
+  globalSetupFixtures,
+  globalTeardownFixtures,
+} from './parallel_run_fixtures';
 
 // Scout UI test fixtures: single-threaded
 export const test = scoutFixtures;
@@ -18,6 +22,8 @@ export const lighthouseTest = lighthouseFixtures;
 export const spaceTest = scoutParallelFixtures;
 // Scout global 'setup' hook for parallel execution
 export const globalSetupHook = globalSetupFixtures;
+// Scout global 'teardown' hook for parallel execution
+export const globalTeardownHook = globalTeardownFixtures;
 
 export type { ScoutTestFixtures, ScoutWorkerFixtures } from './single_thread_fixtures';
 export type {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/parallel_run_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/parallel_run_fixtures.ts
@@ -67,3 +67,23 @@ export const globalSetupFixtures = mergeTests(
   esArchiverFixture,
   apiServicesFixture
 );
+
+/**
+ * Fixtures available in the global teardown hook (`global.teardown.ts`).
+ *
+ * Intentionally narrower than `globalSetupFixtures`: `esArchiver` is omitted on
+ * purpose. Scout's `esArchiver` fixture only exposes `loadIfNeeded` (see
+ * `fixtures/scope/worker/es_archiver.ts`) — archive-driven unloading is not
+ * supported by design, because deleting indexes that way is slow and offers
+ * no real benefit (leftover indexes in the cluster don't affect test outcomes
+ * once setup is idempotent). For state that *does* need to be reset across
+ * configs sharing the cluster (e.g. server-wide feature-flag overrides,
+ * legacy/hand-indexed data), teardown should use direct primitives:
+ *   - `esClient.indices.delete` / `deleteByQuery` / `indices.deleteDataStream`
+ *   - `kbnClient.savedObjects.*` and `kbnClient.uiSettings.{unset,update,updateGlobal}`
+ *   - `apiServices.*` (e.g. `apiServices.core.settings(...)` to revert feature flags)
+ *
+ * This is also consistent with the `scout_no_es_archiver_in_parallel_tests`
+ * ESLint rule, which only allows `esArchiver` in `global.setup.ts`.
+ */
+export const globalTeardownFixtures = mergeTests(coreWorkerFixtures, apiServicesFixture);

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
@@ -15,8 +15,8 @@ export type { SloDataFixture } from './src/playwright/fixtures/worker';
 // re-exported test framework from @kbn/scout
 export { lighthouseTest, tags } from '@kbn/scout';
 
-// Custom global setup hook with profiling support
-export { globalSetupHook } from './src/playwright/global_hook';
+// Custom global setup/teardown hooks with profiling support
+export { globalSetupHook, globalTeardownHook } from './src/playwright/global_hook';
 
 // re-exported fixtures & configuration from @kbn/scout
 export {

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/global_hook/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/global_hook/index.ts
@@ -5,13 +5,24 @@
  * 2.0.
  */
 
-import { globalSetupHook as baseGlobalSetupHook, mergeTests } from '@kbn/scout';
+import {
+  globalSetupHook as baseGlobalSetupHook,
+  globalTeardownHook as baseGlobalTeardownHook,
+  mergeTests,
+} from '@kbn/scout';
 import { profilingSetupFixture } from '../fixtures/worker/profiling/profiling_setup_fixture';
 import { sloDataFixture } from '../fixtures/worker';
 
 // Create a custom global setup hook that includes profiling / slo setup
 export const globalSetupHook = mergeTests(
   baseGlobalSetupHook,
+  profilingSetupFixture,
+  sloDataFixture
+);
+
+// Mirror the setup hook for symmetry
+export const globalTeardownHook = mergeTests(
+  baseGlobalTeardownHook,
   profilingSetupFixture,
   sloDataFixture
 );

--- a/x-pack/solutions/security/packages/kbn-scout-security/index.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/index.ts
@@ -9,7 +9,7 @@
 export { test, spaceTest } from './src/playwright';
 
 // re-exported test framework from @kbn/scout
-export { lighthouseTest, apiTest, globalSetupHook, tags } from '@kbn/scout';
+export { lighthouseTest, apiTest, globalSetupHook, globalTeardownHook, tags } from '@kbn/scout';
 
 // re-exported fixtures & configuration from @kbn/scout
 export {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[scout] add optional globalTeardownHook to Scout (#268489)](https://github.com/elastic/kibana/pull/268489)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-05-12T11:51:22Z","message":"[scout] add optional globalTeardownHook to Scout (#268489)\n\n## Summary\n\nRelated to https://github.com/elastic/appex-qa-team/issues/890\n\nPR adds optional `globalTeardownHook` to Scout\n\nScout already runs `globalSetupHook` once before `parallel` suites to\nseed shared Es/Kibana state, but there's no symmetric way to reset that\nstate after the run. In practice this leaks across configs that share\nthe same cluster in CI (see lanes distribution\n[PR](https://github.com/elastic/kibana/pull/264506)) — server-wide\nfeature-flag overrides, global UI settings, and hand-indexed data\ningested by `global.setup.ts` survive into the next config's run.\n\nWe've already seen this break tests: e.g. UX Scout config seeding\n`apm-8.0.0-*` indexes makes the Observability landing-page redirect\nshort-circuit to /`app/apm/services` instead of\n/`app/observabilityOnboarding` for any subsequent config.\n\nScope:\n- New `globalTeardownHook` exported from `@kbn/scout` (and re-exported\nfrom `@kbn/scout-oblt` / `@kbn/scout-security`), mirroring\n`globalSetupHook`.\n- Auto-discovered as `parallel_tests/global.teardown.ts` whenever\n`runGlobalSetup: true` — no new config flag, opt-in by file presence.\n- Wired through Playwright's per-project teardown field, so it runs once\nafter all workers finish, even on test failure.\n\nFixture surface is intentionally narrower than setup: **esClient**,\n**kbnClient**, **apiServices**, plus log / config / kbnUrl. **esArchiver\nis not exposed** — Scout's esArchiver fixture has only ever supported\n`loadIfNeeded;` archive unloading is _slow and unnecessary_ because\nleftover indexes don't break tests when setup is idempotent.\n\n`global.teardown.ts`\n```ts\n\nimport { globalTeardownHook } from '@kbn/scout';\n\nglobalTeardownHook('Cleaning after Streams tests', async ({ apiServices, log }) => {\n  log.debug('[setup] Disabling streams...');\n  await apiServices.streams.disable();\n});\n\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"27b0b1bcc07a9a9f530eb27538d58df3d9db3870","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0"],"title":"[scout] add optional globalTeardownHook to Scout","number":268489,"url":"https://github.com/elastic/kibana/pull/268489","mergeCommit":{"message":"[scout] add optional globalTeardownHook to Scout (#268489)\n\n## Summary\n\nRelated to https://github.com/elastic/appex-qa-team/issues/890\n\nPR adds optional `globalTeardownHook` to Scout\n\nScout already runs `globalSetupHook` once before `parallel` suites to\nseed shared Es/Kibana state, but there's no symmetric way to reset that\nstate after the run. In practice this leaks across configs that share\nthe same cluster in CI (see lanes distribution\n[PR](https://github.com/elastic/kibana/pull/264506)) — server-wide\nfeature-flag overrides, global UI settings, and hand-indexed data\ningested by `global.setup.ts` survive into the next config's run.\n\nWe've already seen this break tests: e.g. UX Scout config seeding\n`apm-8.0.0-*` indexes makes the Observability landing-page redirect\nshort-circuit to /`app/apm/services` instead of\n/`app/observabilityOnboarding` for any subsequent config.\n\nScope:\n- New `globalTeardownHook` exported from `@kbn/scout` (and re-exported\nfrom `@kbn/scout-oblt` / `@kbn/scout-security`), mirroring\n`globalSetupHook`.\n- Auto-discovered as `parallel_tests/global.teardown.ts` whenever\n`runGlobalSetup: true` — no new config flag, opt-in by file presence.\n- Wired through Playwright's per-project teardown field, so it runs once\nafter all workers finish, even on test failure.\n\nFixture surface is intentionally narrower than setup: **esClient**,\n**kbnClient**, **apiServices**, plus log / config / kbnUrl. **esArchiver\nis not exposed** — Scout's esArchiver fixture has only ever supported\n`loadIfNeeded;` archive unloading is _slow and unnecessary_ because\nleftover indexes don't break tests when setup is idempotent.\n\n`global.teardown.ts`\n```ts\n\nimport { globalTeardownHook } from '@kbn/scout';\n\nglobalTeardownHook('Cleaning after Streams tests', async ({ apiServices, log }) => {\n  log.debug('[setup] Disabling streams...');\n  await apiServices.streams.disable();\n});\n\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"27b0b1bcc07a9a9f530eb27538d58df3d9db3870"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/268489","number":268489,"mergeCommit":{"message":"[scout] add optional globalTeardownHook to Scout (#268489)\n\n## Summary\n\nRelated to https://github.com/elastic/appex-qa-team/issues/890\n\nPR adds optional `globalTeardownHook` to Scout\n\nScout already runs `globalSetupHook` once before `parallel` suites to\nseed shared Es/Kibana state, but there's no symmetric way to reset that\nstate after the run. In practice this leaks across configs that share\nthe same cluster in CI (see lanes distribution\n[PR](https://github.com/elastic/kibana/pull/264506)) — server-wide\nfeature-flag overrides, global UI settings, and hand-indexed data\ningested by `global.setup.ts` survive into the next config's run.\n\nWe've already seen this break tests: e.g. UX Scout config seeding\n`apm-8.0.0-*` indexes makes the Observability landing-page redirect\nshort-circuit to /`app/apm/services` instead of\n/`app/observabilityOnboarding` for any subsequent config.\n\nScope:\n- New `globalTeardownHook` exported from `@kbn/scout` (and re-exported\nfrom `@kbn/scout-oblt` / `@kbn/scout-security`), mirroring\n`globalSetupHook`.\n- Auto-discovered as `parallel_tests/global.teardown.ts` whenever\n`runGlobalSetup: true` — no new config flag, opt-in by file presence.\n- Wired through Playwright's per-project teardown field, so it runs once\nafter all workers finish, even on test failure.\n\nFixture surface is intentionally narrower than setup: **esClient**,\n**kbnClient**, **apiServices**, plus log / config / kbnUrl. **esArchiver\nis not exposed** — Scout's esArchiver fixture has only ever supported\n`loadIfNeeded;` archive unloading is _slow and unnecessary_ because\nleftover indexes don't break tests when setup is idempotent.\n\n`global.teardown.ts`\n```ts\n\nimport { globalTeardownHook } from '@kbn/scout';\n\nglobalTeardownHook('Cleaning after Streams tests', async ({ apiServices, log }) => {\n  log.debug('[setup] Disabling streams...');\n  await apiServices.streams.disable();\n});\n\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"27b0b1bcc07a9a9f530eb27538d58df3d9db3870"}}]}] BACKPORT-->