### PR TITLE
[Sig Events] Add filtering for Discoveries API endpoint

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/sig_events/discoveries/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/sig_events/discoveries/index.ts
@@ -9,12 +9,16 @@ import { z } from '@kbn/zod/v4';
 
 export const discoverySchema = z.object({
   '@timestamp': z.iso.datetime(),
+  kind: z.enum(['finding', 'clearance']),
   status: z.string().optional(),
   discovery_id: z.string(),
   discovery_slug: z.string(),
+  closes: z.string().optional(),
+  grouped_into: z.string().optional(),
+  closed_by_execution_id: z.string().optional(),
   rule_names: z.array(z.string()),
   stream_names: z.array(z.string()),
-  grouped_discovery_ids: z.array(z.string()),
+  grouped_discovery_ids: z.array(z.string()).optional(),
   title: z.string().optional(),
   summary: z.string().optional(),
   root_cause: z.string().optional(),

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/detections/detection_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/detections/detection_client.ts
@@ -8,6 +8,7 @@
 import type { IDataStreamClient } from '@kbn/data-streams';
 import { esql } from '@elastic/esql';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import { andWhere } from '../esql_utils';
 import { type CommonSearchOptions } from '../query_utils';
 import { type LatestSourceWhereCondition, runLatestSourceEsqlQuery } from '../latest_source_query';
 import {
@@ -35,13 +36,6 @@ export interface DetectionsSearchOptions extends CommonSearchOptions {
     to?: string;
   };
 }
-
-const andWhere = (
-  current: LatestSourceWhereCondition | undefined,
-  next: LatestSourceWhereCondition
-): LatestSourceWhereCondition => {
-  return current ? esql.exp`${current} AND ${next}` : next;
-};
 
 export class DetectionClient {
   constructor(

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/discoveries/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/discoveries/data_stream.ts
@@ -16,9 +16,13 @@ export const discoveriesMappings = {
   dynamic: false,
   properties: {
     '@timestamp': mappings.date({ format: 'strict_date_optional_time' }),
+    kind: mappings.keyword(),
     status: mappings.keyword(),
     discovery_id: mappings.keyword(),
     discovery_slug: mappings.keyword(),
+    closes: mappings.keyword(),
+    grouped_into: mappings.keyword(),
+    closed_by_execution_id: mappings.keyword(),
     rule_names: mappings.keyword(),
     stream_names: mappings.keyword(),
     grouped_discovery_ids: mappings.keyword(),
@@ -45,7 +49,7 @@ export const discoveriesDataStream: DataStreamDefinition<
   StoredDiscovery
 > = {
   name: DISCOVERIES_DATA_STREAM,
-  version: 1,
+  version: 2,
   hidden: true,
   template: {
     priority: 500,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/discoveries/discovery_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/discoveries/discovery_client.ts
@@ -6,9 +6,11 @@
  */
 
 import type { IDataStreamClient } from '@kbn/data-streams';
+import { esql } from '@elastic/esql';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import { andWhere } from '../esql_utils';
 import { type CommonSearchOptions } from '../query_utils';
-import { runLatestSourceEsqlQuery } from '../latest_source_query';
+import { type LatestSourceWhereCondition, runLatestSourceEsqlQuery } from '../latest_source_query';
 import {
   DISCOVERIES_DATA_STREAM,
   type Discovery,
@@ -20,6 +22,17 @@ export type DiscoveryDataStreamClient = IDataStreamClient<
   typeof discoveriesMappings,
   StoredDiscovery
 >;
+
+export interface DiscoveriesSearchOptions extends CommonSearchOptions {
+  kind?: 'finding' | 'clearance';
+  discovery_id?: string;
+  discovery_slug?: string[];
+  closes?: string;
+  was_grouped?: boolean;
+  rule_names?: string[];
+  stream_names?: string[];
+  closed_by_execution_id?: string;
+}
 
 export class DiscoveryClient {
   constructor(
@@ -37,12 +50,73 @@ export class DiscoveryClient {
     });
   }
 
-  async findLatest(options: CommonSearchOptions = {}): Promise<{ hits: Discovery[] }> {
+  async findLatest(options: DiscoveriesSearchOptions = {}): Promise<{ hits: Discovery[] }> {
+    let where: LatestSourceWhereCondition | undefined;
+
+    if (options.kind) {
+      where = andWhere(where, esql.exp`${esql.col('kind')} == ${esql.str(options.kind)}`);
+    }
+
+    if (options.discovery_id) {
+      where = andWhere(
+        where,
+        esql.exp`${esql.col('discovery_id')} == ${esql.str(options.discovery_id)}`
+      );
+    }
+
+    if (options.discovery_slug?.length) {
+      const discoverySlugLiterals = options.discovery_slug.map((discoverySlug) =>
+        esql.str(discoverySlug)
+      );
+      where = andWhere(
+        where,
+        esql.exp`${esql.col('discovery_slug')} IN (${discoverySlugLiterals})`
+      );
+    }
+
+    if (options.closes) {
+      where = andWhere(where, esql.exp`${esql.col('closes')} == ${esql.str(options.closes)}`);
+    }
+
+    if (options.was_grouped === true) {
+      where = andWhere(where, esql.exp`${esql.col('grouped_into')} IS NOT NULL`);
+    }
+
+    if (options.was_grouped === false) {
+      where = andWhere(where, esql.exp`${esql.col('grouped_into')} IS NULL`);
+    }
+
+    if (options.rule_names?.length) {
+      const ruleNamesLiterals = options.rule_names.map((ruleName) => esql.str(ruleName));
+      where = andWhere(
+        where,
+        esql.exp`MV_INTERSECTS(${esql.col('rule_names')}, [${ruleNamesLiterals}])`
+      );
+    }
+
+    if (options.stream_names?.length) {
+      const streamNamesLiterals = options.stream_names.map((streamName) => esql.str(streamName));
+      where = andWhere(
+        where,
+        esql.exp`MV_INTERSECTS(${esql.col('stream_names')}, [${streamNamesLiterals}])`
+      );
+    }
+
+    if (options.closed_by_execution_id) {
+      where = andWhere(
+        where,
+        esql.exp`${esql.col('closed_by_execution_id')} == ${esql.str(
+          options.closed_by_execution_id
+        )}`
+      );
+    }
+
     return runLatestSourceEsqlQuery<Discovery>({
       esClient: this.clients.esClient,
       space: this.clients.space,
       options,
       index: DISCOVERIES_DATA_STREAM,
+      where,
       groupBy: 'discovery_id',
     });
   }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/esql_utils.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/esql_utils.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { esql } from '@elastic/esql';
+import type { LatestSourceWhereCondition } from './latest_source_query';
+
+export const andWhere = (
+  current: LatestSourceWhereCondition | undefined,
+  next: LatestSourceWhereCondition
+): LatestSourceWhereCondition => {
+  return current ? esql.exp`${current} AND ${next}` : next;
+};
+
+export const orWhere = (
+  current: LatestSourceWhereCondition | undefined,
+  next: LatestSourceWhereCondition
+): LatestSourceWhereCondition => {
+  return current ? esql.exp`${current} OR ${next}` : next;
+};

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/discoveries/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/discoveries/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { discoverySchema, type Discovery } from '@kbn/streams-schema';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
 import { z } from '@kbn/zod/v4';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import { createServerRoute } from '../../../create_server_route';
@@ -27,6 +28,20 @@ const discoveriesSearchRoute = createServerRoute({
     query: z.object({
       from: z.iso.datetime().optional(),
       to: z.iso.datetime().optional(),
+      kind: z.enum(['finding', 'clearance']).optional(),
+      discovery_id: z.string().optional(),
+      discovery_slug: z
+        .union([z.string().transform((value) => [value]), z.array(z.string())])
+        .optional(),
+      closes: z.string().optional(),
+      was_grouped: BooleanFromString.optional(),
+      rule_names: z
+        .union([z.string().transform((value) => [value]), z.array(z.string())])
+        .optional(),
+      stream_names: z
+        .union([z.string().transform((value) => [value]), z.array(z.string())])
+        .optional(),
+      closed_by_execution_id: z.string().optional(),
     }),
   }),
   handler: async ({


### PR DESCRIPTION
This change adds filtering params to the Discoveries search endpoint required by the current [🔒 discoveries workflow](https://github.com/elastic/streams-program/blob/main/significant-events/discovery/workflows/discovery/workflow.yaml)