### PR TITLE
[Data views/Index Patterns][Scout] Set longer poll timeout

### DIFF
--- a/src/platform/plugins/shared/data_views/test/scout/api/tests/data_views/default_data_view.spec.ts
+++ b/src/platform/plugins/shared/data_views/test/scout/api/tests/data_views/default_data_view.spec.ts
@@ -26,16 +26,19 @@ apiTest.describe(
 
     function expectDefaultDataView(apiClient: ApiClientFixture, defaultId: string) {
       return expect
-        .poll(async () => {
-          const getResponse = await apiClient.get(scopedPath(defaultPath), {
-            headers: {
-              ...COMMON_HEADERS,
-              ...adminApiCredentials.apiKeyHeader,
-            },
-            responseType: 'json',
-          });
-          return getResponse.body[serviceKeyId];
-        })
+        .poll(
+          async () => {
+            const getResponse = await apiClient.get(scopedPath(defaultPath), {
+              headers: {
+                ...COMMON_HEADERS,
+                ...adminApiCredentials.apiKeyHeader,
+              },
+              responseType: 'json',
+            });
+            return getResponse.body[serviceKeyId];
+          },
+          { timeout: 30_000 }
+        )
         .toBe(defaultId);
     }
 

--- a/src/platform/plugins/shared/data_views/test/scout/api/tests/index_patterns/default_index_pattern.spec.ts
+++ b/src/platform/plugins/shared/data_views/test/scout/api/tests/index_patterns/default_index_pattern.spec.ts
@@ -28,16 +28,19 @@ apiTest.describe(
 
     function expectDefaultIndexPattern(apiClient: ApiClientFixture, defaultId: string) {
       return expect
-        .poll(async () => {
-          const getResponse = await apiClient.get(scopedPath(defaultPath), {
-            headers: {
-              ...COMMON_HEADERS,
-              ...adminApiCredentials.apiKeyHeader,
-            },
-            responseType: 'json',
-          });
-          return getResponse.body[serviceKeyId];
-        })
+        .poll(
+          async () => {
+            const getResponse = await apiClient.get(scopedPath(defaultPath), {
+              headers: {
+                ...COMMON_HEADERS,
+                ...adminApiCredentials.apiKeyHeader,
+              },
+              responseType: 'json',
+            });
+            return getResponse.body[serviceKeyId];
+          },
+          { timeout: 30_000 }
+        )
         .toBe(defaultId);
     }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/265545
Closes https://github.com/elastic/kibana/issues/265649
Closes https://github.com/elastic/kibana/issues/265664

Just trying to see if using a bigger timeout as suggested by the investigation in https://github.com/elastic/kibana/issues/265649 mitigates the problem, it may be enough for the UI settings cache/refresh to get the update.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->