### PR TITLE
[9.4] [AI Infra] Fix failing GenAI Settings Scout tests (#260496)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -77,7 +77,7 @@ pageLoadAssetSize:
   filesManagement: 5208
   fileUpload: 22957
   fleet: 209495
-  genAiSettings: 5663
+  genAiSettings: 6400
   globalSearch: 6890
   globalSearchBar: 26122
   globalSearchProviders: 4646

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/plugin.test.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/plugin.test.ts
@@ -11,10 +11,16 @@ import type { ManagementSetup } from '@kbn/management-plugin/public';
 import { GenAiSettingsPlugin } from './plugin';
 
 describe('GenAI Settings Plugin', () => {
-  describe('Licensing', () => {
-    const createManagementMock = () => {
-      const registerApp = jest.fn();
-      return {
+  const createAppMock = () => ({
+    enable: jest.fn(),
+    disable: jest.fn(),
+  });
+
+  const createManagementMock = (app = createAppMock()) => {
+    const registerApp = jest.fn().mockReturnValue(app);
+    return {
+      app,
+      management: {
         sections: {
           section: {
             ai: {
@@ -24,101 +30,181 @@ describe('GenAI Settings Plugin', () => {
         },
       } as unknown as ManagementSetup & {
         sections: { section: { ai: { registerApp: jest.Mock } } };
-      };
+      },
     };
+  };
 
-    const createCoreSetupMock = (
-      coreStart: Partial<CoreStart>,
-      licensing: any
-    ): CoreSetup<any, any> =>
-      ({
-        getStartServices: jest.fn().mockResolvedValue([coreStart, { licensing } as any, {} as any]),
-      } as any);
+  const createCoreSetupMock = (): CoreSetup<any, any> =>
+    ({
+      getStartServices: jest.fn(),
+    } as any);
 
-    const createPlugin = () =>
-      new GenAiSettingsPlugin({
-        config: { get: jest.fn(() => ({})) },
-        env: { packageInfo: { buildFlavor: 'traditional', branch: 'main' } },
-      } as unknown as PluginInitializerContext);
+  const createCoreStartMock = (
+    capabilities: Partial<CoreStart['application']['capabilities']>
+  ): CoreStart =>
+    ({
+      application: { capabilities },
+    } as any);
 
-    it('does not register the app when license is not enterprise', async () => {
+  const createPlugin = () =>
+    new GenAiSettingsPlugin({
+      config: { get: jest.fn(() => ({})) },
+      env: { packageInfo: { buildFlavor: 'traditional', branch: 'main' } },
+    } as unknown as PluginInitializerContext);
+
+  describe('setup()', () => {
+    it('always registers the app synchronously', () => {
       const plugin = createPlugin();
-      const management = createManagementMock();
+      const { management } = createManagementMock();
 
-      const license$ = new BehaviorSubject<any>({ hasAtLeast: () => false });
-      const coreStart: Partial<CoreStart> = {
-        application: {
-          capabilities: {
-            actions: { show: true, execute: true },
-          },
-        },
-      } as any;
-      const coreSetup = createCoreSetupMock(coreStart, { license$ });
-
-      await plugin.setup(coreSetup, { management });
-
-      expect(management.sections.section.ai.registerApp).not.toHaveBeenCalled();
-    });
-
-    it('registers the app only when license is enterprise and capabilities allow it', async () => {
-      const plugin = createPlugin();
-      const management = createManagementMock();
-
-      const license$ = new BehaviorSubject<any>({
-        hasAtLeast: (level: string) => level === 'enterprise',
-      });
-      const coreStart: Partial<CoreStart> = {
-        application: {
-          capabilities: {
-            actions: { show: true, execute: true },
-          },
-        },
-      } as any;
-      const coreSetup = createCoreSetupMock(coreStart, { license$ });
-
-      await plugin.setup(coreSetup, { management });
+      plugin.setup(createCoreSetupMock(), { management });
 
       expect(management.sections.section.ai.registerApp).toHaveBeenCalledTimes(1);
     });
 
-    it('registers the app when enterprise license and anonymization capabilities allow it', async () => {
+    it('disables the app immediately after registration', () => {
+      const app = createAppMock();
+      const { management } = createManagementMock(app);
+
       const plugin = createPlugin();
-      const management = createManagementMock();
+      plugin.setup(createCoreSetupMock(), { management });
 
-      const license$ = new BehaviorSubject<any>({
-        hasAtLeast: (level: string) => level === 'enterprise',
-      });
-      const coreStart: Partial<CoreStart> = {
-        application: {
-          capabilities: {
-            anonymization: { show: true, manage: false },
-          },
-        },
-      } as any;
-      const coreSetup = createCoreSetupMock(coreStart, { license$ });
-
-      await plugin.setup(coreSetup, { management });
-
-      expect(management.sections.section.ai.registerApp).toHaveBeenCalledTimes(1);
+      expect(app.disable).toHaveBeenCalledTimes(1);
+      expect(app.enable).not.toHaveBeenCalled();
     });
+  });
 
-    it('does not register the app when anonymization capabilities exist but license is not enterprise', async () => {
+  describe('start()', () => {
+    describe('Licensing', () => {
+      it('enables the app when license is enterprise and connectors capabilities allow it', () => {
+        const app = createAppMock();
+        const { management } = createManagementMock(app);
+        const plugin = createPlugin();
+        plugin.setup(createCoreSetupMock(), { management });
+
+        const license$ = new BehaviorSubject<any>({
+          hasAtLeast: (level: string) => level === 'enterprise',
+        });
+        const coreStart = createCoreStartMock({
+          actions: { show: true, execute: true },
+        });
+
+        plugin.start(coreStart, { licensing: { license$ } } as any);
+
+        expect(app.enable).toHaveBeenCalledTimes(1);
+      });
+
+      it('enables the app when license is enterprise and anonymization capabilities allow it', () => {
+        const app = createAppMock();
+        const { management } = createManagementMock(app);
+        const plugin = createPlugin();
+        plugin.setup(createCoreSetupMock(), { management });
+
+        const license$ = new BehaviorSubject<any>({
+          hasAtLeast: (level: string) => level === 'enterprise',
+        });
+        const coreStart = createCoreStartMock({
+          anonymization: { show: true, manage: false },
+        });
+
+        plugin.start(coreStart, { licensing: { license$ } } as any);
+
+        expect(app.enable).toHaveBeenCalledTimes(1);
+      });
+
+      it('keeps the app disabled when license is not enterprise', () => {
+        const app = createAppMock();
+        const { management } = createManagementMock(app);
+        const plugin = createPlugin();
+        plugin.setup(createCoreSetupMock(), { management });
+
+        const license$ = new BehaviorSubject<any>({ hasAtLeast: () => false });
+        const coreStart = createCoreStartMock({
+          actions: { show: true, execute: true },
+        });
+
+        plugin.start(coreStart, { licensing: { license$ } } as any);
+
+        expect(app.enable).not.toHaveBeenCalled();
+        // disable() called once from setup() and once from start() subscription
+        expect(app.disable).toHaveBeenCalledTimes(2);
+      });
+
+      it('keeps the app disabled when enterprise license exists but no capabilities match', () => {
+        const app = createAppMock();
+        const { management } = createManagementMock(app);
+        const plugin = createPlugin();
+        plugin.setup(createCoreSetupMock(), { management });
+
+        const license$ = new BehaviorSubject<any>({
+          hasAtLeast: (level: string) => level === 'enterprise',
+        });
+        const coreStart = createCoreStartMock({
+          actions: { show: false, execute: false },
+          anonymization: { show: false, manage: false },
+        });
+
+        plugin.start(coreStart, { licensing: { license$ } } as any);
+
+        expect(app.enable).not.toHaveBeenCalled();
+        expect(app.disable).toHaveBeenCalledTimes(2);
+      });
+
+      it('keeps the app disabled when anonymization capabilities exist but license is not enterprise', () => {
+        const app = createAppMock();
+        const { management } = createManagementMock(app);
+        const plugin = createPlugin();
+        plugin.setup(createCoreSetupMock(), { management });
+
+        const license$ = new BehaviorSubject<any>({ hasAtLeast: () => false });
+        const coreStart = createCoreStartMock({
+          anonymization: { show: true, manage: true },
+        });
+
+        plugin.start(coreStart, { licensing: { license$ } } as any);
+
+        expect(app.enable).not.toHaveBeenCalled();
+        expect(app.disable).toHaveBeenCalledTimes(2);
+      });
+
+      it('reacts to license changes — disables then re-enables when license upgrades', () => {
+        const app = createAppMock();
+        const { management } = createManagementMock(app);
+        const plugin = createPlugin();
+        plugin.setup(createCoreSetupMock(), { management });
+
+        const license$ = new BehaviorSubject<any>({ hasAtLeast: () => false });
+        const coreStart = createCoreStartMock({
+          actions: { show: true, execute: true },
+        });
+
+        plugin.start(coreStart, { licensing: { license$ } } as any);
+        expect(app.enable).not.toHaveBeenCalled();
+
+        // License upgrades to enterprise
+        license$.next({ hasAtLeast: (level: string) => level === 'enterprise' });
+        expect(app.enable).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('stop()', () => {
+    it('unsubscribes from the license observable', () => {
+      const app = createAppMock();
+      const { management } = createManagementMock(app);
       const plugin = createPlugin();
-      const management = createManagementMock();
+      plugin.setup(createCoreSetupMock(), { management });
 
       const license$ = new BehaviorSubject<any>({ hasAtLeast: () => false });
-      const coreStart: Partial<CoreStart> = {
-        application: {
-          capabilities: {
-            anonymization: { show: true, manage: true },
-          },
-        },
-      } as any;
-      const coreSetup = createCoreSetupMock(coreStart, { license$ });
+      const coreStart = createCoreStartMock({
+        actions: { show: true, execute: true },
+      });
 
-      await plugin.setup(coreSetup, { management });
+      plugin.start(coreStart, { licensing: { license$ } } as any);
+      expect(license$.observed).toBe(true);
 
-      expect(management.sections.section.ai.registerApp).not.toHaveBeenCalled();
+      plugin.stop();
+      expect(license$.observed).toBe(false);
     });
   });
 });

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/plugin.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/plugin.ts
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
+import type { Subscription } from 'rxjs';
 import { i18n } from '@kbn/i18n';
 import type { Plugin } from '@kbn/core/public';
 import { type CoreSetup, type CoreStart, type PluginInitializerContext } from '@kbn/core/public';
-import type { ManagementSetup } from '@kbn/management-plugin/public';
+import type { ManagementApp, ManagementSetup } from '@kbn/management-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { ProductDocBasePluginStart } from '@kbn/product-doc-base-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
-import { firstValueFrom } from 'rxjs';
 import type { GenAiSettingsConfigType } from '../common/config';
 
 export interface GenAiSettingsStartDeps {
@@ -42,52 +42,72 @@ export class GenAiSettingsPlugin
       GenAiSettingsStartDeps
     >
 {
+  private registeredApp?: ManagementApp;
+  private licensingSubscription?: Subscription;
+
   constructor(private initializerContext: PluginInitializerContext<GenAiSettingsConfigType>) {}
 
-  public async setup(
+  public setup(
     core: CoreSetup<GenAiSettingsStartDeps, GenAiSettingsPluginStart>,
     { management }: GenAiSettingsSetupDeps
-  ): Promise<GenAiSettingsPluginSetup> {
-    const [coreStart, { licensing }] = await core.getStartServices();
-    const capabilities = coreStart.application.capabilities;
+  ): GenAiSettingsPluginSetup {
+    // This section depends mainly on Connectors feature, but should have its own Kibana feature setting in the future.
+    this.registeredApp = management.sections.section.ai.registerApp({
+      id: 'genAiSettings',
+      title: i18n.translate('genAiSettings.managementSectionLabel', {
+        defaultMessage: 'GenAI Settings',
+      }),
+      order: 1,
+      keywords: ['ai', 'generative', 'settings', 'configuration'],
 
-    const hasEnterpriseLicense = licensing
-      ? (await firstValueFrom(licensing.license$)).hasAtLeast('enterprise')
-      : false;
+      mount: async (mountParams) => {
+        const { mountManagementSection } = await import('./management_section/mount_section');
+
+        return mountManagementSection({
+          core,
+          mountParams,
+          config: this.initializerContext.config.get(),
+        });
+      },
+    });
+
+    // Default to disabled until license and capability checks run in start()
+    this.registeredApp.disable();
+
+    return {};
+  }
+
+  public start(
+    coreStart: CoreStart,
+    { licensing }: GenAiSettingsStartDeps
+  ): GenAiSettingsPluginStart {
+    const { capabilities } = coreStart.application;
 
     const hasConnectorsReadPrivilege =
       capabilities.actions?.show === true && capabilities.actions?.execute === true;
     const hasAnonymizationPrivilege =
       capabilities.anonymization?.show === true || capabilities.anonymization?.manage === true;
 
-    // This section depends mainly on Connectors feature, but should have its own Kibana feature setting in the future.
-    if (hasEnterpriseLicense && (hasConnectorsReadPrivilege || hasAnonymizationPrivilege)) {
-      management.sections.section.ai.registerApp({
-        id: 'genAiSettings',
-        title: i18n.translate('genAiSettings.managementSectionLabel', {
-          defaultMessage: 'GenAI Settings',
-        }),
-        order: 1,
-        keywords: ['ai', 'generative', 'settings', 'configuration'],
+    if (licensing) {
+      this.licensingSubscription = licensing.license$.subscribe((license) => {
+        const hasEnterpriseLicense = license.hasAtLeast('enterprise');
 
-        mount: async (mountParams) => {
-          const { mountManagementSection } = await import('./management_section/mount_section');
-
-          return mountManagementSection({
-            core,
-            mountParams,
-            config: this.initializerContext.config.get(),
-          });
-        },
+        if (
+          this.registeredApp &&
+          hasEnterpriseLicense &&
+          (hasConnectorsReadPrivilege || hasAnonymizationPrivilege)
+        ) {
+          this.registeredApp.enable();
+        } else if (this.registeredApp) {
+          this.registeredApp.disable();
+        }
       });
     }
 
     return {};
   }
 
-  public start(coreStart: CoreStart): GenAiSettingsPluginStart {
-    return {};
+  public stop() {
+    this.licensingSubscription?.unsubscribe();
   }
-
-  public stop() {}
 }

--- a/x-pack/platform/plugins/private/gen_ai_settings/test/scout/ui/parallel_tests/page_display.spec.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/test/scout/ui/parallel_tests/page_display.spec.ts
@@ -9,8 +9,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 import { spaceTest } from '../fixtures';
 
-// Failing: See https://github.com/elastic/kibana/issues/258770
-spaceTest.describe.skip(
+spaceTest.describe(
   'GenAI Settings - Page Display',
   {
     tag: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[AI Infra] Fix failing GenAI Settings Scout tests (#260496)](https://github.com/elastic/kibana/pull/260496)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Krasocki","email":"104936644+KodeRad@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-22T09:22:39Z","message":"[AI Infra] Fix failing GenAI Settings Scout tests (#260496)\n\n## Summary\n\nThis PR fixes the issues with failing GenAI Settings Scout test:\n\nhttps://github.com/elastic/kibana/issues/260169\nhttps://github.com/elastic/kibana/issues/260019\nhttps://github.com/elastic/kibana/issues/259689\nhttps://github.com/elastic/kibana/issues/258770\nhttps://github.com/elastic/kibana/issues/261872\nhttps://github.com/elastic/kibana/issues/264278\n\nGenAI Settings previously called\nmanagement.sections.section.ai.registerApp() only after async work in\nsetup() (getStartServices, licensing). That deferred registration could\nlose the race on slower VMs: Stack Management could build its route list\nbefore the app existed, so deep links to GenAI Settings sometimes landed\non the management landing page while navigation still showed the item.\n\nOther management apps typically register synchronously in setup() and\ngate visibility separately. We now register the management app\nimmediately in setup(), default it to disabled, and enable/disable it\nfrom start() based on enterprise license and connector/anonymization\ncapabilities (with a license subscription for changes).\n\nThere is a retry logic added to the scout test, so it can wait for the\nlicense to resolve and then retry.\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: James Gowdy <jgowdy@elastic.co>","sha":"956f97420b1033ff70b563c2769302a6122c93eb","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":[":ml","release_note:skip","Team:ML","backport:version","Team:One Workflow","reviewer:coderabbit","reviewer:macroscope","v9.5.0","v9.4.2"],"title":"[AI Infra] Fix failing GenAI Settings Scout tests","number":260496,"url":"https://github.com/elastic/kibana/pull/260496","mergeCommit":{"message":"[AI Infra] Fix failing GenAI Settings Scout tests (#260496)\n\n## Summary\n\nThis PR fixes the issues with failing GenAI Settings Scout test:\n\nhttps://github.com/elastic/kibana/issues/260169\nhttps://github.com/elastic/kibana/issues/260019\nhttps://github.com/elastic/kibana/issues/259689\nhttps://github.com/elastic/kibana/issues/258770\nhttps://github.com/elastic/kibana/issues/261872\nhttps://github.com/elastic/kibana/issues/264278\n\nGenAI Settings previously called\nmanagement.sections.section.ai.registerApp() only after async work in\nsetup() (getStartServices, licensing). That deferred registration could\nlose the race on slower VMs: Stack Management could build its route list\nbefore the app existed, so deep links to GenAI Settings sometimes landed\non the management landing page while navigation still showed the item.\n\nOther management apps typically register synchronously in setup() and\ngate visibility separately. We now register the management app\nimmediately in setup(), default it to disabled, and enable/disable it\nfrom start() based on enterprise license and connector/anonymization\ncapabilities (with a license subscription for changes).\n\nThere is a retry logic added to the scout test, so it can wait for the\nlicense to resolve and then retry.\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: James Gowdy <jgowdy@elastic.co>","sha":"956f97420b1033ff70b563c2769302a6122c93eb"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260496","number":260496,"mergeCommit":{"message":"[AI Infra] Fix failing GenAI Settings Scout tests (#260496)\n\n## Summary\n\nThis PR fixes the issues with failing GenAI Settings Scout test:\n\nhttps://github.com/elastic/kibana/issues/260169\nhttps://github.com/elastic/kibana/issues/260019\nhttps://github.com/elastic/kibana/issues/259689\nhttps://github.com/elastic/kibana/issues/258770\nhttps://github.com/elastic/kibana/issues/261872\nhttps://github.com/elastic/kibana/issues/264278\n\nGenAI Settings previously called\nmanagement.sections.section.ai.registerApp() only after async work in\nsetup() (getStartServices, licensing). That deferred registration could\nlose the race on slower VMs: Stack Management could build its route list\nbefore the app existed, so deep links to GenAI Settings sometimes landed\non the management landing page while navigation still showed the item.\n\nOther management apps typically register synchronously in setup() and\ngate visibility separately. We now register the management app\nimmediately in setup(), default it to disabled, and enable/disable it\nfrom start() based on enterprise license and connector/anonymization\ncapabilities (with a license subscription for changes).\n\nThere is a retry logic added to the scout test, so it can wait for the\nlicense to resolve and then retry.\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: James Gowdy <jgowdy@elastic.co>","sha":"956f97420b1033ff70b563c2769302a6122c93eb"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->