### PR TITLE
[kbn-evals] Forward TRACING_EXPORTERS from vault profile to Scout

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
@@ -448,6 +448,24 @@ export const startCmd: Command<void> = {
         log.info(
           `[2/4] Starting Scout server (backgrounded, stateful/classic, ${serverConfigSet})...`
         );
+        // Forward the env overrides that the Scout server config consumes
+        // when launching ES / Kibana. Notably:
+        //   - GCS_CREDENTIALS  -> ES gcs.client.default.credentials_file
+        //                        secure setting (snapshot restore from GCS)
+        //   - TRACING_EXPORTERS -> Kibana --telemetry.tracing.exporters
+        //                         (fan-out OTLP destinations from config.json)
+        // Without TRACING_EXPORTERS, Scout falls back to the localhost:4318
+        // + phoenix defaults in `classic.stateful.config.ts`, so any custom
+        // tracing destinations declared in the vault profile are silently
+        // dropped.
+        const scoutEnv: Record<string, string> = {};
+        if (profileEnvOverrides.GCS_CREDENTIALS) {
+          scoutEnv.GCS_CREDENTIALS = profileEnvOverrides.GCS_CREDENTIALS;
+        }
+        if (profileEnvOverrides.TRACING_EXPORTERS) {
+          scoutEnv.TRACING_EXPORTERS = profileEnvOverrides.TRACING_EXPORTERS;
+        }
+
         startService(
           repoRoot,
           'scout',
@@ -457,9 +475,7 @@ export const startCmd: Command<void> = {
           {
             connectorsHash: connectorsHash(),
             serverConfigSet,
-            env: profileEnvOverrides.GCS_CREDENTIALS
-              ? { GCS_CREDENTIALS: profileEnvOverrides.GCS_CREDENTIALS }
-              : undefined,
+            env: Object.keys(scoutEnv).length > 0 ? scoutEnv : undefined,
           }
         );
 


### PR DESCRIPTION
## Summary

`envFromExportProfile` resolves `tracingExporters` from a vault profile
(`config.json`) into the `TRACING_EXPORTERS` env var so that the Scout
server config consumes it and emits Kibana's
`--telemetry.tracing.exporters` arg accordingly. However,
`kbn-evals/.../cli/commands/start.ts` was only forwarding
`GCS_CREDENTIALS` into the Scout child process — `TRACING_EXPORTERS` was
computed but never crossed the process boundary.

The consequence is silent: Scout falls back to its hardcoded localhost
defaults (`http://localhost:4318/v1/traces` + a Phoenix endpoint) and
any custom OTLP fan-out targets declared in the profile (a local trace
stack alongside the golden cluster, an alternative collector, multi-
destination fan-out, etc.) are dropped without any log line indicating
the override was discarded.

This PR forwards both env vars. No behaviour change when
`TRACING_EXPORTERS` is unset, and existing `GCS_CREDENTIALS` forwarding
is preserved.

## How to verify

1. Set `tracingExporters` in a vault profile's `config.json` to fan out
   to e.g. both a remote cluster and a local OTLP collector:
   ```json
   "tracingExporters": [
     { "http": { "url": "https://<remote>/v1/traces", "headers": { "Authorization": "ApiKey ..." } } },
     { "http": { "url": "http://localhost:4328/v1/traces" } }
   ]
   ```
2. Run `node scripts/evals start --export-profile <profile>` and verify
   Kibana's `--telemetry.tracing.exporters` CLI arg contains both URLs
   (before this PR: only the localhost defaults).

## Risks

Minimal. The env var is only set when the vault profile declares
`tracingExporters`; otherwise the path is identical to before.

## Context

Discovered while wiring a local trace stack for the alerts-rag eval
suite, where the profile was setting `tracingExporters` correctly but
Kibana spans were never landing locally — only the LangSmith /
golden-cluster destinations declared elsewhere via the env. Root cause
was this missing forward.

## Checklist

- [x] Behavior verified locally end-to-end (local trace cluster received
      ~5,800 Kibana spans incl. 72 `inference`-scope `ChatComplete` spans)
- [x] No new env vars introduced (existing `TRACING_EXPORTERS` contract
      preserved)
- [x] No public API changes

Made with [Cursor](https://cursor.com)