### PR TITLE
[9.4] [ResponseOps] Fix Webhook http headers reset on blur/focus (#268941)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/use_secret_headers.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/use_secret_headers.test.tsx
@@ -8,7 +8,7 @@
 /* eslint-disable no-console */
 
 import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { useSecretHeaders } from './use_secret_headers';
@@ -98,5 +98,30 @@ describe('useSecretHeaders', () => {
         })
       );
     });
+  });
+
+  it('does not refetch secret headers on window focus', async () => {
+    getMock.mockResolvedValue(['secret-key']);
+    const { result } = renderHook(() => useSecretHeaders('connector1', true), {
+      wrapper: customWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(['secret-key']);
+    });
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        writable: true,
+        value: 'visible',
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual(['secret-key']);
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/use_secret_headers.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/common/auth/use_secret_headers.tsx
@@ -34,6 +34,8 @@ export function useSecretHeaders(
       enabled: isEdit && Boolean(connectorId),
       initialData: [],
       refetchOnMount: 'always',
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
       onError: (error: ServerError) => {
         toasts.addError(error.body?.message ? new Error(error.body.message) : error, {
           title: i18n.translate('xpack.stackConnectors.public.common.errorFetchingSecretHeaders', {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps] Fix Webhook http headers reset on blur/focus (#268941)](https://github.com/elastic/kibana/pull/268941)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-13T08:42:52Z","message":"[ResponseOps] Fix Webhook http headers reset on blur/focus (#268941)\n\n## Summary\n\ncloses https://github.com/elastic/kibana/issues/266283\n\n\n\nhttps://github.com/user-attachments/assets/adc56318-aa2a-49bf-9dbb-1e15f4acf9a0","sha":"359bb944dca18d1737b23e9a1eb14016b583e144","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:skip","Team:ResponseOps","v9.5.0"],"title":"[ResponseOps] Fix Webhook http headers reset on blur/focus","number":268941,"url":"https://github.com/elastic/kibana/pull/268941","mergeCommit":{"message":"[ResponseOps] Fix Webhook http headers reset on blur/focus (#268941)\n\n## Summary\n\ncloses https://github.com/elastic/kibana/issues/266283\n\n\n\nhttps://github.com/user-attachments/assets/adc56318-aa2a-49bf-9dbb-1e15f4acf9a0","sha":"359bb944dca18d1737b23e9a1eb14016b583e144"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/268941","number":268941,"mergeCommit":{"message":"[ResponseOps] Fix Webhook http headers reset on blur/focus (#268941)\n\n## Summary\n\ncloses https://github.com/elastic/kibana/issues/266283\n\n\n\nhttps://github.com/user-attachments/assets/adc56318-aa2a-49bf-9dbb-1e15f4acf9a0","sha":"359bb944dca18d1737b23e9a1eb14016b583e144"}}]}] BACKPORT-->