### PR TITLE
[Fleet] Add known issue for bulk agent actions affecting other spaces (#258069)

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -14,7 +14,7 @@ Applies to: {{stack}} 8.19.0–8.19.13, 9.0.x, 9.1.x, 9.2.0–9.2.7, 9.3.0–9.3
 
 **Details**
 
-A KQL operator precedence bug in Fleet's bulk action code causes the namespace filter to be ignored when a user-supplied kuery is also present. When issuing a bulk agent action (unenroll, reassign, upgrade, or rollback) with "Select everything on all pages" in the UI, or using the bulk actions API with a `kuery` parameter, agents in other {{kib}} spaces can be unintentionally affected.
+A KQL operator precedence issue in Fleet's bulk action code causes the namespace filter to be ignored when a user-supplied kuery is also present. When issuing a bulk agent action (unenroll, reassign, upgrade, or rollback) with "Select everything on all pages" in the UI, or using the bulk actions API with a `kuery` parameter, agents in other {{kib}} spaces can be unintentionally affected.
 
 **Workaround**
 
@@ -22,7 +22,7 @@ When performing bulk agent actions across all pages, select agents individually 
 
 **Resolved**
 
-This issue is resolved in {{stack}} 8.19.14, 9.2.8, and 9.3.3. Versions 9.0 and 9.1 are end of life — upgrade to {{stack}} 9.2.8+ or 9.3.3+.
+This issue is resolved in {{stack}} 8.19.14, 9.2.8, 9.3.3, 9.4.0. Versions 9.0 and 9.1 are end of life — upgrade to {{stack}} 9.2.8+ or 9.3.3+.
 
 ::::
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -10,7 +10,7 @@ For Elastic Security known issues, refer to [Elastic Security known issues](docs
 
 ::::{dropdown} Fleet bulk agent actions can affect agents in other spaces
 
-Applies to: {{stack}} 8.19.0–8.19.13, 9.0.x, 9.1.x, 9.2.0–9.2.7, 9.3.0–9.3.2
+Applies to: {{stack}} 9.0.x, 9.1.x, 9.2.0–9.2.7, 9.3.0–9.3.2
 
 **Details**
 
@@ -22,7 +22,7 @@ When performing bulk agent actions across all pages, select agents individually 
 
 **Resolved**
 
-This issue is resolved in {{stack}} 8.19.14, 9.2.8, 9.3.3, 9.4.0. Versions 9.0 and 9.1 are end of life — upgrade to {{stack}} 9.2.8+ or 9.3.3+.
+This issue is resolved in {{stack}} 9.2.8, 9.3.3, 9.4.0. Versions 9.0 and 9.1 are end of life — upgrade to {{stack}} 9.2.8+ or 9.3.3+.
 
 ::::
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -10,7 +10,7 @@ For Elastic Security known issues, refer to [Elastic Security known issues](docs
 
 ::::{dropdown} Fleet bulk agent actions can affect agents in other spaces
 
-Applies to: {{stack}} 9.0.x, 9.1.x, 9.2.0–9.2.7, 9.3.0–9.3.2
+Applies to: {{stack}} 9.1.x, 9.2.0–9.2.7, 9.3.0–9.3.2
 
 **Details**
 
@@ -22,7 +22,7 @@ When performing bulk agent actions across all pages, select agents individually 
 
 **Resolved**
 
-This issue is resolved in {{stack}} 9.2.8, 9.3.3, 9.4.0. Versions 9.0 and 9.1 are end of life — upgrade to {{stack}} 9.2.8+ or 9.3.3+.
+This issue is resolved in {{stack}} 9.2.8, 9.3.3, 9.4.0. Version 9.1 is end of life — upgrade to {{stack}} 9.2.8+ or 9.3.3+.
 
 ::::
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -8,6 +8,24 @@ For Elastic {{observability}} known issues, refer to [Elastic Observability know
 
 For Elastic Security known issues, refer to [Elastic Security known issues](docs-content://release-notes/elastic-security/known-issues.md).
 
+::::{dropdown} Fleet bulk agent actions can affect agents in other spaces
+
+Applies to: {{stack}} 8.19.0–8.19.13, 9.0.x, 9.1.x, 9.2.0–9.2.7, 9.3.0–9.3.2
+
+**Details**
+
+A KQL operator precedence bug in Fleet's bulk action code causes the namespace filter to be ignored when a user-supplied kuery is also present. When issuing a bulk agent action (unenroll, reassign, upgrade, or rollback) with "Select everything on all pages" in the UI, or using the bulk actions API with a `kuery` parameter, agents in other {{kib}} spaces can be unintentionally affected.
+
+**Workaround**
+
+When performing bulk agent actions across all pages, select agents individually or in smaller batches using explicit filtering within a single space rather than relying on "Select everything on all pages" with a kuery.
+
+**Resolved**
+
+This issue is resolved in {{stack}} 8.19.14, 9.2.8, and 9.3.3. Versions 9.0 and 9.1 are end of life — upgrade to {{stack}} 9.2.8+ or 9.3.3+.
+
+::::
+
 ::::{dropdown} Stack alerts remain active instead of transitioning to recovered
 
 Applies to: {{stack}} 9.2.7, 9.2.8, 9.3.2, 9.3.3


### PR DESCRIPTION
## Summary

Adds a known issue entry for https://github.com/elastic/kibana/issues/258069 — a KQL operator precedence bug in Fleet's bulk action code that causes namespace isolation to break when a user-supplied kuery is present.

## Affected versions

| Branch | Last vulnerable | First fixed |
|---|---|---|
| 9.1 | 9.1.10 (all — EOL) | Upgrade to 9.2.8+ or 9.3.3+ |
| 9.2 | 9.2.7 | 9.2.8 |
| 9.3 | 9.3.2 | 9.3.3 |

## Test plan

- [ ] Verify version ranges are accurate against the fix PRs
- [ ] Verify the dropdown renders correctly in docs preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)