### PR TITLE
[Security Solution] Add rulesClient.bulkCreate(), optionally delaying rulesClient.bulkEnableTasks()

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/common/rule_circuit_breaker_error_message.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/rule_circuit_breaker_error_message.ts
@@ -47,6 +47,12 @@ const getBulkEnableRuleErrorSummary = () => {
   });
 };
 
+const getBulkCreateRuleErrorSummary = () => {
+  return i18n.translate('xpack.alerting.ruleCircuitBreaker.error.bulkCreateSummary', {
+    defaultMessage: `Rules cannot be bulk created. The maximum number of runs per minute would be exceeded.`,
+  });
+};
+
 const getRuleCircuitBreakerErrorDetail = ({
   interval,
   intervalAvailable,
@@ -84,7 +90,7 @@ export const getRuleCircuitBreakerErrorMessage = ({
   name?: string;
   interval: number;
   intervalAvailable: number;
-  action: 'update' | 'create' | 'enable' | 'bulkEdit' | 'bulkEnable';
+  action: 'update' | 'create' | 'enable' | 'bulkEdit' | 'bulkEnable' | 'bulkCreate';
   rules?: number;
 }) => {
   let errorMessageSummary: string;
@@ -104,6 +110,9 @@ export const getRuleCircuitBreakerErrorMessage = ({
       break;
     case 'bulkEnable':
       errorMessageSummary = getBulkEnableRuleErrorSummary();
+      break;
+    case 'bulkCreate':
+      errorMessageSummary = getBulkCreateRuleErrorSummary();
       break;
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -1,0 +1,639 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  coreFeatureFlagsMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+  savedObjectsRepositoryMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
+import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
+import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
+import type { ActionsAuthorization, ActionsClient } from '@kbn/actions-plugin/server';
+import { createMockConnector } from '@kbn/actions-plugin/server/application/connector/mocks';
+import { ruleTypeRegistryMock } from '../../../../rule_type_registry.mock';
+import { alertingAuthorizationMock } from '../../../../authorization/alerting_authorization.mock';
+import type { AlertingAuthorization } from '../../../../authorization/alerting_authorization';
+import { ConnectorAdapterRegistry } from '../../../../connector_adapters/connector_adapter_registry';
+import { backfillClientMock } from '../../../../backfill_client/backfill_client.mock';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { getBeforeSetup, setGlobalDate } from '../../../../rules_client/tests/lib';
+import type { ConstructorOptions } from '../../../../rules_client/rules_client';
+import { RulesClient } from '../../../../rules_client/rules_client';
+import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
+import { validateScheduleLimit } from '../get_schedule_frequency';
+import { RuleAuditAction } from '../../../../rules_client/common/audit_events';
+
+const BULK_CREATE_AS_DISABLED_PREFIX = 'Rule created in a disabled state: ';
+
+jest.mock('../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation', () => ({
+  bulkMarkApiKeysForInvalidation: jest.fn(),
+}));
+
+jest.mock('../get_schedule_frequency', () => ({
+  validateScheduleLimit: jest.fn(),
+}));
+
+jest.mock('@kbn/core-saved-objects-utils-server', () => {
+  const actual = jest.requireActual('@kbn/core-saved-objects-utils-server');
+  return {
+    ...actual,
+    SavedObjectsUtils: {
+      generateId: jest.fn(),
+    },
+  };
+});
+
+import { SavedObjectsUtils } from '@kbn/core-saved-objects-utils-server';
+
+const taskManager = taskManagerMock.createStart();
+const ruleTypeRegistry = ruleTypeRegistryMock.create();
+const unsecuredSavedObjectsClient = savedObjectsClientMock.create();
+const encryptedSavedObjects = encryptedSavedObjectsMock.createClient();
+const authorization = alertingAuthorizationMock.create();
+const actionsAuthorization = actionsAuthorizationMock.create();
+const auditLogger = auditLoggerMock.create();
+const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
+
+const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  taskManager,
+  ruleTypeRegistry,
+  unsecuredSavedObjectsClient,
+  authorization: authorization as unknown as AlertingAuthorization,
+  actionsAuthorization: actionsAuthorization as unknown as ActionsAuthorization,
+  spaceId: 'default',
+  namespace: 'default',
+  getUserName: jest.fn(),
+  createAPIKey: jest.fn(),
+  logger: loggingSystemMock.create().get(),
+  internalSavedObjectsRepository,
+  encryptedSavedObjectsClient: encryptedSavedObjects,
+  getActionsClient: jest.fn(),
+  getEventLogClient: jest.fn(),
+  kibanaVersion: 'v8.0.0',
+  auditLogger,
+  maxScheduledPerMinute: 10000,
+  minimumScheduleInterval: { value: '1m', enforce: false },
+  isAuthenticationTypeAPIKey: jest.fn(),
+  getAuthenticationAPIKey: jest.fn(),
+  getAlertIndicesAlias: jest.fn(),
+  alertsService: null,
+  backfillClient: backfillClientMock.create(),
+  connectorAdapterRegistry: new ConnectorAdapterRegistry(),
+  isSystemAction: jest.fn(),
+  uiSettings: uiSettingsServiceMock.createStartContract(),
+  featureFlags: coreFeatureFlagsMock.createStart(),
+  isServerless: false,
+};
+
+setGlobalDate();
+
+const baseRule = (overrides: Record<string, unknown> = {}) => ({
+  enabled: false,
+  name: 'r',
+  tags: [],
+  alertTypeId: '123',
+  consumer: 'bar',
+  schedule: { interval: '1m' },
+  throttle: null,
+  notifyWhen: null,
+  params: { foo: true },
+  actions: [],
+  ...overrides,
+});
+
+const buildBulkResponse = (
+  rules: Array<{ id: string; error?: { message: string; statusCode: number } }>
+) => ({
+  saved_objects: rules.map((r) => ({
+    id: r.id,
+    type: RULE_SAVED_OBJECT_TYPE,
+    references: [],
+    ...(r.error
+      ? { error: { ...r.error, error: 'Conflict' } }
+      : {
+          attributes: {
+            alertTypeId: '123',
+            name: `name-${r.id}`,
+            enabled: false,
+            consumer: 'bar',
+            schedule: { interval: '1m' },
+            params: { foo: true },
+            actions: [],
+            createdBy: 'elastic',
+            updatedBy: 'elastic',
+            createdAt: '2019-02-12T21:01:22.479Z',
+            updatedAt: '2019-02-12T21:01:22.479Z',
+            snoozeSchedule: [],
+            muteAll: false,
+            mutedInstanceIds: [],
+            executionStatus: { status: 'pending', lastExecutionDate: '2019-02-12T21:01:22.479Z' },
+            revision: 0,
+            running: false,
+            apiKey: null,
+            apiKeyOwner: null,
+            apiKeyCreatedByUser: null,
+          },
+        }),
+  })) as never,
+});
+
+describe('bulkCreateRules', () => {
+  let rulesClient: RulesClient;
+  let actionsClient: jest.Mocked<ActionsClient>;
+
+  beforeEach(async () => {
+    getBeforeSetup(rulesClientParams, taskManager, ruleTypeRegistry);
+    (auditLogger.log as jest.Mock).mockClear();
+    (bulkMarkApiKeysForInvalidation as jest.Mock).mockReset();
+    (validateScheduleLimit as jest.Mock).mockReset();
+    let counter = 0;
+    (SavedObjectsUtils.generateId as jest.Mock).mockImplementation(() => `mock-id-${++counter}`);
+    rulesClient = new RulesClient(rulesClientParams);
+    actionsClient = (await rulesClientParams.getActionsClient()) as jest.Mocked<ActionsClient>;
+    actionsClient.getBulk.mockResolvedValue([
+      createMockConnector({ id: '1', actionTypeId: 'test', name: 'a' }),
+    ]);
+    actionsClient.listTypes.mockResolvedValue([]);
+    actionsClient.isSystemAction.mockReturnValue(false);
+    rulesClientParams.getActionsClient.mockResolvedValue(actionsClient);
+    rulesClientParams.createAPIKey.mockResolvedValue({
+      apiKeysEnabled: true,
+      result: { id: 'key-id', name: 'key', api_key: 'key-value' } as never,
+    });
+    rulesClientParams.isAuthenticationTypeAPIKey.mockReturnValue(false);
+    taskManager.bulkSchedule.mockImplementation(async (tasks) => tasks as never);
+    taskManager.bulkEnable.mockResolvedValue({ tasks: [], errors: [] } as never);
+  });
+
+  test('returns empty result for empty input without touching SO/TM/key clients', async () => {
+    const result = await rulesClient.bulkCreateRules({ rules: [] });
+    expect(result).toEqual({ rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] });
+    expect(unsecuredSavedObjectsClient.bulkCreate).not.toHaveBeenCalled();
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+  });
+
+  test('all-disabled happy path: single bulkCreate, no TM, no API keys', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a' }) }, { data: baseRule({ name: 'b' }) }],
+    });
+
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(taskManager.bulkEnable).not.toHaveBeenCalled();
+    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+    expect(result.rules).toHaveLength(2);
+    expect(result.taskIdsFailedToBeEnabled).toEqual([]);
+  });
+
+  test('all-enabled happy path: API keys, bulkSchedule, bulkCreate, bulkEnable', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'a', enabled: true }) },
+        { data: baseRule({ name: 'b', enabled: true }) },
+      ],
+    });
+
+    expect(rulesClientParams.createAPIKey).toHaveBeenCalledTimes(2);
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    const scheduledIds = (taskManager.bulkSchedule.mock.calls[0][0] as Array<{ id: string }>).map(
+      (t) => t.id
+    );
+    expect(scheduledIds).toEqual(['mock-id-1', 'mock-id-2']);
+    // tasks are scheduled disabled; bulkEnable flips them on
+    expect(
+      (taskManager.bulkSchedule.mock.calls[0][0] as Array<{ enabled: boolean }>).every(
+        (t) => t.enabled === false
+      )
+    ).toBe(true);
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-1', 'mock-id-2']);
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+    expect(result.rules).toHaveLength(2);
+    expect(result.taskIdsFailedToBeEnabled).toEqual([]);
+  });
+
+  describe('skipTaskEnabling', () => {
+    test('skips taskManager.bulkEnable and returns enabled task ids in taskIdsFailedToBeEnabled', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'a', enabled: true }) },
+          { data: baseRule({ name: 'b', enabled: true }) },
+        ],
+        skipTaskEnabling: true,
+      });
+
+      expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+      expect(taskManager.bulkEnable).not.toHaveBeenCalled();
+      expect(result.taskIdsFailedToBeEnabled).toEqual(['mock-id-1', 'mock-id-2']);
+    });
+
+    test('returns empty taskIdsFailedToBeEnabled when no rule is enabled', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([{ id: 'mock-id-1' }])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [{ data: baseRule({ name: 'a' }) }],
+        skipTaskEnabling: true,
+      });
+
+      expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+      expect(taskManager.bulkEnable).not.toHaveBeenCalled();
+      expect(result.taskIdsFailedToBeEnabled).toEqual([]);
+    });
+
+    test('excludes per-row SO failure ids from taskIdsFailedToBeEnabled', async () => {
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+        buildBulkResponse([
+          { id: 'mock-id-1' },
+          { id: 'mock-id-2', error: { message: '409', statusCode: 409 } },
+        ])
+      );
+
+      const result = await rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'a', enabled: true }) },
+          { data: baseRule({ name: 'b', enabled: true }) },
+        ],
+        skipTaskEnabling: true,
+      });
+
+      expect(taskManager.bulkEnable).not.toHaveBeenCalled();
+      expect(result.taskIdsFailedToBeEnabled).toEqual(['mock-id-1']);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].rule.id).toBe('mock-id-2');
+    });
+
+    test('empty-input early return returns standard shape', async () => {
+      const result = await rulesClient.bulkCreateRules({ rules: [], skipTaskEnabling: true });
+      expect(result).toEqual({
+        rules: [],
+        errors: [],
+        total: 0,
+        taskIdsFailedToBeEnabled: [],
+      });
+    });
+  });
+
+  test('mixed enabled+disabled happy path', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }, { data: baseRule({ name: 'b' }) }],
+    });
+
+    expect(rulesClientParams.createAPIKey).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-1']);
+    expect(result.errors).toEqual([]);
+    expect(result.total).toBe(2);
+  });
+
+  test('Phase 1 per-rule throw is isolated', async () => {
+    let calls = 0;
+    ruleTypeRegistry.get.mockImplementation((typeId: string) => {
+      calls += 1;
+      if (calls === 1) throw new Error('rule type not found');
+      return {
+        id: typeId,
+        name: 'Test',
+        actionGroups: [{ id: 'default', name: 'Default' }],
+        recoveryActionGroup: { id: 'recovered', name: 'Recovered' },
+        defaultActionGroupId: 'default',
+        minimumLicenseRequired: 'basic',
+        isExportable: true,
+        async executor() {
+          return { state: {} };
+        },
+        category: 'test',
+        producer: 'alerts',
+        solution: 'stack',
+        validate: { params: { validate: (p: unknown) => p } },
+        validLegacyConsumers: [],
+      } as never;
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'fails' }) }, { data: baseRule({ name: 'ok' }) }],
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('fails');
+    expect(result.rules).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+  });
+
+  test('Phase 1 API key creation failure: enabled rule degrades to disabled, no key minted, SO still written, no scheduling', async () => {
+    rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('keys disabled'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled-keyfail', enabled: true }) },
+        { data: baseRule({ name: 'enabled-ok', enabled: true }) },
+      ],
+    });
+
+    // Both rules persisted in a single SO bulkCreate. The first one is demoted
+    // to disabled because its key mint failed; the second is scheduled normally.
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    const persistedAttrsByName = new Map(
+      (
+        unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+          attributes: { name: string; enabled: boolean; apiKey: string | null };
+        }>
+      ).map((o) => [o.attributes.name, o.attributes])
+    );
+    expect(persistedAttrsByName.get('enabled-keyfail')?.enabled).toBe(false);
+    expect(persistedAttrsByName.get('enabled-keyfail')?.apiKey).toBeNull();
+    expect(persistedAttrsByName.get('enabled-ok')?.enabled).toBe(true);
+    // Only the surviving enabled rule was scheduled / enabled.
+    expect(taskManager.bulkSchedule).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkSchedule.mock.calls[0][0]).toHaveLength(1);
+    expect(taskManager.bulkEnable).toHaveBeenCalledWith(['mock-id-2']);
+    // No key mint succeeded for the demoted rule, so nothing to invalidate.
+    expect(bulkMarkApiKeysForInvalidation).not.toHaveBeenCalled();
+    expect(result.rules).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'api_key_creation_failed',
+        rule: expect.objectContaining({ name: 'enabled-keyfail' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
+    expect(result.errors[0].message).toContain('keys disabled');
+  });
+
+  test('Phase 2 schedule-limit trip: enabled rule degrades to disabled, key invalidated, SO still written for both', async () => {
+    (validateScheduleLimit as jest.Mock).mockResolvedValue({
+      interval: 100,
+      intervalAvailable: 50,
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    // The enabled rule contributed an API key → must be invalidated
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
+    // Both rules persisted in a single SO bulkCreate; the originally-enabled
+    // one is degraded to disabled (no scheduledTaskId, no API key fields).
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    const persistedAttrsByName = new Map(
+      (
+        unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+          attributes: { name: string; enabled: boolean; scheduledTaskId?: string | null };
+        }>
+      ).map((o) => [o.attributes.name, o.attributes])
+    );
+    expect(persistedAttrsByName.get('enabled')?.enabled).toBe(false);
+    expect(persistedAttrsByName.get('enabled')?.scheduledTaskId).toBeUndefined();
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(result.rules).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'schedule_limit_exceeded',
+        rule: expect.objectContaining({ name: 'enabled' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
+  });
+
+  test('Phase 3 whole TM throw: enabled subset degrades to disabled, disabled subset unaffected', async () => {
+    taskManager.bulkSchedule.mockRejectedValueOnce(new Error('cluster unavailable'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalled();
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    expect(result.rules).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'task_schedule_failed',
+        rule: expect.objectContaining({ name: 'enabled' }),
+      })
+    );
+    expect(result.errors[0].message).toContain('cluster unavailable');
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
+  });
+
+  test('Phase 3 silent per-task drop: dropped rule degrades to disabled and SO is still written', async () => {
+    taskManager.bulkSchedule.mockImplementationOnce(async (tasks) => {
+      return [tasks[0]] as never;
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'kept', enabled: true }) },
+        { data: baseRule({ name: 'dropped', enabled: true }) },
+      ],
+    });
+
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    expect(result.rules).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({
+        disabledReason: 'task_validation_failed',
+        rule: expect.objectContaining({ name: 'dropped' }),
+      })
+    );
+    expect(result.errors[0].message.startsWith(BULK_CREATE_AS_DISABLED_PREFIX)).toBe(true);
+  });
+
+  test('Phase 4 per-row error on Phase-3-scheduled id: per-rule key invalidated, bulkRemove called', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1', error: { message: 'conflict', statusCode: 409 } }])
+    );
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'enabled', enabled: true }) }],
+    });
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+    // Per-row error path now batches TM cleanup into a single bulkRemove.
+    expect(taskManager.bulkRemove).toHaveBeenCalledWith(['mock-id-1']);
+    expect(taskManager.removeIfExists).not.toHaveBeenCalled();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].status).toBe(409);
+    expect(result.errors[0].disabledReason).toBeUndefined();
+    expect(result.rules).toHaveLength(0);
+  });
+
+  test('Phase 4 per-row error on caller-supplied id NOT in newlyScheduledTaskIds: NO TM cleanup', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'caller-id', error: { message: 'conflict', statusCode: 409 } }])
+    );
+
+    await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'disabled-collision' }), options: { id: 'caller-id' } }],
+    });
+
+    expect(taskManager.removeIfExists).not.toHaveBeenCalled();
+    expect(taskManager.bulkRemove).not.toHaveBeenCalled();
+  });
+
+  test('Phase 4 whole-call throw: invalidates every newly-minted key and best-effort bulkRemove of scheduled ids, then rethrows', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockRejectedValueOnce(new Error('SO down'));
+
+    await expect(
+      rulesClient.bulkCreateRules({
+        rules: [
+          { data: baseRule({ name: 'a', enabled: true }) },
+          { data: baseRule({ name: 'b', enabled: true }) },
+        ],
+      })
+    ).rejects.toThrow('SO down');
+
+    expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledTimes(1);
+    expect(taskManager.bulkRemove).toHaveBeenCalledWith(['mock-id-1', 'mock-id-2']);
+  });
+
+  test('Phase 5 per-task enable error: surfaced in taskIdsFailedToBeEnabled, no SO rollback', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }])
+    );
+    taskManager.bulkEnable.mockResolvedValueOnce({
+      tasks: [],
+      errors: [{ id: 'mock-id-1', error: { type: 'foo', message: 'no' } }],
+    } as never);
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+    });
+
+    expect(result.taskIdsFailedToBeEnabled).toEqual(['mock-id-1']);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('every demotion path stamps a machine-readable disabledReason on the error', async () => {
+    // schedule_limit_exceeded
+    (validateScheduleLimit as jest.Mock).mockResolvedValueOnce({
+      interval: 100,
+      intervalAvailable: 50,
+    });
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-1' }])
+    );
+    const phase2 = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'a', enabled: true }) }],
+    });
+    expect(phase2.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'schedule_limit_exceeded' })
+    );
+
+    // task_schedule_failed
+    taskManager.bulkSchedule.mockRejectedValueOnce(new Error('tm boom'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-2' }])
+    );
+    const phase3a = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'b', enabled: true }) }],
+    });
+    expect(phase3a.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'task_schedule_failed' })
+    );
+
+    // task_validation_failed (silent drop)
+    taskManager.bulkSchedule.mockImplementationOnce(async () => [] as never);
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-3' }])
+    );
+    const phase3b = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'c', enabled: true }) }],
+    });
+    expect(phase3b.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'task_validation_failed' })
+    );
+
+    // api_key_creation_failed
+    rulesClientParams.createAPIKey.mockRejectedValueOnce(new Error('no keys'));
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValueOnce(
+      buildBulkResponse([{ id: 'mock-id-4' }])
+    );
+    const phase1 = await rulesClient.bulkCreateRules({
+      rules: [{ data: baseRule({ name: 'd', enabled: true }) }],
+    });
+    expect(phase1.errors[0]).toEqual(
+      expect.objectContaining({ disabledReason: 'api_key_creation_failed' })
+    );
+  });
+
+  // Caller-side chunking is covered by import_rules.test.ts; bulkCreateRules handles one batch per call.
+
+  test('emits per-rule CREATE audit event for surviving rules and ENABLE for the enabled subset', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(
+      buildBulkResponse([{ id: 'mock-id-1' }, { id: 'mock-id-2' }])
+    );
+
+    await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseRule({ name: 'enabled', enabled: true }) },
+        { data: baseRule({ name: 'disabled' }) },
+      ],
+    });
+
+    const actions = (auditLogger.log as jest.Mock).mock.calls
+      .map(([event]) => event?.event?.action)
+      .filter(Boolean);
+    expect(actions.filter((a) => a === RuleAuditAction.CREATE)).toHaveLength(2);
+    expect(actions.filter((a) => a === RuleAuditAction.ENABLE)).toHaveLength(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -1,0 +1,308 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import pMap from 'p-map';
+import { withSpan } from '@kbn/apm-utils';
+import type { SavedObject, SavedObjectsBulkCreateObject } from '@kbn/core/server';
+import { SavedObjectsUtils } from '@kbn/core/server';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { getRuleCircuitBreakerErrorMessage } from '../../../../../common';
+import { updateMeta } from '../../../../rules_client/lib';
+import { API_KEY_GENERATE_CONCURRENCY } from '../../../../rules_client/common/constants';
+import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
+import { bulkEnableTasks } from '../bulk_enable_tasks';
+import { bulkCreateRulesSo } from '../../../../data/rule';
+import type { RawRule, SanitizedRule } from '../../../../types';
+import type { BulkOperationError, RulesClientContext } from '../../../../rules_client/types';
+import type { RuleParams } from '../../types';
+import { validateScheduleLimit } from '../get_schedule_frequency';
+import type {
+  ApiKeyEntry,
+  PreparedRule,
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+} from './types';
+import {
+  buildTaskInstance,
+  collectNewKeysToInvalidate,
+  demotePreparedRules,
+  flushKeysToInvalidate,
+  prepareRule,
+  toSanitizedRule,
+} from './utils';
+
+export async function bulkCreateRules<Params extends RuleParams = never>(
+  context: RulesClientContext,
+  params: BulkCreateRulesParams<Params>
+): Promise<BulkCreateRulesResult<Params>> {
+  const { rules } = params;
+  const { logger } = context;
+  const total = rules.length;
+
+  if (total === 0) {
+    return { rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] };
+  }
+
+  const username = await context.getUserName();
+  const actionsClient = await context.getActionsClient();
+
+  const inputsWithIds = rules.map((rule) => ({
+    id: rule.options?.id ?? SavedObjectsUtils.generateId(),
+    rule,
+  }));
+
+  logger.debug(`Bulk creating batch of ${total} rules`);
+
+  // Phase 1: per-rule prepare (validation + api key generation).
+  // NOTE: in order to minimise external calls, the values below get mutated
+  // at different stages in the process (ie if we fail schedule creation),
+  // so that we invalidate keys and create rule SOs in a single batch at the end.
+  const preparedRules = new Map<string, PreparedRule>();
+  const keysToInvalidate = new Set<string>();
+  const apiKeysMap = new Map<string, ApiKeyEntry>();
+  const errors: BulkOperationError[] = [];
+  const authzCache = new Map<string, Promise<void>>();
+
+  await pMap(
+    inputsWithIds,
+    async ({ id, rule }) => {
+      const { prepared, error } = await prepareRule({
+        context,
+        actionsClient,
+        username,
+        id,
+        rule,
+        authzCache,
+        errors,
+        apiKeysMap,
+      });
+      if (prepared) preparedRules.set(id, prepared);
+      else if (error) errors.push(error);
+    },
+    { concurrency: API_KEY_GENERATE_CONCURRENCY }
+  );
+
+  // No survivors? Flush out any keys created and return
+  if (preparedRules.size === 0) {
+    await flushKeysToInvalidate(keysToInvalidate, context);
+    return { rules: [], errors, total, taskIdsFailedToBeEnabled: [] };
+  }
+
+  // Phase 2: validate schedule-limits, enabled subset only.
+  const enabled = [...preparedRules.values()].filter((p) => p.enabled);
+
+  if (enabled.length > 0) {
+    const updatedInterval = enabled.map((r) => r.schedule.interval);
+    const validationPayload = await validateScheduleLimit({ context, updatedInterval });
+    const enabledIds = enabled.map((p) => p.id);
+    if (validationPayload) {
+      const reasonMessage = getRuleCircuitBreakerErrorMessage({
+        interval: validationPayload.interval,
+        intervalAvailable: validationPayload.intervalAvailable,
+        action: 'bulkCreate',
+        rules: enabledIds.length,
+      });
+      logger.debug(`Demoting ${enabledIds.length} rules -> disabled, schedule limit exceeded.`);
+      demotePreparedRules({
+        ids: enabledIds,
+        reason: 'schedule_limit_exceeded',
+        message: reasonMessage,
+        preparedRules,
+        apiKeysMap,
+        keysToInvalidate,
+        errors,
+        username,
+      });
+    }
+  }
+
+  // Phase 3: schedule tasks for the surviving enabled subset.
+  const survivingEnabled = [...preparedRules.values()].filter((p) => p.enabled);
+  const newlyScheduledTaskIds = new Set<string>();
+
+  if (survivingEnabled.length > 0) {
+    const tasksToSchedule = survivingEnabled.map((preparedRule) =>
+      buildTaskInstance(context, preparedRule)
+    );
+
+    let scheduledIds: string[] = [];
+    const survivingEnabledIds = survivingEnabled.map((p) => p.id);
+    try {
+      const scheduledTasks = await withSpan(
+        { name: 'taskManager.bulkSchedule', type: 'tasks' },
+        () => context.taskManager.bulkSchedule(tasksToSchedule)
+      );
+      scheduledIds = scheduledTasks.map((task) => task.id);
+    } catch (error) {
+      // Whole-call TM throw: demote enabled subset to disabled, continue.
+      logger.warn(
+        `Demoting ${survivingEnabledIds.length} rules -> disabled, task scheduling failed.`
+      );
+      demotePreparedRules({
+        ids: survivingEnabledIds,
+        reason: 'task_schedule_failed',
+        message: `Failed to schedule tasks: ${error.message}`,
+        preparedRules,
+        apiKeysMap,
+        keysToInvalidate,
+        errors,
+        username,
+      });
+    }
+
+    if (scheduledIds.length > 0) {
+      scheduledIds.forEach((id) => newlyScheduledTaskIds.add(id));
+    }
+
+    // Silent per-task drops: bulkSchedule's `taskInstanceToAttributes` validation
+    // logs+skips invalid instances. Diff requested vs returned and demote the missing ones.
+    if (preparedRules.size > 0 && scheduledIds.length < survivingEnabledIds.length) {
+      const returned = new Set(scheduledIds);
+      const dropped = survivingEnabledIds.filter((id) => !returned.has(id));
+      if (dropped.length > 0) {
+        logger.warn(`Demoting ${dropped.length} rules -> disabled, task validation failed.`);
+        demotePreparedRules({
+          ids: dropped,
+          reason: 'task_validation_failed',
+          message: 'Task scheduling silently dropped this rule (validation failure in task store)',
+          preparedRules,
+          apiKeysMap,
+          keysToInvalidate,
+          errors,
+          username,
+        });
+      }
+    }
+  }
+
+  // Audit per-rule CREATE event before persistence (mirrors createRuleSavedObject).
+  for (const prepared of preparedRules.values()) {
+    context.auditLogger?.log(
+      ruleAuditEvent({
+        action: RuleAuditAction.CREATE,
+        outcome: 'unknown',
+        savedObject: { type: RULE_SAVED_OBJECT_TYPE, id: prepared.id, name: prepared.name },
+      })
+    );
+  }
+
+  // Phase 4: bulk SO create (no overwrite — id collisions surface as per-row 409)
+  const bulkObjects: Array<SavedObjectsBulkCreateObject<RawRule>> = [...preparedRules.values()].map(
+    (prepared) => ({
+      type: RULE_SAVED_OBJECT_TYPE,
+      id: prepared.id,
+      attributes: updateMeta(context, prepared.rawRule),
+      references: prepared.references,
+    })
+  );
+
+  let bulkResponse;
+  try {
+    bulkResponse = await withSpan(
+      { name: 'unsecuredSavedObjectsClient.bulkCreate', type: 'rules' },
+      () =>
+        bulkCreateRulesSo({
+          savedObjectsClient: context.unsecuredSavedObjectsClient,
+          bulkCreateRuleAttributes: bulkObjects,
+        })
+    );
+  } catch (error) {
+    // Whole-call SO failure (auth, timeout, etc): invalidate every newly-minted
+    // key, best-effort orphan-task cleanup, then rethrow.
+    for (const k of collectNewKeysToInvalidate(apiKeysMap.values())) keysToInvalidate.add(k);
+    await flushKeysToInvalidate(keysToInvalidate, context);
+    if (newlyScheduledTaskIds.size > 0) {
+      try {
+        await context.taskManager.bulkRemove([...newlyScheduledTaskIds]);
+      } catch (cleanupError) {
+        logger.error(
+          `bulkCreateRules: failed to clean up tasks ${[...newlyScheduledTaskIds].join(
+            ', '
+          )} after SO bulkCreate threw: ${cleanupError.message}`
+        );
+      }
+    }
+    throw error;
+  }
+
+  // Phase 4 per-row outcomes.
+  const successfulSos: Array<SavedObject<RawRule>> = [];
+  const taskIdsToEnable: string[] = [];
+  const taskIdsToCleanUp: string[] = [];
+
+  for (const so of bulkResponse.saved_objects) {
+    if (so.error) {
+      errors.push({
+        message: so.error.message ?? 'n/a',
+        status: so.error.statusCode,
+        rule: { id: so.id, name: preparedRules.get(so.id)?.name ?? 'n/a' },
+      });
+
+      const apiKey = apiKeysMap.get(so.id);
+      if (apiKey) {
+        for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
+      }
+
+      // Only ids we scheduled in Phase 3. Skipping caller-supplied id collisions
+      // avoids nuking a pre-existing rule's task on a 409.
+      if (newlyScheduledTaskIds.has(so.id)) {
+        taskIdsToCleanUp.push(so.id);
+      }
+    } else {
+      successfulSos.push(so as SavedObject<RawRule>);
+      if (newlyScheduledTaskIds.has(so.id)) {
+        taskIdsToEnable.push(so.id);
+        // Audit per-rule ENABLE for the enabled subset (mirrors single-rule semantics).
+        context.auditLogger?.log(
+          ruleAuditEvent({
+            action: RuleAuditAction.ENABLE,
+            outcome: 'unknown',
+            savedObject: {
+              type: RULE_SAVED_OBJECT_TYPE,
+              id: so.id,
+              name: preparedRules.get(so.id)?.name,
+            },
+          })
+        );
+      }
+    }
+  }
+
+  // Single batched TM cleanup for per-row failures.
+  if (taskIdsToCleanUp.length > 0) {
+    try {
+      logger.warn(`Cleaning up ${taskIdsToCleanUp.length} tasks where SO creation failed.`);
+      await context.taskManager.bulkRemove(taskIdsToCleanUp);
+    } catch (cleanupError) {
+      logger.error(
+        `bulkCreateRules: failed to clean up tasks ${taskIdsToCleanUp.join(
+          ', '
+        )} after SO per-row errors: ${cleanupError.message}`
+      );
+    }
+  }
+
+  // Phase 5: enable scheduled tasks. If skipTaskEnabling, caller enables them later.
+  const taskIdsFailedToBeEnabled = params.skipTaskEnabling
+    ? [...taskIdsToEnable]
+    : (await bulkEnableTasks(context, { taskIds: taskIdsToEnable })).taskIdsFailedToBeEnabled;
+
+  // Single end-of-function flush for all collected key invalidations.
+  await flushKeysToInvalidate(keysToInvalidate, context);
+
+  // Phase 6: domain transform + return.
+  const sanitizedRules: Array<SanitizedRule<Params>> = successfulSos.map((so) =>
+    toSanitizedRule<Params>(context, so, context.ruleTypeRegistry)
+  );
+
+  return {
+    rules: sanitizedRules,
+    errors,
+    total,
+    taskIdsFailedToBeEnabled,
+  };
+}

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { BulkCreateRulesItem, BulkCreateRulesParams, BulkCreateRulesResult } from './types';
+export { bulkCreateRules } from './bulk_create_rules';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectReference } from '@kbn/core/server';
+import type { IntervalSchedule } from '../../../../../common';
+import type { RuleParams } from '../../types';
+import type { CreateRuleData } from '../create/types';
+import type { CreateRuleOptions } from '../create/create_rule';
+import type { BulkOperationError, RulesClientContext } from '../../../../rules_client/types';
+import type { RawRule, SanitizedRule } from '../../../../types';
+
+export interface PreparedRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  rawRule: RawRule;
+  references: SavedObjectReference[];
+  schedule: IntervalSchedule;
+  consumer: string;
+  ruleTypeId: string;
+}
+
+export interface ApiKeyEntry {
+  apiKey: string | null;
+  uiamApiKey: string | null;
+  apiKeyCreatedByUser: boolean | null;
+}
+
+export interface PrepareRuleArgs<Params extends RuleParams> {
+  context: RulesClientContext;
+  actionsClient: Awaited<ReturnType<RulesClientContext['getActionsClient']>>;
+  username: string | null;
+  id: string;
+  rule: BulkCreateRulesItem<Params>;
+  authzCache: Map<string, Promise<void>>;
+  errors: BulkCreateOperationError[];
+  apiKeysMap: Map<string, ApiKeyEntry>;
+}
+
+export interface BulkCreateRulesItem<Params extends RuleParams = never> {
+  data: CreateRuleData<Params>;
+  options?: CreateRuleOptions;
+  allowMissingConnectorSecrets?: boolean;
+}
+
+export interface BulkCreateRulesParams<Params extends RuleParams = never> {
+  rules: Array<BulkCreateRulesItem<Params>>;
+  // If true, skip Phase 5 (taskManager.bulkEnable);
+  skipTaskEnabling?: boolean;
+}
+
+export type BulkCreateDisabledReason =
+  | 'api_key_creation_failed'
+  | 'schedule_limit_exceeded'
+  | 'task_schedule_failed'
+  | 'task_validation_failed';
+
+export interface BulkCreateOperationError extends BulkOperationError {
+  disabledReason?: BulkCreateDisabledReason;
+}
+
+export interface BulkCreateRulesResult<Params extends RuleParams = never> {
+  rules: Array<SanitizedRule<Params>>;
+  errors: BulkCreateOperationError[];
+  total: number;
+  taskIdsFailedToBeEnabled: string[];
+}

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/utils.ts
@@ -1,0 +1,386 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import Semver from 'semver';
+import { i18n } from '@kbn/i18n';
+import type { SavedObject } from '@kbn/core/server';
+import type { TaskInstanceWithDeprecatedFields } from '@kbn/task-manager-plugin/server/task';
+
+import { validateAndAuthorizeSystemActions } from '../../../../lib/validate_authorize_system_actions';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { parseDuration } from '../../../../../common';
+import { WriteOperations, AlertingAuthorizationEntity } from '../../../../authorization';
+import {
+  validateRuleTypeParams,
+  getRuleNotifyWhenType,
+  getDefaultMonitoringRuleDomainProperties,
+} from '../../../../lib';
+import { getRuleExecutionStatusPending } from '../../../../lib/rule_execution_status';
+import {
+  addGeneratedActionValues,
+  createNewAPIKeySet,
+  extractReferences,
+  validateActions,
+} from '../../../../rules_client/lib';
+import {
+  addMissingUiamKeyTagIfNeeded,
+  apiKeyAsAlertAttributes,
+  apiKeyAsRuleDomainProperties,
+} from '../../../../rules_client/common';
+import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
+import { bulkMarkApiKeysForInvalidation } from '../../../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
+import type { RawRule, RuleTypeRegistry, SanitizedRule } from '../../../../types';
+import type { BulkOperationError, RulesClientContext } from '../../../../rules_client/types';
+import type { RuleDomain, RuleParams } from '../../types';
+import {
+  transformRuleAttributesToRuleDomain,
+  transformRuleDomainToRule,
+  transformRuleDomainToRuleAttributes,
+} from '../../transforms';
+import { ruleDomainSchema } from '../../schemas';
+import { createRuleDataSchema } from '../create/schemas';
+import type {
+  PreparedRule,
+  PrepareRuleArgs,
+  ApiKeyEntry,
+  BulkCreateOperationError,
+  BulkCreateDisabledReason,
+} from './types';
+
+export const getBulkCreateAsDisabledMessage = (message: string): string =>
+  i18n.translate('xpack.alerting.rulesClient.bulkCreate.ruleCreatedDisabledErrorMessage', {
+    defaultMessage: 'Rule created in a disabled state: {message}',
+    values: { message },
+  });
+
+export const collectNewKeysToInvalidate = (entries: Iterable<ApiKeyEntry>): string[] => {
+  const keys: string[] = [];
+  for (const { apiKey, uiamApiKey, apiKeyCreatedByUser } of entries) {
+    if (apiKey && !apiKeyCreatedByUser) keys.push(apiKey);
+    if (uiamApiKey && !apiKeyCreatedByUser) keys.push(uiamApiKey);
+  }
+  return keys;
+};
+
+export const buildTaskInstance = (
+  context: RulesClientContext,
+  prepared: PreparedRule
+): TaskInstanceWithDeprecatedFields => ({
+  id: prepared.id,
+  taskType: `alerting:${prepared.ruleTypeId}`,
+  schedule: prepared.schedule,
+  params: {
+    alertId: prepared.id,
+    spaceId: context.spaceId,
+    consumer: prepared.consumer,
+  },
+  state: {
+    previousStartedAt: null,
+    alertTypeState: {},
+    alertInstances: {},
+  },
+  scope: ['alerting'],
+  // Tasks are scheduled disabled. Phase 5 enables them via taskManager.bulkEnable
+  // so per-task validation drops never produce a running task without a rule SO,
+  // and the activation can randomise schedule datetimes across the batch.
+  enabled: false,
+});
+
+export const toSanitizedRule = <Params extends RuleParams = never>(
+  context: RulesClientContext,
+  so: SavedObject<RawRule>,
+  ruleTypeRegistry: RuleTypeRegistry
+): SanitizedRule<Params> => {
+  const ruleType = ruleTypeRegistry.get(so.attributes.alertTypeId);
+  const ruleDomain: RuleDomain<Params> = transformRuleAttributesToRuleDomain<Params>(
+    so.attributes,
+    {
+      id: so.id,
+      logger: context.logger,
+      ruleType,
+      references: so.references,
+      omitGeneratedValues: false,
+    },
+    context.isSystemAction
+  );
+
+  try {
+    ruleDomainSchema.validate(ruleDomain);
+  } catch (e) {
+    context.logger.warn(`Error validating bulk-created rule domain object for id: ${so.id}, ${e}`);
+  }
+
+  return transformRuleDomainToRule<Params>(ruleDomain, { isPublic: true }) as SanitizedRule<Params>;
+};
+
+export const prepareRule = async <Params extends RuleParams>({
+  context,
+  actionsClient,
+  username,
+  id,
+  rule,
+  authzCache,
+  errors,
+  apiKeysMap,
+}: PrepareRuleArgs<Params>): Promise<{ prepared?: PreparedRule; error?: BulkOperationError }> => {
+  const { allowMissingConnectorSecrets } = rule;
+
+  try {
+    const { actions: genActions, systemActions: genSystemActions } = await addGeneratedActionValues(
+      rule.data.actions,
+      rule.data.systemActions,
+      context
+    );
+    const data = { ...rule.data, actions: genActions, systemActions: genSystemActions };
+
+    try {
+      createRuleDataSchema.validate(data);
+    } catch (validationError) {
+      throw Boom.badRequest(`Error validating create data - ${validationError.message}`);
+    }
+
+    // ruleTypeRegistry.get throws 400 if not registered.
+    context.ruleTypeRegistry.get(data.alertTypeId);
+
+    const authzKey = `${data.alertTypeId}::${data.consumer}`;
+    if (!authzCache.has(authzKey)) {
+      authzCache.set(
+        authzKey,
+        context.authorization.ensureAuthorized({
+          ruleTypeId: data.alertTypeId,
+          consumer: data.consumer,
+          operation: WriteOperations.Create,
+          entity: AlertingAuthorizationEntity.Rule,
+        })
+      );
+    }
+    try {
+      await authzCache.get(authzKey)!;
+    } catch (authzError) {
+      context.auditLogger?.log(
+        ruleAuditEvent({
+          action: RuleAuditAction.CREATE,
+          savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: data.name },
+          error: authzError,
+        })
+      );
+      throw authzError;
+    }
+
+    context.ruleTypeRegistry.ensureRuleTypeEnabled(data.alertTypeId);
+    const ruleType = context.ruleTypeRegistry.get(data.alertTypeId);
+    const validatedRuleTypeParams = validateRuleTypeParams(data.params, ruleType.validate.params);
+
+    await validateActions(context, ruleType, data, allowMissingConnectorSecrets);
+    await validateAndAuthorizeSystemActions({
+      actionsClient,
+      actionsAuthorization: context.actionsAuthorization,
+      connectorAdapterRegistry: context.connectorAdapterRegistry,
+      systemActions: data.systemActions ?? [],
+      rule: { consumer: data.consumer, producer: ruleType.producer },
+    });
+
+    const intervalInMs = parseDuration(data.schedule.interval);
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      context.minimumScheduleInterval.enforce
+    ) {
+      throw Boom.badRequest(
+        `Error creating rule: the interval is less than the allowed minimum interval of ${context.minimumScheduleInterval.value}`
+      );
+    }
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      !context.minimumScheduleInterval.enforce
+    ) {
+      context.logger.warn(
+        `Rule schedule interval (${data.schedule.interval}) for "${ruleType.id}" rule type with ID "${id}" is less than the minimum value (${context.minimumScheduleInterval.value}). Running rules at this interval may impact alerting performance. Set "xpack.alerting.rules.minimumScheduleInterval.enforce" to true to prevent creation of these rules.`
+      );
+    }
+
+    // Mint API key for enabled rules.
+    // Soft-fail: a key-mint failure does NOT reject the rule. We persist it as
+    // disabled, push a degraded error so the caller knows, and let downstream
+    // phases treat it as a never-enabled rule. Re-enabling later will re-mint.
+    let effectiveEnabled = data.enabled;
+    let apiKeyProps:
+      | ReturnType<typeof apiKeyAsRuleDomainProperties>
+      | Awaited<ReturnType<typeof createNewAPIKeySet>> = apiKeyAsRuleDomainProperties(
+      null,
+      username,
+      false
+    );
+    if (data.enabled) {
+      try {
+        apiKeyProps = await createNewAPIKeySet(context, {
+          id: ruleType.id,
+          ruleName: data.name,
+          username,
+          shouldUpdateApiKey: true,
+          errorMessage: 'Error creating rule: could not create API key',
+        });
+        apiKeysMap.set(id, {
+          apiKey: apiKeyProps.apiKey ?? null,
+          uiamApiKey: apiKeyProps.uiamApiKey ?? null,
+          apiKeyCreatedByUser: apiKeyProps.apiKeyCreatedByUser ?? null,
+        });
+      } catch (apiKeyErr) {
+        effectiveEnabled = false;
+        apiKeyProps = apiKeyAsRuleDomainProperties(null, username, false);
+        errors.push({
+          message: getBulkCreateAsDisabledMessage(apiKeyErr.message),
+          status: apiKeyErr.output?.statusCode,
+          rule: { id, name: data.name },
+          disabledReason: 'api_key_creation_failed',
+        });
+      }
+    }
+
+    const allActions = [...data.actions, ...(data.systemActions ?? [])];
+    const artifacts = data.artifacts ?? {};
+    const {
+      references,
+      params: updatedParams,
+      actions: actionsWithRefs,
+      artifacts: artifactsWithRefs,
+    } = await extractReferences(context, ruleType, allActions, validatedRuleTypeParams, artifacts);
+
+    const createTime = Date.now();
+    const lastRunTimestamp = new Date();
+    const legacyId = Semver.lt(context.kibanaVersion, '8.0.0') ? id : null;
+    const notifyWhen = getRuleNotifyWhenType(data.notifyWhen ?? null, data.throttle ?? null);
+    const throttle = data.throttle ?? null;
+    const { systemActions: _sa, actions: _a, ...restData } = data;
+
+    const tagsWithUiamCheck = await addMissingUiamKeyTagIfNeeded(
+      data.tags,
+      apiKeyProps.uiamApiKey,
+      apiKeyProps.apiKeyCreatedByUser,
+      context.isServerless,
+      context.featureFlags
+    );
+
+    const ruleAttributes = transformRuleDomainToRuleAttributes({
+      actionsWithRefs,
+      artifactsWithRefs,
+      rule: {
+        ...restData,
+        tags: tagsWithUiamCheck,
+        ...apiKeyProps,
+        enabled: effectiveEnabled,
+        id,
+        createdBy: username,
+        updatedBy: username,
+        createdAt: new Date(createTime),
+        updatedAt: new Date(createTime),
+        snoozeSchedule: [],
+        muteAll: false,
+        mutedInstanceIds: [],
+        notifyWhen,
+        throttle,
+        executionStatus: getRuleExecutionStatusPending(lastRunTimestamp.toISOString()),
+        monitoring: getDefaultMonitoringRuleDomainProperties(lastRunTimestamp.toISOString()),
+        revision: 0,
+        running: false,
+      } as unknown as RuleDomain<Params>,
+      params: { legacyId, paramsWithRefs: updatedParams },
+    });
+
+    if (effectiveEnabled) {
+      ruleAttributes.lastEnabledAt = new Date(createTime).toISOString();
+      ruleAttributes.scheduledTaskId = id;
+    }
+
+    const prepared = {
+      id,
+      name: data.name,
+      enabled: effectiveEnabled,
+      rawRule: ruleAttributes,
+      references,
+      schedule: data.schedule,
+      consumer: data.consumer,
+      ruleTypeId: data.alertTypeId,
+    };
+    return { prepared };
+  } catch (err) {
+    const error = {
+      message: err.message,
+      status: err.output?.statusCode,
+      rule: { id, name: rule.data?.name ?? 'n/a' },
+    };
+    return { error };
+  }
+};
+
+/**
+ * Demote in-memory (enabled -> disabled): flips a set of currently-enabled
+ * prepared rules to disabled, queues their API keys for invalidation, records a degraded
+ * error so the caller can surface "rule was created in a disabled state".
+ */
+export const demotePreparedRules = ({
+  ids,
+  reason,
+  message,
+  preparedRules,
+  apiKeysMap,
+  keysToInvalidate,
+  errors,
+  username,
+}: {
+  ids: string[];
+  reason: BulkCreateDisabledReason;
+  message: string;
+  preparedRules: Map<string, PreparedRule>;
+  apiKeysMap: Map<string, ApiKeyEntry>;
+  keysToInvalidate: Set<string>;
+  errors: BulkCreateOperationError[];
+  username: string | null;
+}): void => {
+  for (const id of ids) {
+    const prepared = preparedRules.get(id);
+    if (!prepared || !prepared.enabled) continue;
+
+    const apiKey = apiKeysMap.get(id);
+    if (apiKey) {
+      for (const k of collectNewKeysToInvalidate([apiKey])) keysToInvalidate.add(k);
+      apiKeysMap.delete(id);
+    }
+
+    // Re-shape `rawRule` to the disabled-rule form.
+    const nullKey = apiKeyAsAlertAttributes(null, username, false);
+    prepared.rawRule = {
+      ...prepared.rawRule,
+      ...nullKey,
+      uiamApiKey: null,
+      enabled: false,
+    };
+    delete prepared.rawRule.scheduledTaskId;
+    delete prepared.rawRule.lastEnabledAt;
+    prepared.enabled = false;
+
+    errors.push({
+      message: getBulkCreateAsDisabledMessage(message),
+      rule: { id, name: prepared.name },
+      disabledReason: reason,
+    });
+  }
+};
+
+export const flushKeysToInvalidate = async (
+  keysToInvalidate: Set<string>,
+  context: RulesClientContext
+): Promise<void> => {
+  if (keysToInvalidate.size === 0) return;
+  // Note: ES Call via savedObjectsClient.bulkCreate() under the hood
+  await bulkMarkApiKeysForInvalidation(
+    { apiKeys: [...keysToInvalidate] },
+    context.logger,
+    context.unsecuredSavedObjectsClient
+  );
+  keysToInvalidate.clear();
+};

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.ts
@@ -16,8 +16,6 @@ import type {
   SavedObjectsFindResult,
 } from '@kbn/core/server';
 import { withSpan } from '@kbn/apm-utils';
-import type { Logger } from '@kbn/core/server';
-import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { TaskStatus } from '@kbn/task-manager-plugin/server';
 import type { TaskInstanceWithDeprecatedFields } from '@kbn/task-manager-plugin/server/task';
 import { RuleChangeTrackingAction } from '@kbn/alerting-types';
@@ -46,6 +44,7 @@ import type { RulesClientContext, BulkOperationError } from '../../../../rules_c
 import { validateScheduleLimit } from '../get_schedule_frequency';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
 import type { BulkEnableRulesParams, BulkEnableRulesResult } from './types';
+import { bulkEnableTasks } from '../bulk_enable_tasks';
 import { bulkEnableRulesParamsSchema } from './schemas';
 import { transformRuleAttributesToRuleDomain, transformRuleDomainToRule } from '../../transforms';
 import { ruleDomainSchema } from '../../schemas';
@@ -117,10 +116,8 @@ export const bulkEnableRules = async <Params extends RuleParams>(
 
   const [taskIdsToEnable] = accListSpecificForBulkOperation;
 
-  const taskIdsFailedToBeEnabled = await tryToEnableTasks({
-    taskIdsToEnable,
-    logger: context.logger,
-    taskManager: context.taskManager,
+  const { taskIdsFailedToBeEnabled } = await bulkEnableTasks(context, {
+    taskIds: taskIdsToEnable,
   });
 
   const updatedRules = rules.map(({ id, attributes, references }) => {
@@ -442,50 +439,4 @@ const bulkEnableRulesWithOCC = async (
     rules: rules as Array<SavedObjectsBulkUpdateObject<RawRule>>,
     accListSpecificForBulkOperation: [taskIdsToEnable],
   };
-};
-
-export const tryToEnableTasks = async ({
-  taskIdsToEnable,
-  logger,
-  taskManager,
-}: {
-  taskIdsToEnable: string[];
-  logger: Logger;
-  taskManager: TaskManagerStartContract;
-}) => {
-  const taskIdsFailedToBeEnabled: string[] = [];
-
-  if (taskIdsToEnable.length > 0) {
-    try {
-      const resultFromEnablingTasks = await withSpan(
-        { name: 'taskManager.bulkEnable', type: 'rules' },
-        async () => taskManager.bulkEnable(taskIdsToEnable)
-      );
-      resultFromEnablingTasks?.errors?.forEach((error) => {
-        taskIdsFailedToBeEnabled.push(error.id);
-      });
-      if (resultFromEnablingTasks.tasks.length) {
-        logger.debug(
-          `Successfully enabled schedules for underlying tasks: ${resultFromEnablingTasks.tasks
-            .map((task) => task.id)
-            .join(', ')}`
-        );
-      }
-      if (resultFromEnablingTasks.errors.length) {
-        logger.error(
-          `Failure to enable schedules for underlying tasks: ${resultFromEnablingTasks.errors
-            .map((error) => error.id)
-            .join(', ')}`
-        );
-      }
-    } catch (error) {
-      taskIdsFailedToBeEnabled.push(...taskIdsToEnable);
-      logger.error(
-        `Failure to enable schedules for underlying tasks: ${taskIdsToEnable.join(
-          ', '
-        )}. TaskManager bulkEnable failed with Error: ${error.message}`
-      );
-    }
-  }
-  return taskIdsFailedToBeEnabled;
 };

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable_tasks/bulk_enable_tasks.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable_tasks/bulk_enable_tasks.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { withSpan } from '@kbn/apm-utils';
+import type { RulesClientContext } from '../../../../rules_client/types';
+import type { BulkEnableTasksParams, BulkEnableTasksResult } from './types';
+
+// Enable previously scheduled task manager tasks; returns ids whose enable failed.
+export const bulkEnableTasks = async (
+  context: RulesClientContext,
+  params: BulkEnableTasksParams
+): Promise<BulkEnableTasksResult> => {
+  const { taskIds } = params;
+  const { logger, taskManager } = context;
+  const taskIdsFailedToBeEnabled: string[] = [];
+
+  if (taskIds.length === 0) {
+    return { taskIdsFailedToBeEnabled };
+  }
+
+  try {
+    const resultFromEnablingTasks = await withSpan(
+      { name: 'taskManager.bulkEnable', type: 'rules' },
+      async () => taskManager.bulkEnable(taskIds)
+    );
+    resultFromEnablingTasks?.errors?.forEach((error) => {
+      taskIdsFailedToBeEnabled.push(error.id);
+    });
+    if (resultFromEnablingTasks.tasks.length) {
+      logger.debug(
+        `Successfully enabled schedules for underlying tasks: ${resultFromEnablingTasks.tasks
+          .map((task) => task.id)
+          .join(', ')}`
+      );
+    }
+    if (resultFromEnablingTasks.errors.length) {
+      logger.error(
+        `Failure to enable schedules for underlying tasks: ${resultFromEnablingTasks.errors
+          .map((error) => error.id)
+          .join(', ')}`
+      );
+    }
+  } catch (error) {
+    taskIdsFailedToBeEnabled.push(...taskIds);
+    logger.error(
+      `Failure to enable schedules for underlying tasks: ${taskIds.join(
+        ', '
+      )}. TaskManager bulkEnable failed with Error: ${error.message}`
+    );
+  }
+
+  return { taskIdsFailedToBeEnabled };
+};

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable_tasks/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable_tasks/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { BulkEnableTasksParams, BulkEnableTasksResult } from './types';
+
+export { bulkEnableTasks } from './bulk_enable_tasks';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable_tasks/types/bulk_enable_tasks_types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable_tasks/types/bulk_enable_tasks_types.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface BulkEnableTasksParams {
+  taskIds: string[];
+}
+
+export interface BulkEnableTasksResult {
+  taskIdsFailedToBeEnabled: string[];
+}

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable_tasks/types/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable_tasks/types/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type * from './bulk_enable_tasks_types';

--- a/x-pack/platform/plugins/shared/alerting/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/index.ts
@@ -40,6 +40,11 @@ export { RuleNotifyWhen } from '../common';
 export type { AlertingServerSetup, AlertingServerStart } from './plugin';
 export type { RulesClientCreateOptions } from './rules_client_factory';
 export type { FindResult, BulkEditOperation, BulkOperationError } from './rules_client';
+export type {
+  BulkCreateRulesItem,
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+} from './application/rule/methods/bulk_create';
 export type { Rule } from './application/rule/types';
 export type { PublicAlert as Alert } from './alert';
 export { parseDuration, isRuleSnoozed } from './lib';

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
@@ -52,8 +52,12 @@ const createRulesClientMock = () => {
     bulkGetRules: jest.fn(),
     bulkEdit: jest.fn(),
     bulkEditRuleParamsWithReadAuth: jest.fn(),
+    bulkCreateRules: jest
+      .fn()
+      .mockResolvedValue({ rules: [], errors: [], total: 0, taskIdsFailedToBeEnabled: [] }),
     bulkDeleteRules: jest.fn(),
     bulkEnableRules: jest.fn(),
+    bulkEnableTasks: jest.fn().mockResolvedValue({ taskIdsFailedToBeEnabled: [] }),
     bulkDisableRules: jest.fn(),
     snooze: jest.fn(),
     unsnooze: jest.fn(),

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
@@ -60,6 +60,10 @@ import type { BulkEditRuleParamsOptions } from '../application/rule/methods/bulk
 import { bulkEditRuleParamsWithReadAuth } from '../application/rule/methods/bulk_edit_params/bulk_edit_rule_params';
 import type { BulkEnableRulesParams } from '../application/rule/methods/bulk_enable';
 import { bulkEnableRules } from '../application/rule/methods/bulk_enable';
+import type { BulkCreateRulesParams } from '../application/rule/methods/bulk_create';
+import { bulkCreateRules } from '../application/rule/methods/bulk_create';
+import type { BulkEnableTasksParams } from '../application/rule/methods/bulk_enable_tasks';
+import { bulkEnableTasks } from '../application/rule/methods/bulk_enable_tasks';
 import { enableRule } from '../application/rule/methods/enable_rule/enable_rule';
 import { updateRuleApiKey } from '../application/rule/methods/update_api_key/update_rule_api_key';
 import { disableRule } from '../application/rule/methods/disable/disable_rule';
@@ -200,6 +204,9 @@ export class RulesClient {
 
   public bulkGetRules = <Params extends RuleTypeParams = never>(params: BulkGetRulesParams) =>
     bulkGetRules<Params>(this.context, params);
+  public bulkCreateRules = <Params extends RuleTypeParams = never>(
+    params: BulkCreateRulesParams<Params>
+  ) => bulkCreateRules<Params>(this.context, params);
   public bulkDeleteRules = (options: BulkDeleteRulesRequestBody) =>
     bulkDeleteRules(this.context, options);
   public bulkEdit = <Params extends RuleTypeParams>(options: BulkEditOptions<Params>) =>
@@ -209,6 +216,7 @@ export class RulesClient {
     options: BulkEditRuleParamsOptions<Params>
   ) => bulkEditRuleParamsWithReadAuth<Params>(this.context, options);
   public bulkEnableRules = (params: BulkEnableRulesParams) => bulkEnableRules(this.context, params);
+  public bulkEnableTasks = (params: BulkEnableTasksParams) => bulkEnableTasks(this.context, params);
   public bulkDisableRules = (options: BulkDisableRulesRequestBody) =>
     bulkDisableRules(this.context, options);
 


### PR DESCRIPTION
**Resolves: elastic/kibana#264893**
**Relates to: elastic/kibana#264890** (epic)

## Summary

Adds `rulesClient.bulkCreate()` to the Alerting framework. Standalone and not wired to anything.

The method natively handles both **disabled and enabled** rules in a single call (per-rule API-key minting, `taskManager.bulkSchedule`, audit, demotion-on-failure), and exposes a new `rulesClient.bulkEnableTasks()` method that callers can invoke once at the end of the HTTP request to flip the scheduled tasks to `enabled: true`.

Rough performance figures:

| Area | Local | ECH 1GB | Impact |
| --- | --- | --- | --- |
| **Rule installation**: <br>(1800 disabled)<br> | ~95s ->  ~21s | ~95s -> ~21s | 4-5x faster |
| **Rule import**:<br>(1000 enabled) | ~65s -> 21s | ~110s -> 42s | 2-3x faster |


### Special treatment for "enabled" rules: Enable tasks at the end.

When `bulkCreate({ skipTaskEnabling: true })` is used, the per-batch `taskManager.bulkEnable` step is skipped - callers accumulate task ids across batches and call `bulkEnableTasks(taskIds)` once at the end. 

This removes the per-batch contention on `.kibana_alerting_cases*` / `.kibana_task_manager` that previously dominated import time once tasks started running. Locally this means this last step takes 1s instead of ~30 it added to the whole process (when interleaved into each batch).

## Other Attempts

This PR has been put together after the following attempts.

1. Attempt [#266713](https://github.com/elastic/kibana/pull/266713): rule create + enable in batches of 50 rules/tasks.
2. Attempt [#268133](https://github.com/elastic/kibana/pull/268133): look at current waste (multiple calls per rule that could be made up-front) and try to make the process a bit more optimal.
3. Attempt [#268420](https://github.com/elastic/kibana/pull/268420): split TM schedule validation and task creation into a background phase that could be executed after all rule SOs were created.
4. Attempt [#268778](https://github.com/elastic/kibana/pull/268778): breakthrough - same as the current PR but with the Security Solution wiring included.

Current PR is the alerting-only slice extracted from [#268778](https://github.com/elastic/kibana/pull/268778) so it can land independently and be wired into Security Solution (rule import / prebuilt installation) in a follow-up PR.

## How to test:

While this PR only contains changes to the alerting framework, there is a way to apply a few changes locally and use detection rules "Import" and "Add Elastic Rules" to debug the code.

1. Apply patch https://github.com/sdesalas/kibana-knowledge/blob/main/patches/wiring-for-bulk-create.patch locally

```
git apply wiring-for-bulk-create.patch
```

2. Update your `kibana.dev.yml`

```
xpack.securitySolution.enableExperimental:
  - 'bulkCreateRulesEnabled'
```

3. Run Kibana locally. Security > Detection Rules

- For `bulkCreate` using **disabled** rules: use "Add Elastic Rules" to install ~1800 prebuilt rules.
- For `bulkCreate` using **enabled** rules: use the "Import" functionality with 1000 enabled rules from this set: https://github.com/sdesalas/kibana-knowledge/tree/main/data/rules-import

You will need to bulk delete rules in between attempts.

4. Use the following script to check created tasks:

https://github.com/sdesalas/kibana-knowledge/blob/main/scripts/check-tasks.sh

```
> ./check-tasks.sh
...
rules:           1000
rules_enabled:   1000
tasks:           1000
tasks_enabled:   1000
api_key_owner:   1000
apiKey present:  1000
```

All five counts should be equal under "happy path" scenarios.

## Automated Testing

Note that while this PR has been manually tested, it is intentionally light on unit tests and missing integration/FTR tests entirely. 

This is to avoid wasted time if the approach needs to be modified significantly after feedback from @elastic/response-ops.