### PR TITLE
docs: add 9.4.0 release note for dashboard panel limits

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -118,6 +118,7 @@ New {{ech}} deployments now default to 2 GB of RAM for each {{kib}} instance.
 % sections
 * Extends the selectable area for dragging, collapsing and expanding sections to their entire header [#258502]({{kib-pull}}258502).
 * Allows dragging of opened collapsible sections [#257191]({{kib-pull}}257191).
+* Enforces panel limits on dashboards: up to 100 top-level items (panels, unpinned controls, and sections combined), up to 100 panels per section, and up to 100 pinned controls [#256102]({{kib-pull}}256102).
 
 % dashboard usability
 * Makes the filter pills section collapsible [#255887]({{kib-pull}}255887).


### PR DESCRIPTION
## Summary

Adds a release note entry for [#256102](https://github.com/elastic/kibana/pull/256102), which set `maxSize: 100` on dashboard panel arrays but was labeled `release_note:skip`.

The enforcement of these limits is a user-visible behavioral change. Documentation has been added in elastic/docs-content#6481.

Added under the **Dashboards and Visualizations** section of the 9.4.0 release notes.