### PR TITLE
[9.3] [Lens as code] add defensive conversion in cases (#255889)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/moon.yml
+++ b/x-pack/platform/plugins/shared/cases/moon.yml
@@ -104,6 +104,11 @@ dependsOn:
   - '@kbn/zod'
   - '@kbn/securitysolution-es-utils'
   - '@kbn/openapi-generator'
+  - '@kbn/workflows-extensions'
+  - '@kbn/workflows'
+  - '@kbn/lens-embeddable-utils'
+  - '@kbn/resizable-layout'
+  - '@kbn/css-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/cases/moon.yml
+++ b/x-pack/platform/plugins/shared/cases/moon.yml
@@ -103,12 +103,7 @@ dependsOn:
   - '@kbn/react-query'
   - '@kbn/zod'
   - '@kbn/securitysolution-es-utils'
-  - '@kbn/openapi-generator'
-  - '@kbn/workflows-extensions'
-  - '@kbn/workflows'
   - '@kbn/lens-embeddable-utils'
-  - '@kbn/resizable-layout'
-  - '@kbn/css-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
@@ -31,6 +31,8 @@ import type { EmbeddablePackageState } from '@kbn/embeddable-plugin/public';
 import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
 import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
 import type { TimeRange } from '@kbn/data-plugin/common';
+import { isLensAPIFormat } from '@kbn/lens-embeddable-utils/config_builder/utils';
+import { LensConfigBuilder } from '@kbn/lens-embeddable-utils';
 import { useKibana } from '../../../../common/lib/kibana';
 import { DRAFT_COMMENT_STORAGE_ID, ID } from './constants';
 import { CommentEditorContext } from '../../context';
@@ -87,7 +89,13 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
   }, [clearDraftComment, currentAppId, embeddable, onCancel]);
 
   const handleAdd = useCallback(
-    (attributes: Record<string, unknown>, timeRange?: TimeRange) => {
+    (_attributes: Record<string, unknown>, timeRange?: TimeRange) => {
+      // For now, Lens attributes can come in either the API format or the internal format
+      // depending on the value of the lens.apiFormat feature flag
+      const attributes = isLensAPIFormat(_attributes)
+        ? new LensConfigBuilder().fromAPIFormat(_attributes)
+        : _attributes;
+
       onSave(
         `!{${ID}${JSON.stringify({
           timeRange: convertToAbsoluteTimeRange(timeRange),
@@ -105,10 +113,16 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
 
   const handleUpdate = useCallback(
     (
-      attributes: Record<string, unknown>,
+      _attributes: Record<string, unknown>,
       timeRange: TimeRange | undefined,
       position: EuiMarkdownAstNodePosition
     ) => {
+      // For now, Lens attributes can come in either the API format or the internal format
+      // depending on the value of the lens.apiFormat feature flag
+      const attributes = isLensAPIFormat(_attributes)
+        ? new LensConfigBuilder().fromAPIFormat(_attributes)
+        : _attributes;
+
       markdownContext.replaceNode(
         position,
         `!{${ID}${JSON.stringify({

--- a/x-pack/platform/plugins/shared/cases/tsconfig.json
+++ b/x-pack/platform/plugins/shared/cases/tsconfig.json
@@ -100,13 +100,8 @@
     "@kbn/react-query",
     "@kbn/zod",
     "@kbn/securitysolution-es-utils",
-    "@kbn/response-ops-retry-service",
     "@kbn/openapi-generator",
-    "@kbn/workflows-extensions",
-    "@kbn/workflows",
     "@kbn/lens-embeddable-utils",
-    "@kbn/resizable-layout",
-    "@kbn/css-utils"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/platform/plugins/shared/cases/tsconfig.json
+++ b/x-pack/platform/plugins/shared/cases/tsconfig.json
@@ -100,7 +100,13 @@
     "@kbn/react-query",
     "@kbn/zod",
     "@kbn/securitysolution-es-utils",
-    "@kbn/openapi-generator"
+    "@kbn/response-ops-retry-service",
+    "@kbn/openapi-generator",
+    "@kbn/workflows-extensions",
+    "@kbn/workflows",
+    "@kbn/lens-embeddable-utils",
+    "@kbn/resizable-layout",
+    "@kbn/css-utils"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Lens as code] add defensive conversion in cases (#255889)](https://github.com/elastic/kibana/pull/255889)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2026-03-12T17:46:56Z","message":"[Lens as code] add defensive conversion in cases (#255889)\n\n## Summary\n\nFix https://github.com/elastic/kibana/issues/255320\n\nTemporarily, the cases plugin needs to be able to handle both the Lens\nAPI spec and the Lens State. Once the API becomes GA and is used by Lens\nitself, the feature flag will be removed and the logic can always expect\nthe API spec.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9e6a18e92e4b4d88e428167e70c0de1a31343578","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.3.0","v9.4.0","v9.5.0"],"title":"[Lens as code] add defensive conversion in cases","number":255889,"url":"https://github.com/elastic/kibana/pull/255889","mergeCommit":{"message":"[Lens as code] add defensive conversion in cases (#255889)\n\n## Summary\n\nFix https://github.com/elastic/kibana/issues/255320\n\nTemporarily, the cases plugin needs to be able to handle both the Lens\nAPI spec and the Lens State. Once the API becomes GA and is used by Lens\nitself, the feature flag will be removed and the logic can always expect\nthe API spec.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9e6a18e92e4b4d88e428167e70c0de1a31343578"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255889","number":255889,"mergeCommit":{"message":"[Lens as code] add defensive conversion in cases (#255889)\n\n## Summary\n\nFix https://github.com/elastic/kibana/issues/255320\n\nTemporarily, the cases plugin needs to be able to handle both the Lens\nAPI spec and the Lens State. Once the API becomes GA and is used by Lens\nitself, the feature flag will be removed and the logic can always expect\nthe API spec.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9e6a18e92e4b4d88e428167e70c0de1a31343578"}},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->