### PR TITLE
feat(inference-endpoints): allow features to opt out of global default connector

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/common/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/common/types.ts
@@ -67,6 +67,7 @@ export interface InferenceFeatureResponse {
   recommendedEndpoints: string[];
   isBeta?: boolean;
   isTechPreview?: boolean;
+  ignoreGlobalDefault?: boolean;
   visibilityCondition?: {
     key: string;
     value: string | number | boolean | null;

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/feature_section.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/feature_section.tsx
@@ -36,7 +36,7 @@ interface FeatureSectionProps {
   invalidEndpointIds: Set<string>;
   isTechPreview?: boolean;
   isBeta?: boolean;
-  globalDefaultId: string;
+  globalDefaultId: string | undefined;
 }
 
 export const FeatureSection: React.FC<FeatureSectionProps> = ({

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.test.tsx
@@ -56,6 +56,16 @@ const childFeature: InferenceFeatureConfig = {
   recommendedEndpoints: ['ep-1'],
 };
 
+const optOutChildFeature: InferenceFeatureConfig = {
+  featureId: 'child_opt_out',
+  parentFeatureId: 'workflows',
+  featureName: 'Workflow Feature',
+  featureDescription: 'runs in background',
+  taskType: 'chat_completion',
+  recommendedEndpoints: [],
+  ignoreGlobalDefault: true,
+};
+
 const defaultFormState = {
   isLoading: false,
   isSaving: false,
@@ -390,6 +400,97 @@ describe('ModelSettings', () => {
     expect(mockNavigateToUrl).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.queryByTestId('unsavedChangesModal')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ignoreGlobalDefault sections', () => {
+    const optOutFormState = {
+      ...defaultFormState,
+      sections: [
+        {
+          featureId: 'workflows',
+          featureName: 'Workflows',
+          featureDescription: 'Background workflows',
+          taskType: '',
+          recommendedEndpoints: [],
+          children: [optOutChildFeature],
+        },
+      ],
+    };
+
+    it('renders opt-out sections even when featureSpecificModels is off', () => {
+      mockUseModelSettingsForm.mockReturnValue(optOutFormState);
+      mockUseDefaultModelSettings.mockReturnValue({
+        ...defaultModelSettingsState,
+        state: { enableAi: true, defaultModelId: 'pre-1', featureSpecificModels: false },
+      });
+
+      render(
+        <Wrapper>
+          <ModelSettings />
+        </Wrapper>
+      );
+
+      expect(screen.getByTestId('featureSection-Workflows')).toBeInTheDocument();
+    });
+
+    it('shows the ignoreGlobalDefault callout when featureSpecificModels is off and opt-out sections exist', () => {
+      mockUseModelSettingsForm.mockReturnValue(optOutFormState);
+      mockUseDefaultModelSettings.mockReturnValue({
+        ...defaultModelSettingsState,
+        state: { enableAi: true, defaultModelId: 'pre-1', featureSpecificModels: false },
+      });
+
+      render(
+        <Wrapper>
+          <ModelSettings />
+        </Wrapper>
+      );
+
+      expect(screen.getByTestId('ignoreGlobalDefaultCallout')).toBeInTheDocument();
+    });
+
+    it('does not show the ignoreGlobalDefault callout when featureSpecificModels is on', () => {
+      mockUseModelSettingsForm.mockReturnValue(optOutFormState);
+
+      render(
+        <Wrapper>
+          <ModelSettings />
+        </Wrapper>
+      );
+
+      expect(screen.queryByTestId('ignoreGlobalDefaultCallout')).not.toBeInTheDocument();
+    });
+
+    it('hides opt-out sections when enableAi is off', () => {
+      mockUseModelSettingsForm.mockReturnValue(optOutFormState);
+      mockUseDefaultModelSettings.mockReturnValue({
+        ...defaultModelSettingsState,
+        state: { enableAi: false, defaultModelId: 'pre-1', featureSpecificModels: false },
+      });
+
+      render(
+        <Wrapper>
+          <ModelSettings />
+        </Wrapper>
+      );
+
+      expect(screen.queryByTestId('featureSection-Workflows')).not.toBeInTheDocument();
+    });
+
+    it('does not render regular sections in default-only mode', () => {
+      mockUseDefaultModelSettings.mockReturnValue({
+        ...defaultModelSettingsState,
+        state: { enableAi: true, defaultModelId: 'pre-1', featureSpecificModels: false },
+      });
+
+      render(
+        <Wrapper>
+          <ModelSettings />
+        </Wrapper>
+      );
+
+      expect(screen.queryByTestId('featureSection-Search')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -133,6 +133,12 @@ export const ModelSettings: React.FC = () => {
 
   const showFeatureSections = enableAi && featureSpecificModels;
 
+  const { optOutSections, regularSections } = useMemo(() => {
+    const optOut = sections.filter((s) => s.children.every((f) => f.ignoreGlobalDefault));
+    const regular = sections.filter((s) => s.children.some((f) => !f.ignoreGlobalDefault));
+    return { optOutSections: optOut, regularSections: regular };
+  }, [sections]);
+
   if (connectorsLoading || isLoading) {
     return (
       <EuiPageTemplate.Section
@@ -196,6 +202,60 @@ export const ModelSettings: React.FC = () => {
           defaultModelSettings={defaultModelSettings}
           validation={defaultModelValidation}
         />
+        {enableAi && optOutSections.length > 0 && (
+          <>
+            {!featureSpecificModels && (
+              <>
+                <EuiSpacer size="l" />
+                <EuiCallOut
+                  data-test-subj="ignoreGlobalDefaultCallout"
+                  color="primary"
+                  iconType="iInCircle"
+                  title={i18n.translate(
+                    'xpack.searchInferenceEndpoints.settings.ignoreGlobalDefault.calloutTitle',
+                    {
+                      defaultMessage: 'These features manage their own model selection',
+                    }
+                  )}
+                >
+                  <p>
+                    {i18n.translate(
+                      'xpack.searchInferenceEndpoints.settings.ignoreGlobalDefault.calloutDescription',
+                      {
+                        defaultMessage:
+                          'The global default model setting does not apply to these features. You can still configure them individually below.',
+                      }
+                    )}
+                  </p>
+                </EuiCallOut>
+              </>
+            )}
+            <EuiSpacer size="xl" />
+            {optOutSections.map((section) => (
+              <React.Fragment key={section.featureId}>
+                <FeatureSection
+                  parentName={section.featureName}
+                  parentDescription={section.featureDescription}
+                  features={section.children.map((f) => ({
+                    endpointIds: assignments[f.featureId] ?? f.recommendedEndpoints,
+                    effectiveRecommendedEndpoints:
+                      effectiveRecommendedEndpoints[f.featureId] ?? f.recommendedEndpoints,
+                    feature: f,
+                    hasSavedObject: hasSavedObject[f.featureId] ?? false,
+                    isFeatureDirty: dirtyFeatureIds.has(f.featureId),
+                  }))}
+                  onEndpointsChange={updateEndpoints}
+                  invalidEndpointIds={invalidEndpointIds}
+                  isBeta={section.isBeta}
+                  isTechPreview={section.isTechPreview}
+                  globalDefaultId={undefined}
+                />
+                <EuiSpacer size="xl" />
+              </React.Fragment>
+            ))}
+          </>
+        )}
+
         {showFeatureSections && (
           <>
             {invalidEndpointIds.size > 0 && (
@@ -255,7 +315,7 @@ export const ModelSettings: React.FC = () => {
                 data-test-subj="settings-no-features"
               />
             ) : (
-              sections.map((section) => (
+              regularSections.map((section) => (
                 <React.Fragment key={section.featureId}>
                   <FeatureSection
                     parentName={section.featureName}

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.test.tsx
@@ -140,7 +140,7 @@ describe('SubFeatureCard', () => {
     globalRowOverrides?: Partial<{
       hasSavedObject: boolean;
       isFeatureDirty: boolean;
-      globalDefaultId: string;
+      globalDefaultId: string | undefined;
     }>
   ) =>
     render(
@@ -543,6 +543,17 @@ describe('SubFeatureCard', () => {
       expect(
         screen.getByText('Inference endpoint Claude is no longer available')
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('ignoreGlobalDefault — globalDefaultId undefined', () => {
+    it('does not render the global default locked row when globalDefaultId is undefined', () => {
+      renderCard(['ep-1'], undefined, new Set(), ['__different__'], {
+        hasSavedObject: false,
+        globalDefaultId: undefined,
+      });
+
+      expect(screen.queryByTestId('global-default-row-test_feature')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
@@ -54,7 +54,7 @@ interface SubFeatureCardProps {
   invalidEndpointIds: Set<string>;
   hasSavedObject: boolean;
   isFeatureDirty: boolean;
-  globalDefaultId: string;
+  globalDefaultId: string | undefined;
 }
 
 export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
@@ -118,9 +118,10 @@ export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
   const canAddMore =
     !feature.maxNumberOfEndpoints || endpointIds.length < feature.maxNumberOfEndpoints;
 
-  const showGlobalDefaultRow = !hasSavedObject && globalDefaultId !== NO_DEFAULT_MODEL;
+  const showGlobalDefaultRow =
+    !hasSavedObject && !!globalDefaultId && globalDefaultId !== NO_DEFAULT_MODEL;
   const { icon: globalDefaultIcon = 'compute', label: globalDefaultLabel = globalDefaultId } =
-    endpointDisplayMap.get(globalDefaultId) ?? {};
+    (globalDefaultId ? endpointDisplayMap.get(globalDefaultId) : undefined) ?? {};
 
   const handleRemove = useCallback(
     (index: number) => {
@@ -495,7 +496,7 @@ interface GlobalDefaultLockedRowProps {
   icon: string;
   label: string;
   showBadge: boolean;
-  globalDefaultId: string;
+  globalDefaultId: string | undefined;
 }
 
 const GlobalDefaultLockedRow: React.FC<GlobalDefaultLockedRowProps> = ({
@@ -526,7 +527,7 @@ const GlobalDefaultLockedRow: React.FC<GlobalDefaultLockedRowProps> = ({
             min-width: 0;
           `}
         >
-          <EuiToolTip title={label} content={globalDefaultId} position="top">
+          <EuiToolTip title={label} content={globalDefaultId ?? ''} position="top">
             <EuiText
               size="s"
               color="subdued"
@@ -565,7 +566,7 @@ interface RecommendedEndpointsListProps {
     icon: string;
     label: string;
     showBadge: boolean;
-    globalDefaultId: string;
+    globalDefaultId: string | undefined;
   };
 }
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/resolve_models_for_feature.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/resolve_models_for_feature.test.ts
@@ -57,13 +57,18 @@ describe('resolveModelsForFeature', () => {
     getConnectorById = jest.fn();
   });
 
-  const resolve = (uiSettings: UiSettings = {}, featureId = 'my_feature') =>
+  const resolve = (
+    uiSettings: UiSettings = {},
+    featureId = 'my_feature',
+    ignoreGlobalDefault = false
+  ) =>
     resolveModelsForFeature({
       getForFeature,
       getConnectorList,
       getConnectorById,
       uiSettingsClient: createUiSettingsClient(uiSettings),
       featureId,
+      ignoreGlobalDefault,
       logger,
     });
 
@@ -333,6 +338,77 @@ describe('resolveModelsForFeature', () => {
       connectors: [{ ...recommended, isRecommended: true }],
       warnings: [],
       soEntryFound: false,
+    });
+  });
+
+  describe('ignoreGlobalDefault', () => {
+    it('bypasses defaultConnectorOnly and returns the full feature list when ignoreGlobalDefault is true', async () => {
+      const recommended = inferenceConnector('rec');
+      const other = inferenceConnector('other');
+      const defaultConnector = inferenceConnector('default');
+      getForFeature.mockResolvedValue({
+        endpoints: [recommended],
+        warnings: [],
+        soEntryFound: false,
+      });
+      getConnectorList.mockResolvedValue([recommended, other]);
+      getConnectorById.mockResolvedValue(defaultConnector);
+
+      const result = await resolve(
+        { defaultConnectorId: 'default', defaultConnectorOnly: true },
+        'my_feature',
+        true
+      );
+
+      expect(getForFeature).toHaveBeenCalledWith('my_feature');
+      expect(getConnectorList).toHaveBeenCalledTimes(1);
+      expect(result.connectors).not.toContain(defaultConnector);
+      expect(result).toEqual({
+        connectors: [{ ...recommended, isRecommended: true }, other],
+        warnings: [],
+        soEntryFound: false,
+      });
+    });
+
+    it('does not prepend the global default when ignoreGlobalDefault is true and soEntryFound is false', async () => {
+      const recommended = inferenceConnector('rec');
+      const other = inferenceConnector('other');
+      const defaultConnector = inferenceConnector('default');
+      getForFeature.mockResolvedValue({
+        endpoints: [recommended],
+        warnings: [],
+        soEntryFound: false,
+      });
+      getConnectorList.mockResolvedValue([recommended, other]);
+      getConnectorById.mockResolvedValue(defaultConnector);
+
+      const result = await resolve({ defaultConnectorId: 'default' }, 'my_feature', true);
+
+      expect(getConnectorById).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        connectors: [{ ...recommended, isRecommended: true }, other],
+        warnings: [],
+        soEntryFound: false,
+      });
+    });
+
+    it('still returns only the default connector when ignoreGlobalDefault is false and defaultConnectorOnly is set', async () => {
+      const defaultConnector = inferenceConnector('default-id');
+      getConnectorById.mockResolvedValue(defaultConnector);
+
+      const result = await resolve(
+        { defaultConnectorId: 'default-id', defaultConnectorOnly: true },
+        'my_feature',
+        false
+      );
+
+      expect(getForFeature).not.toHaveBeenCalled();
+      expect(getConnectorList).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        connectors: [defaultConnector],
+        warnings: [],
+        soEntryFound: false,
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/resolve_models_for_feature.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/resolve_models_for_feature.ts
@@ -48,6 +48,7 @@ export const resolveModelsForFeature = async ({
   getConnectorById,
   uiSettingsClient,
   featureId,
+  ignoreGlobalDefault = false,
   logger,
 }: {
   getForFeature: (featureId: string) => Promise<ResolvedInferenceEndpoints>;
@@ -55,6 +56,7 @@ export const resolveModelsForFeature = async ({
   getConnectorById: (id: string) => Promise<InferenceConnector>;
   uiSettingsClient: IUiSettingsClient;
   featureId: string;
+  ignoreGlobalDefault?: boolean;
   logger: Logger;
 }): Promise<ResolvedConnectorsForFeature> => {
   const [defaultConnectorId, defaultConnectorOnly] = await Promise.all([
@@ -71,7 +73,7 @@ export const resolveModelsForFeature = async ({
     }
   };
 
-  if (defaultConnectorOnly) {
+  if (defaultConnectorOnly && !ignoreGlobalDefault) {
     if (!defaultConnectorId || defaultConnectorId === NO_DEFAULT_CONNECTOR) {
       return { connectors: [], warnings: [], soEntryFound: false };
     }
@@ -98,7 +100,12 @@ export const resolveModelsForFeature = async ({
   const merged = mergeConnectors(featureResult.endpoints, allConnectors, soEntryFound);
 
   let connectors: ApiInferenceConnector[] = merged;
-  if (!soEntryFound && defaultConnectorId && defaultConnectorId !== NO_DEFAULT_CONNECTOR) {
+  if (
+    !soEntryFound &&
+    !ignoreGlobalDefault &&
+    defaultConnectorId &&
+    defaultConnectorId !== NO_DEFAULT_CONNECTOR
+  ) {
     const defaultConnector = await fetchConnectorById(defaultConnectorId);
     if (defaultConnector) {
       connectors = [

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
@@ -189,6 +189,7 @@ export class SearchInferenceEndpointsPlugin
           const resolveFeatureEndpoints = (fId: string) =>
             getForFeatureFn(featureRegistry, soClient, getConnectorById, fId, this.logger);
           const getConnectorList = () => plugins.inference.getConnectorList(request);
+          const feature = featureRegistry.get(featureId);
 
           const result = await resolveModelsForFeature({
             getForFeature: resolveFeatureEndpoints,
@@ -196,6 +197,7 @@ export class SearchInferenceEndpointsPlugin
             getConnectorById,
             uiSettingsClient,
             featureId,
+            ignoreGlobalDefault: feature?.ignoreGlobalDefault ?? false,
             logger: this.logger,
           });
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/routes.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/routes.ts
@@ -40,6 +40,7 @@ export function defineRoutes({
   defineInferenceConnectorsRoute({
     logger,
     router,
+    featureRegistry,
     getForFeature,
     getConnectorList,
     getConnectorById,

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/routes/inference_connectors.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/routes/inference_connectors.test.ts
@@ -15,6 +15,7 @@ import {
 import { MockRouter } from '../../__mocks__/router.mock';
 import { ROUTE_VERSIONS } from '../../common/constants';
 import { APIRoutes } from '../../common/types';
+import type { InferenceFeatureRegistry } from '../inference_feature_registry';
 import { defineInferenceConnectorsRoute } from './inference_connectors';
 
 const inferenceConnector = (connectorId: string) => ({
@@ -51,6 +52,13 @@ const createContext = ({
     }),
   } as unknown as jest.Mocked<RequestHandlerContext>);
 
+const makeFeatureRegistry = (ignoreGlobalDefault = false): InferenceFeatureRegistry =>
+  ({
+    get: jest.fn(() =>
+      ignoreGlobalDefault ? { featureId: 'my_feature', ignoreGlobalDefault: true } : undefined
+    ),
+  } as unknown as InferenceFeatureRegistry);
+
 describe('GET /internal/search_inference_endpoints/connectors', () => {
   const mockLogger = loggingSystemMock.createLogger().get();
   let mockRouter: MockRouter;
@@ -58,7 +66,10 @@ describe('GET /internal/search_inference_endpoints/connectors', () => {
   let getConnectorList: jest.Mock;
   let getConnectorById: jest.Mock;
 
-  const registerRoute = (settings: SettingsValues = {}) => {
+  const registerRoute = (
+    settings: SettingsValues = {},
+    featureRegistry: InferenceFeatureRegistry = makeFeatureRegistry()
+  ) => {
     mockRouter = new MockRouter({
       context: createContext(settings),
       method: 'get',
@@ -68,6 +79,7 @@ describe('GET /internal/search_inference_endpoints/connectors', () => {
     defineInferenceConnectorsRoute({
       logger: mockLogger,
       router: mockRouter.router,
+      featureRegistry,
       getForFeature,
       getConnectorList,
       getConnectorById,
@@ -348,6 +360,34 @@ describe('GET /internal/search_inference_endpoints/connectors', () => {
     expect(mockRouter.response.ok).toHaveBeenCalledWith({
       body: {
         connectors: [],
+        soEntryFound: false,
+      },
+    });
+  });
+
+  it('returns the full feature list when ignoreGlobalDefault is true even with defaultConnectorOnly set', async () => {
+    const recommended = inferenceConnector('rec');
+    const other = inferenceConnector('other');
+    const defaultConnector = inferenceConnector('default-id');
+    getForFeature.mockResolvedValue({
+      endpoints: [recommended],
+      warnings: [],
+      soEntryFound: false,
+    });
+    getConnectorList.mockResolvedValue([recommended, other]);
+    getConnectorById.mockResolvedValue(defaultConnector);
+    registerRoute(
+      { defaultConnectorId: 'default-id', defaultConnectorOnly: true },
+      makeFeatureRegistry(true)
+    );
+
+    await mockRouter.callRoute({ query: { featureId: 'my_feature' } });
+
+    expect(getForFeature).toHaveBeenCalledTimes(1);
+    expect(getConnectorList).toHaveBeenCalledTimes(1);
+    expect(mockRouter.response.ok).toHaveBeenCalledWith({
+      body: {
+        connectors: [{ ...recommended, isRecommended: true }, other],
         soEntryFound: false,
       },
     });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/routes/inference_connectors.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/routes/inference_connectors.ts
@@ -11,18 +11,21 @@ import type { InferenceConnector } from '@kbn/inference-common';
 import { APIRoutes } from '../../common/types';
 import { ROUTE_VERSIONS } from '../../common/constants';
 import type { ResolvedInferenceEndpoints } from '../types';
+import type { InferenceFeatureRegistry } from '../inference_feature_registry';
 import { errorHandler } from '../utils/error_handler';
 import { resolveModelsForFeature } from '../lib/resolve_models_for_feature';
 
 export const defineInferenceConnectorsRoute = ({
   logger,
   router,
+  featureRegistry,
   getForFeature,
   getConnectorList,
   getConnectorById,
 }: {
   logger: Logger;
   router: IRouter;
+  featureRegistry: InferenceFeatureRegistry;
   getForFeature: (featureId: string, request: KibanaRequest) => Promise<ResolvedInferenceEndpoints>;
   getConnectorList: (request: KibanaRequest) => Promise<InferenceConnector[]>;
   getConnectorById: (id: string, request: KibanaRequest) => Promise<InferenceConnector>;
@@ -58,6 +61,7 @@ export const defineInferenceConnectorsRoute = ({
       errorHandler(logger)(async (context, request, response) => {
         const { featureId } = request.query;
         const uiSettingsClient = (await context.core).uiSettings.client;
+        const feature = featureRegistry.get(featureId);
 
         const result = await resolveModelsForFeature({
           getForFeature: (fId) => getForFeature(fId, request),
@@ -65,6 +69,7 @@ export const defineInferenceConnectorsRoute = ({
           getConnectorById: (id) => getConnectorById(id, request),
           uiSettingsClient,
           featureId,
+          ignoreGlobalDefault: feature?.ignoreGlobalDefault ?? false,
           logger,
         });
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
@@ -25,6 +25,13 @@ export interface InferenceFeatureConfig {
   recommendedEndpoints: string[];
   isTechPreview?: boolean;
   isBeta?: boolean;
+  /**
+   * When true, this feature is excluded from global-default-connector behaviour:
+   * the global default is never prepended to its model list, and the feature is
+   * shown in the Feature Settings UI even when "Only allow the default model" mode
+   * is active.  This is a developer-set flag and is not exposed to end users.
+   */
+  ignoreGlobalDefault?: boolean;
   visibilityCondition?: {
     key: string;
     value: string | number | boolean | null;


### PR DESCRIPTION
## Summary

Implements [search-team#14228](https://github.com/elastic/search-team/issues/14228).

Adds an `ignoreGlobalDefault?: boolean` flag to `InferenceFeatureConfig` so features (e.g. Significant Events running via Task Manager) can opt out of the global default connector at registration time.

### Changes

- **`InferenceFeatureConfig` / `InferenceFeatureResponse`**: new optional `ignoreGlobalDefault` field
- **`resolveModelsForFeature`**: skips the "default only" short-circuit and global-default prepend when `ignoreGlobalDefault: true`
- **`defineInferenceConnectorsRoute`**: forwards the flag from `InferenceFeatureRegistry` to the resolver
- **`plugin.ts` `endpoints.getForFeature`**: same forwarding
- **UI `model_settings.tsx`**: splits sections into opt-out and regular groups — opt-out sections always render when AI is enabled; an `EuiCallOut` explains the exception when "default only" mode is active
- **`feature_section.tsx` / `sub_feature_card.tsx`**: `globalDefaultId` prop widened to `string | undefined`

### Behaviour

| Scenario | `ignoreGlobalDefault: false` (default) | `ignoreGlobalDefault: true` |
|---|---|---|
| `defaultConnectorOnly: true` | Returns only the global default | Returns full feature connector list |
| No SO override | Global default prepended | No global default prepended |
| Feature Settings UI in "default only" mode | Feature section hidden | Feature section always visible + callout shown |

### Test plan

- [ ] `yarn kbn bootstrap` (worktree has no node_modules)
- [ ] `node scripts/type_check --project x-pack/platform/plugins/shared/search_inference_endpoints/tsconfig.json`
- [ ] `node scripts/eslint --fix $(git diff main...HEAD --name-only)`
- [ ] `node scripts/jest x-pack/platform/plugins/shared/search_inference_endpoints`
- [ ] `node scripts/i18n_check --fix`
- [ ] `node scripts/check_changes.ts`


Made with [Cursor](https://cursor.com)