### PR TITLE
[CI] Full typecheck on main

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -148,6 +148,8 @@ steps:
       diskSizeGb: 105
     key: check_types
     timeout_in_minutes: 60
+    env:
+      UPLOAD_ARCHIVE: 'true'
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -163,7 +163,8 @@ steps:
     timeout_in_minutes: 60
     env:
       CHECK_GATE: 'true'
-      WITH_ARCHIVE: 'true'
+      RESTORE_ARCHIVE: 'true'
+      UPLOAD_ARCHIVE: 'true'
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -163,6 +163,7 @@ steps:
     timeout_in_minutes: 60
     env:
       CHECK_GATE: 'true'
+      WITH_ARCHIVE: 'true'
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/scripts/steps/typecheck/check_types.sh
+++ b/.buildkite/scripts/steps/typecheck/check_types.sh
@@ -8,4 +8,8 @@ source .buildkite/scripts/common/util.sh
 
 echo --- Check Types
 
-node scripts/type_check --with-archive
+if [ -n "${WITH_ARCHIVE:-}" ]; then
+  node scripts/type_check --with-archive
+else
+  node scripts/type_check
+fi

--- a/.buildkite/scripts/steps/typecheck/check_types.sh
+++ b/.buildkite/scripts/steps/typecheck/check_types.sh
@@ -8,8 +8,12 @@ source .buildkite/scripts/common/util.sh
 
 echo --- Check Types
 
-if [ -n "${WITH_ARCHIVE:-}" ]; then
-  node scripts/type_check --with-archive
-else
-  node scripts/type_check
+args=()
+if [ -n "${RESTORE_ARCHIVE:-}" ]; then
+  args+=(--restore-archive)
 fi
+if [ -n "${UPLOAD_ARCHIVE:-}" ]; then
+  args+=(--upload-archive)
+fi
+
+node scripts/type_check "${args[@]}"

--- a/packages/kbn-ts-type-check-cli/execute_type_check_validation.ts
+++ b/packages/kbn-ts-type-check-cli/execute_type_check_validation.ts
@@ -168,7 +168,10 @@ export interface ExecuteTypeCheckValidationOptions {
   extendedDiagnostics?: boolean;
   pretty?: boolean;
   verbose?: boolean;
-  withArchive?: boolean;
+  /** Restore cached `target/types` artifacts from GCS before running `tsc -b`. */
+  restoreArchive?: boolean;
+  /** Upload the resulting `target/types` artifacts to GCS after a successful `tsc -b`. */
+  uploadArchive?: boolean;
 }
 
 /**
@@ -183,7 +186,8 @@ export const executeTypeCheckValidation = async ({
   extendedDiagnostics = false,
   pretty = true,
   verbose = false,
-  withArchive = false,
+  restoreArchive = false,
+  uploadArchive = false,
 }: ExecuteTypeCheckValidationOptions): Promise<TscValidationResult | null> => {
   // Lazy-load so reusable consumers can avoid TS project metadata work until needed.
   const { TS_PROJECTS } = await import('@kbn/ts-projects');
@@ -285,10 +289,10 @@ export const executeTypeCheckValidation = async ({
       rootRefsConfigCreated = true;
     }
 
-    if (withArchive) {
+    if (restoreArchive) {
       await restoreTSBuildArtifacts(log);
     } else {
-      log.verbose('Skipping TypeScript cache restore because --with-archive was not provided.');
+      log.verbose('Skipping TypeScript cache restore because --restore-archive was not provided.');
     }
 
     createdConfigs = await createTypeCheckConfigs(log, selectedProjects, TS_PROJECTS);
@@ -325,8 +329,7 @@ export const executeTypeCheckValidation = async ({
 
   // Cleanup always runs, even if setup or tsc failed partway through
   try {
-    // Archive artifacts (only after successful tsc)
-    if (withArchive && !tscFailed) {
+    if (uploadArchive && !tscFailed) {
       const localChanges = await detectLocalChanges();
       const hasLocalChanges = localChanges.length > 0;
       if (hasLocalChanges) {
@@ -341,8 +344,8 @@ export const executeTypeCheckValidation = async ({
       } else {
         await archiveTSBuildArtifacts(log);
       }
-    } else if (!withArchive) {
-      log.verbose('Skipping TypeScript cache archive because --with-archive was not provided.');
+    } else if (!uploadArchive) {
+      log.verbose('Skipping TypeScript cache archive because --upload-archive was not provided.');
     }
   } finally {
     if (cleanup) {

--- a/packages/kbn-ts-type-check-cli/run_type_check_cli.test.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_cli.test.ts
@@ -376,6 +376,36 @@ describe('run_type_check_cli', () => {
     expect(mockArchiveTSBuildArtifacts).toHaveBeenCalledTimes(1);
   });
 
+  it('only uploads (not restores) when --upload-archive is used on the contract path', async () => {
+    tsProjectsState.projects = [createProject()];
+    mockGetMoonChangedFiles.mockResolvedValue(['packages/foo/src/index.ts']);
+    mockGetAffectedMoonProjectsFromChangedFiles.mockResolvedValue([
+      { id: 'foo', sourceRoot: 'packages/foo' },
+    ]);
+
+    const ctx = createContext({ profile: 'quick', 'upload-archive': true });
+    await contractHandler(ctx);
+
+    expect(mockRestoreTSBuildArtifacts).not.toHaveBeenCalled();
+    expect(ctx.procRunner.run).toHaveBeenCalledTimes(1);
+    expect(mockArchiveTSBuildArtifacts).toHaveBeenCalledTimes(1);
+  });
+
+  it('only restores (not uploads) when --restore-archive is used on the contract path', async () => {
+    tsProjectsState.projects = [createProject()];
+    mockGetMoonChangedFiles.mockResolvedValue(['packages/foo/src/index.ts']);
+    mockGetAffectedMoonProjectsFromChangedFiles.mockResolvedValue([
+      { id: 'foo', sourceRoot: 'packages/foo' },
+    ]);
+
+    const ctx = createContext({ profile: 'quick', 'restore-archive': true });
+    await contractHandler(ctx);
+
+    expect(mockRestoreTSBuildArtifacts).toHaveBeenCalledTimes(1);
+    expect(ctx.procRunner.run).toHaveBeenCalledTimes(1);
+    expect(mockArchiveTSBuildArtifacts).not.toHaveBeenCalled();
+  });
+
   it('skips staged scope immediately when nothing is staged', async () => {
     tsProjectsState.projects = [createProject()];
     mockHasStagedChanges.mockResolvedValue(false);

--- a/packages/kbn-ts-type-check-cli/run_type_check_contract_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_contract_cli.ts
@@ -37,6 +37,7 @@ export const runTypeCheckContractCli = () => {
         onWarning: (message) => log.warning(message),
       });
 
+      const withArchive = flagsReader.boolean('with-archive');
       await executeTypeCheckValidation({
         baseContext,
         log,
@@ -44,7 +45,8 @@ export const runTypeCheckContractCli = () => {
         cleanup: flagsReader.boolean('cleanup'),
         extendedDiagnostics: flagsReader.boolean('extended-diagnostics'),
         verbose: flagsReader.boolean('verbose'),
-        withArchive: flagsReader.boolean('with-archive'),
+        restoreArchive: withArchive || flagsReader.boolean('restore-archive'),
+        uploadArchive: withArchive || flagsReader.boolean('upload-archive'),
       });
     },
     {
@@ -69,7 +71,14 @@ export const runTypeCheckContractCli = () => {
     `,
       flags: {
         string: ['project', ...VALIDATION_RUN_STRING_FLAGS],
-        boolean: ['clean-cache', 'cleanup', 'extended-diagnostics', 'with-archive'],
+        boolean: [
+          'clean-cache',
+          'cleanup',
+          'extended-diagnostics',
+          'with-archive',
+          'restore-archive',
+          'upload-archive',
+        ],
         help: [
           {
             flag: '--project [path]',
@@ -90,8 +99,16 @@ export const runTypeCheckContractCli = () => {
             description: 'Turn on extended diagnostics in the TypeScript compiler',
           },
           {
+            flag: '--restore-archive',
+            description: 'Restore cached artifacts from GCS before running tsc',
+          },
+          {
+            flag: '--upload-archive',
+            description: 'Upload resulting artifacts to GCS after a successful tsc run',
+          },
+          {
             flag: '--with-archive',
-            description: 'Restore cached artifacts before running and archive results afterwards',
+            description: 'Shorthand for `--restore-archive --upload-archive`',
           },
         ],
       },

--- a/packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts
@@ -32,7 +32,9 @@ export const runLegacyTypeCheckCli = () => {
     async ({ log, flagsReader, procRunner }) => {
       const { TS_PROJECTS } = await import('@kbn/ts-projects');
       const shouldCleanCache = flagsReader.boolean('clean-cache');
-      const shouldUseArchive = flagsReader.boolean('with-archive');
+      const withArchive = flagsReader.boolean('with-archive');
+      const shouldRestoreArchive = withArchive || flagsReader.boolean('restore-archive');
+      const shouldUploadArchive = withArchive || flagsReader.boolean('upload-archive');
 
       if (shouldCleanCache) {
         await cleanTypeCheckCaches(log, TS_PROJECTS);
@@ -47,10 +49,12 @@ export const runLegacyTypeCheckCli = () => {
       // a reference to every composite project in the repo.
       await updateRootRefsConfig(log);
 
-      if (shouldUseArchive) {
+      if (shouldRestoreArchive) {
         await restoreTSBuildArtifacts(log);
       } else {
-        log.verbose('Skipping TypeScript cache restore because --with-archive was not provided.');
+        log.verbose(
+          'Skipping TypeScript cache restore because --restore-archive was not provided.'
+        );
       }
 
       const projectFilter = normalizeProjectPath(flagsReader.path('project'), log);
@@ -91,10 +95,10 @@ export const runLegacyTypeCheckCli = () => {
       }
 
       try {
-        const localChanges = shouldUseArchive ? await detectLocalChanges() : [];
+        const localChanges = shouldUploadArchive ? await detectLocalChanges() : [];
         const hasLocalChanges = localChanges.length > 0;
 
-        if (shouldUseArchive) {
+        if (shouldUploadArchive) {
           if (hasLocalChanges) {
             const changedFiles = localChanges.join('\n');
             const message = `uncommitted changes were detected after the TypeScript build. TypeScript cache artifacts must be generated from a clean working tree.\nChanged files:\n${changedFiles}`;
@@ -108,7 +112,9 @@ export const runLegacyTypeCheckCli = () => {
             await archiveTSBuildArtifacts(log);
           }
         } else {
-          log.verbose('Skipping TypeScript cache archive because --with-archive was not provided.');
+          log.verbose(
+            'Skipping TypeScript cache archive because --upload-archive was not provided.'
+          );
         }
       } finally {
         if (flagsReader.boolean('cleanup')) {
@@ -138,7 +144,14 @@ export const runLegacyTypeCheckCli = () => {
     `,
       flags: {
         string: ['project'],
-        boolean: ['clean-cache', 'cleanup', 'extended-diagnostics', 'with-archive'],
+        boolean: [
+          'clean-cache',
+          'cleanup',
+          'extended-diagnostics',
+          'with-archive',
+          'restore-archive',
+          'upload-archive',
+        ],
         help: `
         --project [path]        Path to a tsconfig.json file determines the project to check
         --help                  Show this message
@@ -148,7 +161,9 @@ export const runLegacyTypeCheckCli = () => {
                                   identify that none of the imports have changed (it uses creation/update
                                   times) but cleaning them prevents leaving garbage around the repo.
         --extended-diagnostics  Turn on extended diagnostics in the TypeScript compiler
-        --with-archive          Restore cached artifacts before running and archive results afterwards
+        --restore-archive       Restore cached artifacts from GCS before running tsc
+        --upload-archive        Upload resulting artifacts to GCS after a successful tsc run
+        --with-archive          Shorthand for \`--restore-archive --upload-archive\`
       `,
       },
     }


### PR DESCRIPTION
## Summary
On-merge's typecheck won't use prior archives, always builds fresh, and uploads that fresh for PRs based on this state of main.

We've seen a few cases when an invalid cache caused a type issue to stay unnoticed, we can hopefully reduce these cases if we don't rely on prior archives in the on-merge pipeline, where speed is not critical. 

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->