### PR TITLE
[Task Manager] Claim nudge PoC via inter-node HTTP

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import type { Logger } from '@kbn/core/server';
+import type { HttpClaimNudgeClient } from './http_claim_nudge_client';
+
+export interface TaskManagerClaimNudgeService {
+  readonly claimNudge$: Observable<void>;
+  start(): void;
+  stop(): void;
+  notify(): Promise<void>;
+  emitLocalNudge(source: string): void;
+}
+
+class BaseClaimNudgeService implements TaskManagerClaimNudgeService {
+  protected readonly logger: Logger;
+  protected readonly claimNudgeSubject = new Subject<void>();
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  public get claimNudge$() {
+    return this.claimNudgeSubject.asObservable();
+  }
+
+  public start() {}
+  public stop() {}
+
+  public async notify() {}
+
+  public emitLocalNudge(source: string) {
+    this.logger.info(`[claim_nudge] received_nudge source=${source}, triggering_immediate_poll`);
+    this.claimNudgeSubject.next();
+  }
+}
+
+export class NoopClaimNudgeService extends BaseClaimNudgeService {
+  public override async notify() {
+    this.logger.info('[claim_nudge] strategy=noop, skipping notify');
+  }
+}
+
+export class GlobalCheckpointsClaimNudgeService extends BaseClaimNudgeService {
+  public override async notify() {
+    this.logger.info(
+      '[claim_nudge] strategy=global_checkpoints unavailable in this deployment, falling back to regular poll interval'
+    );
+  }
+}
+
+export class HttpClaimNudgeService extends BaseClaimNudgeService {
+  private readonly client: HttpClaimNudgeClient;
+
+  constructor(logger: Logger, client: HttpClaimNudgeClient) {
+    super(logger);
+    this.client = client;
+  }
+
+  public override async notify() {
+    await this.client.notify();
+  }
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.ts
@@ -10,17 +10,28 @@ import type { Observable } from 'rxjs';
 import type { Logger } from '@kbn/core/server';
 import type { HttpClaimNudgeClient } from './http_claim_nudge_client';
 
+export interface ClaimNudgeTarget {
+  taskId: string;
+  version: string;
+  taskType: string;
+}
+
+export interface ClaimNudgeEvent {
+  source: string;
+  taskTargets: ClaimNudgeTarget[];
+}
+
 export interface TaskManagerClaimNudgeService {
-  readonly claimNudge$: Observable<void>;
+  readonly claimNudge$: Observable<ClaimNudgeEvent>;
   start(): void;
   stop(): void;
-  notify(): Promise<void>;
-  emitLocalNudge(source: string): void;
+  notify(taskTargets?: ClaimNudgeTarget[]): Promise<void>;
+  emitLocalNudge(source: string, taskTargets?: ClaimNudgeTarget[]): void;
 }
 
 class BaseClaimNudgeService implements TaskManagerClaimNudgeService {
   protected readonly logger: Logger;
-  protected readonly claimNudgeSubject = new Subject<void>();
+  protected readonly claimNudgeSubject = new Subject<ClaimNudgeEvent>();
 
   constructor(logger: Logger) {
     this.logger = logger;
@@ -33,22 +44,24 @@ class BaseClaimNudgeService implements TaskManagerClaimNudgeService {
   public start() {}
   public stop() {}
 
-  public async notify() {}
+  public async notify(_taskTargets?: ClaimNudgeTarget[]) {}
 
-  public emitLocalNudge(source: string) {
-    this.logger.info(`[claim_nudge] received_nudge source=${source}, triggering_immediate_poll`);
-    this.claimNudgeSubject.next();
+  public emitLocalNudge(source: string, taskTargets: ClaimNudgeTarget[] = []) {
+    this.logger.info(
+      `[claim_nudge] received_nudge source=${source} task_targets=${taskTargets.length}, triggering_immediate_poll`
+    );
+    this.claimNudgeSubject.next({ source, taskTargets });
   }
 }
 
 export class NoopClaimNudgeService extends BaseClaimNudgeService {
-  public override async notify() {
+  public override async notify(_taskTargets?: ClaimNudgeTarget[]) {
     this.logger.info('[claim_nudge] strategy=noop, skipping notify');
   }
 }
 
 export class GlobalCheckpointsClaimNudgeService extends BaseClaimNudgeService {
-  public override async notify() {
+  public override async notify(_taskTargets?: ClaimNudgeTarget[]) {
     this.logger.info(
       '[claim_nudge] strategy=global_checkpoints unavailable in this deployment, falling back to regular poll interval'
     );
@@ -63,7 +76,7 @@ export class HttpClaimNudgeService extends BaseClaimNudgeService {
     this.client = client;
   }
 
-  public override async notify() {
-    await this.client.notify();
+  public override async notify(taskTargets: ClaimNudgeTarget[] = []) {
+    await this.client.notify(taskTargets);
   }
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/claim_nudge_service.ts
@@ -29,12 +29,16 @@ export interface TaskManagerClaimNudgeService {
   emitLocalNudge(source: string, taskTargets?: ClaimNudgeTarget[]): void;
 }
 
-class BaseClaimNudgeService implements TaskManagerClaimNudgeService {
+type NotifyHandler = (taskTargets?: ClaimNudgeTarget[]) => Promise<void>;
+
+class ClaimNudgeService implements TaskManagerClaimNudgeService {
   protected readonly logger: Logger;
   protected readonly claimNudgeSubject = new Subject<ClaimNudgeEvent>();
+  private readonly notifyHandler: NotifyHandler;
 
-  constructor(logger: Logger) {
+  constructor(logger: Logger, notifyHandler: NotifyHandler = async () => {}) {
     this.logger = logger;
+    this.notifyHandler = notifyHandler;
   }
 
   public get claimNudge$() {
@@ -44,7 +48,9 @@ class BaseClaimNudgeService implements TaskManagerClaimNudgeService {
   public start() {}
   public stop() {}
 
-  public async notify(_taskTargets?: ClaimNudgeTarget[]) {}
+  public async notify(taskTargets?: ClaimNudgeTarget[]) {
+    await this.notifyHandler(taskTargets);
+  }
 
   public emitLocalNudge(source: string, taskTargets: ClaimNudgeTarget[] = []) {
     this.logger.info(
@@ -54,29 +60,27 @@ class BaseClaimNudgeService implements TaskManagerClaimNudgeService {
   }
 }
 
-export class NoopClaimNudgeService extends BaseClaimNudgeService {
-  public override async notify(_taskTargets?: ClaimNudgeTarget[]) {
-    this.logger.info('[claim_nudge] strategy=noop, skipping notify');
-  }
+export function createNoopClaimNudgeService(logger: Logger): TaskManagerClaimNudgeService {
+  return new ClaimNudgeService(logger, async () => {
+    logger.info('[claim_nudge] strategy=noop, skipping notify');
+  });
 }
 
-export class GlobalCheckpointsClaimNudgeService extends BaseClaimNudgeService {
-  public override async notify(_taskTargets?: ClaimNudgeTarget[]) {
-    this.logger.info(
+export function createGlobalCheckpointsClaimNudgeService(
+  logger: Logger
+): TaskManagerClaimNudgeService {
+  return new ClaimNudgeService(logger, async () => {
+    logger.info(
       '[claim_nudge] strategy=global_checkpoints unavailable in this deployment, falling back to regular poll interval'
     );
-  }
+  });
 }
 
-export class HttpClaimNudgeService extends BaseClaimNudgeService {
-  private readonly client: HttpClaimNudgeClient;
-
-  constructor(logger: Logger, client: HttpClaimNudgeClient) {
-    super(logger);
-    this.client = client;
-  }
-
-  public override async notify(taskTargets: ClaimNudgeTarget[] = []) {
-    await this.client.notify(taskTargets);
-  }
+export function createHttpClaimNudgeService(
+  logger: Logger,
+  client: HttpClaimNudgeClient
+): TaskManagerClaimNudgeService {
+  return new ClaimNudgeService(logger, async (taskTargets = []) => {
+    await client.notify(taskTargets);
+  });
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
@@ -146,6 +146,7 @@ export class HttpClaimNudgeClient {
             headers: {
               'content-type': 'application/json',
               'x-elastic-internal-origin': 'task-manager',
+              'kbn-xsrf': 'task-manager-claim-nudge',
               'content-length': '2',
             },
           },

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
@@ -62,7 +62,9 @@ export class HttpClaimNudgeClient {
 
     if (!this.hasLoggedConnectivityCheck) {
       this.logger.info(
-        `[claim_nudge] connectivity_check node_targets=${JSON.stringify(addresses)} path=${this.nudgePath} timeout_ms=${this.timeoutMs}`
+        `[claim_nudge] connectivity_check node_targets=${JSON.stringify(addresses)} path=${
+          this.nudgePath
+        } timeout_ms=${this.timeoutMs}`
       );
       this.hasLoggedConnectivityCheck = true;
     }
@@ -122,9 +124,7 @@ export class HttpClaimNudgeClient {
       discoveredNodes: activeNodes.length,
     };
 
-    this.logger.info(
-      `[claim_nudge] refreshed_node_cache nodes=${addresses.length} cache_age_ms=0`
-    );
+    this.logger.info(`[claim_nudge] refreshed_node_cache nodes=${addresses.length} cache_age_ms=0`);
 
     return {
       discoveredNodes: activeNodes.length,

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
@@ -149,6 +149,7 @@ export class HttpClaimNudgeClient {
               'kbn-xsrf': 'task-manager-claim-nudge',
               'content-length': '2',
             },
+            ...(isHttps ? { rejectUnauthorized: false } : {}),
           },
           (response) => {
             const statusCode = response.statusCode ?? 0;

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
@@ -9,6 +9,7 @@ import { request as httpRequest } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { URL } from 'node:url';
 import type { Logger } from '@kbn/core/server';
+import type { ClaimNudgeTarget } from './claim_nudge_service';
 import type { KibanaDiscoveryService } from '../kibana_discovery_service';
 
 export interface HttpClaimNudgeClientOptions {
@@ -46,11 +47,12 @@ export class HttpClaimNudgeClient {
     this.nudgePath = `${serverBasePath}/internal/task_manager/_claim_nudge`;
   }
 
-  public async notify() {
+  public async notify(taskTargets: ClaimNudgeTarget[] = []) {
     const { addresses, discoveredNodes } = await this.getNodeAddresses();
+    const requestBody = JSON.stringify({ taskTargets });
 
     this.logger.info(
-      `[claim_nudge] notify discovered_nodes=${discoveredNodes} addressable_nodes=${addresses.length}`
+      `[claim_nudge] notify discovered_nodes=${discoveredNodes} addressable_nodes=${addresses.length} task_targets=${taskTargets.length}`
     );
 
     if (addresses.length === 0) {
@@ -66,7 +68,9 @@ export class HttpClaimNudgeClient {
     }
 
     const results = await Promise.allSettled(
-      addresses.map((address) => this.sendNudgeRequest(address, this.nudgePath, this.timeoutMs))
+      addresses.map((address) =>
+        this.sendNudgeRequest(address, this.nudgePath, this.timeoutMs, requestBody)
+      )
     );
 
     let successCount = 0;
@@ -128,7 +132,7 @@ export class HttpClaimNudgeClient {
     };
   }
 
-  private sendNudgeRequest(address: string, path: string, timeoutMs: number) {
+  private sendNudgeRequest(address: string, path: string, timeoutMs: number, body: string) {
     const url = new URL(address);
     const isHttps = url.protocol === 'https:';
     const requestFn = isHttps ? httpsRequest : httpRequest;
@@ -147,7 +151,7 @@ export class HttpClaimNudgeClient {
               'content-type': 'application/json',
               'x-elastic-internal-origin': 'task-manager',
               'kbn-xsrf': 'task-manager-claim-nudge',
-              'content-length': '2',
+              'content-length': String(Buffer.byteLength(body, 'utf8')),
             },
             ...(isHttps ? { rejectUnauthorized: false } : {}),
           },
@@ -171,7 +175,7 @@ export class HttpClaimNudgeClient {
           );
         });
 
-        request.write('{}');
+        request.write(body);
         request.end();
       }
     );

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/http_claim_nudge_client.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { URL } from 'node:url';
+import type { Logger } from '@kbn/core/server';
+import type { KibanaDiscoveryService } from '../kibana_discovery_service';
+
+export interface HttpClaimNudgeClientOptions {
+  logger: Logger;
+  kibanaDiscoveryService: KibanaDiscoveryService;
+  timeoutMs: number;
+  serverBasePath: string;
+}
+
+interface CachedAddressSet {
+  cachedAt: number;
+  addresses: string[];
+  discoveredNodes: number;
+}
+
+const NODE_CACHE_TTL_MS = 5_000;
+
+export class HttpClaimNudgeClient {
+  private readonly logger: Logger;
+  private readonly kibanaDiscoveryService: KibanaDiscoveryService;
+  private readonly timeoutMs: number;
+  private readonly nudgePath: string;
+  private addressCache: CachedAddressSet | undefined;
+  private hasLoggedConnectivityCheck = false;
+
+  constructor({
+    logger,
+    kibanaDiscoveryService,
+    timeoutMs,
+    serverBasePath,
+  }: HttpClaimNudgeClientOptions) {
+    this.logger = logger;
+    this.kibanaDiscoveryService = kibanaDiscoveryService;
+    this.timeoutMs = timeoutMs;
+    this.nudgePath = `${serverBasePath}/internal/task_manager/_claim_nudge`;
+  }
+
+  public async notify() {
+    const { addresses, discoveredNodes } = await this.getNodeAddresses();
+
+    this.logger.info(
+      `[claim_nudge] notify discovered_nodes=${discoveredNodes} addressable_nodes=${addresses.length}`
+    );
+
+    if (addresses.length === 0) {
+      this.logger.info('[claim_nudge] notify discovered_nodes=0, skipping HTTP nudge');
+      return;
+    }
+
+    if (!this.hasLoggedConnectivityCheck) {
+      this.logger.info(
+        `[claim_nudge] connectivity_check node_targets=${JSON.stringify(addresses)} path=${this.nudgePath} timeout_ms=${this.timeoutMs}`
+      );
+      this.hasLoggedConnectivityCheck = true;
+    }
+
+    const results = await Promise.allSettled(
+      addresses.map((address) => this.sendNudgeRequest(address, this.nudgePath, this.timeoutMs))
+    );
+
+    let successCount = 0;
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        successCount += 1;
+        this.logger.info(
+          `[claim_nudge] notify node=${result.value.address} status=${result.value.statusCode} response_ms=${result.value.elapsedMs}`
+        );
+      } else {
+        this.logger.info(`[claim_nudge] notify failed: ${result.reason}`);
+      }
+    }
+
+    if (successCount === 0) {
+      this.logger.info(
+        '[claim_nudge] all_nodes_failed for notify, tasks will be claimed by regular poll interval'
+      );
+    }
+  }
+
+  private async getNodeAddresses() {
+    const now = Date.now();
+    if (this.addressCache && now - this.addressCache.cachedAt < NODE_CACHE_TTL_MS) {
+      return {
+        discoveredNodes: this.addressCache.discoveredNodes,
+        addresses: this.addressCache.addresses,
+      };
+    }
+
+    let activeNodes: Awaited<ReturnType<KibanaDiscoveryService['getActiveKibanaNodes']>>;
+    try {
+      activeNodes = await this.kibanaDiscoveryService.getActiveKibanaNodes();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.info(`[claim_nudge] discovery_failed while fetching active nodes: ${message}`);
+      return {
+        discoveredNodes: 0,
+        addresses: [],
+      };
+    }
+    const addresses = activeNodes
+      .map((node) => node.attributes.address)
+      .filter((address): address is string => Boolean(address));
+
+    this.addressCache = {
+      cachedAt: now,
+      addresses,
+      discoveredNodes: activeNodes.length,
+    };
+
+    this.logger.info(
+      `[claim_nudge] refreshed_node_cache nodes=${addresses.length} cache_age_ms=0`
+    );
+
+    return {
+      discoveredNodes: activeNodes.length,
+      addresses,
+    };
+  }
+
+  private sendNudgeRequest(address: string, path: string, timeoutMs: number) {
+    const url = new URL(address);
+    const isHttps = url.protocol === 'https:';
+    const requestFn = isHttps ? httpsRequest : httpRequest;
+
+    return new Promise<{ address: string; statusCode: number; elapsedMs: number }>(
+      (resolve, reject) => {
+        const startedAt = Date.now();
+        const request = requestFn(
+          {
+            protocol: url.protocol,
+            hostname: url.hostname,
+            port: url.port,
+            path,
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              'x-elastic-internal-origin': 'task-manager',
+              'content-length': '2',
+            },
+          },
+          (response) => {
+            const statusCode = response.statusCode ?? 0;
+            response.resume();
+            resolve({
+              address,
+              statusCode,
+              elapsedMs: Date.now() - startedAt,
+            });
+          }
+        );
+
+        request.setTimeout(timeoutMs, () => {
+          request.destroy(new Error(`timed_out=true response_ms=${Date.now() - startedAt}`));
+        });
+        request.on('error', (error) => {
+          reject(
+            `node=${address} failed: ${error.message} (response_ms=${Date.now() - startedAt})`
+          );
+        });
+
+        request.write('{}');
+        request.end();
+      }
+    );
+  }
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { TaskManagerClaimNudgeService } from './claim_nudge_service';
+export {
+  GlobalCheckpointsClaimNudgeService,
+  HttpClaimNudgeService,
+  NoopClaimNudgeService,
+} from './claim_nudge_service';
+export { HttpClaimNudgeClient } from './http_claim_nudge_client';

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/index.ts
@@ -6,6 +6,7 @@
  */
 
 export type { TaskManagerClaimNudgeService } from './claim_nudge_service';
+export type { ClaimNudgeEvent, ClaimNudgeTarget } from './claim_nudge_service';
 export {
   GlobalCheckpointsClaimNudgeService,
   HttpClaimNudgeService,

--- a/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/claim_nudge/index.ts
@@ -8,8 +8,8 @@
 export type { TaskManagerClaimNudgeService } from './claim_nudge_service';
 export type { ClaimNudgeEvent, ClaimNudgeTarget } from './claim_nudge_service';
 export {
-  GlobalCheckpointsClaimNudgeService,
-  HttpClaimNudgeService,
-  NoopClaimNudgeService,
+  createGlobalCheckpointsClaimNudgeService,
+  createHttpClaimNudgeService,
+  createNoopClaimNudgeService,
 } from './claim_nudge_service';
 export { HttpClaimNudgeClient } from './http_claim_nudge_client';

--- a/x-pack/platform/plugins/shared/task_manager/server/config.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/config.ts
@@ -93,7 +93,7 @@ const claimNudgeConfig = schema.object({
       schema.literal(CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS),
       schema.literal(CLAIM_NUDGE_STRATEGY_DISABLED),
     ],
-    { defaultValue: CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS }
+    { defaultValue: CLAIM_NUDGE_STRATEGY_HTTP }
   ),
   http_timeout_ms: schema.number({
     defaultValue: 2000,

--- a/x-pack/platform/plugins/shared/task_manager/server/config.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/config.ts
@@ -44,6 +44,9 @@ export const DEFAULT_ACTIVE_NODES_LOOK_BACK_DURATION = '30s';
 const FIVE_MIN_IN_MS = 5 * 60 * 1000;
 
 export const DEFAULT_KIBANAS_PER_PARTITION = 2;
+export const CLAIM_NUDGE_STRATEGY_HTTP = 'http';
+export const CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS = 'global_checkpoints';
+export const CLAIM_NUDGE_STRATEGY_DISABLED = 'disabled';
 
 export enum ApiKeyType {
   ES = 'es',
@@ -81,6 +84,21 @@ const eventLoopDelaySchema = schema.object({
 const requestTimeoutsConfig = schema.object({
   /* The request timeout config for task manager's updateByQuery default:30s, min:10s, max:10m */
   update_by_query: schema.number({ defaultValue: 1000 * 30, min: 1000 * 10, max: 1000 * 60 * 10 }),
+});
+
+const claimNudgeConfig = schema.object({
+  strategy: schema.oneOf(
+    [
+      schema.literal(CLAIM_NUDGE_STRATEGY_HTTP),
+      schema.literal(CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS),
+      schema.literal(CLAIM_NUDGE_STRATEGY_DISABLED),
+    ],
+    { defaultValue: CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS }
+  ),
+  http_timeout_ms: schema.number({
+    defaultValue: 2000,
+    min: 100,
+  }),
 });
 
 const validateDuration = (duration: string) => {
@@ -223,6 +241,7 @@ export const configSchema = schema.object(
     claim_strategy: schema.string({ defaultValue: CLAIM_STRATEGY_MGET }),
     request_timeouts: requestTimeoutsConfig,
     auto_calculate_default_ech_capacity: schema.boolean({ defaultValue: false }),
+    claim_nudge: claimNudgeConfig,
   },
   {
     validate: (config) => {

--- a/x-pack/platform/plugins/shared/task_manager/server/kibana_discovery_service/kibana_discovery_service.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/kibana_discovery_service/kibana_discovery_service.ts
@@ -16,6 +16,7 @@ import { isClusterBlockException } from '../lib/errors';
 interface DiscoveryServiceParams {
   config: TaskManagerConfig['discovery'];
   currentNode: string;
+  nodeAddress?: string;
   savedObjectsRepository: ISavedObjectsRepository;
   logger: Logger;
   onNodesCounted?: (numOfNodes: number) => void;
@@ -24,6 +25,7 @@ interface DiscoveryServiceParams {
 interface DiscoveryServiceUpsertParams {
   id: string;
   lastSeen: string;
+  address?: string;
 }
 
 export const DEFAULT_TIMEOUT = 2000;
@@ -38,6 +40,9 @@ export class KibanaDiscoveryService {
   private stopped = false;
   private timer: NodeJS.Timeout | undefined;
   private onNodesCounted?: (numOfNodes: number) => void;
+  private readonly nodeAddress?: string;
+  private hasLoggedAddressAdvertisement = false;
+  private hasLoggedStartupSmokeTest = false;
 
   constructor(opts: DiscoveryServiceParams) {
     this.activeNodesLookBack = opts.config.active_nodes_lookback;
@@ -46,17 +51,19 @@ export class KibanaDiscoveryService {
     this.logger = opts.logger;
     this.currentNode = opts.currentNode;
     this.onNodesCounted = opts.onNodesCounted;
+    this.nodeAddress = opts.nodeAddress;
   }
 
-  private async upsertCurrentNode({ id, lastSeen }: DiscoveryServiceUpsertParams) {
+  private async upsertCurrentNode({ id, lastSeen, address }: DiscoveryServiceUpsertParams) {
     await this.savedObjectsRepository.update<BackgroundTaskNode>(
       BACKGROUND_TASK_NODE_SO_NAME,
       id,
       {
         id,
         last_seen: lastSeen,
+        address,
       },
-      { upsert: { id, last_seen: lastSeen }, refresh: false }
+      { upsert: { id, last_seen: lastSeen, address }, refresh: false }
     );
   }
 
@@ -66,10 +73,28 @@ export class KibanaDiscoveryService {
       const lastSeenDate = new Date();
       const lastSeen = lastSeenDate.toISOString();
       try {
-        await this.upsertCurrentNode({ id: this.currentNode, lastSeen });
+        await this.upsertCurrentNode({
+          id: this.currentNode,
+          lastSeen,
+          address: this.nodeAddress,
+        });
         if (!this.started) {
           this.logger.info('Kibana Discovery Service has been started');
           this.started = true;
+        }
+        if (this.nodeAddress && !this.hasLoggedAddressAdvertisement) {
+          this.logger.info(
+            `[claim_nudge] advertising_address=${this.nodeAddress} for node ${this.currentNode}`
+          );
+          this.hasLoggedAddressAdvertisement = true;
+        }
+        if (!this.hasLoggedStartupSmokeTest) {
+          this.logger.info(
+            `[claim_nudge] startup_smoke_test discovery_upsert_ok node_id=${this.currentNode} advertised_address=${
+              this.nodeAddress ?? 'null'
+            }`
+          );
+          this.hasLoggedStartupSmokeTest = true;
         }
       } catch (e) {
         if (isClusterBlockException(e)) {

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -83,10 +83,10 @@ import {
 } from './invalidate_api_keys/invalidate_api_keys_task';
 import { createApiKeyStrategy } from './api_key_strategy';
 import {
-  GlobalCheckpointsClaimNudgeService,
+  createGlobalCheckpointsClaimNudgeService,
   HttpClaimNudgeClient,
-  HttpClaimNudgeService,
-  NoopClaimNudgeService,
+  createHttpClaimNudgeService,
+  createNoopClaimNudgeService,
 } from './claim_nudge';
 import {
   CLAIM_NUDGE_STRATEGY_DISABLED,
@@ -516,11 +516,11 @@ export class TaskManagerPlugin
         timeoutMs: this.config.claim_nudge.http_timeout_ms,
         serverBasePath: http.basePath.serverBasePath,
       });
-      this.claimNudgeService = new HttpClaimNudgeService(this.logger, claimNudgeClient);
+      this.claimNudgeService = createHttpClaimNudgeService(this.logger, claimNudgeClient);
     } else if (claimNudgeStrategy === CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS) {
-      this.claimNudgeService = new GlobalCheckpointsClaimNudgeService(this.logger);
+      this.claimNudgeService = createGlobalCheckpointsClaimNudgeService(this.logger);
     } else {
-      this.claimNudgeService = new NoopClaimNudgeService(this.logger);
+      this.claimNudgeService = createNoopClaimNudgeService(this.logger);
     }
     if (this.shouldRunBackgroundTasks) {
       this.claimNudgeService.start();

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -341,7 +341,8 @@ export class TaskManagerPlugin
       router,
       logger: this.logger,
       shouldRunTasks: this.shouldRunBackgroundTasks,
-      onClaimNudge: (source: string) => this.claimNudgeService?.emitLocalNudge(source),
+      onClaimNudge: (source: string, taskTargets) =>
+        this.claimNudgeService?.emitLocalNudge(source, taskTargets),
     });
 
     core.status.derivedStatus$.subscribe((status) =>

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -21,6 +21,7 @@ import type {
   Logger,
   CoreStart,
 } from '@kbn/core/server';
+import { hostname } from 'node:os';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/server';
 import type { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-shared';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
@@ -47,10 +48,15 @@ import { TaskTypeDictionary } from './task_type_dictionary';
 import type { AggregationOpts, FetchResult, SearchOpts } from './task_store';
 import { TaskStore } from './task_store';
 import { TaskScheduling } from './task_scheduling';
-import { backgroundTaskUtilizationRoute, healthRoute, metricsRoute } from './routes';
+import {
+  backgroundTaskUtilizationRoute,
+  claimNudgeRoute,
+  healthRoute,
+  metricsRoute,
+} from './routes';
 import type { MonitoringStats } from './monitoring';
 import { createMonitoringStats } from './monitoring';
-import type { ConcreteTaskInstance, TaskEventLogger } from './task';
+import { TaskPriority, type ConcreteTaskInstance, type TaskEventLogger } from './task';
 import { registerTaskManagerUsageCollector } from './usage';
 import { TASK_MANAGER_INDEX } from './constants';
 import { AdHocTaskCounter } from './lib/adhoc_task_counter';
@@ -76,6 +82,18 @@ import {
   scheduleInvalidateApiKeyTask,
 } from './invalidate_api_keys/invalidate_api_keys_task';
 import { createApiKeyStrategy } from './api_key_strategy';
+import {
+  GlobalCheckpointsClaimNudgeService,
+  HttpClaimNudgeClient,
+  HttpClaimNudgeService,
+  NoopClaimNudgeService,
+} from './claim_nudge';
+import {
+  CLAIM_NUDGE_STRATEGY_DISABLED,
+  CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS,
+  CLAIM_NUDGE_STRATEGY_HTTP,
+} from './config';
+import type { TaskManagerClaimNudgeService } from './claim_nudge';
 
 export interface TaskManagerSetupContract {
   /**
@@ -124,6 +142,8 @@ export interface TaskManagerPluginsSetup {
 }
 
 const LogHealthForBackgroundTasksOnlyMinutes = 60;
+const TaskManagerLatencyProbeTaskType = 'task_manager:latency_probe';
+const TaskManagerLatencyProbeIntervalMs = 10_000;
 
 export class TaskManagerPlugin
   implements
@@ -155,11 +175,13 @@ export class TaskManagerPlugin
   private numOfKibanaInstances$: Subject<number> = new BehaviorSubject(1);
   private canEncryptSavedObjects: boolean;
   private licenseSubscriber?: PublicMethodsOf<LicenseSubscriber>;
+  private claimNudgeService?: TaskManagerClaimNudgeService;
   private invalidateApiKeyFn?: ApiKeyInvalidationFn;
   private taskEventLogger?: TaskEventLogger;
   private invalidateUiamApiKeyFn?: UiamApiKeyInvalidationFn;
   private taskStore?: TaskStore;
   private startContract?: TaskManagerStartContract;
+  private probeScheduleIntervalId?: NodeJS.Timeout;
 
   constructor(private readonly initContext: PluginInitializerContext) {
     this.initContext = initContext;
@@ -176,6 +198,62 @@ export class TaskManagerPlugin
   isNodeBackgroundTasksOnly() {
     const { backgroundTasks, migrator, ui } = this.nodeRoles;
     return backgroundTasks && !migrator && !ui;
+  }
+
+  private deriveNodeAddress({
+    host,
+    port,
+    protocol,
+  }: {
+    host: string;
+    port: number;
+    protocol: 'http' | 'https' | 'socket';
+  }) {
+    const podIp = process.env.POD_IP;
+    const osHostname = hostname();
+    this.logger.info(
+      `[claim_nudge] address_resolution_inputs server.host=${host} server.port=${port} protocol=${protocol} pod_ip=${
+        podIp ?? 'undefined'
+      } os_hostname=${osHostname}`
+    );
+
+    if (protocol === 'socket') {
+      this.logger.info('[claim_nudge] self_address=null (socket protocol is not supported)');
+      return undefined;
+    }
+
+    if (host === 'localhost' || host === '127.0.0.1') {
+      this.logger.info(
+        `[claim_nudge] self_address=null (server.host=${host} is not externally reachable, HTTP nudge will not advertise this node)`
+      );
+      return undefined;
+    }
+
+    const resolvedHost = host === '0.0.0.0' || host === '::' ? podIp || osHostname : host;
+    const address = `${protocol}://${resolvedHost}:${port}`;
+
+    this.logger.info(
+      `[claim_nudge] self_address=${address} (hostname=${resolvedHost}, port=${port}, protocol=${protocol})`
+    );
+    return address;
+  }
+
+  private getClaimNudgeStrategy(isServerless: boolean) {
+    if (this.config.claim_nudge.strategy === CLAIM_NUDGE_STRATEGY_DISABLED) {
+      this.logger.info('[claim_nudge] strategy=disabled (explicit config)');
+      return CLAIM_NUDGE_STRATEGY_DISABLED;
+    }
+
+    if (
+      isServerless &&
+      this.config.claim_nudge.strategy === CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS
+    ) {
+      this.logger.info('[claim_nudge] strategy=http (auto-detected: serverless=true)');
+      return CLAIM_NUDGE_STRATEGY_HTTP;
+    }
+
+    this.logger.info(`[claim_nudge] strategy=${this.config.claim_nudge.strategy}`);
+    return this.config.claim_nudge.strategy;
   }
 
   private invalidateApiKey(params: InvalidateAPIKeysParams) {
@@ -259,6 +337,12 @@ export class TaskManagerPlugin
       resetMetrics$: this.resetMetrics$,
       taskManagerId: this.taskManagerId,
     });
+    claimNudgeRoute({
+      router,
+      logger: this.logger,
+      shouldRunTasks: this.shouldRunBackgroundTasks,
+      onClaimNudge: (source: string) => this.claimNudgeService?.emitLocalNudge(source),
+    });
 
     core.status.derivedStatus$.subscribe((status) =>
       this.logger.debug(`status core.status.derivedStatus now set to ${status.level}`)
@@ -302,6 +386,36 @@ export class TaskManagerPlugin
       core.getStartServices,
       this.definitions
     );
+    this.definitions.registerTaskDefinitions({
+      [TaskManagerLatencyProbeTaskType]: {
+        title: 'Task Manager latency probe',
+        timeout: '5m',
+        priority: TaskPriority.Normal,
+        createTaskRunner: ({ taskInstance }) => ({
+          run: async () => {
+            const startedAtMs = Date.now();
+            const params = (taskInstance.params ?? {}) as { scheduleRequestedAtMs?: number };
+            const scheduleRequestedAtMs = params.scheduleRequestedAtMs ?? 0;
+            const scheduledAtMs = taskInstance.scheduledAt.valueOf();
+
+            this.logger.info(
+              `[tm_latency_probe] run_started_at=${new Date(
+                startedAtMs
+              ).toISOString()} schedule_requested_at=${new Date(
+                scheduleRequestedAtMs
+              ).toISOString()} task_scheduled_at=${taskInstance.scheduledAt.toISOString()} delta_from_requested_ms=${
+                startedAtMs - scheduleRequestedAtMs
+              } delta_from_scheduled_ms=${startedAtMs - scheduledAtMs}`
+            );
+
+            return {
+              state: {},
+              shouldDeleteTask: true,
+            };
+          },
+        }),
+      },
+    });
 
     if (this.config.unsafe.exclude_task_types.length) {
       this.logger.warn(
@@ -340,6 +454,13 @@ export class TaskManagerPlugin
     { cloud, licensing }: TaskManagerPluginsStart
   ): TaskManagerStartContract {
     this.licenseSubscriber = new LicenseSubscriber(licensing.license$);
+    const isServerless = this.initContext.env.packageInfo.buildFlavor === 'serverless';
+    const claimNudgeStrategy = this.getClaimNudgeStrategy(isServerless);
+    const nodeAddress = this.deriveNodeAddress({
+      host: http.getServerInfo().hostname,
+      port: http.getServerInfo().port,
+      protocol: http.getServerInfo().protocol,
+    });
 
     const savedObjectsRepository = savedObjects.createInternalRepository([
       TASK_SO_NAME,
@@ -351,6 +472,7 @@ export class TaskManagerPlugin
       savedObjectsRepository,
       logger: this.logger,
       currentNode: this.taskManagerId!,
+      nodeAddress,
       config: this.config.discovery,
       onNodesCounted: (numOfNodes: number) => this.numOfKibanaInstances$.next(numOfNodes),
     });
@@ -386,8 +508,22 @@ export class TaskManagerPlugin
       apiKeyStrategy,
     });
     this.taskStore = taskStore;
-
-    const isServerless = this.initContext.env.packageInfo.buildFlavor === 'serverless';
+    if (claimNudgeStrategy === CLAIM_NUDGE_STRATEGY_HTTP) {
+      const claimNudgeClient = new HttpClaimNudgeClient({
+        logger: this.logger,
+        kibanaDiscoveryService: this.kibanaDiscoveryService,
+        timeoutMs: this.config.claim_nudge.http_timeout_ms,
+        serverBasePath: http.basePath.serverBasePath,
+      });
+      this.claimNudgeService = new HttpClaimNudgeService(this.logger, claimNudgeClient);
+    } else if (claimNudgeStrategy === CLAIM_NUDGE_STRATEGY_GLOBAL_CHECKPOINTS) {
+      this.claimNudgeService = new GlobalCheckpointsClaimNudgeService(this.logger);
+    } else {
+      this.claimNudgeService = new NoopClaimNudgeService(this.logger);
+    }
+    if (this.shouldRunBackgroundTasks) {
+      this.claimNudgeService.start();
+    }
 
     const defaultCapacity = getDefaultCapacity({
       autoCalculateDefaultEchCapacity: this.config.auto_calculate_default_ech_capacity,
@@ -442,6 +578,7 @@ export class TaskManagerPlugin
         startingCapacity,
         apiKeyStrategy,
         eventLogger: this.taskEventLogger!,
+        claimNudge$: this.claimNudgeService?.claimNudge$,
       });
     }
 
@@ -470,7 +607,54 @@ export class TaskManagerPlugin
       middleware: this.middleware,
       taskManagerId: taskStore.taskManagerId,
       taskPollingLifecycle: this.taskPollingLifecycle,
+      claimNudgeService: this.claimNudgeService,
     });
+
+    if (this.shouldRunBackgroundTasks) {
+      const scheduleProbeTask = () => {
+        const scheduleRequestedAtMs = Date.now();
+        const probeTaskId = `tm-latency-probe-${this.taskManagerId}-${scheduleRequestedAtMs}`;
+        this.logger.info(
+          `[tm_latency_probe] scheduling_one_time_task id=${probeTaskId} schedule_requested_at=${new Date(
+            scheduleRequestedAtMs
+          ).toISOString()}`
+        );
+
+        taskScheduling
+          .schedule(
+            {
+              id: probeTaskId,
+              taskType: TaskManagerLatencyProbeTaskType,
+              params: { scheduleRequestedAtMs },
+              state: {},
+              enabled: true,
+              priority: TaskPriority.Normal,
+            },
+            { requestImmediateClaim: true }
+          )
+          .then(() => {
+            const persistedAtMs = Date.now();
+            this.logger.info(
+              `[tm_latency_probe] task_scheduled id=${probeTaskId} persisted_at=${new Date(
+                persistedAtMs
+              ).toISOString()} persistence_delta_ms=${persistedAtMs - scheduleRequestedAtMs}`
+            );
+          })
+          .catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.info(`[tm_latency_probe] failed_scheduling id=${probeTaskId}: ${message}`);
+          });
+      };
+
+      scheduleProbeTask();
+      this.logger.info(
+        `[tm_latency_probe] using setInterval(${TaskManagerLatencyProbeIntervalMs}ms) to schedule one-time probe tasks`
+      );
+      this.probeScheduleIntervalId = setInterval(
+        scheduleProbeTask,
+        TaskManagerLatencyProbeIntervalMs
+      );
+    }
 
     scheduleDeleteInactiveNodesTaskDefinition(this.logger, taskScheduling).catch(() => {});
     scheduleInvalidateApiKeyTask(
@@ -518,6 +702,11 @@ export class TaskManagerPlugin
     // Stop polling for tasks
     if (this.taskPollingLifecycle) {
       this.taskPollingLifecycle.stop();
+    }
+    this.claimNudgeService?.stop();
+    if (this.probeScheduleIntervalId) {
+      clearInterval(this.probeScheduleIntervalId);
+      this.probeScheduleIntervalId = undefined;
     }
 
     if (this.kibanaDiscoveryService?.isStarted()) {

--- a/x-pack/platform/plugins/shared/task_manager/server/polling/task_poller.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling/task_poller.ts
@@ -15,6 +15,7 @@ import { Subject } from 'rxjs';
 import type { Option } from 'fp-ts/Option';
 import { none } from 'fp-ts/Option';
 import type { Logger } from '@kbn/core/server';
+import type { ClaimNudgeEvent, ClaimNudgeTarget } from '../claim_nudge';
 import { TaskErrorSource } from '../task_running';
 import type { Result } from '../lib/result_type';
 import { asOk, asErr } from '../lib/result_type';
@@ -26,7 +27,8 @@ interface Opts<H> {
   initialPollInterval: number;
   pollInterval$: Observable<number>;
   pollIntervalDelay$?: Observable<number>;
-  claimNudge$?: Observable<void>;
+  claimNudge$?: Observable<ClaimNudgeEvent>;
+  onTaskTargetNudge?: (taskTargets: ClaimNudgeTarget[]) => Promise<void>;
   getCapacity: () => number;
   work: WorkFn<H>;
 }
@@ -54,6 +56,7 @@ export function createTaskPoller<T, H>({
   pollInterval$,
   pollIntervalDelay$,
   claimNudge$,
+  onTaskTargetNudge,
   getCapacity,
   work,
 }: Opts<H>): TaskPoller<T, H> {
@@ -130,8 +133,15 @@ export function createTaskPoller<T, H>({
       });
     }
     if (claimNudge$) {
-      claimNudge$.subscribe(() => {
+      claimNudge$.subscribe((event) => {
         if (!running) {
+          return;
+        }
+
+        if (event.taskTargets.length > 0) {
+          onTaskTargetNudge?.(event.taskTargets).catch((e) => {
+            subject.next(asPollingError(e, PollingErrorType.PollerError));
+          });
           return;
         }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/polling/task_poller.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling/task_poller.ts
@@ -26,6 +26,7 @@ interface Opts<H> {
   initialPollInterval: number;
   pollInterval$: Observable<number>;
   pollIntervalDelay$?: Observable<number>;
+  claimNudge$?: Observable<void>;
   getCapacity: () => number;
   work: WorkFn<H>;
 }
@@ -52,11 +53,14 @@ export function createTaskPoller<T, H>({
   initialPollInterval,
   pollInterval$,
   pollIntervalDelay$,
+  claimNudge$,
   getCapacity,
   work,
 }: Opts<H>): TaskPoller<T, H> {
   const hasCapacity = () => getCapacity() > 0;
   let running: boolean = false;
+  let isCycleRunning: boolean = false;
+  let nudgeRequested: boolean = false;
   let timeoutId: NodeJS.Timeout | null = null;
   let hasSubscribed: boolean = false;
   let pollInterval = initialPollInterval;
@@ -65,6 +69,7 @@ export function createTaskPoller<T, H>({
 
   async function runCycle() {
     timeoutId = null;
+    isCycleRunning = true;
     const start = Date.now();
     try {
       if (hasCapacity()) {
@@ -75,16 +80,22 @@ export function createTaskPoller<T, H>({
       }
     } catch (e) {
       subject.next(asPollingError<T>(e, PollingErrorType.WorkError));
+    } finally {
+      isCycleRunning = false;
     }
 
     if (running) {
       // Set the next runCycle call
+      const nextDelay = nudgeRequested
+        ? 0
+        : Math.max(pollInterval - (Date.now() - start) + (pollIntervalDelay % pollInterval), 0);
+      nudgeRequested = false;
       timeoutId = setTimeout(
         () =>
           runCycle().catch((e) => {
             subject.next(asPollingError(e, PollingErrorType.PollerError));
           }),
-        Math.max(pollInterval - (Date.now() - start) + (pollIntervalDelay % pollInterval), 0)
+        nextDelay
       );
       // Reset delay, it's designed to shuffle only once
       pollIntervalDelay = 0;
@@ -116,6 +127,27 @@ export function createTaskPoller<T, H>({
       pollIntervalDelay$.subscribe((delay) => {
         pollIntervalDelay = delay;
         logger.debug(`Task poller now delaying emission by ${delay}ms`);
+      });
+    }
+    if (claimNudge$) {
+      claimNudge$.subscribe(() => {
+        if (!running) {
+          return;
+        }
+
+        if (isCycleRunning) {
+          nudgeRequested = true;
+          return;
+        }
+
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+
+        runCycle().catch((e) => {
+          subject.next(asPollingError(e, PollingErrorType.PollerError));
+        });
       });
     }
     hasSubscribed = true;

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -83,6 +83,7 @@ export interface TaskPollingLifecycleOpts {
   startingCapacity: number;
   apiKeyStrategy: ApiKeyStrategy;
   eventLogger: TaskEventLogger;
+  claimNudge$?: Observable<void>;
 }
 
 export type TaskLifecycleEvent =
@@ -148,6 +149,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     startingCapacity,
     apiKeyStrategy,
     eventLogger,
+    claimNudge$,
   }: TaskPollingLifecycleOpts) {
     this.basePathService = basePathService;
     this.logger = logger;
@@ -224,6 +226,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
       initialPollInterval: pollInterval,
       pollInterval$: this.pollIntervalConfiguration$,
       pollIntervalDelay$,
+      claimNudge$,
       getCapacity: () => {
         const capacity = this.pool.availableCapacity();
         if (!capacity) {

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -41,6 +41,7 @@ import { fillPool, FillPoolResult } from './lib/fill_pool';
 import type { Middleware } from './lib/middleware';
 import { intervalFromNow } from './lib/intervals';
 import type { ConcreteTaskInstance, TaskEventLogger } from './task';
+import { TaskCost } from './task';
 import { createTaskPoller, PollingError, PollingErrorType } from './polling';
 import { TaskPool } from './task_pool';
 import type { TaskRunner } from './task_running';
@@ -53,8 +54,10 @@ import type { TaskTypeDictionary } from './task_type_dictionary';
 import { delayOnClaimConflicts } from './polling';
 import { TaskClaiming } from './queries/task_claiming';
 import type { ClaimOwnershipResult } from './task_claimers';
+import { claimTasksById } from './task_claimers/claim_by_id';
 import type { TaskPartitioner } from './lib/task_partitioner';
 import type { TaskPoller } from './polling/task_poller';
+import type { ClaimNudgeEvent, ClaimNudgeTarget } from './claim_nudge';
 import {
   createCapacityScan,
   createPollIntervalScan,
@@ -83,7 +86,7 @@ export interface TaskPollingLifecycleOpts {
   startingCapacity: number;
   apiKeyStrategy: ApiKeyStrategy;
   eventLogger: TaskEventLogger;
-  claimNudge$?: Observable<void>;
+  claimNudge$?: Observable<ClaimNudgeEvent>;
 }
 
 export type TaskLifecycleEvent =
@@ -227,6 +230,9 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
       pollInterval$: this.pollIntervalConfiguration$,
       pollIntervalDelay$,
       claimNudge$,
+      onTaskTargetNudge: async (taskTargets: ClaimNudgeTarget[]) => {
+        await this.claimAndRunTasksById(taskTargets);
+      },
       getCapacity: () => {
         const capacity = this.pool.availableCapacity();
         if (!capacity) {
@@ -312,26 +318,85 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
       // wrap each task in a Task Runner
       this.createTaskRunnerForTask,
       // place tasks in the Task Pool
-      async (tasks: TaskRunner[]) => {
-        const tasksToRun = [];
-        const removeTaskPromises = [];
-        for (const task of tasks) {
-          if (task.isAdHocTaskAndOutOfAttempts) {
-            this.logger.debug(`Removing ${task} because the max attempts have been reached.`);
-            removeTaskPromises.push(task.removeTask());
-          } else {
-            tasksToRun.push(task);
-          }
-        }
-        // Wait for all the promises at once to speed up the polling cycle
-        const [result] = await Promise.all([this.pool.run(tasksToRun), ...removeTaskPromises]);
-        // Emit the load after fetching tasks, giving us a good metric for evaluating how
-        // busy Task manager tends to be in this Kibana instance
-        this.emitEvent(asTaskManagerStatEvent('load', asOk(this.pool.usedCapacityPercentage)));
-        return result;
-      }
+      async (tasks: TaskRunner[]) => this.runClaimedTaskRunners(tasks)
     );
   };
+
+  private async claimAndRunTasksById(taskTargets: ClaimNudgeTarget[]) {
+    if (taskTargets.length === 0) {
+      return;
+    }
+
+    for (const target of taskTargets) {
+      const taskDefinition = this.definitions.get(target.taskType);
+      if (!taskDefinition) {
+        this.logger.info(
+          `[claim_nudge] claim_by_id skipped task_id=${target.taskId} reason=unknown_task_type`
+        );
+        continue;
+      }
+
+      const reservationCost = taskDefinition.cost ?? TaskCost.Normal;
+      if (!this.pool.reserveCapacity(reservationCost)) {
+        this.logger.info(
+          `[claim_nudge] claim_by_id skipped task_id=${target.taskId} reason=no_capacity`
+        );
+        continue;
+      }
+
+      let reservationReleased = false;
+      try {
+        const claimResult = await claimTasksById({
+          taskTargets: [target],
+          taskStore: this.store,
+          definitions: this.definitions,
+          logger: this.logger,
+        });
+
+        if (!claimResult.docs.length) {
+          this.pool.releaseCapacity(reservationCost);
+          reservationReleased = true;
+          continue;
+        }
+
+        const runners = claimResult.docs.map(this.createTaskRunnerForTask);
+        await this.runClaimedTaskRunners(runners, reservationCost);
+        reservationReleased = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.info(`[claim_nudge] claim_by_id failed task_id=${target.taskId} reason=${message}`);
+      } finally {
+        if (!reservationReleased) {
+          this.pool.releaseCapacity(reservationCost);
+        }
+      }
+    }
+  }
+
+  private async runClaimedTaskRunners(tasks: TaskRunner[], reservedCapacity?: number) {
+    const tasksToRun = [];
+    const removeTaskPromises = [];
+    for (const task of tasks) {
+      if (task.isAdHocTaskAndOutOfAttempts) {
+        this.logger.debug(`Removing ${task} because the max attempts have been reached.`);
+        removeTaskPromises.push(task.removeTask());
+      } else {
+        tasksToRun.push(task);
+      }
+    }
+
+    const runPromise =
+      reservedCapacity !== undefined
+        ? this.pool.runWithReservedCapacity(tasksToRun, reservedCapacity)
+        : this.pool.run(tasksToRun);
+
+    // Wait for all the promises at once to speed up the polling cycle
+    const [result] = await Promise.all([runPromise, ...removeTaskPromises]);
+    // Emit the load after fetching tasks, giving us a good metric for evaluating how
+    // busy Task manager tends to be in this Kibana instance
+    this.emitEvent(asTaskManagerStatEvent('load', asOk(this.pool.usedCapacityPercentage)));
+    return result;
+  }
 
   private subscribeToPoller(
     poller$: Observable<Result<TimedFillPoolResult, PollingError<string>>>

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -364,7 +364,9 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
         reservationReleased = true;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        this.logger.info(`[claim_nudge] claim_by_id failed task_id=${target.taskId} reason=${message}`);
+        this.logger.info(
+          `[claim_nudge] claim_by_id failed task_id=${target.taskId} reason=${message}`
+        );
       } finally {
         if (!reservationReleased) {
           this.pool.releaseCapacity(reservationCost);

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/claim_nudge.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/claim_nudge.ts
@@ -29,7 +29,12 @@ const claimNudgeBodySchema = schema.object({
   ),
 });
 
-export function claimNudgeRoute({ router, logger, shouldRunTasks, onClaimNudge }: ClaimNudgeRouteParams) {
+export function claimNudgeRoute({
+  router,
+  logger,
+  shouldRunTasks,
+  onClaimNudge,
+}: ClaimNudgeRouteParams) {
   router.post(
     {
       path: '/internal/task_manager/_claim_nudge',
@@ -53,7 +58,9 @@ export function claimNudgeRoute({ router, logger, shouldRunTasks, onClaimNudge }
     },
     async (_, request, response) => {
       if (!shouldRunTasks) {
-        logger.info('[claim_nudge] received_nudge but node is not running background tasks, ignoring');
+        logger.info(
+          '[claim_nudge] received_nudge but node is not running background tasks, ignoring'
+        );
         return response.ok({ body: { acknowledged: true } });
       }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/claim_nudge.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/claim_nudge.ts
@@ -30,6 +30,7 @@ export function claimNudgeRoute({ router, logger, shouldRunTasks, onClaimNudge }
         },
       },
       validate: false,
+      xsrfRequired: false,
       options: {
         access: 'public',
       },

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/claim_nudge.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/claim_nudge.ts
@@ -7,13 +7,27 @@
 
 import type { IRouter } from '@kbn/core/server';
 import type { Logger } from '@kbn/core/server';
+import { schema } from '@kbn/config-schema';
+import type { ClaimNudgeTarget } from '../claim_nudge';
 
 export interface ClaimNudgeRouteParams {
   router: IRouter;
   logger: Logger;
   shouldRunTasks: boolean;
-  onClaimNudge: (source: string) => void;
+  onClaimNudge: (source: string, taskTargets: ClaimNudgeTarget[]) => void;
 }
+
+const claimNudgeBodySchema = schema.object({
+  taskTargets: schema.maybe(
+    schema.arrayOf(
+      schema.object({
+        taskId: schema.string(),
+        version: schema.string(),
+        taskType: schema.string(),
+      })
+    )
+  ),
+});
 
 export function claimNudgeRoute({ router, logger, shouldRunTasks, onClaimNudge }: ClaimNudgeRouteParams) {
   router.post(
@@ -29,7 +43,9 @@ export function claimNudgeRoute({ router, logger, shouldRunTasks, onClaimNudge }
           reason: 'Route is internal system-to-system signaling.',
         },
       },
-      validate: false,
+      validate: {
+        body: schema.maybe(claimNudgeBodySchema),
+      },
       xsrfRequired: false,
       options: {
         access: 'public',
@@ -41,7 +57,7 @@ export function claimNudgeRoute({ router, logger, shouldRunTasks, onClaimNudge }
         return response.ok({ body: { acknowledged: true } });
       }
 
-      onClaimNudge(request.id);
+      onClaimNudge(request.id, request.body?.taskTargets ?? []);
       return response.ok({ body: { acknowledged: true } });
     }
   );

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/claim_nudge.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/claim_nudge.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRouter } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
+
+export interface ClaimNudgeRouteParams {
+  router: IRouter;
+  logger: Logger;
+  shouldRunTasks: boolean;
+  onClaimNudge: (source: string) => void;
+}
+
+export function claimNudgeRoute({ router, logger, shouldRunTasks, onClaimNudge }: ClaimNudgeRouteParams) {
+  router.post(
+    {
+      path: '/internal/task_manager/_claim_nudge',
+      security: {
+        authc: {
+          enabled: false,
+          reason: 'Route supports internal Kibana-to-Kibana request authentication.',
+        },
+        authz: {
+          enabled: false,
+          reason: 'Route is internal system-to-system signaling.',
+        },
+      },
+      validate: false,
+      options: {
+        access: 'public',
+      },
+    },
+    async (_, request, response) => {
+      if (!shouldRunTasks) {
+        logger.info('[claim_nudge] received_nudge but node is not running background tasks, ignoring');
+        return response.ok({ body: { acknowledged: true } });
+      }
+
+      onClaimNudge(request.id);
+      return response.ok({ body: { acknowledged: true } });
+    }
+  );
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/index.ts
@@ -8,3 +8,4 @@
 export { healthRoute } from './health';
 export { backgroundTaskUtilizationRoute } from './background_task_utilization';
 export { metricsRoute } from './metrics';
+export { claimNudgeRoute } from './claim_nudge';

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/mappings.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/mappings.ts
@@ -105,6 +105,9 @@ export const backgroundTaskNodeMapping: SavedObjectsTypeMappingDefinition = {
     last_seen: {
       type: 'date',
     },
+    address: {
+      type: 'keyword',
+    },
   },
 };
 

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/background_task_node_model_versions.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/model_versions/background_task_node_model_versions.ts
@@ -6,13 +6,31 @@
  */
 
 import type { SavedObjectsModelVersionMap } from '@kbn/core-saved-objects-server';
-import { backgroundTaskNodeSchemaV1 } from '../schemas/background_task_node';
+import {
+  backgroundTaskNodeSchemaV1,
+  backgroundTaskNodeSchemaV2,
+} from '../schemas/background_task_node';
 
 export const backgroundTaskNodeModelVersions: SavedObjectsModelVersionMap = {
   '1': {
     changes: [],
     schemas: {
+      forwardCompatibility: backgroundTaskNodeSchemaV1.extends({}, { unknowns: 'ignore' }),
       create: backgroundTaskNodeSchemaV1,
+    },
+  },
+  '2': {
+    changes: [
+      {
+        type: 'mappings_addition',
+        addedMappings: {
+          address: { type: 'keyword' },
+        },
+      },
+    ],
+    schemas: {
+      forwardCompatibility: backgroundTaskNodeSchemaV2.extends({}, { unknowns: 'ignore' }),
+      create: backgroundTaskNodeSchemaV2,
     },
   },
 };

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/background_task_node.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/schemas/background_task_node.ts
@@ -13,4 +13,10 @@ export const backgroundTaskNodeSchemaV1 = schema.object({
   last_seen: schema.string(),
 });
 
-export type BackgroundTaskNode = TypeOf<typeof backgroundTaskNodeSchemaV1>;
+export const backgroundTaskNodeSchemaV2 = schema.object({
+  id: schema.string(),
+  last_seen: schema.string(),
+  address: schema.maybe(schema.string()),
+});
+
+export type BackgroundTaskNode = TypeOf<typeof backgroundTaskNodeSchemaV2>;

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -570,7 +570,19 @@ export interface ApiKeyOptions {
   regenerateApiKey?: boolean;
 }
 
-export type ScheduleOptions = Record<string, unknown> & ApiKeyOptions;
+export type ScheduleOptions = Record<string, unknown> &
+  ApiKeyOptions & {
+    /**
+     * Requests immediate claiming behavior for latency-sensitive tasks.
+     * Internally this maps to refresh + claim nudge.
+     */
+    requestImmediateClaim?: boolean;
+    /**
+     * Controls SO refresh behavior after scheduling.
+     * Prefer `requestImmediateClaim` for user-facing latency-sensitive paths.
+     */
+    refresh?: boolean;
+  };
 
 // Local event log interface to avoid a circular dependency with @kbn/event-log-plugin in .tsconfig
 export interface TaskEventLogger {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/claim_by_id.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/claim_by_id.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { ClaimNudgeTarget } from '../claim_nudge';
+import type { ConcreteTaskInstance, PartialConcreteTaskInstance } from '../task';
+import type { TaskStore } from '../task_store';
+import type { TaskTypeDictionary } from '../task_type_dictionary';
+import { buildClaimUpdate } from './lib/build_claim_update';
+import { executeClaimUpdates } from './lib/execute_claim_updates';
+
+export interface ClaimByIdResult {
+  docs: ConcreteTaskInstance[];
+  conflicts: number;
+  errors: number;
+}
+
+interface ClaimTasksByIdOpts {
+  taskTargets: ClaimNudgeTarget[];
+  taskStore: TaskStore;
+  definitions: TaskTypeDictionary;
+  logger: Logger;
+}
+
+export async function claimTasksById({
+  taskTargets,
+  taskStore,
+  definitions,
+  logger,
+}: ClaimTasksByIdOpts): Promise<ClaimByIdResult> {
+  const uniqueTargets = [...new Map(taskTargets.map((target) => [target.taskId, target])).values()];
+  const updates: PartialConcreteTaskInstance[] = [];
+
+  for (const target of uniqueTargets) {
+    const taskDefinition = definitions.get(target.taskType);
+    if (!taskDefinition) {
+      logger.info(
+        `[claim_nudge] claim_by_id skipped task_id=${target.taskId} task_type=${target.taskType} reason=unknown_task_type`
+      );
+      continue;
+    }
+
+    updates.push(
+      buildClaimUpdate({
+        taskId: target.taskId,
+        version: target.version,
+        taskType: target.taskType,
+        attempts: 0,
+        retryAt: null,
+        runAt: new Date(),
+        schedule: null,
+        timeoutOverride: undefined,
+        ownerId: taskStore.taskManagerId,
+        definitions,
+      })
+    );
+  }
+
+  const { docs, conflicts, updateErrors, getErrors } = await executeClaimUpdates({
+    taskStore,
+    updates,
+    logger,
+    logPrefix: '[claim_nudge] claim_by_id',
+  });
+
+  return {
+    docs,
+    conflicts,
+    errors: updateErrors + getErrors,
+  };
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/lib/build_claim_update.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/lib/build_claim_update.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ConcreteTaskInstance, PartialConcreteTaskInstance } from '../../task';
+import { TaskStatus } from '../../task';
+import type { TaskTypeDictionary } from '../../task_type_dictionary';
+import { getRetryAt } from '../../lib/get_retry_at';
+
+export interface BuildClaimUpdateOpts {
+  taskId: string;
+  version: string;
+  taskType: string;
+  attempts: number;
+  retryAt: Date | string | null;
+  runAt: Date | string;
+  schedule: ConcreteTaskInstance['schedule'] | null;
+  timeoutOverride: string | undefined;
+  ownerId: string;
+  definitions: TaskTypeDictionary;
+}
+
+export function buildClaimUpdate({
+  taskId,
+  version,
+  taskType,
+  attempts,
+  retryAt,
+  runAt,
+  schedule,
+  timeoutOverride,
+  ownerId,
+  definitions,
+}: BuildClaimUpdateOpts): PartialConcreteTaskInstance {
+  const now = new Date();
+  const retryAtDate = retryAt ? new Date(retryAt) : null;
+  const runAtDate = new Date(runAt);
+
+  return {
+    id: taskId,
+    version,
+    scheduledAt:
+      retryAtDate != null && retryAtDate.getTime() < Date.now() ? retryAtDate : runAtDate,
+    status: TaskStatus.Running,
+    startedAt: now,
+    attempts: attempts + 1,
+    retryAt:
+      getRetryAt(
+        {
+          attempts,
+          schedule,
+          timeoutOverride,
+        } as unknown as ConcreteTaskInstance,
+        definitions.get(taskType)
+      ) ?? null,
+    ownerId,
+  };
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/lib/execute_claim_updates.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/lib/execute_claim_updates.ts
@@ -57,7 +57,10 @@ export async function executeClaimUpdates({
 
   const docs = (await taskStore.bulkGet(Object.keys(updatedTasks))).reduce<ConcreteTaskInstance[]>(
     (acc, taskResult) => {
-      if (isOk(taskResult) && taskResult.value.version === updatedTasks[taskResult.value.id].version) {
+      if (
+        isOk(taskResult) &&
+        taskResult.value.version === updatedTasks[taskResult.value.id].version
+      ) {
         acc.push(taskResult.value);
       } else if (isOk(taskResult)) {
         conflicts += 1;

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/lib/execute_claim_updates.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/lib/execute_claim_updates.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { ConcreteTaskInstance, PartialConcreteTaskInstance } from '../../task';
+import type { TaskStore } from '../../task_store';
+import { isOk } from '../../lib/result_type';
+
+export interface ExecuteClaimUpdatesResult {
+  docs: ConcreteTaskInstance[];
+  conflicts: number;
+  updateErrors: number;
+  getErrors: number;
+}
+
+interface ExecuteClaimUpdatesOpts {
+  taskStore: TaskStore;
+  updates: PartialConcreteTaskInstance[];
+  logger: Logger;
+  logPrefix: string;
+}
+
+export async function executeClaimUpdates({
+  taskStore,
+  updates,
+  logger,
+  logPrefix,
+}: ExecuteClaimUpdatesOpts): Promise<ExecuteClaimUpdatesResult> {
+  const updatedTasks: Record<string, PartialConcreteTaskInstance> = {};
+  let conflicts = 0;
+  let updateErrors = 0;
+  let getErrors = 0;
+
+  const updateResults = await taskStore.bulkPartialUpdate(updates);
+  for (const updateResult of updateResults) {
+    if (isOk(updateResult)) {
+      updatedTasks[updateResult.value.id] = updateResult.value;
+      continue;
+    }
+
+    const { id, type, error, status } = updateResult.error;
+    if (status === 409) {
+      conflicts += 1;
+    } else {
+      updateErrors += 1;
+      logger.error(
+        `${logPrefix} update_failed task_id=${id} task_type=${type} status=${String(
+          status ?? 'unknown'
+        )} error=${JSON.stringify(error)}`
+      );
+    }
+  }
+
+  const docs = (await taskStore.bulkGet(Object.keys(updatedTasks))).reduce<ConcreteTaskInstance[]>(
+    (acc, taskResult) => {
+      if (isOk(taskResult) && taskResult.value.version === updatedTasks[taskResult.value.id].version) {
+        acc.push(taskResult.value);
+      } else if (isOk(taskResult)) {
+        conflicts += 1;
+      } else {
+        getErrors += 1;
+        logger.error(
+          `${logPrefix} get_failed task_id=${taskResult.error.id} task_type=${taskResult.error.type} error=${taskResult.error.error.message}`
+        );
+      }
+      return acc;
+    },
+    []
+  );
+
+  return {
+    docs,
+    conflicts,
+    updateErrors,
+    getErrors,
+  };
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
@@ -46,7 +46,7 @@ import {
 } from '../queries/mark_available_tasks_as_claimed';
 
 import type { TaskStore, SearchOpts } from '../task_store';
-import { isOk, asOk } from '../lib/result_type';
+import { asOk } from '../lib/result_type';
 import { buildClaimUpdate } from './lib/build_claim_update';
 import { executeClaimUpdates } from './lib/execute_claim_updates';
 import { selectTasksByCapacity } from './lib/task_selector_by_capacity';

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
@@ -27,7 +27,7 @@ import type {
   ConcreteTaskInstanceVersion,
   PartialConcreteTaskInstance,
 } from '../task';
-import { TaskStatus, TaskCost } from '../task';
+import { TaskCost } from '../task';
 import { TASK_MANAGER_TRANSACTION_TYPE } from '../task_running';
 import { TASK_MANAGER_MARK_AS_CLAIMED } from '../queries/task_claiming';
 import type { TaskClaim } from '../task_events';
@@ -47,10 +47,11 @@ import {
 
 import type { TaskStore, SearchOpts } from '../task_store';
 import { isOk, asOk } from '../lib/result_type';
+import { buildClaimUpdate } from './lib/build_claim_update';
+import { executeClaimUpdates } from './lib/execute_claim_updates';
 import { selectTasksByCapacity } from './lib/task_selector_by_capacity';
 import { getTaskCost } from './lib/get_task_cost';
 import type { TaskPartitioner } from '../lib/task_partitioner';
-import { getRetryAt } from '../lib/get_retry_at';
 
 interface OwnershipClaimingOpts {
   claimOwnershipUntil: Date;
@@ -176,23 +177,23 @@ async function claimAvailableTasks(opts: TaskClaimerOpts): Promise<ClaimOwnershi
   }
 
   // build the updated task objects we'll claim
-  const now = new Date();
   const taskUpdates: PartialConcreteTaskInstance[] = [];
   for (const task of tasksToRun) {
     try {
-      taskUpdates.push({
-        id: task.id,
-        version: task.version,
-        scheduledAt:
-          task.retryAt != null && new Date(task.retryAt).getTime() < Date.now()
-            ? task.retryAt
-            : task.runAt,
-        status: TaskStatus.Running,
-        startedAt: now,
-        attempts: task.attempts + 1,
-        retryAt: getRetryAt(task, definitions.get(task.taskType)) ?? null,
-        ownerId: taskStore.taskManagerId,
-      });
+      taskUpdates.push(
+        buildClaimUpdate({
+          taskId: task.id,
+          version: task.version,
+          taskType: task.taskType,
+          attempts: task.attempts,
+          retryAt: task.retryAt,
+          runAt: task.runAt,
+          schedule: task.schedule,
+          timeoutOverride: task.timeoutOverride,
+          ownerId: taskStore.taskManagerId,
+          definitions,
+        })
+      );
     } catch (error) {
       logger.error(
         `Error validating task schema ${task.id}:${task.taskType} during claim: ${JSON.stringify(
@@ -203,47 +204,17 @@ async function claimAvailableTasks(opts: TaskClaimerOpts): Promise<ClaimOwnershi
     }
   }
 
-  // perform the task object updates, deal with errors
-  const updatedTasks: Record<string, PartialConcreteTaskInstance> = {};
-  let conflicts = 0;
-  let bulkUpdateErrors = 0;
-  let bulkGetErrors = 0;
-
-  const updateResults = await taskStore.bulkPartialUpdate(taskUpdates);
-  for (const updateResult of updateResults) {
-    if (isOk(updateResult)) {
-      updatedTasks[updateResult.value.id] = updateResult.value;
-    } else {
-      const { id, type, error, status } = updateResult.error;
-
-      // check for 409 conflict errors
-      if (status === 409) {
-        conflicts++;
-      } else {
-        logger.error(`Error updating task ${id}:${type} during claim: ${JSON.stringify(error)}`);
-        bulkUpdateErrors++;
-      }
-    }
-  }
-
-  // perform an mget to get the full task instance for claiming
-  const fullTasksToRun = (await taskStore.bulkGet(Object.keys(updatedTasks))).reduce<
-    ConcreteTaskInstance[]
-  >((acc, task) => {
-    if (isOk(task) && task.value.version !== updatedTasks[task.value.id].version) {
-      logger.warn(
-        `Task ${task.value.id} was modified during the claiming phase, skipping until the next claiming cycle.`
-      );
-      conflicts++;
-    } else if (isOk(task)) {
-      acc.push(task.value);
-    } else {
-      const { id, type, error } = task.error;
-      logger.error(`Error getting full task ${id}:${type} during claim: ${error.message}`);
-      bulkGetErrors++;
-    }
-    return acc;
-  }, []);
+  const {
+    docs: fullTasksToRun,
+    conflicts,
+    updateErrors: bulkUpdateErrors,
+    getErrors: bulkGetErrors,
+  } = await executeClaimUpdates({
+    taskStore,
+    updates: taskUpdates,
+    logger,
+    logPrefix: '[task_claimer_mget]',
+  });
 
   // TODO: need a better way to generate stats
   const message = `task claimer claimed: ${fullTasksToRun.length}; stale: ${staleTasks.length}; conflicts: ${conflicts}; missing: ${missingTasks.length}; capacity reached: ${leftOverTasks.length}; updateErrors: ${bulkUpdateErrors}; getErrors: ${bulkGetErrors}; malformed data errors: ${tasksWithMalformedData.length}`;

--- a/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_pool/task_pool.ts
@@ -49,6 +49,7 @@ const VERSION_CONFLICT_MESSAGE = 'Task has been claimed by another Kibana servic
  */
 export class TaskPool {
   private tasksInPool = new Map<string, TaskRunner>();
+  private reservedCapacity = 0;
   private logger: Logger;
   private load$ = new Subject<TaskManagerStat>();
   private definitions: TaskTypeDictionary;
@@ -116,10 +117,44 @@ export class TaskPool {
     // the poller and the pool from hanging due to lack of capacity
     this.cancelExpiredTasks();
 
-    return this.capacityCalculator.availableCapacity(
+    const available = this.capacityCalculator.availableCapacity(
       this.tasksInPool,
       taskType ? this.definitions.get(taskType) : null
     );
+    return Math.max(available - this.reservedCapacity, 0);
+  }
+
+  public reserveCapacity(amount: number) {
+    if (amount <= 0) {
+      return true;
+    }
+
+    if (this.availableCapacity() < amount) {
+      return false;
+    }
+
+    this.reservedCapacity += amount;
+    return true;
+  }
+
+  public releaseCapacity(amount: number) {
+    if (amount <= 0) {
+      return;
+    }
+
+    this.reservedCapacity = Math.max(this.reservedCapacity - amount, 0);
+  }
+
+  public async runWithReservedCapacity(
+    tasks: TaskRunner[],
+    reservedCapacity: number
+  ): Promise<TaskPoolRunResult> {
+    try {
+      const availableCapacity = Math.max(this.availableCapacity() + reservedCapacity, 0);
+      return await this.runWithAvailableCapacity(tasks, availableCapacity);
+    } finally {
+      this.releaseCapacity(reservedCapacity);
+    }
   }
 
   /**
@@ -138,9 +173,13 @@ export class TaskPool {
    * @returns {Promise<boolean>}
    */
   public async run(tasks: TaskRunner[]): Promise<TaskPoolRunResult> {
-    // Note `this.availableCapacity` has side effects, so we just want
-    // to call it once for this bit of the code.
-    const availableCapacity = this.availableCapacity();
+    return await this.runWithAvailableCapacity(tasks, this.availableCapacity());
+  }
+
+  private async runWithAvailableCapacity(
+    tasks: TaskRunner[],
+    availableCapacity: number
+  ): Promise<TaskPoolRunResult> {
     const [tasksToRun, leftOverTasks] = this.capacityCalculator.determineTasksToRunBasedOnCapacity(
       tasks,
       availableCapacity

--- a/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
@@ -30,6 +30,7 @@ import { calculateNextRunAtFromSchedule } from './lib/get_next_run_at';
 import { TaskAlreadyRunningError } from './lib/errors';
 import type { TaskPollingLifecycle } from './polling_lifecycle';
 import { getExecutionId } from './lib/get_execution_id';
+import type { TaskManagerClaimNudgeService } from './claim_nudge';
 
 const VERSION_CONFLICT_STATUS = 409;
 const NOT_FOUND_STATUS = 404;
@@ -40,6 +41,7 @@ export interface TaskSchedulingOpts {
   middleware: Middleware;
   taskManagerId: string;
   taskPollingLifecycle?: TaskPollingLifecycle; // subscribe to task lifecycle events
+  claimNudgeService?: TaskManagerClaimNudgeService;
 }
 
 /**
@@ -71,6 +73,7 @@ export class TaskScheduling {
   private logger: Logger;
   private middleware: Middleware;
   private readonly taskPolling: TaskPollingLifecycle | undefined;
+  private readonly claimNudgeService: TaskManagerClaimNudgeService | undefined;
 
   /**
    * Initializes the task manager, preventing any further addition of middleware,
@@ -82,6 +85,7 @@ export class TaskScheduling {
     this.middleware = opts.middleware;
     this.store = opts.taskStore;
     this.taskPolling = opts.taskPollingLifecycle;
+    this.claimNudgeService = opts.claimNudgeService;
   }
 
   /**
@@ -95,7 +99,7 @@ export class TaskScheduling {
     options?: ScheduleOptions
   ): Promise<ConcreteTaskInstance> {
     const { taskInstance: modifiedTask } = await this.middleware.beforeSave({
-      ...omit(options, 'apiKey', 'request'),
+      ...omit(options, 'apiKey', 'request', 'requestImmediateClaim', 'refresh'),
       taskInstance: ensureDeprecatedFieldsAreCorrected(taskInstance, this.logger),
     });
 
@@ -104,18 +108,34 @@ export class TaskScheduling {
         ? agent.currentTraceparent
         : '';
 
-    return await this.store.schedule(
+    const shouldRequestImmediateClaim =
+      options?.requestImmediateClaim === true || options?.refresh === true;
+    const effectiveRefresh = shouldRequestImmediateClaim ? true : options?.refresh;
+
+    const scheduledTask = await this.store.schedule(
       {
         ...modifiedTask,
         traceparent: traceparent || '',
         enabled: modifiedTask.enabled ?? true,
       },
-      options?.request
+      options?.request || effectiveRefresh !== undefined
         ? {
             request: options?.request,
+            refresh: effectiveRefresh,
           }
         : undefined
     );
+
+    if (shouldRequestImmediateClaim && this.claimNudgeService) {
+      try {
+        await this.claimNudgeService.notify();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.info(`[claim_nudge] notify failed during schedule: ${message}`);
+      }
+    }
+
+    return scheduledTask;
   }
 
   /**
@@ -135,7 +155,7 @@ export class TaskScheduling {
     const modifiedTasks = await Promise.all(
       taskInstances.map(async (taskInstance) => {
         const { taskInstance: modifiedTask } = await this.middleware.beforeSave({
-          ...omit(options, 'apiKey', 'request'),
+          ...omit(options, 'apiKey', 'request', 'requestImmediateClaim', 'refresh'),
           taskInstance: ensureDeprecatedFieldsAreCorrected(taskInstance, this.logger),
         });
         return {
@@ -148,9 +168,10 @@ export class TaskScheduling {
 
     return await this.store.bulkSchedule(
       modifiedTasks,
-      options?.request
+      options?.request || options?.refresh !== undefined
         ? {
             request: options?.request,
+            refresh: options?.refresh,
           }
         : undefined
     );

--- a/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_scheduling.ts
@@ -30,6 +30,7 @@ import { calculateNextRunAtFromSchedule } from './lib/get_next_run_at';
 import { TaskAlreadyRunningError } from './lib/errors';
 import type { TaskPollingLifecycle } from './polling_lifecycle';
 import { getExecutionId } from './lib/get_execution_id';
+import type { ClaimNudgeTarget } from './claim_nudge';
 import type { TaskManagerClaimNudgeService } from './claim_nudge';
 
 const VERSION_CONFLICT_STATUS = 409;
@@ -110,7 +111,7 @@ export class TaskScheduling {
 
     const shouldRequestImmediateClaim =
       options?.requestImmediateClaim === true || options?.refresh === true;
-    const effectiveRefresh = shouldRequestImmediateClaim ? true : options?.refresh;
+    const effectiveRefresh = options?.requestImmediateClaim === true ? false : options?.refresh;
 
     const scheduledTask = await this.store.schedule(
       {
@@ -128,7 +129,12 @@ export class TaskScheduling {
 
     if (shouldRequestImmediateClaim && this.claimNudgeService) {
       try {
-        await this.claimNudgeService.notify();
+        const claimTarget: ClaimNudgeTarget = {
+          taskId: scheduledTask.id,
+          version: scheduledTask.version,
+          taskType: scheduledTask.taskType,
+        };
+        await this.claimNudgeService.notify([claimTarget]);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         this.logger.info(`[claim_nudge] notify failed during schedule: ${message}`);
@@ -166,15 +172,30 @@ export class TaskScheduling {
       })
     );
 
-    return await this.store.bulkSchedule(
+    const shouldRequestImmediateClaim =
+      options?.requestImmediateClaim === true || options?.refresh === true;
+    const effectiveRefresh = options?.requestImmediateClaim === true ? false : options?.refresh;
+
+    const scheduledTasks = await this.store.bulkSchedule(
       modifiedTasks,
-      options?.request || options?.refresh !== undefined
+      options?.request || effectiveRefresh !== undefined
         ? {
             request: options?.request,
-            refresh: options?.refresh,
+            refresh: effectiveRefresh,
           }
         : undefined
     );
+
+    if (shouldRequestImmediateClaim && this.claimNudgeService) {
+      try {
+        await this.claimNudgeService.notify();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.info(`[claim_nudge] notify failed during bulk_schedule: ${message}`);
+      }
+    }
+
+    return scheduledTasks;
   }
 
   public async bulkDisable(

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -70,6 +70,10 @@ import type { ApiKeyStrategy, ApiKeySOFields, InvalidationTarget } from './api_k
 import { getFirstRunAt } from './lib/get_first_run_at';
 import { isInterval } from './lib/intervals';
 
+interface TaskStoreScheduleOptions extends ApiKeyOptions {
+  refresh?: boolean;
+}
+
 export interface StoreOpts {
   esClient: ElasticsearchClient;
   index: string;
@@ -441,7 +445,7 @@ export class TaskStore {
    */
   public async schedule(
     taskInstance: TaskInstance,
-    options?: ApiKeyOptions
+    options?: TaskStoreScheduleOptions
   ): Promise<ConcreteTaskInstance> {
     return this.executionContextRunner.run(() => this._schedule(taskInstance, options), {
       id: 'schedule',
@@ -449,7 +453,7 @@ export class TaskStore {
   }
   private async _schedule(
     taskInstance: TaskInstance,
-    options?: ApiKeyOptions
+    options?: TaskStoreScheduleOptions
   ): Promise<ConcreteTaskInstance> {
     try {
       this.validateCanEncryptSavedObjects(options?.request);
@@ -478,7 +482,7 @@ export class TaskStore {
           ...apiKeySOFields,
           runAt: getFirstRunAt({ taskInstance: validatedTaskInstance, logger: this.logger }),
         },
-        { id, refresh: false }
+        { id, refresh: options?.refresh ?? false }
       );
       if (
         get(taskInstance, 'schedule.interval', null) == null &&
@@ -509,7 +513,7 @@ export class TaskStore {
    */
   public async bulkSchedule(
     taskInstances: TaskInstance[],
-    options?: ApiKeyOptions
+    options?: TaskStoreScheduleOptions
   ): Promise<ConcreteTaskInstance[]> {
     return this.executionContextRunner.run(() => this._bulkSchedule(taskInstances, options), {
       id: 'bulk-schedule',
@@ -518,7 +522,7 @@ export class TaskStore {
 
   private async _bulkSchedule(
     taskInstances: TaskInstance[],
-    options?: ApiKeyOptions
+    options?: TaskStoreScheduleOptions
   ): Promise<ConcreteTaskInstance[]> {
     try {
       this.validateCanEncryptSavedObjects(options?.request);
@@ -566,7 +570,7 @@ export class TaskStore {
     let savedObjects;
     try {
       savedObjects = await soClient.bulkCreate<SerializedConcreteTaskInstance>(objects, {
-        refresh: false,
+        refresh: options?.refresh ?? false,
         overwrite: true,
       });
       this.adHocTaskCounter.increment(


### PR DESCRIPTION
## Summary

**Proof of concept** to cut task **scheduling→run latency** — especially on serverless, where the global-checkpoints wakeup that speeds up claiming on stateful ES isn't available. Today a freshly-scheduled task waits up to a full poll interval before a background node claims it. This PR adds an HTTP **"claim nudge"**: right after a latency-sensitive task is persisted, the scheduling node pings the background task nodes over HTTP and hands them the task's `id`/`version` so they claim and run it immediately instead of waiting for the next poll.

It auto-enables on serverless and keeps the existing `global_checkpoints` / no-op behavior as fallbacks, so nothing changes for stateful deployments unless opted in.

## How it works

End-to-end path when a task is scheduled with `requestImmediateClaim: true`:

1. **Schedule** — `TaskScheduling.schedule()` persists the task, then calls `claimNudgeService.notify([{ taskId, version, taskType }])` with the exact target. Claim-by-id is version-checked, so it deliberately skips the `refresh: true` write it would otherwise need.
2. **Discover targets** — `HttpClaimNudgeClient` reads the active background nodes' advertised addresses from the discovery saved objects (cached ~5s) and fans out a `POST /internal/task_manager/_claim_nudge` to each, carrying `{ taskTargets }`. Fan-out is `Promise.allSettled` with a per-node timeout (`http_timeout_ms`, default 2s).
3. **Advertise addresses** — each node self-advertises its reachable `address` (derived from `server.host`/port/protocol, falling back to `POD_IP`/hostname for `0.0.0.0`; skipped for `localhost`/sockets) by writing it onto its `background-task-node` heartbeat SO. Adds an `address` keyword mapping + a model-version migration.
4. **Receive** — the internal `_claim_nudge` route (authn/authz off, system-to-system) emits a local `ClaimNudgeEvent { source, taskTargets }` on the node's `claimNudge$`. Nodes not running background tasks just ack and ignore.
5. **React in the poller** —
   - **Targeted** (event has `taskTargets`): `claimAndRunTasksById()` reserves pool capacity, claims exactly those tasks by id via a version-checked partial update, and runs them — no query, no waiting for a poll cycle.
   - **Untargeted** (empty nudge, e.g. `bulkSchedule`): the poller runs its next cycle immediately (cancels the pending timeout, or flags the in-flight cycle to re-run at delay `0`).
6. **Capacity safety** — `TaskPool` gains `reserveCapacity` / `releaseCapacity` / `runWithReservedCapacity` so direct claim-by-id runs don't oversubscribe the pool against the normal poll loop.

Claim-by-id and the existing mget claimer now share `buildClaimUpdate` + `executeClaimUpdates` helpers, so both mark-as-claimed paths stay consistent.

### Strategies & config (`xpack.task_manager.claim_nudge.*`)

| Setting | Default | Notes |
|---|---|---|
| `strategy` | `http` | `http` = inter-node HTTP nudge; `global_checkpoints` = log-only fallback (auto-upgrades to `http` on serverless); `disabled` = no-op baseline |
| `http_timeout_ms` | `2000` | per-node nudge request timeout |

## How to see it work

A temporary `task_manager:latency_probe` task is included purely for measurement: every background node schedules a one-shot probe every 10s with `requestImmediateClaim: true` and logs the scheduling→run delta.

1. Deploy to serverless (auto-selects `http`), or run ≥2 local nodes with `xpack.task_manager.claim_nudge.strategy: http` and a non-`localhost` `server.host` so addresses advertise.
2. Watch the Kibana logs (info level):
   - **Startup:** `[claim_nudge] strategy=http …`, `[claim_nudge] self_address=… / advertising_address=…`, `[claim_nudge] startup_smoke_test …`
   - **On each nudge (sender):** `[claim_nudge] notify discovered_nodes=N addressable_nodes=M task_targets=1`, then per node `[claim_nudge] notify node=… status=200 response_ms=…`
   - **On the receiver:** `[claim_nudge] received_nudge source=… task_targets=1, triggering_immediate_poll` → `[claim_nudge] claim_by_id …`
   - **Latency:** `[tm_latency_probe] run_started_at=… delta_from_requested_ms=… delta_from_scheduled_ms=…`
3. Compare `delta_from_requested_ms` against `strategy: disabled` (baseline = poll-interval latency) to quantify the improvement.

> Note: PoC — the `[tm_latency_probe]` task and verbose info logs are temporary measurement scaffolding, not intended to merge as-is.

## Test plan
- [ ] `node scripts/jest x-pack/platform/plugins/shared/task_manager/server/polling/task_poller.test.ts`
- [ ] `node scripts/jest x-pack/platform/plugins/shared/task_manager/server/task_scheduling.test.ts`
- [ ] `node scripts/jest x-pack/platform/plugins/shared/task_manager/server/kibana_discovery_service/kibana_discovery_service.test.ts`
- [ ] `node scripts/check_changes.ts`
- [ ] Deploy to serverless and verify `[claim_nudge]` / `[tm_latency_probe]` logs

Made with [Cursor](https://cursor.com)