### PR TITLE
Upgrade webpack-dev-server 5.2.3 → 5.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2218,7 +2218,7 @@
     "webpack": "5.96.1",
     "webpack-bundle-analyzer": "4.10.2",
     "webpack-cli": "5.1.4",
-    "webpack-dev-server": "5.2.3",
+    "webpack-dev-server": "5.2.4",
     "webpack-merge": "6.0.1",
     "webpack-sources": "3.2.3",
     "whatwg-fetch": "3.6.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36968,10 +36968,10 @@ webpack-dev-middleware@^7.4.2:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz#7f36a78be7ac88833fd87757edee31469a9e47d3"
-  integrity sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==
+webpack-dev-server@5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz#6e6306ce59848ed322c235e48b326632b1eed6d6"
+  integrity sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==
   dependencies:
     "@types/bonjour" "^3.5.13"
     "@types/connect-history-api-fallback" "^1.5.4"


### PR DESCRIPTION
## Summary

Upgrades webpack-dev-server from v5.2.3 to v5.2.4

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->