### PR TITLE
[ci] Move moon cache to GCS

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -25,7 +25,7 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
   fi
   # Check if there's a cache artifact uploaded from a previous step
   if [[ -z "${KBN_BOOTSTRAP_NO_PREBUILT:-}" ]]; then
-    if download_tmp_artifact moon-cache.tar.zst "$HOME" "$BUILDKITE_BUILD_ID"; then
+    if download_tmp_artifact moon-cache.tar.zst "$HOME" "$BUILDKITE_BUILD_ID" false; then
       echo "Found moon-cache.tar.zst artifact, extracting to ./.moon/cache"
       mkdir -p ./.moon/cache
       echo "Extracting moon-cache.tar.zst to ./.moon/cache"

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -25,7 +25,7 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
   fi
   # Check if there's a cache artifact uploaded from a previous step
   if [[ -z "${KBN_BOOTSTRAP_NO_PREBUILT:-}" ]]; then
-    if (buildkite-agent artifact download --step "store_cache" "moon-cache.tar.zst" ~/); then
+    if download_tmp_artifact moon-cache.tar.zst "$HOME" "$BUILDKITE_BUILD_ID"; then
       echo "Found moon-cache.tar.zst artifact, extracting to ./.moon/cache"
       mkdir -p ./.moon/cache
       echo "Extracting moon-cache.tar.zst to ./.moon/cache"

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -189,7 +189,7 @@ download_artifact() {
 
 GCS_CI_ARTIFACT_REGIONS=("asia-south2" "europe-west2" "northamerica-northeast2" "southamerica-east1" "us-central1" "us-east1" "us-west1")
 download_tmp_artifact() {
-  local artifact_name="$1" dest_dir="$2" build_id="$3"
+  local artifact_name="$1" dest_dir="$2" build_id="$3" fallback="${4:-true}"
   local region use_gcs=false
 
   for region in "${GCS_CI_ARTIFACT_REGIONS[@]}"; do
@@ -207,6 +207,10 @@ download_tmp_artifact() {
       return 0
     fi
     echo "GCS download failed for ${artifact_name} from kibana-ci-artifacts-${BUILDKITE_AGENT_GCP_REGION} (build ${build_id})."
+  fi
+
+  if [[ "$fallback" != "true" ]]; then
+    return 1
   fi
 
   echo "Falling back to Buildkite artifact download for ${artifact_name} (build ${build_id})."

--- a/.buildkite/scripts/steps/store_cache.sh
+++ b/.buildkite/scripts/steps/store_cache.sh
@@ -14,6 +14,6 @@ if [[ ! -d .moon/cache ]]; then
 else
   tar -cf ~/moon-cache.tar.zst -I 'zstd -19 -T0' .moon/cache || echo "Failed to archive moon cache"
   cd ~/
-  buildkite-agent artifact upload moon-cache.tar.zst || echo "Failed to upload moon cache"
+  upload_tmp_artifact ~/moon-cache.tar.zst moon-cache.tar.zst "$BUILDKITE_BUILD_ID" || echo "Failed to upload moon cache"
   echo "Moon cache archived as moon-cache.tar.zst"
 fi


### PR DESCRIPTION
Part of an effort to move shared files between build agents to temporary storage on GCS, where we can more closely manage regions and lifecycles.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->