### PR TITLE
[Dataset Quality] Fix `fieldCaps` assertion and un-skip suite 

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
@@ -58,8 +58,7 @@ const detailsObject = {
   defaultRetentionPeriod: '30d',
 };
 
-// Failing: See https://github.com/elastic/kibana/issues/269160
-describe.skip('getDataStreamDetails', () => {
+describe('getDataStreamDetails', () => {
   let esClient: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
   let mockESClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
   let mockDatasetQualityESClient: {
@@ -434,6 +433,15 @@ describe.skip('getDataStreamDetails', () => {
           index: 'logs-test-default',
           fields: ['*'],
           include_unmapped: false,
+          index_filter: {
+            range: {
+              '@timestamp': {
+                gte: 1234567890,
+                lte: 1234567900,
+                format: 'epoch_millis',
+              },
+            },
+          },
         });
         expect(mockESClient.fieldCaps).not.toHaveBeenCalled();
         expect(result).toEqual(detailsObject);


### PR DESCRIPTION
closes #269160 

## Summary

Two of my PRs merged 3 seconds apart on `main` produced a merge conflict:

- [#267994](https://github.com/elastic/kibana/pull/267994) added a test asserting `fieldCaps` is called **without** `index_filter`.
- [#267939](https://github.com/elastic/kibana/pull/267939) changed the implementation to **include** `index_filter` (needed by the new `service.name` aggregatable guard).

Each PR was green individually, but the combination broke `main`. The suite was temporarily skipped  [#269160 comment](https://github.com/elastic/kibana/issues/269160#issuecomment-4443238241).

This PR updates the assertion to match the implementation and un-skips the suite.
