### PR TITLE
[ResponseOps] skipFIPS failing test.

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
@@ -110,97 +110,100 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
       });
     });
 
-    it('should not trigger actions when snoozed', async () => {
-      const { body: createdConnector, status: connStatus } = await supertest
-        .post(`${getUrlPrefix(Spaces.space1.id)}/api/actions/connector`)
-        .set('kbn-xsrf', 'foo')
-        .send({
-          name: 'MY Connector',
-          connector_type_id: 'test.noop',
-          config: {},
-          secrets: {},
-        });
-      expect(connStatus).to.be(200);
-      objectRemover.add(Spaces.space1.id, createdConnector.id, 'connector', 'actions');
+    describe('should not trigger actions when snoozed', function () {
+      this.tags('skipFIPS');
+      it('should not trigger actions when snoozed', async () => {
+        const { body: createdConnector, status: connStatus } = await supertest
+          .post(`${getUrlPrefix(Spaces.space1.id)}/api/actions/connector`)
+          .set('kbn-xsrf', 'foo')
+          .send({
+            name: 'MY Connector',
+            connector_type_id: 'test.noop',
+            config: {},
+            secrets: {},
+          });
+        expect(connStatus).to.be(200);
+        objectRemover.add(Spaces.space1.id, createdConnector.id, 'connector', 'actions');
 
-      log.info('creating rule');
-      const { body: createdRule, status: ruleStatus } = await supertest
-        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
-        .set('kbn-xsrf', 'foo')
-        .send(
-          getTestRuleData({
-            name: 'should not trigger actions when snoozed',
-            rule_type_id: 'test.patternFiring',
-            schedule: { interval: '1s' },
-            throttle: null,
-            notify_when: 'onActiveAlert',
-            params: {
-              pattern: { instance: arrayOfTrues(100) },
-            },
-            actions: [
-              {
-                id: createdConnector.id,
-                group: 'default',
-                params: {},
+        log.info('creating rule');
+        const { body: createdRule, status: ruleStatus } = await supertest
+          .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
+          .set('kbn-xsrf', 'foo')
+          .send(
+            getTestRuleData({
+              name: 'should not trigger actions when snoozed',
+              rule_type_id: 'test.patternFiring',
+              schedule: { interval: '1s' },
+              throttle: null,
+              notify_when: 'onActiveAlert',
+              params: {
+                pattern: { instance: arrayOfTrues(100) },
               },
-            ],
-          })
-        );
-      expect(ruleStatus).to.be(200);
-      objectRemover.add(Spaces.space1.id, createdRule.id, 'rule', 'alerting');
+              actions: [
+                {
+                  id: createdConnector.id,
+                  group: 'default',
+                  params: {},
+                },
+              ],
+            })
+          );
+        expect(ruleStatus).to.be(200);
+        objectRemover.add(Spaces.space1.id, createdRule.id, 'rule', 'alerting');
 
-      // wait for an action to be triggered
-      log.info('wait for rule to trigger an action');
-      await getRuleEvents(createdRule.id);
+        // wait for an action to be triggered
+        log.info('wait for rule to trigger an action');
+        await getRuleEvents(createdRule.id);
 
-      log.info('start snoozing');
-      await alertUtils.getSnoozeRequest(createdRule.id).send({
-        schedule: {
-          custom: {
-            duration: '10s',
-            start: new Date().toISOString(),
-            recurring: {
-              occurrences: 1,
+        log.info('start snoozing');
+        await alertUtils.getSnoozeRequest(createdRule.id).send({
+          schedule: {
+            custom: {
+              duration: '10s',
+              start: new Date().toISOString(),
+              recurring: {
+                occurrences: 1,
+              },
             },
           },
-        },
-      });
+        });
 
-      // This test was failing, we now use the persisted schedule so the time
-      // boundaries match the server. Client Date.now() vs server side value
-      // might be a possible cause of the flakiness here.
-      const { body: ruleWithSnooze } = await supertestWithoutAuth
-        .get(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rule/${createdRule.id}`)
-        .set('kbn-xsrf', 'foo')
-        .expect(200);
-      const { rRule, duration: snoozeDurationMs } = ruleWithSnooze.snooze_schedule[0];
-      const snoozeWindowStartMs = Date.parse(rRule.dtstart);
-      const snoozeWindowEndMs = snoozeWindowStartMs + snoozeDurationMs;
+        // This test was failing, we now use the persisted schedule so the time
+        // boundaries match the server. Client Date.now() vs server side value
+        // might be a possible cause of the flakiness here.
+        const { body: ruleWithSnooze } = await supertestWithoutAuth
+          .get(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rule/${createdRule.id}`)
+          .set('kbn-xsrf', 'foo')
+          .expect(200);
+        const { rRule, duration: snoozeDurationMs } = ruleWithSnooze.snooze_schedule[0];
+        const snoozeWindowStartMs = Date.parse(rRule.dtstart);
+        const snoozeWindowEndMs = snoozeWindowStartMs + snoozeDurationMs;
 
-      // wait for 4 triggered actions - in case some fired before snooze went into effect
-      log.info('wait for snoozing to end');
-      const ruleEvents = await getRuleEvents(createdRule.id, 4);
-      let actionsBefore = 0;
-      let actionsDuring = 0;
-      let actionsAfter = 0;
+        // wait for 4 triggered actions - in case some fired before snooze went into effect
+        log.info('wait for snoozing to end');
+        const ruleEvents = await getRuleEvents(createdRule.id, 4);
+        let actionsBefore = 0;
+        let actionsDuring = 0;
+        let actionsAfter = 0;
 
-      for (const event of ruleEvents) {
-        const timestamp = event?.['@timestamp'];
-        if (!timestamp) continue;
+        for (const event of ruleEvents) {
+          const timestamp = event?.['@timestamp'];
+          if (!timestamp) continue;
 
-        const time = new Date(timestamp).valueOf();
-        if (time < snoozeWindowStartMs) {
-          actionsBefore++;
-        } else if (time > snoozeWindowEndMs) {
-          actionsAfter++;
-        } else {
-          actionsDuring++;
+          const time = new Date(timestamp).valueOf();
+          if (time < snoozeWindowStartMs) {
+            actionsBefore++;
+          } else if (time > snoozeWindowEndMs) {
+            actionsAfter++;
+          } else {
+            actionsDuring++;
+          }
         }
-      }
 
-      expect(actionsBefore).to.be.greaterThan(0, 'no actions triggered before snooze');
-      expect(actionsAfter).to.be.greaterThan(0, 'no actions triggered after snooze');
-      expect(actionsDuring).to.be(0);
+        expect(actionsBefore).to.be.greaterThan(0, 'no actions triggered before snooze');
+        expect(actionsAfter).to.be.greaterThan(0, 'no actions triggered after snooze');
+        expect(actionsDuring).to.be(0);
+      });
     });
 
     describe('prevent more than 5 schedules from being added to a rule', function () {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/229549

## Summary

The same test is now flaky but for a different reason, and only on kibana-fips.

Now it is failing with `Error: expected 200 "OK", got 401 "Unauthorized"`

I think a big refactor would be needed in the utils to avoid this error.

However, since some tests in this suite already have the `skipFIPS` tag, I will do the same for this one.