### PR TITLE
[9.3] [Cloud Security] Fix CIS integration page object race conditions and unskip flaky tests

### DIFF
--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group2/pages/cis_integrations/cnvm/cis_integration_cnvm.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group2/pages/cis_integrations/cnvm/cis_integration_cnvm.ts
@@ -14,8 +14,7 @@ export default function (providerContext: FtrProviderContext) {
   const { getPageObjects, getService } = providerContext;
   const pageObjects = getPageObjects(['cloudPostureDashboard', 'cisAddIntegration', 'header']);
 
-  // Failing: See https://github.com/elastic/kibana/issues/248313
-  describe.skip('Test adding Cloud Security Posture Integrations CNVM', function () {
+  describe('Test adding Cloud Security Posture Integrations CNVM', function () {
     this.tags(['cloud_security_posture_cis_integration_cnvm']);
     let cisIntegration: typeof pageObjects.cisAddIntegration;
     const retry = getService('retry');

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group2/pages/cis_integrations/cspm/cis_integration_aws.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group2/pages/cis_integrations/cspm/cis_integration_aws.ts
@@ -29,8 +29,7 @@ export default function (providerContext: FtrProviderContext) {
   const logger = getService('log');
   const saveIntegrationPolicyTimeout = 1000 * 30; // 30 seconds
 
-  // Failing: See https://github.com/elastic/kibana/issues/256807
-  describe.skip('Test adding Cloud Security Posture Integrations CSPM AWS', function () {
+  describe('Test adding Cloud Security Posture Integrations CSPM AWS', function () {
     this.tags(['cloud_security_posture_cis_integration_cspm_aws']);
     let cisIntegration: typeof pageObjects.cisAddIntegration;
 
@@ -235,8 +234,7 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/225030
-    describe.skip('CIS_AWS Organization Manual Shared Access', () => {
+    describe('CIS_AWS Organization Manual Shared Access', () => {
       it('CIS_AWS Organization Manual Shared Access Workflow', async () => {
         const sharedCredentialFile = 'sharedCredentialFileTest';
         const sharedCredentialProfileName = 'sharedCredentialProfileNameTest';

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
@@ -289,10 +289,10 @@ export function AddCisIntegrationFormPageProvider({
   };
 
   const clickFirstElementOnIntegrationTableAddAgent = async () => {
-    const integrationList = await testSubjects.exists(TEST_IDS.ADD_AGENT_BUTTON);
-    if (integrationList) {
-      await testSubjects.click(TEST_IDS.ADD_AGENT_BUTTON);
-    }
+    await retry.waitFor('Add Agent button to appear', async () => {
+      return await testSubjects.exists(TEST_IDS.ADD_AGENT_BUTTON);
+    });
+    await testSubjects.click(TEST_IDS.ADD_AGENT_BUTTON);
   };
 
   const clickLaunchAndGetCurrentUrl = async (buttonId: string) => {
@@ -460,9 +460,7 @@ export function AddCisIntegrationFormPageProvider({
   };
 
   const getFieldValueInAddAgentFlyout = async (field: string, value: string) => {
-    /* Newly added/edited integration always shows up on top by default as such we can just always click the most top if we want to check for the latest one  */
-    const integrationList = await testSubjects.findAll(TEST_IDS.AGENT_ENROLLMENT_FLYOUT);
-    await integrationList[0].click();
+    await testSubjects.find(TEST_IDS.AGENT_ENROLLMENT_FLYOUT);
     await PageObjects.header.waitUntilLoadingHasFinished();
     const fieldValue = await (await testSubjects.find(field)).getAttribute(value);
     return fieldValue;

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
@@ -121,9 +121,7 @@ export function AddCisIntegrationFormPageProvider({
     },
 
     getFieldValueInEditPage: async (field: string) => {
-      /* Newly added/edited integration always shows up on top by default as such we can just always click the most top if we want to check for the latest one  */
-      const integrationList = await testSubjects.findAll(TEST_IDS.INTEGRATION_NAME_LINK);
-      await integrationList[0].click();
+      await navigateToEditIntegrationPage();
       const fieldValue = await (await testSubjects.find(field)).getAttribute('value');
       return fieldValue;
     },
@@ -136,12 +134,15 @@ export function AddCisIntegrationFormPageProvider({
     },
 
     getFieldValueInAddAgentFlyout: async (field: string, value: string) => {
-      /* Newly added/edited integration always shows up on top by default as such we can just always click the most top if we want to check for the latest one  */
-      const integrationList = await testSubjects.findAll(TEST_IDS.AGENT_ENROLLMENT_FLYOUT);
-      await integrationList[0].click();
-      await PageObjects.header.waitUntilLoadingHasFinished();
-      const fieldValue = (await (await testSubjects.find(field)).getAttribute(value)) ?? '';
-      return fieldValue;
+      return await retry.tryForTime(20_000, async () => {
+        await testSubjects.find(TEST_IDS.AGENT_ENROLLMENT_FLYOUT);
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        const fieldValue = (await (await testSubjects.find(field)).getAttribute(value)) ?? '';
+        if (fieldValue === '') {
+          throw new Error(`Field "${field}" attribute "${value}" not yet available`);
+        }
+        return fieldValue;
+      });
     },
     showLaunchCloudShellAgentlessButton: async () => {
       return await testSubjects.exists('launchGoogleCloudShellAgentlessButton');
@@ -240,6 +241,9 @@ export function AddCisIntegrationFormPageProvider({
   };
 
   const navigateToEditIntegrationPage = async () => {
+    await retry.waitFor('integration name link to appear', async () => {
+      return await testSubjects.exists(TEST_IDS.INTEGRATION_NAME_LINK);
+    });
     await testSubjects.click(TEST_IDS.INTEGRATION_NAME_LINK);
   };
 
@@ -284,8 +288,10 @@ export function AddCisIntegrationFormPageProvider({
   };
 
   const clickFirstElementOnIntegrationTable = async () => {
-    const integrationList = await testSubjects.findAll(TEST_IDS.INTEGRATION_NAME_LINK);
-    await integrationList[0].click();
+    await retry.waitFor('integration name link to appear', async () => {
+      return await testSubjects.exists(TEST_IDS.INTEGRATION_NAME_LINK);
+    });
+    await testSubjects.click(TEST_IDS.INTEGRATION_NAME_LINK);
   };
 
   const clickFirstElementOnIntegrationTableAddAgent = async () => {


### PR DESCRIPTION
## Summary

Backport of #258555 and #269114 to 9.3.

Fixes race conditions in `add_cis_integration_form_page.ts` page object methods that caused intermittent failures in CIS integration tests. Additionally un-skips the AWS CSPM and CNVM test suites that were temporarily skipped due to these failures.

**Root cause:** `testSubjects.findAll()[0]` silently returns `undefined` when the element isn't found yet (no throw), causing crashes. Fixed with explicit `retry.waitFor` DOM-ready guards and `retry.tryForTime` for async state.

**Fixes in this backport:**
- `navigateToEditIntegrationPage`: adds `retry.waitFor` before `testSubjects.click`
- `clickFirstElementOnIntegrationTable`: adds `retry.waitFor` before click
- `cisGcp.getFieldValueInEditPage`: replaces `findAll()[0]` with `find()`
- `cisGcp.getFieldValueInAddAgentFlyout`: replaces `findAll()[0]` with `find()` + `retry.tryForTime`
- Removes outer `describe.skip` from AWS CSPM and CNVM suites (added as workaround)

Related: #256867 #256807 #248313 #260706

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/GUIDELINE.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_changes)
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Low — changes are test-only (page objects and test files). No production code affected. The unskips restore tests that were suppressed as a workaround; the fixes address the root cause of those failures.