### PR TITLE
[Lens as Code] Cleanup query parameters

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/persistence/lens_client.ts
+++ b/x-pack/platform/plugins/shared/lens/public/persistence/lens_client.ts
@@ -22,11 +22,7 @@ import {
   type LensSearchRequestQuery,
   type LensSearchResponseBody,
 } from '../../server';
-import type {
-  LensCreateRequestQuery,
-  LensItemMeta,
-  LensUpdateRequestQuery,
-} from '../../server/api/routes/types';
+import type { LensItemMeta, LensUpdateRequestQuery } from '../../server/api/routes/types';
 import { getLensBuilder } from '../lazy_builder';
 
 export interface LensItemResponse<M extends Record<string, string | boolean> = {}> {
@@ -92,8 +88,7 @@ export class LensClient {
 
   async create(
     { description, visualizationType, state, title, version }: LooseLensAttributes,
-    references: Reference[],
-    options: LensCreateRequestQuery = {}
+    references: Reference[]
   ): Promise<LensItemResponse> {
     if (visualizationType === null) {
       throw new Error('Missing visualization type');
@@ -123,7 +118,6 @@ export class LensClient {
       LENS_INTERNAL_VIS_API_PATH,
       {
         body: JSON.stringify(body),
-        query: options,
         version: LENS_INTERNAL_API_VERSION,
       }
     );

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/create.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/create.ts
@@ -14,11 +14,7 @@ import {
 } from '../../../../../common/constants';
 import type { LensCreateIn, LensSavedObject } from '../../../../content_management';
 import type { LensCreateResponseBody, RegisterAPIRouteFn } from '../../../types';
-import {
-  lensCreateRequestBodySchema,
-  lensCreateRequestQuerySchema,
-  lensCreateResponseBodySchema,
-} from './schema';
+import { lensCreateRequestBodySchema, lensCreateResponseBodySchema } from './schema';
 import { getLensInternalRequestConfig, getLensInternalResponseItem } from './utils';
 
 export const registerLensInternalVisualizationsCreateAPIRoute: RegisterAPIRouteFn = (
@@ -50,7 +46,6 @@ export const registerLensInternalVisualizationsCreateAPIRoute: RegisterAPIRouteF
       version: LENS_INTERNAL_API_VERSION,
       validate: {
         request: {
-          query: lensCreateRequestQuerySchema,
           body: lensCreateRequestBodySchema,
         },
         response: {
@@ -87,7 +82,7 @@ export const registerLensInternalVisualizationsCreateAPIRoute: RegisterAPIRouteF
       try {
         // Note: these types are to enforce loose param typings of client methods
         const { references, ...data } = getLensInternalRequestConfig(builder, req.body);
-        const options: LensCreateIn['options'] = { ...req.query, references };
+        const options: LensCreateIn['options'] = { references };
         const { result } = await client.create(data, options);
 
         if (result.item.error) {

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/create.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/create.ts
@@ -8,18 +8,10 @@
 import { schema } from '@kbn/config-schema';
 import { lensApiConfigSchema } from '@kbn/lens-embeddable-utils';
 
-import { lensCMCreateOptionsSchema, lensItemDataSchemaV2 } from '../../../../../content_management';
+import { lensItemDataSchemaV2 } from '../../../../../content_management';
 import { lensItemDataSchemaV0 } from '../../../../../content_management/v0';
 import { lensItemDataSchemaV1 } from '../../../../../content_management/v1';
-import { pickFromObjectSchema } from '../../../../../utils';
 import { lensResponseItemSchema } from './common';
-
-export const lensCreateRequestQuerySchema = schema.object(
-  {
-    ...pickFromObjectSchema(lensCMCreateOptionsSchema.getPropSchemas(), ['overwrite']),
-  },
-  { unknowns: 'forbid' }
-);
 
 export const lensCreateRequestBodySchema = schema.oneOf([
   lensApiConfigSchema,

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/types.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/types.ts
@@ -12,7 +12,6 @@ import type { TypeOf } from '@kbn/config-schema';
 import type { lensCMGetResultSchema } from '../../../../content_management';
 import type {
   lensCreateRequestBodySchema,
-  lensCreateRequestQuerySchema,
   lensCreateResponseBodySchema,
   lensDeleteRequestParamsSchema,
   lensGetRequestParamsSchema,
@@ -30,7 +29,6 @@ export type LensItemMeta = TypeOf<typeof lensItemMetaSchema>;
 export type LensResponseItem = TypeOf<typeof lensResponseItemSchema>;
 export type CMItemResultMeta = TypeOf<typeof lensCMGetResultSchema>['meta'];
 
-export type LensCreateRequestQuery = TypeOf<typeof lensCreateRequestQuerySchema>;
 export type LensCreateRequestBody = TypeOf<typeof lensCreateRequestBodySchema>;
 export type LensCreateResponseBody = TypeOf<typeof lensCreateResponseBodySchema>;
 

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/create.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/create.ts
@@ -20,11 +20,7 @@ import type { LensCreateIn, LensSavedObject } from '../../../content_management'
 import type { RegisterAPIRouteFn } from '../../types';
 import type { LensCreateResponseBody } from './types';
 import { getLensRequestConfig, getLensResponseItem } from './utils';
-import {
-  lensCreateRequestBodySchema,
-  lensCreateRequestQuerySchema,
-  lensCreateResponseBodySchema,
-} from './schema';
+import { lensCreateRequestBodySchema, lensCreateResponseBodySchema } from './schema';
 
 export const registerLensVisualizationsCreateAPIRoute: RegisterAPIRouteFn = (
   router,
@@ -59,7 +55,6 @@ export const registerLensVisualizationsCreateAPIRoute: RegisterAPIRouteFn = (
       version: LENS_API_VERSION,
       validate: {
         request: {
-          query: lensCreateRequestQuerySchema,
           body: lensCreateRequestBodySchema,
         },
         response: {
@@ -90,7 +85,7 @@ export const registerLensVisualizationsCreateAPIRoute: RegisterAPIRouteFn = (
 
         try {
           const { references, ...data } = getLensRequestConfig(builder, req.body);
-          const options: LensCreateIn['options'] = { ...req.query, references };
+          const options: LensCreateIn['options'] = { references };
           const { result } = await client.create(data, options);
           const responseItem = getLensResponseItem(builder, result.item);
 

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/schema/create.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/schema/create.ts
@@ -5,19 +5,9 @@
  * 2.0.
  */
 
-import { schema } from '@kbn/config-schema';
 import { lensApiConfigSchemaNoESQL } from '@kbn/lens-embeddable-utils';
 
-import { lensCMCreateOptionsSchema } from '../../../../content_management';
-import { pickFromObjectSchema } from '../../../../utils';
 import { lensResponseItemSchema } from './common';
-
-export const lensCreateRequestQuerySchema = schema.object(
-  {
-    ...pickFromObjectSchema(lensCMCreateOptionsSchema.getPropSchemas(), ['overwrite']),
-  },
-  { unknowns: 'forbid' }
-);
 
 export const lensCreateRequestBodySchema = lensApiConfigSchemaNoESQL;
 

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/schema/search.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/schema/search.ts
@@ -17,10 +17,11 @@ export const lensSearchRequestQuerySchema = schema.object({
         description:
           'The saved object fields to include in each result. When omitted, all fields are returned.',
       },
+      maxSize: 100,
     })
   ),
   search_fields: schema.maybe(
-    schema.oneOf([schema.string(), schema.arrayOf(schema.string())], {
+    schema.oneOf([schema.string(), schema.arrayOf(schema.string()), { maxSize: 100 }], {
       meta: {
         description:
           'The fields to match the `query` text against. Defaults to `title` when omitted.',
@@ -64,7 +65,7 @@ const lensSearchResponseMetaSchema = schema.object(
 
 export const lensSearchResponseBodySchema = schema.object(
   {
-    data: schema.arrayOf(lensResponseItemSchema, { maxSize: 100 }),
+    data: schema.arrayOf(lensResponseItemSchema, { maxSize: 1000 }),
     meta: lensSearchResponseMetaSchema,
   },
   { unknowns: 'forbid' }

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/schema/search.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/schema/search.ts
@@ -21,7 +21,7 @@ export const lensSearchRequestQuerySchema = schema.object({
     })
   ),
   search_fields: schema.maybe(
-    schema.oneOf([schema.string(), schema.arrayOf(schema.string()), { maxSize: 100 }], {
+    schema.oneOf([schema.string(), schema.arrayOf(schema.string(), { maxSize: 100 })], {
       meta: {
         description:
           'The fields to match the `query` text against. Defaults to `title` when omitted.',

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/schema/search.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/schema/search.ts
@@ -8,12 +8,25 @@
 import { schema } from '@kbn/config-schema';
 import { searchOptionsSchemas } from '@kbn/content-management-utils';
 
-import { lensCMSearchOptionsSchema } from '../../../../content_management';
 import { lensResponseItemSchema } from './common';
 
 export const lensSearchRequestQuerySchema = schema.object({
-  fields: lensCMSearchOptionsSchema.getPropSchemas().fields,
-  search_fields: lensCMSearchOptionsSchema.getPropSchemas().searchFields,
+  fields: schema.maybe(
+    schema.arrayOf(schema.string(), {
+      meta: {
+        description:
+          'The saved object fields to include in each result. When omitted, all fields are returned.',
+      },
+    })
+  ),
+  search_fields: schema.maybe(
+    schema.oneOf([schema.string(), schema.arrayOf(schema.string())], {
+      meta: {
+        description:
+          'The fields to match the `query` text against. Defaults to `title` when omitted.',
+      },
+    })
+  ),
   query: schema.maybe(
     schema.string({
       meta: {

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/types.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/types.ts
@@ -11,7 +11,6 @@ import type { TypeOf } from '@kbn/config-schema';
 
 import type {
   lensCreateRequestBodySchema,
-  lensCreateRequestQuerySchema,
   lensCreateResponseBodySchema,
   lensDeleteRequestParamsSchema,
   lensGetRequestParamsSchema,
@@ -26,7 +25,6 @@ import type { lensResponseItemSchema } from './schema/common';
 
 export type LensResponseItem = TypeOf<typeof lensResponseItemSchema>;
 
-export type LensCreateRequestQuery = TypeOf<typeof lensCreateRequestQuerySchema>;
 export type LensCreateRequestBody = TypeOf<typeof lensCreateRequestBodySchema>;
 export type LensCreateResponseBody = TypeOf<typeof lensCreateResponseBodySchema>;
 


### PR DESCRIPTION
## Summary

Changes:
- Removed `overwrite` query param on `POST /api/visualizations` route, unused and had no affect.
- Explicitly define `fields` and `search_fields` params on search route with added desciptions.

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->