### PR TITLE
[9.4] [AI Assistant] Update Agent Builder announcement modal revert flow (#267906)

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.test.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.test.tsx
@@ -13,6 +13,7 @@ import { EuiProvider } from '@elastic/eui';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { AgentBuilderAnnouncementModal } from './agent_builder_announcement_modal';
 import * as i18n from './translations';
+import { AGENT_BUILDER_LEARN_MORE_URL } from './announcement_urls';
 
 const defaultProps = {
   variant: '1b' as const,
@@ -73,7 +74,13 @@ describe('AgentBuilderAnnouncementModal', () => {
 
     expect(screen.getByText(i18n.FEATURE_TAKES_ACTION_TITLE)).toBeInTheDocument();
     expect(screen.getByTestId('agentBuilderAnnouncementImportantNotes')).toBeInTheDocument();
+    expect(screen.getByText(i18n.NOTE_REPLACES_LEGACY_AGENTS)).toBeInTheDocument();
+    expect(screen.getByText(i18n.NOTE_HISTORY_UNTOUCHED)).toBeInTheDocument();
     expect(screen.getByText(i18n.NOTE_REVERT_IN_SETTINGS)).toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementLearnMoreLink')).toHaveAttribute(
+      'href',
+      AGENT_BUILDER_LEARN_MORE_URL
+    );
     expect(screen.getByTestId('agentBuilderAnnouncementRevertButton')).toBeInTheDocument();
   });
 
@@ -82,7 +89,13 @@ describe('AgentBuilderAnnouncementModal', () => {
 
     expect(screen.queryByText(i18n.FEATURE_TAKES_ACTION_TITLE)).not.toBeInTheDocument();
     expect(screen.getByTestId('agentBuilderAnnouncementImportantNotes')).toBeInTheDocument();
+    expect(screen.getByText(i18n.NOTE_REPLACES_LEGACY_AGENTS)).toBeInTheDocument();
+    expect(screen.getByText(i18n.NOTE_HISTORY_UNTOUCHED)).toBeInTheDocument();
     expect(screen.getByText(i18n.NOTE_CONTACT_ADMIN)).toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementLearnMoreLink')).toHaveAttribute(
+      'href',
+      AGENT_BUILDER_LEARN_MORE_URL
+    );
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
   });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.tsx
@@ -39,7 +39,7 @@ const VARIANT_CONTENT: Record<
   '2a': PriorAssistantAdminRevert,
 };
 
-const MODAL_MAX_WIDTH = 576;
+const MODAL_MAX_WIDTH = 570;
 
 /** Header product icon gradient (design: blue → purple). */
 const AGENT_PRODUCT_ICON_GRADIENT_START = '#1750BA';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/announcement_urls.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/announcement_urls.ts
@@ -8,3 +8,7 @@
 /** Docs link for Release notes CTA until a dedicated release-notes URL is provided. */
 export const AGENT_BUILDER_RELEASE_NOTES_URL =
   'https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder';
+
+/** Docs link for the "Learn more" note about replacing legacy Threat Hunting and Observability Agents. */
+export const AGENT_BUILDER_LEARN_MORE_URL =
+  'https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/builtin-agents-reference#built-in-agents-in-previous-versions';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/translations.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/translations.ts
@@ -59,17 +59,29 @@ export const IMPORTANT_NOTES_TITLE = i18n.translate(
   { defaultMessage: 'Important notes:' }
 );
 
+export const NOTE_REPLACES_LEGACY_AGENTS = i18n.translate(
+  'xpack.agentBuilder.announcementModal.noteReplacesLegacyAgents',
+  {
+    defaultMessage: 'Elastic Al Agent replaces Threat Hunting Agent and Observability Agent',
+  }
+);
+
+export const NOTE_REPLACES_LEGACY_AGENTS_LEARN_MORE = i18n.translate(
+  'xpack.agentBuilder.announcementModal.noteReplacesLegacyAgentsLearnMore',
+  { defaultMessage: 'Learn more' }
+);
+
 export const NOTE_HISTORY_UNTOUCHED = i18n.translate(
   'xpack.agentBuilder.announcementModal.noteHistoryUntouched',
   {
-    defaultMessage: 'Your chat history, prompts, and data are untouched',
+    defaultMessage: 'AI Assistant chat history, prompts, and data are untouched',
   }
 );
 
 export const NOTE_REVERT_IN_SETTINGS = i18n.translate(
   'xpack.agentBuilder.announcementModal.noteRevertInSettings',
   {
-    defaultMessage: 'Revert back to AI Assistant anytime in GenAI Settings',
+    defaultMessage: 'Revert all users in this space to AI Assistant anytime in GenAI Settings',
   }
 );
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/prior_assistant_admin_revert.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/prior_assistant_admin_revert.tsx
@@ -11,6 +11,7 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiModalBody,
   EuiModalFooter,
   EuiText,
@@ -21,6 +22,7 @@ import {
   AnnouncementReleaseNotesButton,
   announcementModalFooterCss,
 } from '../announcement_ui_shared';
+import { AGENT_BUILDER_LEARN_MORE_URL } from '../announcement_urls';
 import * as i18n from '../translations';
 import type { AnnouncementModalVariantProps } from './types';
 
@@ -39,8 +41,8 @@ export function PriorAssistantAdminRevert({ onContinue }: AnnouncementModalVaria
       margin: ${euiTheme.size.s} 0 0;
       margin-left: 0;
       margin-bottom: 0;
-      padding-left: 0;
-      list-style-position: inside;
+      padding-left: ${euiTheme.size.l};
+      list-style-position: outside;
     }
 
     && li + li {
@@ -64,6 +66,17 @@ export function PriorAssistantAdminRevert({ onContinue }: AnnouncementModalVaria
             data-test-subj="agentBuilderAnnouncementImportantNotes"
           >
             <ul css={notesListCss}>
+              <li>
+                {i18n.NOTE_REPLACES_LEGACY_AGENTS}{' '}
+                <EuiLink
+                  href={AGENT_BUILDER_LEARN_MORE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-test-subj="agentBuilderAnnouncementLearnMoreLink"
+                >
+                  {i18n.NOTE_REPLACES_LEGACY_AGENTS_LEARN_MORE}
+                </EuiLink>
+              </li>
               <li>{i18n.NOTE_HISTORY_UNTOUCHED}</li>
               <li>{i18n.NOTE_CONTACT_ADMIN}</li>
             </ul>

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/prior_assistant_space_admin_revert.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/prior_assistant_space_admin_revert.tsx
@@ -12,6 +12,7 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiModalBody,
   EuiModalFooter,
   useEuiTheme,
@@ -22,6 +23,7 @@ import {
   AnnouncementReleaseNotesButton,
   announcementModalFooterCss,
 } from '../announcement_ui_shared';
+import { AGENT_BUILDER_LEARN_MORE_URL } from '../announcement_urls';
 import * as i18n from '../translations';
 import type { AnnouncementModalVariantProps } from './types';
 
@@ -44,8 +46,8 @@ export function PriorAssistantSpaceAdminRevert({
       margin: ${euiTheme.size.s} 0 0;
       margin-left: 0;
       margin-bottom: 0;
-      padding-left: 0;
-      list-style-position: inside;
+      padding-left: ${euiTheme.size.l};
+      list-style-position: outside;
     }
 
     && li + li {
@@ -67,6 +69,17 @@ export function PriorAssistantSpaceAdminRevert({
             data-test-subj="agentBuilderAnnouncementImportantNotes"
           >
             <ul css={notesListCss}>
+              <li>
+                {i18n.NOTE_REPLACES_LEGACY_AGENTS}{' '}
+                <EuiLink
+                  href={AGENT_BUILDER_LEARN_MORE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-test-subj="agentBuilderAnnouncementLearnMoreLink"
+                >
+                  {i18n.NOTE_REPLACES_LEGACY_AGENTS_LEARN_MORE}
+                </EuiLink>
+              </li>
               <li>{i18n.NOTE_HISTORY_UNTOUCHED}</li>
               <li>{i18n.NOTE_REVERT_IN_SETTINGS}</li>
             </ul>
@@ -77,6 +90,7 @@ export function PriorAssistantSpaceAdminRevert({
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty
+              flush="left"
               onClick={onRevert}
               data-test-subj="agentBuilderAnnouncementRevertButton"
             >

--- a/x-pack/platform/plugins/shared/agent_builder/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder/moon.yml
@@ -123,6 +123,7 @@ dependsOn:
   - '@kbn/response-ops-oauth-hooks'
   - '@kbn/connector-specs'
   - '@kbn/core-user-profile-browser'
+  - '@kbn/react-kibana-mount'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
@@ -108,6 +108,8 @@ function buildServices({
 
   const http = createHttpMock({ observabilityConversationCount, securityTotal });
 
+  const addSuccess = jest.fn();
+
   const services = {
     settings: {
       client: {
@@ -115,7 +117,7 @@ function buildServices({
         get$: jest.fn((key: string) =>
           key === AI_CHAT_EXPERIENCE_TYPE ? of(chatExperience) : of(undefined)
         ),
-        set: jest.fn(),
+        set: jest.fn().mockResolvedValue(undefined),
       },
       globalClient: {
         get: (key: string) => (key === HIDE_ANNOUNCEMENTS_ID ? hideAnnouncements : undefined),
@@ -126,12 +128,28 @@ function buildServices({
       getActiveSpace$: () => space$.asObservable(),
     },
     analytics: { reportEvent },
-    application: { navigateToApp, capabilities: chatExperienceCapabilities },
+    application: {
+      navigateToApp,
+      getUrlForApp: jest.fn().mockReturnValue('/app/management/ai/genAiSettings'),
+      capabilities: chatExperienceCapabilities,
+    },
+    notifications: { toasts: { addSuccess } },
+    i18n: { Context: ({ children }: { children: React.ReactNode }) => <>{children}</> },
+    theme: {},
     userProfile,
     http,
   };
 
-  return { services, reportEvent, navigateToApp, partialUpdate, userProfile, space$, http };
+  return {
+    services,
+    reportEvent,
+    navigateToApp,
+    addSuccess,
+    partialUpdate,
+    userProfile,
+    space$,
+    http,
+  };
 }
 
 function renderController(services: ReturnType<typeof buildServices>['services']) {
@@ -280,9 +298,9 @@ describe('AgentBuilderAnnouncementModalController', () => {
     expect(screen.queryByTestId('agentBuilderAnnouncementContinueButton')).not.toBeInTheDocument();
   });
 
-  it('calls partialUpdate, reports OptOut telemetry, navigates to GenAI settings, and hides the modal on revert', async () => {
+  it('calls partialUpdate, reports OptOut telemetry, sets Classic experience, shows success toast, and hides the modal on revert', async () => {
     const user = userEvent.setup();
-    const { services, reportEvent, navigateToApp, partialUpdate } = buildServices({
+    const { services, reportEvent, addSuccess, partialUpdate } = buildServices({
       observabilityConversationCount: 1,
     });
     renderController(services);
@@ -305,7 +323,13 @@ describe('AgentBuilderAnnouncementModalController', () => {
       announcement_variant: '1b',
       had_prior_ai_assistant_usage: true,
     });
-    expect(navigateToApp).toHaveBeenCalledWith('management', { path: '/ai/genAiSettings' });
+    expect(services.settings.client.set).toHaveBeenCalledWith(
+      AI_CHAT_EXPERIENCE_TYPE,
+      AIChatExperience.Classic
+    );
+    expect(addSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Reverted to AI Assistant' })
+    );
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
@@ -6,13 +6,19 @@
  */
 
 import React, { useMemo, useState } from 'react';
+import { EuiIcon, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import useObservable from 'react-use/lib/useObservable';
 import { EMPTY } from 'rxjs';
 import type {
   AnalyticsServiceStart,
   ApplicationStart,
   HttpStart,
+  I18nStart,
   IUiSettingsClient,
+  NotificationsStart,
+  ThemeServiceStart,
 } from '@kbn/core/public';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
 import { AIChatExperience, canUserChangeSpaceChatExperience } from '@kbn/ai-assistant-common';
@@ -20,6 +26,7 @@ import { useGlobalUiSetting, useKibana } from '@kbn/kibana-react-plugin/public';
 import { AI_CHAT_EXPERIENCE_TYPE, HIDE_ANNOUNCEMENTS_ID } from '@kbn/management-settings-ids';
 import { AgentBuilderAnnouncementModal } from '@kbn/agent-builder-browser';
 import { AGENT_BUILDER_EVENT_TYPES } from '@kbn/agent-builder-common/telemetry';
+import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { useAgentBuilderAnnouncementModalSeenState } from './use_agent_builder_announcement_modal_seen';
 import {
@@ -27,11 +34,111 @@ import {
   useAiAssistantPriorUsage,
 } from './use_ai_assistant_prior_usage';
 
+interface ShowToastParams {
+  notifications: NotificationsStart;
+  i18nService: I18nStart;
+  theme: ThemeServiceStart;
+  userProfile: UserProfileServiceStart;
+  genAiSettingsUrl: string;
+}
+
+interface ShowCtaToastParams extends ShowToastParams {
+  canRevertToAssistant: boolean;
+}
+
+function showRevertToast({
+  notifications,
+  i18nService,
+  theme,
+  userProfile,
+  genAiSettingsUrl,
+}: ShowToastParams) {
+  notifications.toasts.addSuccess({
+    title: i18n.translate('xpack.agentBuilder.announcement.revertToast.title', {
+      defaultMessage: 'Reverted to AI Assistant',
+    }),
+    text: toMountPoint(
+      <>
+        <p>
+          {i18n.translate('xpack.agentBuilder.announcement.revertToast.body', {
+            defaultMessage: 'All users in this space will now use the AI Assistant.',
+          })}
+        </p>
+        <p>
+          <FormattedMessage
+            id="xpack.agentBuilder.announcement.revertToast.manageLink"
+            defaultMessage="Manage further changes in {link}"
+            values={{
+              link: (
+                <EuiLink href={genAiSettingsUrl}>
+                  {'GenAI '}
+                  <span style={{ whiteSpace: 'nowrap' }}>
+                    {'Settings '}
+                    <EuiIcon type="popout" size="s" aria-hidden="true" />
+                  </span>
+                </EuiLink>
+              ),
+            }}
+          />
+        </p>
+      </>,
+      { i18n: i18nService, theme, userProfile }
+    ),
+  });
+}
+
+function showCtaToast({
+  notifications,
+  i18nService,
+  theme,
+  userProfile,
+  canRevertToAssistant,
+  genAiSettingsUrl,
+}: ShowCtaToastParams) {
+  notifications.toasts.addSuccess({
+    title: i18n.translate('xpack.agentBuilder.announcement.ctaToast.title', {
+      defaultMessage: "You're now using AI Agent",
+    }),
+    ...(canRevertToAssistant && {
+      text: toMountPoint(
+        <>
+          <p>
+            {i18n.translate('xpack.agentBuilder.announcement.ctaToast.body', {
+              defaultMessage: 'All users in this space will use AI Agent.',
+            })}
+          </p>
+          <p>
+            <FormattedMessage
+              id="xpack.agentBuilder.announcement.ctaToast.manageLink"
+              defaultMessage="Manage further changes in {link}"
+              values={{
+                link: (
+                  <EuiLink href={genAiSettingsUrl}>
+                    {'GenAI '}
+                    <span style={{ whiteSpace: 'nowrap' }}>
+                      {'Settings '}
+                      <EuiIcon type="popout" size="s" aria-hidden="true" />
+                    </span>
+                  </EuiLink>
+                ),
+              }}
+            />
+          </p>
+        </>,
+        { i18n: i18nService, theme, userProfile }
+      ),
+    }),
+  });
+}
+
 export function AgentBuilderAnnouncementModalController() {
   const { services } = useKibana<{
     spaces?: SpacesPluginStart;
     analytics: AnalyticsServiceStart;
     application: ApplicationStart;
+    i18n: I18nStart;
+    notifications: NotificationsStart;
+    theme: ThemeServiceStart;
     userProfile: UserProfileServiceStart;
     http: HttpStart;
     settings: { client: IUiSettingsClient; globalClient: IUiSettingsClient };
@@ -86,15 +193,40 @@ export function AgentBuilderAnnouncementModalController() {
           source: 'agent_builder_nav_control',
           ...telemetryContext,
         });
+        const genAiSettingsUrl = services.application.getUrlForApp('management', {
+          path: '/ai/genAiSettings',
+        });
+        showCtaToast({
+          notifications: services.notifications,
+          i18nService: services.i18n,
+          theme: services.theme,
+          userProfile: services.userProfile,
+          canRevertToAssistant,
+          genAiSettingsUrl,
+        });
         setIsDismissed(true);
       }}
-      onRevert={() => {
+      onRevert={async () => {
         void markSeen().catch(() => {});
         services.analytics.reportEvent(AGENT_BUILDER_EVENT_TYPES.OptOut, {
           source: 'agent_builder_nav_control',
           ...telemetryContext,
         });
-        services.application.navigateToApp('management', { path: '/ai/genAiSettings' });
+        try {
+          await services.settings.client.set(AI_CHAT_EXPERIENCE_TYPE, AIChatExperience.Classic);
+          const genAiSettingsUrl = services.application.getUrlForApp('management', {
+            path: '/ai/genAiSettings',
+          });
+          showRevertToast({
+            notifications: services.notifications,
+            i18nService: services.i18n,
+            theme: services.theme,
+            userProfile: services.userProfile,
+            genAiSettingsUrl,
+          });
+        } catch (_err) {
+          // silent
+        }
         setIsDismissed(true);
       }}
     />

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_agent_builder_announcement_modal_seen.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_agent_builder_announcement_modal_seen.ts
@@ -9,6 +9,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { firstValueFrom, take } from 'rxjs';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
 
+const ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY = 'kibana.agentBuilderAnnouncementModalSeen';
+
 function parseSeenMap(json: string | undefined): Record<string, boolean> {
   if (!json) {
     return {};
@@ -35,6 +37,15 @@ function legacyMapHasAnyDismissed(map: Record<string, boolean>): boolean {
 export async function getAnnouncementModalSeen(
   userProfile: UserProfileServiceStart
 ): Promise<boolean> {
+  // localStorage fallback for environments where user profile updates are unavailable (e.g. reverse proxy auth)
+  try {
+    if (localStorage.getItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY) === 'true') {
+      return true;
+    }
+  } catch {
+    // ignore storage access errors
+  }
+
   const enabled = await firstValueFrom(userProfile.getEnabled$().pipe(take(1)));
   if (!enabled) {
     return true;
@@ -64,6 +75,13 @@ export async function getAnnouncementModalSeen(
 export async function setAnnouncementModalSeen(
   userProfile: UserProfileServiceStart
 ): Promise<void> {
+  try {
+    if (localStorage.getItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY) === 'true') {
+      return;
+    }
+  } catch {
+    // ignore storage access errors
+  }
   const enabled = await firstValueFrom(userProfile.getEnabled$().pipe(take(1)));
   if (!enabled) {
     return;
@@ -85,7 +103,12 @@ export async function setAnnouncementModalSeen(
       },
     });
   } catch {
-    // No browser fallback; UI still hides via local isDismissed on the controller.
+    // Fall back to localStorage when user profile updates are unavailable (e.g., reverse proxy auth).
+    try {
+      localStorage.setItem(ANNOUNCEMENT_MODAL_SEEN_STORAGE_KEY, 'true');
+    } catch {
+      // ignore storage access errors
+    }
   }
 }
 

--- a/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
@@ -111,6 +111,7 @@
     "@kbn/search-inference-endpoints",
     "@kbn/response-ops-oauth-hooks",
     "@kbn/connector-specs",
-    "@kbn/core-user-profile-browser"
+    "@kbn/core-user-profile-browser",
+    "@kbn/react-kibana-mount"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[AI Assistant] Update Agent Builder announcement modal revert flow (#267906)](https://github.com/elastic/kibana/pull/267906)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-05-12T16:26:57Z","message":"[AI Assistant] Update Agent Builder announcement modal revert flow (#267906)\n\n## Summary\n\n### What\nUpdates the Agent Builder announcement modal revert flow so that\nclicking \"Revert\" immediately switches all space users back to AI\nAssistant and shows a success toast — instead of navigating the admin\naway to GenAI Settings. The copy has also been updated to reflect the\nnew designs.\n\n### Why\nThe prior UX navigated the admin to the GenAI Settings page on revert,\nwhich was disruptive. Per the updated design (#267670), the revert\naction should be instant with clear confirmation, and only link to\nsettings for further management.\n\nFollow up fix to: https://github.com/elastic/kibana/issues/264152\nCloses #267670\n\n### Changes\n\n- `onRevert` handler now calls\n`settings.client.set(AI_CHAT_EXPERIENCE_TYPE, AIChatExperience.Classic)`\ndirectly\n- Displays a success toast (\"Reverted to AI Assistant\") with body text\nand a link to GenAI Settings\n- Revert button (`EuiButtonEmpty`) gains `flush=\"left\"` per EUI\nguidelines\n- Updates note translation: \"Revert all users in this space to AI\nAssistant anytime in GenAI Settings\"\n- Adds `I18nStart`, `NotificationsStart`, `ThemeServiceStart` to\ncontroller service types; adds `@kbn/react-kibana-mount` dependency for\n`toMountPoint`\n- Updates unit tests to assert on `settings.client.set`, `addSuccess`,\nand removal of the revert button\n\n\nhttps://github.com/user-attachments/assets/43511083-8633-401b-b12b-034129faa5a7\n\n\n\nhttps://github.com/user-attachments/assets/c35d7d64-1674-49d8-8550-564f561faa4b\n\n\n\nhttps://github.com/user-attachments/assets/64ee467e-bd56-47b2-b089-2b7951b12901\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions.\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Data loss**: None. The revert sets a reversible UI settings value;\nno persisted data is removed.\n- **Broken workflows**: Low. The revert action is now immediate rather\nthan requiring navigation, which is strictly better UX. If\n`settings.client.set` fails, the error is caught silently and the modal\nstill closes — no user-visible breakage.\n- **Regressions**: Low. Changes are contained to the announcement modal\ncontroller and its tests. No shared logic was modified.\n- **Performance**: None.\n\n### Release note\n\n> Updates the Agent Builder announcement modal so that the \"Revert\"\nbutton immediately switches all space users back to AI Assistant and\nshows a confirmation toast with a link to GenAI Settings.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba56c2dac48ad471947feb73fe138f8688599198","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting","backport:version","v9.4.0","v9.5.0"],"title":"[AI Assistant] Update Agent Builder announcement modal revert flow","number":267906,"url":"https://github.com/elastic/kibana/pull/267906","mergeCommit":{"message":"[AI Assistant] Update Agent Builder announcement modal revert flow (#267906)\n\n## Summary\n\n### What\nUpdates the Agent Builder announcement modal revert flow so that\nclicking \"Revert\" immediately switches all space users back to AI\nAssistant and shows a success toast — instead of navigating the admin\naway to GenAI Settings. The copy has also been updated to reflect the\nnew designs.\n\n### Why\nThe prior UX navigated the admin to the GenAI Settings page on revert,\nwhich was disruptive. Per the updated design (#267670), the revert\naction should be instant with clear confirmation, and only link to\nsettings for further management.\n\nFollow up fix to: https://github.com/elastic/kibana/issues/264152\nCloses #267670\n\n### Changes\n\n- `onRevert` handler now calls\n`settings.client.set(AI_CHAT_EXPERIENCE_TYPE, AIChatExperience.Classic)`\ndirectly\n- Displays a success toast (\"Reverted to AI Assistant\") with body text\nand a link to GenAI Settings\n- Revert button (`EuiButtonEmpty`) gains `flush=\"left\"` per EUI\nguidelines\n- Updates note translation: \"Revert all users in this space to AI\nAssistant anytime in GenAI Settings\"\n- Adds `I18nStart`, `NotificationsStart`, `ThemeServiceStart` to\ncontroller service types; adds `@kbn/react-kibana-mount` dependency for\n`toMountPoint`\n- Updates unit tests to assert on `settings.client.set`, `addSuccess`,\nand removal of the revert button\n\n\nhttps://github.com/user-attachments/assets/43511083-8633-401b-b12b-034129faa5a7\n\n\n\nhttps://github.com/user-attachments/assets/c35d7d64-1674-49d8-8550-564f561faa4b\n\n\n\nhttps://github.com/user-attachments/assets/64ee467e-bd56-47b2-b089-2b7951b12901\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions.\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Data loss**: None. The revert sets a reversible UI settings value;\nno persisted data is removed.\n- **Broken workflows**: Low. The revert action is now immediate rather\nthan requiring navigation, which is strictly better UX. If\n`settings.client.set` fails, the error is caught silently and the modal\nstill closes — no user-visible breakage.\n- **Regressions**: Low. Changes are contained to the announcement modal\ncontroller and its tests. No shared logic was modified.\n- **Performance**: None.\n\n### Release note\n\n> Updates the Agent Builder announcement modal so that the \"Revert\"\nbutton immediately switches all space users back to AI Assistant and\nshows a confirmation toast with a link to GenAI Settings.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba56c2dac48ad471947feb73fe138f8688599198"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267906","number":267906,"mergeCommit":{"message":"[AI Assistant] Update Agent Builder announcement modal revert flow (#267906)\n\n## Summary\n\n### What\nUpdates the Agent Builder announcement modal revert flow so that\nclicking \"Revert\" immediately switches all space users back to AI\nAssistant and shows a success toast — instead of navigating the admin\naway to GenAI Settings. The copy has also been updated to reflect the\nnew designs.\n\n### Why\nThe prior UX navigated the admin to the GenAI Settings page on revert,\nwhich was disruptive. Per the updated design (#267670), the revert\naction should be instant with clear confirmation, and only link to\nsettings for further management.\n\nFollow up fix to: https://github.com/elastic/kibana/issues/264152\nCloses #267670\n\n### Changes\n\n- `onRevert` handler now calls\n`settings.client.set(AI_CHAT_EXPERIENCE_TYPE, AIChatExperience.Classic)`\ndirectly\n- Displays a success toast (\"Reverted to AI Assistant\") with body text\nand a link to GenAI Settings\n- Revert button (`EuiButtonEmpty`) gains `flush=\"left\"` per EUI\nguidelines\n- Updates note translation: \"Revert all users in this space to AI\nAssistant anytime in GenAI Settings\"\n- Adds `I18nStart`, `NotificationsStart`, `ThemeServiceStart` to\ncontroller service types; adds `@kbn/react-kibana-mount` dependency for\n`toMountPoint`\n- Updates unit tests to assert on `settings.client.set`, `addSuccess`,\nand removal of the revert button\n\n\nhttps://github.com/user-attachments/assets/43511083-8633-401b-b12b-034129faa5a7\n\n\n\nhttps://github.com/user-attachments/assets/c35d7d64-1674-49d8-8550-564f561faa4b\n\n\n\nhttps://github.com/user-attachments/assets/64ee467e-bd56-47b2-b089-2b7951b12901\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions.\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Data loss**: None. The revert sets a reversible UI settings value;\nno persisted data is removed.\n- **Broken workflows**: Low. The revert action is now immediate rather\nthan requiring navigation, which is strictly better UX. If\n`settings.client.set` fails, the error is caught silently and the modal\nstill closes — no user-visible breakage.\n- **Regressions**: Low. Changes are contained to the announcement modal\ncontroller and its tests. No shared logic was modified.\n- **Performance**: None.\n\n### Release note\n\n> Updates the Agent Builder announcement modal so that the \"Revert\"\nbutton immediately switches all space users back to AI Assistant and\nshows a confirmation toast with a link to GenAI Settings.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba56c2dac48ad471947feb73fe138f8688599198"}}]}] BACKPORT-->