### PR TITLE
test(entity-analytics-evals): add distractor spec for V2 skill routing

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v2/entity_store_v2_distractors.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/evals/v2/entity_store_v2_distractors.spec.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-security';
+import { evaluate } from '../../src/evaluate';
+
+/**
+ * Entity Store V2 - distractor (negative) routing evals.
+ *
+ * Companion to the positive-routing specs (`entity_store_v2_search_entities`,
+ * `entity_store_v2_get_entity`, `entity_store_v2_multi_skill`). These examples
+ * verify that the entity-analytics skill is NOT invoked and that
+ * `security.search_entities` / `security.get_entity` are NOT called for
+ * questions that look superficially entity-related (mention "user", "host",
+ * "risk", "entity") but actually concern other domains — Kibana platform
+ * assets, observability data, threat-hunting investigations, ML configuration,
+ * or off-topic prompts.
+ *
+ * Why this matters: per `kbn-evals` conventions, distractors improve skill
+ * selection accuracy and reduce false positives. Without them, the eval suite
+ * only measures recall (does the skill fire when it should?) but not
+ * precision (does it stay quiet when it shouldn't?). False activations are
+ * expensive: they spend tokens, surface irrelevant entity data, and erode user
+ * trust in the agent's routing.
+ *
+ * Enforcement: assertions are LLM-judged via the `criteria` array. The
+ * framework does not currently expose a native "must NOT call X" assertion,
+ * so each example pins a `criteria` line that explicitly forbids the
+ * entity-analytics tool calls and instructs the judge to confirm the
+ * conversation steps respect the constraint. The `metadata.shouldNotActivateSkill`
+ * field is annotation-only — it documents reviewer intent and lets dataset
+ * filters segregate negative tests, but does not by itself fail the example.
+ *
+ * Dataset categories represented (one example per row keeps reviewer scan
+ * fast; expand within a category if a regression motivates it):
+ *   1. Kibana platform / asset queries (dashboards, indices)
+ *   2. Observability queries (APM, logs)
+ *   3. Lexical lures — words that look entity-shaped in non-entity contexts
+ *      (Kibana auth audit user count, Elasticsearch host as deployment
+ *      target, "risk" appetite as a non-security usage)
+ *   4. Adjacent security skills the agent should route to instead
+ *      (threat-hunting, alert-analysis, ML configuration)
+ *   5. Off-topic / out-of-scope prompts
+ */
+evaluate.describe(
+  'SIEM Entity Analytics V2 Skill - Distractors',
+  { tag: tags.serverless.security.complete },
+  () => {
+    evaluate(
+      'entity store v2: distractor questions do not activate entity tools',
+      async ({ evaluateDataset }) => {
+        await evaluateDataset({
+          dataset: {
+            name: 'entity-analytics-v2: distractors',
+            description:
+              'Negative tests: queries that should NOT invoke security.search_entities or security.get_entity, even when they superficially mention "entity", "user", "host", or "risk". Improves precision of the entity-analytics skill selector by giving the dataset a "stay quiet" signal alongside the positive activation signals in the sibling specs.',
+            examples: [
+              // ───────────────────────────────────────────────────────────
+              // 1. Kibana platform / asset queries
+              // ───────────────────────────────────────────────────────────
+              {
+                input: {
+                  question: 'Show me the available dashboards in Kibana.',
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity — this is a Kibana asset discovery query, not an entity-store risk lookup.',
+                    'Either route to a Kibana platform tool (e.g. dashboards/find), explain that the agent does not have access to a dashboards listing tool, or suggest the in-product navigation. Do not fabricate dashboard names or counts.',
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+              {
+                input: {
+                  question:
+                    'Which indices are available in this cluster? List anything starting with "logs-".',
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity — this is an Elasticsearch index discovery query, unrelated to the entity store.',
+                    'Either route to an index-listing capability (e.g. platform.core.list_indices) or explain the agent does not have one available. Do not fabricate index names.',
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+
+              // ───────────────────────────────────────────────────────────
+              // 2. Observability queries
+              // ───────────────────────────────────────────────────────────
+              {
+                input: {
+                  question: 'What is the current status of my APM services?',
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity — APM service health is an observability concern, not a security entity-store concern.',
+                    "Either route to an observability tool/skill or explain that this is outside the security agent's scope. Do not fabricate service names or health metrics.",
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+
+              // ───────────────────────────────────────────────────────────
+              // 3. Lexical lures — entity-shaped words in non-entity contexts
+              // ───────────────────────────────────────────────────────────
+              {
+                input: {
+                  question:
+                    'How many users have logged in to Kibana itself today? I want to see Kibana audit activity.',
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity — this asks about Kibana platform login audit, not entity-store risk profiles for monitored users.',
+                    "Either route to a Kibana audit log capability or explain that this is a platform-audit question and not the agent's entity-store responsibility. Do not invent user counts.",
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+              {
+                input: {
+                  question:
+                    'How do I add a new Elasticsearch host to my cluster? I have a fresh node ready to join.',
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity — "host" here means an Elasticsearch cluster node, not a monitored host entity in the entity store.',
+                    'Provide cluster-management guidance (or link out to the relevant docs) without invoking entity-analytics tools.',
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+              {
+                input: {
+                  question:
+                    "What is our team's risk appetite for adopting new SaaS vendors? I need to draft a procurement policy.",
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity — "risk appetite" here is an organisational/policy concept, not an entity risk score in the entity store.',
+                    "Acknowledge the question is outside the agent's data scope, or offer general policy-shape guidance, without touching entity-analytics tools.",
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+
+              // ───────────────────────────────────────────────────────────
+              // 4. Adjacent security skills the agent should route to instead
+              // ───────────────────────────────────────────────────────────
+              {
+                input: {
+                  question:
+                    'Hunt for unusual outbound network connections from our endpoints over the last 24 hours.',
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity — this is a threat-hunting query that should activate the threat-hunting skill (ES|QL over endpoint/network logs), not the entity-analytics skill.',
+                    'Either describe the threat-hunting approach or route to threat-hunting tools. Do not invoke entity-store lookups as a substitute for log analysis.',
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+              {
+                input: {
+                  question:
+                    'Walk me through triaging this critical "Suspicious PowerShell" alert on host WIN-DC01: alert id alert-12345.',
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity as the primary action — this is an alert-triage workflow that should route to the alert-analysis skill (security.alerts and friends).',
+                    'It is acceptable for alert-analysis to subsequently call entity tools as part of its workflow, but the primary skill activation must be alert-analysis, not entity-analytics. The model should not jump straight to entity lookups for the host without first inspecting the alert.',
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+              {
+                input: {
+                  question:
+                    'Which ML jobs are currently running for security anomaly detection? I want to confirm the lateral movement detection module is enabled.',
+                },
+                output: {
+                  criteria: [
+                    'Do not call security.search_entities or security.get_entity — this is a pure ML configuration / job-status question, with no entity-store dimension.',
+                    'Route to find.security.ml.jobs or an equivalent ML status capability. Do not invent job names or statuses.',
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+
+              // ───────────────────────────────────────────────────────────
+              // 5. Off-topic / out-of-scope prompts
+              // ───────────────────────────────────────────────────────────
+              {
+                input: {
+                  question: "What's the weather in San Francisco today?",
+                },
+                output: {
+                  criteria: [
+                    "Do not call security.search_entities or security.get_entity — this is unrelated to the security agent's domain.",
+                    "Decline politely or explain the agent's scope. Do not fabricate weather data or invoke any security tools.",
+                  ],
+                },
+                metadata: {
+                  query_intent: 'Distractor',
+                  shouldNotActivateSkill: 'entity-analytics',
+                },
+              },
+            ],
+          },
+        });
+      }
+    );
+  }
+);

--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/src/evaluate_dataset.ts
@@ -68,7 +68,17 @@ interface DatasetExample extends Example {
     toolCalls?: ToolCallAssertion[];
     attachments?: AttachmentAssertion[];
   };
-  metadata?: { query_intent?: string };
+  metadata?: {
+    query_intent?: string;
+    /**
+     * Annotation-only marker for distractor / negative examples — names the skill
+     * that MUST NOT be invoked. Not enforced by an evaluator (the criteria array
+     * does the actual enforcement); used by reviewers and dataset filters to
+     * recognise an example as a negative test. Keep in sync with the canonical
+     * skill `name` (e.g. `entity-analytics`).
+     */
+    shouldNotActivateSkill?: string;
+  };
 }
 
 interface ChatTaskOutput {


### PR DESCRIPTION
## Summary

Adds `entity_store_v2_distractors.spec.ts` to the entity-analytics V2 evaluation suite. The file contains 10 negative-routing examples — questions that mention entity-shaped words ("user", "host", "risk", "entity") in contexts where `security.search_entities` and `security.get_entity` should NOT be called.

It's a companion to the three existing positive-routing specs (`entity_store_v2_search_entities`, `entity_store_v2_get_entity`, `entity_store_v2_multi_skill`), which only assert that the right tools fire when they should. The new file gives the suite a complementary "should not fire" surface.

## Honest scope of evidence

I have **not** run this dataset against a live Agent Builder. Today's false-activation rate for the entity-analytics skill on these prompts is therefore unknown. This PR is the **discovery seam** — the first eval run will produce the actual evidence (which prompts are mis-routed today, if any), and the next iteration can decide whether the current 10 examples are the right ones, need to be expanded, or need to be tightened.

What I can defend today:

- The 10 examples are well-formed against the suite's existing `DatasetExample` shape (`criteria` + `toolCalls` + `metadata`).
- The metadata interface widening (`shouldNotActivateSkill?: string`) is backwards-compatible and additive — existing examples continue to compile unchanged.
- Tool IDs referenced in the spec (`security.search_entities`, `security.get_entity`, `find.security.ml.jobs`) are verified against the registered IDs in the codebase.
- CI lint + type-check is the appropriate gate for landing the dataset itself.

What I **cannot** defend without running the evals:

- That precision will improve.
- That today's false-activation rate is nonzero on any of these 10 prompts.
- That this set of 10 is sufficient (or even the right shape) to catch the precision regression it targets.

The right next step is a real eval run against a configured Kibana + Agent Builder; I'll post results as a follow-up comment on this PR when I have them, and the dataset can be tightened or expanded in a fixup commit.

## What's in the spec

10 examples across 5 categories. Each example forbids the entity-analytics tool calls explicitly via the `criteria` array and either routes the model to the correct alternate tool/skill or asks it to decline gracefully:

| Category | Example question | Why it's a lure |
|---|---|---|
| **Kibana platform** | _Show me the available dashboards in Kibana._ | Asset discovery, not entity-store |
| **Kibana platform** | _Which indices are available in this cluster?_ | ES index listing, not entity-store |
| **Observability** | _What is the current status of my APM services?_ | Different solution domain |
| **Lexical lure** | _How many users have logged in to Kibana itself today?_ | "users" = Kibana auth audit, not monitored entities |
| **Lexical lure** | _How do I add a new Elasticsearch host to my cluster?_ | "host" = ES node, not monitored entity |
| **Lexical lure** | _What is our team's risk appetite for adopting new SaaS vendors?_ | "risk" = policy concept, not entity risk score |
| **Adjacent skill** | _Hunt for unusual outbound network connections..._ | Routes to `threat-hunting` skill |
| **Adjacent skill** | _Walk me through triaging this critical 'Suspicious PowerShell' alert..._ | Routes to `alert-analysis` skill |
| **Adjacent skill** | _Which ML jobs are currently running for security anomaly detection?_ | Routes to `find.security.ml.jobs` |
| **Off-topic** | _What's the weather in San Francisco today?_ | Out of scope |

## Enforcement model

The framework currently has no native "must NOT call X" assertion, so:

- **Active enforcement** — the `criteria` array tells the LLM judge to confirm the conversation steps respect the constraint (the judge has access to `output.steps`). Every example pins a `criteria` line that explicitly forbids the entity-analytics tool calls.
- **Annotation-only** — `metadata.shouldNotActivateSkill: 'entity-analytics'` documents reviewer intent and lets dataset filters segregate negative from positive tests, but does not by itself fail the example.

If false-activation rate becomes a regression target tracked over time, a follow-up could add a `mustNotCall: string[]` field to `DatasetExample.output` and a small evaluator that hard-fails on any forbidden tool call. Out of scope for this PR — the LLM-judge approach is consistent with the suite's existing `criteria`-based shape and adds zero new evaluator surface.

## Side-quest: multi-skill spec audit

While here, I read `entity_store_v2_multi_skill.spec.ts` (4 examples covering `security.search_entities` / `security.get_entity` × `find.security.ml.jobs` combos). Findings — none gated this PR, all are follow-up candidates:

| # | Severity | Finding | Recommendation |
|---|---|---|---|
| 1 | ✅ verified | Tool ID `find.security.ml.jobs` matches the registered ID at [`find_security_ml_jobs.ts:23,139`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_security_ml_jobs/inline_tools/find_security_ml_jobs/find_security_ml_jobs.ts#L23). | None. |
| 2 | minor | All 4 examples carry `metadata.query_intent: 'Factual'` — no discrimination from the search/get-entity specs that also use `Factual`. | Use `'Multi-Skill Routing'` or `'Cross-Domain'` so dataset filters can scope to multi-skill regressions. |
| 3 | minor | No `metadata.expectedSkill` annotation. | Add `expectedSkills: ['entity-analytics', 'find-security-ml-jobs']` once the skill-invocation evaluator supports an array. |
| 4 | minor | Criteria text interpolates `padJobIds.slice(0, 2)` / `lmdJobIds.slice(0, 2)` — if those arrays are reordered, the example IDs surfaced to the LLM judge change silently. | Pin a stable subset, or describe the job category by name and let the judge accept any ID from that category. Mild — the criteria string is constructed at runtime, so the test stays in sync; only `git blame` on the spec gets noisier. |
| 5 | minor | No tool-call ordering enforced. The natural order for "find high-risk entities AND check for anomalies" is `search_entities` → `find.security.ml.jobs`, but the criteria don't say so. | Document that order is not enforced (current behaviour) or add an ordering criterion. Probably fine as-is — both tools must be called, and order doesn't affect correctness of the answer. |
| 6 | gap | No multi-skill chaining of two entity-analytics tools (e.g. `search_entities` → `get_entity` for "find the riskiest user, then show me their full profile"). All 4 multi-skill examples are entity-analytics + ML. | Add a second multi-skill class once the use case becomes important. |
| 7 | gap | No use of `acceptableAlternativeToolIds` (supported in `evaluate_dataset.ts`). For ML, an alternative could be a generic ML-info path. | Optional, only worth adding if a real alternative tool exists today. |
| 8 | gap | No "ML-only" routing test inside the multi-skill spec (e.g. "show me current ML anomalies" with no entity context — should route to ML alone, not entity-analytics). | Either add a single example here or split into an ML-only spec. |

## Test plan

- [ ] CI lint + type-check pass (the new spec is test-only TS; the `evaluate_dataset.ts` change is a backwards-compatible field addition to an internal interface).
- [ ] Existing positive specs continue to pass (no production code touched, no shared-fixture changes).
- [ ] **Required before claiming any precision improvement:** Run the dataset against a real Kibana + Agent Builder, capture per-example pass/fail, and post results as a follow-up comment on this PR. Until that happens, the precision claim stays unsubstantiated.

## Dependency on PR #269193

None. This PR is authored against `main` and does not depend on the observability-wiring PR being merged. The two PRs touch the same suite but in non-conflicting locations (#269193 modifies `evaluate.ts` + the evaluator list in `evaluate_dataset.ts`; this PR adds a spec file + widens an unrelated interface in `evaluate_dataset.ts`). They will rebase cleanly in either order.
