### PR TITLE
Add navigable dependency links to KI details flyout

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/jest.config.js
+++ b/x-pack/platform/plugins/shared/streams_app/jest.config.js
@@ -14,9 +14,9 @@ module.exports = {
     '<rootDir>/x-pack/platform/plugins/shared/streams_app/server',
   ],
   setupFiles: ['<rootDir>/x-pack/platform/plugins/shared/streams_app/.storybook/jest_setup.js'],
-  collectCoverage: true,
   collectCoverageFrom: [
     '<rootDir>/x-pack/platform/plugins/shared/streams_app/{public,common,server}/**/*.{js,ts,tsx}',
+    '!<rootDir>/x-pack/platform/plugins/shared/streams_app/**/*.stories.{js,ts,tsx}',
   ],
 
   coverageReporters: ['html'],

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/knowledge_indicators_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/knowledge_indicators_table.tsx
@@ -108,6 +108,7 @@ export function KnowledgeIndicatorsTable() {
     selectedKnowledgeIndicator,
     selectedKnowledgeIndicatorId,
     selectedKnowledgeIndicators,
+    setSelectedKnowledgeIndicator,
     setSelectedKnowledgeIndicators,
     knowledgeIndicatorsToDelete,
     setKnowledgeIndicatorsToDelete,
@@ -316,8 +317,10 @@ export function KnowledgeIndicatorsTable() {
       {selectedKnowledgeIndicator ? (
         <KnowledgeIndicatorDetailsFlyout
           knowledgeIndicator={selectedKnowledgeIndicator}
+          allKnowledgeIndicators={knowledgeIndicators}
           occurrencesByQueryId={occurrencesByQueryId}
           onClose={closeFlyout}
+          onNavigateTo={setSelectedKnowledgeIndicator}
         />
       ) : null}
       {knowledgeIndicatorsToDelete.length > 0 ? (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_table.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_table.ts
@@ -380,6 +380,7 @@ export function useKnowledgeIndicatorsTable() {
     selectedKnowledgeIndicator,
     selectedKnowledgeIndicatorId,
     selectedKnowledgeIndicators,
+    setSelectedKnowledgeIndicator,
     setSelectedKnowledgeIndicators,
     knowledgeIndicatorsToDelete,
     setKnowledgeIndicatorsToDelete,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/index.tsx
@@ -309,8 +309,10 @@ export function StreamDetailSignificantEventsView({ definition }: Props) {
       {selectedKnowledgeIndicator ? (
         <KnowledgeIndicatorDetailsFlyout
           knowledgeIndicator={selectedKnowledgeIndicator}
+          allKnowledgeIndicators={knowledgeIndicators}
           occurrencesByQueryId={occurrencesByQueryId}
           onClose={closeFlyout}
+          onNavigateTo={setSelectedKnowledgeIndicator}
         />
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicator_details_flyout/knowledge_indicator_details_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicator_details_flyout/knowledge_indicator_details_flyout.tsx
@@ -46,14 +46,18 @@ import { KnowledgeIndicatorQueryDetailsContent } from './knowledge_indicator_que
 
 interface Props {
   knowledgeIndicator: KnowledgeIndicator;
+  allKnowledgeIndicators?: KnowledgeIndicator[];
   occurrencesByQueryId: Record<string, Array<{ x: number; y: number }>>;
   onClose: () => void;
+  onNavigateTo?: (ki: KnowledgeIndicator) => void;
 }
 
 export function KnowledgeIndicatorDetailsFlyout({
   knowledgeIndicator,
+  allKnowledgeIndicators,
   occurrencesByQueryId,
   onClose,
+  onNavigateTo,
 }: Props) {
   const flyoutTitleId = useGeneratedHtmlId({ prefix: 'knowledgeIndicatorDetailsFlyoutTitle' });
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -275,7 +279,11 @@ export function KnowledgeIndicatorDetailsFlyout({
 
         <EuiFlyoutBody>
           {knowledgeIndicator.kind === 'feature' ? (
-            <KnowledgeIndicatorFeatureDetailsContent feature={knowledgeIndicator.feature} />
+            <KnowledgeIndicatorFeatureDetailsContent
+              feature={knowledgeIndicator.feature}
+              allKnowledgeIndicators={allKnowledgeIndicators}
+              onNavigateTo={onNavigateTo}
+            />
           ) : (
             <KnowledgeIndicatorQueryDetailsContent
               query={knowledgeIndicator.query}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicator_details_flyout/knowledge_indicator_feature_details_content.stories.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicator_details_flyout/knowledge_indicator_feature_details_content.stories.tsx
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import type { KnowledgeIndicator } from '@kbn/streams-ai';
+import type { Feature } from '@kbn/streams-schema';
+import { KnowledgeIndicatorFeatureDetailsContent } from './knowledge_indicator_feature_details_content';
+
+function makeFeature(overrides: Partial<Feature> & Pick<Feature, 'id' | 'type'>): Feature {
+  return {
+    stream_name: 'logs.otel',
+    description: '',
+    properties: {},
+    confidence: 80,
+    uuid: overrides.id,
+    status: 'active',
+    last_seen: '2026-04-19T08:43:02.482Z',
+    expires_at: '2026-08-10T14:00:57Z',
+    ...overrides,
+  };
+}
+
+function makeFeatureKI(
+  overrides: Partial<Feature> & Pick<Feature, 'id' | 'type'>
+): KnowledgeIndicator {
+  return { kind: 'feature', feature: makeFeature(overrides) };
+}
+
+const cartServiceFeature = makeFeature({
+  id: 'cart-service',
+  type: 'entity',
+  subtype: 'service',
+  title: 'Cart Service',
+  description:
+    'Cart service in the otel-demo application handles cart retrieval through a Valkey-backed cart store. Current logs add direct evidence of the ValkeyCartStore implementation being invoked for GetCartAsync requests.',
+  confidence: 94,
+  properties: { name: 'cart', technology: 'valkey' },
+  tags: ['entity', 'service', 'cart', 'valkey', 'kubernetes'],
+  evidence: [
+    'resource.attributes.app=cart',
+    'resource.attributes.k8s.deployment.name=cart',
+    'resource.attributes.container.image.tag=1.12.0-cartservice',
+    'info: cartservice.cartstore.ValkeyCartStore[0]',
+    'GetCartAsync called with userId=',
+  ],
+  meta: {
+    image_name: 'ghcr.io/open-telemetry/demo',
+    note: 'Application logs reference ValkeyCartStore, indicating a Valkey-backed cart store within the cart service.',
+    kubernetes_namespace: 'otel-demo',
+    container_name: 'cart',
+    pod_example: 'cart-7cf546695d-hjpwr',
+    store_implementation: 'cartservice.cartstore.ValkeyCartStore',
+  },
+});
+
+const checkoutServiceKI = makeFeatureKI({
+  id: 'checkout-service',
+  type: 'entity',
+  subtype: 'service',
+  title: 'Checkout Service',
+  description:
+    'Checkout service orchestrates order processing in the otel-demo application. Current logs add direct evidence that checkout handles PlaceOrder requests with USD user currency context and records successful payment completion with transaction identifiers.',
+  confidence: 92,
+  properties: { name: 'checkout' },
+  tags: ['entity', 'service', 'checkout', 'kubernetes', 'orders'],
+  evidence: [
+    'resource.attributes.app=checkout',
+    'resource.attributes.k8s.deployment.name=checkout',
+    'payment went through (transaction_id: 722ef666-a214-4dd7-b969-8a5e16b9a83d)',
+    'order confirmation email sent to "moore@example.com"',
+  ],
+  meta: {
+    kubernetes_namespace: 'otel-demo',
+    image_tag: '1.12.0-checkoutservice',
+  },
+});
+
+const paymentServiceKI = makeFeatureKI({
+  id: 'payment-service',
+  type: 'entity',
+  subtype: 'service',
+  title: 'Payment Service',
+  description:
+    'Payment service in the otel-demo application runs as the payment Kubernetes deployment and exposes a gRPC server on port 50051.',
+  confidence: 95,
+  properties: { protocol: 'grpc', name: 'payment', currency: 'USD', technology: 'nodejs' },
+  tags: ['entity', 'service', 'payment', 'grpc', 'nodejs', 'kubernetes'],
+  evidence: [
+    'resource.attributes.app=payment',
+    'PaymentService gRPC server started on port 50051',
+    'Charge request received.',
+    'attributes.msg=Transaction complete.',
+  ],
+  meta: {
+    port: 50051,
+    security_note: 'Logs contain full credit card number and CVV in plaintext request fields.',
+  },
+});
+
+const emailServiceKI = makeFeatureKI({
+  id: 'email-service',
+  type: 'entity',
+  subtype: 'service',
+  title: 'Email Service',
+  description:
+    'Email service in the otel-demo application sends order confirmation emails over an HTTP endpoint.',
+  confidence: 94,
+  properties: { protocol: 'http', name: 'email' },
+  tags: ['entity', 'service', 'email', 'http', 'kubernetes'],
+});
+
+const frontendKI = makeFeatureKI({
+  id: 'frontend',
+  type: 'entity',
+  subtype: 'service',
+  title: 'Frontend',
+  description:
+    'Frontend service for the otel-demo application runs as the Kubernetes frontend deployment and serves a Next.js web application over Node.js.',
+  confidence: 95,
+  properties: { framework: 'nextjs', name: 'frontend', technology: 'nodejs' },
+  tags: ['entity', 'service', 'frontend', 'nodejs', 'nextjs'],
+});
+
+const valkeyKI = makeFeatureKI({
+  id: 'valkey',
+  type: 'technology',
+  subtype: 'database_engine',
+  title: 'Valkey',
+  description:
+    'Valkey runs as a standalone deployment in the otel-demo namespace and persists in-memory database state to disk.',
+  confidence: 88,
+  properties: { name: 'valkey', technology: 'valkey' },
+  tags: ['technology', 'database', 'cache', 'valkey'],
+});
+
+const cartServiceKI: KnowledgeIndicator = { kind: 'feature', feature: cartServiceFeature };
+
+const depFrontendToCart = makeFeatureKI({
+  id: 'frontend-cart-grpc',
+  type: 'dependency',
+  subtype: 'service_dependency',
+  title: 'frontend → cart',
+  confidence: 86,
+  properties: { protocol: 'grpc', source: 'frontend', target: 'cart' },
+  tags: ['dependency', 'grpc', 'frontend', 'cart'],
+});
+
+const depCartToValkey = makeFeatureKI({
+  id: 'cart-valkey-store',
+  type: 'dependency',
+  subtype: 'service_dependency',
+  title: 'cart → Valkey',
+  confidence: 80,
+  properties: { protocol: 'internal', source: 'cart', target: 'valkey' },
+  tags: ['dependency', 'service', 'valkey', 'cart-store'],
+});
+
+const depCheckoutToPayment = makeFeatureKI({
+  id: 'checkout-payment-transaction',
+  type: 'dependency',
+  subtype: 'service_dependency',
+  title: 'checkout → payment',
+  confidence: 82,
+  properties: { protocol: 'internal', source: 'checkout', target: 'payment' },
+  tags: ['dependency', 'service', 'payment'],
+});
+
+const depCheckoutToEmail = makeFeatureKI({
+  id: 'checkout-email-http',
+  type: 'dependency',
+  subtype: 'service_dependency',
+  title: 'checkout → email',
+  confidence: 76,
+  properties: { protocol: 'http', source: 'checkout', target: 'email' },
+  tags: ['dependency', 'service_dependency', 'email', 'http'],
+});
+
+const allKnowledgeIndicators: KnowledgeIndicator[] = [
+  cartServiceKI,
+  checkoutServiceKI,
+  paymentServiceKI,
+  emailServiceKI,
+  frontendKI,
+  valkeyKI,
+  depFrontendToCart,
+  depCartToValkey,
+  depCheckoutToPayment,
+  depCheckoutToEmail,
+];
+
+const meta: Meta<typeof KnowledgeIndicatorFeatureDetailsContent> = {
+  component: KnowledgeIndicatorFeatureDetailsContent,
+  title: 'streams/KnowledgeIndicatorFeatureDetailsContent',
+};
+
+export default meta;
+type Story = StoryObj<typeof KnowledgeIndicatorFeatureDetailsContent>;
+
+export const EntityWithDependencies: Story = {
+  args: {
+    feature: cartServiceFeature,
+    allKnowledgeIndicators,
+    onNavigateTo: action('onNavigateTo'),
+  },
+};
+
+export const EntityWithMultipleDependencies: Story = {
+  args: {
+    feature: checkoutServiceKI.kind === 'feature' ? checkoutServiceKI.feature : cartServiceFeature,
+    allKnowledgeIndicators,
+    onNavigateTo: action('onNavigateTo'),
+  },
+};
+
+export const EntityNoDependencies: Story = {
+  args: {
+    feature: paymentServiceKI.kind === 'feature' ? paymentServiceKI.feature : cartServiceFeature,
+    allKnowledgeIndicators,
+    onNavigateTo: action('onNavigateTo'),
+  },
+};
+
+export const DependencyFeature: Story = {
+  args: {
+    feature:
+      depCheckoutToPayment.kind === 'feature' ? depCheckoutToPayment.feature : cartServiceFeature,
+    allKnowledgeIndicators,
+    onNavigateTo: action('onNavigateTo'),
+  },
+};
+
+export const WithoutAllKnowledgeIndicators: Story = {
+  args: {
+    feature: cartServiceFeature,
+  },
+};
+
+export const MinimalFeature: Story = {
+  args: {
+    feature: makeFeature({
+      id: 'isolated-service',
+      type: 'entity',
+      subtype: 'service',
+      title: 'Isolated Service',
+    }),
+    allKnowledgeIndicators: [],
+    onNavigateTo: action('onNavigateTo'),
+  },
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicator_details_flyout/knowledge_indicator_feature_details_content.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicator_details_flyout/knowledge_indicator_feature_details_content.test.tsx
@@ -1,0 +1,291 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { KnowledgeIndicator } from '@kbn/streams-ai';
+import type { Feature } from '@kbn/streams-schema';
+import { KnowledgeIndicatorFeatureDetailsContent } from './knowledge_indicator_feature_details_content';
+import { DEPENDENCY_FEATURE_TYPE } from '../utils/get_ki_dependencies';
+
+function makeFeature(overrides: Partial<Feature> & Pick<Feature, 'id' | 'type'>): Feature {
+  return {
+    stream_name: 'test-stream',
+    description: '',
+    properties: {},
+    confidence: 80,
+    uuid: overrides.id,
+    status: 'active',
+    last_seen: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeFeatureKI(
+  overrides: Partial<Feature> & Pick<Feature, 'id' | 'type'>
+): KnowledgeIndicator {
+  return { kind: 'feature', feature: makeFeature(overrides) };
+}
+
+const renderWithProviders = (ui: React.ReactElement) => render(<I18nProvider>{ui}</I18nProvider>);
+
+describe('KnowledgeIndicatorFeatureDetailsContent', () => {
+  const baseFeature = makeFeature({
+    id: 'checkout-service',
+    type: 'entity',
+    title: 'Checkout Service',
+    description: 'Handles checkout flow',
+    confidence: 85,
+    properties: { region: 'us-east-1' },
+    tags: ['backend', 'critical'],
+    evidence: ['Found in logs', 'Seen in traces'],
+    meta: { source: 'auto' },
+    subtype: 'microservice',
+    last_seen: '2026-05-01T00:00:00Z',
+    expires_at: '2026-06-01T00:00:00Z',
+  });
+
+  it('renders general information fields', () => {
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={baseFeature} />);
+
+    expect(screen.getByTestId('streamsAppFeatureDetailsFlyoutId')).toHaveTextContent(
+      'checkout-service'
+    );
+    expect(screen.getByText('Entity')).toBeInTheDocument();
+    expect(screen.getByText('microservice')).toBeInTheDocument();
+    expect(screen.getByText('85')).toBeInTheDocument();
+  });
+
+  it('renders description', () => {
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={baseFeature} />);
+
+    expect(screen.getByText('Handles checkout flow')).toBeInTheDocument();
+  });
+
+  it('renders fallback when description is empty', () => {
+    const feature = makeFeature({ id: 'test', type: 'entity', description: '' });
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={feature} />);
+
+    expect(screen.getByText('No description available')).toBeInTheDocument();
+  });
+
+  it('renders tags', () => {
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={baseFeature} />);
+
+    expect(screen.getByText('backend')).toBeInTheDocument();
+    expect(screen.getByText('critical')).toBeInTheDocument();
+  });
+
+  it('renders empty value when no tags', () => {
+    const feature = makeFeature({ id: 'test', type: 'entity', tags: [] });
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={feature} />);
+
+    expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+  });
+
+  it('renders evidence items', () => {
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={baseFeature} />);
+
+    expect(screen.getByText('Found in logs')).toBeInTheDocument();
+    expect(screen.getByText('Seen in traces')).toBeInTheDocument();
+  });
+
+  it('renders fallback when no evidence', () => {
+    const feature = makeFeature({ id: 'test', type: 'entity' });
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={feature} />);
+
+    expect(screen.getByText('No evidence available')).toBeInTheDocument();
+  });
+
+  it('renders meta as JSON', () => {
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={baseFeature} />);
+
+    const metaPanel = screen.getByTestId('streamsAppFeatureDetailsFlyoutMeta');
+    expect(metaPanel).toHaveTextContent(/"source": "auto"/);
+  });
+
+  it('renders fallback when no meta', () => {
+    const feature = makeFeature({ id: 'test', type: 'entity' });
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={feature} />);
+
+    expect(screen.getByText('No meta information')).toBeInTheDocument();
+  });
+
+  it('renders raw document JSON', () => {
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={baseFeature} />);
+
+    const rawDoc = screen.getByTestId('streamsAppFeatureDetailsFlyoutRawDocument');
+    expect(rawDoc).toHaveTextContent('checkout-service');
+  });
+
+  it('renders string properties', () => {
+    const feature = makeFeature({
+      id: 'test',
+      type: 'entity',
+      properties: { region: 'us-east-1', count: 42 },
+    });
+    renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={feature} />);
+
+    expect(screen.getByText('region')).toBeInTheDocument();
+    expect(screen.getByText('us-east-1')).toBeInTheDocument();
+    // non-string properties are filtered out
+    expect(screen.queryByText('count')).not.toBeInTheDocument();
+  });
+
+  describe('dependencies panel', () => {
+    const paymentKI = makeFeatureKI({
+      id: 'payment-service',
+      type: 'entity',
+      title: 'Payment Service',
+    });
+    const depKI = makeFeatureKI({
+      id: 'dep-checkout-payment',
+      type: DEPENDENCY_FEATURE_TYPE,
+      properties: { source: 'checkout', target: 'payment' },
+    });
+
+    it('does not render dependencies panel without allKnowledgeIndicators', () => {
+      renderWithProviders(<KnowledgeIndicatorFeatureDetailsContent feature={baseFeature} />);
+
+      expect(screen.queryByText('Dependencies')).not.toBeInTheDocument();
+    });
+
+    it('renders empty dependencies message when no relationships found', () => {
+      renderWithProviders(
+        <KnowledgeIndicatorFeatureDetailsContent
+          feature={baseFeature}
+          allKnowledgeIndicators={[makeFeatureKI({ ...baseFeature })]}
+        />
+      );
+
+      expect(screen.getByText('Dependencies')).toBeInTheDocument();
+      expect(screen.getByText('No dependency relationships found')).toBeInTheDocument();
+    });
+
+    it('renders dependency table when relationships exist', () => {
+      const checkoutFeatureKI = makeFeatureKI({ ...baseFeature });
+      renderWithProviders(
+        <KnowledgeIndicatorFeatureDetailsContent
+          feature={baseFeature}
+          allKnowledgeIndicators={[checkoutFeatureKI, paymentKI, depKI]}
+        />
+      );
+
+      expect(screen.getByText('Dependencies')).toBeInTheDocument();
+      expect(screen.getByText('Depends on')).toBeInTheDocument();
+      expect(screen.getByText('Payment Service')).toBeInTheDocument();
+    });
+
+    it('does not render dependencies panel for dependency-type features', () => {
+      const depFeature = makeFeature({
+        id: 'dep-1',
+        type: DEPENDENCY_FEATURE_TYPE,
+        properties: { source: 'a', target: 'b' },
+      });
+      renderWithProviders(
+        <KnowledgeIndicatorFeatureDetailsContent feature={depFeature} allKnowledgeIndicators={[]} />
+      );
+
+      expect(screen.queryByText('Dependencies')).not.toBeInTheDocument();
+    });
+
+    it('calls onNavigateTo when clicking a dependency KI link', async () => {
+      const onNavigateTo = jest.fn();
+      const checkoutFeatureKI = makeFeatureKI({ ...baseFeature });
+      renderWithProviders(
+        <KnowledgeIndicatorFeatureDetailsContent
+          feature={baseFeature}
+          allKnowledgeIndicators={[checkoutFeatureKI, paymentKI, depKI]}
+          onNavigateTo={onNavigateTo}
+        />
+      );
+
+      await userEvent.click(screen.getByText('Payment Service'));
+      expect(onNavigateTo).toHaveBeenCalledWith(paymentKI);
+    });
+
+    it('calls onNavigateTo when clicking a relationship badge link', async () => {
+      const onNavigateTo = jest.fn();
+      const checkoutFeatureKI = makeFeatureKI({ ...baseFeature });
+      renderWithProviders(
+        <KnowledgeIndicatorFeatureDetailsContent
+          feature={baseFeature}
+          allKnowledgeIndicators={[checkoutFeatureKI, paymentKI, depKI]}
+          onNavigateTo={onNavigateTo}
+        />
+      );
+
+      await userEvent.click(screen.getByText('Depends on'));
+      expect(onNavigateTo).toHaveBeenCalledWith(depKI);
+    });
+
+    it('renders dependency KI name as plain text without onNavigateTo', () => {
+      const checkoutFeatureKI = makeFeatureKI({ ...baseFeature });
+      renderWithProviders(
+        <KnowledgeIndicatorFeatureDetailsContent
+          feature={baseFeature}
+          allKnowledgeIndicators={[checkoutFeatureKI, paymentKI, depKI]}
+        />
+      );
+
+      const paymentText = screen.getByText('Payment Service');
+      expect(paymentText.closest('a')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('navigable properties', () => {
+    it('renders source/target property values as links when KI is found', async () => {
+      const depFeature = makeFeature({
+        id: 'dep-1',
+        type: DEPENDENCY_FEATURE_TYPE,
+        properties: { source: 'checkout', target: 'payment' },
+      });
+      const checkoutKI = makeFeatureKI({
+        id: 'checkout-service',
+        type: 'entity',
+        title: 'Checkout Service',
+      });
+      const paymentKI = makeFeatureKI({
+        id: 'payment-service',
+        type: 'entity',
+        title: 'Payment Service',
+      });
+      const onNavigateTo = jest.fn();
+
+      renderWithProviders(
+        <KnowledgeIndicatorFeatureDetailsContent
+          feature={depFeature}
+          allKnowledgeIndicators={[checkoutKI, paymentKI]}
+          onNavigateTo={onNavigateTo}
+        />
+      );
+
+      await userEvent.click(screen.getByText('checkout'));
+      expect(onNavigateTo).toHaveBeenCalledWith(checkoutKI);
+    });
+
+    it('renders non-ref property values as plain text', () => {
+      const feature = makeFeature({
+        id: 'test',
+        type: 'entity',
+        properties: { region: 'us-east-1' },
+      });
+      renderWithProviders(
+        <KnowledgeIndicatorFeatureDetailsContent
+          feature={feature}
+          allKnowledgeIndicators={[]}
+          onNavigateTo={jest.fn()}
+        />
+      );
+
+      const regionText = screen.getByText('us-east-1');
+      expect(regionText.closest('a')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicator_details_flyout/knowledge_indicator_feature_details_content.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicator_details_flyout/knowledge_indicator_feature_details_content.tsx
@@ -7,26 +7,43 @@
 
 import {
   EuiBadge,
+  EuiBasicTable,
   EuiCodeBlock,
   EuiDescriptionList,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHealth,
   EuiHorizontalRule,
+  EuiLink,
   EuiText,
+  EuiToolTip,
+  type EuiBasicTableColumn,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import type { KnowledgeIndicator } from '@kbn/streams-ai';
 import type { Feature } from '@kbn/streams-schema';
 import { upperFirst } from 'lodash';
 import React, { useMemo } from 'react';
 import { InfoPanel } from '../../../info_panel';
 import { getConfidenceColor } from '../utils/get_confidence_color';
+import {
+  getKIDependencies,
+  findKIByIdentifier,
+  DEPENDENCY_FEATURE_TYPE,
+  type KIDependencyRelation,
+} from '../utils/get_ki_dependencies';
 
 interface Props {
   feature: Feature;
+  allKnowledgeIndicators?: KnowledgeIndicator[];
+  onNavigateTo?: (ki: KnowledgeIndicator) => void;
 }
 
-export function KnowledgeIndicatorFeatureDetailsContent({ feature }: Props) {
+export function KnowledgeIndicatorFeatureDetailsContent({
+  feature,
+  allKnowledgeIndicators,
+  onNavigateTo,
+}: Props) {
   const listItems = useMemo(() => {
     const tags = feature.tags?.length ? feature.tags : [];
 
@@ -53,11 +70,24 @@ export function KnowledgeIndicatorFeatureDetailsContent({ feature }: Props) {
           <EuiText size="s">
             {Object.entries(feature.properties)
               .filter(([, value]) => typeof value === 'string')
-              .map(([key, value]) => (
-                <EuiText size="s" key={key}>
-                  <strong>{key}</strong> {value as string}
-                </EuiText>
-              ))}
+              .map(([key, value]) => {
+                const strValue = value as string;
+                const isRefKey = key === 'source' || key === 'target';
+                const referencedKI =
+                  isRefKey && allKnowledgeIndicators
+                    ? findKIByIdentifier(strValue, allKnowledgeIndicators)
+                    : undefined;
+                return (
+                  <EuiText size="s" key={key}>
+                    <strong>{key}</strong>{' '}
+                    {referencedKI && onNavigateTo ? (
+                      <EuiLink onClick={() => onNavigateTo(referencedKI)}>{strValue}</EuiLink>
+                    ) : (
+                      strValue
+                    )}
+                  </EuiText>
+                );
+              })}
           </EuiText>
         ),
       },
@@ -91,10 +121,97 @@ export function KnowledgeIndicatorFeatureDetailsContent({ feature }: Props) {
         description: <EuiText size="s">{feature.expires_at ?? EMPTY_VALUE}</EuiText>,
       },
     ];
-  }, [feature]);
+  }, [feature, allKnowledgeIndicators, onNavigateTo]);
 
   const evidence = feature.evidence?.length ? feature.evidence : [];
   const hasMeta = Object.keys(feature.meta ?? {}).length > 0;
+
+  const { dependsOn, dependents } = useMemo(() => {
+    if (!allKnowledgeIndicators || feature.type === DEPENDENCY_FEATURE_TYPE) {
+      return { dependsOn: [], dependents: [] };
+    }
+    const thisKI: KnowledgeIndicator = { kind: 'feature', feature };
+    return getKIDependencies(thisKI, allKnowledgeIndicators);
+  }, [feature, allKnowledgeIndicators]);
+
+  const hasDependencies = dependsOn.length > 0 || dependents.length > 0;
+  const showDependenciesPanel = feature.type !== DEPENDENCY_FEATURE_TYPE;
+
+  const dependsOnLabel = i18n.translate('xpack.streams.featureDetailsFlyout.dependsOnLabel', {
+    defaultMessage: 'Depends on',
+  });
+  const dependedOnByLabel = i18n.translate('xpack.streams.featureDetailsFlyout.dependedOnByLabel', {
+    defaultMessage: 'Depended on by',
+  });
+
+  const dependencyRows = useMemo(() => {
+    const rows: Array<{ direction: string; relation: KIDependencyRelation }> = [];
+    for (const relation of dependsOn) {
+      rows.push({ direction: dependsOnLabel, relation });
+    }
+    for (const relation of dependents) {
+      rows.push({ direction: dependedOnByLabel, relation });
+    }
+    return rows;
+  }, [dependsOn, dependents, dependsOnLabel, dependedOnByLabel]);
+
+  const dependencyColumns: Array<
+    EuiBasicTableColumn<{ direction: string; relation: KIDependencyRelation }>
+  > = useMemo(
+    () => [
+      {
+        field: 'relation',
+        name: i18n.translate('xpack.streams.featureDetailsFlyout.relationshipColumnLabel', {
+          defaultMessage: 'Relationship',
+        }),
+        width: '175px',
+        render: (relation: KIDependencyRelation, row: { direction: string }) => {
+          const via = relation.via;
+          const badge = (
+            <EuiBadge color={row.direction === dependsOnLabel ? 'hollow' : 'default'}>
+              {row.direction}
+            </EuiBadge>
+          );
+          if (onNavigateTo) {
+            return (
+              <EuiToolTip
+                content={i18n.translate(
+                  'xpack.streams.featureDetailsFlyout.viewDependencyTooltip',
+                  { defaultMessage: 'View dependency' }
+                )}
+              >
+                <EuiLink onClick={() => onNavigateTo(via)}>{badge}</EuiLink>
+              </EuiToolTip>
+            );
+          }
+          return badge;
+        },
+      },
+      {
+        field: 'relation',
+        name: i18n.translate('xpack.streams.featureDetailsFlyout.knowledgeIndicatorColumnLabel', {
+          defaultMessage: 'Knowledge indicator',
+        }),
+        render: (relation: KIDependencyRelation) => {
+          const ki = relation.ki;
+          const label =
+            ki.kind === 'feature'
+              ? ki.feature.title ?? ki.feature.id
+              : ki.query.title ?? ki.query.id;
+          return onNavigateTo ? (
+            <EuiLink onClick={() => onNavigateTo(ki)}>{label}</EuiLink>
+          ) : (
+            <EuiText>{label}</EuiText>
+          );
+        },
+      },
+    ],
+    [onNavigateTo, dependsOnLabel]
+  );
+
+  const dependenciesLabel = i18n.translate('xpack.streams.featureDetailsFlyout.dependenciesLabel', {
+    defaultMessage: 'Dependencies',
+  });
 
   return (
     <EuiFlexGroup direction="column" gutterSize="m">
@@ -113,9 +230,29 @@ export function KnowledgeIndicatorFeatureDetailsContent({ feature }: Props) {
           ))}
         </InfoPanel>
       </EuiFlexItem>
+      {showDependenciesPanel && (hasDependencies || allKnowledgeIndicators) && (
+        <EuiFlexItem>
+          <InfoPanel title={dependenciesLabel}>
+            {hasDependencies ? (
+              <EuiBasicTable
+                items={dependencyRows}
+                columns={dependencyColumns}
+                rowHeader="direction"
+                tableCaption={dependenciesLabel}
+              />
+            ) : (
+              <EuiText size="s">
+                {i18n.translate('xpack.streams.featureDetailsFlyout.noDependenciesAvailable', {
+                  defaultMessage: 'No dependency relationships found',
+                })}
+              </EuiText>
+            )}
+          </InfoPanel>
+        </EuiFlexItem>
+      )}
       <EuiFlexItem>
         <InfoPanel title={DESCRIPTION_LABEL}>
-          <EuiText>{feature.description || NO_DESCRIPTION_AVAILABLE}</EuiText>
+          <EuiText size="s">{feature.description || NO_DESCRIPTION_AVAILABLE}</EuiText>
         </InfoPanel>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/utils/get_ki_dependencies.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/utils/get_ki_dependencies.test.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KnowledgeIndicator } from '@kbn/streams-ai';
+import type { Feature } from '@kbn/streams-schema';
+import {
+  normalizeServiceName,
+  findKIByIdentifier,
+  getKIDependencies,
+  DEPENDENCY_FEATURE_TYPE,
+} from './get_ki_dependencies';
+
+function makeFeature(overrides: Partial<Feature> & Pick<Feature, 'id' | 'type'>): Feature {
+  return {
+    stream_name: 'test-stream',
+    description: '',
+    properties: {},
+    confidence: 80,
+    uuid: overrides.id,
+    status: 'active',
+    last_seen: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeFeatureKI(
+  overrides: Partial<Feature> & Pick<Feature, 'id' | 'type'>
+): KnowledgeIndicator {
+  return { kind: 'feature', feature: makeFeature(overrides) };
+}
+
+function makeQueryKI(id: string, title?: string): KnowledgeIndicator {
+  return {
+    kind: 'query',
+    query: {
+      id,
+      title: title ?? id,
+      description: '',
+      type: 'match',
+      esql: { query: 'FROM test' },
+      severity_score: 50,
+    },
+    rule: { backed: false, id: `rule-${id}` },
+    stream_name: 'test-stream',
+  };
+}
+
+describe('normalizeServiceName', () => {
+  it('lowercases and strips -service suffix', () => {
+    expect(normalizeServiceName('Checkout-Service')).toBe('checkout');
+  });
+
+  it('strips " Service" suffix with space', () => {
+    expect(normalizeServiceName('Payment Service')).toBe('payment');
+  });
+
+  it('handles plain lowercase names', () => {
+    expect(normalizeServiceName('checkout')).toBe('checkout');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeServiceName('  api  ')).toBe('api');
+  });
+
+  it('handles null/undefined by coercing to string', () => {
+    expect(normalizeServiceName(null)).toBe('');
+    expect(normalizeServiceName(undefined)).toBe('');
+  });
+
+  it('handles non-string values', () => {
+    expect(normalizeServiceName(42)).toBe('42');
+  });
+});
+
+describe('findKIByIdentifier', () => {
+  const checkoutKI = makeFeatureKI({
+    id: 'checkout-service',
+    type: 'entity',
+    title: 'Checkout Service',
+  });
+  const paymentKI = makeFeatureKI({
+    id: 'payment-service',
+    type: 'entity',
+    title: 'Payment Service',
+  });
+  const queryKI = makeQueryKI('query-1');
+  const allKIs = [checkoutKI, paymentKI, queryKI];
+
+  it('matches by exact id', () => {
+    expect(findKIByIdentifier('checkout-service', allKIs)).toBe(checkoutKI);
+  });
+
+  it('matches by exact title', () => {
+    expect(findKIByIdentifier('Payment Service', allKIs)).toBe(paymentKI);
+  });
+
+  it('matches by normalized short name against id', () => {
+    expect(findKIByIdentifier('checkout', allKIs)).toBe(checkoutKI);
+  });
+
+  it('matches by normalized short name against title', () => {
+    expect(findKIByIdentifier('payment', allKIs)).toBe(paymentKI);
+  });
+
+  it('returns undefined when no match', () => {
+    expect(findKIByIdentifier('unknown', allKIs)).toBeUndefined();
+  });
+
+  it('skips query KIs', () => {
+    expect(findKIByIdentifier('query-1', allKIs)).toBeUndefined();
+  });
+});
+
+describe('getKIDependencies', () => {
+  const checkoutKI = makeFeatureKI({
+    id: 'checkout-service',
+    type: 'entity',
+    title: 'Checkout Service',
+  });
+  const paymentKI = makeFeatureKI({
+    id: 'payment-service',
+    type: 'entity',
+    title: 'Payment Service',
+  });
+  const apiKI = makeFeatureKI({ id: 'api-service', type: 'entity', title: 'API Service' });
+
+  const depCheckoutToPayment = makeFeatureKI({
+    id: 'dep-checkout-payment',
+    type: DEPENDENCY_FEATURE_TYPE,
+    properties: { source: 'checkout', target: 'payment' },
+  });
+
+  const depApiToCheckout = makeFeatureKI({
+    id: 'dep-api-checkout',
+    type: DEPENDENCY_FEATURE_TYPE,
+    properties: { source: 'api', target: 'checkout' },
+  });
+
+  const allKIs = [checkoutKI, paymentKI, apiKI, depCheckoutToPayment, depApiToCheckout];
+
+  it('returns empty for query KIs', () => {
+    const queryKI = makeQueryKI('q1');
+    const result = getKIDependencies(queryKI, allKIs);
+    expect(result).toEqual({ dependsOn: [], dependents: [] });
+  });
+
+  it('finds outgoing dependencies (dependsOn)', () => {
+    const result = getKIDependencies(checkoutKI, allKIs);
+    expect(result.dependsOn).toHaveLength(1);
+    expect(result.dependsOn[0].via).toBe(depCheckoutToPayment);
+    expect(result.dependsOn[0].ki).toBe(paymentKI);
+  });
+
+  it('finds incoming dependencies (dependents)', () => {
+    const result = getKIDependencies(checkoutKI, allKIs);
+    expect(result.dependents).toHaveLength(1);
+    expect(result.dependents[0].via).toBe(depApiToCheckout);
+    expect(result.dependents[0].ki).toBe(apiKI);
+  });
+
+  it('finds both directions for a middle node', () => {
+    const result = getKIDependencies(checkoutKI, allKIs);
+    expect(result.dependsOn).toHaveLength(1);
+    expect(result.dependents).toHaveLength(1);
+  });
+
+  it('finds only dependents for a leaf target', () => {
+    const result = getKIDependencies(paymentKI, allKIs);
+    expect(result.dependsOn).toHaveLength(0);
+    expect(result.dependents).toHaveLength(1);
+    expect(result.dependents[0].ki).toBe(checkoutKI);
+  });
+
+  it('finds only dependsOn for a root source', () => {
+    const result = getKIDependencies(apiKI, allKIs);
+    expect(result.dependsOn).toHaveLength(1);
+    expect(result.dependsOn[0].ki).toBe(checkoutKI);
+    expect(result.dependents).toHaveLength(0);
+  });
+
+  it('returns empty when KI has no relationships', () => {
+    const isolatedKI = makeFeatureKI({ id: 'isolated', type: 'entity' });
+    const result = getKIDependencies(isolatedKI, allKIs);
+    expect(result).toEqual({ dependsOn: [], dependents: [] });
+  });
+
+  it('skips dependency edges where the referenced KI is not found', () => {
+    const danglingDep = makeFeatureKI({
+      id: 'dep-checkout-unknown',
+      type: DEPENDENCY_FEATURE_TYPE,
+      properties: { source: 'checkout', target: 'nonexistent' },
+    });
+    const result = getKIDependencies(checkoutKI, [...allKIs, danglingDep]);
+    // The dangling dep's target doesn't resolve, so dependsOn only has the payment one
+    expect(result.dependsOn).toHaveLength(1);
+    expect(result.dependsOn[0].ki).toBe(paymentKI);
+  });
+
+  it('supports from/to as alternative property names', () => {
+    const depWithFromTo = makeFeatureKI({
+      id: 'dep-from-to',
+      type: DEPENDENCY_FEATURE_TYPE,
+      properties: { from: 'checkout', to: 'api' },
+    });
+    const kis = [checkoutKI, apiKI, depWithFromTo];
+    const result = getKIDependencies(checkoutKI, kis);
+    expect(result.dependsOn).toHaveLength(1);
+    expect(result.dependsOn[0].ki).toBe(apiKI);
+  });
+
+  it('matches by exact title', () => {
+    const depByTitle = makeFeatureKI({
+      id: 'dep-by-title',
+      type: DEPENDENCY_FEATURE_TYPE,
+      properties: { source: 'Checkout Service', target: 'Payment Service' },
+    });
+    const kis = [checkoutKI, paymentKI, depByTitle];
+    const result = getKIDependencies(checkoutKI, kis);
+    expect(result.dependsOn).toHaveLength(1);
+    expect(result.dependsOn[0].ki).toBe(paymentKI);
+  });
+
+  it('matches by exact id', () => {
+    const depById = makeFeatureKI({
+      id: 'dep-by-id',
+      type: DEPENDENCY_FEATURE_TYPE,
+      properties: { source: 'checkout-service', target: 'payment-service' },
+    });
+    const kis = [checkoutKI, paymentKI, depById];
+    const result = getKIDependencies(checkoutKI, kis);
+    expect(result.dependsOn).toHaveLength(1);
+  });
+
+  it('handles KI with empty title gracefully', () => {
+    const noTitleKI = makeFeatureKI({ id: 'no-title', type: 'entity' });
+    const dep = makeFeatureKI({
+      id: 'dep-to-notitle',
+      type: DEPENDENCY_FEATURE_TYPE,
+      properties: { source: 'checkout', target: 'no-title' },
+    });
+    const kis = [checkoutKI, noTitleKI, dep];
+    const result = getKIDependencies(checkoutKI, kis);
+    expect(result.dependsOn).toHaveLength(1);
+    expect(result.dependsOn[0].ki).toBe(noTitleKI);
+  });
+
+  it('does not match dependency KIs against themselves', () => {
+    const result = getKIDependencies(depCheckoutToPayment, allKIs);
+    // dependency-type KIs shouldn't have dependencies of their own resolved
+    // (the feature type would need to not be DEPENDENCY_FEATURE_TYPE to enter the loop)
+    // but since depCheckoutToPayment IS a dependency type, its feature.type === 'dependency',
+    // and we only look at depFeatures. It won't match itself as source/target.
+    expect(result.dependsOn).toHaveLength(0);
+    expect(result.dependents).toHaveLength(0);
+  });
+
+  it('handles dependency with missing properties', () => {
+    const depNoProps = makeFeatureKI({
+      id: 'dep-no-props',
+      type: DEPENDENCY_FEATURE_TYPE,
+      properties: {},
+    });
+    const kis = [checkoutKI, paymentKI, depNoProps];
+    const result = getKIDependencies(checkoutKI, kis);
+    expect(result).toEqual({ dependsOn: [], dependents: [] });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/utils/get_ki_dependencies.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/utils/get_ki_dependencies.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KnowledgeIndicator } from '@kbn/streams-ai';
+
+export const DEPENDENCY_FEATURE_TYPE = 'dependency';
+
+export interface KIDependencyRelation {
+  via: KnowledgeIndicator;
+  ki: KnowledgeIndicator;
+}
+
+export interface KIDependencies {
+  dependsOn: KIDependencyRelation[];
+  dependents: KIDependencyRelation[];
+}
+
+export function normalizeServiceName(value: unknown): string {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[-\s]service$/, '')
+    .trim();
+}
+
+export function findKIByIdentifier(
+  identifier: unknown,
+  allKIs: KnowledgeIndicator[]
+): KnowledgeIndicator | undefined {
+  const identNorm = normalizeServiceName(identifier);
+  return allKIs.find(
+    (other) =>
+      other.kind === 'feature' &&
+      (other.feature.id === identifier ||
+        other.feature.title === identifier ||
+        normalizeServiceName(other.feature.id) === identNorm ||
+        normalizeServiceName(other.feature.title) === identNorm)
+  );
+}
+
+export function getKIDependencies(
+  ki: KnowledgeIndicator,
+  allKIs: KnowledgeIndicator[]
+): KIDependencies {
+  if (ki.kind !== 'feature') return { dependsOn: [], dependents: [] };
+
+  const currentId = ki.feature.id;
+  const currentTitle = ki.feature.title ?? '';
+  const currentIdNorm = normalizeServiceName(currentId);
+  const currentTitleNorm = normalizeServiceName(currentTitle);
+
+  const depFeatures = allKIs.filter(
+    (other): other is KnowledgeIndicator & { kind: 'feature' } =>
+      other.kind === 'feature' && other.feature.type === DEPENDENCY_FEATURE_TYPE
+  );
+
+  const dependsOn: KIDependencyRelation[] = [];
+  const dependents: KIDependencyRelation[] = [];
+
+  const matchesCurrent = (v: unknown): boolean => {
+    if (v === currentId || (currentTitle !== '' && v === currentTitle)) return true;
+    const vNorm = normalizeServiceName(v);
+    return vNorm === currentIdNorm || (currentTitleNorm !== '' && vNorm === currentTitleNorm);
+  };
+
+  const findKI = (identifier: unknown): KnowledgeIndicator | undefined =>
+    findKIByIdentifier(identifier, allKIs);
+
+  for (const depKI of depFeatures) {
+    const props = (depKI.feature.properties ?? {}) as Record<string, unknown>;
+    const source = props.source ?? props.from;
+    const target = props.target ?? props.to;
+
+    if (matchesCurrent(source)) {
+      const targetKI = findKI(target);
+      if (targetKI) dependsOn.push({ via: depKI, ki: targetKI });
+    }
+
+    if (matchesCurrent(target)) {
+      const sourceKI = findKI(source);
+      if (sourceKI) dependents.push({ via: depKI, ki: sourceKI });
+    }
+  }
+
+  return { dependsOn, dependents };
+}


### PR DESCRIPTION
## Summary

- Adds a **Dependencies** panel to the knowledge indicator (KI) feature details flyout, showing both "depends on" and "depended on by" relationships derived from dependency-type features
- Source/target property values on dependency-type KIs render as navigable links that switch the flyout to the referenced KI
- Relationship badges and KI names in the dependencies table are clickable links (when `onNavigateTo` is provided), enabling in-flyout navigation between related knowledge indicators
- Adds `get_ki_dependencies` utility with fuzzy matching (`normalizeServiceName`, `findKIByIdentifier`) to resolve dependency edges to their corresponding KIs
- Includes unit tests for the utility and component, plus Storybook stories
- Excludes `.stories.tsx` files from jest coverage collection

## Test plan

- [ ] Open a stream with knowledge indicators that include dependency-type features
- [ ] Open the details flyout for an entity KI — verify the Dependencies panel shows correct "depends on" / "depended on by" rows
- [ ] Click a KI name link in the dependencies table — verify the flyout navigates to that KI
- [ ] Click a relationship badge — verify the flyout navigates to the dependency KI
- [ ] Open a dependency-type KI — verify source/target property values are rendered as links to the referenced entity KIs
- [ ] Open a KI with no dependencies — verify "No dependency relationships found" message
- [ ] Open a dependency-type KI — verify no Dependencies panel is shown (avoids circular reference)
- [ ] Verify unit tests pass: `node scripts/jest x-pack/platform/plugins/shared/streams_app`

<img width="1804" height="1068" alt="CleanShot 2026-05-12 at 19 36 55@2x" src="https://github.com/user-attachments/assets/50283fbe-6daa-4338-8572-7736267ba9c5" />
