### PR TITLE
[ci] Do not ingest test logs by default

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -92,6 +92,10 @@ if is_pr; then
   if is_pr_with_label "ci:security-genai-run-evals-local-prompts"; then
     export IS_SECURITY_AI_PROMPT_TEST=true
   fi
+
+  if is_pr_with_label "ci:ingest-test-logs"; then
+    export CI_STATS_INGEST_TEST_LOGS=true
+  fi
   
   export BUILD_URL="$BUILDKITE_BUILD_URL"
 

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/ci_stats_ftr_reporter.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/reporter/ci_stats_ftr_reporter.ts
@@ -90,7 +90,10 @@ export function setupCiStatsFtrTestGroupReporter({
       result: runnable.isFailed() ? 'fail' : runnable.isPending() ? 'skip' : 'pass',
       type,
       error: error?.stack,
-      stdout: getSnapshotOfRunnableLogs(runnable),
+      stdout:
+        process.env.CI_STATS_INGEST_TEST_LOGS === 'true'
+          ? getSnapshotOfRunnableLogs(runnable)
+          : undefined,
     });
   }
 

--- a/src/platform/packages/shared/kbn-test/src/jest/ci_stats_jest_reporter.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/ci_stats_jest_reporter.ts
@@ -127,7 +127,10 @@ export default class CiStatsJestReporter extends BaseReporter {
         suites: t.ancestorTitles,
         type: 'test',
         error: t.failureMessages.join('\n\n'),
-        stdout: testResult.console?.map(formatConsoleLine).join('\n'),
+        stdout:
+          process.env.CI_STATS_INGEST_TEST_LOGS === 'true'
+            ? testResult.console?.map(formatConsoleLine).join('\n')
+            : undefined,
       });
     }
   }


### PR DESCRIPTION
These logs aren't needed at the level of continuous ingestion.  This skips attaching stdouts unless the label `ci:ingest-test-logs` is added.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->