### PR TITLE
Serverless test readme - remove duplicate link and fix typo

### DIFF
--- a/x-pack/platform/test/serverless/README.md
+++ b/x-pack/platform/test/serverless/README.md
@@ -7,7 +7,6 @@ The tests and helper methods (services, page objects) defined here in
 
 For instructions on how to set up Docker for serverless ES images, please refer to
 [src/platform/packages/shared/kbn-es/README](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es/README.mdx).
-[src/platform/packages/shared/kbn-es/README](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es/README.mdx).
 
 ## Platform Serverless Testing Structure and Conventions
 
@@ -88,7 +87,7 @@ Platform serverless tests should only be added when testing functionality that i
 
 ### Roles-based testing
 
-Each serverless project has its own set of SAML roles with [specfic permissions defined in roles.yml](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles)
+Each serverless project has its own set of SAML roles with [specific permissions defined in roles.yml](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles)
 and in order to properly test Kibana functionality, test design requires to login with
 a project-supported SAML role. FTR provides `samlAuth` service to do SAML authentication, that allows UI tests to set
 the SAML cookie in the browser context and generates api key to use in the api integration tests. See examples below.

--- a/x-pack/platform/test/serverless/README.md
+++ b/x-pack/platform/test/serverless/README.md
@@ -371,7 +371,7 @@ For tests using package registry we have enabled a configuration that uses a doc
 To be able to run this version locally you must have a Docker daemon running in your system and set `FLEET_PACKAGE_REGISTRY_PORT` env var. In order to set this variable execute
 
 ```bash
-export set FLEET_PACKAGE_REGISTRY_PORT=12345
+export FLEET_PACKAGE_REGISTRY_PORT=12345
 ```
 
 To unset the variable, and run the tests against the real endpoint again, execute


### PR DESCRIPTION
This PR applies two small fixes to the serverless test README.md file: it removes a duplicate link and fixes a typo.