### PR TITLE
[Trace waterfall] Fix scroll position not resetting on service badge navigation

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/scroll_to_top_on_path_change.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/scroll_to_top_on_path_change.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { APP_MAIN_SCROLL_CONTAINER_ID } from '@kbn/core-chrome-layout-constants';
 import type { Location } from 'history';
 import { Component } from 'react';
 
@@ -15,7 +16,7 @@ interface Props {
 export class ScrollToTopOnPathChange extends Component<Props> {
   public componentDidUpdate(prevProps: Props) {
     if (this.props.location.pathname !== prevProps.location.pathname) {
-      window.scrollTo(0, 0);
+      document.getElementById(APP_MAIN_SCROLL_CONTAINER_ID)?.scrollTo(0, 0);
     }
   }
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/265870

The originally reported bug (service badge performing a full page reload instead of SPA navigation) is no longer reproducible. 

It was fixed by a combination of https://github.com/elastic/kibana/pull/264989, which replaced `e.stopPropagation()` on the badge with the `data-prevent-row-click` pattern, and https://github.com/elastic/kibana/pull/216194, which introduced a global click interceptor that routes same-origin anchor clicks through `navigateToUrl`.

|Navigate from APM|Navigate from Discover|
|-|-|
|<img alt="service_badge_link_from_apm" src="https://github.com/user-attachments/assets/154658ad-f9b5-4258-8ac4-41b238a950aa" />|<img alt="service_badge_link_from_discover" src="https://github.com/user-attachments/assets/11f1fdaa-dc21-4886-9a82-2364240cb835" />|


However, a related UX issue remained: after navigating to the service overview from the trace waterfall, the scroll position was not reset to the top. `ScrollToTopOnPathChange` was calling `window.scrollTo(0, 0)`, but in Kibana's layout the scrollable area is the `APP_MAIN_SCROLL_CONTAINER_ID` div, not `window`. The fix targets the correct container.

<img width="1916" height="966" alt="service_badge_link_from_apm_scroll_reset" src="https://github.com/user-attachments/assets/8996b40f-f2e3-4019-8a31-d8f02cb19b6e" />


### How to test

- Start Kibana with APM data 
- Open a trace in APM (Services > select a service > Transactions > open a transaction with a long waterfall)
- Scroll down so the waterfall is visible near the bottom of the page
- Click the service name badge on any span row
- Verify the service overview page loads scrolled to the top, not to the bottom

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->