### PR TITLE
[CI] Trigger backport reviewer workflow on labeled event

### DIFF
--- a/.github/workflows/assign-backport-reviewer.yml
+++ b/.github/workflows/assign-backport-reviewer.yml
@@ -7,7 +7,7 @@ on:
       - '9.*'
       - '[1-9][0-9]*.*'
     types:
-      - opened
+      - labeled
 
 permissions:
   contents: read
@@ -17,8 +17,8 @@ jobs:
     name: Find reviewer for manual backport
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.user.login != 'kibanamachine' &&
-      contains(github.event.pull_request.labels.*.name, 'backport')
+      github.event.label.name == 'backport' &&
+      github.event.pull_request.user.login != 'kibanamachine'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
This workflow triggered on `pull_request_target: opened` and gated on the `backport` label. PR-creation APIs don't accept labels, so the label is added in a follow-up call. This creates a race condition where sometimes `opened` has the labels ([example](https://github.com/elastic/kibana/actions/runs/25578184880)) and other times it does not ([example](https://github.com/elastic/kibana/actions/runs/25819905631))

Switching to `types: [labeled]` removes the race condition. GitHub fires a `labeled` webhook for every label addition regardless of source.