### PR TITLE
[kbn-evals] Fix trace-based evaluators on OTel-native trace clusters (trace.id -> trace_id)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/factory.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/factory.test.ts
@@ -37,7 +37,7 @@ describe('createTraceBasedEvaluator', () => {
 
     mockConfig = {
       name: 'Test Evaluator',
-      buildQuery: (traceId: string) => `FROM traces-* | WHERE trace.id == "${traceId}"`,
+      buildQuery: (traceId: string) => `FROM traces-* | WHERE trace_id == "${traceId}"`,
       extractResult: (response) => response.values[0][0] as number | null,
     };
   });
@@ -61,7 +61,7 @@ describe('createTraceBasedEvaluator', () => {
     await evaluateWith(evaluator, VALID_TRACE_ID);
 
     expect(mockEsClient.esql.query as jest.Mock).toHaveBeenCalledWith({
-      query: `FROM traces-* | WHERE trace.id == "${VALID_TRACE_ID}"`,
+      query: `FROM traces-* | WHERE trace_id == "${VALID_TRACE_ID}"`,
     });
   });
 

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/latency.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/latency.ts
@@ -23,7 +23,7 @@ export function createLatencyEvaluator({
     config: {
       name: 'Latency',
       buildQuery: (traceId) => `FROM traces-*
-| WHERE trace.id == "${traceId}"
+| WHERE trace_id == "${traceId}"
 | STATS total_duration_ns = MAX(duration)
 | EVAL latency_seconds = TO_DOUBLE(total_duration_ns) / 1000000000
 | KEEP latency_seconds`,
@@ -49,7 +49,7 @@ export function createSpanLatencyEvaluator({
     config: {
       name: 'Latency',
       buildQuery: (traceId) => `FROM traces-*
-| WHERE trace.id == "${traceId}" AND name == "${spanName}"
+| WHERE trace_id == "${traceId}" AND name == "${spanName}"
 | EVAL latency_seconds = TO_DOUBLE(duration) / 1000000000
 | KEEP latency_seconds`,
       extractResult: (response) => {

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/skill_invocation.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/skill_invocation.test.ts
@@ -59,7 +59,7 @@ describe('createSkillInvocationEvaluator', () => {
     await evaluateWith(evaluator, VALID_TRACE_ID);
 
     const calledQuery = (mockEsClient.esql.query as jest.Mock).mock.calls[0][0].query;
-    expect(calledQuery).toContain(`trace.id == "${VALID_TRACE_ID}"`);
+    expect(calledQuery).toContain(`trace_id == "${VALID_TRACE_ID}"`);
     expect(calledQuery).toContain('total_spans = COUNT(*)');
     expect(calledQuery).toContain('attributes.elastic.inference.span.kind == "TOOL"');
     expect(calledQuery).toContain('attributes.gen_ai.tool.name == "filestore.read"');

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/skill_invocation.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/skill_invocation.ts
@@ -33,7 +33,7 @@ export function createSkillInvocationEvaluator({
     config: {
       name: `Skill Invoked (${skillName})`,
       buildQuery: (traceId) => `FROM traces-*
-| WHERE trace.id == "${traceId}"
+| WHERE trace_id == "${traceId}"
 | STATS
   total_spans = COUNT(*),
   total_tool_spans = COUNT(

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/tokens.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/tokens.ts
@@ -23,7 +23,7 @@ export function createOutputTokensEvaluator({
     config: {
       name: 'Output Tokens',
       buildQuery: (traceId) => `FROM traces-*
-        | WHERE trace.id == "${traceId}"
+        | WHERE trace_id == "${traceId}"
         | STATS 
         output_tokens = SUM(attributes.gen_ai.usage.output_tokens)`,
       extractResult: (response) => {
@@ -50,7 +50,7 @@ export function createInputTokensEvaluator({
     config: {
       name: 'Input Tokens',
       buildQuery: (traceId) => `FROM traces-*
-        | WHERE trace.id == "${traceId}"
+        | WHERE trace_id == "${traceId}"
         | STATS 
         input_tokens = SUM(attributes.gen_ai.usage.input_tokens)`,
       extractResult: (response) => {
@@ -77,7 +77,7 @@ export function createCachedTokensEvaluator({
     config: {
       name: 'Cached Tokens',
       buildQuery: (traceId) => `FROM traces-*
-        | WHERE trace.id == "${traceId}"
+        | WHERE trace_id == "${traceId}"
         | STATS 
         cached_tokens = SUM(attributes.gen_ai.usage.cached_input_tokens)`,
       extractResult: (response) => {

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/tool_calls.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based/tool_calls.ts
@@ -23,7 +23,7 @@ export function createToolCallsEvaluator({
     config: {
       name: 'Tool Calls',
       buildQuery: (traceId) => `FROM traces-*
-| WHERE trace.id == "${traceId}" AND attributes.elastic.inference.span.kind == "TOOL"
+| WHERE trace_id == "${traceId}" AND attributes.elastic.inference.span.kind == "TOOL"
 | STATS 
   tool_calls = COUNT(*)`,
       extractResult: (response) => {


### PR DESCRIPTION
## Summary

The six trace-based evaluators in `@kbn/evals` (Latency, Span Latency,
Input/Output/Cached Tokens, Tool Calls, Skill Invocation) all built
ES|QL queries shaped like:

```esql
FROM traces-* | WHERE trace.id == \"<traceId>\" | ...
```

This silently breaks against any cluster whose `traces-*` data stream
uses the OTel-native mapping (keyword `trace_id`, `trace.id` exposed
only as a field-alias). ES|QL has a [documented limitation][esql-limit]
that it does not resolve field aliases inside `WHERE` clauses, so the
query rejects with:

```
verification_exception: Unknown column [trace.id]
```

The evaluator's per-row retry budget then exhausts and the evaluator
emits N/A — so the failure mode is *invisible* unless someone reads
the per-row trace logs.

[esql-limit]: https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-limitations.html#esql-limitations-field-types

### How was this missed?

The golden cluster's APM-classic ingest pipeline happens to emit
`trace.id` as a concrete field (not an alias), so the queries kept
working there. The failure only surfaces against an OTel-native trace
stack — e.g. an EDOT collector, a vanilla otel-collector, or any
cluster fed by recent OTel SDKs without the APM-style translation.

Discovered while wiring a local trace stack for the alerts-rag eval
suite alongside the golden cluster: locally every trace-based
evaluator returned N/A; on CI (golden cluster only) the same
evaluators returned proper numbers.

## Fix

Flip the queries to `trace_id` (the canonical OTel keyword). This is
safe across both schemas — APM-classic clusters also store `trace_id`
on the concrete record alongside the legacy ECS `trace.id` field, so
the queries continue to work against the golden cluster *and* start
working against OTel-native clusters.

### Files touched

Mechanical \`s/trace.id/trace_id/\` inside the ES|QL query templates
only. No behaviour change beyond the query string.

- \`src/evaluators/trace_based/latency.ts\` (2 queries: trace-wide + per-span)
- \`src/evaluators/trace_based/tokens.ts\` (3 queries: input/output/cached)
- \`src/evaluators/trace_based/tool_calls.ts\`
- \`src/evaluators/trace_based/skill_invocation.ts\`
- \`factory.test.ts\` and \`skill_invocation.test.ts\` updated to match.

## Verification

- 19/19 jest tests pass in
  \`x-pack/platform/packages/shared/kbn-evals/src/evaluators/trace_based\`
  (\`factory.test.ts\`, \`skill_invocation.test.ts\`).
- ESLint clean.
- Scoped type-check clean.

## Risks

Minimal. Both schemas expose \`trace_id\` as a concrete keyword field;
the previous \`trace.id\` was only working on APM-classic clusters
because of an alias-but-also-concrete double mapping unique to that
ingest path. No public API changes.

## Related

Surfaces while running the alerts-rag eval suite (\`security-alerts-rag-regression\`)
against a local Scout cluster with a fan-out OTel exporter. Sister PR
[\#268975](https://github.com/elastic/kibana/pull/268975) addresses the
adjacent issue that \`TRACING_EXPORTERS\` was not being forwarded from
the vault profile into Scout in the first place.

## Checklist

- [x] All six trace evaluators audited and converted.
- [x] Both ECS test fixtures (\`factory.test.ts\`, \`skill_invocation.test.ts\`) updated.
- [x] No new env vars / no public API changes.

Made with [Cursor](https://cursor.com)