### PR TITLE
[SLO] Add APM execution-context labels to SLO server routes and services

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/moon.yml
+++ b/x-pack/solutions/observability/plugins/slo/moon.yml
@@ -101,6 +101,7 @@ dependsOn:
   - '@kbn/core-theme-browser'
   - '@kbn/ebt-tools'
   - '@kbn/alerting-rule-utils'
+  - '@kbn/apm-utils'
   - '@kbn/discover-shared-plugin'
   - '@kbn/server-route-repository-client'
   - '@kbn/response-ops-alerts-table'

--- a/x-pack/solutions/observability/plugins/slo/server/routes/create_slo_server_route.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/create_slo_server_route.ts
@@ -7,6 +7,7 @@
 import { createServerRouteFactory } from '@kbn/server-route-repository';
 import type { Boom } from '@hapi/boom';
 import { forbidden, notFound, conflict, badRequest } from '@hapi/boom';
+import { addSpanLabels } from '@kbn/apm-utils';
 import type { CreateServerRouteFactory } from '@kbn/server-route-repository-utils/src/typings';
 import type { SLORouteHandlerResources } from './types';
 import {
@@ -46,6 +47,7 @@ export const createSloServerRoute: CreateServerRouteFactory<
   return createPlainSloServerRoute({
     ...config,
     handler: (options) => {
+      addSpanLabels({ plugin: 'slo' });
       return handler(options).catch((error) => {
         if (error instanceof SLOError) {
           throw handleSLOError(error);

--- a/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
@@ -14,6 +14,7 @@ import type {
   Logger,
   SavedObjectsClientContract,
 } from '@kbn/core/server';
+import { addTransactionLabels } from '@kbn/apm-utils';
 import type { CreateSLOParams, CreateSLOResponse } from '@kbn/slo-schema';
 import { ALL_VALUE } from '@kbn/slo-schema';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
@@ -41,6 +42,7 @@ import { createTempSummaryDocument } from './summary_transform_generator/helpers
 import type { TransformManager } from './transform_manager';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
 import { getTransformQueryComposite } from './utils/get_transform_compite_query';
+import { getSloApmLabels } from './utils';
 
 export class CreateSLO {
   constructor(
@@ -57,6 +59,7 @@ export class CreateSLO {
 
   public async execute(params: CreateSLOParams): Promise<CreateSLOResponse> {
     const slo = this.toSLO(params);
+    addTransactionLabels(getSloApmLabels(slo));
     validateSLO(slo);
 
     await Promise.all([

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { addTransactionLabels } from '@kbn/apm-utils';
 import type { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 import type { IScopedClusterClient } from '@kbn/core/server';
 import {
@@ -18,6 +19,7 @@ import {
 import { retryTransientEsErrors } from '../utils/retry';
 import type { SLODefinitionRepository } from './slo_definition_repository';
 import type { TransformManager } from './transform_manager';
+import { getSloApmLabels } from './utils';
 
 interface Options {
   skipDataDeletion: boolean;
@@ -42,6 +44,7 @@ export class DeleteSLO {
     }
   ): Promise<void> {
     const slo = await this.repository.findById(sloId);
+    addTransactionLabels(getSloApmLabels(slo));
 
     // First delete the linked resources before deleting the data
     const rollupTransformId = getSLOTransformId(slo.id, slo.revision);

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_burn_rates.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_burn_rates.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { addTransactionLabels } from '@kbn/apm-utils';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/core/server';
@@ -13,6 +14,7 @@ import type { Duration } from '../domain/models';
 import { DefaultBurnRatesClient } from './burn_rates_client';
 import { SLODefinitionClient } from './slo_definition_client';
 import { DefaultSLODefinitionRepository } from './slo_definition_repository';
+import { getSloApmLabels } from './utils';
 
 interface Services {
   soClient: SavedObjectsClientContract;
@@ -49,6 +51,7 @@ export async function getBurnRates({
   const definitionClient = new SLODefinitionClient(repository, esClient, logger);
 
   const { slo } = await definitionClient.execute(sloId, spaceId, remoteName);
+  addTransactionLabels(getSloApmLabels(slo));
   const burnRates = await burnRatesClient.calculate(slo, instanceId, windows, remoteName);
 
   return { burnRates };

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_slo.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
+import { addTransactionLabels } from '@kbn/apm-utils';
 import type { GetSLOParams, GetSLOResponse } from '@kbn/slo-schema';
 import { ALL_VALUE, getSLOResponseSchema } from '@kbn/slo-schema';
 import type { SLODefinitionClient } from './slo_definition_client';
 import type { SummaryClient } from './summary_client';
+import { getSloApmLabels } from './utils';
 
 export class GetSLO {
   constructor(
@@ -24,6 +26,7 @@ export class GetSLO {
     const instanceId = params.instanceId ?? ALL_VALUE;
     const remoteName = params.remoteName;
     const { slo, remote } = await this.definitionClient.execute(sloId, spaceId, remoteName);
+    addTransactionLabels(getSloApmLabels(slo));
     const { summary, groupings, meta } = await this.summaryClient.computeSummary({
       slo,
       instanceId,

--- a/x-pack/solutions/observability/plugins/slo/server/services/manage_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/manage_slo.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import { addTransactionLabels } from '@kbn/apm-utils';
 import { getSLOSummaryTransformId, getSLOTransformId } from '../../common/constants';
 import type { SLODefinitionRepository } from './slo_definition_repository';
 import type { TransformManager } from './transform_manager';
+import { getSloApmLabels } from './utils';
 
 export class ManageSLO {
   constructor(
@@ -19,6 +21,7 @@ export class ManageSLO {
 
   async enable(sloId: string) {
     const slo = await this.repository.findById(sloId);
+    addTransactionLabels(getSloApmLabels(slo));
     if (slo.enabled) {
       return;
     }
@@ -33,6 +36,7 @@ export class ManageSLO {
 
   async disable(sloId: string) {
     const slo = await this.repository.findById(sloId);
+    addTransactionLabels(getSloApmLabels(slo));
     if (!slo.enabled) {
       return;
     }

--- a/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IngestPutPipelineRequest } from '@elastic/elasticsearch/lib/api/types';
+import { addTransactionLabels } from '@kbn/apm-utils';
 import type { IBasePath, IScopedClusterClient, Logger } from '@kbn/core/server';
 import { asyncForEach } from '@kbn/std';
 import type { ResetSLOResponse } from '@kbn/slo-schema';
@@ -30,6 +31,7 @@ import type { SLODefinitionRepository } from './slo_definition_repository';
 import { createTempSummaryDocument } from './summary_transform_generator/helpers/create_temp_summary';
 import type { TransformManager } from './transform_manager';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
+import { getSloApmLabels } from './utils';
 
 export class ResetSLO {
   constructor(
@@ -44,6 +46,7 @@ export class ResetSLO {
 
   public async execute(sloId: string): Promise<ResetSLOResponse> {
     const originalSlo = await this.repository.findById(sloId);
+    addTransactionLabels(getSloApmLabels(originalSlo));
     await assertExpectedIndicatorSourceIndexPrivileges(
       originalSlo,
       this.scopedClusterClient.asCurrentUser

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -7,6 +7,7 @@
 
 import type { IngestPutPipelineRequest } from '@elastic/elasticsearch/lib/api/types';
 import type { IBasePath, IScopedClusterClient, Logger } from '@kbn/core/server';
+import { addTransactionLabels } from '@kbn/apm-utils';
 import type { UpdateSLOParams, UpdateSLOResponse } from '@kbn/slo-schema';
 import { updateSLOResponseSchema } from '@kbn/slo-schema';
 import { asyncForEach } from '@kbn/std';
@@ -32,6 +33,7 @@ import type { SLODefinitionRepository } from './slo_definition_repository';
 import { createTempSummaryDocument } from './summary_transform_generator/helpers/create_temp_summary';
 import type { TransformManager } from './transform_manager';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
+import { getSloApmLabels } from './utils';
 
 export class UpdateSLO {
   constructor(
@@ -52,6 +54,7 @@ export class UpdateSLO {
       groupBy: !!params.groupBy ? params.groupBy : originalSlo.groupBy,
       settings: Object.assign({}, originalSlo.settings, params.settings),
     });
+    addTransactionLabels(getSloApmLabels(updatedSlo));
 
     if (isEqual(originalSlo, updatedSlo)) {
       return this.toResponse(originalSlo);

--- a/x-pack/solutions/observability/plugins/slo/server/services/utils/get_slo_apm_labels.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/utils/get_slo_apm_labels.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALL_VALUE } from '@kbn/slo-schema';
+import { createSLO, createKQLCustomIndicator } from '../fixtures/slo';
+import {
+  sevenDaysRolling,
+  thirtyDaysRolling,
+  monthlyCalendarAligned,
+  weeklyCalendarAligned,
+} from '../fixtures/time_window';
+import { getSloApmLabels } from './get_slo_apm_labels';
+
+describe('getSloApmLabels', () => {
+  it('returns all four labels for a rolling SLO with no group-by', () => {
+    const slo = createSLO({
+      indicator: createKQLCustomIndicator(),
+      timeWindow: sevenDaysRolling(),
+      budgetingMethod: 'occurrences',
+      groupBy: ALL_VALUE,
+    });
+
+    expect(getSloApmLabels(slo)).toEqual({
+      'slo_indicator_type': 'sli.kql.custom',
+      'slo_budgeting_method': 'occurrences',
+      'slo_time_window': 'rolling_7d',
+      'slo_has_group_by': false,
+      'slo_prevent_initial_backfill': false,
+    });
+  });
+
+  it('serialises a 30-day rolling window correctly', () => {
+    const slo = createSLO({ timeWindow: thirtyDaysRolling() });
+
+    expect(getSloApmLabels(slo)['slo_time_window']).toBe('rolling_30d');
+  });
+
+  it('serialises a monthly calendar-aligned window correctly', () => {
+    const slo = createSLO({ timeWindow: monthlyCalendarAligned() });
+
+    expect(getSloApmLabels(slo)['slo_time_window']).toBe('calendarAligned_1M');
+  });
+
+  it('serialises a weekly calendar-aligned window correctly', () => {
+    const slo = createSLO({ timeWindow: weeklyCalendarAligned() });
+
+    expect(getSloApmLabels(slo)['slo_time_window']).toBe('calendarAligned_1w');
+  });
+
+  it('returns has_group_by true when groupBy is a real field', () => {
+    const slo = createSLO({ groupBy: 'host.name' });
+
+    expect(getSloApmLabels(slo)['slo_has_group_by']).toBe(true);
+  });
+
+  it('returns has_group_by false when groupBy is ALL_VALUE', () => {
+    const slo = createSLO({ groupBy: ALL_VALUE });
+
+    expect(getSloApmLabels(slo)['slo_has_group_by']).toBe(false);
+  });
+
+  it('returns timeslices budgeting method', () => {
+    const slo = createSLO({ budgetingMethod: 'timeslices', objective: { target: 0.99, timesliceTarget: 0.95, timesliceWindow: sevenDaysRolling().duration } });
+
+    expect(getSloApmLabels(slo)['slo_budgeting_method']).toBe('timeslices');
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/utils/get_slo_apm_labels.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/utils/get_slo_apm_labels.test.ts
@@ -25,47 +25,54 @@ describe('getSloApmLabels', () => {
     });
 
     expect(getSloApmLabels(slo)).toEqual({
-      'slo_indicator_type': 'sli.kql.custom',
-      'slo_budgeting_method': 'occurrences',
-      'slo_time_window': 'rolling_7d',
-      'slo_has_group_by': false,
-      'slo_prevent_initial_backfill': false,
+      slo_indicator_type: 'sli.kql.custom',
+      slo_budgeting_method: 'occurrences',
+      slo_time_window: 'rolling_7d',
+      slo_has_group_by: false,
+      slo_prevent_initial_backfill: false,
     });
   });
 
   it('serialises a 30-day rolling window correctly', () => {
     const slo = createSLO({ timeWindow: thirtyDaysRolling() });
 
-    expect(getSloApmLabels(slo)['slo_time_window']).toBe('rolling_30d');
+    expect(getSloApmLabels(slo).slo_time_window).toBe('rolling_30d');
   });
 
   it('serialises a monthly calendar-aligned window correctly', () => {
     const slo = createSLO({ timeWindow: monthlyCalendarAligned() });
 
-    expect(getSloApmLabels(slo)['slo_time_window']).toBe('calendarAligned_1M');
+    expect(getSloApmLabels(slo).slo_time_window).toBe('calendarAligned_1M');
   });
 
   it('serialises a weekly calendar-aligned window correctly', () => {
     const slo = createSLO({ timeWindow: weeklyCalendarAligned() });
 
-    expect(getSloApmLabels(slo)['slo_time_window']).toBe('calendarAligned_1w');
+    expect(getSloApmLabels(slo).slo_time_window).toBe('calendarAligned_1w');
   });
 
   it('returns has_group_by true when groupBy is a real field', () => {
     const slo = createSLO({ groupBy: 'host.name' });
 
-    expect(getSloApmLabels(slo)['slo_has_group_by']).toBe(true);
+    expect(getSloApmLabels(slo).slo_has_group_by).toBe(true);
   });
 
   it('returns has_group_by false when groupBy is ALL_VALUE', () => {
     const slo = createSLO({ groupBy: ALL_VALUE });
 
-    expect(getSloApmLabels(slo)['slo_has_group_by']).toBe(false);
+    expect(getSloApmLabels(slo).slo_has_group_by).toBe(false);
   });
 
   it('returns timeslices budgeting method', () => {
-    const slo = createSLO({ budgetingMethod: 'timeslices', objective: { target: 0.99, timesliceTarget: 0.95, timesliceWindow: sevenDaysRolling().duration } });
+    const slo = createSLO({
+      budgetingMethod: 'timeslices',
+      objective: {
+        target: 0.99,
+        timesliceTarget: 0.95,
+        timesliceWindow: sevenDaysRolling().duration,
+      },
+    });
 
-    expect(getSloApmLabels(slo)['slo_budgeting_method']).toBe('timeslices');
+    expect(getSloApmLabels(slo).slo_budgeting_method).toBe('timeslices');
   });
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/utils/get_slo_apm_labels.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/utils/get_slo_apm_labels.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ALL_VALUE } from '@kbn/slo-schema';
+import type { SLODefinition } from '../../domain/models';
+
+export const getSloApmLabels = (slo: SLODefinition) => ({
+  slo_indicator_type: slo.indicator.type,
+  slo_budgeting_method: slo.budgetingMethod,
+  slo_time_window: `${slo.timeWindow.type}_${slo.timeWindow.duration.format()}`,
+  slo_has_group_by: slo.groupBy !== ALL_VALUE,
+  slo_prevent_initial_backfill: slo.settings.preventInitialBackfill,
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/utils/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/utils/index.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+export { getSloApmLabels } from './get_slo_apm_labels';
 import { get } from 'lodash';
 import type { Groupings } from '../../domain/models';
 

--- a/x-pack/solutions/observability/plugins/slo/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/slo/tsconfig.json
@@ -96,6 +96,7 @@
     "@kbn/core-theme-browser",
     "@kbn/ebt-tools",
     "@kbn/alerting-rule-utils",
+    "@kbn/apm-utils",
     "@kbn/discover-shared-plugin",
     "@kbn/server-route-repository-client",
     "@kbn/response-ops-alerts-table",


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/269235

- Introduces `getSloApmLabels(slo)` utility returning five structured labels (`slo_indicator_type`, `slo_budgeting_method`, `slo_time_window`, `slo_has_group_by`, `slo_prevent_initial_backfill`) from an `SLODefinition`.
- Adds `addSpanLabels({ plugin: 'slo' })` to the `createSloServerRoute` factory, labeling every SLO HTTP route's APM span.
- Adds `addTransactionLabels(getSloApmLabels(slo))` to all single-SLO service operations so APM transactions carry rich SLO metadata: `create_slo`, `update_slo`, `reset_slo`, `delete_slo`, `manage_slo` (enable/disable), `get_slo`, and `get_burn_rates`.

This makes it possible to slice APM performance data by SLO indicator type, time window type, and budgeting method across all user-facing SLO operations.

## Test plan

- [ ] Unit tests for `getSloApmLabels` pass: `node scripts/jest x-pack/solutions/observability/plugins/slo/server/services/utils/get_slo_apm_labels.test.ts`
- [ ] Type check clean: `node scripts/type_check --project x-pack/solutions/observability/plugins/slo/tsconfig.json`
- [ ] Lint clean: `node scripts/eslint x-pack/solutions/observability/plugins/slo/server/services/`
- [ ] Exercise `GET /api/observability/slos/{id}`, `DELETE`, `POST .../enable`, `POST .../disable`, `GET .../burn_rates` and confirm APM transactions carry `labels.plugin = "slo"` and the five `labels.slo_*` fields.

Add this into your kibana.dev.yml file and then you'll find the apm transactions on [Elastic cloud APM](https://kibana-cloud-apm.elastic.dev/app/apm/services?comparisonEnabled=true&environment=kdelemme&rangeFrom=now-15m&rangeTo=now&offset=1d)

```yaml
elastic.apm.active: true
elastic.apm.transactionSampleRate: 1
elastic.apm.environment: YOUR_NAME
```

## Example

<img width="1478" height="616" alt="image" src="https://github.com/user-attachments/assets/bbdda74f-c6ec-476c-9957-b0d3cbc926a8" />

<img width="1594" height="936" alt="image" src="https://github.com/user-attachments/assets/d7f2e643-d788-46b6-af4a-f37fefc6fc95" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)