### PR TITLE
[APM] Service Map: remove double border on anomaly nodes

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/service_map/constants.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/service_map/constants.ts
@@ -45,7 +45,7 @@ export const DEPENDENCY_NODE_DIAMOND_SIZE = 48;
 
 /** Border width (px) for service and dependency nodes when not selected. */
 export const NODE_BORDER_WIDTH_DEFAULT = 3;
-/** Border width (px) for service and dependency nodes when selected or critical. */
+/** Border width (px) for service and dependency nodes when selected. */
 export const NODE_BORDER_WIDTH_SELECTED = 4;
 // When rotated 45deg, the diagonal becomes the width/height: size * sqrt(2)
 export const DEPENDENCY_NODE_DIAMOND_CONTAINER_SIZE = Math.ceil(

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_node.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_node.tsx
@@ -9,7 +9,6 @@ import React, { useMemo, memo } from 'react';
 import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import { useEuiTheme, EuiBadge, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { getAgentIcon } from '@kbn/custom-icons';
-import { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { getSeverity, getSeverityColor } from '../../../../common/anomaly_detection';
@@ -39,30 +38,19 @@ export const ServiceNode = memo(
     const navigateToAlertsTab = useServiceMapAlertsTabNavigate(data.label);
     const isDarkMode = colorMode === 'DARK';
 
-    const { borderColor, borderWidth, borderStyle } = useMemo(() => {
+    const { borderColor, borderWidth } = useMemo(() => {
       const score = data.serviceAnomalyStats?.anomalyScore;
-
-      if (score !== undefined) {
-        const severity = getSeverity(score);
-        const isHighSeverity =
-          severity === ML_ANOMALY_SEVERITY.CRITICAL || severity === ML_ANOMALY_SEVERITY.MAJOR;
-
-        return {
-          borderColor: getSeverityColor(score),
-          borderWidth:
-            isHighSeverity || selected
-              ? `${NODE_BORDER_WIDTH_SELECTED}px`
-              : `${NODE_BORDER_WIDTH_DEFAULT}px`,
-          borderStyle: isHighSeverity ? ('double' as const) : ('solid' as const),
-        };
-      }
+      const hasScore = score !== undefined;
 
       return {
-        borderColor: selected ? euiTheme.colors.primary : euiTheme.colors.mediumShade,
+        borderColor: hasScore
+          ? getSeverityColor(score)
+          : selected
+          ? euiTheme.colors.primary
+          : euiTheme.colors.mediumShade,
         borderWidth: selected
           ? `${NODE_BORDER_WIDTH_SELECTED}px`
           : `${NODE_BORDER_WIDTH_DEFAULT}px`,
-        borderStyle: 'solid' as const,
       };
     }, [data.serviceAnomalyStats, selected, euiTheme]);
 
@@ -117,7 +105,7 @@ export const ServiceNode = memo(
       width: ${SERVICE_NODE_CIRCLE_SIZE}px;
       height: ${SERVICE_NODE_CIRCLE_SIZE}px;
       border-radius: 50%;
-      border: ${borderWidth} ${borderStyle} ${borderColor};
+      border: ${borderWidth} solid ${borderColor};
       background: ${euiTheme.colors.backgroundBasePlain};
       display: flex;
       align-items: center;

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_map/service_node.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_map/service_node.tsx
@@ -9,7 +9,6 @@ import React, { useMemo, memo } from 'react';
 import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import { useEuiTheme, EuiBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { getAgentIcon } from '@kbn/custom-icons';
-import { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { getSeverity, getSeverityColor } from '../../../../common/anomaly_detection';
@@ -28,30 +27,19 @@ export const ServiceNode = memo(
     const { euiTheme, colorMode } = useEuiTheme();
     const isDarkMode = colorMode === 'DARK';
 
-    const { borderColor, borderWidth, borderStyle } = useMemo(() => {
+    const { borderColor, borderWidth } = useMemo(() => {
       const score = data.serviceAnomalyStats?.anomalyScore;
-
-      if (score !== undefined) {
-        const severity = getSeverity(score);
-        const isHighSeverity =
-          severity === ML_ANOMALY_SEVERITY.CRITICAL || severity === ML_ANOMALY_SEVERITY.MAJOR;
-
-        return {
-          borderColor: getSeverityColor(score),
-          borderWidth:
-            isHighSeverity || selected
-              ? `${NODE_BORDER_WIDTH_SELECTED}px`
-              : `${NODE_BORDER_WIDTH_DEFAULT}px`,
-          borderStyle: isHighSeverity ? ('double' as const) : ('solid' as const),
-        };
-      }
+      const hasScore = score !== undefined;
 
       return {
-        borderColor: selected ? euiTheme.colors.primary : euiTheme.colors.mediumShade,
+        borderColor: hasScore
+          ? getSeverityColor(score)
+          : selected
+          ? euiTheme.colors.primary
+          : euiTheme.colors.mediumShade,
         borderWidth: selected
           ? `${NODE_BORDER_WIDTH_SELECTED}px`
           : `${NODE_BORDER_WIDTH_DEFAULT}px`,
-        borderStyle: 'solid' as const,
       };
     }, [data.serviceAnomalyStats, selected, euiTheme]);
 
@@ -112,7 +100,7 @@ export const ServiceNode = memo(
       width: ${SERVICE_NODE_CIRCLE_SIZE}px;
       height: ${SERVICE_NODE_CIRCLE_SIZE}px;
       border-radius: 50%;
-      border: ${borderWidth} ${borderStyle} ${borderColor};
+      border: ${borderWidth} solid ${borderColor};
       background: ${euiTheme.colors.backgroundBasePlain};
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary

Closes #267891.

After [#267278](https://github.com/elastic/kibana/pull/267278) aligned Service Map anomaly colors with Service Inventory, CRITICAL/MAJOR nodes were rendered with both a `border-style: double` and a thicker border width. As noted in the issue, these add a second visual signal on top of the severity color, which is the intended carrier.

This PR drops both extra signals:

- Always use `border-style: solid` on service nodes.
- Only thicken the border for the `selected` state (same behavior as nodes without an anomaly score).
- Severity color continues to come from `getSeverityColor(anomalyScore)`.

Applied to both the main service map node and the shared (alert-details preview) variant so they stay in parity. Diamond / dependency nodes are unaffected (they never had double borders). Constant JSDoc for `NODE_BORDER_WIDTH_SELECTED` updated to drop the now-incorrect "or critical" mention.

## Demo

### Before

https://github.com/user-attachments/assets/495e3752-4b61-4660-a5e9-635605046b11


### After

https://github.com/user-attachments/assets/62446ac1-c1cf-4391-95a2-693f6cd4f051



## Test plan

- [x] Service Map renders CRITICAL/MAJOR anomaly nodes with the severity color but a normal solid border (no double border, no thicker stroke).
- [x] Selecting any node still shows the thicker border.
- [x] Alert details Service Map preview matches the main map.
- [x] `node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_node.test.tsx` passes.
- [x] Storybook stories under `service_map/__stories__/service_node.stories.tsx` look correct across low/mid/high anomaly scores.