### PR TITLE
[Docs] Add workflow to generate PR changelog list when Serverless release completes

### DIFF
--- a/.buildkite/pipelines/quality-gates/emergency/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/emergency/pipeline.tests-production.yaml
@@ -28,7 +28,7 @@ steps:
         CHECK_SYNTHETICS_TAG: serverless-platform-core-validation
 
   - label: ':memo: Trigger serverless changelog'
-    if: build.env("ENVIRONMENT") == "production-noncanary" && build.env("DEPLOYMENT_SLICES") =~ /(^|.*, *)production-noncanary-ds-5( *,.*|$)/
+    if: build.env("ENVIRONMENT") == "production-noncanary" && build.env("DEPLOYMENT_SLICES") =~ /(^|.*, *)production-noncanary-ds-5( *,.*|$$)/
     command: .buildkite/scripts/pipelines/quality_gates/trigger_serverless_changelog_workflow.sh
     env:
       SERVICE_VERSION: ${SERVICE_VERSION:-""}

--- a/.buildkite/pipelines/quality-gates/emergency/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/emergency/pipeline.tests-production.yaml
@@ -27,6 +27,13 @@ steps:
         CHECK_SYNTHETICS: true
         CHECK_SYNTHETICS_TAG: serverless-platform-core-validation
 
+  - label: ':memo: Trigger serverless changelog'
+    if: build.env("ENVIRONMENT") == "production-noncanary" && build.env("DEPLOYMENT_SLICES") =~ /(^|.*, *)production-noncanary-ds-5( *,.*|$)/
+    command: .buildkite/scripts/pipelines/quality_gates/trigger_serverless_changelog_workflow.sh
+    env:
+      SERVICE_VERSION: ${SERVICE_VERSION:-""}
+      TARGET_ENV: production-noncanary-ds-5
+
   - input: 'Cancel bake time step early?'
     if: build.env("ENVIRONMENT") == "production-canary"
     fields:

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -28,7 +28,7 @@ steps:
         CHECK_SYNTHETICS_TAG: serverless-platform-core-validation
 
   - label: ':memo: Trigger serverless changelog'
-    if: build.env("ENVIRONMENT") == "production-noncanary" && build.env("DEPLOYMENT_SLICES") =~ /(^|.*, *)production-noncanary-ds-5( *,.*|$)/
+    if: build.env("ENVIRONMENT") == "production-noncanary" && build.env("DEPLOYMENT_SLICES") =~ /(^|.*, *)production-noncanary-ds-5( *,.*|$$)/
     command: .buildkite/scripts/pipelines/quality_gates/trigger_serverless_changelog_workflow.sh
     env:
       SERVICE_VERSION: ${SERVICE_VERSION:-""}

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -27,6 +27,13 @@ steps:
         CHECK_SYNTHETICS: true
         CHECK_SYNTHETICS_TAG: serverless-platform-core-validation
 
+  - label: ':memo: Trigger serverless changelog'
+    if: build.env("ENVIRONMENT") == "production-noncanary" && build.env("DEPLOYMENT_SLICES") =~ /(^|.*, *)production-noncanary-ds-5( *,.*|$)/
+    command: .buildkite/scripts/pipelines/quality_gates/trigger_serverless_changelog_workflow.sh
+    env:
+      SERVICE_VERSION: ${SERVICE_VERSION:-""}
+      TARGET_ENV: production-noncanary-ds-5
+
   - input: 'Cancel bake time step early?'
     if: build.env("ENVIRONMENT") == "production-canary"
     fields:

--- a/.buildkite/scripts/pipelines/quality_gates/trigger_serverless_changelog_workflow.sh
+++ b/.buildkite/scripts/pipelines/quality_gates/trigger_serverless_changelog_workflow.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+WORKFLOW_FILE="generate_serverless_changelog.yml"
+WORKFLOW_REF="main"
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN is required to dispatch the serverless changelog workflow" >&2
+  exit 1
+fi
+
+if [[ -z "${SERVICE_VERSION:-}" ]]; then
+  echo "SERVICE_VERSION is required to generate the serverless changelog" >&2
+  exit 1
+fi
+
+if [[ -z "${TARGET_ENV:-}" ]]; then
+  echo "TARGET_ENV is required to generate the serverless changelog" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to dispatch the serverless changelog workflow" >&2
+  exit 1
+fi
+
+echo "--- Triggering ${WORKFLOW_FILE} for ${TARGET_ENV} at ${SERVICE_VERSION}"
+
+payload="$(
+  jq -n \
+    --arg ref "${WORKFLOW_REF}" \
+    --arg service_version "${SERVICE_VERSION}" \
+    --arg target_env "${TARGET_ENV}" \
+    --arg build_url "${BUILDKITE_BUILD_URL:-}" \
+    --arg build_message "${BUILDKITE_MESSAGE:-}" \
+    '{
+      ref: $ref,
+      inputs: {
+        service_version: $service_version,
+        target_env: $target_env,
+        build_url: $build_url,
+        build_message: $build_message
+      }
+    }'
+)"
+
+response_file="$(mktemp)"
+status_code="$(
+  curl -sS \
+    -o "${response_file}" \
+    -w "%{http_code}" \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/elastic/kibana/actions/workflows/${WORKFLOW_FILE}/dispatches" \
+    -d "${payload}" || true
+)"
+
+if [[ "${status_code}" != "204" && "${status_code}" != "200" ]]; then
+  echo "Failed to dispatch ${WORKFLOW_FILE}. GitHub API returned ${status_code}:" >&2
+  cat "${response_file}" >&2
+  rm -f "${response_file}"
+  exit 1
+fi
+
+rm -f "${response_file}"
+echo "Triggered ${WORKFLOW_FILE} for ${TARGET_ENV} at ${SERVICE_VERSION}"

--- a/.buildkite/scripts/pipelines/quality_gates/trigger_serverless_changelog_workflow.sh
+++ b/.buildkite/scripts/pipelines/quality_gates/trigger_serverless_changelog_workflow.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 WORKFLOW_FILE="generate_serverless_changelog.yml"
 WORKFLOW_REF="main"
+WORKFLOW_URL="https://github.com/elastic/kibana/actions/workflows/${WORKFLOW_FILE}"
+WORKFLOW_RUNS_URL="${WORKFLOW_URL}?query=event%3Aworkflow_dispatch+branch%3A${WORKFLOW_REF}"
 
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
   echo "GITHUB_TOKEN is required to dispatch the serverless changelog workflow" >&2
@@ -65,5 +67,11 @@ if [[ "${status_code}" != "204" && "${status_code}" != "200" ]]; then
   exit 1
 fi
 
+workflow_run_url=""
+if [[ -s "${response_file}" ]]; then
+  workflow_run_url="$(jq -r '.html_url // empty' <"${response_file}")"
+fi
+
 rm -f "${response_file}"
 echo "Triggered ${WORKFLOW_FILE} for ${TARGET_ENV} at ${SERVICE_VERSION}"
+echo "Workflow runs: ${workflow_run_url:-${WORKFLOW_RUNS_URL}}"

--- a/.github/scripts/generate_serverless_changelog.js
+++ b/.github/scripts/generate_serverless_changelog.js
@@ -1,0 +1,296 @@
+const GITHUB_OWNER = 'elastic';
+const KIBANA_REPO = 'kibana';
+const SERVERLESS_GITOPS_REPO = 'serverless-gitops';
+const VERSIONS_FILE_PATH = 'services/kibana/versions.yaml';
+const COMMITS_TO_FIND = 5;
+const GITHUB_API_VERSION = '2022-11-28';
+
+const requiredEnv = (name) => {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+};
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const chunk = (items, size) => {
+  const chunks = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+
+  return chunks;
+};
+
+const githubRequest = async ({ path, method = 'GET', query = {}, body }) => {
+  const url = new URL(`https://api.github.com${path}`);
+
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${requiredEnv('GITHUB_TOKEN')}`,
+      'X-GitHub-Api-Version': GITHUB_API_VERSION,
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed: ${method} ${url} ${response.status} ${text}`);
+  }
+
+  return {
+    data: text ? JSON.parse(text) : undefined,
+    link: response.headers.get('link'),
+  };
+};
+
+const findServerlessGitOpsCommits = async ({ envSearch, repo, filePath }) => {
+  const matchingCommits = [];
+  let page = 1;
+
+  while (matchingCommits.length < COMMITS_TO_FIND) {
+    const { data: commits } = await githubRequest({
+      path: `/repos/${GITHUB_OWNER}/${repo}/commits`,
+      query: {
+        path: filePath,
+        per_page: '100',
+        page: String(page),
+      },
+    });
+
+    if (commits.length === 0) {
+      break;
+    }
+
+    for (const commit of commits) {
+      if (commit.commit.message.includes(envSearch)) {
+        matchingCommits.push(commit);
+        if (matchingCommits.length === COMMITS_TO_FIND) {
+          return matchingCommits;
+        }
+      }
+    }
+
+    page += 1;
+  }
+
+  return matchingCommits;
+};
+
+const findKibanaServerlessDeployedCommit = async ({ gitOpsSha, envSearch, repo, filePath }) => {
+  try {
+    const { data } = await githubRequest({
+      path: `/repos/${GITHUB_OWNER}/${repo}/contents/${filePath}`,
+      query: {
+        ref: gitOpsSha,
+      },
+    });
+
+    if (!data.content) {
+      throw new Error(`File content not available for commit ${gitOpsSha}`);
+    }
+
+    const content = Buffer.from(data.content, 'base64').toString('utf8');
+    const regex = new RegExp(`${escapeRegExp(envSearch)}:\\s+"([a-f0-9]{7,40})"`);
+    const match = content.match(regex);
+
+    if (!match || !match[1]) {
+      throw new Error(`Could not find ${envSearch} in ${filePath} for commit ${gitOpsSha}`);
+    }
+
+    return { gitOpsSha, kibanaSha: match[1] };
+  } catch (error) {
+    throw new Error(`Error extracting deployed SHA from commit ${gitOpsSha}: ${error}`);
+  }
+};
+
+const getServerlessReleases = async ({ envSearch }) => {
+  const matchingCommits = await findServerlessGitOpsCommits({
+    envSearch,
+    repo: SERVERLESS_GITOPS_REPO,
+    filePath: VERSIONS_FILE_PATH,
+  });
+
+  if (matchingCommits.length === 0) {
+    throw new Error(`Could not find matching commits for ${envSearch} in serverless-gitops repo`);
+  }
+
+  return Promise.all(
+    matchingCommits.map((commit) =>
+      findKibanaServerlessDeployedCommit({
+        gitOpsSha: commit.sha,
+        envSearch,
+        repo: SERVERLESS_GITOPS_REPO,
+        filePath: VERSIONS_FILE_PATH,
+      })
+    )
+  );
+};
+
+const getCompareResults = async ({ older, newer }) => {
+  const compareResults = [];
+  let page = 1;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const { data, link } = await githubRequest({
+      path: `/repos/${GITHUB_OWNER}/${KIBANA_REPO}/compare/${older.kibanaSha}...${newer.kibanaSha}`,
+      query: {
+        per_page: '250',
+        page: String(page),
+      },
+    });
+
+    compareResults.push(data);
+    hasNextPage = Boolean(link?.includes('rel="next"'));
+    page += 1;
+  }
+
+  return compareResults;
+};
+
+const getPrsForServerless = async ({ older, newer, excludedLabels = [], includedLabels = [] }) => {
+  const compareResult = await getCompareResults({ older, newer });
+
+  const commitNodeIds = compareResult.reduce((acc, results) => {
+    return acc.concat(results.commits.map((commit) => commit.node_id));
+  }, []);
+
+  const query = `
+    query($commitNodeIds: [ID!]!) {
+      nodes(ids: $commitNodeIds) {
+        ... on Commit {
+          associatedPullRequests(first: 1) {
+            nodes {
+              id
+              url
+              title
+              number
+              body
+              author {
+                login
+              }
+              labels(first: 50) {
+                nodes {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const pullRequests = [];
+  const chunks = chunk(commitNodeIds, 20);
+  const results = await Promise.all(
+    chunks.map(async (commitNodeIdChunk) => {
+      const { data: response } = await githubRequest({
+        path: '/graphql',
+        method: 'POST',
+        body: {
+          query,
+          variables: {
+            commitNodeIds: commitNodeIdChunk,
+          },
+        },
+      });
+
+      if (response.errors) {
+        throw new Error(`GitHub GraphQL request failed: ${JSON.stringify(response.errors)}`);
+      }
+
+      return response.data;
+    })
+  );
+
+  results.forEach((result) => {
+    result.nodes.forEach((node) => {
+      if (node?.associatedPullRequests) {
+        node.associatedPullRequests.nodes?.forEach((pr) => {
+          if (pr?.labels?.nodes) {
+            const prLabels = pr.labels.nodes.map((label) => label.name);
+            const hasExcludedLabel = prLabels.some((label) => excludedLabels.includes(label));
+            const hasIncludedLabel =
+              includedLabels.length === 0 ||
+              prLabels.some((label) => includedLabels.includes(label));
+
+            if (!hasExcludedLabel && hasIncludedLabel) {
+              pullRequests.push(pr);
+            }
+          }
+        });
+      }
+    });
+  });
+
+  const prs = pullRequests.map((pr) => {
+    return {
+      ...pr,
+      labels: pr.labels?.nodes ?? [],
+      user: pr.author,
+      html_url: pr.url,
+    };
+  });
+
+  return Array.from(new Map(prs.map((pr) => [pr.html_url, pr])).values());
+};
+
+const selectReleases = ({ releases, serviceVersion }) => {
+  const currentReleaseIndex = releases.findIndex(({ kibanaSha }) => kibanaSha === serviceVersion);
+
+  if (currentReleaseIndex === -1) {
+    throw new Error(`Could not find ${serviceVersion} in recent serverless releases`);
+  }
+
+  const previousRelease = releases[currentReleaseIndex + 1];
+
+  if (!previousRelease) {
+    throw new Error(`Could not find the previous serverless release before ${serviceVersion}`);
+  }
+
+  return {
+    newer: releases[currentReleaseIndex],
+    older: previousRelease,
+  };
+};
+
+const main = async () => {
+  const serviceVersion = requiredEnv('SERVICE_VERSION');
+  const targetEnv = requiredEnv('TARGET_ENV');
+
+  console.log(`Generating serverless changelog for ${targetEnv}`);
+  console.log(`Current service version: ${serviceVersion}`);
+
+  if (process.env.BUILDKITE_BUILD_URL) {
+    console.log(`Triggered by Buildkite build: ${process.env.BUILDKITE_BUILD_URL}`);
+  }
+
+  const releases = await getServerlessReleases({ envSearch: targetEnv });
+  const { newer, older } = selectReleases({ releases, serviceVersion });
+
+  console.log(`Previous service version: ${older.kibanaSha}`);
+
+  const prs = await getPrsForServerless({ older, newer });
+
+  console.log(prs.map(({ html_url: htmlUrl }) => htmlUrl).join('\n'));
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/scripts/generate_serverless_changelog.js
+++ b/.github/scripts/generate_serverless_changelog.js
@@ -81,15 +81,30 @@ const findKibanaServerlessDeployedCommit = async ({
 };
 
 const matchKibanaTagsToReleaseCommits = async ({ github, serverlessReleases }) => {
-  // Need to retrieve all the tags because ref tags are always last.
-  const tags = await github.paginate(github.rest.repos.listTags, {
+  const releaseShaLength = serverlessReleases[0]?.kibanaSha.length;
+  const releaseShas = new Set(serverlessReleases.map(({ kibanaSha }) => kibanaSha));
+  const tagsByReleaseSha = new Map();
+
+  for await (const response of github.paginate.iterator(github.rest.repos.listTags, {
     owner: GITHUB_OWNER,
     repo: KIBANA_REPO,
     per_page: 100,
-  });
+  })) {
+    for (const tag of response.data) {
+      const releaseSha = tag.commit.sha.slice(0, releaseShaLength);
+
+      if (releaseShas.has(releaseSha)) {
+        tagsByReleaseSha.set(releaseSha, tag);
+      }
+    }
+
+    if (tagsByReleaseSha.size === serverlessReleases.length) {
+      break;
+    }
+  }
 
   return serverlessReleases.flatMap((release) => {
-    const tagForReleaseCommit = tags.find((tag) => tag.commit.sha.startsWith(release.kibanaSha));
+    const tagForReleaseCommit = tagsByReleaseSha.get(release.kibanaSha);
 
     if (!tagForReleaseCommit) {
       console.warn(`No tag found for the release commit ${release.kibanaSha}, removing.`);

--- a/.github/scripts/generate_serverless_changelog.js
+++ b/.github/scripts/generate_serverless_changelog.js
@@ -2,7 +2,6 @@ const GITHUB_OWNER = 'elastic';
 const KIBANA_REPO = 'kibana';
 const SERVERLESS_GITOPS_REPO = 'serverless-gitops';
 const VERSIONS_FILE_PATH = 'services/kibana/versions.yaml';
-const SERVERLESS_EXCLUDED_LABELS = ['backport', 'release_note:skip', 'reverted'];
 
 const requiredEnv = (name) => {
   const value = process.env[name];
@@ -81,8 +80,6 @@ const findKibanaServerlessDeployedCommit = async ({
 };
 
 const matchKibanaTagsToReleaseCommits = async ({ github, serverlessReleases }) => {
-  const releaseShaLength = serverlessReleases[0]?.kibanaSha.length;
-  const releaseShas = new Set(serverlessReleases.map(({ kibanaSha }) => kibanaSha));
   const tagsByReleaseSha = new Map();
 
   for await (const response of github.paginate.iterator(github.rest.repos.listTags, {
@@ -91,10 +88,10 @@ const matchKibanaTagsToReleaseCommits = async ({ github, serverlessReleases }) =
     per_page: 100,
   })) {
     for (const tag of response.data) {
-      const releaseSha = tag.commit.sha.slice(0, releaseShaLength);
+      const release = serverlessReleases.find(({ kibanaSha }) => tag.commit.sha.startsWith(kibanaSha));
 
-      if (releaseShas.has(releaseSha)) {
-        tagsByReleaseSha.set(releaseSha, tag);
+      if (release) {
+        tagsByReleaseSha.set(release.kibanaSha, tag);
       }
     }
 
@@ -152,8 +149,6 @@ const getPrsForServerless = async ({
   github,
   serverlessReleases,
   selectedServerlessSHAs,
-  excludedLabels = [],
-  includedLabels = [],
 }) => {
   if (selectedServerlessSHAs.size !== 2) {
     throw new Error('Exactly two serverless releases must be selected');
@@ -200,11 +195,6 @@ const getPrsForServerless = async ({
               author {
                 login
               }
-              labels(first: 50) {
-                nodes {
-                  name
-                }
-              }
             }
           }
         }
@@ -228,16 +218,8 @@ const getPrsForServerless = async ({
     result.nodes.forEach((node) => {
       if (node?.associatedPullRequests) {
         node.associatedPullRequests.nodes?.forEach((pr) => {
-          if (pr?.labels?.nodes) {
-            const prLabels = pr.labels.nodes.map((label) => label.name);
-            const hasExcludedLabel = prLabels.some((label) => excludedLabels.includes(label));
-            const hasIncludedLabel =
-              includedLabels.length === 0 ||
-              prLabels.some((label) => includedLabels.includes(label));
-
-            if (!hasExcludedLabel && hasIncludedLabel) {
-              pullRequests.push(pr);
-            }
+          if (pr) {
+            pullRequests.push(pr);
           }
         });
       }
@@ -247,7 +229,6 @@ const getPrsForServerless = async ({
   const prs = pullRequests.map((pr) => {
     return {
       ...pr,
-      labels: pr.labels?.nodes ?? [],
       user: pr.author,
       html_url: pr.url,
     };
@@ -308,7 +289,6 @@ const generateServerlessChangelog = async ({ github }) => {
     github,
     serverlessReleases: releases,
     selectedServerlessSHAs: new Set([newer.kibanaSha, older.kibanaSha]),
-    excludedLabels: SERVERLESS_EXCLUDED_LABELS,
   });
 
   console.log(prs.map(({ html_url: htmlUrl }) => htmlUrl).sort().join('\n'));

--- a/.github/scripts/generate_serverless_changelog.js
+++ b/.github/scripts/generate_serverless_changelog.js
@@ -217,15 +217,13 @@ const getPrsForServerless = async ({
     return result.nodes.flatMap((node) => node?.associatedPullRequests?.nodes ?? []).filter(Boolean);
   });
 
-  const prs = pullRequests.map((pr) => {
+  return pullRequests.map((pr) => {
     return {
       ...pr,
       user: pr.author,
       html_url: pr.url,
     };
   });
-
-  return Array.from(new Map(prs.map((pr) => [pr.html_url, pr])).values());
 };
 
 const selectReleases = ({ releases, serviceVersion }) => {

--- a/.github/scripts/generate_serverless_changelog.js
+++ b/.github/scripts/generate_serverless_changelog.js
@@ -2,8 +2,7 @@ const GITHUB_OWNER = 'elastic';
 const KIBANA_REPO = 'kibana';
 const SERVERLESS_GITOPS_REPO = 'serverless-gitops';
 const VERSIONS_FILE_PATH = 'services/kibana/versions.yaml';
-const COMMITS_TO_FIND = 5;
-const GITHUB_API_VERSION = '2022-11-28';
+const SERVERLESS_EXCLUDED_LABELS = ['backport', 'release_note:skip', 'reverted'];
 
 const requiredEnv = (name) => {
   const value = process.env[name];
@@ -15,8 +14,6 @@ const requiredEnv = (name) => {
   return value;
 };
 
-const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
 const chunk = (items, size) => {
   const chunks = [];
 
@@ -27,84 +24,50 @@ const chunk = (items, size) => {
   return chunks;
 };
 
-const githubRequest = async ({ path, method = 'GET', query = {}, body }) => {
-  const url = new URL(`https://api.github.com${path}`);
-
-  for (const [key, value] of Object.entries(query)) {
-    url.searchParams.set(key, value);
-  }
-
-  const response = await fetch(url, {
-    method,
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${requiredEnv('GITHUB_TOKEN')}`,
-      'X-GitHub-Api-Version': GITHUB_API_VERSION,
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-
-  const text = await response.text();
-
-  if (!response.ok) {
-    throw new Error(`GitHub API request failed: ${method} ${url} ${response.status} ${text}`);
-  }
-
-  return {
-    data: text ? JSON.parse(text) : undefined,
-    link: response.headers.get('link'),
-  };
-};
-
-const findServerlessGitOpsCommits = async ({ envSearch, repo, filePath }) => {
+const findServerlessGitOpsCommits = async ({ github, envSearch, repo, filePath }) => {
+  const commitsToFind = 5;
   const matchingCommits = [];
-  let page = 1;
 
-  while (matchingCommits.length < COMMITS_TO_FIND) {
-    const { data: commits } = await githubRequest({
-      path: `/repos/${GITHUB_OWNER}/${repo}/commits`,
-      query: {
-        path: filePath,
-        per_page: '100',
-        page: String(page),
-      },
-    });
-
-    if (commits.length === 0) {
-      break;
-    }
-
-    for (const commit of commits) {
+  for await (const response of github.paginate.iterator(github.rest.repos.listCommits, {
+    owner: GITHUB_OWNER,
+    repo,
+    path: filePath,
+    per_page: 100,
+  })) {
+    for (const commit of response.data) {
       if (commit.commit.message.includes(envSearch)) {
         matchingCommits.push(commit);
-        if (matchingCommits.length === COMMITS_TO_FIND) {
+        if (matchingCommits.length === commitsToFind) {
           return matchingCommits;
         }
       }
     }
-
-    page += 1;
   }
 
   return matchingCommits;
 };
 
-const findKibanaServerlessDeployedCommit = async ({ gitOpsSha, envSearch, repo, filePath }) => {
+const findKibanaServerlessDeployedCommit = async ({
+  github,
+  gitOpsSha,
+  envSearch,
+  repo,
+  filePath,
+}) => {
   try {
-    const { data } = await githubRequest({
-      path: `/repos/${GITHUB_OWNER}/${repo}/contents/${filePath}`,
-      query: {
-        ref: gitOpsSha,
-      },
+    const fileResponse = await github.rest.repos.getContent({
+      owner: GITHUB_OWNER,
+      repo,
+      path: filePath,
+      ref: gitOpsSha,
     });
 
-    if (!data.content) {
+    if (!('content' in fileResponse.data)) {
       throw new Error(`File content not available for commit ${gitOpsSha}`);
     }
 
-    const content = Buffer.from(data.content, 'base64').toString('utf8');
-    const regex = new RegExp(`${escapeRegExp(envSearch)}:\\s+"([a-f0-9]{7,40})"`);
+    const content = Buffer.from(fileResponse.data.content, 'base64').toString('utf8');
+    const regex = new RegExp(`${envSearch}:\\s+"([a-f0-9]{7,40})"`);
     const match = content.match(regex);
 
     if (!match || !match[1]) {
@@ -117,8 +80,35 @@ const findKibanaServerlessDeployedCommit = async ({ gitOpsSha, envSearch, repo, 
   }
 };
 
-const getServerlessReleases = async ({ envSearch }) => {
+const matchKibanaTagsToReleaseCommits = async ({ github, serverlessReleases }) => {
+  // Need to retrieve all the tags because ref tags are always last.
+  const tags = await github.paginate(github.rest.repos.listTags, {
+    owner: GITHUB_OWNER,
+    repo: KIBANA_REPO,
+    per_page: 100,
+  });
+
+  return serverlessReleases.flatMap((release) => {
+    const tagForReleaseCommit = tags.find((tag) => tag.commit.sha.startsWith(release.kibanaSha));
+
+    if (!tagForReleaseCommit) {
+      console.warn(`No tag found for the release commit ${release.kibanaSha}, removing.`);
+      return [];
+    }
+
+    return [
+      {
+        ...release,
+        releaseTag: tagForReleaseCommit,
+        releaseDate: new Date(Number(tagForReleaseCommit.name.split('@')[1]) * 1000),
+      },
+    ];
+  });
+};
+
+const getServerlessReleases = async ({ github, envSearch }) => {
   const matchingCommits = await findServerlessGitOpsCommits({
+    github,
     envSearch,
     repo: SERVERLESS_GITOPS_REPO,
     filePath: VERSIONS_FILE_PATH,
@@ -128,42 +118,54 @@ const getServerlessReleases = async ({ envSearch }) => {
     throw new Error(`Could not find matching commits for ${envSearch} in serverless-gitops repo`);
   }
 
-  return Promise.all(
-    matchingCommits.map((commit) =>
-      findKibanaServerlessDeployedCommit({
-        gitOpsSha: commit.sha,
-        envSearch,
-        repo: SERVERLESS_GITOPS_REPO,
-        filePath: VERSIONS_FILE_PATH,
-      })
-    )
+  const deployedShaPromises = matchingCommits.map((commit) =>
+    findKibanaServerlessDeployedCommit({
+      github,
+      gitOpsSha: commit.sha,
+      envSearch,
+      repo: SERVERLESS_GITOPS_REPO,
+      filePath: VERSIONS_FILE_PATH,
+    })
   );
+
+  const serverlessReleases = await Promise.all(deployedShaPromises);
+
+  return matchKibanaTagsToReleaseCommits({ github, serverlessReleases });
 };
 
-const getCompareResults = async ({ older, newer }) => {
-  const compareResults = [];
-  let page = 1;
-  let hasNextPage = true;
-
-  while (hasNextPage) {
-    const { data, link } = await githubRequest({
-      path: `/repos/${GITHUB_OWNER}/${KIBANA_REPO}/compare/${older.kibanaSha}...${newer.kibanaSha}`,
-      query: {
-        per_page: '250',
-        page: String(page),
-      },
-    });
-
-    compareResults.push(data);
-    hasNextPage = Boolean(link?.includes('rel="next"'));
-    page += 1;
+const getPrsForServerless = async ({
+  github,
+  serverlessReleases,
+  selectedServerlessSHAs,
+  excludedLabels = [],
+  includedLabels = [],
+}) => {
+  if (selectedServerlessSHAs.size !== 2) {
+    throw new Error('Exactly two serverless releases must be selected');
   }
 
-  return compareResults;
-};
+  const [newer, older] = Array.from(selectedServerlessSHAs)
+    .map((sha) => {
+      return serverlessReleases.find(({ kibanaSha }) => kibanaSha === sha);
+    })
+    .sort((a, b) => {
+      if (a?.releaseDate && b?.releaseDate) {
+        return Number(b.releaseDate) - Number(a.releaseDate);
+      }
 
-const getPrsForServerless = async ({ older, newer, excludedLabels = [], includedLabels = [] }) => {
-  const compareResult = await getCompareResults({ older, newer });
+      return 0;
+    });
+
+  const serverlessReleaseDate = new Date(Number(newer?.releaseTag?.name.split('@')[1]) * 1000);
+  console.log(`Serverless release date: ${serverlessReleaseDate.toISOString()}`);
+
+  // Get all the merge commits between the two releases.
+  const compareResult = await github.paginate(github.rest.repos.compareCommitsWithBasehead, {
+    owner: GITHUB_OWNER,
+    repo: KIBANA_REPO,
+    basehead: `${older?.kibanaSha}...${newer?.kibanaSha}`,
+    per_page: 250,
+  });
 
   const commitNodeIds = compareResult.reduce((acc, results) => {
     return acc.concat(results.commits.map((commit) => commit.node_id));
@@ -198,23 +200,12 @@ const getPrsForServerless = async ({ older, newer, excludedLabels = [], included
   const pullRequests = [];
   const chunks = chunk(commitNodeIds, 20);
   const results = await Promise.all(
-    chunks.map(async (commitNodeIdChunk) => {
-      const { data: response } = await githubRequest({
-        path: '/graphql',
-        method: 'POST',
-        body: {
-          query,
-          variables: {
-            commitNodeIds: commitNodeIdChunk,
-          },
-        },
-      });
+    chunks.map((commitNodeIdChunk) => {
+      const variables = {
+        commitNodeIds: commitNodeIdChunk,
+      };
 
-      if (response.errors) {
-        throw new Error(`GitHub GraphQL request failed: ${JSON.stringify(response.errors)}`);
-      }
-
-      return response.data;
+      return github.graphql(query, variables);
     })
   );
 
@@ -251,25 +242,38 @@ const getPrsForServerless = async ({ older, newer, excludedLabels = [], included
 };
 
 const selectReleases = ({ releases, serviceVersion }) => {
-  const currentReleaseIndex = releases.findIndex(({ kibanaSha }) => kibanaSha === serviceVersion);
+  const sortedReleases = [...releases].sort((a, b) => {
+    if (a?.releaseDate && b?.releaseDate) {
+      const releaseDateDiff = Number(b.releaseDate) - Number(a.releaseDate);
+
+      if (releaseDateDiff !== 0) {
+        return releaseDateDiff;
+      }
+    }
+
+    // Release dates are based on the Unix timestamp in the tag name, so a deploy-fix can have the same date as a new release.
+    return (a.releaseTag?.name ?? '').localeCompare(b.releaseTag?.name ?? '');
+  });
+
+  const currentReleaseIndex = sortedReleases.findIndex(({ kibanaSha }) => kibanaSha === serviceVersion);
 
   if (currentReleaseIndex === -1) {
     throw new Error(`Could not find ${serviceVersion} in recent serverless releases`);
   }
 
-  const previousRelease = releases[currentReleaseIndex + 1];
+  const previousRelease = sortedReleases[currentReleaseIndex + 1];
 
   if (!previousRelease) {
     throw new Error(`Could not find the previous serverless release before ${serviceVersion}`);
   }
 
   return {
-    newer: releases[currentReleaseIndex],
+    newer: sortedReleases[currentReleaseIndex],
     older: previousRelease,
   };
 };
 
-const main = async () => {
+const generateServerlessChangelog = async ({ github }) => {
   const serviceVersion = requiredEnv('SERVICE_VERSION');
   const targetEnv = requiredEnv('TARGET_ENV');
 
@@ -280,17 +284,19 @@ const main = async () => {
     console.log(`Triggered by Buildkite build: ${process.env.BUILDKITE_BUILD_URL}`);
   }
 
-  const releases = await getServerlessReleases({ envSearch: targetEnv });
+  const releases = await getServerlessReleases({ github, envSearch: targetEnv });
   const { newer, older } = selectReleases({ releases, serviceVersion });
 
   console.log(`Previous service version: ${older.kibanaSha}`);
 
-  const prs = await getPrsForServerless({ older, newer });
+  const prs = await getPrsForServerless({
+    github,
+    serverlessReleases: releases,
+    selectedServerlessSHAs: new Set([newer.kibanaSha, older.kibanaSha]),
+    excludedLabels: SERVERLESS_EXCLUDED_LABELS,
+  });
 
-  console.log(prs.map(({ html_url: htmlUrl }) => htmlUrl).join('\n'));
+  console.log(prs.map(({ html_url: htmlUrl }) => htmlUrl).sort().join('\n'));
 };
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+module.exports = generateServerlessChangelog;

--- a/.github/scripts/generate_serverless_changelog.js
+++ b/.github/scripts/generate_serverless_changelog.js
@@ -202,7 +202,6 @@ const getPrsForServerless = async ({
     }
   `;
 
-  const pullRequests = [];
   const chunks = chunk(commitNodeIds, 20);
   const results = await Promise.all(
     chunks.map((commitNodeIdChunk) => {
@@ -214,16 +213,8 @@ const getPrsForServerless = async ({
     })
   );
 
-  results.forEach((result) => {
-    result.nodes.forEach((node) => {
-      if (node?.associatedPullRequests) {
-        node.associatedPullRequests.nodes?.forEach((pr) => {
-          if (pr) {
-            pullRequests.push(pr);
-          }
-        });
-      }
-    });
+  const pullRequests = results.flatMap((result) => {
+    return result.nodes.flatMap((node) => node?.associatedPullRequests?.nodes ?? []).filter(Boolean);
   });
 
   const prs = pullRequests.map((pr) => {

--- a/.github/workflows/generate_serverless_changelog.yml
+++ b/.github/workflows/generate_serverless_changelog.yml
@@ -10,7 +10,8 @@ on:
         type: string
       target_env:
         description: Serverless target environment
-        required: true
+        required: false
+        default: production-noncanary-ds-5
         type: string
       build_url:
         description: Buildkite build URL that triggered this workflow
@@ -33,15 +34,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-
       - name: Generate serverless changelog
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.KIBANAMACHINE_TOKEN }}
           SERVICE_VERSION: ${{ inputs.service_version }}
           TARGET_ENV: ${{ inputs.target_env }}
           BUILDKITE_BUILD_URL: ${{ inputs.build_url }}
           BUILDKITE_MESSAGE: ${{ inputs.build_message }}
-        run: node .github/scripts/generate_serverless_changelog.js
+        with:
+          github-token: ${{ secrets.KIBANAMACHINE_TOKEN }}
+          script: |
+            const generateServerlessChangelog = require('./.github/scripts/generate_serverless_changelog');
+            await generateServerlessChangelog({ github, core });

--- a/.github/workflows/generate_serverless_changelog.yml
+++ b/.github/workflows/generate_serverless_changelog.yml
@@ -1,0 +1,47 @@
+---
+name: Generate Serverless Changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      service_version:
+        description: Kibana service version deployed to the target environment
+        required: true
+        type: string
+      target_env:
+        description: Serverless target environment
+        required: true
+        type: string
+      build_url:
+        description: Buildkite build URL that triggered this workflow
+        required: false
+        type: string
+      build_message:
+        description: Buildkite build message that triggered this workflow
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+
+      - name: Generate serverless changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.KIBANAMACHINE_TOKEN }}
+          SERVICE_VERSION: ${{ inputs.service_version }}
+          TARGET_ENV: ${{ inputs.target_env }}
+          BUILDKITE_BUILD_URL: ${{ inputs.build_url }}
+          BUILDKITE_MESSAGE: ${{ inputs.build_message }}
+        run: node .github/scripts/generate_serverless_changelog.js


### PR DESCRIPTION
## Summary

- Closes #268706 
- Adds a step to the serverless release quality gates which will trigger a GH workflow to generate changelogs when the last non-canary deployment slice completes
- Adds a workflow that will start the generate changelogs process
- For now the process is simply create the list of PRs which were in this release, per @lcawl
- The PR list generation is almost 1:1 of the code that has been used in the Kibana release notes tool [here](https://github.com/elastic/kibana-release-notes/blob/main/src/common/github-service.ts#L286)

### Testing
- Ran `github/scripts/generate_serverless_changelog.js` locally and compared to the list generated in the release notes tool. Using `SERVICE_VERSION=208865236325` resolved previous release `22e59448526e` and produced the expected 39 PR URLs.
- Small test locally for the `if` condition in the BK `yml`:

```
Buildkite YAML regex literal: /(^|.*, *)production-noncanary-ds-5( *,.*|$$)/
PASS "production-noncanary-ds-5" => true
PASS "production-noncanary-ds-4,production-noncanary-ds-5" => true
PASS "production-noncanary-ds-4, production-noncanary-ds-5" => true
PASS "production-noncanary-ds-5,production-noncanary-ds-4" => true
PASS "production-noncanary-ds-1" => false
PASS "production-canary-ds-5" => false
PASS "production-canary-ds-1" => false
PASS "production-noncanary-ds-50" => false
PASS "foo-production-noncanary-ds-5" => false
PASS "" => false
```

