### PR TITLE
[ES|QL] Allow null in combination with any other type in CASE()

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/expressions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/expressions.ts
@@ -127,7 +127,7 @@ export function getExpressionType(
        * at least we know that the final argument to case will never be a conditional
        * expression, always a result expression.
        *
-       * One problem with this is that if a false case is not provided, the return type
+       * One problem with this is that if a elseValue is not provided, the return type
        * will be null, which we aren't detecting. But this is ok because we consider
        * userDefinedColumns and fields to be nullable anyways and account for that during validation.
        */

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/signatures/matchers.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/signatures/matchers.ts
@@ -160,6 +160,7 @@ function areRepeatingValuesCompatible(givenTypes: Array<SupportedDataType | 'unk
 
   return rest.every(
     (type) =>
+      type === 'null' ||
       type === 'unknown' ||
       type === 'param' ||
       type === first ||

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/signatures/matchers.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/signatures/matchers.ts
@@ -21,6 +21,13 @@ export const PARAM_TYPES_THAT_SUPPORT_IMPLICIT_STRING_CASTING: FunctionParameter
   'boolean',
 ];
 
+/** Types that are always compatible with other types in repeating signatures. */
+const REPEATING_SIGNATURE_ALWAYS_COMPATIBLE_TYPES: SupportedDataType[] = [
+  'null',
+  'unknown',
+  'param',
+];
+
 /** Checks whether one argument type can be used for one parameter type. */
 export function argMatchesParamType(
   givenType: SupportedDataType | 'unknown',
@@ -151,18 +158,18 @@ function areRepeatingValuesCompatible(givenTypes: Array<SupportedDataType | 'unk
   const { length } = givenTypes;
   const isValuePosition = (index: number) =>
     index % 2 === 1 || (length % 2 === 1 && index === length - 1);
-  const valueTypes = givenTypes.filter((_, index) => isValuePosition(index));
+  const valueTypes = givenTypes.filter(
+    (type, index) =>
+      isValuePosition(index) && !REPEATING_SIGNATURE_ALWAYS_COMPATIBLE_TYPES.includes(type)
+  );
   const [first, ...rest] = valueTypes;
 
-  if (!first || first === 'unknown' || first === 'param') {
+  if (!first) {
     return true;
   }
 
   return rest.every(
     (type) =>
-      type === 'null' ||
-      type === 'unknown' ||
-      type === 'param' ||
       type === first ||
       areCompatibleStringTypes(first, type) ||
       (first === 'long' && type === 'integer')

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/functions.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/functions.test.ts
@@ -1154,7 +1154,7 @@ describe('function validation', () => {
       ]);
     });
 
-    it('allows null as a result value for any value type', async () => {
+    it('allows null as a result value in combination with other types', async () => {
       const { expectErrors } = await setup();
 
       await expectErrors(
@@ -1163,7 +1163,7 @@ describe('function validation', () => {
       );
     });
 
-    it('allows null as the elseValue for any value type', async () => {
+    it('allows null as the elseValue in combination with other types', async () => {
       const { expectErrors } = await setup();
 
       await expectErrors('FROM index | EVAL result = CONDITIONAL_MOCK(booleanField, 42, null)', []);

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/functions.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/functions.test.ts
@@ -1153,5 +1153,20 @@ describe('function validation', () => {
         getNoValidCallSignatureError('conditional_mock', ['keyword', 'keyword']),
       ]);
     });
+
+    it('allows null as a result value for any value type', async () => {
+      const { expectErrors } = await setup();
+
+      await expectErrors(
+        'FROM index | EVAL result = CONDITIONAL_MOCK(booleanField, "text", booleanField, null)',
+        []
+      );
+    });
+
+    it('allows null as the elseValue for any value type', async () => {
+      const { expectErrors } = await setup();
+
+      await expectErrors('FROM index | EVAL result = CONDITIONAL_MOCK(booleanField, 42, null)', []);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/functions.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/functions.test.ts
@@ -1163,6 +1163,15 @@ describe('function validation', () => {
       );
     });
 
+    it('allows null as a result value in combination with other types, being null in the first position', async () => {
+      const { expectErrors } = await setup();
+
+      await expectErrors(
+        'FROM index | EVAL result = CONDITIONAL_MOCK(booleanField, null, booleanField, "text")',
+        []
+      );
+    });
+
     it('allows null as the elseValue in combination with other types', async () => {
       const { expectErrors } = await setup();
 


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/269029

## Summary
`null` value should be accepted in combination with any other type in the result positions of a CASE() function.
In ES|QL all columns are nullable.

## Before
<img width="747" height="694" alt="image" src="https://github.com/user-attachments/assets/b1db9329-0d31-49d9-8ac0-66d59aa932a5" />

## After
<img width="487" height="287" alt="image" src="https://github.com/user-attachments/assets/b11f5a05-f037-4afb-9ab1-095748217842" />





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->