### PR TITLE
[Fleet] Parse top-level elasticsearch fields on package upgrade or reinstall

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.test.ts
@@ -317,6 +317,69 @@ describe('parseTopLevelElasticsearchEntry', () => {
       },
     });
   });
+  it('Should preserve index_mode', () => {
+    expect(parseTopLevelElasticsearchEntry({ index_mode: 'time_series' })).toEqual({
+      index_mode: 'time_series',
+    });
+  });
+  it('Should preserve source_mode', () => {
+    expect(parseTopLevelElasticsearchEntry({ source_mode: 'synthetic' })).toEqual({
+      source_mode: 'synthetic',
+    });
+  });
+  it('Should preserve dynamic_dataset and dynamic_namespace', () => {
+    expect(
+      parseTopLevelElasticsearchEntry({ dynamic_dataset: true, dynamic_namespace: true })
+    ).toEqual({ dynamic_dataset: true, dynamic_namespace: true });
+  });
+  it('Should not include junk keys but preserve all documented fields', () => {
+    expect(
+      parseTopLevelElasticsearchEntry({
+        index_mode: 'time_series',
+        source_mode: 'synthetic',
+        dynamic_dataset: true,
+        dynamic_namespace: true,
+        privileges: { indices: ['auto_configure', 'create_doc'] },
+        'index_template.settings': { 'index.lifecycle.name': 'my-policy' },
+        unknown_field: 'should be dropped',
+      })
+    ).toEqual({
+      index_mode: 'time_series',
+      source_mode: 'synthetic',
+      dynamic_dataset: true,
+      dynamic_namespace: true,
+      privileges: { indices: ['auto_configure', 'create_doc'] },
+      'index_template.settings': { 'index.lifecycle.name': 'my-policy' },
+    });
+  });
+  it('should handle the same documented fields as parseDataStreamElasticsearchEntry', () => {
+    // This test guards against adding a new field to parseDataStreamElasticsearchEntry
+    // and forgetting to add it to parseTopLevelElasticsearchEntry.
+    // ingest_pipeline.name and index_template.data_stream are intentionally data-stream-only
+    // and must remain in the exclusion list below.
+    const allDocumentedFields = {
+      index_mode: 'time_series',
+      source_mode: 'synthetic',
+      dynamic_dataset: true,
+      dynamic_namespace: true,
+      privileges: { indices: ['auto_configure'], cluster: ['monitor'] },
+      index_template: {
+        mappings: { dynamic: false },
+        settings: { 'index.lifecycle.name': 'my-policy' },
+      },
+    };
+
+    const fromDataStream = parseDataStreamElasticsearchEntry(allDocumentedFields);
+    const fromTopLevel = parseTopLevelElasticsearchEntry(allDocumentedFields);
+
+    const {
+      'ingest_pipeline.name': _ingestPipeline,
+      'index_template.data_stream': _dataStream,
+      ...dataStreamComparable
+    } = fromDataStream;
+
+    expect(fromTopLevel).toEqual(dataStreamComparable);
+  });
 });
 
 describe('parseAndVerifyArchive', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
@@ -771,6 +771,30 @@ export function parseTopLevelElasticsearchEntry(elasticsearch?: Record<string, a
   }
 
   // @ts-expect-error upgrade typescript v5.1.6
+  if (expandedElasticsearch?.index_mode) {
+    // @ts-expect-error upgrade typescript v5.1.6
+    parsedElasticsearchEntry.index_mode = expandedElasticsearch.index_mode;
+  }
+
+  // @ts-expect-error upgrade typescript v5.1.6
+  if (expandedElasticsearch?.source_mode) {
+    // @ts-expect-error upgrade typescript v5.1.6
+    parsedElasticsearchEntry.source_mode = expandedElasticsearch.source_mode;
+  }
+
+  // @ts-expect-error upgrade typescript v5.1.6
+  if (expandedElasticsearch?.dynamic_dataset) {
+    // @ts-expect-error upgrade typescript v5.1.6
+    parsedElasticsearchEntry.dynamic_dataset = expandedElasticsearch.dynamic_dataset;
+  }
+
+  // @ts-expect-error upgrade typescript v5.1.6
+  if (expandedElasticsearch?.dynamic_namespace) {
+    // @ts-expect-error upgrade typescript v5.1.6
+    parsedElasticsearchEntry.dynamic_namespace = expandedElasticsearch.dynamic_namespace;
+  }
+
+  // @ts-expect-error upgrade typescript v5.1.6
   if (expandedElasticsearch?.index_template?.mappings) {
     parsedElasticsearchEntry['index_template.mappings'] = expandDottedEntries(
       // @ts-expect-error upgrade typescript v5.1.6
@@ -785,6 +809,7 @@ export function parseTopLevelElasticsearchEntry(elasticsearch?: Record<string, a
       expandedElasticsearch.index_template.settings
     );
   }
+
   return parsedElasticsearchEntry;
 }
 


### PR DESCRIPTION
## Summary

When reinstalling or upgrading a package, not all top-level `elasticsearch` attributes were being parsed, so some settings might change after reinstall or upgrades.

This is affecting packages with the following `elasticsearch` attributes: `index_mode`, `source_mode`, `dynamic_namespace`, `dynamic_dataset`.

This may lead to silently change settings that affect storage efficiency.

Found with Package Spec compliance tests, a test expecting `index_mode: time_series` is failing if the test is executed twice: https://github.com/elastic/package-spec/blob/f58be77fbc09f24c6ac9c12b6b8a519284a22118/compliance/features/basic.feature#L21

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.4"]} ONMERGE-->