### PR TITLE
[EDR Workflows][Onweek][Exceptions Builder] UI fix for AndOrBadge used in various artifact forms

### DIFF
--- a/x-pack/solutions/security/plugins/lists/public/exceptions/components/and_or_badge/rounded_badge.tsx
+++ b/x-pack/solutions/security/plugins/lists/public/exceptions/components/and_or_badge/rounded_badge.tsx
@@ -23,7 +23,8 @@ const RoundBadge = styled(EuiBadge)`
   margin: 0 5px 0 5px;
   padding: 7px 6px 4px 6px;
   user-select: none;
-  width: 34px;
+  width: 40px;
+  height: 40px;
   .euiBadge__content {
     position: relative;
     top: -1px;

--- a/x-pack/solutions/security/plugins/lists/public/exceptions/components/and_or_badge/rounded_badge.tsx
+++ b/x-pack/solutions/security/plugins/lists/public/exceptions/components/and_or_badge/rounded_badge.tsx
@@ -18,7 +18,6 @@ const RoundBadge = styled(EuiBadge)`
   border-radius: 100%;
   display: inline-flex;
   font-size: 9px;
-  height: 34px;
   justify-content: center;
   margin: 0 5px 0 5px;
   padding: 7px 6px 4px 6px;


### PR DESCRIPTION
## Summary
Trusted apps basic mode clearly shows `AND` text within the "AND badge" connector when adding multiple conditions. Advanced mode uses a different underlying component for the badge, which does not provide enough width to show the entire AND text, effectively truncating it to show only `A...`.

- [x] Adjust the width of the AndOrBadge used in various artifact forms such as Endpoint Exceptions, Trusted Apps advanced mode and Event Filters to properly show `AND` in the badge. 

BEFORE
<img width="1273" height="714" alt="image" src="https://github.com/user-attachments/assets/7ff61ed4-d666-414e-94d2-d2ba6ae0c210" />

AFTER
<img width="705" height="692" alt="image" src="https://github.com/user-attachments/assets/4112beff-0254-434e-97ce-c7642bc31053" />


