### PR TITLE
[FTR] Collect per-method timing across providers

### DIFF
--- a/.buildkite/scripts/lifecycle/aggregate_ftr_timing.ts
+++ b/.buildkite/scripts/lifecycle/aggregate_ftr_timing.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { execSync } from 'child_process';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+interface TimingRow {
+  name: string;
+  calls: number;
+  totalMs: number;
+  meanMs: number;
+  minMs: number;
+  maxMs: number;
+}
+
+const DOWNLOAD_DIR = 'target/ftr-timing-parts';
+const OUT_FILE = 'target/test-metrics/ftr-service-timing-aggregate.ndjson';
+
+const exec = (cmd: string) => execSync(cmd, { stdio: 'inherit' });
+const tryExec = (cmd: string) => {
+  try {
+    execSync(cmd, { stdio: 'inherit' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+mkdirSync(DOWNLOAD_DIR, { recursive: true });
+mkdirSync('target/test-metrics', { recursive: true });
+
+// Each test job uploads a file named ftr-service-timing-<job-id>.ndjson so that
+// the Buildkite agent can distinguish them (downloading an exact filename fails
+// with "Multiple artifacts found" when several jobs emit the same path).
+const downloaded = tryExec(
+  `.buildkite/scripts/common/download_artifact.sh --include-retried-jobs "target/test-metrics/ftr-service-timing-*.ndjson" "${DOWNLOAD_DIR}"`
+);
+if (!downloaded) {
+  console.log('No ftr-service-timing-*.ndjson artifacts found; skipping aggregation.');
+  process.exit(0);
+}
+
+const aggregate = new Map<string, Omit<TimingRow, 'name' | 'meanMs'>>();
+
+for (const file of readdirSync(DOWNLOAD_DIR, { recursive: true }) as string[]) {
+  if (!file.endsWith('.ndjson')) continue;
+  const content = readFileSync(join(DOWNLOAD_DIR, file), 'utf8');
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    const row: TimingRow = JSON.parse(line);
+    const existing = aggregate.get(row.name);
+    if (existing) {
+      existing.calls += row.calls;
+      existing.totalMs += row.totalMs;
+      existing.minMs = Math.min(existing.minMs, row.minMs);
+      existing.maxMs = Math.max(existing.maxMs, row.maxMs);
+    } else {
+      aggregate.set(row.name, {
+        calls: row.calls,
+        totalMs: row.totalMs,
+        minMs: row.minMs,
+        maxMs: row.maxMs,
+      });
+    }
+  }
+}
+
+const rows = [...aggregate.entries()]
+  .map(([name, s]) => ({
+    name,
+    calls: s.calls,
+    totalMs: s.totalMs,
+    meanMs: Math.round(s.totalMs / s.calls),
+    minMs: s.minMs,
+    maxMs: s.maxMs,
+  }))
+  .sort((a, b) => b.totalMs - a.totalMs);
+
+writeFileSync(OUT_FILE, rows.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf8');
+
+console.log(`Aggregated ${aggregate.size} methods from ${rows.length} entries → ${OUT_FILE}`);
+exec(`buildkite-agent artifact upload "${OUT_FILE}"`);

--- a/.buildkite/scripts/lifecycle/post_build.sh
+++ b/.buildkite/scripts/lifecycle/post_build.sh
@@ -14,6 +14,12 @@ if [[ "${BUILDKITE_RETRY_COUNT:-0}" == "0" ]]; then
   ts-node "$(dirname "${0}")/ci_stats_complete.ts"
 fi
 
+PR_LABELS="${GITHUB_PR_LABELS:-$(buildkite-agent meta-data get "ingest:pr_labels" 2>/dev/null || true)}"
+
+if [[ "$PR_LABELS" == *"ci:collect-ftr-timing"* ]]; then
+  ts-node "$(dirname "${0}")/aggregate_ftr_timing.ts"
+fi
+
 if [[ "${GITHUB_PR_NUMBER:-}" ]]; then
   DOCS_CHANGES_URL="https://kibana_bk_$GITHUB_PR_NUMBER}.docs-preview.app.elstc.co/diff"
   DOCS_CHANGES=$(curl --connect-timeout 10 -m 10 -sf "$DOCS_CHANGES_URL" || echo '')

--- a/.buildkite/scripts/lifecycle/post_build.sh
+++ b/.buildkite/scripts/lifecycle/post_build.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source .buildkite/scripts/common/util.sh
+
 BUILD_SUCCESSFUL=$(ts-node "$(dirname "${0}")/build_status.ts")
 export BUILD_SUCCESSFUL
 
@@ -14,9 +16,7 @@ if [[ "${BUILDKITE_RETRY_COUNT:-0}" == "0" ]]; then
   ts-node "$(dirname "${0}")/ci_stats_complete.ts"
 fi
 
-PR_LABELS="${GITHUB_PR_LABELS:-$(buildkite-agent meta-data get "ingest:pr_labels" 2>/dev/null || true)}"
-
-if [[ "$PR_LABELS" == *"ci:collect-ftr-timing"* ]]; then
+if is_pr_with_label "ci:collect-ftr-timing"; then
   ts-node "$(dirname "${0}")/aggregate_ftr_timing.ts"
 fi
 

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/functional_test_runner.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/functional_test_runner.ts
@@ -23,6 +23,9 @@ import {
   SuiteTracker,
   EsVersion,
   DedicatedTaskRunner,
+  ftrTimingRegistry,
+  ftrTimingEnabled,
+  activateTiming,
 } from './lib';
 import { createEsClientForFtrConfig } from '../ftr_es_client';
 
@@ -63,6 +66,17 @@ export class FunctionalTestRunner {
           await this.validateEsVersion();
         }
         await providers.loadAll();
+
+        if (ftrTimingEnabled) {
+          const jobId = process.env.BUILDKITE_JOB_ID ?? `local-${Date.now()}`;
+          const timingFile = Path.resolve(
+            REPO_ROOT,
+            `target/test-metrics/ftr-service-timing-${jobId}.ndjson`
+          );
+          lifecycle.cleanup.add(() => {
+            ftrTimingRegistry.writeToFile(timingFile);
+          });
+        }
       }
 
       const customTestRunner = this.config.get('testRunner');
@@ -120,6 +134,9 @@ export class FunctionalTestRunner {
       }
 
       this.log.info('Starting tests');
+      if (ftrTimingEnabled) {
+        activateTiming();
+      }
       return await runTests(lifecycle, mocha, abortSignal);
     });
   }

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/providers/ftr_timing_registry.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/providers/ftr_timing_registry.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { appendFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+const LABEL = 'ci:collect-ftr-timing';
+
+export const ftrTimingEnabled = (process.env.GITHUB_PR_LABELS ?? '').split(',').includes(LABEL);
+
+// Timing wrappers must be transparent during test definition (e.g. setupMocha/loadTests)
+// because callsites()-based file detection in test helpers like APM's registry.ts uses
+// callsites()[1] to identify the caller. An active wrapper function would shift that
+// frame and cause incorrect file attribution. Call activateTiming() only after all
+// test files are loaded (i.e. just before runTests).
+let timingActive = false;
+export const activateTiming = () => {
+  timingActive = true;
+};
+
+interface TimingEntry {
+  calls: number;
+  totalMs: number;
+  minMs: number;
+  maxMs: number;
+}
+
+export class FtrTimingRegistry {
+  private readonly entries = new Map<string, TimingEntry>();
+
+  record(name: string, durationMs: number) {
+    const entry = this.entries.get(name);
+    if (entry) {
+      entry.calls++;
+      entry.totalMs += durationMs;
+      if (durationMs < entry.minMs) entry.minMs = durationMs;
+      if (durationMs > entry.maxMs) entry.maxMs = durationMs;
+    } else {
+      this.entries.set(name, {
+        calls: 1,
+        totalMs: durationMs,
+        minMs: durationMs,
+        maxMs: durationMs,
+      });
+    }
+  }
+
+  writeToFile(filePath: string) {
+    if (this.entries.size === 0) return;
+
+    const rows = [...this.entries.entries()]
+      .map(([name, s]) => ({
+        name,
+        calls: s.calls,
+        totalMs: Math.round(s.totalMs),
+        meanMs: Math.round(s.totalMs / s.calls),
+        minMs: Math.round(s.minMs),
+        maxMs: Math.round(s.maxMs),
+      }))
+      .sort((a, b) => b.totalMs - a.totalMs);
+
+    mkdirSync(dirname(filePath), { recursive: true });
+    appendFileSync(filePath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf8');
+  }
+}
+
+export const ftrTimingRegistry = new FtrTimingRegistry();
+
+/**
+ * Wraps every method on `instance` in a timing proxy that records each call's
+ * wall-clock duration into `ftrTimingRegistry`. Skips `init` so that
+ * `isAsyncInstance` detection continues to work on async providers.
+ *
+ * Only called when `ftrTimingEnabled` is true.
+ */
+export function createTimingProxy(
+  name: string,
+  instance: { [k: string | symbol]: any }
+): typeof instance {
+  return new Proxy(instance, {
+    get(_, prop, receiver) {
+      const value = Reflect.get(instance, prop, receiver);
+
+      if (typeof value !== 'function' || prop === 'init' || typeof prop === 'symbol') {
+        return value;
+      }
+
+      if (!timingActive) {
+        return value;
+      }
+
+      const wrapper = function (...args: any[]) {
+        const start = Date.now();
+        const methodName = `${name}.${String(prop)}`;
+        let returned: any;
+        try {
+          // Bind to instance (not the proxy) so that internal `this.foo` accesses
+          // bypass the proxy and avoid wrapping things like axios instances.
+          returned = value.apply(instance, args);
+        } catch (err) {
+          ftrTimingRegistry.record(methodName, Date.now() - start);
+          throw err;
+        }
+        if (returned instanceof Promise) {
+          return returned.finally(() => {
+            ftrTimingRegistry.record(methodName, Date.now() - start);
+          });
+        }
+        ftrTimingRegistry.record(methodName, Date.now() - start);
+        return returned;
+      };
+      // Forward property access on the wrapper to the original function so that
+      // sub-properties like `fn.skip` remain accessible.
+      return new Proxy(wrapper, {
+        get(_target, p) {
+          return Reflect.get(value, p);
+        },
+      });
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/providers/index.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/providers/index.ts
@@ -11,3 +11,4 @@ export { ProviderCollection } from './provider_collection';
 export * from './read_provider_spec';
 export { createAsyncInstance } from './async_instance';
 export type { Provider } from './read_provider_spec';
+export { ftrTimingRegistry, ftrTimingEnabled, activateTiming } from './ftr_timing_registry';

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/providers/provider_collection.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/providers/provider_collection.ts
@@ -15,6 +15,7 @@ import type { Providers, ProviderFn } from './read_provider_spec';
 import { isProviderConstructor } from './read_provider_spec';
 import { createVerboseInstance } from './verbose_instance';
 import { instrumentProvider } from './instrument_provider';
+import { createTimingProxy, ftrTimingEnabled } from './ftr_timing_registry';
 
 export class ProviderCollection {
   static callProviderFn(providerFn: ProviderFn, ctx: any) {
@@ -113,11 +114,11 @@ export class ProviderCollection {
           instance &&
           typeof instance === 'object'
         ) {
-          instance = createVerboseInstance(
-            this.log,
-            type === 'PageObject' ? `PageObjects.${name}` : name,
-            instance
-          );
+          const displayName = type === 'PageObject' ? `PageObjects.${name}` : name;
+          if (ftrTimingEnabled) {
+            instance = createTimingProxy(displayName, instance);
+          }
+          instance = createVerboseInstance(this.log, displayName, instance);
         }
 
         instances.set(provider, instance);


### PR DESCRIPTION
Adds a timing proxy that wraps all FTR provider and page object methods, recording wall-clock stats (calls, totalMs, min, max) per method name. Gated on the `ci:collect-ftr-timing` PR label with zero overhead otherwise. Results are written per-job to `target/test-metrics/ftr-service-timing.ndjson` and aggregated into a single build artifact by a new `post-build` step.

Updates #269385
