### PR TITLE
[SpaceTime 2/5] Create @kbn/apm-api-shared package

### DIFF
--- a/src/platform/packages/shared/kbn-apm-api-shared/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/index.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export {
+  createCallApmApiV2,
+  type APMClientV2,
+  type AutoAbortedAPMClientV2,
+  type APIReturnType,
+} from './src/create_call_apm_api';
+export { routeDefinitions } from './src/routes';
+export type { SharedAPMRouteRepository } from './src/routes';
+export type * from './src/routes/historical_data';
+export type * from './src/routes/suggestions';
+export type * from './src/routes/agent_keys';
+export type * from './src/routes/traces';
+export type * from './src/routes/span_links';
+export type * from './src/routes/observability_overview';
+export type * from './src/routes/agent_explorer';
+export type * from './src/routes/alerts';
+export type * from './src/routes/assistant_functions';
+export type * from './src/routes/correlations';
+export type * from './src/routes/custom_dashboards';
+export type * from './src/routes/dependencies';
+export type * from './src/routes/transactions';
+export type * from './src/routes/services';
+export type * from './src/routes/service_map';
+export type * from './src/routes/errors';
+export type * from './src/routes/infrastructure';
+export type * from './src/routes/environments';
+export type * from './src/routes/event_metadata';
+export type * from './src/routes/fallback_to_transactions';
+export type * from './src/routes/latency_distribution';
+export type * from './src/routes/metrics';
+export type * from './src/routes/profiling';
+export type * from './src/routes/service_groups';
+export type * from './src/routes/time_range_metadata';
+export type * from './src/routes/custom_links';
+export type * from './src/routes/anomaly_detection';
+export type * from './src/routes/mobile';
+export type * from './src/routes/mobile_errors';
+export type * from './src/routes/mobile_crashes';
+export type * from './src/routes/data_view';
+export type * from './src/routes/diagnostics';
+export type * from './src/routes/fleet';
+export type * from './src/routes/debug_telemetry';
+export type * from './src/routes/storage_explorer';
+export type * from './src/routes/source_maps';
+export type * from './src/routes/agent_configuration';
+export { sourceMapRt } from './src/routes/source_maps';
+export { filterOptionsRt, payloadRt } from './src/routes/custom_links';
+export {
+  rangeRt,
+  kueryRt,
+  probabilityRt,
+  offsetRt,
+  serviceTransactionDataSourceRt,
+  transactionDataSourceRt,
+  filtersRt,
+} from './src/default_api_types';
+export {
+  OBSERVABILITY_APM_CPS_ENABLED_DEFAULT,
+  OBSERVABILITY_APM_CPS_ENABLED_FEATURE_FLAG,
+} from './src/cps_feature_flag';

--- a/src/platform/packages/shared/kbn-apm-api-shared/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-apm-api-shared/kibana.jsonc
@@ -1,0 +1,10 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/apm-api-shared",
+  "owner": [
+    "@elastic/obs-presentation-team",
+    "@elastic/obs-exploration-team"
+  ],
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/src/platform/packages/shared/kbn-apm-api-shared/package.json
+++ b/src/platform/packages/shared/kbn-apm-api-shared/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/apm-api-shared",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0"
+}

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/call_api.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/call_api.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CoreSetup, CoreStart } from '@kbn/core/public';
+import { isString, startsWith } from 'lodash';
+import { LRUCache as LRU } from 'lru-cache';
+import hash from 'object-hash';
+import type { FetchOptions } from './create_call_apm_api';
+
+function fetchOptionsWithDebug(fetchOptions: FetchOptions, inspectableEsQueriesEnabled: boolean) {
+  const debugEnabled =
+    inspectableEsQueriesEnabled && startsWith(fetchOptions.pathname, '/internal/apm');
+
+  const { body, ...rest } = fetchOptions;
+
+  return {
+    ...rest,
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    query: {
+      ...fetchOptions.query,
+      ...(debugEnabled ? { _inspect: true } : {}),
+    },
+  };
+}
+
+const cache = new LRU<string, any>({ max: 100, ttl: 1000 * 60 * 60 });
+
+export function clearCache() {
+  cache.clear();
+}
+
+export type CallApi = typeof callApi;
+
+export async function callApi<T = void>(
+  { http, uiSettings }: CoreStart | CoreSetup,
+  fetchOptions: FetchOptions
+): Promise<T> {
+  const inspectableEsQueriesEnabled: boolean =
+    // For now this needs to be hardcoded as we cannot import the key, as it lives inside the observability plugin,
+    // and refactoring it is outside the scope of this PR, but ideally this should be imported from the same place as the key is defined
+    uiSettings?.get('observability:enableInspectEsQueries') ?? false;
+  const cacheKey = getCacheKey(fetchOptions);
+  const cacheResponse = cache.get(cacheKey);
+  if (cacheResponse) {
+    return cacheResponse;
+  }
+
+  const {
+    pathname,
+    method = 'get',
+    ...options
+  } = fetchOptionsWithDebug(fetchOptions, inspectableEsQueriesEnabled);
+
+  const lowercaseMethod = method.toLowerCase() as 'get' | 'post' | 'put' | 'delete' | 'patch';
+
+  const res = await http[lowercaseMethod]<T>(pathname, options);
+
+  if (isCachable(fetchOptions)) {
+    cache.set(cacheKey, res);
+  }
+
+  return res;
+}
+
+// only cache items that has a time range with `start` and `end` params,
+// and where `end` is not a timestamp in the future
+function isCachable(fetchOptions: FetchOptions) {
+  if (fetchOptions.isCachable !== undefined) {
+    return fetchOptions.isCachable;
+  }
+
+  if (!(fetchOptions.query && fetchOptions.query.start && fetchOptions.query.end)) {
+    return false;
+  }
+
+  return (
+    isString(fetchOptions.query.end) && new Date(fetchOptions.query.end).getTime() < Date.now()
+  );
+}
+
+// order the options object to make sure that two objects with the same arguments, produce produce the
+// same cache key regardless of the order of properties
+function getCacheKey(options: FetchOptions) {
+  const { pathname, method, body, query, headers } = options;
+  return hash({ pathname, method, body, query, headers });
+}

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/cps_feature_flag.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/cps_feature_flag.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** Use with `feature_flags.overrides` in kibana.yml to toggle CPS integration for APM. */
+export const OBSERVABILITY_APM_CPS_ENABLED_FEATURE_FLAG = 'observability.apm.cpsEnabled' as const;
+
+/**
+ * Fallback when the flag is unset and no override exists (same default as the removed
+ * `xpack.apm.featureFlags.apmCPSEnabled` setting).
+ */
+export const OBSERVABILITY_APM_CPS_ENABLED_DEFAULT = true;

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/create_call_apm_api.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/create_call_apm_api.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { CoreStart } from '@kbn/core/public';
+import type { EndpointOf, ReturnOf } from '@kbn/server-route-repository-utils';
+import { formatRequest } from '@kbn/server-route-repository-utils';
+import { type RouteRepositoryClient } from '@kbn/server-route-repository';
+import type { HttpFetchOptions } from '@kbn/core/public';
+import type { ICPSManager } from '@kbn/cps-utils';
+import type { SharedAPMRouteRepository } from './routes';
+import type { CallApi } from './call_api';
+import { callApi } from './call_api';
+import {
+  OBSERVABILITY_APM_CPS_ENABLED_DEFAULT,
+  OBSERVABILITY_APM_CPS_ENABLED_FEATURE_FLAG,
+} from './cps_feature_flag';
+
+export type FetchOptions = Omit<HttpFetchOptions, 'body'> & {
+  pathname: string;
+  isCachable?: boolean;
+  method?: string;
+  body?: any;
+};
+
+type APMClientOptions = Omit<FetchOptions, 'query' | 'body' | 'pathname' | 'signal'> & {
+  signal: AbortSignal | null;
+};
+
+export type APMClientV2 = RouteRepositoryClient<
+  SharedAPMRouteRepository,
+  APMClientOptions
+>['fetch'];
+
+export type AutoAbortedAPMClientV2 = RouteRepositoryClient<
+  SharedAPMRouteRepository,
+  Omit<APMClientOptions, 'signal'>
+>['fetch'];
+
+type APIEndpoint = EndpointOf<SharedAPMRouteRepository>;
+
+export type APIReturnType<TEndpoint extends APIEndpoint> = ReturnOf<
+  SharedAPMRouteRepository,
+  TEndpoint
+>;
+
+interface Dependencies {
+  cpsManager?: ICPSManager;
+}
+
+export function createCallApmApiV2(
+  core: CoreStart,
+  { cpsManager }: Dependencies = {}
+): APMClientV2 {
+  return ((endpoint, options) => {
+    const { params } = options as unknown as {
+      params?: Partial<Record<string, any>>;
+    };
+
+    const { method, pathname, version } = formatRequest(endpoint, params?.path);
+    const isCpsEnabled = core.featureFlags.getBooleanValue(
+      OBSERVABILITY_APM_CPS_ENABLED_FEATURE_FLAG,
+      OBSERVABILITY_APM_CPS_ENABLED_DEFAULT
+    );
+    const projectRouting = isCpsEnabled ? cpsManager?.getProjectRouting() : undefined;
+
+    return callApi(core, {
+      ...options,
+      method,
+      pathname,
+      body: params?.body,
+      query: params?.query,
+      version,
+      headers: {
+        ...(options as any)?.headers,
+        ...(projectRouting ? { 'x-project-routing': projectRouting } : {}),
+      },
+    } as unknown as Parameters<CallApi>[1]);
+  }) as APMClientV2;
+}

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/default_api_types.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/default_api_types.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { either } from 'fp-ts/Either';
+import { isoToEpochRt, toNumberRt } from '@kbn/io-ts-utils';
+import type { BoolQuery } from '@kbn/es-query';
+import { ApmDocumentType, RollupInterval } from '@kbn/apm-types';
+
+export const rangeRt = t.type({
+  start: isoToEpochRt,
+  end: isoToEpochRt,
+});
+
+export const kueryRt = t.type({ kuery: t.string });
+
+export const probabilityRt = t.type({
+  probability: toNumberRt,
+});
+
+export const offsetRt = t.partial({
+  offset: t.string,
+});
+
+export const serviceTransactionDataSourceRt = t.type({
+  documentType: t.union([
+    t.literal(ApmDocumentType.ServiceTransactionMetric),
+    t.literal(ApmDocumentType.TransactionMetric),
+    t.literal(ApmDocumentType.TransactionEvent),
+  ]),
+  rollupInterval: t.union([
+    t.literal(RollupInterval.OneMinute),
+    t.literal(RollupInterval.TenMinutes),
+    t.literal(RollupInterval.SixtyMinutes),
+    t.literal(RollupInterval.None),
+  ]),
+});
+
+export const transactionDataSourceRt = t.type({
+  documentType: t.union([
+    t.literal(ApmDocumentType.TransactionMetric),
+    t.literal(ApmDocumentType.TransactionEvent),
+  ]),
+  rollupInterval: t.union([
+    t.literal(RollupInterval.OneMinute),
+    t.literal(RollupInterval.TenMinutes),
+    t.literal(RollupInterval.SixtyMinutes),
+    t.literal(RollupInterval.None),
+  ]),
+});
+
+const BoolQueryRt = t.type({
+  should: t.array(t.record(t.string, t.unknown)),
+  must: t.array(t.record(t.string, t.unknown)),
+  must_not: t.array(t.record(t.string, t.unknown)),
+  filter: t.array(t.record(t.string, t.unknown)),
+});
+
+export const filtersRt = new t.Type<BoolQuery, string, unknown>(
+  'BoolQuery',
+  BoolQueryRt.is,
+  (input: unknown, context: t.Context) =>
+    either.chain(t.string.validate(input, context), (value: string) => {
+      try {
+        const filters = JSON.parse(value);
+        const decoded = {
+          should: [],
+          must: [],
+          must_not: filters.must_not ? [...filters.must_not] : [],
+          filter: filters.filter ? [...filters.filter] : [],
+        };
+        return t.success(decoded);
+      } catch (err) {
+        return t.failure(input, context, err.message);
+      }
+    }),
+  (filters: BoolQuery): string => JSON.stringify(filters)
+);

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/mock_create_call_apm_api.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/mock_create_call_apm_api.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { CoreStart } from '@kbn/core/public';
+import { createCallApmApiV2 } from './create_call_apm_api';
+
+const coreMock = {
+  featureFlags: { getBooleanValue: () => false },
+} as unknown as CoreStart;
+
+export function mockCreateCallApmApiV2(core: CoreStart = {} as CoreStart) {
+  return createCallApmApiV2({ ...coreMock, ...core });
+}

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/create_or_update_configuration.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/create_or_update_configuration.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt } from '@kbn/io-ts-utils';
+import { agentConfigurationIntakeRt } from '@kbn/apm-agent-configuration';
+import { defineRoute } from '../types';
+
+export const createOrUpdateAgentConfigurationRoute = defineRoute<void>()({
+  endpoint: 'PUT /api/apm/settings/agent-configuration 2023-10-31',
+  params: t.intersection([
+    t.partial({ query: t.partial({ overwrite: toBooleanRt }) }),
+    t.type({ body: agentConfigurationIntakeRt }),
+  ]),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/delete_configuration.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/delete_configuration.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { serviceRt } from '@kbn/apm-agent-configuration';
+import { defineRoute } from '../types';
+
+export interface DeleteAgentConfigurationResponse {
+  result: string;
+}
+
+export const deleteAgentConfigurationRoute = defineRoute<DeleteAgentConfigurationResponse>()({
+  endpoint: 'DELETE /api/apm/settings/agent-configuration 2023-10-31',
+  params: t.type({
+    body: t.type({
+      service: serviceRt,
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/get_agent_name.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/get_agent_name.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+
+export interface AgentConfigurationAgentNameResponse {
+  agentName: string | undefined;
+}
+
+export const agentConfigurationAgentNameRoute = defineRoute<AgentConfigurationAgentNameResponse>()({
+  endpoint: 'GET /api/apm/settings/agent-configuration/agent_name 2023-10-31',
+  params: t.type({
+    query: t.type({ serviceName: t.string }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/get_single_configuration.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/get_single_configuration.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { AgentConfiguration } from '@kbn/apm-agent-configuration';
+import { serviceRt } from '@kbn/apm-agent-configuration';
+import { defineRoute } from '../types';
+
+export type GetSingleAgentConfigurationResponse = AgentConfiguration;
+
+export const getSingleAgentConfigurationRoute = defineRoute<GetSingleAgentConfigurationResponse>()({
+  endpoint: 'GET /api/apm/settings/agent-configuration/view 2023-10-31',
+  params: t.partial({
+    query: serviceRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/index.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { listAgentConfigurationsRoute } from './list_configurations';
+import { getSingleAgentConfigurationRoute } from './get_single_configuration';
+import { deleteAgentConfigurationRoute } from './delete_configuration';
+import { createOrUpdateAgentConfigurationRoute } from './create_or_update_configuration';
+import { searchAgentConfigurationRoute } from './search_configuration';
+import { listAgentConfigurationEnvironmentsRoute } from './list_environments';
+import { agentConfigurationAgentNameRoute } from './get_agent_name';
+
+export const agentConfigurationRouteDefinitions = {
+  list: listAgentConfigurationsRoute,
+  getSingle: getSingleAgentConfigurationRoute,
+  delete: deleteAgentConfigurationRoute,
+  createOrUpdate: createOrUpdateAgentConfigurationRoute,
+  search: searchAgentConfigurationRoute,
+  listEnvironments: listAgentConfigurationEnvironmentsRoute,
+  agentName: agentConfigurationAgentNameRoute,
+};
+
+export type { ListAgentConfigurationsResponse } from './list_configurations';
+export type { GetSingleAgentConfigurationResponse } from './get_single_configuration';
+export type { DeleteAgentConfigurationResponse } from './delete_configuration';
+export type {
+  AgentConfigSearchParams,
+  SearchAgentConfigurationResponse,
+} from './search_configuration';
+export type {
+  AgentConfigurationEnvironmentsResponse,
+  ListAgentConfigurationEnvironmentsResponse,
+} from './list_environments';
+export type { AgentConfigurationAgentNameResponse } from './get_agent_name';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/list_configurations.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/list_configurations.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { AgentConfiguration } from '@kbn/apm-agent-configuration';
+import { defineRoute } from '../types';
+
+export interface ListAgentConfigurationsResponse {
+  configurations: AgentConfiguration[];
+}
+
+export const listAgentConfigurationsRoute = defineRoute<ListAgentConfigurationsResponse>()({
+  endpoint: 'GET /api/apm/settings/agent-configuration 2023-10-31',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/list_environments.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/list_environments.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+
+export type AgentConfigurationEnvironmentsResponse = Array<{
+  name: string;
+  alreadyConfigured: boolean;
+}>;
+
+export interface ListAgentConfigurationEnvironmentsResponse {
+  environments: AgentConfigurationEnvironmentsResponse;
+}
+
+export const listAgentConfigurationEnvironmentsRoute =
+  defineRoute<ListAgentConfigurationEnvironmentsResponse>()({
+    endpoint: 'GET /api/apm/settings/agent-configuration/environments 2023-10-31',
+    params: t.partial({
+      query: t.partial({ serviceName: t.string }),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/search_configuration.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/search_configuration.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SearchHit } from '@kbn/es-types';
+import type { AgentConfiguration } from '@kbn/apm-agent-configuration';
+import { serviceRt } from '@kbn/apm-agent-configuration';
+import { defineRoute } from '../types';
+
+const searchParamsRt = t.intersection([
+  t.type({ service: serviceRt }),
+  t.partial({ etag: t.string, mark_as_applied_by_agent: t.boolean, error: t.string }),
+]);
+
+export type AgentConfigSearchParams = t.TypeOf<typeof searchParamsRt>;
+
+export type SearchAgentConfigurationResponse = SearchHit<
+  AgentConfiguration,
+  undefined,
+  undefined
+> | null;
+
+export const searchAgentConfigurationRoute = defineRoute<SearchAgentConfigurationResponse>()({
+  endpoint: 'POST /api/apm/settings/agent-configuration/search 2023-10-31',
+  params: t.type({
+    body: searchParamsRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_explorer/agent_instances.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_explorer/agent_instances.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+
+export type AgentExplorerAgentInstancesResponse = Array<{
+  serviceNode: string;
+  environments: string[];
+  agentVersion: string;
+  lastReport: string;
+}>;
+
+export interface AgentExplorerAgentInstancesRouteResponse {
+  items: AgentExplorerAgentInstancesResponse;
+}
+
+export const agentInstancesRoute = defineRoute<AgentExplorerAgentInstancesRouteResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/agent_instances',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([environmentRt, kueryRt, rangeRt, probabilityRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_explorer/agents_per_service.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_explorer/agents_per_service.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { AgentName } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+
+export interface AgentExplorerAgentsResponse {
+  items: Array<{
+    agentDocsPageUrl: string | undefined;
+    serviceName: string;
+    environments: string[];
+    agentName: AgentName;
+    agentVersion: string[];
+    agentTelemetryAutoVersion: string[];
+    instances: number;
+    latestVersion?: string;
+  }>;
+}
+
+export const agentsPerServiceRoute = defineRoute<AgentExplorerAgentsResponse>()({
+  endpoint: 'GET /internal/apm/get_agents_per_service',
+  params: t.type({
+    query: t.intersection([
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      probabilityRt,
+      t.partial({
+        serviceName: t.string,
+        agentLanguage: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_explorer/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_explorer/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { agentsPerServiceRoute } from './agents_per_service';
+import { latestAgentVersionsRoute } from './latest_agent_versions';
+import { agentInstancesRoute } from './agent_instances';
+
+export const agentExplorerRouteDefinitions = {
+  agentsPerService: agentsPerServiceRoute,
+  latestAgentVersions: latestAgentVersionsRoute,
+  agentInstances: agentInstancesRoute,
+};
+
+export type { AgentExplorerAgentsResponse } from './agents_per_service';
+export type { AgentLatestVersionsResponse } from './latest_agent_versions';
+export type {
+  AgentExplorerAgentInstancesResponse,
+  AgentExplorerAgentInstancesRouteResponse,
+} from './agent_instances';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_explorer/latest_agent_versions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_explorer/latest_agent_versions.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type {
+  AgentName,
+  ElasticApmAgentLatestVersion,
+  OtelAgentLatestVersion,
+} from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+type AgentLatestVersions = Record<AgentName, ElasticApmAgentLatestVersion | OtelAgentLatestVersion>;
+
+export interface AgentLatestVersionsResponse {
+  data: AgentLatestVersions;
+  error?: { message: string; type?: string; statusCode?: string };
+}
+
+export const latestAgentVersionsRoute = defineRoute<AgentLatestVersionsResponse>()({
+  endpoint: 'GET /internal/apm/get_latest_agent_versions',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/agent_keys.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/agent_keys.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { ApiKey } from '@kbn/security-plugin-types-common';
+import { defineRoute } from '../types';
+
+export interface AgentKeysResponse {
+  agentKeys: ApiKey[];
+}
+
+export const agentKeysRoute = defineRoute<AgentKeysResponse>()({
+  endpoint: 'GET /internal/apm/agent_keys',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/agent_keys_privileges.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/agent_keys_privileges.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface AgentKeysPrivilegesResponse {
+  areApiKeysEnabled: boolean;
+  isAdmin: boolean;
+  canManage: boolean;
+}
+
+export const agentKeysPrivilegesRoute = defineRoute<AgentKeysPrivilegesResponse>()({
+  endpoint: 'GET /internal/apm/agent_keys/privileges',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/create_agent_key.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/create_agent_key.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SecurityCreateApiKeyResponse } from '@elastic/elasticsearch/lib/api/types';
+import { defineRoute } from '../types';
+
+export interface CreateAgentKeyResponse {
+  agentKey: SecurityCreateApiKeyResponse;
+}
+
+export const createAgentKeyRoute = defineRoute<CreateAgentKeyResponse>()({
+  endpoint: 'POST /api/apm/agent_keys 2023-10-31',
+  params: t.type({
+    body: t.type({
+      name: t.string,
+      privileges: t.array(
+        t.union([t.literal('event:write'), t.literal('config_agent:read')])
+      ),
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { agentKeysRoute } from './agent_keys';
+import { agentKeysPrivilegesRoute } from './agent_keys_privileges';
+import { invalidateAgentKeyRoute } from './invalidate_agent_key';
+import { createAgentKeyRoute } from './create_agent_key';
+
+export const agentKeysRouteDefinitions = {
+  agentKeys: agentKeysRoute,
+  agentKeysPrivileges: agentKeysPrivilegesRoute,
+  invalidateAgentKey: invalidateAgentKeyRoute,
+  createAgentKey: createAgentKeyRoute,
+};
+
+export type { AgentKeysResponse } from './agent_keys';
+export type { AgentKeysPrivilegesResponse } from './agent_keys_privileges';
+export type { InvalidateAgentKeyResponse } from './invalidate_agent_key';
+export type { CreateAgentKeyResponse } from './create_agent_key';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/invalidate_agent_key.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_keys/invalidate_agent_key.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+
+export interface InvalidateAgentKeyResponse {
+  invalidatedAgentKeys: string[];
+}
+
+export const invalidateAgentKeyRoute = defineRoute<InvalidateAgentKeyResponse>()({
+  endpoint: 'POST /internal/apm/api_key/invalidate',
+  params: t.type({
+    body: t.type({ id: t.string }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/error_count_chart_preview.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/error_count_chart_preview.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { alertParamsRt, type PreviewChartResponse } from './types';
+
+export interface ErrorCountChartPreviewResponse {
+  errorCountChartPreview: PreviewChartResponse;
+}
+
+export const errorCountChartPreviewRoute = defineRoute<ErrorCountChartPreviewResponse>()({
+  endpoint: 'GET /internal/apm/rule_types/error_count/chart_preview',
+  params: t.type({ query: alertParamsRt }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { transactionErrorRateChartPreviewRoute } from './transaction_error_rate_chart_preview';
+import { errorCountChartPreviewRoute } from './error_count_chart_preview';
+import { transactionDurationChartPreviewRoute } from './transaction_duration_chart_preview';
+
+export const alertsRouteDefinitions = {
+  transactionErrorRateChartPreview: transactionErrorRateChartPreviewRoute,
+  errorCountChartPreview: errorCountChartPreviewRoute,
+  transactionDurationChartPreview: transactionDurationChartPreviewRoute,
+};
+
+export type {
+  AlertParams,
+  PreviewChartResponse,
+  PreviewChartResponseItem,
+} from './types';
+export type { TransactionErrorRateChartPreviewResponse } from './transaction_error_rate_chart_preview';
+export type { ErrorCountChartPreviewResponse } from './error_count_chart_preview';
+export type { TransactionDurationChartPreviewResponse } from './transaction_duration_chart_preview';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/transaction_duration_chart_preview.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/transaction_duration_chart_preview.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { alertParamsRt, type PreviewChartResponse } from './types';
+
+export interface TransactionDurationChartPreviewResponse {
+  latencyChartPreview: PreviewChartResponse;
+}
+
+export const transactionDurationChartPreviewRoute =
+  defineRoute<TransactionDurationChartPreviewResponse>()({
+    endpoint: 'GET /internal/apm/rule_types/transaction_duration/chart_preview',
+    params: t.type({ query: alertParamsRt }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/transaction_error_rate_chart_preview.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/transaction_error_rate_chart_preview.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { alertParamsRt, type PreviewChartResponse } from './types';
+
+export interface TransactionErrorRateChartPreviewResponse {
+  errorRateChartPreview: PreviewChartResponse;
+}
+
+export const transactionErrorRateChartPreviewRoute =
+  defineRoute<TransactionErrorRateChartPreviewResponse>()({
+    endpoint: 'GET /internal/apm/rule_types/transaction_error_rate/chart_preview',
+    params: t.type({ query: alertParamsRt }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/types.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/alerts/types.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt } from '@kbn/io-ts-utils';
+import { AggregationType, environmentRt, type Coordinate } from '@kbn/apm-types';
+import { rangeRt } from '../../default_api_types';
+
+const searchConfigurationRt = t.type({
+  query: t.type({
+    query: t.union([t.string, t.record(t.string, t.any)]),
+    language: t.string,
+  }),
+});
+
+export const alertParamsRt = t.intersection([
+  t.partial({
+    aggregationType: t.union([
+      t.literal(AggregationType.Avg),
+      t.literal(AggregationType.P95),
+      t.literal(AggregationType.P99),
+    ]),
+    serviceName: t.string,
+    errorGroupingKey: t.string,
+    transactionType: t.string,
+    transactionName: t.string,
+  }),
+  environmentRt,
+  rangeRt,
+  t.type({
+    interval: t.string,
+  }),
+  t.partial({
+    groupBy: t.array(t.string),
+    searchConfiguration: jsonRt.pipe(searchConfigurationRt),
+  }),
+]);
+
+export type AlertParams = t.TypeOf<typeof alertParamsRt>;
+
+export interface PreviewChartResponseItem {
+  name: string;
+  data: Coordinate[];
+}
+
+export interface PreviewChartResponse {
+  series: PreviewChartResponseItem[];
+  totalGroups: number;
+}

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/anomaly_detection_environments.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/anomaly_detection_environments.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface AnomalyDetectionEnvironmentsResponse {
+  environments: string[];
+}
+
+export const anomalyDetectionEnvironmentsRoute =
+  defineRoute<AnomalyDetectionEnvironmentsResponse>()({
+    endpoint: 'GET /internal/apm/settings/anomaly-detection/environments',
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/anomaly_detection_jobs.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/anomaly_detection_jobs.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { ApmMlJob } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface AnomalyDetectionJobsResponse {
+  jobs: ApmMlJob[];
+  hasLegacyJobs: boolean;
+}
+
+export const anomalyDetectionJobsRoute = defineRoute<AnomalyDetectionJobsResponse>()({
+  endpoint: 'GET /internal/apm/settings/anomaly-detection/jobs',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/anomaly_detection_update_to_v3.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/anomaly_detection_update_to_v3.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface AnomalyDetectionUpdateToV3Response {
+  update: boolean;
+}
+
+export const anomalyDetectionUpdateToV3Route = defineRoute<AnomalyDetectionUpdateToV3Response>()({
+  endpoint: 'POST /internal/apm/settings/anomaly-detection/update_to_v3',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/create_anomaly_detection_jobs.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/create_anomaly_detection_jobs.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentStringRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface CreateAnomalyDetectionJobsResponse {
+  jobCreated: true;
+}
+
+export const createAnomalyDetectionJobsRoute = defineRoute<CreateAnomalyDetectionJobsResponse>()({
+  endpoint: 'POST /internal/apm/settings/anomaly-detection/jobs',
+  params: t.type({
+    body: t.type({
+      environments: t.array(environmentStringRt),
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/anomaly_detection/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { anomalyDetectionJobsRoute } from './anomaly_detection_jobs';
+import { createAnomalyDetectionJobsRoute } from './create_anomaly_detection_jobs';
+import { anomalyDetectionEnvironmentsRoute } from './anomaly_detection_environments';
+import { anomalyDetectionUpdateToV3Route } from './anomaly_detection_update_to_v3';
+
+export const anomalyDetectionRouteDefinitions = {
+  jobs: anomalyDetectionJobsRoute,
+  createJobs: createAnomalyDetectionJobsRoute,
+  environments: anomalyDetectionEnvironmentsRoute,
+  updateToV3: anomalyDetectionUpdateToV3Route,
+};
+
+export type { AnomalyDetectionJobsResponse } from './anomaly_detection_jobs';
+export type { CreateAnomalyDetectionJobsResponse } from './create_anomaly_detection_jobs';
+export type { AnomalyDetectionEnvironmentsResponse } from './anomaly_detection_environments';
+export type { AnomalyDetectionUpdateToV3Response } from './anomaly_detection_update_to_v3';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/assistant_functions/get_apm_timeseries.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/assistant_functions/get_apm_timeseries.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { getApmTimeseriesRt, type ApmTimeseries } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface GetApmTimeseriesResponse {
+  content: Array<Omit<ApmTimeseries, 'data'>>;
+  data: ApmTimeseries[];
+}
+
+export const getApmTimeseriesRoute = defineRoute<GetApmTimeseriesResponse>()({
+  endpoint: 'POST /internal/apm/assistant/get_apm_timeseries',
+  params: t.type({
+    body: getApmTimeseriesRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/assistant_functions/get_downstream_dependencies.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/assistant_functions/get_downstream_dependencies.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { downstreamDependenciesRouteRt, type APMDownstreamDependency } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface GetDownstreamDependenciesResponse {
+  content: APMDownstreamDependency[];
+}
+
+export const getDownstreamDependenciesRoute = defineRoute<GetDownstreamDependenciesResponse>()({
+  endpoint: 'GET /internal/apm/assistant/get_downstream_dependencies',
+  params: t.type({
+    query: downstreamDependenciesRouteRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/assistant_functions/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/assistant_functions/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { getApmTimeseriesRoute } from './get_apm_timeseries';
+import { getDownstreamDependenciesRoute } from './get_downstream_dependencies';
+
+export const assistantFunctionsRouteDefinitions = {
+  getApmTimeseries: getApmTimeseriesRoute,
+  getDownstreamDependencies: getDownstreamDependenciesRoute,
+};
+
+export type { GetApmTimeseriesResponse } from './get_apm_timeseries';
+export type { GetDownstreamDependenciesResponse } from './get_downstream_dependencies';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_candidates_transactions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_candidates_transactions.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+import { correlationsTransactionQueryRt } from './types';
+
+export interface DurationFieldCandidatesResponse {
+  fieldCandidates: string[];
+}
+
+export const fieldCandidatesTransactionsRoute = defineRoute<DurationFieldCandidatesResponse>()({
+  endpoint: 'GET /internal/apm/correlations/field_candidates/transactions',
+  params: t.type({
+    query: t.intersection([correlationsTransactionQueryRt, environmentRt, kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_value_pairs_transactions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_value_pairs_transactions.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { FieldValuePair } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+import { correlationsTransactionQueryRt } from './types';
+
+export interface FieldValuePairsResponse {
+  fieldValuePairs: FieldValuePair[];
+  errors: any[];
+}
+
+export const fieldValuePairsTransactionsRoute = defineRoute<FieldValuePairsResponse>()({
+  endpoint: 'POST /internal/apm/correlations/field_value_pairs/transactions',
+  params: t.type({
+    body: t.intersection([
+      correlationsTransactionQueryRt,
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      t.type({ fieldCandidates: t.array(t.string) }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_value_stats_transactions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_value_stats_transactions.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { TopValuesStats } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+import { correlationsTransactionQueryRt } from './types';
+
+export type FieldValueStatsTransactionsResponse = TopValuesStats;
+
+export const fieldValueStatsTransactionsRoute = defineRoute<FieldValueStatsTransactionsResponse>()(
+  {
+    endpoint: 'GET /internal/apm/correlations/field_value_stats/transactions',
+    params: t.type({
+      query: t.intersection([
+        t.partial({ samplerShardSize: t.string }),
+        correlationsTransactionQueryRt,
+        environmentRt,
+        kueryRt,
+        rangeRt,
+        t.type({
+          fieldName: t.string,
+          fieldValue: t.union([t.string, t.number]),
+        }),
+      ]),
+    }),
+  }
+);

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { fieldCandidatesTransactionsRoute } from './field_candidates_transactions';
+import { fieldValueStatsTransactionsRoute } from './field_value_stats_transactions';
+import { fieldValuePairsTransactionsRoute } from './field_value_pairs_transactions';
+import { significantCorrelationsTransactionsRoute } from './significant_correlations_transactions';
+import { pValuesTransactionsRoute } from './p_values_transactions';
+import { unifiedCorrelationsRoute } from './unified_correlations';
+
+export const correlationsRouteDefinitions = {
+  fieldCandidatesTransactions: fieldCandidatesTransactionsRoute,
+  fieldValueStatsTransactions: fieldValueStatsTransactionsRoute,
+  fieldValuePairsTransactions: fieldValuePairsTransactionsRoute,
+  significantCorrelationsTransactions: significantCorrelationsTransactionsRoute,
+  pValuesTransactions: pValuesTransactionsRoute,
+  unifiedCorrelations: unifiedCorrelationsRoute,
+};
+
+export type { DurationFieldCandidatesResponse } from './field_candidates_transactions';
+export type { FieldValueStatsTransactionsResponse } from './field_value_stats_transactions';
+export type { FieldValuePairsResponse } from './field_value_pairs_transactions';
+export type { SignificantCorrelationsResponse } from './significant_correlations_transactions';
+export type { PValuesResponse } from './p_values_transactions';
+export type { UnifiedCorrelationsRouteResponse } from './unified_correlations';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/p_values_transactions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/p_values_transactions.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { FailedTransactionsCorrelation } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+import { correlationsTransactionQueryRt } from './types';
+
+export interface PValuesResponse {
+  failedTransactionsCorrelations: FailedTransactionsCorrelation[];
+  ccsWarning: boolean;
+  fallbackResult?: FailedTransactionsCorrelation;
+}
+
+export const pValuesTransactionsRoute = defineRoute<PValuesResponse>()({
+  endpoint: 'POST /internal/apm/correlations/p_values/transactions',
+  params: t.type({
+    body: t.intersection([
+      t.intersection([
+        t.partial({
+          durationMin: toNumberRt,
+          durationMax: toNumberRt,
+        }),
+        correlationsTransactionQueryRt,
+        environmentRt,
+      ]),
+      t.intersection([kueryRt, rangeRt, t.type({ fieldCandidates: t.array(t.string) })]),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/significant_correlations_transactions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/significant_correlations_transactions.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { LatencyCorrelation } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+import { correlationsTransactionQueryRt } from './types';
+
+export interface SignificantCorrelationsResponse {
+  latencyCorrelations: LatencyCorrelation[];
+  ccsWarning: boolean;
+  totalDocCount: number;
+  fallbackResult?: LatencyCorrelation;
+}
+
+export const significantCorrelationsTransactionsRoute =
+  defineRoute<SignificantCorrelationsResponse>()({
+    endpoint: 'POST /internal/apm/correlations/significant_correlations/transactions',
+    params: t.type({
+      body: t.intersection([
+        t.partial({
+          durationMin: toNumberRt,
+          durationMax: toNumberRt,
+        }),
+        correlationsTransactionQueryRt,
+        environmentRt,
+        kueryRt,
+        rangeRt,
+        t.type({
+          fieldValuePairs: t.array(
+            t.type({
+              fieldName: t.string,
+              fieldValue: t.union([t.string, toNumberRt]),
+            })
+          ),
+        }),
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/types.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+
+export const correlationsTransactionQueryRt = t.partial({
+  serviceName: t.string,
+  transactionName: t.string,
+  transactionType: t.string,
+});
+
+export const entityTypeRt = t.union([t.literal('transaction'), t.literal('exit_span')]);
+
+export const metricRt = t.union([t.literal('latency'), t.literal('failure_rate')]);

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/unified_correlations.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/unified_correlations.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt, toNumberRt } from '@kbn/io-ts-utils';
+import type { CorrelationsResponse } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+import { entityTypeRt, metricRt } from './types';
+
+export type UnifiedCorrelationsRouteResponse = CorrelationsResponse;
+
+export const unifiedCorrelationsRoute = defineRoute<UnifiedCorrelationsRouteResponse>()({
+  endpoint: 'POST /internal/apm/correlations',
+  params: t.type({
+    body: t.intersection([
+      t.type({
+        entityType: entityTypeRt,
+        metric: metricRt,
+      }),
+      t.partial({
+        fieldCandidates: t.array(t.string),
+        durationMin: toNumberRt,
+        durationMax: toNumberRt,
+        percentileThreshold: toNumberRt,
+        includeHistogram: toBooleanRt,
+        kuery: t.string,
+      }),
+      rangeRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_dashboards/delete_service_dashboard.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_dashboards/delete_service_dashboard.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+
+export const deleteServiceDashboardRoute = defineRoute<void>()({
+  endpoint: 'DELETE /internal/apm/custom-dashboard',
+  params: t.type({
+    query: t.type({
+      customDashboardId: t.string,
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_dashboards/get_service_dashboards.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_dashboards/get_service_dashboards.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SavedApmCustomDashboard } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface GetServiceDashboardsResponse {
+  serviceDashboards: SavedApmCustomDashboard[];
+}
+
+export const getServiceDashboardsRoute = defineRoute<GetServiceDashboardsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/dashboards',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_dashboards/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_dashboards/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { saveServiceDashboardRoute } from './save_service_dashboard';
+import { getServiceDashboardsRoute } from './get_service_dashboards';
+import { deleteServiceDashboardRoute } from './delete_service_dashboard';
+
+export const customDashboardsRouteDefinitions = {
+  saveServiceDashboard: saveServiceDashboardRoute,
+  getServiceDashboards: getServiceDashboardsRoute,
+  deleteServiceDashboard: deleteServiceDashboardRoute,
+};
+
+export type { SaveServiceDashboardResponse } from './save_service_dashboard';
+export type { GetServiceDashboardsResponse } from './get_service_dashboards';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_dashboards/save_service_dashboard.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_dashboards/save_service_dashboard.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SavedApmCustomDashboard } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export type SaveServiceDashboardResponse = SavedApmCustomDashboard;
+
+export const saveServiceDashboardRoute = defineRoute<SaveServiceDashboardResponse>()({
+  endpoint: 'POST /internal/apm/custom-dashboard',
+  params: t.type({
+    query: t.union([
+      t.partial({
+        customDashboardId: t.string,
+      }),
+      t.undefined,
+    ]),
+    body: t.type({
+      dashboardSavedObjectId: t.string,
+      kuery: t.union([t.string, t.undefined]),
+      serviceNameFilterEnabled: t.boolean,
+      serviceEnvironmentFilterEnabled: t.boolean,
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/create_custom_link.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/create_custom_link.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { payloadRt } from './custom_link_types';
+
+export const createCustomLinkRoute = defineRoute<void>()({
+  endpoint: 'POST /internal/apm/settings/custom_links',
+  params: t.type({
+    body: payloadRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/custom_link_transaction.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/custom_link_transaction.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Transaction } from '@kbn/apm-types/es_schemas_ui';
+import { defineRoute } from '../types';
+import { filterOptionsRt } from './custom_link_types';
+
+export type CustomLinkTransactionResponse = Transaction;
+
+export const customLinkTransactionRoute = defineRoute<CustomLinkTransactionResponse>()({
+  endpoint: 'GET /internal/apm/settings/custom_links/transaction',
+  params: t.partial({
+    query: filterOptionsRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/custom_link_types.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/custom_link_types.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+
+export const filterOptionsRt = t.partial({
+  'service.name': t.string,
+  'service.environment': t.string,
+  'transaction.name': t.string,
+  'transaction.type': t.string,
+});
+
+export const payloadRt = t.intersection([
+  t.type({
+    label: t.string,
+    url: t.string,
+  }),
+  t.partial({
+    id: t.string,
+    filters: t.array(
+      t.type({
+        key: t.union([t.literal(''), t.keyof(filterOptionsRt.props)]),
+        value: t.string,
+      })
+    ),
+  }),
+]);

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/delete_custom_link.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/delete_custom_link.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+
+export interface DeleteCustomLinkResponse {
+  result: string;
+}
+
+export const deleteCustomLinkRoute = defineRoute<DeleteCustomLinkResponse>()({
+  endpoint: 'DELETE /internal/apm/settings/custom_links/{id}',
+  params: t.type({
+    path: t.type({
+      id: t.string,
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { customLinkTransactionRoute } from './custom_link_transaction';
+import { listCustomLinksRoute } from './list_custom_links';
+import { createCustomLinkRoute } from './create_custom_link';
+import { updateCustomLinkRoute } from './update_custom_link';
+import { deleteCustomLinkRoute } from './delete_custom_link';
+
+export const customLinksRouteDefinitions = {
+  transaction: customLinkTransactionRoute,
+  list: listCustomLinksRoute,
+  create: createCustomLinkRoute,
+  update: updateCustomLinkRoute,
+  delete: deleteCustomLinkRoute,
+};
+
+export type { CustomLinkTransactionResponse } from './custom_link_transaction';
+export type { ListCustomLinksResponse } from './list_custom_links';
+export type { DeleteCustomLinkResponse } from './delete_custom_link';
+export { filterOptionsRt, payloadRt } from './custom_link_types';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/list_custom_links.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/list_custom_links.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { CustomLink } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { filterOptionsRt } from './custom_link_types';
+
+export interface ListCustomLinksResponse {
+  customLinks: CustomLink[];
+}
+
+export const listCustomLinksRoute = defineRoute<ListCustomLinksResponse>()({
+  endpoint: 'GET /internal/apm/settings/custom_links',
+  params: t.partial({
+    query: filterOptionsRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/update_custom_link.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/custom_links/update_custom_link.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { payloadRt } from './custom_link_types';
+
+export const updateCustomLinkRoute = defineRoute<void>()({
+  endpoint: 'PUT /internal/apm/settings/custom_links/{id}',
+  params: t.type({
+    path: t.type({
+      id: t.string,
+    }),
+    body: payloadRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/data_view/data_view_index_pattern.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/data_view/data_view_index_pattern.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { APMIndices } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface DataViewIndexPatternResponse {
+  apmDataViewIndexPattern: string;
+  apmIndices: APMIndices;
+}
+
+export const dataViewIndexPatternRoute = defineRoute<DataViewIndexPatternResponse>()({
+  endpoint: 'GET /internal/apm/data_view/index_pattern',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/data_view/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/data_view/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { staticDataViewRoute } from './static_data_view';
+import { dataViewIndexPatternRoute } from './data_view_index_pattern';
+
+export const dataViewRouteDefinitions = {
+  static: staticDataViewRoute,
+  indexPattern: dataViewIndexPatternRoute,
+};
+
+export type { CreateDataViewResponse } from './static_data_view';
+export type { DataViewIndexPatternResponse } from './data_view_index_pattern';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/data_view/static_data_view.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/data_view/static_data_view.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { defineRoute } from '../types';
+
+export type CreateDataViewResponse = Promise<
+  { created: boolean; dataView: DataView } | { created: boolean; reason?: string }
+>;
+
+export const staticDataViewRoute = defineRoute<CreateDataViewResponse>()({
+  endpoint: 'POST /internal/apm/data_view/static',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/debug_telemetry/debug_telemetry.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/debug_telemetry/debug_telemetry.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { APMTelemetry } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export type DebugTelemetryResponse = APMTelemetry;
+
+export const debugTelemetryRoute = defineRoute<DebugTelemetryResponse>()({
+  endpoint: 'GET /internal/apm/debug-telemetry',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/debug_telemetry/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/debug_telemetry/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { debugTelemetryRoute } from './debug_telemetry';
+
+export const debugTelemetryRouteDefinitions = {
+  debugTelemetry: debugTelemetryRoute,
+};
+
+export type { DebugTelemetryResponse } from './debug_telemetry';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/error_rate_charts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/error_rate_charts.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { dependencyChartQueryRt } from './types';
+
+export interface DependencyErrorRateChartsResponse {
+  currentTimeseries: Array<{ x: number; y: number }>;
+  comparisonTimeseries: Array<{ x: number; y: number }> | null;
+}
+
+export const dependencyErrorRateChartsRoute = defineRoute<DependencyErrorRateChartsResponse>()({
+  endpoint: 'GET /internal/apm/dependencies/charts/error_rate',
+  params: t.type({ query: dependencyChartQueryRt }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/index.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { topDependenciesRoute } from './top_dependencies';
+import { topDependenciesStatisticsRoute } from './top_dependencies_statistics';
+import { upstreamServicesRoute } from './upstream_services';
+import { dependencyMetadataRoute } from './metadata';
+import { dependencyLatencyChartsRoute } from './latency_charts';
+import { dependencyThroughputChartsRoute } from './throughput_charts';
+import { dependencyErrorRateChartsRoute } from './error_rate_charts';
+import { dependencyOperationsRoute } from './operations';
+import { dependencyLatencyDistributionRoute } from './latency_distribution';
+import { topDependencySpansRoute } from './top_dependency_spans';
+
+export const dependenciesRouteDefinitions = {
+  topDependencies: topDependenciesRoute,
+  topDependenciesStatistics: topDependenciesStatisticsRoute,
+  upstreamServices: upstreamServicesRoute,
+  metadata: dependencyMetadataRoute,
+  latencyCharts: dependencyLatencyChartsRoute,
+  throughputCharts: dependencyThroughputChartsRoute,
+  errorRateCharts: dependencyErrorRateChartsRoute,
+  operations: dependencyOperationsRoute,
+  latencyDistribution: dependencyLatencyDistributionRoute,
+  topDependencySpans: topDependencySpansRoute,
+};
+
+export type { TopDependenciesResponse } from './top_dependencies';
+export type { DependenciesTimeseriesStatisticsResponse } from './top_dependencies_statistics';
+export type { UpstreamServicesForDependencyResponse } from './upstream_services';
+export type { MetadataForDependencyResponse, DependencyMetadataRouteResponse } from './metadata';
+export type { LatencyChartsDependencyResponse } from './latency_charts';
+export type { ThroughputChartsForDependencyResponse } from './throughput_charts';
+export type { DependencyErrorRateChartsResponse } from './error_rate_charts';
+export type { DependencyOperation, DependencyOperationsResponse } from './operations';
+export type { DependencyLatencyDistributionResponse } from './latency_distribution';
+export type { DependencySpan, TopDependencySpansResponse } from './top_dependency_spans';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/latency_charts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/latency_charts.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { dependencyChartQueryRt } from './types';
+
+export interface LatencyChartsDependencyResponse {
+  currentTimeseries: Array<{ x: number; y: number }>;
+  comparisonTimeseries: Array<{ x: number; y: number }> | null;
+}
+
+export const dependencyLatencyChartsRoute = defineRoute<LatencyChartsDependencyResponse>()({
+  endpoint: 'GET /internal/apm/dependencies/charts/latency',
+  params: t.type({ query: dependencyChartQueryRt }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/latency_distribution.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/latency_distribution.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { OverallLatencyDistributionResponse } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt } from '../../default_api_types';
+
+export interface DependencyLatencyDistributionResponse {
+  allSpansDistribution: OverallLatencyDistributionResponse;
+  failedSpansDistribution: OverallLatencyDistributionResponse;
+}
+
+export const dependencyLatencyDistributionRoute =
+  defineRoute<DependencyLatencyDistributionResponse>()({
+    endpoint: 'GET /internal/apm/dependencies/charts/distribution',
+    params: t.type({
+      query: t.intersection([
+        t.type({
+          dependencyName: t.string,
+          spanName: t.string,
+          percentileThreshold: toNumberRt,
+        }),
+        rangeRt,
+        kueryRt,
+        environmentRt,
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/metadata.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/metadata.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface MetadataForDependencyResponse {
+  spanType: string | undefined;
+  spanSubtype: string | undefined;
+}
+
+export interface DependencyMetadataRouteResponse {
+  metadata: MetadataForDependencyResponse;
+}
+
+export const dependencyMetadataRoute = defineRoute<DependencyMetadataRouteResponse>()({
+  endpoint: 'GET /internal/apm/dependencies/metadata',
+  params: t.type({
+    query: t.intersection([t.type({ dependencyName: t.string }), rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/operations.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/operations.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt, offsetRt } from '../../default_api_types';
+
+export interface DependencyOperation {
+  spanName: string;
+  latency: number | null;
+  throughput: number;
+  failureRate: number | null;
+  impact: number;
+  timeseries: Record<
+    'latency' | 'throughput' | 'failureRate',
+    Array<{ x: number; y: number | null }>
+  >;
+}
+
+export interface DependencyOperationsResponse {
+  operations: DependencyOperation[];
+}
+
+export const dependencyOperationsRoute = defineRoute<DependencyOperationsResponse>()({
+  endpoint: 'GET /internal/apm/dependencies/operations',
+  params: t.type({
+    query: t.intersection([
+      rangeRt,
+      environmentRt,
+      kueryRt,
+      offsetRt,
+      t.type({
+        dependencyName: t.string,
+        searchServiceDestinationMetrics: toBooleanRt,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/throughput_charts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/throughput_charts.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { dependencyChartQueryRt } from './types';
+
+export interface ThroughputChartsForDependencyResponse {
+  currentTimeseries: Array<{ x: number; y: number | null }>;
+  comparisonTimeseries: Array<{ x: number; y: number | null }> | null;
+}
+
+export const dependencyThroughputChartsRoute =
+  defineRoute<ThroughputChartsForDependencyResponse>()({
+    endpoint: 'GET /internal/apm/dependencies/charts/throughput',
+    params: t.type({ query: dependencyChartQueryRt }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependencies.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependencies.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { ConnectionStats, Node } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt } from '../../default_api_types';
+
+export interface TopDependenciesResponse {
+  dependencies: Array<{
+    currentStats: ConnectionStats & { impact: number };
+    previousStats: (ConnectionStats & { impact: number }) | null;
+    location: Node;
+  }>;
+  sampled: boolean;
+}
+
+export const topDependenciesRoute = defineRoute<TopDependenciesResponse>()({
+  endpoint: 'GET /internal/apm/dependencies/top_dependencies',
+  params: t.type({
+    query: t.intersection([rangeRt, environmentRt, kueryRt, t.type({ numBuckets: toNumberRt })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependencies_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependencies_statistics.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+interface Statistics {
+  latency: Array<{ x: number; y: number }>;
+  errorRate: Array<{ x: number; y: number }>;
+  throughput: Array<{ x: number; y: number | null }>;
+}
+
+export interface DependenciesTimeseriesStatisticsResponse {
+  currentTimeseries: Record<string, Statistics>;
+  comparisonTimeseries: Record<string, Statistics> | null;
+}
+
+export const topDependenciesStatisticsRoute =
+  defineRoute<DependenciesTimeseriesStatisticsResponse>()({
+    endpoint: 'POST /internal/apm/dependencies/top_dependencies/statistics',
+    params: t.type({
+      query: t.intersection([
+        t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
+        t.type({ numBuckets: toNumberRt }),
+      ]),
+      body: t.type({ dependencyNames: jsonRt.pipe(t.array(t.string)) }),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependency_spans.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependency_spans.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { AgentName, EventOutcome } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt } from '../../default_api_types';
+
+export interface DependencySpan {
+  '@timestamp': number;
+  spanId: string;
+  spanName: string;
+  serviceName: string;
+  agentName: AgentName;
+  traceId: string;
+  transactionId?: string;
+  transactionType?: string;
+  transactionName?: string;
+  duration: number;
+  outcome: EventOutcome;
+}
+
+export interface TopDependencySpansResponse {
+  spans: DependencySpan[];
+}
+
+export const topDependencySpansRoute = defineRoute<TopDependencySpansResponse>()({
+  endpoint: 'GET /internal/apm/dependencies/operations/spans',
+  params: t.type({
+    query: t.intersection([
+      rangeRt,
+      environmentRt,
+      kueryRt,
+      t.type({ dependencyName: t.string, spanName: t.string }),
+      t.partial({ sampleRangeFrom: toNumberRt, sampleRangeTo: toNumberRt }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/types.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export const dependencyChartQueryRt = t.intersection([
+  t.type({
+    dependencyName: t.string,
+    spanName: t.string,
+    searchServiceDestinationMetrics: toBooleanRt,
+  }),
+  rangeRt,
+  kueryRt,
+  environmentRt,
+  offsetRt,
+]);

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/upstream_services.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/upstream_services.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { ConnectionStats, Node } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt, offsetRt } from '../../default_api_types';
+
+export interface UpstreamServicesForDependencyResponse {
+  services: Array<{
+    location: Node;
+    currentStats: ConnectionStats & { impact: number };
+    previousStats: (ConnectionStats & { impact: number }) | null;
+  }>;
+}
+
+export const upstreamServicesRoute = defineRoute<UpstreamServicesForDependencyResponse>()({
+  endpoint: 'GET /internal/apm/dependencies/upstream_services',
+  params: t.intersection([
+    t.type({
+      query: t.intersection([
+        t.type({ dependencyName: t.string }),
+        rangeRt,
+        t.type({ numBuckets: toNumberRt }),
+      ]),
+    }),
+    t.partial({
+      query: t.intersection([environmentRt, offsetRt, kueryRt]),
+    }),
+  ]),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/diagnostics/get_diagnostics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/diagnostics/get_diagnostics.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { isoToEpochRt } from '@kbn/io-ts-utils';
+import type {
+  FieldCapsResponse,
+  IndicesDataStream,
+  IndicesGetIndexTemplateIndexTemplateItem,
+  IndicesGetResponse,
+  IngestGetPipelineResponse,
+  SecurityHasPrivilegesPrivileges,
+} from '@elastic/elasticsearch/lib/api/types';
+import type { APMIndices, ApmEvent, IndiciesItem } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface DiagnosticsResponse {
+  esResponses: {
+    existingIndexTemplates: IndicesGetIndexTemplateIndexTemplateItem[];
+    fieldCaps?: FieldCapsResponse;
+    indices?: IndicesGetResponse;
+    ingestPipelines?: IngestGetPipelineResponse;
+  };
+  diagnosticsPrivileges: {
+    index: Record<string, SecurityHasPrivilegesPrivileges>;
+    cluster: Record<string, boolean>;
+    hasAllClusterPrivileges: boolean;
+    hasAllIndexPrivileges: boolean;
+    hasAllPrivileges: boolean;
+  };
+  apmIndices: APMIndices;
+  apmIndexTemplates: Array<{
+    name: string;
+    isNonStandard: boolean;
+    exists: boolean;
+  }>;
+  fleetPackageInfo: {
+    isInstalled: boolean;
+    version?: string;
+  };
+  kibanaVersion: string;
+  elasticsearchVersion: string;
+  apmEvents: ApmEvent[];
+  invalidIndices?: IndiciesItem[];
+  validIndices?: IndiciesItem[];
+  dataStreams: IndicesDataStream[];
+  nonDataStreamIndices: string[];
+  indexTemplatesByIndexPattern: Array<{
+    indexPattern: string;
+    indexTemplates: Array<{
+      priority: number | undefined;
+      isNonStandard: boolean;
+      templateIndexPatterns: string[];
+      templateName: string;
+    }>;
+  }>;
+  params: { start: number; end: number; kuery?: string };
+}
+
+export const getDiagnosticsRoute = defineRoute<DiagnosticsResponse>()({
+  endpoint: 'GET /internal/apm/diagnostics',
+  params: t.partial({
+    query: t.partial({
+      kuery: t.string,
+      start: isoToEpochRt,
+      end: isoToEpochRt,
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/diagnostics/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/diagnostics/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { serviceMapDiagnosticsRoute } from './service_map_diagnostics';
+import { getDiagnosticsRoute } from './get_diagnostics';
+
+export const diagnosticsRouteDefinitions = {
+  serviceMap: serviceMapDiagnosticsRoute,
+  getDiagnostics: getDiagnosticsRoute,
+};
+
+export type { DiagnosticsResponse } from './get_diagnostics';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/diagnostics/service_map_diagnostics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/diagnostics/service_map_diagnostics.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { ServiceMapDiagnosticResponse } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export const serviceMapDiagnosticsRoute = defineRoute<ServiceMapDiagnosticResponse>()({
+  endpoint: 'POST /internal/apm/diagnostics/service-map',
+  params: t.type({
+    body: t.intersection([
+      rangeRt,
+      t.type({
+        sourceNode: t.string,
+        destinationNode: t.string,
+      }),
+      t.partial({
+        traceId: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/environments/environments.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/environments/environments.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Environment } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface EnvironmentsResponse {
+  environments: Environment[];
+}
+
+export const environmentsRoute = defineRoute<EnvironmentsResponse>()({
+  endpoint: 'GET /internal/apm/environments',
+  params: t.type({
+    query: t.intersection([
+      t.partial({ serviceName: t.string }),
+      rangeRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/environments/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/environments/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { environmentsRoute } from './environments';
+
+export const environmentsRouteDefinitions = {
+  environments: environmentsRoute,
+};
+
+export type { EnvironmentsResponse } from './environments';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_distribution.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_distribution.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { Coordinate } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface ErrorDistributionResponse {
+  currentPeriod: Array<{ x: number; y: number }>;
+  previousPeriod: Coordinate[];
+  bucketSize: number;
+}
+
+export const errorDistributionRoute = defineRoute<ErrorDistributionResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/errors/distribution',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.partial({
+        groupId: t.string,
+        transactionName: t.string,
+        bucketSizeInSeconds: toNumberRt,
+      }),
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      offsetRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_group_samples.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_group_samples.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface ErrorGroupSampleIdsResponse {
+  errorSampleIds: string[];
+  occurrencesCount: number;
+}
+
+export const errorGroupSamplesRoute = defineRoute<ErrorGroupSampleIdsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/errors/{groupId}/samples',
+  params: t.type({
+    path: t.type({ serviceName: t.string, groupId: t.string }),
+    query: t.intersection([environmentRt, kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_groups_detailed_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_groups_detailed_statistics.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import type { Coordinate } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface ErrorGroupDetailedStat {
+  groupId: string;
+  timeseries: Coordinate[];
+}
+
+export interface ErrorGroupPeriodsResponse {
+  currentPeriod: Record<string, ErrorGroupDetailedStat>;
+  previousPeriod: Record<string, ErrorGroupDetailedStat>;
+}
+
+export const errorsDetailedStatisticsRoute = defineRoute<ErrorGroupPeriodsResponse>()({
+  endpoint: 'POST /internal/apm/services/{serviceName}/errors/groups/detailed_statistics',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      offsetRt,
+      t.type({ numBuckets: toNumberRt }),
+    ]),
+    body: t.type({ groupIds: jsonRt.pipe(t.array(t.string)) }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_groups_main_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_groups_main_statistics.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface ErrorGroupMainStatisticsResponse {
+  errorGroups: Array<{
+    groupId: string;
+    name: string;
+    lastSeen: number;
+    occurrences: number;
+    culprit: string | undefined;
+    handled: boolean | undefined;
+    type: string | undefined;
+    traceId: string | undefined;
+  }>;
+  maxCountExceeded: boolean;
+}
+
+export const errorsMainStatisticsRoute = defineRoute<ErrorGroupMainStatisticsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/errors/groups/main_statistics',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.partial({
+        sortField: t.string,
+        sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
+        searchQuery: t.string,
+      }),
+      environmentRt,
+      kueryRt,
+      rangeRt,
+    ]),
+  }),
+});
+
+export const errorsMainStatisticsByTransactionNameRoute =
+  defineRoute<ErrorGroupMainStatisticsResponse>()({
+    endpoint:
+      'GET /internal/apm/services/{serviceName}/errors/groups/main_statistics_by_transaction_name',
+    params: t.type({
+      path: t.type({ serviceName: t.string }),
+      query: t.intersection([
+        t.type({
+          transactionType: t.string,
+          transactionName: t.string,
+          maxNumberOfErrorGroups: toNumberRt,
+        }),
+        environmentRt,
+        kueryRt,
+        rangeRt,
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_sample_details.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_sample_details.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Transaction, APMError } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface ErrorSampleDetailsResponse {
+  transaction: Transaction | undefined;
+  error: Omit<APMError, 'transaction' | 'error'> & {
+    transaction?: { id?: string; type?: string };
+    user_agent?: { name?: string; version?: string };
+    error: {
+      id: string;
+    } & Omit<APMError['error'], 'exception' | 'log'> & {
+        exception?: APMError['error']['exception'];
+        log?: APMError['error']['log'];
+      };
+  };
+}
+
+export const errorSampleDetailsRoute = defineRoute<ErrorSampleDetailsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/errors/{groupId}/error/{errorId}',
+  params: t.type({
+    path: t.type({ serviceName: t.string, groupId: t.string, errorId: t.string }),
+    query: t.intersection([environmentRt, kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/index.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import {
+  errorsMainStatisticsRoute,
+  errorsMainStatisticsByTransactionNameRoute,
+} from './error_groups_main_statistics';
+import { errorsDetailedStatisticsRoute } from './error_groups_detailed_statistics';
+import { errorGroupSamplesRoute } from './error_group_samples';
+import { errorSampleDetailsRoute } from './error_sample_details';
+import { errorDistributionRoute } from './error_distribution';
+import { topErroneousTransactionsRoute } from './top_erroneous_transactions';
+
+export const errorsRouteDefinitions = {
+  mainStatistics: errorsMainStatisticsRoute,
+  mainStatisticsByTransactionName: errorsMainStatisticsByTransactionNameRoute,
+  detailedStatistics: errorsDetailedStatisticsRoute,
+  groupSamples: errorGroupSamplesRoute,
+  sampleDetails: errorSampleDetailsRoute,
+  distribution: errorDistributionRoute,
+  topErroneousTransactions: topErroneousTransactionsRoute,
+};
+
+export type { ErrorGroupMainStatisticsResponse } from './error_groups_main_statistics';
+export type {
+  ErrorGroupDetailedStat,
+  ErrorGroupPeriodsResponse,
+} from './error_groups_detailed_statistics';
+export type { ErrorGroupSampleIdsResponse } from './error_group_samples';
+export type { ErrorSampleDetailsResponse } from './error_sample_details';
+export type { ErrorDistributionResponse } from './error_distribution';
+export type { TopErroneousTransactionsResponse } from './top_erroneous_transactions';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/top_erroneous_transactions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/top_erroneous_transactions.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface TopErroneousTransactionsResponse {
+  topErroneousTransactions: Array<{
+    transactionName: string;
+    currentPeriodTimeseries: Array<{ x: number; y: number }>;
+    previousPeriodTimeseries: Array<{ x: number; y: number }>;
+    transactionType: string | undefined;
+    occurrences: number;
+  }>;
+}
+
+export const topErroneousTransactionsRoute = defineRoute<TopErroneousTransactionsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/errors/{groupId}/top_erroneous_transactions',
+  params: t.type({
+    path: t.type({ serviceName: t.string, groupId: t.string }),
+    query: t.intersection([
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      offsetRt,
+      t.type({ numBuckets: toNumberRt }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/event_metadata/event_metadata.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/event_metadata/event_metadata.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { processorEventRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface EventMetadataResponse {
+  metadata: Partial<Record<string, unknown[]>>;
+}
+
+export const eventMetadataRoute = defineRoute<EventMetadataResponse>()({
+  endpoint: 'GET /internal/apm/event_metadata/{processorEvent}/{id}',
+  params: t.type({
+    path: t.type({
+      processorEvent: processorEventRt,
+      id: t.string,
+    }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/event_metadata/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/event_metadata/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { eventMetadataRoute } from './event_metadata';
+
+export const eventMetadataRouteDefinitions = {
+  eventMetadata: eventMetadataRoute,
+};
+
+export type { EventMetadataResponse } from './event_metadata';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fallback_to_transactions/fallback_to_transactions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fallback_to_transactions/fallback_to_transactions.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface FallbackToTransactionsResponse {
+  fallbackToTransactions: boolean;
+}
+
+export const fallbackToTransactionsRoute = defineRoute<FallbackToTransactionsResponse>()({
+  endpoint: 'GET /internal/apm/fallback_to_transactions',
+  params: t.partial({
+    query: t.intersection([kueryRt, t.partial(rangeRt.props)]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fallback_to_transactions/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fallback_to_transactions/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { fallbackToTransactionsRoute } from './fallback_to_transactions';
+
+export const fallbackToTransactionsRouteDefinitions = {
+  fallbackToTransactions: fallbackToTransactionsRoute,
+};
+
+export type { FallbackToTransactionsResponse } from './fallback_to_transactions';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/cloud_apm_package_policy.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/cloud_apm_package_policy.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import { defineRoute } from '../types';
+
+export interface CloudApmPackagePolicyResponse {
+  cloudApmPackagePolicy: PackagePolicy;
+}
+
+export const cloudApmPackagePolicyRoute = defineRoute<CloudApmPackagePolicyResponse>()({
+  endpoint: 'POST /internal/apm/fleet/cloud_apm_package_policy',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/fleet_agents.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/fleet_agents.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface FleetAgentResponse {
+  cloudStandaloneSetup:
+    | { apmServerUrl: string | undefined; secretToken: string | undefined }
+    | undefined;
+  isFleetEnabled: boolean;
+  fleetAgents: Array<{
+    id: string;
+    name: string;
+    apmServerUrl: any;
+    secretToken: any;
+  }>;
+}
+
+export const fleetAgentsRoute = defineRoute<FleetAgentResponse>()({
+  endpoint: 'GET /internal/apm/fleet/agents',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/has_apm_policies.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/has_apm_policies.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface HasApmPoliciesResponse {
+  hasApmPolicies: boolean;
+}
+
+export const hasApmPoliciesRoute = defineRoute<HasApmPoliciesResponse>()({
+  endpoint: 'GET /internal/apm/fleet/has_apm_policies',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { hasApmPoliciesRoute } from './has_apm_policies';
+import { fleetAgentsRoute } from './fleet_agents';
+import { saveApmServerSchemaRoute } from './save_apm_server_schema';
+import { unsupportedApmServerSchemaRoute } from './unsupported_apm_server_schema';
+import { migrationCheckRoute } from './migration_check';
+import { cloudApmPackagePolicyRoute } from './cloud_apm_package_policy';
+import { javaAgentVersionsRoute } from './java_agent_versions';
+
+export const fleetRouteDefinitions = {
+  hasApmPolicies: hasApmPoliciesRoute,
+  agents: fleetAgentsRoute,
+  saveSchema: saveApmServerSchemaRoute,
+  unsupportedSchema: unsupportedApmServerSchemaRoute,
+  migrationCheck: migrationCheckRoute,
+  cloudApmPackagePolicy: cloudApmPackagePolicyRoute,
+  javaAgentVersions: javaAgentVersionsRoute,
+};
+
+export type { HasApmPoliciesResponse } from './has_apm_policies';
+export type { FleetAgentResponse } from './fleet_agents';
+export type {
+  UnsupportedApmServerSchema,
+  UnsupportedApmServerSchemaResponse,
+} from './unsupported_apm_server_schema';
+export type { RunMigrationCheckResponse } from './migration_check';
+export type { CloudApmPackagePolicyResponse } from './cloud_apm_package_policy';
+export type { JavaAgentVersionsResponse } from './java_agent_versions';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/java_agent_versions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/java_agent_versions.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface JavaAgentVersionsResponse {
+  versions: string[] | undefined;
+}
+
+export const javaAgentVersionsRoute = defineRoute<JavaAgentVersionsResponse>()({
+  endpoint: 'GET /internal/apm/fleet/java_agent_versions',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/migration_check.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/migration_check.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import { defineRoute } from '../types';
+
+export interface RunMigrationCheckResponse {
+  has_cloud_agent_policy: boolean;
+  has_cloud_apm_package_policy: boolean;
+  cloud_apm_migration_enabled: boolean;
+  has_required_role: boolean | undefined;
+  cloud_apm_package_policy: PackagePolicy | undefined;
+  has_apm_integrations: boolean;
+  latest_apm_package_version: string;
+}
+
+export const migrationCheckRoute = defineRoute<RunMigrationCheckResponse>()({
+  endpoint: 'GET /internal/apm/fleet/migration_check',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/save_apm_server_schema.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/save_apm_server_schema.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+
+export const saveApmServerSchemaRoute = defineRoute<void>()({
+  endpoint: 'POST /api/apm/fleet/apm_server_schema 2023-10-31',
+  params: t.type({
+    body: t.type({
+      schema: t.record(t.string, t.unknown),
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/unsupported_apm_server_schema.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/fleet/unsupported_apm_server_schema.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export type UnsupportedApmServerSchema = Array<{ key: string; value: unknown }>;
+
+export interface UnsupportedApmServerSchemaResponse {
+  unsupported: UnsupportedApmServerSchema;
+}
+
+export const unsupportedApmServerSchemaRoute = defineRoute<UnsupportedApmServerSchemaResponse>()({
+  endpoint: 'GET /internal/apm/fleet/apm_server_schema/unsupported',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/historical_data/has_data.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/historical_data/has_data.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface HasDataResponse {
+  hasData: boolean;
+}
+
+export const hasDataRoute = defineRoute<HasDataResponse>()({
+  endpoint: 'GET /internal/apm/has_data',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/historical_data/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/historical_data/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { hasDataRoute } from './has_data';
+
+export const historicalDataRouteDefinitions = {
+  hasData: hasDataRoute,
+};
+
+export type { HasDataResponse } from './has_data';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/index.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { historicalDataRouteDefinitions } from './historical_data';
+import { suggestionsRouteDefinitions } from './suggestions';
+import { agentKeysRouteDefinitions } from './agent_keys';
+import { tracesRouteDefinitions } from './traces';
+import { spanLinksRouteDefinitions } from './span_links';
+import { observabilityOverviewRouteDefinitions } from './observability_overview';
+import { agentExplorerRouteDefinitions } from './agent_explorer';
+import { alertsRouteDefinitions } from './alerts';
+import { assistantFunctionsRouteDefinitions } from './assistant_functions';
+import { correlationsRouteDefinitions } from './correlations';
+import { customDashboardsRouteDefinitions } from './custom_dashboards';
+import { dependenciesRouteDefinitions } from './dependencies';
+import { transactionsRouteDefinitions } from './transactions';
+import { servicesRouteDefinitions } from './services';
+import { serviceMapRouteDefinitions } from './service_map';
+import { errorsRouteDefinitions } from './errors';
+import { infrastructureRouteDefinitions } from './infrastructure';
+import { environmentsRouteDefinitions } from './environments';
+import { eventMetadataRouteDefinitions } from './event_metadata';
+import { fallbackToTransactionsRouteDefinitions } from './fallback_to_transactions';
+import { latencyDistributionRouteDefinitions } from './latency_distribution';
+import { metricsRouteDefinitions } from './metrics';
+import { profilingRouteDefinitions } from './profiling';
+import { serviceGroupsRouteDefinitions } from './service_groups';
+import { timeRangeMetadataRouteDefinitions } from './time_range_metadata';
+import { customLinksRouteDefinitions } from './custom_links';
+import { anomalyDetectionRouteDefinitions } from './anomaly_detection';
+import { mobileRouteDefinitions } from './mobile';
+import { mobileErrorsRouteDefinitions } from './mobile_errors';
+import { mobileCrashesRouteDefinitions } from './mobile_crashes';
+import { dataViewRouteDefinitions } from './data_view';
+import { diagnosticsRouteDefinitions } from './diagnostics';
+import { fleetRouteDefinitions } from './fleet';
+import { debugTelemetryRouteDefinitions } from './debug_telemetry';
+import { storageExplorerRouteDefinitions } from './storage_explorer';
+import { sourceMapsRouteDefinitions } from './source_maps';
+import { agentConfigurationRouteDefinitions } from './agent_configuration';
+import type { BuildGroupedRepository } from './types';
+
+export const routeDefinitions = {
+  historicalData: historicalDataRouteDefinitions,
+  suggestions: suggestionsRouteDefinitions,
+  agentKeys: agentKeysRouteDefinitions,
+  traces: tracesRouteDefinitions,
+  spanLinks: spanLinksRouteDefinitions,
+  observabilityOverview: observabilityOverviewRouteDefinitions,
+  agentExplorer: agentExplorerRouteDefinitions,
+  alerts: alertsRouteDefinitions,
+  assistantFunctions: assistantFunctionsRouteDefinitions,
+  correlations: correlationsRouteDefinitions,
+  customDashboards: customDashboardsRouteDefinitions,
+  dependencies: dependenciesRouteDefinitions,
+  transactions: transactionsRouteDefinitions,
+  services: servicesRouteDefinitions,
+  serviceMap: serviceMapRouteDefinitions,
+  errors: errorsRouteDefinitions,
+  infrastructure: infrastructureRouteDefinitions,
+  environments: environmentsRouteDefinitions,
+  eventMetadata: eventMetadataRouteDefinitions,
+  fallbackToTransactions: fallbackToTransactionsRouteDefinitions,
+  latencyDistribution: latencyDistributionRouteDefinitions,
+  metrics: metricsRouteDefinitions,
+  profiling: profilingRouteDefinitions,
+  serviceGroups: serviceGroupsRouteDefinitions,
+  timeRangeMetadata: timeRangeMetadataRouteDefinitions,
+  customLinks: customLinksRouteDefinitions,
+  anomalyDetection: anomalyDetectionRouteDefinitions,
+  mobile: mobileRouteDefinitions,
+  mobileErrors: mobileErrorsRouteDefinitions,
+  mobileCrashes: mobileCrashesRouteDefinitions,
+  dataView: dataViewRouteDefinitions,
+  diagnostics: diagnosticsRouteDefinitions,
+  fleet: fleetRouteDefinitions,
+  debugTelemetry: debugTelemetryRouteDefinitions,
+  storageExplorer: storageExplorerRouteDefinitions,
+  sourceMaps: sourceMapsRouteDefinitions,
+  agentConfiguration: agentConfigurationRouteDefinitions,
+};
+
+export type SharedAPMRouteRepository = BuildGroupedRepository<typeof routeDefinitions>;

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/infrastructure/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/infrastructure/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { infrastructureAttributesRoute } from './infrastructure_attributes';
+
+export const infrastructureRouteDefinitions = {
+  infrastructureAttributes: infrastructureAttributesRoute,
+};
+
+export type { InfrastructureAttributesResponse } from './infrastructure_attributes';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/infrastructure/infrastructure_attributes.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/infrastructure/infrastructure_attributes.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface InfrastructureAttributesResponse {
+  containerIds: string[];
+  hostNames: string[];
+  podNames: string[];
+}
+
+export const infrastructureAttributesRoute = defineRoute<InfrastructureAttributesResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/infrastructure_attributes',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([kueryRt, rangeRt, environmentRt, t.partial({ agentName: t.string })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { latencyOverallTransactionDistributionRoute } from './overall_transaction_distribution';
+import { latencyOverallSpanDistributionRoute } from './overall_span_distribution';
+
+export const latencyDistributionRouteDefinitions = {
+  overallTransactionDistribution: latencyOverallTransactionDistributionRoute,
+  overallSpanDistribution: latencyOverallSpanDistributionRoute,
+};
+
+export type { LatencyOverallTransactionDistributionResponse } from './overall_transaction_distribution';
+export type { LatencyOverallSpanDistributionResponse } from './overall_span_distribution';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/overall_span_distribution.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/overall_span_distribution.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { OverallLatencyDistributionResponse } from '@kbn/apm-types';
+import { environmentRt, latencyDistributionChartTypeRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type LatencyOverallSpanDistributionResponse = OverallLatencyDistributionResponse;
+
+export const latencyOverallSpanDistributionRoute =
+  defineRoute<LatencyOverallSpanDistributionResponse>()({
+    endpoint: 'POST /internal/apm/latency/overall_distribution/spans',
+    params: t.type({
+      body: t.intersection([
+        t.partial({
+          serviceName: t.string,
+          spanName: t.string,
+          transactionId: t.string,
+          termFilters: t.array(
+            t.type({
+              fieldName: t.string,
+              fieldValue: t.union([t.string, toNumberRt]),
+            })
+          ),
+          durationMin: toNumberRt,
+          durationMax: toNumberRt,
+          isOtel: t.boolean,
+        }),
+        environmentRt,
+        kueryRt,
+        rangeRt,
+        t.type({
+          percentileThreshold: toNumberRt,
+          chartType: latencyDistributionChartTypeRt,
+        }),
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/overall_transaction_distribution.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/latency_distribution/overall_transaction_distribution.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { OverallLatencyDistributionResponse } from '@kbn/apm-types';
+import { environmentRt, latencyDistributionChartTypeRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type LatencyOverallTransactionDistributionResponse = OverallLatencyDistributionResponse;
+
+export const latencyOverallTransactionDistributionRoute =
+  defineRoute<LatencyOverallTransactionDistributionResponse>()({
+    endpoint: 'POST /internal/apm/latency/overall_distribution/transactions',
+    params: t.type({
+      body: t.intersection([
+        t.partial({
+          serviceName: t.string,
+          transactionName: t.string,
+          transactionType: t.string,
+          termFilters: t.array(
+            t.type({
+              fieldName: t.string,
+              fieldValue: t.union([t.string, toNumberRt]),
+            })
+          ),
+          durationMin: toNumberRt,
+          durationMax: toNumberRt,
+        }),
+        environmentRt,
+        kueryRt,
+        rangeRt,
+        t.type({
+          percentileThreshold: toNumberRt,
+          chartType: latencyDistributionChartTypeRt,
+        }),
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/index.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { metricsChartsRoute } from './metrics_charts';
+import { serviceMetricsNodesRoute } from './service_nodes';
+import { serverlessMetricsChartsRoute } from './serverless_charts';
+import { serverlessActiveInstancesRoute } from './serverless_active_instances';
+import { serverlessFunctionsOverviewRoute } from './serverless_functions_overview';
+import { serverlessSummaryRoute } from './serverless_summary';
+
+export const metricsRouteDefinitions = {
+  charts: metricsChartsRoute,
+  nodes: serviceMetricsNodesRoute,
+  serverlessCharts: serverlessMetricsChartsRoute,
+  serverlessActiveInstances: serverlessActiveInstancesRoute,
+  serverlessFunctionsOverview: serverlessFunctionsOverviewRoute,
+  serverlessSummary: serverlessSummaryRoute,
+};
+
+export type {
+  FetchAndTransformMetrics,
+  GenericMetricsChart,
+  MetricsChartsResponse,
+} from './metrics_charts';
+export type { ServiceNodesResponse, ServiceMetricsNodesRouteResponse } from './service_nodes';
+export type { ServerlessMetricsChartsResponse } from './serverless_charts';
+export type {
+  ActiveInstanceTimeseries,
+  ActiveInstanceOverview,
+  ServerlessActiveInstancesResponse,
+} from './serverless_active_instances';
+export type {
+  ServerlessFunctionsOverviewResponse,
+  ServerlessFunctionsOverviewRouteResponse,
+} from './serverless_functions_overview';
+export type {
+  AwsLambdaArchitecture,
+  AWSLambdaPriceFactor,
+  ServerlessSummaryResponse,
+} from './serverless_summary';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/metrics_charts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/metrics_charts.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Coordinate, YUnit, ChartType } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface FetchAndTransformMetrics {
+  title: string;
+  key: string;
+  yUnit: YUnit;
+  series: Array<{
+    title: string;
+    key: string;
+    type: ChartType;
+    overallValue: number;
+    data: Coordinate[];
+  }>;
+  description?: string;
+}
+
+export type GenericMetricsChart = FetchAndTransformMetrics;
+
+export interface MetricsChartsResponse {
+  charts: FetchAndTransformMetrics[];
+}
+
+export const metricsChartsRoute = defineRoute<MetricsChartsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/metrics/charts',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.type({ agentName: t.string }),
+      t.partial({ serviceNodeName: t.string }),
+      environmentRt,
+      kueryRt,
+      rangeRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_active_instances.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_active_instances.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Coordinate } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface ActiveInstanceTimeseries {
+  serverlessDuration: Coordinate[];
+  billedDuration: Coordinate[];
+}
+
+export interface ActiveInstanceOverview {
+  activeInstanceName: string;
+  serverlessId: string;
+  serverlessFunctionName: string;
+  timeseries: ActiveInstanceTimeseries;
+  serverlessDurationAvg: number | null;
+  billedDurationAvg: number | null;
+  avgMemoryUsed?: number | null;
+  memorySize: number | null;
+}
+
+export interface ServerlessActiveInstancesResponse {
+  activeInstances: ActiveInstanceOverview[];
+  timeseries: Coordinate[];
+}
+
+export const serverlessActiveInstancesRoute = defineRoute<ServerlessActiveInstancesResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/metrics/serverless/active_instances',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([environmentRt, kueryRt, rangeRt, t.partial({ serverlessId: t.string })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_charts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_charts.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import type { FetchAndTransformMetrics } from './metrics_charts';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, transactionDataSourceRt } from '../../default_api_types';
+
+export interface ServerlessMetricsChartsResponse {
+  charts: FetchAndTransformMetrics[];
+}
+
+export const serverlessMetricsChartsRoute = defineRoute<ServerlessMetricsChartsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/metrics/serverless/charts',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      t.partial({ serverlessId: t.string }),
+      t.intersection([transactionDataSourceRt, t.type({ bucketSizeInSeconds: toNumberRt })]),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_functions_overview.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_functions_overview.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type ServerlessFunctionsOverviewResponse = Array<{
+  serverlessId: string;
+  serverlessFunctionName: string;
+  serverlessDurationAvg: number | null;
+  billedDurationAvg: number | null;
+  coldStartCount: number | null;
+  avgMemoryUsed: number | undefined;
+  memorySize: number | null;
+}>;
+
+export interface ServerlessFunctionsOverviewRouteResponse {
+  serverlessFunctionsOverview: ServerlessFunctionsOverviewResponse;
+}
+
+export const serverlessFunctionsOverviewRoute =
+  defineRoute<ServerlessFunctionsOverviewRouteResponse>()({
+    endpoint: 'GET /internal/apm/services/{serviceName}/metrics/serverless/functions_overview',
+    params: t.type({
+      path: t.type({ serviceName: t.string }),
+      query: t.intersection([environmentRt, kueryRt, rangeRt]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_summary.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_summary.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type AwsLambdaArchitecture = 'arm' | 'x86_64';
+
+export type AWSLambdaPriceFactor = Record<AwsLambdaArchitecture, number>;
+
+export interface ServerlessSummaryResponse {
+  memoryUsageAvgRate: number | undefined;
+  serverlessFunctionsTotal: number | undefined;
+  serverlessDurationAvg: number | null | undefined;
+  billedDurationAvg: number | null | undefined;
+  estimatedCost: number | undefined;
+}
+
+export const serverlessSummaryRoute = defineRoute<ServerlessSummaryResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/metrics/serverless/summary',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([environmentRt, kueryRt, rangeRt, t.partial({ serverlessId: t.string })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/service_nodes.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/service_nodes.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type ServiceNodesResponse = Array<{
+  name: string;
+  cpu: number | null;
+  heapMemory: number | null;
+  hostName: string | null | undefined;
+  nonHeapMemory: number | null;
+  threadCount: number | null;
+}>;
+
+export interface ServiceMetricsNodesRouteResponse {
+  serviceNodes: ServiceNodesResponse;
+}
+
+export const serviceMetricsNodesRoute = defineRoute<ServiceMetricsNodesRouteResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/metrics/nodes',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([kueryRt, rangeRt, environmentRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/index.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { mobileFiltersRoute } from './mobile_filters';
+import { mobileMostUsedChartsRoute } from './mobile_most_used_charts';
+import { mobileStatsRoute } from './mobile_stats';
+import { mobileLocationStatsRoute } from './mobile_location_stats';
+import { mobileSessionsRoute } from './mobile_sessions';
+import { mobileHttpRequestsRoute } from './mobile_http_requests';
+import { mobileTermsByFieldRoute } from './mobile_terms_by_field';
+import { mobileMainStatisticsRoute } from './mobile_main_statistics';
+import { mobileDetailedStatisticsRoute } from './mobile_detailed_statistics';
+
+export const mobileRouteDefinitions = {
+  filters: mobileFiltersRoute,
+  mostUsedCharts: mobileMostUsedChartsRoute,
+  stats: mobileStatsRoute,
+  locationStats: mobileLocationStatsRoute,
+  sessions: mobileSessionsRoute,
+  httpRequests: mobileHttpRequestsRoute,
+  termsByField: mobileTermsByFieldRoute,
+  mainStatistics: mobileMainStatisticsRoute,
+  detailedStatistics: mobileDetailedStatisticsRoute,
+};
+
+export type { MobileFiltersResponse, MobileFiltersRouteResponse } from './mobile_filters';
+export type {
+  MobileMostUsedChartResponse,
+  MobileMostUsedChartsRouteResponse,
+} from './mobile_most_used_charts';
+export type { MobilePeriodStats } from './mobile_stats';
+export type { MobileLocationStats } from './mobile_location_stats';
+export type { SessionsTimeseries } from './mobile_sessions';
+export type { HttpRequestsTimeseries } from './mobile_http_requests';
+export type {
+  MobileTermsByFieldResponse,
+  MobileTermsByFieldRouteResponse,
+} from './mobile_terms_by_field';
+export type { MobileMainStatisticsResponse } from './mobile_main_statistics';
+export type {
+  MobileDetailedStatistics,
+  MobileDetailedStatisticsResponse,
+} from './mobile_detailed_statistics';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_detailed_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_detailed_statistics.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt } from '@kbn/io-ts-utils';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface MobileDetailedStatistics {
+  fieldName: string;
+  latency: Coordinate[];
+  throughput: Coordinate[];
+}
+
+export interface MobileDetailedStatisticsResponse {
+  currentPeriod: Record<string, MobileDetailedStatistics>;
+  previousPeriod: Record<string, MobileDetailedStatistics>;
+}
+
+export const mobileDetailedStatisticsRoute = defineRoute<MobileDetailedStatisticsResponse>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/detailed_statistics',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      offsetRt,
+      environmentRt,
+      t.type({
+        field: t.string,
+        fieldValues: jsonRt.pipe(t.array(t.string)),
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_filters.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_filters.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type MobilePropertyType } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type MobileFiltersResponse = Array<{
+  key: MobilePropertyType;
+  options: string[];
+}>;
+
+export interface MobileFiltersRouteResponse {
+  mobileFilters: MobileFiltersResponse;
+}
+
+export const mobileFiltersRoute = defineRoute<MobileFiltersRouteResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/mobile/filters',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      t.partial({
+        transactionType: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_http_requests.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_http_requests.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface HttpRequestsTimeseries {
+  currentPeriod: { timeseries: Coordinate[]; value: number | null | undefined };
+  previousPeriod: { timeseries: Coordinate[]; value: number | null | undefined };
+}
+
+export const mobileHttpRequestsRoute = defineRoute<HttpRequestsTimeseries>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/transactions/charts/http_requests',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      offsetRt,
+      t.partial({
+        transactionType: t.string,
+        transactionName: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_location_stats.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_location_stats.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+type Timeseries = Array<{ x: number; y: number }>;
+
+interface LocationStats {
+  mostSessions: {
+    location?: string;
+    value: number | null | undefined;
+    timeseries: Timeseries;
+  };
+  mostRequests: {
+    location?: string;
+    value: number | null | undefined;
+    timeseries: Timeseries;
+  };
+}
+
+export interface MobileLocationStats {
+  currentPeriod: LocationStats;
+  previousPeriod: LocationStats;
+}
+
+export const mobileLocationStatsRoute = defineRoute<MobileLocationStats>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/location/stats',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      offsetRt,
+      t.partial({
+        locationField: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_main_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_main_statistics.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface MobileMainStatisticsResponse {
+  mainStatistics: Array<{
+    name: string | number;
+    latency: number | null;
+    throughput: number;
+    crashRate: number;
+  }>;
+}
+
+export const mobileMainStatisticsRoute = defineRoute<MobileMainStatisticsResponse>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/main_statistics',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      t.type({
+        field: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_most_used_charts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_most_used_charts.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type MobilePropertyType } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type MobileMostUsedChartResponse = Array<{
+  key: MobilePropertyType;
+  options: Array<{
+    key: string | number;
+    docCount: number;
+  }>;
+}>;
+
+export interface MobileMostUsedChartsRouteResponse {
+  mostUsedCharts: Array<{
+    key: MobilePropertyType;
+    options: MobileMostUsedChartResponse[number]['options'];
+  }>;
+}
+
+export const mobileMostUsedChartsRoute = defineRoute<MobileMostUsedChartsRouteResponse>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/most_used_charts',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      t.partial({
+        transactionType: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_sessions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_sessions.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface SessionsTimeseries {
+  currentPeriod: { timeseries: Coordinate[]; value: number | null | undefined };
+  previousPeriod: { timeseries: Coordinate[]; value: number | null | undefined };
+}
+
+export const mobileSessionsRoute = defineRoute<SessionsTimeseries>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/transactions/charts/sessions',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      offsetRt,
+      t.partial({
+        transactionType: t.string,
+        transactionName: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_stats.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_stats.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+interface MobileStatsTimeseries {
+  x: number;
+  y: number;
+}
+
+interface MobileStats {
+  sessions: { timeseries: MobileStatsTimeseries[]; value: number | null | undefined };
+  requests: { timeseries: MobileStatsTimeseries[]; value: number | null | undefined };
+  crashRate: { timeseries: MobileStatsTimeseries[]; value: number | null | undefined };
+  launchTimes: { timeseries: MobileStatsTimeseries[]; value: number | null | undefined };
+}
+
+export interface MobilePeriodStats {
+  currentPeriod: MobileStats;
+  previousPeriod: MobileStats;
+}
+
+export const mobileStatsRoute = defineRoute<MobilePeriodStats>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/stats',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      offsetRt,
+      t.partial({
+        transactionType: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_terms_by_field.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_terms_by_field.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type MobileTermsByFieldResponse = Array<{
+  label: string;
+  count: number;
+}>;
+
+export interface MobileTermsByFieldRouteResponse {
+  terms: MobileTermsByFieldResponse;
+}
+
+export const mobileTermsByFieldRoute = defineRoute<MobileTermsByFieldRouteResponse>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/terms',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      t.type({
+        size: toNumberRt,
+        fieldName: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_detailed_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_detailed_statistics.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface CrashGroupDetailedStat {
+  groupId: string;
+  timeseries: Coordinate[];
+}
+
+export interface MobileCrashesGroupPeriodsResponse {
+  currentPeriod: Record<string, CrashGroupDetailedStat>;
+  previousPeriod: Record<string, CrashGroupDetailedStat>;
+}
+
+export const crashDetailedStatisticsRoute = defineRoute<MobileCrashesGroupPeriodsResponse>()({
+  endpoint: 'POST /internal/apm/mobile-services/{serviceName}/crashes/groups/detailed_statistics',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      offsetRt,
+      t.type({
+        numBuckets: toNumberRt,
+      }),
+    ]),
+    body: t.type({ groupIds: jsonRt.pipe(t.array(t.string)) }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_distribution.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_distribution.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface CrashDistributionResponse {
+  currentPeriod: Array<{ x: number; y: number }>;
+  previousPeriod: Coordinate[];
+  bucketSize: number;
+}
+
+export const crashDistributionRoute = defineRoute<CrashDistributionResponse>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/crashes/distribution',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      t.partial({
+        groupId: t.string,
+      }),
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      offsetRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_main_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_main_statistics.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type MobileCrashGroupMainStatisticsResponse = Array<{
+  groupId: string;
+  name: string;
+  lastSeen: number;
+  occurrences: number;
+  culprit: string | undefined;
+  handled: boolean | undefined;
+  type: string | undefined;
+}>;
+
+export interface CrashMainStatisticsRouteResponse {
+  errorGroups: MobileCrashGroupMainStatisticsResponse;
+}
+
+export const crashMainStatisticsRoute = defineRoute<CrashMainStatisticsRouteResponse>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/crashes/groups/main_statistics',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      t.partial({
+        sortField: t.string,
+        sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
+      }),
+      environmentRt,
+      kueryRt,
+      rangeRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { crashDistributionRoute } from './crash_distribution';
+import { crashMainStatisticsRoute } from './crash_main_statistics';
+import { crashDetailedStatisticsRoute } from './crash_detailed_statistics';
+
+export const mobileCrashesRouteDefinitions = {
+  distribution: crashDistributionRoute,
+  mainStatistics: crashMainStatisticsRoute,
+  detailedStatistics: crashDetailedStatisticsRoute,
+};
+
+export type { CrashDistributionResponse } from './crash_distribution';
+export type {
+  MobileCrashGroupMainStatisticsResponse,
+  CrashMainStatisticsRouteResponse,
+} from './crash_main_statistics';
+export type {
+  CrashGroupDetailedStat,
+  MobileCrashesGroupPeriodsResponse,
+} from './crash_detailed_statistics';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/index.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { mobileHttpErrorRateRoute } from './mobile_http_error_rate';
+import { mobileErrorsDetailedStatisticsRoute } from './mobile_errors_detailed_statistics';
+import { mobileErrorTermsRoute } from './mobile_error_terms';
+import { mobileErrorsMainStatisticsRoute } from './mobile_errors_main_statistics';
+
+export const mobileErrorsRouteDefinitions = {
+  httpErrorRate: mobileHttpErrorRateRoute,
+  detailedStatistics: mobileErrorsDetailedStatisticsRoute,
+  errorTerms: mobileErrorTermsRoute,
+  mainStatistics: mobileErrorsMainStatisticsRoute,
+};
+
+export type { MobileHttpErrorsTimeseries } from './mobile_http_error_rate';
+export type {
+  MobileErrorGroupDetailedStat,
+  MobileErrorGroupPeriodsResponse,
+} from './mobile_errors_detailed_statistics';
+export type {
+  MobileErrorTermsByFieldResponse,
+  MobileErrorTermsRouteResponse,
+} from './mobile_error_terms';
+export type {
+  MobileErrorGroupMainStatisticsResponse,
+  MobileErrorsMainStatisticsRouteResponse,
+} from './mobile_errors_main_statistics';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_error_terms.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_error_terms.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type MobileErrorTermsByFieldResponse = Array<{
+  label: string;
+  count: number;
+}>;
+
+export interface MobileErrorTermsRouteResponse {
+  terms: MobileErrorTermsByFieldResponse;
+}
+
+export const mobileErrorTermsRoute = defineRoute<MobileErrorTermsRouteResponse>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/error_terms',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      kueryRt,
+      rangeRt,
+      environmentRt,
+      t.type({
+        size: toNumberRt,
+        fieldName: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_detailed_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_detailed_statistics.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface MobileErrorGroupDetailedStat {
+  groupId: string;
+  timeseries: Coordinate[];
+}
+
+export interface MobileErrorGroupPeriodsResponse {
+  currentPeriod: Record<string, MobileErrorGroupDetailedStat>;
+  previousPeriod: Record<string, MobileErrorGroupDetailedStat>;
+}
+
+export const mobileErrorsDetailedStatisticsRoute = defineRoute<MobileErrorGroupPeriodsResponse>()({
+  endpoint: 'POST /internal/apm/mobile-services/{serviceName}/errors/groups/detailed_statistics',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      offsetRt,
+      t.type({
+        numBuckets: toNumberRt,
+      }),
+    ]),
+    body: t.type({ groupIds: jsonRt.pipe(t.array(t.string)) }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_main_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_main_statistics.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type MobileErrorGroupMainStatisticsResponse = Array<{
+  groupId: string;
+  name: string;
+  lastSeen: number;
+  occurrences: number;
+  culprit: string | undefined;
+  handled: boolean | undefined;
+  type: string | undefined;
+}>;
+
+export interface MobileErrorsMainStatisticsRouteResponse {
+  errorGroups: MobileErrorGroupMainStatisticsResponse;
+}
+
+export const mobileErrorsMainStatisticsRoute =
+  defineRoute<MobileErrorsMainStatisticsRouteResponse>()({
+    endpoint: 'GET /internal/apm/mobile-services/{serviceName}/errors/groups/main_statistics',
+    params: t.type({
+      path: t.type({
+        serviceName: t.string,
+      }),
+      query: t.intersection([
+        t.partial({
+          sortField: t.string,
+          sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
+        }),
+        environmentRt,
+        kueryRt,
+        rangeRt,
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_http_error_rate.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_http_error_rate.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface MobileHttpErrorsTimeseries {
+  currentPeriod: { timeseries: Coordinate[] };
+  previousPeriod: { timeseries: Coordinate[] };
+}
+
+export const mobileHttpErrorRateRoute = defineRoute<MobileHttpErrorsTimeseries>()({
+  endpoint: 'GET /internal/apm/mobile-services/{serviceName}/error/http_error_rate',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/observability_overview/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/observability_overview/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { observabilityOverviewHasDataRoute } from './observability_overview_has_data';
+import { observabilityOverviewRoute } from './observability_overview';
+
+export const observabilityOverviewRouteDefinitions = {
+  observabilityOverviewHasData: observabilityOverviewHasDataRoute,
+  observabilityOverview: observabilityOverviewRoute,
+};
+
+export type { ObservabilityOverviewHasDataResponse } from './observability_overview_has_data';
+export type { ObservabilityOverviewResponse } from './observability_overview';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/observability_overview/observability_overview.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/observability_overview/observability_overview.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface ObservabilityOverviewResponse {
+  serviceCount: number;
+  transactionPerMinute: {
+    value: number | undefined;
+    timeseries: Array<{ x: number; y: number | null }>;
+  };
+}
+
+export const observabilityOverviewRoute = defineRoute<ObservabilityOverviewResponse>()({
+  endpoint: 'GET /internal/apm/observability_overview',
+  params: t.type({
+    query: t.intersection([rangeRt, t.type({ bucketSize: toNumberRt, intervalString: t.string })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/observability_overview/observability_overview_has_data.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/observability_overview/observability_overview_has_data.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface ObservabilityOverviewHasDataResponse {
+  hasData: boolean;
+  indices: Readonly<{
+    error: string;
+    onboarding: string;
+    span: string;
+    transaction: string;
+    metric: string;
+  }>;
+}
+
+export const observabilityOverviewHasDataRoute =
+  defineRoute<ObservabilityOverviewHasDataResponse>()({
+    endpoint: 'GET /internal/apm/observability_overview/has_data',
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/flamegraph.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/flamegraph.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { BaseFlameGraph } from '@kbn/profiling-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type ServicesFlamegraphResponse = BaseFlameGraph;
+
+export const servicesFlamegraphRoute = defineRoute<ServicesFlamegraphResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/profiling/flamegraph',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      kueryRt,
+      environmentRt,
+      rangeRt,
+      t.partial({ transactionName: t.string }),
+      t.type({ transactionType: t.string }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/functions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/functions.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { TopNFunctions } from '@kbn/profiling-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type ServicesFunctionsResponse = TopNFunctions;
+
+export const servicesFunctionsRoute = defineRoute<ServicesFunctionsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/profiling/functions',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      environmentRt,
+      rangeRt,
+      t.partial({ transactionName: t.string }),
+      t.type({
+        startIndex: toNumberRt,
+        endIndex: toNumberRt,
+        transactionType: t.string,
+      }),
+      kueryRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/hosts_flamegraph.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/hosts_flamegraph.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { BaseFlameGraph } from '@kbn/profiling-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt, serviceTransactionDataSourceRt } from '../../default_api_types';
+
+export interface ProfilingHostsFlamegraphResponse {
+  flamegraph: BaseFlameGraph;
+  hostNames: string[];
+  containerIds: string[];
+}
+
+export const profilingHostsFlamegraphRoute = defineRoute<ProfilingHostsFlamegraphResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/profiling/hosts/flamegraph',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([rangeRt, environmentRt, serviceTransactionDataSourceRt, kueryRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/hosts_functions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/hosts_functions.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { TopNFunctions } from '@kbn/profiling-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt, serviceTransactionDataSourceRt } from '../../default_api_types';
+
+export interface ProfilingHostsFunctionsResponse {
+  functions: TopNFunctions;
+  hostNames: string[];
+  containerIds: string[];
+}
+
+export const profilingHostsFunctionsRoute = defineRoute<ProfilingHostsFunctionsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/profiling/hosts/functions',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      rangeRt,
+      environmentRt,
+      serviceTransactionDataSourceRt,
+      t.type({ startIndex: toNumberRt, endIndex: toNumberRt }),
+      kueryRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { servicesFlamegraphRoute } from './flamegraph';
+import { servicesFunctionsRoute } from './functions';
+import { profilingStatusRoute } from './status';
+import { profilingHostsFlamegraphRoute } from './hosts_flamegraph';
+import { profilingHostsFunctionsRoute } from './hosts_functions';
+
+export const profilingRouteDefinitions = {
+  flamegraph: servicesFlamegraphRoute,
+  functions: servicesFunctionsRoute,
+  status: profilingStatusRoute,
+  hostsFlamegraph: profilingHostsFlamegraphRoute,
+  hostsFunctions: profilingHostsFunctionsRoute,
+};
+
+export type { ServicesFlamegraphResponse } from './flamegraph';
+export type { ServicesFunctionsResponse } from './functions';
+export type { ProfilingStatusResponse } from './status';
+export type { ProfilingHostsFlamegraphResponse } from './hosts_flamegraph';
+export type { ProfilingHostsFunctionsResponse } from './hosts_functions';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/status.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/status.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface ProfilingStatusResponse {
+  initialized: boolean;
+}
+
+export const profilingStatusRoute = defineRoute<ProfilingStatusResponse>()({
+  endpoint: 'GET /internal/apm/profiling/status',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/delete_service_group.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/delete_service_group.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+
+export const serviceGroupDeleteRoute = defineRoute<void>()({
+  endpoint: 'DELETE /internal/apm/service-group',
+  params: t.type({
+    query: t.type({ serviceGroupId: t.string }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/get_service_group.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/get_service_group.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SavedServiceGroup } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface ServiceGroupResponse {
+  serviceGroup: SavedServiceGroup;
+}
+
+export const serviceGroupRoute = defineRoute<ServiceGroupResponse>()({
+  endpoint: 'GET /internal/apm/service-group',
+  params: t.type({
+    query: t.type({ serviceGroup: t.string }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/get_service_groups.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/get_service_groups.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import type { SavedServiceGroup } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface ServiceGroupsResponse {
+  serviceGroups: SavedServiceGroup[];
+}
+
+export const serviceGroupsRoute = defineRoute<ServiceGroupsResponse>()({
+  endpoint: 'GET /internal/apm/service-groups',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { serviceGroupsRoute } from './get_service_groups';
+import { serviceGroupRoute } from './get_service_group';
+import { serviceGroupSaveRoute } from './save_service_group';
+import { serviceGroupDeleteRoute } from './delete_service_group';
+import { serviceGroupServicesRoute } from './lookup_services';
+import { serviceGroupCountsRoute } from './service_group_counts';
+
+export const serviceGroupsRouteDefinitions = {
+  list: serviceGroupsRoute,
+  get: serviceGroupRoute,
+  save: serviceGroupSaveRoute,
+  delete: serviceGroupDeleteRoute,
+  services: serviceGroupServicesRoute,
+  counts: serviceGroupCountsRoute,
+};
+
+export type { ServiceGroupsResponse } from './get_service_groups';
+export type { ServiceGroupResponse } from './get_service_group';
+export type { SaveServiceGroupResponse } from './save_service_group';
+export type { LookupServicesResponse, LookupServicesRouteResponse } from './lookup_services';
+export type { ServiceGroupCounts } from './service_group_counts';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/lookup_services.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/lookup_services.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { AgentName } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt } from '../../default_api_types';
+
+export type LookupServicesResponse = Array<{
+  serviceName: string;
+  environments: string[];
+  agentName: AgentName;
+}>;
+
+export interface LookupServicesRouteResponse {
+  items: LookupServicesResponse;
+}
+
+export const serviceGroupServicesRoute = defineRoute<LookupServicesRouteResponse>()({
+  endpoint: 'GET /internal/apm/service-group/services',
+  params: t.type({
+    query: t.intersection([rangeRt, t.partial(kueryRt.props)]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/save_service_group.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/save_service_group.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SavedServiceGroup } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export type SaveServiceGroupResponse = SavedServiceGroup;
+
+export const serviceGroupSaveRoute = defineRoute<SaveServiceGroupResponse>()({
+  endpoint: 'POST /internal/apm/service-group',
+  params: t.type({
+    query: t.union([t.partial({ serviceGroupId: t.string }), t.undefined]),
+    body: t.type({
+      groupName: t.string,
+      kuery: t.string,
+      description: t.union([t.string, t.undefined]),
+      color: t.union([t.string, t.undefined]),
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/service_group_counts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_groups/service_group_counts.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export type ServiceGroupCounts = Record<string, { services: number; alerts: number }>;
+
+export const serviceGroupCountsRoute = defineRoute<ServiceGroupCounts>()({
+  endpoint: 'GET /internal/apm/service-group/counts',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/dependency_node.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/dependency_node.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { NodeStats } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, offsetRt } from '../../default_api_types';
+
+export interface ServiceMapServiceDependencyInfoResponse {
+  currentPeriod: NodeStats;
+  previousPeriod: NodeStats | undefined;
+}
+
+export const serviceMapDependencyNodeRoute = defineRoute<ServiceMapServiceDependencyInfoResponse>()(
+  {
+    endpoint: 'GET /internal/apm/service-map/dependency',
+    params: t.type({
+      query: t.intersection([
+        t.type({
+          dependencies: t.union([t.string, t.array(t.string)]),
+        }),
+        t.partial({ sourceServiceName: t.string }),
+        environmentRt,
+        rangeRt,
+        offsetRt,
+      ]),
+    }),
+  }
+);

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { serviceMapRoute } from './service_map';
+import { serviceMapServiceNodeRoute } from './service_node';
+import { serviceMapDependencyNodeRoute } from './dependency_node';
+import { serviceMapServiceBadgesRoute } from './service_badges';
+
+export const serviceMapRouteDefinitions = {
+  serviceMap: serviceMapRoute,
+  serviceNode: serviceMapServiceNodeRoute,
+  dependencyNode: serviceMapDependencyNodeRoute,
+  serviceBadges: serviceMapServiceBadgesRoute,
+};
+
+export type { ServiceMapRouteResponse } from './service_map';
+export type { ServiceMapServiceNodeInfoResponse } from './service_node';
+export type { ServiceMapServiceDependencyInfoResponse } from './dependency_node';
+export type { ServiceSloStatsResponse, ServiceMapServiceBadgesResponse } from './service_badges';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_badges.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_badges.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt } from '@kbn/io-ts-utils';
+import type { SloStatus } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import type { ServiceAlertsResponse } from '../services/service_alerts_count';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export type ServiceSloStatsResponse = Array<{
+  serviceName: string;
+  sloStatus: SloStatus;
+  sloCount: number;
+}>;
+
+export interface ServiceMapServiceBadgesResponse {
+  alerts: ServiceAlertsResponse;
+  slos: ServiceSloStatsResponse;
+}
+
+export const serviceMapServiceBadgesRoute = defineRoute<ServiceMapServiceBadgesResponse>()({
+  endpoint: 'POST /internal/apm/service-map/service_badges',
+  params: t.type({
+    query: t.intersection([environmentRt, rangeRt, t.partial({ kuery: t.string })]),
+    body: t.type({ serviceNames: jsonRt.pipe(t.array(t.string)) }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_map.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_map.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { ServiceMapResponse } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt } from '../../default_api_types';
+
+export type ServiceMapRouteResponse = ServiceMapResponse;
+
+export const serviceMapRoute = defineRoute<ServiceMapRouteResponse>()({
+  endpoint: 'GET /internal/apm/service-map',
+  params: t.type({
+    query: t.intersection([
+      t.partial({
+        serviceName: t.string,
+        serviceGroup: t.string,
+        kuery: kueryRt.props.kuery,
+      }),
+      environmentRt,
+      rangeRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_node.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_node.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { NodeStats } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, offsetRt } from '../../default_api_types';
+
+export interface ServiceMapServiceNodeInfoResponse {
+  currentPeriod: NodeStats;
+  previousPeriod: NodeStats | undefined;
+}
+
+export const serviceMapServiceNodeRoute = defineRoute<ServiceMapServiceNodeInfoResponse>()({
+  endpoint: 'GET /internal/apm/service-map/service/{serviceName}',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([environmentRt, rangeRt, offsetRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/index.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { servicesListRoute } from './services_list';
+import { servicesDetailedStatisticsRoute } from './services_detailed_statistics';
+import { serviceMetadataDetailsRoute } from './service_metadata_details';
+import { serviceMetadataIconsRoute } from './service_metadata_icons';
+import { serviceAgentRoute } from './service_agent';
+import { serviceTransactionTypesRoute } from './service_transaction_types';
+import { serviceNodeMetadataRoute } from './service_node_metadata';
+import { serviceAnnotationsSearchRoute } from './service_annotations_search';
+import { serviceThroughputRoute } from './service_throughput';
+import { serviceInstancesMainStatisticsRoute } from './service_instances_main_statistics';
+import { serviceInstancesDetailedStatisticsRoute } from './service_instances_detailed_statistics';
+import { serviceInstancesMetadataDetailsRoute } from './service_instances_metadata_details';
+import { serviceDependenciesRoute } from './service_dependencies';
+import { serviceDependenciesBreakdownRoute } from './service_dependencies_breakdown';
+import { serviceAnomalyChartsRoute } from './service_anomaly_charts';
+import { serviceAlertsCountRoute } from './service_alerts_count';
+import { serviceSlosRoute } from './service_slos';
+
+export const servicesRouteDefinitions = {
+  servicesList: servicesListRoute,
+  detailedStatistics: servicesDetailedStatisticsRoute,
+  metadataDetails: serviceMetadataDetailsRoute,
+  metadataIcons: serviceMetadataIconsRoute,
+  agent: serviceAgentRoute,
+  transactionTypes: serviceTransactionTypesRoute,
+  nodeMetadata: serviceNodeMetadataRoute,
+  annotationsSearch: serviceAnnotationsSearchRoute,
+  throughput: serviceThroughputRoute,
+  instancesMainStatistics: serviceInstancesMainStatisticsRoute,
+  instancesDetailedStatistics: serviceInstancesDetailedStatisticsRoute,
+  instancesMetadataDetails: serviceInstancesMetadataDetailsRoute,
+  dependencies: serviceDependenciesRoute,
+  dependenciesBreakdown: serviceDependenciesBreakdownRoute,
+  anomalyCharts: serviceAnomalyChartsRoute,
+  alertsCount: serviceAlertsCountRoute,
+  slos: serviceSlosRoute,
+};
+
+export type { ServicesItemsResponse, MergedServiceStat } from './services_list';
+export type {
+  ServiceTransactionDetailedStat,
+  ServiceTransactionDetailedStatPeriodsResponse,
+} from './services_detailed_statistics';
+export type { ServiceMetadataDetails } from './service_metadata_details';
+export type { ServiceMetadataIcons } from './service_metadata_icons';
+export type { ServiceAgentResponse } from './service_agent';
+export type { ServiceTransactionTypesResponse } from './service_transaction_types';
+export type { ServiceNodeMetadataResponse } from './service_node_metadata';
+export type { ServiceAnnotationResponse } from './service_annotations_search';
+export type {
+  ServiceThroughputResponse,
+  ServiceThroughputRouteResponse,
+} from './service_throughput';
+export type {
+  ServiceInstanceMainStatisticsResponse,
+  ServiceInstancesMainStatisticsRouteResponse,
+} from './service_instances_main_statistics';
+export type {
+  ServiceInstancesDetailedStat,
+  ServiceInstancesDetailedStatisticsResponse,
+} from './service_instances_detailed_statistics';
+export type {
+  ServiceInstanceMetadataDetailsResponse,
+  ServiceInstanceContainerMetadataDetails,
+  ServiceInstancesMetadataDetailsRouteResponse,
+} from './service_instances_metadata_details';
+export type {
+  ServiceDependenciesResponse,
+  ServiceDependenciesRouteResponse,
+} from './service_dependencies';
+export type {
+  ServiceDependenciesBreakdownResponse,
+  ServiceDependenciesBreakdownRouteResponse,
+} from './service_dependencies_breakdown';
+export type { ServiceAnomalyChartsResponse } from './service_anomaly_charts';
+export type {
+  ServiceAlertsResponse,
+  ServiceAlertsCountRouteResponse,
+} from './service_alerts_count';
+export type { ServiceSlosResponse, StatusCounts } from './service_slos';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_agent.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_agent.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { ServerlessType } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface ServiceAgentResponse {
+  agentName?: string;
+  runtimeName?: string;
+  runtimeVersion?: string;
+  telemetrySdkName?: string;
+  telemetrySdkLanguage?: string;
+  serverlessType?: ServerlessType;
+}
+
+export const serviceAgentRoute = defineRoute<ServiceAgentResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/agent',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_alerts_count.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_alerts_count.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export type ServiceAlertsResponse = Array<{
+  serviceName: string;
+  alertsCount: number;
+}>;
+
+export type ServiceAlertsCountRouteResponse = ServiceAlertsResponse[number];
+
+export const serviceAlertsCountRoute = defineRoute<ServiceAlertsCountRouteResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/alerts_count',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([rangeRt, environmentRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_annotations_search.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_annotations_search.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Annotation } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface ServiceAnnotationResponse {
+  annotations: Annotation[];
+}
+
+export const serviceAnnotationsSearchRoute = defineRoute<ServiceAnnotationResponse>()({
+  endpoint: 'GET /api/apm/services/{serviceName}/annotation/search 2023-10-31',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([environmentRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_anomaly_charts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_anomaly_charts.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { ServiceAnomalyTimeseries } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface ServiceAnomalyChartsResponse {
+  allAnomalyTimeseries: ServiceAnomalyTimeseries[];
+}
+
+export const serviceAnomalyChartsRoute = defineRoute<ServiceAnomalyChartsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/anomaly_charts',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([rangeRt, environmentRt, t.type({ transactionType: t.string })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_dependencies.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_dependencies.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { ConnectionStatsItemWithImpact } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, offsetRt } from '../../default_api_types';
+
+export type ServiceDependenciesResponse = Array<
+  Omit<ConnectionStatsItemWithImpact, 'stats'> & {
+    currentStats: ConnectionStatsItemWithImpact['stats'];
+    previousStats: ConnectionStatsItemWithImpact['stats'] | null;
+  }
+>;
+
+export interface ServiceDependenciesRouteResponse {
+  serviceDependencies: ServiceDependenciesResponse;
+}
+
+export const serviceDependenciesRoute = defineRoute<ServiceDependenciesRouteResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/dependencies',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([t.type({ numBuckets: toNumberRt }), environmentRt, rangeRt, offsetRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_dependencies_breakdown.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_dependencies_breakdown.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, kueryRt } from '../../default_api_types';
+
+export type ServiceDependenciesBreakdownResponse = Array<{
+  title: string;
+  data: Array<{ x: number; y: number }>;
+}>;
+
+export interface ServiceDependenciesBreakdownRouteResponse {
+  breakdown: ServiceDependenciesBreakdownResponse;
+}
+
+export const serviceDependenciesBreakdownRoute =
+  defineRoute<ServiceDependenciesBreakdownRouteResponse>()({
+    endpoint: 'GET /internal/apm/services/{serviceName}/dependencies/breakdown',
+    params: t.type({
+      path: t.type({ serviceName: t.string }),
+      query: t.intersection([environmentRt, rangeRt, kueryRt]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_detailed_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_detailed_statistics.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import type { Coordinate } from '@kbn/apm-types';
+import { environmentRt, latencyAggregationTypeRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface ServiceInstancesDetailedStat {
+  serviceNodeName: string;
+  errorRate?: Coordinate[];
+  latency?: Coordinate[];
+  throughput?: Coordinate[];
+  cpuUsage?: Coordinate[];
+  memoryUsage?: Coordinate[];
+}
+
+export interface ServiceInstancesDetailedStatisticsResponse {
+  currentPeriod: Record<string, ServiceInstancesDetailedStat>;
+  previousPeriod: Record<string, ServiceInstancesDetailedStat>;
+}
+
+export const serviceInstancesDetailedStatisticsRoute =
+  defineRoute<ServiceInstancesDetailedStatisticsResponse>()({
+    endpoint:
+      'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
+    params: t.type({
+      path: t.type({ serviceName: t.string }),
+      query: t.intersection([
+        t.type({
+          latencyAggregationType: latencyAggregationTypeRt,
+          transactionType: t.string,
+          serviceNodeIds: jsonRt.pipe(t.array(t.string)),
+          numBuckets: toNumberRt,
+        }),
+        environmentRt,
+        kueryRt,
+        rangeRt,
+        offsetRt,
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_main_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_main_statistics.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, instancesSortFieldRt, latencyAggregationTypeRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export type ServiceInstanceMainStatisticsResponse = Array<{
+  serviceNodeName: string;
+  errorRate?: number;
+  latency?: number;
+  throughput?: number;
+  cpuUsage?: number | null;
+  memoryUsage?: number | null;
+}>;
+
+export interface ServiceInstancesMainStatisticsRouteResponse {
+  currentPeriod: ServiceInstanceMainStatisticsResponse;
+  previousPeriod: ServiceInstanceMainStatisticsResponse;
+}
+
+export const serviceInstancesMainStatisticsRoute =
+  defineRoute<ServiceInstancesMainStatisticsRouteResponse>()({
+    endpoint: 'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics',
+    params: t.type({
+      path: t.type({ serviceName: t.string }),
+      query: t.intersection([
+        t.type({
+          latencyAggregationType: latencyAggregationTypeRt,
+          transactionType: t.string,
+          sortField: instancesSortFieldRt,
+          sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
+        }),
+        offsetRt,
+        environmentRt,
+        kueryRt,
+        rangeRt,
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_metadata_details.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_metadata_details.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Agent, Service, Container, Kubernetes, Host, Cloud } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface ServiceInstanceMetadataDetailsResponse {
+  '@timestamp': string;
+  agent?: Agent;
+  service?: Service;
+  container?: Container;
+  kubernetes?: Kubernetes;
+  host?: Host;
+  cloud?: Cloud;
+}
+
+export type ServiceInstanceContainerMetadataDetails =
+  | {
+      kubernetes: Kubernetes;
+    }
+  | undefined;
+
+export type ServiceInstancesMetadataDetailsRouteResponse = ServiceInstanceMetadataDetailsResponse &
+  (ServiceInstanceContainerMetadataDetails | {});
+
+export const serviceInstancesMetadataDetailsRoute =
+  defineRoute<ServiceInstancesMetadataDetailsRouteResponse>()({
+    endpoint:
+      'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
+    params: t.type({
+      path: t.type({
+        serviceName: t.string,
+        serviceNodeName: t.string,
+      }),
+      query: rangeRt,
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_metadata_details.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_metadata_details.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface ServiceMetadataDetails {
+  service?: {
+    versions?: string[];
+    runtime?: {
+      name?: string;
+      version?: string;
+    };
+    framework?: string;
+    agent: {
+      name: string;
+      version: string;
+    };
+  };
+  opentelemetry?: {
+    language?: string;
+    sdkVersion?: string;
+    autoVersion?: string;
+  };
+  container?: {
+    ids?: string[];
+    image?: string;
+    os?: string;
+    totalNumberInstances?: number;
+  };
+  serverless?: {
+    type?: string;
+    functionNames?: string[];
+    faasTriggerTypes?: string[];
+    hostArchitecture?: string;
+  };
+  cloud?: {
+    provider?: string;
+    availabilityZones?: string[];
+    regions?: string[];
+    machineTypes?: string[];
+    projectName?: string;
+    serviceName?: string;
+  };
+  kubernetes?: {
+    deployments?: string[];
+    namespaces?: string[];
+    replicasets?: string[];
+    containerImages?: string[];
+  };
+}
+
+export const serviceMetadataDetailsRoute = defineRoute<ServiceMetadataDetails>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/metadata/details',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([rangeRt, environmentRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_metadata_icons.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_metadata_icons.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { ContainerType, ServerlessType } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface ServiceMetadataIcons {
+  agentName?: string;
+  containerType?: ContainerType;
+  serverlessType?: ServerlessType;
+  cloudProvider?: string;
+}
+
+export const serviceMetadataIconsRoute = defineRoute<ServiceMetadataIcons>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/metadata/icons',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_node_metadata.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_node_metadata.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, serviceTransactionDataSourceRt } from '../../default_api_types';
+
+export interface ServiceNodeMetadataResponse {
+  host: string | number;
+  containerId: string | number;
+}
+
+export const serviceNodeMetadataRoute = defineRoute<ServiceNodeMetadataResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/node/{serviceNodeName}/metadata',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+      serviceNodeName: t.string,
+    }),
+    query: t.intersection([kueryRt, rangeRt, environmentRt, serviceTransactionDataSourceRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_slos.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_slos.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+
+export interface StatusCounts {
+  violated: number;
+  degrading: number;
+  healthy: number;
+  noData: number;
+}
+
+export interface ServiceSlosResponse {
+  results: SLOWithSummaryResponse[];
+  total: number;
+  page: number;
+  perPage: number;
+  activeAlerts: Record<string, number>;
+  statusCounts: StatusCounts;
+}
+
+export const serviceSlosRoute = defineRoute<ServiceSlosResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/slos',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      environmentRt,
+      t.type({
+        page: toNumberRt,
+        perPage: toNumberRt,
+      }),
+      t.partial({
+        statusFilters: jsonRt.pipe(t.array(t.string)),
+        kqlQuery: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_throughput.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_throughput.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { Coordinate } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import {
+  kueryRt,
+  rangeRt,
+  offsetRt,
+  filtersRt,
+  serviceTransactionDataSourceRt,
+} from '../../default_api_types';
+
+export type ServiceThroughputResponse = Coordinate[];
+
+export interface ServiceThroughputRouteResponse {
+  currentPeriod: ServiceThroughputResponse;
+  previousPeriod: ServiceThroughputResponse;
+}
+
+export const serviceThroughputRoute = defineRoute<ServiceThroughputRouteResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/throughput',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.type({ bucketSizeInSeconds: toNumberRt }),
+      t.partial({ transactionType: t.string, transactionName: t.string, filters: filtersRt }),
+      t.intersection([environmentRt, kueryRt, rangeRt, offsetRt, serviceTransactionDataSourceRt]),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_transaction_types.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_transaction_types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { rangeRt, serviceTransactionDataSourceRt } from '../../default_api_types';
+
+export interface ServiceTransactionTypesResponse {
+  transactionTypes: string[];
+}
+
+export const serviceTransactionTypesRoute = defineRoute<ServiceTransactionTypesResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/transaction_types',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([rangeRt, serviceTransactionDataSourceRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_detailed_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_detailed_statistics.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import type { Coordinate } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import {
+  kueryRt,
+  rangeRt,
+  offsetRt,
+  probabilityRt,
+  serviceTransactionDataSourceRt,
+} from '../../default_api_types';
+
+export interface ServiceTransactionDetailedStat {
+  serviceName: string;
+  latency: Coordinate[];
+  transactionErrorRate?: Coordinate[];
+  throughput?: Coordinate[];
+}
+
+export interface ServiceTransactionDetailedStatPeriodsResponse {
+  currentPeriod: Record<string, ServiceTransactionDetailedStat>;
+  previousPeriod: Record<string, ServiceTransactionDetailedStat>;
+}
+
+export const servicesDetailedStatisticsRoute =
+  defineRoute<ServiceTransactionDetailedStatPeriodsResponse>()({
+    endpoint: 'POST /internal/apm/services/detailed_statistics',
+    params: t.type({
+      query: t.intersection([
+        environmentRt,
+        kueryRt,
+        rangeRt,
+        t.intersection([offsetRt, probabilityRt, serviceTransactionDataSourceRt]),
+        t.type({
+          bucketSizeInSeconds: toNumberRt,
+        }),
+      ]),
+      body: t.type({ serviceNames: jsonRt.pipe(t.array(t.string)) }),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_list.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_list.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt } from '@kbn/io-ts-utils';
+import type { AgentName } from '@kbn/elastic-agent-utils';
+import type { ServiceHealthStatus, SloStatus } from '@kbn/apm-types';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import {
+  kueryRt,
+  rangeRt,
+  probabilityRt,
+  serviceTransactionDataSourceRt,
+} from '../../default_api_types';
+
+export interface MergedServiceStat {
+  serviceName: string;
+  transactionType?: string;
+  environments?: string[];
+  agentName?: AgentName;
+  latency?: number | null;
+  transactionErrorRate?: number;
+  throughput?: number;
+  healthStatus?: ServiceHealthStatus;
+  anomalyScore?: number;
+  alertsCount?: number;
+  sloStatus?: SloStatus;
+  sloCount?: number;
+}
+
+export interface ServicesItemsResponse {
+  items: MergedServiceStat[];
+  maxCountExceeded: boolean;
+  serviceOverflowCount: number;
+}
+
+export const servicesListRoute = defineRoute<ServicesItemsResponse>()({
+  endpoint: 'GET /internal/apm/services',
+  params: t.type({
+    query: t.intersection([
+      t.partial({
+        searchQuery: t.string,
+        serviceGroup: t.string,
+      }),
+      t.intersection([
+        probabilityRt,
+        t.intersection([
+          serviceTransactionDataSourceRt,
+          t.type({
+            useDurationSummary: toBooleanRt,
+          }),
+        ]),
+        environmentRt,
+        kueryRt,
+        rangeRt,
+      ]),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/delete_source_map.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/delete_source_map.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+
+export const deleteSourceMapRoute = defineRoute<void>()({
+  endpoint: 'DELETE /api/apm/sourcemaps/{id} 2023-10-31',
+  params: t.type({
+    path: t.type({
+      id: t.string,
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { listSourceMapsRoute } from './list_source_maps';
+import { uploadSourceMapRoute } from './upload_source_map';
+import { deleteSourceMapRoute } from './delete_source_map';
+import { migrateFleetArtifactsRoute } from './migrate_fleet_artifacts';
+
+export const sourceMapsRouteDefinitions = {
+  list: listSourceMapsRoute,
+  upload: uploadSourceMapRoute,
+  delete: deleteSourceMapRoute,
+  migrateFleetArtifacts: migrateFleetArtifactsRoute,
+};
+
+export { sourceMapRt, type SourceMap, type ApmSourceMapArtifactBody } from './source_map_types';
+export type { ListSourceMapArtifactsResponse } from './list_source_maps';
+export type { UploadSourceMapResponse } from './upload_source_map';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/list_source_maps.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/list_source_maps.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { defineRoute } from '../types';
+import type { ApmSourceMapArtifactBody } from './source_map_types';
+
+export interface ListSourceMapArtifactsResponse {
+  artifacts: Array<{
+    body: ApmSourceMapArtifactBody;
+    id: string;
+    created: string;
+    compressionAlgorithm: 'none' | 'zlib';
+    encryptionAlgorithm: 'none';
+    decodedSha256: string;
+    decodedSize: number;
+    encodedSha256: string;
+    encodedSize: number;
+    identifier: string;
+    packageName: string;
+    relative_url: string;
+    type?: string | undefined;
+  }>;
+  total: number;
+}
+export const listSourceMapsRoute = defineRoute<ListSourceMapArtifactsResponse | undefined>()({
+  endpoint: 'GET /api/apm/sourcemaps 2023-10-31',
+  params: t.partial({
+    query: t.partial({
+      page: toNumberRt,
+      perPage: toNumberRt,
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/migrate_fleet_artifacts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/migrate_fleet_artifacts.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export const migrateFleetArtifactsRoute = defineRoute<void>()({
+  endpoint: 'POST /internal/apm/sourcemaps/migrate_fleet_artifacts',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/source_map_types.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/source_map_types.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+
+export const sourceMapRt = t.intersection([
+  t.type({
+    version: t.number,
+    sources: t.array(t.string),
+    mappings: t.string,
+  }),
+  t.partial({
+    names: t.array(t.string),
+    file: t.string,
+    sourceRoot: t.string,
+    sourcesContent: t.array(t.union([t.string, t.null])),
+  }),
+]);
+
+export type SourceMap = t.TypeOf<typeof sourceMapRt>;
+
+export interface ApmSourceMapArtifactBody {
+  serviceName: string;
+  serviceVersion: string;
+  bundleFilepath: string;
+  sourceMap: SourceMap;
+}

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/upload_source_map.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/upload_source_map.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt } from '@kbn/io-ts-utils';
+import type { Artifact } from '@kbn/fleet-plugin/server';
+import { defineRoute } from '../types';
+import { sourceMapRt } from './source_map_types';
+
+export const uploadSourceMapRoute = defineRoute<Artifact | undefined>()({
+  endpoint: 'POST /api/apm/sourcemaps 2023-10-31',
+  params: t.type({
+    body: t.type({
+      service_name: t.string,
+      service_version: t.string,
+      bundle_filepath: t.string,
+      sourcemap: t.union([t.string, t.any]).pipe(jsonRt).pipe(sourceMapRt),
+    }),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/span_links/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/span_links/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { linkedParentsRoute } from './linked_parents';
+import { linkedChildrenRoute } from './linked_children';
+import { spanLinksRoute } from './span_links';
+
+export const spanLinksRouteDefinitions = {
+  linkedParents: linkedParentsRoute,
+  linkedChildren: linkedChildrenRoute,
+  spanLinks: spanLinksRoute,
+};
+
+export type { LinkedParentsResponse } from './linked_parents';
+export type { LinkedChildrenResponse } from './linked_children';
+export type { SpanLinksResponse } from './span_links';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/span_links/linked_children.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/span_links/linked_children.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SpanLinkDetails } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface LinkedChildrenResponse {
+  spanLinksDetails: SpanLinkDetails[];
+}
+
+export const linkedChildrenRoute = defineRoute<LinkedChildrenResponse>()({
+  endpoint: 'GET /internal/apm/traces/{traceId}/span_links/{spanId}/children',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+      spanId: t.string,
+    }),
+    query: t.intersection([kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/span_links/linked_parents.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/span_links/linked_parents.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SpanLinkDetails } from '@kbn/apm-types';
+import { processorEventRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface LinkedParentsResponse {
+  spanLinksDetails: SpanLinkDetails[];
+}
+
+export const linkedParentsRoute = defineRoute<LinkedParentsResponse>()({
+  endpoint: 'GET /internal/apm/traces/{traceId}/span_links/{spanId}/parents',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+      spanId: t.string,
+    }),
+    query: t.intersection([kueryRt, rangeRt, t.type({ processorEvent: processorEventRt })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/span_links/span_links.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/span_links/span_links.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { SpanLinkDetails } from '@kbn/apm-types';
+import { processorEventRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface SpanLinksResponse {
+  outgoingSpanLinks: SpanLinkDetails[];
+  incomingSpanLinks: SpanLinkDetails[];
+}
+
+export const spanLinksRoute = defineRoute<SpanLinksResponse>()({
+  endpoint: 'GET /internal/apm/traces/{traceId}/span_links/{spanId}',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+      spanId: t.string,
+    }),
+    query: t.intersection([kueryRt, rangeRt, t.partial({ processorEvent: processorEventRt })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/index.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { storageExplorerRoute } from './storage_explorer';
+import { storageExplorerServiceDetailsRoute } from './storage_explorer_service_details';
+import { storageChartRoute } from './storage_chart';
+import { storageExplorerPrivilegesRoute } from './storage_explorer_privileges';
+import { storageExplorerSummaryStatsRoute } from './storage_explorer_summary_stats';
+import { storageExplorerIsCrossClusterRoute } from './storage_explorer_is_cross_cluster';
+import { storageExplorerGetServicesRoute } from './storage_explorer_get_services';
+
+export const storageExplorerRouteDefinitions = {
+  storageExplorer: storageExplorerRoute,
+  serviceDetails: storageExplorerServiceDetailsRoute,
+  chart: storageChartRoute,
+  privileges: storageExplorerPrivilegesRoute,
+  summaryStats: storageExplorerSummaryStatsRoute,
+  isCrossCluster: storageExplorerIsCrossClusterRoute,
+  getServices: storageExplorerGetServicesRoute,
+};
+
+export type {
+  StorageExplorerServiceStatisticsResponse,
+  StorageExplorerRouteResponse,
+} from './storage_explorer';
+export type { StorageDetailsResponse } from './storage_explorer_service_details';
+export type { SizeTimeseriesResponse, StorageChartRouteResponse } from './storage_chart';
+export type { StorageExplorerPrivilegesResponse } from './storage_explorer_privileges';
+export type { StorageExplorerSummaryStatisticsResponse } from './storage_explorer_summary_stats';
+export type { StorageExplorerIsCrossClusterResponse } from './storage_explorer_is_cross_cluster';
+export type { StorageExplorerGetServicesResponse } from './storage_explorer_get_services';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_chart.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_chart.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, indexLifecyclePhaseRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+
+export type SizeTimeseriesResponse = Array<{
+  serviceName: string;
+  timeseries: Array<{ x: number; y: number }>;
+}>;
+
+export interface StorageChartRouteResponse {
+  storageTimeSeries: SizeTimeseriesResponse;
+}
+
+export const storageChartRoute = defineRoute<StorageChartRouteResponse>()({
+  endpoint: 'GET /internal/apm/storage_chart',
+  params: t.type({
+    query: t.intersection([indexLifecyclePhaseRt, probabilityRt, environmentRt, kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, indexLifecyclePhaseRt } from '@kbn/apm-types';
+import type { AgentName } from '@kbn/elastic-agent-utils';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+
+export type StorageExplorerServiceStatisticsResponse = Array<{
+  serviceName: string;
+  sampling: number;
+  environments: string[];
+  size: number;
+  agentName: AgentName;
+}>;
+
+export interface StorageExplorerRouteResponse {
+  serviceStatistics: StorageExplorerServiceStatisticsResponse;
+}
+
+export const storageExplorerRoute = defineRoute<StorageExplorerRouteResponse>()({
+  endpoint: 'GET /internal/apm/storage_explorer',
+  params: t.type({
+    query: t.intersection([indexLifecyclePhaseRt, probabilityRt, environmentRt, kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_get_services.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_get_services.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, indexLifecyclePhaseRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface StorageExplorerGetServicesResponse {
+  services: Array<{
+    serviceName: string;
+  }>;
+}
+
+export const storageExplorerGetServicesRoute = defineRoute<StorageExplorerGetServicesResponse>()({
+  endpoint: 'GET /internal/apm/storage_explorer/get_services',
+  params: t.type({
+    query: t.intersection([indexLifecyclePhaseRt, environmentRt, kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_is_cross_cluster.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_is_cross_cluster.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface StorageExplorerIsCrossClusterResponse {
+  isCrossClusterSearch: boolean;
+}
+
+export const storageExplorerIsCrossClusterRoute =
+  defineRoute<StorageExplorerIsCrossClusterResponse>()({
+    endpoint: 'GET /internal/apm/storage_explorer/is_cross_cluster_search',
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_privileges.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_privileges.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { defineRoute } from '../types';
+
+export interface StorageExplorerPrivilegesResponse {
+  hasPrivileges: boolean;
+}
+
+export const storageExplorerPrivilegesRoute = defineRoute<StorageExplorerPrivilegesResponse>()({
+  endpoint: 'GET /internal/apm/storage_explorer/privileges',
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_service_details.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_service_details.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { ProcessorEvent } from '@kbn/apm-types-shared';
+import { environmentRt, indexLifecyclePhaseRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+
+export interface StorageDetailsResponse {
+  processorEventStats: Array<{
+    processorEvent: ProcessorEvent;
+    docs: number;
+    size: number;
+  }>;
+  indicesStats: Array<{
+    indexName: string;
+    numberOfDocs: number;
+    primary: string | number | undefined;
+    replica: string | number | undefined;
+    size: number | undefined;
+    dataStream: string | undefined;
+    lifecyclePhase: string | undefined;
+  }>;
+}
+
+export const storageExplorerServiceDetailsRoute = defineRoute<StorageDetailsResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/storage_details',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    query: t.intersection([indexLifecyclePhaseRt, probabilityRt, environmentRt, kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_summary_stats.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/storage_explorer/storage_explorer_summary_stats.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, indexLifecyclePhaseRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+
+export interface StorageExplorerSummaryStatisticsResponse {
+  tracesPerMinute: number;
+  totalSize: number;
+  diskSpaceUsedPct: number;
+  numberOfServices: number;
+  estimatedIncrementalSize: number;
+  dailyDataGeneration: number;
+}
+
+export const storageExplorerSummaryStatsRoute =
+  defineRoute<StorageExplorerSummaryStatisticsResponse>()({
+    endpoint: 'GET /internal/apm/storage_explorer_summary_stats',
+    params: t.type({
+      query: t.intersection([
+        indexLifecyclePhaseRt,
+        probabilityRt,
+        environmentRt,
+        kueryRt,
+        rangeRt,
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/suggestions/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/suggestions/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { suggestionsRoute } from './suggestions';
+
+export const suggestionsRouteDefinitions = {
+  suggestions: suggestionsRoute,
+};
+
+export type { SuggestionsResponse } from './suggestions';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/suggestions/suggestions.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/suggestions/suggestions.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface SuggestionsResponse {
+  terms: string[];
+}
+
+export const suggestionsRoute = defineRoute<SuggestionsResponse>()({
+  endpoint: 'GET /internal/apm/suggestions',
+  params: t.type({
+    query: t.intersection([
+      t.type({
+        fieldName: t.string,
+        fieldValue: t.string,
+      }),
+      rangeRt,
+      t.partial({ serviceName: t.string }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/time_range_metadata/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/time_range_metadata/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { timeRangeMetadataRoute } from './time_range_metadata';
+
+export const timeRangeMetadataRouteDefinitions = {
+  timeRangeMetadata: timeRangeMetadataRoute,
+};
+
+export type { TimeRangeMetadataResponse } from './time_range_metadata';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/time_range_metadata/time_range_metadata.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/time_range_metadata/time_range_metadata.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt } from '@kbn/io-ts-utils';
+import type { TimeRangeMetadata } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export type TimeRangeMetadataResponse = TimeRangeMetadata;
+
+export const timeRangeMetadataRoute = defineRoute<TimeRangeMetadataResponse>()({
+  endpoint: 'GET /internal/apm/time_range_metadata',
+  params: t.type({
+    query: t.intersection([t.type({ useSpanName: toBooleanRt }), kueryRt, rangeRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/index.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { unifiedTracesByIdRoute } from './unified_traces_by_id';
+import { unifiedTracesByIdSummaryRoute } from './unified_traces_by_id_summary';
+import { unifiedTracesByIdErrorsRoute } from './unified_traces_by_id_errors';
+import { unifiedTracesRootSpanRoute } from './unified_traces_root_span';
+import { rootTransactionByTraceIdRoute } from './root_transaction_by_trace_id';
+import { transactionByNameRoute } from './transaction_by_name';
+import { transactionByIdRoute } from './transaction_by_id';
+import { transactionFromTraceByIdRoute } from './transaction_from_trace_by_id';
+import { spanFromTraceByIdRoute } from './span_from_trace_by_id';
+import { unifiedTraceSpanRoute } from './unified_trace_span';
+import { tracesRoute } from './traces';
+
+export const tracesRouteDefinitions = {
+  unifiedTracesById: unifiedTracesByIdRoute,
+  unifiedTracesByIdSummary: unifiedTracesByIdSummaryRoute,
+  unifiedTracesByIdErrors: unifiedTracesByIdErrorsRoute,
+  unifiedTracesRootSpan: unifiedTracesRootSpanRoute,
+  rootTransactionByTraceId: rootTransactionByTraceIdRoute,
+  transactionByName: transactionByNameRoute,
+  transactionById: transactionByIdRoute,
+  transactionFromTraceById: transactionFromTraceByIdRoute,
+  spanFromTraceById: spanFromTraceByIdRoute,
+  unifiedTraceSpan: unifiedTraceSpanRoute,
+  traces: tracesRoute,
+};
+
+export type { UnifiedTracesByIdResponse } from './unified_traces_by_id';
+export type { UnifiedTracesByIdSummaryResponse } from './unified_traces_by_id_summary';
+export type { UnifiedTracesRootSpanResponse } from './unified_traces_root_span';
+export type { RootTransactionByTraceIdResponse } from './root_transaction_by_trace_id';
+export type { TransactionByNameResponse } from './transaction_by_name';
+export type { TransactionByIdResponse } from './transaction_by_id';
+export type { TransactionFromTraceByIdResponse } from './transaction_from_trace_by_id';
+export type { SpanFromTraceByIdResponse } from './span_from_trace_by_id';
+export type { UnifiedTraceSpanResponse } from './unified_trace_span';
+export type { TopTracesPrimaryStatsResponse, BucketKey } from './traces';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/root_transaction_by_trace_id.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/root_transaction_by_trace_id.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { TransactionDetailRedirectInfo } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface RootTransactionByTraceIdResponse {
+  transaction?: TransactionDetailRedirectInfo;
+}
+
+export const rootTransactionByTraceIdRoute = defineRoute<RootTransactionByTraceIdResponse>()({
+  endpoint: 'GET /internal/apm/traces/{traceId}/root_transaction',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+    }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/span_from_trace_by_id.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/span_from_trace_by_id.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Span, Transaction } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface SpanFromTraceByIdResponse {
+  span?: Span;
+  parentTransaction?: Transaction;
+}
+
+export const spanFromTraceByIdRoute = defineRoute<SpanFromTraceByIdResponse>()({
+  endpoint: 'GET /internal/apm/traces/{traceId}/spans/{spanId}',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+      spanId: t.string,
+    }),
+    query: t.intersection([
+      rangeRt,
+      t.union([t.partial({ parentTransactionId: t.string }), t.undefined]),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/traces.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/traces.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type AgentName } from '@kbn/apm-types';
+import type { TRANSACTION_NAME, SERVICE_NAME } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+
+export type BucketKey = Record<typeof TRANSACTION_NAME | typeof SERVICE_NAME, string>;
+
+export interface TopTracesPrimaryStatsResponse {
+  items: Array<{
+    key: BucketKey;
+    serviceName: string;
+    transactionName: string;
+    averageResponseTime: number | null;
+    transactionsPerMinute: number;
+    transactionType: string;
+    impact: number;
+    agentName: AgentName;
+  }>;
+}
+
+export const tracesRoute = defineRoute<TopTracesPrimaryStatsResponse>()({
+  endpoint: 'GET /internal/apm/traces',
+  params: t.type({
+    query: t.intersection([environmentRt, kueryRt, rangeRt, probabilityRt]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_by_id.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_by_id.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Transaction } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface TransactionByIdResponse {
+  transaction?: Transaction;
+}
+
+export const transactionByIdRoute = defineRoute<TransactionByIdResponse>()({
+  endpoint: 'GET /internal/apm/transactions/{transactionId}',
+  params: t.type({
+    path: t.type({
+      transactionId: t.string,
+    }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_by_name.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_by_name.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { TransactionDetailRedirectInfo } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface TransactionByNameResponse {
+  transaction?: TransactionDetailRedirectInfo;
+}
+
+export const transactionByNameRoute = defineRoute<TransactionByNameResponse>()({
+  endpoint: 'GET /internal/apm/transactions',
+  params: t.type({
+    query: t.intersection([
+      rangeRt,
+      t.type({
+        transactionName: t.string,
+        serviceName: t.string,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_from_trace_by_id.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_from_trace_by_id.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { Transaction } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export type TransactionFromTraceByIdResponse = Transaction;
+
+export const transactionFromTraceByIdRoute = defineRoute<TransactionFromTraceByIdResponse>()({
+  endpoint: 'GET /internal/apm/traces/{traceId}/transactions/{transactionId}',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+      transactionId: t.string,
+    }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_trace_span.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_trace_span.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { UnifiedSpanDocument } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export type UnifiedTraceSpanResponse = UnifiedSpanDocument;
+
+export const unifiedTraceSpanRoute = defineRoute<UnifiedTraceSpanResponse>()({
+  endpoint: 'GET /internal/apm/unified_traces/{traceId}/spans/{spanId}',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+      spanId: t.string,
+    }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt } from '@kbn/io-ts-utils';
+import type { Error as ApmError, TraceItem, Transaction } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface UnifiedTracesByIdResponse {
+  traceItems: TraceItem[];
+  errors: ApmError[];
+  agentMarks: Record<string, number>;
+  entryTransaction?: Transaction;
+  traceDocsTotal: number;
+  maxTraceItems: number;
+}
+
+export const unifiedTracesByIdRoute = defineRoute<UnifiedTracesByIdResponse>()({
+  endpoint: 'GET /internal/apm/unified_traces/{traceId}',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+    }),
+    query: t.intersection([
+      rangeRt,
+      t.partial({
+        serviceName: t.string,
+        entryTransactionId: t.string,
+        ecsOnly: toBooleanRt,
+      }),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id_errors.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id_errors.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { ErrorsByTraceId } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export const unifiedTracesByIdErrorsRoute = defineRoute<ErrorsByTraceId>()({
+  endpoint: 'GET /internal/apm/unified_traces/{traceId}/errors',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+    }),
+    query: t.intersection([rangeRt, t.partial({ docId: t.string })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id_summary.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id_summary.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import type { FocusedTraceItems } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export interface UnifiedTracesByIdSummaryResponse {
+  traceItems?: FocusedTraceItems;
+  summary: { services: number; traceEvents: number; errors: number };
+}
+
+export const unifiedTracesByIdSummaryRoute = defineRoute<UnifiedTracesByIdSummaryResponse>()({
+  endpoint: 'GET /internal/apm/unified_traces/{traceId}/summary',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+    }),
+    query: t.intersection([rangeRt, t.partial({ maxTraceItems: toNumberRt, docId: t.string })]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_root_span.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_root_span.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import type { TraceRootSpan } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt } from '../../default_api_types';
+
+export type UnifiedTracesRootSpanResponse = TraceRootSpan;
+
+export const unifiedTracesRootSpanRoute = defineRoute<UnifiedTracesRootSpanResponse>()({
+  endpoint: 'GET /internal/apm/unified_traces/{traceId}/root_span',
+  params: t.type({
+    path: t.type({
+      traceId: t.string,
+    }),
+    query: rangeRt,
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/breakdown.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/breakdown.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface TransactionBreakdownResponse {
+  timeseries: Array<{
+    title: string;
+    type: string;
+    data: Coordinate[];
+    hideLegend: boolean;
+    legendValue: any;
+  }>;
+}
+
+export const transactionChartsBreakdownRoute = defineRoute<TransactionBreakdownResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/transaction/charts/breakdown',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.type({ transactionType: t.string }),
+      t.partial({ transactionName: t.string }),
+      environmentRt,
+      kueryRt,
+      rangeRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/coldstart_rate.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/coldstart_rate.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+
+export interface ColdstartRateResponse {
+  currentPeriod: {
+    transactionColdstartRate: Coordinate[];
+    average: number | null;
+  };
+  previousPeriod: {
+    transactionColdstartRate: Coordinate[];
+    average: number | null;
+  };
+}
+
+export const transactionChartsColdstartRateRoute = defineRoute<ColdstartRateResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/transactions/charts/coldstart_rate',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.type({ transactionType: t.string }),
+      t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/coldstart_rate_by_transaction_name.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/coldstart_rate_by_transaction_name.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import type { ColdstartRateResponse } from './coldstart_rate';
+
+export type ColdstartRateByTransactionNameResponse = ColdstartRateResponse;
+
+export const transactionChartsColdstartRateByTransactionNameRoute =
+  defineRoute<ColdstartRateByTransactionNameResponse>()({
+    endpoint:
+      'GET /internal/apm/services/{serviceName}/transactions/charts/coldstart_rate_by_transaction_name',
+    params: t.type({
+      path: t.type({ serviceName: t.string }),
+      query: t.intersection([
+        t.type({ transactionType: t.string, transactionName: t.string }),
+        t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/error_rate.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/error_rate.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import {
+  kueryRt,
+  rangeRt,
+  offsetRt,
+  filtersRt,
+  serviceTransactionDataSourceRt,
+} from '../../default_api_types';
+
+export interface FailedTransactionRateResponse {
+  currentPeriod: {
+    timeseries: Coordinate[];
+    average: number | null;
+  };
+  previousPeriod: {
+    timeseries: Coordinate[];
+    average: number | null;
+  };
+}
+
+export const transactionChartsErrorRateRoute = defineRoute<FailedTransactionRateResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/transactions/charts/error_rate',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.type({ transactionType: t.string, bucketSizeInSeconds: toNumberRt }),
+      t.partial({ transactionName: t.string, filters: filtersRt }),
+      t.intersection([environmentRt, kueryRt, rangeRt, offsetRt, serviceTransactionDataSourceRt]),
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/groups_detailed_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/groups_detailed_statistics.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { jsonRt, toBooleanRt, toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt, latencyAggregationTypeRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt, offsetRt, transactionDataSourceRt } from '../../default_api_types';
+
+export interface ServiceTransactionGroupDetailedStat {
+  transactionName: string;
+  latency: Coordinate[];
+  throughput: Coordinate[];
+  errorRate: Coordinate[];
+  impact: number;
+}
+
+export interface ServiceTransactionGroupDetailedStatisticsResponse {
+  currentPeriod: Record<string, ServiceTransactionGroupDetailedStat>;
+  previousPeriod: Record<string, ServiceTransactionGroupDetailedStat>;
+}
+
+export const transactionGroupsDetailedStatisticsRoute =
+  defineRoute<ServiceTransactionGroupDetailedStatisticsResponse>()({
+    endpoint: 'GET /internal/apm/services/{serviceName}/transactions/groups/detailed_statistics',
+    params: t.type({
+      path: t.type({ serviceName: t.string }),
+      query: t.intersection([
+        environmentRt,
+        kueryRt,
+        rangeRt,
+        t.intersection([
+          offsetRt,
+          transactionDataSourceRt,
+          t.type({
+            bucketSizeInSeconds: toNumberRt,
+            useDurationSummary: toBooleanRt,
+          }),
+        ]),
+        t.type({
+          transactionNames: jsonRt.pipe(t.array(t.string)),
+          transactionType: t.string,
+          latencyAggregationType: latencyAggregationTypeRt,
+        }),
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/groups_main_statistics.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/groups_main_statistics.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt } from '@kbn/io-ts-utils';
+import { environmentRt, latencyAggregationTypeRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { rangeRt, transactionDataSourceRt } from '../../default_api_types';
+
+export interface MergedServiceTransactionGroupsResponse {
+  transactionGroups: Array<{
+    alertsCount: number;
+    name: string;
+    transactionType?: string;
+    latency?: number | null;
+    throughput?: number;
+    errorRate?: number;
+    impact?: number;
+  }>;
+  maxCountExceeded: boolean;
+  transactionOverflowCount: number;
+  hasActiveAlerts: boolean;
+}
+
+export const transactionGroupsMainStatisticsRoute =
+  defineRoute<MergedServiceTransactionGroupsResponse>()({
+    endpoint: 'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics',
+    params: t.type({
+      path: t.type({ serviceName: t.string }),
+      query: t.intersection([
+        t.partial({ searchQuery: t.string }),
+        environmentRt,
+        rangeRt,
+        t.type({
+          kuery: t.string,
+          useDurationSummary: toBooleanRt,
+          transactionType: t.string,
+          latencyAggregationType: latencyAggregationTypeRt,
+        }),
+        transactionDataSourceRt,
+      ]),
+    }),
+  });

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/index.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/index.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { transactionGroupsMainStatisticsRoute } from './groups_main_statistics';
+import { transactionGroupsDetailedStatisticsRoute } from './groups_detailed_statistics';
+import { transactionLatencyChartsRoute } from './latency_charts';
+import { transactionTraceSamplesRoute } from './trace_samples';
+import { transactionChartsBreakdownRoute } from './breakdown';
+import { transactionChartsErrorRateRoute } from './error_rate';
+import { transactionChartsColdstartRateRoute } from './coldstart_rate';
+import { transactionChartsColdstartRateByTransactionNameRoute } from './coldstart_rate_by_transaction_name';
+
+export const transactionsRouteDefinitions = {
+  groupsMainStatistics: transactionGroupsMainStatisticsRoute,
+  groupsDetailedStatistics: transactionGroupsDetailedStatisticsRoute,
+  latencyCharts: transactionLatencyChartsRoute,
+  traceSamples: transactionTraceSamplesRoute,
+  chartsBreakdown: transactionChartsBreakdownRoute,
+  chartsErrorRate: transactionChartsErrorRateRoute,
+  chartsColdstartRate: transactionChartsColdstartRateRoute,
+  chartsColdstartRateByTransactionName: transactionChartsColdstartRateByTransactionNameRoute,
+};
+
+export type { MergedServiceTransactionGroupsResponse } from './groups_main_statistics';
+export type {
+  ServiceTransactionGroupDetailedStatisticsResponse,
+  ServiceTransactionGroupDetailedStat,
+} from './groups_detailed_statistics';
+export type { TransactionLatencyResponse } from './latency_charts';
+export type { TransactionTraceSamplesResponse } from './trace_samples';
+export type { TransactionBreakdownResponse } from './breakdown';
+export type { FailedTransactionRateResponse } from './error_rate';
+export type { ColdstartRateResponse } from './coldstart_rate';
+export type { ColdstartRateByTransactionNameResponse } from './coldstart_rate_by_transaction_name';

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/latency_charts.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/latency_charts.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toBooleanRt, toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt, latencyAggregationTypeRt, type Coordinate } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import {
+  kueryRt,
+  rangeRt,
+  offsetRt,
+  filtersRt,
+  serviceTransactionDataSourceRt,
+} from '../../default_api_types';
+
+export interface TransactionLatencyResponse {
+  currentPeriod: {
+    overallAvgDuration: number | null;
+    latencyTimeseries: Coordinate[];
+  };
+  previousPeriod: {
+    overallAvgDuration: number | null;
+    latencyTimeseries: Coordinate[];
+  };
+}
+
+export const transactionLatencyChartsRoute = defineRoute<TransactionLatencyResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/transactions/charts/latency',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.type({
+        latencyAggregationType: latencyAggregationTypeRt,
+        bucketSizeInSeconds: toNumberRt,
+        useDurationSummary: toBooleanRt,
+      }),
+      t.partial({ transactionType: t.string, transactionName: t.string, filters: filtersRt }),
+      t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
+      serviceTransactionDataSourceRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/trace_samples.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/trace_samples.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { environmentRt } from '@kbn/apm-types';
+import { defineRoute } from '../types';
+import { kueryRt, rangeRt } from '../../default_api_types';
+
+export interface TransactionTraceSamplesResponse {
+  traceSamples: Array<{
+    score: number | null | undefined;
+    timestamp: string;
+    transactionId: string;
+    traceId: string;
+  }>;
+}
+
+export const transactionTraceSamplesRoute = defineRoute<TransactionTraceSamplesResponse>()({
+  endpoint: 'GET /internal/apm/services/{serviceName}/transactions/traces/samples',
+  params: t.type({
+    path: t.type({ serviceName: t.string }),
+    query: t.intersection([
+      t.type({ transactionType: t.string, transactionName: t.string }),
+      t.partial({
+        transactionId: t.string,
+        traceId: t.string,
+        sampleRangeFrom: toNumberRt,
+        sampleRangeTo: toNumberRt,
+      }),
+      environmentRt,
+      kueryRt,
+      rangeRt,
+    ]),
+  }),
+});

--- a/src/platform/packages/shared/kbn-apm-api-shared/src/routes/types.ts
+++ b/src/platform/packages/shared/kbn-apm-api-shared/src/routes/types.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { RouteParamsRT, ServerRoute } from '@kbn/server-route-repository-utils';
+
+declare const __response: unique symbol;
+
+export interface WithResponse<T> {
+  readonly [__response]: T;
+}
+
+export type ExtractResponse<T> = T extends WithResponse<infer R>
+  ? R extends void
+    ? void
+    : R extends Record<string, any>
+    ? R
+    : Record<string, never>
+  : Record<string, never>;
+
+export function defineRoute<TResponse extends Record<string, any> | void | null>() {
+  return <
+    const TEndpoint extends string,
+    TParams extends RouteParamsRT | undefined = undefined
+  >(config: {
+    endpoint: TEndpoint;
+    params?: TParams;
+  }) => config as typeof config & WithResponse<TResponse>;
+}
+
+export type BuildRepository<T extends Record<string, { endpoint: string; params?: any }>> = {
+  [K in keyof T as T[K]['endpoint']]: ServerRoute<
+    T[K]['endpoint'],
+    T[K]['params'],
+    any,
+    ExtractResponse<T[K]>,
+    any
+  >;
+};
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
+  ? I
+  : never;
+
+export type BuildGroupedRepository<
+  T extends Record<string, Record<string, { endpoint: string; params?: any }>>
+> = UnionToIntersection<{ [K in keyof T]: BuildRepository<T[K]> }[keyof T]>;

--- a/src/platform/packages/shared/kbn-apm-api-shared/tsconfig.json
+++ b/src/platform/packages/shared/kbn-apm-api-shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["target/**/*"],
+  "kbn_references": [
+    "@kbn/server-route-repository-utils",
+    "@kbn/core-http-browser"
+  ]
+}


### PR DESCRIPTION
## Summary
- Creates `@kbn/apm-api-shared` package with route contracts and typed API client
- Includes `defineRoute()` factory, `BuildGroupedRepository` type machinery
- `createCallApmApiV2()` typed API client creator
- All route definitions for every APM server endpoint

**PR Stack:** 2/5 — depends on #268926. Next: https://github.com/elastic/kibana/pull/268928
## Test plan
- [ ] Package compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)