### PR TITLE
[Security Solution][Entity Analytics] Followups to new maintainer config engine: review-comment renames + customActor data-loss fix (unpushed change)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/__snapshots__/configs.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/__snapshots__/configs.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ACCESSES_ENGINE_CONFIGS golden snapshots aws_cloudtrail: targets-per-actor ES|QL is locked 1`] = `
+exports[`ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS golden snapshots aws_cloudtrail: targets-per-actor ES|QL is locked 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-aws.cloudtrail-__namespace__
 | WHERE event.module == \\"aws\\"
@@ -41,7 +41,7 @@ true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace
 | LIMIT 3500"
 `;
 
-exports[`ACCESSES_ENGINE_CONFIGS golden snapshots elastic_defend: targets-per-actor ES|QL is locked 1`] = `
+exports[`ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS golden snapshots elastic_defend: targets-per-actor ES|QL is locked 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-endpoint.events.security-__namespace__
 | WHERE event.action == \\"log_on\\"
@@ -82,7 +82,7 @@ true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace
 | LIMIT 3500"
 `;
 
-exports[`ACCESSES_ENGINE_CONFIGS golden snapshots system_auth: targets-per-actor ES|QL is locked 1`] = `
+exports[`ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS golden snapshots system_auth: targets-per-actor ES|QL is locked 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-system.auth-__namespace__
 | WHERE event.category IN (\\"authentication\\", \\"session\\")
@@ -123,7 +123,7 @@ true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace
 | LIMIT 3500"
 `;
 
-exports[`ACCESSES_ENGINE_CONFIGS golden snapshots system_security: targets-per-actor ES|QL is locked 1`] = `
+exports[`ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS golden snapshots system_security: targets-per-actor ES|QL is locked 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-system.security-__namespace__
 | WHERE event.action IN (\\"logged-in\\", \\"logged-in-explicit\\")

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.test.ts
@@ -5,19 +5,19 @@
  * 2.0.
  */
 
-import { ACCESSES_ENGINE_CONFIGS } from './configs';
+import { ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS } from './configs';
 import { buildActorDiscoveryQuery } from '../engine/build_actor_discovery_query';
 import { buildTargetsPerActorQuery } from '../engine/build_targets_per_actor_query';
 import { COMPOSITE_PAGE_SIZE } from '../engine/constants';
 import type { BucketedRelationshipIntegrationConfig } from '../engine/types';
 
-const bucketedConfigs = ACCESSES_ENGINE_CONFIGS.filter(
+const bucketedConfigs = ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS.filter(
   (c): c is BucketedRelationshipIntegrationConfig => c.kind === 'bucketed'
 );
 
-describe('ACCESSES_ENGINE_CONFIGS', () => {
+describe('ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS', () => {
   it('ships exactly the four expected integrations', () => {
-    expect(ACCESSES_ENGINE_CONFIGS.map((c) => c.id).sort()).toEqual([
+    expect(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS.map((c) => c.id).sort()).toEqual([
       'aws_cloudtrail',
       'elastic_defend',
       'system_auth',
@@ -26,15 +26,15 @@ describe('ACCESSES_ENGINE_CONFIGS', () => {
   });
 
   it('declares kind: "bucketed" on every accesses config (access-count classification is the contract)', () => {
-    for (const config of ACCESSES_ENGINE_CONFIGS) {
+    for (const config of ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS) {
       expect(config.kind).toBe('bucketed');
     }
     // Sanity-check that the typed filter lined up with the runtime assertion.
-    expect(bucketedConfigs).toHaveLength(ACCESSES_ENGINE_CONFIGS.length);
+    expect(bucketedConfigs).toHaveLength(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS.length);
   });
 
   it('declares targetEntityType "host" on every config (accesses is host-targeted)', () => {
-    for (const config of ACCESSES_ENGINE_CONFIGS) {
+    for (const config of ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS) {
       expect(config.targetEntityType).toBe('host');
     }
   });
@@ -50,12 +50,12 @@ describe('ACCESSES_ENGINE_CONFIGS', () => {
   });
 
   it('requires a target-EUID-exists gate on every accesses config (Step1/Step2 consistency)', () => {
-    for (const config of ACCESSES_ENGINE_CONFIGS) {
+    for (const config of ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS) {
       expect(config.requireTargetEntityIdExists).toBe(true);
     }
   });
 
-  it.each(ACCESSES_ENGINE_CONFIGS)(
+  it.each(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS)(
     '$id: builds a syntactically-locked actor discovery query',
     (config) => {
       const query = buildActorDiscoveryQuery(config, undefined) as {
@@ -70,7 +70,7 @@ describe('ACCESSES_ENGINE_CONFIGS', () => {
     }
   );
 
-  it.each(ACCESSES_ENGINE_CONFIGS)(
+  it.each(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS)(
     '$id: builds a syntactically-locked targets-per-actor ES|QL query',
     (config) => {
       const query = buildTargetsPerActorQuery(config, 'default');
@@ -84,7 +84,7 @@ describe('ACCESSES_ENGINE_CONFIGS', () => {
     }
   );
 
-  it.each(ACCESSES_ENGINE_CONFIGS)(
+  it.each(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS)(
     '$id: emits both bucket-relationship STATS columns',
     (config) => {
       const query = buildTargetsPerActorQuery(config, 'default');
@@ -93,7 +93,7 @@ describe('ACCESSES_ENGINE_CONFIGS', () => {
     }
   );
 
-  it.each(ACCESSES_ENGINE_CONFIGS)(
+  it.each(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS)(
     '$id: filters on event.outcome == "success" in both Step 1 and Step 2',
     (config) => {
       // Step 1: composite-agg additional filter array contains a success term.
@@ -106,7 +106,7 @@ describe('ACCESSES_ENGINE_CONFIGS', () => {
     }
   );
 
-  it.each(ACCESSES_ENGINE_CONFIGS)(
+  it.each(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS)(
     '$id: indexPattern is namespace-templated (namespace appears verbatim in the index name)',
     (config) => {
       expect(config.indexPattern('myns')).toContain('-myns');
@@ -122,7 +122,7 @@ describe('ACCESSES_ENGINE_CONFIGS', () => {
   // Golden snapshots: any future template change will surface here in PR review.
   // Update with `--ci=false -u` only when the change is intentional and reviewed.
   describe('golden snapshots', () => {
-    it.each(ACCESSES_ENGINE_CONFIGS)('$id: targets-per-actor ES|QL is locked', (config) => {
+    it.each(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS)('$id: targets-per-actor ES|QL is locked', (config) => {
       expect(buildTargetsPerActorQuery(config, '__namespace__')).toMatchSnapshot();
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.test.ts
@@ -122,8 +122,11 @@ describe('ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS', () => {
   // Golden snapshots: any future template change will surface here in PR review.
   // Update with `--ci=false -u` only when the change is intentional and reviewed.
   describe('golden snapshots', () => {
-    it.each(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS)('$id: targets-per-actor ES|QL is locked', (config) => {
-      expect(buildTargetsPerActorQuery(config, '__namespace__')).toMatchSnapshot();
-    });
+    it.each(ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS)(
+      '$id: targets-per-actor ES|QL is locked',
+      (config) => {
+        expect(buildTargetsPerActorQuery(config, '__namespace__')).toMatchSnapshot();
+      }
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.ts
@@ -27,7 +27,7 @@ const ACCESSES_BUCKETING = {
   belowThresholdRelationship: 'accesses_infrequently',
 } as const;
 
-export const ACCESSES_ENGINE_CONFIGS: RelationshipIntegrationConfig[] = [
+export const ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipIntegrationConfig[] = [
   {
     kind: 'bucketed',
     id: 'elastic_defend',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/index.ts
@@ -7,8 +7,8 @@
 
 import type { RegisterEntityMaintainerConfig } from '@kbn/entity-store/server';
 
-import { runGenericMaintainer } from '../engine/run_relationship_maintainer';
-import { ACCESSES_ENGINE_CONFIGS } from './configs';
+import { runRelationshipMaintainer } from '../engine/run_relationship_maintainer';
+import { ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS } from './configs';
 
 export const accessesFrequentlyMaintainer: RegisterEntityMaintainerConfig = {
   id: 'accesses_frequently_and_infrequently',
@@ -19,12 +19,12 @@ export const accessesFrequentlyMaintainer: RegisterEntityMaintainerConfig = {
   run: async ({ esClient, logger, status, crudClient, abortController }) => {
     const namespace = status.metadata.namespace;
     logger.info('Starting accesses maintainer run');
-    const result = await runGenericMaintainer({
+    const result = await runRelationshipMaintainer({
       esClient,
       logger,
       namespace,
       crudClient,
-      integrations: ACCESSES_ENGINE_CONFIGS,
+      integrations: ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS,
       abortController,
     });
     logger.info(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/__snapshots__/configs.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/__snapshots__/configs.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`COMMUNICATES_WITH_ENGINE_CONFIGS golden snapshots aws_cloudtrail: targets-per-actor ES|QL is locked 1`] = `
+exports[`COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS golden snapshots aws_cloudtrail: targets-per-actor ES|QL is locked 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-aws.cloudtrail-__namespace__
 | WHERE aws.cloudtrail.user_identity.type IN (\\"IAMUser\\", \\"AssumedRole\\", \\"Root\\", \\"FederatedUser\\", \\"IdentityCenterUser\\")
@@ -28,7 +28,7 @@ true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace
 | LIMIT 3500"
 `;
 
-exports[`COMMUNICATES_WITH_ENGINE_CONFIGS golden snapshots azure_auditlogs: targets-per-actor ES|QL is locked 1`] = `
+exports[`COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS golden snapshots azure_auditlogs: targets-per-actor ES|QL is locked 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-azure.auditlogs-__namespace__
 | WHERE azure.auditlogs.properties.initiated_by.user.userPrincipalName IS NOT NULL
@@ -49,7 +49,7 @@ FROM logs-azure.auditlogs-__namespace__
 | LIMIT 3500"
 `;
 
-exports[`COMMUNICATES_WITH_ENGINE_CONFIGS golden snapshots jamf_pro: targets-per-actor ES|QL is locked 1`] = `
+exports[`COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS golden snapshots jamf_pro: targets-per-actor ES|QL is locked 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-jamf_pro.events-__namespace__
 | WHERE user.name IS NOT NULL
@@ -79,7 +79,7 @@ true, CASE((user.email IS NOT NULL AND user.email != \\"\\" AND entity.namespace
 | LIMIT 3500"
 `;
 
-exports[`COMMUNICATES_WITH_ENGINE_CONFIGS golden snapshots okta: targets-per-actor ES|QL is locked 1`] = `
+exports[`COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS golden snapshots okta: targets-per-actor ES|QL is locked 1`] = `
 "SET unmapped_fields=\\"nullify\\";
 FROM logs-okta.system-__namespace__
 | WHERE event.action IN (\\"user.lifecycle.create\\", \\"user.lifecycle.activate\\", \\"user.lifecycle.deactivate\\", \\"user.lifecycle.suspend\\", \\"user.lifecycle.unsuspend\\", \\"group.user_membership.add\\", \\"group.user_membership.remove\\", \\"application.user_membership.add\\", \\"application.user_membership.remove\\", \\"application.user_membership.change_username\\")

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.test.ts
@@ -182,6 +182,27 @@ describe('COMMUNICATES_WITH_ENGINE_CONFIGS', () => {
       expect(query).toContain('targetEntityId != "user:@entra_id"');
       expect(query).toContain('targetEntityId != "host:"');
     });
+
+    // Regression: every config — including `kind: 'override'` — runs through
+    // Step 1 actor discovery. Before the fix, Step 1 hardcoded an ECS
+    // user-EUID-exists base filter, so Azure auditlogs documents (which have
+    // only `azure.auditlogs.properties.initiated_by.user.userPrincipalName`
+    // and no ECS `user.*` fields) were silently dropped at Step 1, and the
+    // override Step 2 never executed. This test locks in the fix: Step 1
+    // must use the customActor field as the actor-presence gate, not ECS
+    // user.*.
+    it('actor-discovery (Step 1) uses customActor.fields — not ECS user.* — as the actor-presence gate', () => {
+      const query = JSON.stringify(buildActorDiscoveryQuery(azure!, undefined));
+      // The Azure UPN field is required to be non-empty (composite source +
+      // base presence filter both reference it).
+      expect(query).toContain('azure.auditlogs.properties.initiated_by.user.userPrincipalName');
+      // The base filter does NOT depend on ECS user.* fields. (We assert via
+      // exact field-name strings rather than a snapshot to keep the test
+      // resilient to unrelated DSL formatting changes.)
+      expect(query).not.toContain('"user.email"');
+      expect(query).not.toContain('"user.id"');
+      expect(query).not.toContain('"user.name"');
+    });
   });
 
   describe('non-override configs share the COALESCE empty-guard form', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { COMMUNICATES_WITH_ENGINE_CONFIGS } from './configs';
+import { COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS } from './configs';
 import { buildActorDiscoveryQuery } from '../engine/build_actor_discovery_query';
 import { buildTargetsPerActorQuery } from '../engine/build_targets_per_actor_query';
 import { COMPOSITE_PAGE_SIZE } from '../engine/constants';
@@ -14,16 +14,16 @@ import type {
   OverrideRelationshipIntegrationConfig,
 } from '../engine/types';
 
-const standardConfigs = COMMUNICATES_WITH_ENGINE_CONFIGS.filter(
+const standardConfigs = COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS.filter(
   (c): c is StandardRelationshipIntegrationConfig => c.kind === 'standard'
 );
-const overrideConfigs = COMMUNICATES_WITH_ENGINE_CONFIGS.filter(
+const overrideConfigs = COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS.filter(
   (c): c is OverrideRelationshipIntegrationConfig => c.kind === 'override'
 );
 
-describe('COMMUNICATES_WITH_ENGINE_CONFIGS', () => {
+describe('COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS', () => {
   it('ships exactly the four expected integrations', () => {
-    expect(COMMUNICATES_WITH_ENGINE_CONFIGS.map((c) => c.id).sort()).toEqual([
+    expect(COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS.map((c) => c.id).sort()).toEqual([
       'aws_cloudtrail',
       'azure_auditlogs',
       'jamf_pro',
@@ -38,16 +38,16 @@ describe('COMMUNICATES_WITH_ENGINE_CONFIGS', () => {
   });
 
   it('uses only kind: "standard" or "override" (no bucketing — communicates_with is a flat targets list)', () => {
-    for (const config of COMMUNICATES_WITH_ENGINE_CONFIGS) {
+    for (const config of COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS) {
       expect(['standard', 'override']).toContain(config.kind);
     }
     // Sanity-check that filtered partitions cover every config.
     expect(standardConfigs.length + overrideConfigs.length).toBe(
-      COMMUNICATES_WITH_ENGINE_CONFIGS.length
+      COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS.length
     );
   });
 
-  it.each(COMMUNICATES_WITH_ENGINE_CONFIGS)(
+  it.each(COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS)(
     '$id: builds a syntactically-locked actor discovery query',
     (config) => {
       const query = buildActorDiscoveryQuery(config, undefined) as {
@@ -61,7 +61,7 @@ describe('COMMUNICATES_WITH_ENGINE_CONFIGS', () => {
     }
   );
 
-  it.each(COMMUNICATES_WITH_ENGINE_CONFIGS)(
+  it.each(COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS)(
     '$id: indexPattern is namespace-templated',
     (config) => {
       expect(config.indexPattern('myns')).toContain('-myns');
@@ -70,7 +70,7 @@ describe('COMMUNICATES_WITH_ENGINE_CONFIGS', () => {
   );
 
   describe('host-targeted configs (require Step1/Step2 EUID-exists consistency)', () => {
-    const hostTargeted = COMMUNICATES_WITH_ENGINE_CONFIGS.filter(
+    const hostTargeted = COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS.filter(
       (c) => c.targetEntityType === 'host'
     );
 
@@ -222,7 +222,7 @@ describe('COMMUNICATES_WITH_ENGINE_CONFIGS', () => {
   // Golden snapshots: any future template change will surface here in PR review.
   // Update with `--ci=false -u` only when the change is intentional and reviewed.
   describe('golden snapshots', () => {
-    it.each(COMMUNICATES_WITH_ENGINE_CONFIGS)(
+    it.each(COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS)(
       '$id: targets-per-actor ES|QL is locked',
       (config) => {
         expect(buildTargetsPerActorQuery(config, '__namespace__')).toMatchSnapshot();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.ts
@@ -68,7 +68,7 @@ function buildAzureEsqlQuery(namespace: string): string {
 | LIMIT ${COMPOSITE_PAGE_SIZE}`;
 }
 
-export const COMMUNICATES_WITH_ENGINE_CONFIGS: RelationshipIntegrationConfig[] = [
+export const COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipIntegrationConfig[] = [
   {
     kind: 'standard',
     id: 'okta',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/index.ts
@@ -7,8 +7,8 @@
 
 import type { RegisterEntityMaintainerConfig } from '@kbn/entity-store/server';
 
-import { runGenericMaintainer } from '../engine/run_relationship_maintainer';
-import { COMMUNICATES_WITH_ENGINE_CONFIGS } from './configs';
+import { runRelationshipMaintainer } from '../engine/run_relationship_maintainer';
+import { COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS } from './configs';
 
 export const communicatesWithMaintainer: RegisterEntityMaintainerConfig = {
   id: 'communicates_with',
@@ -18,12 +18,12 @@ export const communicatesWithMaintainer: RegisterEntityMaintainerConfig = {
   run: async ({ esClient, logger, status, crudClient, abortController }) => {
     const namespace = status.metadata.namespace;
     logger.info('Starting communicates_with maintainer run');
-    const result = await runGenericMaintainer({
+    const result = await runRelationshipMaintainer({
       esClient,
       logger,
       namespace,
       crudClient,
-      integrations: COMMUNICATES_WITH_ENGINE_CONFIGS,
+      integrations: COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS,
       abortController,
     });
     logger.info(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_actor_discovery_query.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_actor_discovery_query.test.ts
@@ -155,6 +155,85 @@ describe('buildActorDiscoveryQuery (actor discovery)', () => {
     expect(JSON.stringify(result)).toContain('alice');
   });
 
+  // Regression: every config — including `kind: 'override'` — goes through
+  // Step 1 actor discovery. Hardcoding the ECS user-EUID-exists DSL filter
+  // here silently drops every document whose actor identity lives entirely
+  // in `customActor.fields` (e.g. Azure auditlogs docs that have only
+  // `azure.auditlogs.properties.initiated_by.user.userPrincipalName`), so
+  // Step 2 — including override Step 2s — never sees those actors.
+  describe('customActor base actor-presence filter (no ECS user.* dependency)', () => {
+    const customField = 'azure.auditlogs.properties.initiated_by.user.userPrincipalName';
+    const customActorConfig: RelationshipIntegrationConfig = {
+      ...communicatesConfig,
+      customActor: { fields: [customField] },
+    };
+
+    it('does NOT include the ECS user-EUID-exists DSL filter when customActor is set', () => {
+      const filters = (
+        buildActorDiscoveryQuery(customActorConfig, undefined) as {
+          query: { bool: { filter: Array<Record<string, unknown>> } };
+        }
+      ).query.bool.filter;
+      const userShape = JSON.stringify(USER_EUID_FILTER);
+      expect(filters.some((f) => JSON.stringify(f) === userShape)).toBe(false);
+    });
+
+    it('emits an "at least one of customActor.fields is non-empty" filter (each clause: exists AND != "")', () => {
+      const multiFieldConfig: RelationshipIntegrationConfig = {
+        ...communicatesConfig,
+        customActor: { fields: ['custom.actor.one', 'custom.actor.two'] },
+      };
+      const filters = (
+        buildActorDiscoveryQuery(multiFieldConfig, undefined) as {
+          query: { bool: { filter: Array<Record<string, unknown>> } };
+        }
+      ).query.bool.filter;
+      const presenceFilter = filters.find(
+        (f) =>
+          JSON.stringify(f).includes('custom.actor.one') &&
+          JSON.stringify(f).includes('custom.actor.two')
+      ) as
+        | {
+            bool: {
+              should: Array<{
+                bool: { must: Array<Record<string, unknown>> };
+              }>;
+              minimum_should_match: number;
+            };
+          }
+        | undefined;
+      expect(presenceFilter).toBeDefined();
+      expect(presenceFilter!.bool.minimum_should_match).toBe(1);
+      expect(presenceFilter!.bool.should).toHaveLength(2);
+      // Each clause requires the field to exist AND not equal the empty string.
+      const clauseFields = presenceFilter!.bool.should.map((s) => {
+        const exists = s.bool.must.find((m) => 'exists' in m) as
+          | { exists: { field: string } }
+          | undefined;
+        return exists?.exists.field;
+      });
+      expect(new Set(clauseFields)).toEqual(new Set(['custom.actor.one', 'custom.actor.two']));
+    });
+
+    it('preserves the existing requireTargetEntityIdExists target-EUID gate when set alongside customActor', () => {
+      const filters = (
+        buildActorDiscoveryQuery(
+          { ...customActorConfig, requireTargetEntityIdExists: true },
+          undefined
+        ) as { query: { bool: { filter: Array<Record<string, unknown>> } } }
+      ).query.bool.filter;
+      // The actor-side filter must NOT include the ECS user-EUID gate, but
+      // the target-side gate (parameterized by targetEntityType: 'user' for
+      // communicatesConfig) IS still emitted as a separate filter.
+      const userShape = JSON.stringify(USER_EUID_FILTER);
+      const userMatches = filters.filter((f) => JSON.stringify(f) === userShape).length;
+      // requireTargetEntityIdExists with targetEntityType 'user' adds the
+      // user-EUID filter once (target-side only); the actor side uses the
+      // custom-fields presence filter instead.
+      expect(userMatches).toBe(1);
+    });
+  });
+
   it('includes afterKey in composite sources when provided', () => {
     const afterKey = { 'user.name': 'alice', 'user.email': null };
     const result = buildActorDiscoveryQuery(accessesConfig, afterKey);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_actor_discovery_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_actor_discovery_query.ts
@@ -16,15 +16,47 @@ import { LOOKBACK_WINDOW, COMPOSITE_PAGE_SIZE } from './constants';
 // RelationshipIntegrationConfig to support host→host and service→* relationships.
 const USER_IDENTITY_FIELDS = getEuidSourceFields('user').requiresOneOf;
 
+/**
+ * "At least one of these fields exists and is non-empty" DSL.
+ *
+ * Used as the base actor-presence filter when the config supplies its own
+ * `customActor.fields`. The default path (no `customActor`) keeps using
+ * `euid.dsl.getEuidDocumentsContainsIdFilter('user')`, which carries the
+ * full ECS user-EUID semantics (including the `event.outcome != "failure"`
+ * baseline) — that behaviour is unchanged here. This helper exists only so
+ * configs whose actor identity lives outside ECS `user.*` (e.g. Azure
+ * auditlogs `…initiated_by.user.userPrincipalName`) are not silently
+ * filtered out by an ECS-shape requirement they cannot satisfy.
+ */
+const buildAnyActorFieldNonEmptyDsl = (fields: string[]): QueryDslQueryContainer => ({
+  bool: {
+    should: fields.map((field) => ({
+      bool: {
+        must: [{ exists: { field } }, { bool: { must_not: { term: { [field]: '' } } } }],
+      },
+    })),
+    minimum_should_match: 1,
+  },
+});
+
 export const buildActorDiscoveryQuery = (
   config: RelationshipIntegrationConfig,
   afterKey: CompositeAfterKey | undefined
 ): Record<string, unknown> => {
   const actorFields = config.customActor?.fields ?? USER_IDENTITY_FIELDS;
 
+  // Step 1 runs for every kind, including `kind: 'override'`. Hardcoding the
+  // user-EUID DSL filter here would silently drop documents whose actor
+  // identity lives entirely in `customActor.fields` (Azure auditlogs is the
+  // canonical case), and Step 2 — including override Step 2s — would never
+  // see those actors. Match the gate to the actor-fields the config declares.
+  const actorPresenceFilter: QueryDslQueryContainer = config.customActor
+    ? buildAnyActorFieldNonEmptyDsl(config.customActor.fields)
+    : euid.dsl.getEuidDocumentsContainsIdFilter('user');
+
   const baseFilters: QueryDslQueryContainer[] = [
     { range: { '@timestamp': { gte: LOOKBACK_WINDOW, lt: 'now' } } },
-    euid.dsl.getEuidDocumentsContainsIdFilter('user'),
+    actorPresenceFilter,
   ];
 
   if (config.requireTargetEntityIdExists) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_actor_discovery_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_actor_discovery_query.ts
@@ -12,8 +12,8 @@ import { getEuidSourceFields } from '@kbn/entity-store/common/domain/euid';
 import type { RelationshipIntegrationConfig, CompositeAfterKey, CompositeBucket } from './types';
 import { LOOKBACK_WINDOW, COMPOSITE_PAGE_SIZE } from './constants';
 
-// TODO(follow-up): actorEntityType is hardcoded to 'user' — add actorEntityType to
-// RelationshipIntegrationConfig to support host→host and service→* relationships.
+// TODO(#266748): actorEntityType is hardcoded to 'user' — add actorEntityType to
+// RelationshipIntegrationConfig to support host→host, host→service, and service→* relationships.
 const USER_IDENTITY_FIELDS = getEuidSourceFields('user').requiresOneOf;
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.test.ts
@@ -264,6 +264,54 @@ describe('buildTargetsPerActorQuery (targets per actor)', () => {
     });
   });
 
+  // Regression for the same shape of bug fixed in Step 1: when a config
+  // supplies `customActor`, the engine-injected userIdFilter (the
+  // `AND (...)` clause that follows `esqlWhereClause`) must be derived from
+  // `customActor.fields` rather than hardcoded to ECS `user.*`. Otherwise
+  // standard/bucketed configs that opt into a custom actor identity would
+  // silently produce zero rows in Step 2.
+  describe('customActor userId existence gate (no ECS user.* dependency)', () => {
+    const customField = 'custom.actor.field';
+    const customActorConfig: RelationshipIntegrationConfig = {
+      ...commWithUserConfig,
+      customActor: {
+        fields: [customField],
+        evalOverride: `CONCAT("user:", ${customField}, "@custom")`,
+      },
+    };
+
+    it('does NOT include the ECS user-EUID-exists ES|QL filter when customActor is set', () => {
+      const query = buildTargetsPerActorQuery(customActorConfig, 'default');
+      expect(query).not.toContain(`AND (${USER_ESQL_EXISTS})`);
+    });
+
+    it('emits an "any of customActor.fields is non-empty" ES|QL gate immediately after the integration WHERE clause', () => {
+      const multiFieldConfig: RelationshipIntegrationConfig = {
+        ...commWithUserConfig,
+        customActor: {
+          fields: ['custom.actor.one', 'custom.actor.two'],
+          evalOverride: 'CONCAT("user:", custom.actor.one, "@custom")',
+        },
+      };
+      const query = buildTargetsPerActorQuery(multiFieldConfig, 'default');
+      expect(query).toContain('`custom.actor.one` IS NOT NULL');
+      expect(query).toContain('`custom.actor.one` != ""');
+      expect(query).toContain('`custom.actor.two` IS NOT NULL');
+      expect(query).toContain('`custom.actor.two` != ""');
+    });
+
+    it('keeps the requireTargetEntityIdExists target-EUID gate independent of customActor', () => {
+      const query = buildTargetsPerActorQuery(
+        { ...customActorConfig, targetEntityType: 'host', requireTargetEntityIdExists: true },
+        'default'
+      );
+      // Target-side gate is parameterized by targetEntityType, so the
+      // host-EUID gate is still present even though the actor is custom.
+      expect(query).toContain(`AND (${HOST_ESQL_EXISTS})`);
+      expect(query).not.toContain(`AND (${USER_ESQL_EXISTS})`);
+    });
+  });
+
   // Regression guard for an ES|QL quirk where `WHERE col IS NOT NULL`
   // evaluates to FALSE for every row when `col` is produced by CONCAT() over
   // a CASE() with nested CASE arms (as the user EUID actorEval does). Using

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.ts
@@ -40,7 +40,7 @@ function buildRelationshipEsql(
   namespace: string
 ): string {
   const indexPattern = config.indexPattern(namespace);
-  // TODO(follow-up): 'user' hardcoded for actor — thread actorEntityType through config.
+  // TODO(#266748): 'user' hardcoded for actor — thread actorEntityType through config.
   const userFieldEvals = !config.customActor?.evalOverride
     ? getFieldEvaluationsEsql('user')
     : undefined;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.ts
@@ -16,6 +16,25 @@ import type {
 import { COMPOSITE_PAGE_SIZE, ESQL_ENGINE_PREAMBLE } from './constants';
 import { ENGINE_COLUMNS } from './columns';
 
+/**
+ * "At least one of these fields exists and is non-empty" ES|QL fragment.
+ *
+ * Used as the actor-presence gate (the `AND (...)` clause appended after
+ * `esqlWhereClause`) when the config supplies its own `customActor.fields`.
+ * The default path (no `customActor`) keeps using
+ * `euid.esql.getEuidDocumentsContainsIdFilter('user')` — same rationale as
+ * the parallel helper in `build_actor_discovery_query.ts`. Today no shipped
+ * `kind: 'standard' | 'bucketed'` config combines `customActor` with the
+ * default builder, but Step 1 and Step 2 must agree about the actor-presence
+ * gate so the inconsistency cannot reappear silently in a future config.
+ *
+ * Identifiers are backtick-wrapped so dotted-numeric segments (rare for
+ * actor fields today, but cheap insurance) round-trip safely.
+ */
+function buildAnyActorFieldNonEmptyEsql(fields: string[]): string {
+  return fields.map((field) => `(\`${field}\` IS NOT NULL AND \`${field}\` != "")`).join(' OR ');
+}
+
 function buildRelationshipEsql(
   config: StandardRelationshipIntegrationConfig | BucketedRelationshipIntegrationConfig,
   namespace: string
@@ -26,7 +45,9 @@ function buildRelationshipEsql(
     ? getFieldEvaluationsEsql('user')
     : undefined;
   const userFieldEvalsLine = userFieldEvals ? `| EVAL ${userFieldEvals}\n` : '';
-  const userIdFilter = euid.esql.getEuidDocumentsContainsIdFilter('user');
+  const userIdFilter = config.customActor
+    ? buildAnyActorFieldNonEmptyEsql(config.customActor.fields)
+    : euid.esql.getEuidDocumentsContainsIdFilter('user');
   const actorEval =
     config.customActor?.evalOverride ?? euid.esql.getEuidEvaluation('user', { withTypeId: true });
   const targetEval =

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/parse_targets_per_actor_rows.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/parse_targets_per_actor_rows.ts
@@ -8,7 +8,7 @@
 import type { Logger } from '@kbn/logging';
 import type { EntityRelationshipKey } from '@kbn/entity-store/common/domain/definitions/common_fields';
 
-import type { ProcessedEngineRecord, BucketTargetByThresholdConfig } from './types';
+import type { EntityRelationshipRecord, BucketTargetByThresholdConfig } from './types';
 import { ENGINE_COLUMNS } from './columns';
 
 interface EsqlColumn {
@@ -79,10 +79,10 @@ export const parseTargetsPerActorRows = (
   values: unknown[][],
   config: ParseConfig,
   logger: Logger
-): ProcessedEngineRecord[] => {
+): EntityRelationshipRecord[] => {
   warnIfOverrideColumnsMissing(columns, config, logger);
 
-  return values.map((row): ProcessedEngineRecord => {
+  return values.map((row): EntityRelationshipRecord => {
     const record: Record<string, unknown> = {};
     columns.forEach((col, idx) => {
       record[col.name] = row[idx];
@@ -91,7 +91,7 @@ export const parseTargetsPerActorRows = (
     const actorRaw = record[ENGINE_COLUMNS.actor];
     const actorUserId = actorRaw != null ? String(actorRaw) : null;
 
-    // TODO(follow-up): entityType hardcoded to 'user' — use actorEntityType from config.
+    // TODO(#266748): entityType hardcoded to 'user' — use actorEntityType from config.
     if (config.kind === 'bucketed') {
       const { aboveThresholdRelationship: above, belowThresholdRelationship: below } =
         config.bucketTargetByThreshold;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.test.ts
@@ -11,7 +11,7 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 import type { EntityUpdateClient } from '@kbn/entity-store/server';
 import { loggerMock } from '@kbn/logging-mocks';
 
-import { runGenericMaintainer } from './run_relationship_maintainer';
+import { runRelationshipMaintainer } from './run_relationship_maintainer';
 import { COMPOSITE_PAGE_SIZE, MAX_ITERATIONS } from './constants';
 import type { RelationshipIntegrationConfig } from './types';
 
@@ -110,13 +110,13 @@ const aborted = () => {
   return ac;
 };
 
-describe('runGenericMaintainer', () => {
+describe('runRelationshipMaintainer', () => {
   describe('namespace boundary validation (defense-in-depth)', () => {
     it('throws InvalidNamespaceError before issuing any ES request when namespace is malformed', async () => {
       const { esClient, search, esql } = makeEsClient();
       const { crudClient, bulkUpdate } = makeCrudClient();
       await expect(
-        runGenericMaintainer({
+        runRelationshipMaintainer({
           esClient,
           logger: loggerMock.create(),
           namespace: 'bad/value',
@@ -135,7 +135,7 @@ describe('runGenericMaintainer', () => {
       search.mockResolvedValue(successResponse([]));
       const { crudClient } = makeCrudClient();
       await expect(
-        runGenericMaintainer({
+        runRelationshipMaintainer({
           esClient,
           logger: loggerMock.create(),
           namespace: 'default',
@@ -164,7 +164,7 @@ describe('runGenericMaintainer', () => {
       });
       // bulkUpdate returns one 404 and one 500.
       const { crudClient } = makeCrudClient([{ status: 404 }, { status: 500 }]);
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -179,7 +179,7 @@ describe('runGenericMaintainer', () => {
       const { esClient, search } = makeEsClient();
       search.mockResolvedValue(successResponse([]));
       const { crudClient } = makeCrudClient();
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -198,7 +198,7 @@ describe('runGenericMaintainer', () => {
         return successResponse([]);
       });
       const { crudClient } = makeCrudClient();
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -214,7 +214,7 @@ describe('runGenericMaintainer', () => {
   it('returns zeros when no integrations are provided', async () => {
     const { esClient } = makeEsClient();
     const { crudClient, bulkUpdate } = makeCrudClient();
-    const result = await runGenericMaintainer({
+    const result = await runRelationshipMaintainer({
       esClient,
       logger: loggerMock.create(),
       namespace: 'default',
@@ -232,7 +232,7 @@ describe('runGenericMaintainer', () => {
     const { esClient } = makeEsClient();
     const { crudClient } = makeCrudClient();
     const before = new Date().toISOString();
-    const { lastRunTimestamp } = await runGenericMaintainer({
+    const { lastRunTimestamp } = await runRelationshipMaintainer({
       esClient,
       logger: loggerMock.create(),
       namespace: 'default',
@@ -249,7 +249,7 @@ describe('runGenericMaintainer', () => {
       const { esClient, search, esql } = makeEsClient();
       const { crudClient } = makeCrudClient();
       search.mockResolvedValueOnce(successResponse([]));
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -280,7 +280,7 @@ describe('runGenericMaintainer', () => {
         ],
         values: [],
       });
-      await runGenericMaintainer({
+      await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -309,7 +309,7 @@ describe('runGenericMaintainer', () => {
         columns: [{ name: 'actorUserId', type: 'keyword' }],
         values: [],
       });
-      await runGenericMaintainer({
+      await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -331,7 +331,7 @@ describe('runGenericMaintainer', () => {
       search.mockResolvedValue(successResponse(fullPage, { 'user.name': 'never-ends' }));
       esql.mockResolvedValue({ columns: [], values: [] });
       const logger = loggerMock.create();
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger,
         namespace: 'default',
@@ -355,7 +355,7 @@ describe('runGenericMaintainer', () => {
       const { crudClient, bulkUpdate } = makeCrudClient();
       search.mockRejectedValueOnce(indexNotFoundError());
       const logger = loggerMock.create();
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger,
         namespace: 'default',
@@ -376,7 +376,7 @@ describe('runGenericMaintainer', () => {
       search.mockRejectedValueOnce(responseErrorWithType('cluster_block_exception'));
       const logger = loggerMock.create();
       await expect(
-        runGenericMaintainer({
+        runRelationshipMaintainer({
           esClient,
           logger,
           namespace: 'default',
@@ -397,7 +397,7 @@ describe('runGenericMaintainer', () => {
       search.mockRejectedValueOnce(duckTyped);
       const logger = loggerMock.create();
       await expect(
-        runGenericMaintainer({
+        runRelationshipMaintainer({
           esClient,
           logger,
           namespace: 'default',
@@ -416,7 +416,7 @@ describe('runGenericMaintainer', () => {
         throw new Error('aborted');
       });
       const logger = loggerMock.create();
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger,
         namespace: 'default',
@@ -438,7 +438,7 @@ describe('runGenericMaintainer', () => {
       search.mockRejectedValueOnce(realEsError());
       const logger = loggerMock.create();
       await expect(
-        runGenericMaintainer({
+        runRelationshipMaintainer({
           esClient,
           logger,
           namespace: 'default',
@@ -463,7 +463,7 @@ describe('runGenericMaintainer', () => {
         throw new Error('aborted');
       });
       const logger = loggerMock.create();
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger,
         namespace: 'default',
@@ -487,7 +487,7 @@ describe('runGenericMaintainer', () => {
       esql.mockRejectedValueOnce(new Error('parsing_exception: line 1, column 5'));
       const logger = loggerMock.create();
       await expect(
-        runGenericMaintainer({
+        runRelationshipMaintainer({
           esClient,
           logger,
           namespace: 'default',
@@ -512,7 +512,7 @@ describe('runGenericMaintainer', () => {
         );
         esql.mockResolvedValueOnce({ values: [['user:alice@corp']] } as unknown as EsqlResponse);
         const logger = loggerMock.create();
-        const result = await runGenericMaintainer({
+        const result = await runRelationshipMaintainer({
           esClient,
           logger,
           namespace: 'default',
@@ -535,7 +535,7 @@ describe('runGenericMaintainer', () => {
           columns: [{ name: 'actorUserId', type: 'keyword' }],
         } as unknown as EsqlResponse);
         const logger = loggerMock.create();
-        const result = await runGenericMaintainer({
+        const result = await runRelationshipMaintainer({
           esClient,
           logger,
           namespace: 'default',
@@ -556,7 +556,7 @@ describe('runGenericMaintainer', () => {
         );
         esql.mockResolvedValueOnce({} as unknown as EsqlResponse);
         await expect(
-          runGenericMaintainer({
+          runRelationshipMaintainer({
             esClient,
             logger: loggerMock.create(),
             namespace: 'default',
@@ -572,7 +572,7 @@ describe('runGenericMaintainer', () => {
     it('does not call any ES API when aborted before the first integration', async () => {
       const { esClient, search, esql } = makeEsClient();
       const { crudClient, bulkUpdate } = makeCrudClient();
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -601,7 +601,7 @@ describe('runGenericMaintainer', () => {
       // Integration #2 should never reach the ES client. If it does, this
       // unmocked call would return undefined and the test would crash with
       // a TypeError — making the regression highly visible.
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -628,7 +628,7 @@ describe('runGenericMaintainer', () => {
         ac.abort();
         throw new Error('aborted');
       });
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -675,7 +675,7 @@ describe('runGenericMaintainer', () => {
         ],
         values: [['user:carol@okta', ['user:dave@okta']]],
       });
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -707,7 +707,7 @@ describe('runGenericMaintainer', () => {
       });
       // oktaConfig: 0 buckets — no records produced.
       search.mockResolvedValueOnce(successResponse([]));
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -739,7 +739,7 @@ describe('runGenericMaintainer', () => {
         ac.abort();
         return [];
       });
-      const result = await runGenericMaintainer({
+      const result = await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -761,7 +761,7 @@ describe('runGenericMaintainer', () => {
       const { crudClient } = makeCrudClient();
       search.mockResolvedValue(successResponse([]));
       esql.mockResolvedValue({ columns: [], values: [] });
-      await runGenericMaintainer({
+      await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'prod',
@@ -781,7 +781,7 @@ describe('runGenericMaintainer', () => {
         successResponse([{ key: { 'user.name': 'alice' }, doc_count: 1 }])
       );
       esql.mockResolvedValueOnce({ columns: [], values: [] });
-      await runGenericMaintainer({
+      await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -800,7 +800,7 @@ describe('runGenericMaintainer', () => {
       );
       esql.mockResolvedValueOnce({ columns: [], values: [] });
       const ac = new AbortController();
-      await runGenericMaintainer({
+      await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',
@@ -821,7 +821,7 @@ describe('runGenericMaintainer', () => {
         successResponse([{ key: { 'user.name': 'alice' }, doc_count: 1 }])
       );
       esql.mockResolvedValueOnce({ columns: [], values: [] });
-      await runGenericMaintainer({
+      await runRelationshipMaintainer({
         esClient,
         logger: loggerMock.create(),
         namespace: 'default',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.ts
@@ -15,7 +15,7 @@ import type {
   RelationshipIntegrationConfig,
   CompositeAfterKey,
   CompositeBucket,
-  ProcessedEngineRecord,
+  EntityRelationshipRecord,
 } from './types';
 import { buildActorDiscoveryQuery, buildActorPageFilter } from './build_actor_discovery_query';
 import { buildTargetsPerActorQuery } from './build_targets_per_actor_query';
@@ -163,7 +163,7 @@ async function runIntegration(
   let afterKey: CompositeAfterKey | undefined;
   let iterations = 0;
   let totalBuckets = 0;
-  const records: ProcessedEngineRecord[] = [];
+  const records: EntityRelationshipRecord[] = [];
   const transportOpts = abortController ? { signal: abortController.signal } : undefined;
 
   do {
@@ -224,7 +224,7 @@ async function runIntegration(
 }
 
 /**
- * Generic run loop for relationship maintainers.
+ * Run loop for relationship maintainers.
  * Iterates over the provided integration configs and runs the composite agg +
  * ES|QL pipeline for each, writing optimistic EUIDs directly to
  * `entity.relationships[relType].ids` after each integration completes.
@@ -238,7 +238,7 @@ async function runIntegration(
  * persists that integration's partial records (best-effort), then exits
  * the outer loop on the next iteration.
  */
-export const runGenericMaintainer = async ({
+export const runRelationshipMaintainer = async ({
   esClient,
   logger,
   namespace,
@@ -281,7 +281,7 @@ export const runGenericMaintainer = async ({
 
   for (const config of integrations) {
     if (abortController?.signal.aborted) {
-      logger.info('Generic maintainer aborted, skipping remaining integrations');
+      logger.info('Relationship maintainer aborted, skipping remaining integrations');
       break;
     }
     logger.info(`[${config.id}] Processing integration: ${config.name}`);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/types.ts
@@ -249,10 +249,31 @@ export type RelationshipIntegrationConfig =
   | OverrideRelationshipIntegrationConfig;
 
 /**
- * Output record from the generic postprocessor.
- * Each relationship's targets are stored as optimistic EUIDs computed in the ES|QL layer.
+ * Output record from the relationship-maintainer postprocessor.
+ *
+ * `entityType` is currently fixed to `'user'` because every shipped config
+ * computes its actor EUID via `getEuidEvaluation('user', …)` and the engine
+ * hardcodes `'user'` at every producer/builder site. Broadening to
+ * `'user' | 'host' | 'service'` is tracked under the actorEntityType
+ * follow-up (#266748). Agents/engineers implementing #266748 should change
+ * **all** of these sites in lockstep — `grep -rn "266748"` from the
+ * `maintainers/` root surfaces them:
+ *
+ *   1. `engine/types.ts` (this file) — widen `entityType` here and add
+ *      `actorEntityType` to `RelationshipIntegrationConfig`.
+ *   2. `engine/build_actor_discovery_query.ts` — Step 1 user-EUID existence
+ *      filter is parameterized on entity type.
+ *   3. `engine/build_targets_per_actor_query.ts` — Step 2 actor EVAL uses
+ *      `getEuidEvaluation('user', …)`; thread the configured type through.
+ *   4. `engine/parse_targets_per_actor_rows.ts` — drop the `'user' as const`
+ *      on the produced records.
+ *   5. `engine/update_entities.ts` — drop `type: 'user'` on the
+ *      `bulkUpdateEntity` payload.
+ *
+ * Step 1 of the customActor presence-gate fix already derives actor *fields*
+ * from `customActor.fields`; #266748 is what derives the actor *entity type*.
  */
-export interface ProcessedEngineRecord {
+export interface EntityRelationshipRecord {
   /** Full EUID with type prefix, e.g. "user:alice@okta". Null if actor eval failed. */
   entityId: string | null;
   entityType: 'user';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.test.ts
@@ -8,7 +8,7 @@
 import { loggerMock } from '@kbn/logging-mocks';
 import type { EntityUpdateClient } from '@kbn/entity-store/server';
 import { writeEntityIds } from './update_entities';
-import type { ProcessedEngineRecord } from './types';
+import type { EntityRelationshipRecord } from './types';
 
 const makeCrudClient = (errors: Array<{ status: number }> = []): EntityUpdateClient =>
   ({
@@ -25,7 +25,7 @@ describe('writeEntityIds', () => {
 
   it('skips records with null entityId', async () => {
     const crudClient = makeCrudClient();
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: null,
         entityType: 'user',
@@ -39,7 +39,7 @@ describe('writeEntityIds', () => {
 
   it('skips records where all relationship arrays are empty', async () => {
     const crudClient = makeCrudClient();
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: 'user:alice@corp',
         entityType: 'user',
@@ -56,7 +56,7 @@ describe('writeEntityIds', () => {
 
   it('calls bulkUpdateEntity with ids array per relType', async () => {
     const crudClient = makeCrudClient();
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: 'user:alice@corp',
         entityType: 'user',
@@ -77,7 +77,7 @@ describe('writeEntityIds', () => {
 
   it('merges records with the same entityId', async () => {
     const crudClient = makeCrudClient();
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: 'user:alice@corp',
         entityType: 'user',
@@ -101,7 +101,7 @@ describe('writeEntityIds', () => {
 
   it('returns updated/notFound/errors counts and counts only successfully updated entities in `updated`', async () => {
     const crudClient = makeCrudClient([{ status: 404 }]);
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: 'user:alice@corp',
         entityType: 'user',
@@ -119,7 +119,7 @@ describe('writeEntityIds', () => {
 
   it('separates 404 (notFound) from non-404 (errors) in the response counts', async () => {
     const crudClient = makeCrudClient([{ status: 404 }, { status: 500 }, { status: 503 }]);
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: 'user:alice@corp',
         entityType: 'user',
@@ -148,7 +148,7 @@ describe('writeEntityIds', () => {
   it('logs 404 (notFound) at info level — non-zero 404s are surfaced for the caller (was debug)', async () => {
     const logger = loggerMock.create();
     const crudClient = makeCrudClient([{ status: 404 }]);
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: 'user:alice@corp',
         entityType: 'user',
@@ -164,7 +164,7 @@ describe('writeEntityIds', () => {
   it('logs non-404 errors at error level', async () => {
     const logger = loggerMock.create();
     const crudClient = makeCrudClient([{ status: 500 }]);
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: 'user:alice@corp',
         entityType: 'user',
@@ -177,7 +177,7 @@ describe('writeEntityIds', () => {
 
   it('calls bulkUpdateEntity with force: true', async () => {
     const crudClient = makeCrudClient();
-    const records: ProcessedEngineRecord[] = [
+    const records: EntityRelationshipRecord[] = [
       {
         entityId: 'user:alice@corp',
         entityType: 'user',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.ts
@@ -9,19 +9,19 @@ import type { Logger } from '@kbn/logging';
 import type { EntityUpdateClient, BulkObject } from '@kbn/entity-store/server';
 import type { Entity } from '@kbn/entity-store/common/domain/definitions/entity.gen';
 
-import type { ProcessedEngineRecord } from './types';
+import type { EntityRelationshipRecord } from './types';
 
-type ValidRecord = ProcessedEngineRecord & { entityId: string };
+type ValidRecord = EntityRelationshipRecord & { entityId: string };
 
 interface MergedRelationships {
   [relType: string]: Set<string>;
 }
 
-function hasAnyTargets(record: ProcessedEngineRecord): boolean {
+function hasAnyTargets(record: EntityRelationshipRecord): boolean {
   return Object.values(record.relationships).some((rel) => rel.length > 0);
 }
 
-function filterValid(records: ProcessedEngineRecord[]): ValidRecord[] {
+function filterValid(records: EntityRelationshipRecord[]): ValidRecord[] {
   return records.filter((r): r is ValidRecord => r.entityId !== null && hasAnyTargets(r));
 }
 
@@ -67,7 +67,7 @@ export interface WriteEntityIdsResult {
 export const writeEntityIds = async (
   crudClient: EntityUpdateClient,
   logger: Logger,
-  records: ProcessedEngineRecord[]
+  records: EntityRelationshipRecord[]
 ): Promise<WriteEntityIdsResult> => {
   if (records.length === 0) return { updated: 0, notFound: 0, errors: 0 };
 
@@ -85,7 +85,7 @@ export const writeEntityIds = async (
       }
     }
     if (Object.keys(relationships).length > 0) {
-      // TODO(follow-up): entity type hardcoded to 'user' — use actorEntityType from config.
+      // TODO(#266748): entity type hardcoded to 'user' — use actorEntityType from config.
       objects.push({
         type: 'user',
         doc: {


### PR DESCRIPTION
## Summary

Two followups to the merged #266159:

#### 1. CustomActor actor-presence gate fix (data-loss bug)

For `customActor` configs (notably `azure_auditlogs` `communicates_with`), this filter dropped every document that carried only the custom actor fields, so Step 1 returned zero buckets, the override Step 2 never ran, and the entire Azure `communicates_with` maintainer wrote nothing.

Both steps now derive the actor-presence gate from `customActor.fields` when set, otherwise keep calling the existing entity-store helper

Refs: https://github.com/elastic/kibana/pull/266159#discussion_r3189722853

### 2. Naming review from @JordanSh

Three renames for naming consistency:

- `ProcessedEngineRecord` → `EntityRelationshipRecord` (r3225884009)
- `runGenericMaintainer` → `runRelationshipMaintainer` (r3225926566)
- `*_ENGINE_CONFIGS` → `*_INTEGRATION_RELATIONSHIP_CONFIGS` for both `accesses/` and `communicates_with/`

`EntityRelationshipRecord.entityType` is intentionally kept as the literal `'user'` — broadening to `'user' | 'host' | 'service'` is the deferred #266748 work (host→host, host→service, service→\* relationships) and would be aspirational typing today since every producer emits `'user' as const`.

### 3. Tighten the actorEntityType follow-up (#266748) pointers

The four producer/builder TODOs (`build_actor_discovery_query`, `build_targets_per_actor_query`, `parse_targets_per_actor_rows`, `update_entities`) now reference `TODO(#266748)`, and the doc comment on `EntityRelationshipRecord` enumerates every site #266748 must touch. `grep -rn "266748"` from `maintainers/` is now the canonical discovery command when that follow-up lands.

## Test plan

- [x] Type check (`x-pack/solutions/security/plugins/security_solution/tsconfig.json`): clean
- [x] Jest (`entity_analytics/maintainers`): 8/8 suites, 207/207 tests, 8/8 snapshots
- [ ] CI green

Refs:
- https://github.com/elastic/kibana/pull/266159#discussion_r3189722853
- https://github.com/elastic/kibana/pull/266159#discussion_r3225884009
- https://github.com/elastic/kibana/pull/266159#discussion_r3225926566
- https://github.com/elastic/kibana/pull/266159#discussion_r3226064433

🤖 Generated with [Claude Code](https://claude.com/claude-code)