### PR TITLE
[UII] Add larger page size options to agent list table

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
@@ -58,6 +58,111 @@ function safeMetadata(val: any) {
   return val;
 }
 
+// Per-row cells are memoized so EuiBasicTable's re-renders (e.g. on selection
+// change) can skip cells whose inputs are unchanged. Each cell receives only
+// the primitives or stable references it needs, so shallow prop comparison
+// is meaningful.
+
+const StatusCell = React.memo<{ agent: Agent }>(({ agent }) => <AgentHealth agent={agent} />);
+
+const HostCell = React.memo<{ host: string; tags: string[]; href: string }>(
+  ({ host, tags, href }) => (
+    <EuiFlexGroup gutterSize="none" direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiLink href={href}>{safeMetadata(host)}</EuiLink>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <Tags tags={tags} color="subdued" size="xs" />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  )
+);
+
+const PolicyCell = React.memo<{
+  agent: Agent;
+  agentPolicy: AgentPolicy | undefined;
+  isVersionSpecific: boolean;
+}>(({ agent, agentPolicy, isVersionSpecific }) =>
+  agentPolicy ? (
+    <AgentPolicySummaryLine
+      policy={agentPolicy}
+      agent={agent}
+      showPolicyId
+      isVersionSpecific={isVersionSpecific}
+    />
+  ) : null
+);
+
+const CpuCell = React.memo<{ agent: Agent; agentPolicy: AgentPolicy | undefined }>(
+  ({ agent, agentPolicy }) => <>{formatAgentCPU(agent.metrics, agentPolicy)}</>
+);
+
+const MemoryCell = React.memo<{ agent: Agent; agentPolicy: AgentPolicy | undefined }>(
+  ({ agent, agentPolicy }) => <>{formatAgentMemory(agent.metrics, agentPolicy)}</>
+);
+
+const LastCheckinCell = React.memo<{ lastCheckin: string | undefined }>(({ lastCheckin }) =>
+  lastCheckin ? (
+    <EuiToolTip
+      content={
+        <FormattedMessage
+          id="xpack.fleet.agentList.lastActivityTooltip"
+          defaultMessage="Last checked in at {lastCheckin}"
+          values={{
+            lastCheckin: (
+              <FormattedDate
+                value={lastCheckin}
+                year="numeric"
+                month="short"
+                day="2-digit"
+                timeZoneName="short"
+                hour="numeric"
+                minute="numeric"
+              />
+            ),
+          }}
+        />
+      }
+    >
+      <span tabIndex={0}>
+        <FormattedRelative value={lastCheckin} />
+      </span>
+    </EuiToolTip>
+  ) : null
+);
+
+const VersionCell = React.memo<{
+  agent: Agent;
+  version: string;
+  isAgentUpgradable: boolean;
+  latestAgentVersion: string | undefined;
+}>(({ agent, version, isAgentUpgradable, latestAgentVersion }) => (
+  <EuiFlexGroup
+    gutterSize="none"
+    css={css`
+      min-width: 0;
+    `}
+    direction="column"
+  >
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s" className="eui-textNoWrap">
+            {safeMetadata(version)}
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <AgentUpgradeStatus
+            isAgentUpgradable={isAgentUpgradable}
+            agent={agent}
+            latestAgentVersion={latestAgentVersion}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+));
+
 interface Props {
   agents: Agent[];
   isLoading: boolean;
@@ -173,7 +278,7 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
       name: i18n.translate('xpack.fleet.agentList.statusColumnTitle', {
         defaultMessage: 'Status',
       }),
-      render: (active: boolean, agent: any) => <AgentHealth agent={agent} />,
+      render: (active: boolean, agent: any) => <StatusCell agent={agent} />,
     },
     {
       field: AGENTS_TABLE_FIELDS.HOSTNAME,
@@ -183,16 +288,11 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
       }),
       width: '185px',
       render: (host: string, agent: Agent) => (
-        <EuiFlexGroup gutterSize="none" direction="column">
-          <EuiFlexItem grow={false}>
-            <EuiLink href={getHref('agent_details', { agentId: agent.id })}>
-              {safeMetadata(host)}
-            </EuiLink>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <Tags tags={agent.tags ?? []} color="subdued" size="xs" />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <HostCell
+          host={host}
+          tags={agent.tags ?? []}
+          href={getHref('agent_details', { agentId: agent.id })}
+        />
       ),
     },
     {
@@ -203,22 +303,13 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
         defaultMessage: 'Agent policy',
       }),
       width: '220px',
-      render: (policyId: string, agent: Agent) => {
-        const basePolicyId = removeVersionSuffixFromPolicyId(policyId);
-        const agentPolicy = agentPoliciesIndexedById[basePolicyId];
-        const isVersionSpecific = hasVersionSuffix(policyId);
-
-        return (
-          agentPolicy && (
-            <AgentPolicySummaryLine
-              policy={agentPolicy}
-              agent={agent}
-              showPolicyId
-              isVersionSpecific={isVersionSpecific}
-            />
-          )
-        );
-      },
+      render: (policyId: string, agent: Agent) => (
+        <PolicyCell
+          agent={agent}
+          agentPolicy={agentPoliciesIndexedById[removeVersionSuffixFromPolicyId(policyId)]}
+          isVersionSpecific={hasVersionSuffix(policyId)}
+        />
+      ),
     },
 
     {
@@ -241,13 +332,16 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
         </EuiToolTip>
       ),
       width: '75px',
-      render: (metrics: AgentMetrics | undefined, agent: Agent) =>
-        formatAgentCPU(
-          agent.metrics,
-          agent.policy_id
-            ? agentPoliciesIndexedById[removeVersionSuffixFromPolicyId(agent.policy_id)]
-            : undefined
-        ),
+      render: (metrics: AgentMetrics | undefined, agent: Agent) => (
+        <CpuCell
+          agent={agent}
+          agentPolicy={
+            agent.policy_id
+              ? agentPoliciesIndexedById[removeVersionSuffixFromPolicyId(agent.policy_id)]
+              : undefined
+          }
+        />
+      ),
     },
     {
       field: AGENTS_TABLE_FIELDS.METRICS,
@@ -269,13 +363,16 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
         </EuiToolTip>
       ),
       width: '90px',
-      render: (metrics: AgentMetrics | undefined, agent: Agent) =>
-        formatAgentMemory(
-          agent.metrics,
-          agent.policy_id
-            ? agentPoliciesIndexedById[removeVersionSuffixFromPolicyId(agent.policy_id)]
-            : undefined
-        ),
+      render: (metrics: AgentMetrics | undefined, agent: Agent) => (
+        <MemoryCell
+          agent={agent}
+          agentPolicy={
+            agent.policy_id
+              ? agentPoliciesIndexedById[removeVersionSuffixFromPolicyId(agent.policy_id)]
+              : undefined
+          }
+        />
+      ),
     },
     {
       field: AGENTS_TABLE_FIELDS.LAST_CHECKIN,
@@ -284,34 +381,7 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
         defaultMessage: 'Last activity',
       }),
       width: '100px',
-      render: (lastCheckin: string) =>
-        lastCheckin ? (
-          <EuiToolTip
-            content={
-              <FormattedMessage
-                id="xpack.fleet.agentList.lastActivityTooltip"
-                defaultMessage="Last checked in at {lastCheckin}"
-                values={{
-                  lastCheckin: (
-                    <FormattedDate
-                      value={lastCheckin}
-                      year="numeric"
-                      month="short"
-                      day="2-digit"
-                      timeZoneName="short"
-                      hour="numeric"
-                      minute="numeric"
-                    />
-                  ),
-                }}
-              />
-            }
-          >
-            <span tabIndex={0}>
-              <FormattedRelative value={lastCheckin} />
-            </span>
-          </EuiToolTip>
-        ) : undefined,
+      render: (lastCheckin: string) => <LastCheckinCell lastCheckin={lastCheckin} />,
     },
     {
       field: AGENTS_TABLE_FIELDS.VERSION,
@@ -321,30 +391,12 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
         defaultMessage: 'Version',
       }),
       render: (version: string, agent: Agent) => (
-        <EuiFlexGroup
-          gutterSize="none"
-          css={css`
-            min-width: 0;
-          `}
-          direction="column"
-        >
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
-              <EuiFlexItem grow={false}>
-                <EuiText size="s" className="eui-textNoWrap">
-                  {safeMetadata(version)}
-                </EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <AgentUpgradeStatus
-                  isAgentUpgradable={!!(isAgentSelectable(agent) && isAgentUpgradeable(agent))}
-                  agent={agent}
-                  latestAgentVersion={latestAgentVersion}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <VersionCell
+          agent={agent}
+          version={version}
+          isAgentUpgradable={!!(isAgentSelectable(agent) && isAgentUpgradeable(agent))}
+          latestAgentVersion={latestAgentVersion}
+        />
       ),
     },
     {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agents_selection_status.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agents_selection_status.tsx
@@ -145,7 +145,7 @@ export const AgentsSelectionStatus: React.FunctionComponent<{
                 <EuiFlexItem grow={false}>
                   <Button
                     size="xs"
-                    flush="left"
+                    flush="both"
                     data-test-subj="selectedEverythingOnAllPagesButton"
                     onClick={() => setSelectionMode('query')}
                   >

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agents_selection_status.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agents_selection_status.tsx
@@ -163,7 +163,7 @@ export const AgentsSelectionStatus: React.FunctionComponent<{
             <EuiFlexItem grow={false}>
               <Button
                 size="xs"
-                flush="left"
+                flush="both"
                 data-test-subj="clearAgentSelectionButton"
                 onClick={() => {
                   setSelectionMode('manual');

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_header.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_header.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiLink } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiButtonEmpty } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { Agent, SimplifiedAgentStatus } from '../../../../types';
@@ -60,12 +60,12 @@ export const AgentTableHeader: React.FunctionComponent<{
           </EuiFlexItem>
           {isUsingFilter ? (
             <EuiFlexItem grow={false}>
-              <EuiLink onClick={() => clearFilters()}>
+              <EuiButtonEmpty size="xs" flush="left" onClick={() => clearFilters()}>
                 <FormattedMessage
                   id="xpack.fleet.agentList.header.clearFiltersLinkText"
                   defaultMessage="Reset filters"
                 />
-              </EuiLink>
+              </EuiButtonEmpty>
             </EuiFlexItem>
           ) : null}
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.test.tsx
@@ -179,7 +179,7 @@ describe('useFetchAgentsData', () => {
     );
 
     expect(result?.current.page).toEqual({ index: 0, size: 20 });
-    expect(result?.current.pageSizeOptions).toEqual([5, 20, 50]);
+    expect(result?.current.pageSizeOptions).toEqual([20, 50, 100, 200]);
   });
 
   it('sync querystring kuery with current search', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.tsx
@@ -183,7 +183,7 @@ export function useFetchAgentsData() {
     [updateTableState]
   );
 
-  const pageSizeOptions = [5, 20, 50];
+  const pageSizeOptions = [20, 50, 100, 200];
 
   // Sync draftKuery with session storage search
   const [draftKuery, setDraftKuery] = useState<string>(search);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -607,6 +607,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         clearFilters={clearFilters}
         queryHasChanged={queryHasChanged}
       />
+      <EuiSpacer size="l" />
     </>
   );
 };


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/268474. This PR adds `100` and `200` to page size options for agent list table and removes `5` (likely not useful for anyone).

To offset performance impact for the larger page sizes, particularly when selecting rows, we now memoize the table cell contents. PR also includes some minor spacing adjustments that I noticed.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.