### PR TITLE
[Entity Analytics] Fixing access gating for asset criticality updates

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -12,6 +12,7 @@ import { useHasVulnerabilities } from '@kbn/cloud-security-posture/src/hooks/use
 import { TableId } from '@kbn/securitysolution-data-table';
 import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import { EuiSpacer } from '@elastic/eui';
+import { useAssetCriticalityPrivileges } from '../../../entity_analytics/components/asset_criticality/use_asset_criticality';
 import { useUpdateAssetCriticality } from '../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { buildEuidCspPreviewOptions } from '../../../cloud_security_posture/utils/build_euid_csp_preview_options';
 import { useNonClosedAlerts } from '../../../cloud_security_posture/hooks/use_non_closed_alerts';
@@ -188,6 +189,8 @@ export const HostPanel = memo(function HostPanel({
     [entityId, entityStoreV2Enabled, observedHost.entityRecord?.entity?.id]
   );
 
+  const assetCriticalityPrivileges = useAssetCriticalityPrivileges(entityId ?? hostName);
+
   const useEntityStoreInspectForRisk = entityStoreV2Enabled && observedHost.entityRecord != null;
 
   useQueryInspector({
@@ -222,7 +225,9 @@ export const HostPanel = memo(function HostPanel({
       : !!hostRiskData?.host?.risk;
 
   const onCriticalitySave =
-    entityFromStoreResult.entityRecord && observedHost.entityRecord
+    !!assetCriticalityPrivileges.data?.has_write_permissions &&
+    entityFromStoreResult.entityRecord &&
+    observedHost.entityRecord
       ? (level: CriticalityLevelWithUnassigned) =>
           updateAssetCriticalityLevel(level, observedHost.entityRecord)
       : undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -11,6 +11,7 @@ import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/u
 import { TableId } from '@kbn/securitysolution-data-table';
 import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import { EuiSpacer } from '@elastic/eui';
+import { useAssetCriticalityPrivileges } from '../../../entity_analytics/components/asset_criticality/use_asset_criticality';
 import { useUpdateAssetCriticality } from '../../../entity_analytics/api/hooks/use_update_asset_criticality';
 import { buildEuidCspPreviewOptions } from '../../../cloud_security_posture/utils/build_euid_csp_preview_options';
 import { buildUserNamesFilter, type RiskSeverity } from '../../../../common/search_strategy';
@@ -138,6 +139,8 @@ export const UserPanel = memo(function UserPanel({
     [entityIdProp, entityStoreV2Enabled, observedUser.entityRecord?.entity?.id]
   );
 
+  const assetCriticalityPrivileges = useAssetCriticalityPrivileges(entityIdProp ?? userName);
+
   const riskScoreState = useRiskScore({
     riskEntity: EntityType.user,
     filterQuery: userNameFilterQuery,
@@ -230,10 +233,11 @@ export const UserPanel = memo(function UserPanel({
 
   const effectiveRiskScoreState = riskScoreStateFromStore ?? riskScoreState;
 
-  const onCriticalitySave = entityFromStoreResult.entityRecord
-    ? (level: CriticalityLevelWithUnassigned) =>
-        updateAssetCriticalityLevel(level, entityFromStoreResult.entityRecord)
-    : undefined;
+  const onCriticalitySave =
+    !!assetCriticalityPrivileges.data?.has_write_permissions && entityFromStoreResult.entityRecord
+      ? (level: CriticalityLevelWithUnassigned) =>
+          updateAssetCriticalityLevel(level, entityFromStoreResult.entityRecord)
+      : undefined;
 
   const defaultTab = useMemo(() => {
     if (isRiskScoreExist) return EntityDetailsLeftPanelTab.RISK_INPUTS;


### PR DESCRIPTION
## Summary

When we moved the asset criticality badge into the entity summary grid near the top of the flyout, we forgot to move the permissions check, so users with only read access could see the dropdown for updating asset criticality. This adds back the permissions check

## To Verify

1. Start ES and Kibana with all the Entity Store V2 feature flags
2. Navigate to EA page to ensure it's enabled and populate some data using `yarn start org-data`
3. Create a role with limited permissions:
 - Kibana privileges: Read for Security and Read for Management > Saved Objects Management
 - Elasticsearch Index privileges: `read` for `entities-latest-<space-id>` and `.entities.v2.latest.security_<space-id>-*` 
4. Create a user with this role
5. Login as your limited permissions user and go to the Entity Analytics homepage and open the flyout for an entity. You should not be able to change the asset criticality for this entity.
6. Update the role to add `write` and `view_index_metadata` for `entities-latest-<space-id>` and `.entities.v2.latest.security_<space-id>-*`.
7. As your limited permissions user, you should now be able to update the asset criticality for the entity.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->