### PR TITLE
[ResponseOps] Fix Webhook http headers reset on blur/focus

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/use_secret_headers.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/use_secret_headers.test.tsx
@@ -8,7 +8,7 @@
 /* eslint-disable no-console */
 
 import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { useSecretHeaders } from './use_secret_headers';
@@ -98,5 +98,30 @@ describe('useSecretHeaders', () => {
         })
       );
     });
+  });
+
+  it('does not refetch secret headers on window focus', async () => {
+    getMock.mockResolvedValue(['secret-key']);
+    const { result } = renderHook(() => useSecretHeaders('connector1', true), {
+      wrapper: customWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(['secret-key']);
+    });
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        writable: true,
+        value: 'visible',
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual(['secret-key']);
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/use_secret_headers.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/use_secret_headers.tsx
@@ -34,6 +34,8 @@ export function useSecretHeaders(
       enabled: isEdit && Boolean(connectorId),
       initialData: [],
       refetchOnMount: 'always',
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
       onError: (error: ServerError) => {
         toasts.addError(error.body?.message ? new Error(error.body.message) : error, {
           title: i18n.translate('xpack.stackConnectors.public.common.errorFetchingSecretHeaders', {


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/kibana/issues/266283


https://github.com/user-attachments/assets/adc56318-aa2a-49bf-9dbb-1e15f4acf9a0


