### PR TITLE
[CI] make rspack testing less frequent

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-rspack-e2e-test.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-rspack-e2e-test.yml
@@ -41,10 +41,10 @@ spec:
         publish_commit_status: false
         build_tags: false
       schedules:
-        Every 3 hours (main):
-          message: Rspack e2e test (every 3 hours)
+        Every 12 hours (main):
+          message: Rspack e2e test (every 12 hours)
           branch: main
-          cronline: 0 */3 * * * America/New_York
+          cronline: 0 */12 * * * America/New_York
       teams:
         everyone:
           access_level: BUILD_AND_READ


### PR DESCRIPTION
## Summary
Currently, we're not addressing these, it's just adding frequent noise to our alerts channel. We should strive to make Rspack mainstream instead.