### PR TITLE
[rspack] Ignore target/ directories in watch mode

### DIFF
--- a/packages/kbn-rspack-optimizer/src/run_build.ts
+++ b/packages/kbn-rspack-optimizer/src/run_build.ts
@@ -243,7 +243,7 @@ async function runWatchBuild(
     };
 
     log?.info('Setting up RSPack watcher...');
-    log?.debug('Watcher will ignore: /node_modules/');
+    log?.debug('Watcher will ignore: /node_modules/, /target/');
     log?.debug('Aggregate timeout: 50ms');
 
     if (hmrServer) {
@@ -257,7 +257,7 @@ async function runWatchBuild(
     const watching = compiler.watch(
       {
         aggregateTimeout: 50,
-        ignored: /node_modules/,
+        ignored: /node_modules|[/\\]target[/\\]/,
       },
       (err, stats) => {
         if (isShuttingDown) {


### PR DESCRIPTION
## Summary

- Adds `target/` directories to the rspack watcher's ignored pattern alongside `node_modules/`
- TypeScript type-check output (`target/types/*.d.ts`) was triggering unnecessary rspack rebuilds when `tsc` runs concurrently (e.g. via IDE or other tooling)
- This caused a rebuild loop: tsc writes `.d.ts` files → rspack rebuilds → hot-update files written → repeat

## Test plan

- Start dev server in watch mode (`yarn start`)
- Run type-checking concurrently (`node scripts/type_check.js`)
- Verify rspack does not rebuild in response to `target/types/` changes
- Verify rspack still rebuilds when actual source files change