### PR TITLE
[ES|QL] Abort request on Monaco cancellation signal

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -200,11 +200,11 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
 // refresh the esql cache entry after 10 minutes
 const CACHE_INVALIDATE_DELAY = 10 * 60 * 1000;
 
-export const clearCacheWhenOld = (cache: MapCache, esqlQuery: string) => {
-  if (cache.has(esqlQuery)) {
-    const cacheEntry = cache.get(esqlQuery);
+export const clearCacheWhenOld = (cache: MapCache, key: string) => {
+  if (cache.has(key)) {
+    const cacheEntry = cache.get(key);
     if (Date.now() - cacheEntry.timestamp > CACHE_INVALIDATE_DELAY) {
-      cache.delete(esqlQuery);
+      cache.delete(key);
     }
   }
 };

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.ts
@@ -33,6 +33,7 @@ import type { ESQLEditorDeps } from '../types';
 import type { StarredQueryMetadata } from '../editor_footer/esql_starred_queries_service';
 import { useCanCreateLookupIndex } from '../lookup_join';
 import { useCanSuggestResourceBrowser } from '../resource_browser/use_can_suggest_resource_browser';
+import { ESQL_SOURCES_CACHE_KEY, HISTORY_STARRED_ITEMS_CACHE_KEY } from './use_memoized_caches';
 
 type MemoizedFn<TArgs extends unknown[], TResult> = (...args: TArgs) => {
   timestamp: number;
@@ -57,7 +58,8 @@ type MemoizedSources = MemoizedFn<
   [
     CoreStart,
     (() => Promise<ILicense | undefined>) | undefined,
-    ((sources: ESQLSourceResult[]) => Promise<ESQLSourceResult[]>) | undefined
+    ((sources: ESQLSourceResult[]) => Promise<ESQLSourceResult[]>) | undefined,
+    AbortSignal | undefined
   ],
   ReturnType<typeof getESQLSources>
 >;
@@ -109,16 +111,25 @@ export const useEsqlCallbacks = ({
   const columnsAbortControllerRef = useRef<AbortController | undefined>(undefined);
   const previousColumnsQueryRef = useRef<string | undefined>(undefined);
 
-  const getSources = useCallback(async () => {
-    clearCacheWhenOld(dataSourcesCache, minimalQueryRef.current);
-    const getLicense = esqlService?.getLicense;
-    const enrichSources = esqlService?.enrichSources;
-    const sources = await memoizedSources(core, getLicense, enrichSources).result;
-    return sources;
-  }, [dataSourcesCache, minimalQueryRef, memoizedSources, core, esqlService]);
+  const getSources = useCallback(
+    async (_ctx?: Object, signal?: AbortSignal) => {
+      clearCacheWhenOld(dataSourcesCache, ESQL_SOURCES_CACHE_KEY);
+      const getLicense = esqlService?.getLicense;
+      const enrichSources = esqlService?.enrichSources;
+      const sources = await memoizedSources(core, getLicense, enrichSources, undefined).result;
+      if (signal?.aborted) {
+        return [];
+      }
+      return sources;
+    },
+    [dataSourcesCache, memoizedSources, core, esqlService]
+  );
 
   const getColumnsFor = useCallback(
-    async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
+    async (
+      { query: queryToExecute }: { query?: string } | undefined = {},
+      signal?: AbortSignal
+    ) => {
       if (queryToExecute) {
         // Only abort if the query changed — re-requests for the same query
         // (e.g. from concurrent validation passes) should share the same fetch
@@ -161,7 +172,7 @@ export const useEsqlCallbacks = ({
         // Bail out without touching the cache — cache cleanup for the aborted query
         // already happened at abort time. Deleting here would race with a fresh re-request that may
         // have repopulated the same key.
-        if (currentController.signal.aborted) {
+        if (currentController.signal.aborted || signal?.aborted) {
           return [];
         }
 
@@ -191,7 +202,10 @@ export const useEsqlCallbacks = ({
     };
   }, [esqlFieldsCache]);
 
-  const getPolicies = useCallback(async () => getEsqlPolicies(core.http), [core.http]);
+  const getPolicies = useCallback(
+    async (_ctx?: Object, signal?: AbortSignal) => getEsqlPolicies(core.http, signal),
+    [core.http]
+  );
 
   const getPreferences = useCallback(
     async () => ({
@@ -212,24 +226,33 @@ export const useEsqlCallbacks = ({
     [esqlService]
   );
 
-  const getTimeseriesIndicesCallback = useCallback(async () => {
-    return (await getTimeseriesIndices(core.http)) || [];
-  }, [core.http]);
+  const getTimeseriesIndicesCallback = useCallback(
+    async (signal?: AbortSignal) => {
+      return (await getTimeseriesIndices(core.http, signal)) || [];
+    },
+    [core.http]
+  );
 
-  const getViewsCallback = useCallback(async () => {
-    return await getViews(core.http);
-  }, [core.http]);
+  const getViewsCallback = useCallback(
+    async (signal?: AbortSignal) => {
+      return await getViews(core.http, signal);
+    },
+    [core.http]
+  );
 
-  const getDatasetsCallback = useCallback(async () => {
-    return await getDatasets(core.http);
-  }, [core.http]);
+  const getDatasetsCallback = useCallback(
+    async (signal?: AbortSignal) => {
+      return await getDatasets(core.http, signal);
+    },
+    [core.http]
+  );
 
   const getEditorExtensionsCallback = useCallback(
-    async (queryString: string) => {
+    async (queryString: string, signal?: AbortSignal) => {
       // Only fetch recommendations if there's an active solutionId and a non-empty query
       // Otherwise the route will return an error
       if (activeSolutionId && queryString.trim() !== '') {
-        return await getEditorExtensions(core.http, queryString, activeSolutionId);
+        return await getEditorExtensions(core.http, queryString, activeSolutionId, signal);
       }
       return {
         recommendedQueries: [],
@@ -240,8 +263,8 @@ export const useEsqlCallbacks = ({
   );
 
   const getInferenceEndpointsCallback = useCallback(
-    async (taskType: string) => {
-      return (await getInferenceEndpoints(core.http, taskType)) || [];
+    async (taskType: string, signal?: AbortSignal) => {
+      return (await getInferenceEndpoints(core.http, taskType, signal)) || [];
     },
     [core.http]
   );
@@ -262,7 +285,7 @@ export const useEsqlCallbacks = ({
   const getActiveProduct = useCallback(() => core.pricing.getActiveProduct(), [core.pricing]);
 
   const getHistoryStarredItems = useCallback(async () => {
-    clearCacheWhenOld(historyStarredItemsCache, 'historyStarredItems');
+    clearCacheWhenOld(historyStarredItemsCache, HISTORY_STARRED_ITEMS_CACHE_KEY);
     return await memoizedHistoryStarredItems(getHistoryItems, favoritesClient).result;
   }, [historyStarredItemsCache, memoizedHistoryStarredItems, favoritesClient]);
 

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_memoized_caches.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_memoized_caches.ts
@@ -32,6 +32,9 @@ interface UseMemoizedCachesParams {
   pickerProjectRouting: string | undefined;
 }
 
+export const ESQL_SOURCES_CACHE_KEY = 'esqlSources';
+export const HISTORY_STARRED_ITEMS_CACHE_KEY = 'historyStarredItems';
+
 export const useMemoizedCaches = ({
   code,
   core,
@@ -66,19 +69,21 @@ export const useMemoizedCaches = ({
   const effectiveProjectRouting = setProjectRouting ?? pickerProjectRouting;
 
   const { cache: dataSourcesCache, memoizedSources } = useMemo(() => {
-    // Keying on effectiveProjectRouting ensures a fresh cache (and therefore a fresh fetch)
+    // The cache is recreated whenever effectiveProjectRouting changes,ensuring a fresh fetch
     // whenever either the SET statement or the picker selection changes.
     const fn = memoize(
       (
         ...args: [
           CoreStart,
           (() => Promise<ILicense | undefined>) | undefined,
-          ((sources: ESQLSourceResult[]) => Promise<ESQLSourceResult[]>) | undefined
+          ((sources: ESQLSourceResult[]) => Promise<ESQLSourceResult[]>) | undefined,
+          AbortSignal | undefined
         ]
       ) => ({
         timestamp: Date.now(),
-        result: getESQLSources(...args, undefined, effectiveProjectRouting),
-      })
+        result: getESQLSources(...args, effectiveProjectRouting),
+      }),
+      () => ESQL_SOURCES_CACHE_KEY
     );
 
     return { cache: fn.cache, memoizedSources: fn };
@@ -115,7 +120,7 @@ export const useMemoizedCaches = ({
         })(),
       }),
       // Constant key: single cache entry, invalidated via cache.clear() in clearCacheWhenOld()
-      () => 'historyStarredItems'
+      () => HISTORY_STARRED_ITEMS_CACHE_KEY
     );
 
     return { cache: fn.cache, memoizedHistoryStarredItems: fn };
@@ -133,8 +138,8 @@ export const useMemoizedCaches = ({
   minimalQueryRef.current = minimalQuery;
 
   const getJoinIndicesCallback = useCallback<Required<ESQLCallbacks>['getJoinIndices']>(
-    async (cacheOptions) => {
-      const result = await getJoinIndices(minimalQueryRef.current, core.http, cacheOptions);
+    async (cacheOptions, signal?: AbortSignal) => {
+      const result = await getJoinIndices(minimalQueryRef.current, core.http, cacheOptions, signal);
       return result;
     },
     [core.http]

--- a/src/platform/packages/shared/kbn-esql-types/src/editor_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/editor_types.ts
@@ -37,7 +37,10 @@ export interface ESQLQueryStats {
 }
 
 /** @internal **/
-type CallbackFn<Options = {}, Result = string> = (ctx?: Options) => Result[] | Promise<Result[]>;
+type CallbackFn<Options = {}, Result = string> = (
+  ctx?: Options,
+  signal?: AbortSignal
+) => Result[] | Promise<Result[]>;
 
 /**
  * All supported field types in ES|QL. This is all the types
@@ -146,17 +149,26 @@ export interface ESQLCallbacks {
   getFieldsMetadata?: Promise<PartialFieldsMetadataClient>;
   getVariables?: () => ESQLControlVariable[] | undefined;
   canSuggestVariables?: () => boolean;
-  getJoinIndices?: (cacheOptions?: {
-    forceRefresh?: boolean;
-  }) => Promise<{ indices: IndexAutocompleteItem[] }>;
-  getTimeseriesIndices?: () => Promise<{ indices: IndexAutocompleteItem[] }>;
-  getViews?: () => Promise<EsqlViewsResult>;
-  getDatasets?: () => Promise<EsqlDatasetsResult>;
-  getEditorExtensions?: (queryString: string) => Promise<{
+  getJoinIndices?: (
+    cacheOptions?: {
+      forceRefresh?: boolean;
+    },
+    signal?: AbortSignal
+  ) => Promise<{ indices: IndexAutocompleteItem[] }>;
+  getTimeseriesIndices?: (signal?: AbortSignal) => Promise<{ indices: IndexAutocompleteItem[] }>;
+  getViews?: (signal?: AbortSignal) => Promise<EsqlViewsResult>;
+  getDatasets?: (signal?: AbortSignal) => Promise<EsqlDatasetsResult>;
+  getEditorExtensions?: (
+    queryString: string,
+    signal?: AbortSignal
+  ) => Promise<{
     recommendedQueries: RecommendedQuery[];
     recommendedFields: RecommendedField[];
   }>;
-  getInferenceEndpoints?: (taskType: string) => Promise<InferenceEndpointsAutocompleteResult>;
+  getInferenceEndpoints?: (
+    taskType: string,
+    signal?: AbortSignal
+  ) => Promise<InferenceEndpointsAutocompleteResult>;
   getLicense?: () => Promise<Pick<ILicense, 'hasAtLeast'> | undefined>;
   getActiveProduct?: () => PricingProduct | undefined;
   getHistoryStarredItems?: () => Promise<string[]>;

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/datasets.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/datasets.ts
@@ -18,15 +18,15 @@ import { cacheParametrizedAsyncFunction } from './utils/cache';
  * @returns A promise that resolves to the datasets list.
  */
 export const getDatasets = cacheParametrizedAsyncFunction(
-  async (http: HttpStart) => {
+  async (http: HttpStart, signal?: AbortSignal) => {
     try {
-      const result = await http.get<EsqlDatasetsResult>(DATASETS_ROUTE);
+      const result = await http.get<EsqlDatasetsResult>(DATASETS_ROUTE, { signal });
       return result ?? { datasets: [] };
     } catch {
       return { datasets: [] };
     }
   },
-  (http: HttpStart) => 'datasets',
+  (http: HttpStart, _signal?: AbortSignal) => 'datasets',
   1000 * 60 * 5, // Keep the value in cache for 5 minutes
   1000 * 15 // Refresh the cache in the background only if 15 seconds passed since the last call
 );

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/extensions.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/extensions.ts
@@ -57,18 +57,21 @@ export const analyzeSourceQuery = (
 const getEditorExtensionsFromRegistry = async (
   http: HttpStart,
   queryString: string,
-  activeSolutionId: ESQLRegistrySolutionId
+  activeSolutionId: ESQLRegistrySolutionId,
+  signal?: AbortSignal
 ): Promise<EditorExtensions> => {
   const encodedQuery = encodeURIComponent(queryString);
   const result = await http.get<EditorExtensions>(
-    `${REGISTRY_EXTENSIONS_ROUTE}${activeSolutionId}/${encodedQuery}`
+    `${REGISTRY_EXTENSIONS_ROUTE}${activeSolutionId}/${encodedQuery}`,
+    { signal }
   );
   return result;
 };
 
 const cachedGetEditorExtensions = cacheParametrizedAsyncFunction(
   getEditorExtensionsFromRegistry,
-  (_http, queryString, activeSolutionId) => `${queryString}-${activeSolutionId}`,
+  (_http, queryString, activeSolutionId, _signal?: AbortSignal) =>
+    `${queryString}-${activeSolutionId}`,
   1000 * 60 * 10, // Keep the value in cache for 10 minutes
   1000 * 60 * 5 // Refresh the cache in the background only if 5 minutes passed since the last call
 );
@@ -86,16 +89,22 @@ const cachedGetEditorExtensions = cacheParametrizedAsyncFunction(
 export const getEditorExtensions = (
   http: HttpStart,
   queryString: string,
-  activeSolutionId: ESQLRegistrySolutionId
+  activeSolutionId: ESQLRegistrySolutionId,
+  signal?: AbortSignal
 ): Promise<EditorExtensions> => {
   const analysis = analyzeSourceQuery(queryString);
   if (!analysis) {
     // Still fetch from the server so standalone queries are returned
-    return cachedGetEditorExtensions(http, '_', activeSolutionId);
+    return cachedGetEditorExtensions(http, '_', activeSolutionId, signal);
   }
   // Normalize to a minimal query so the HTTP URL is always identical for a
   // given index pattern — even when the cache triggers a background refresh
   // with a later, longer query string.
   const { commandName, indexPattern } = analysis;
-  return cachedGetEditorExtensions(http, `${commandName} ${indexPattern}`, activeSolutionId);
+  return cachedGetEditorExtensions(
+    http,
+    `${commandName} ${indexPattern}`,
+    activeSolutionId,
+    signal
+  );
 };

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/inference.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/inference.ts
@@ -18,12 +18,13 @@ import { cacheParametrizedAsyncFunction } from './utils/cache';
  * @returns A promise that resolves to an InferenceEndpointsAutocompleteResult object.
  */
 export const getInferenceEndpoints = cacheParametrizedAsyncFunction(
-  async (http: HttpStart, taskType: string) => {
+  async (http: HttpStart, taskType: string, signal?: AbortSignal) => {
     return await http.get<InferenceEndpointsAutocompleteResult>(
-      `/internal/esql/autocomplete/inference_endpoints/${encodeURIComponent(taskType)}`
+      `/internal/esql/autocomplete/inference_endpoints/${encodeURIComponent(taskType)}`,
+      { signal }
     );
   },
-  (http: HttpStart, taskType: string) => taskType,
+  (http: HttpStart, taskType: string, _signal?: AbortSignal) => taskType,
   1000 * 60 * 5, // Keep the value in cache for 5 minutes
   1000 * 15 // Refresh the cache in the background only if 15 seconds passed since the last call
 );

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/lookup_indices.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/lookup_indices.ts
@@ -13,17 +13,17 @@ import { cacheParametrizedAsyncFunction } from './utils/cache';
 import { getRemoteClustersFromESQLQuery } from '../query_parsing_helpers';
 
 const getLookupIndices = cacheParametrizedAsyncFunction(
-  async (http: HttpStart, remoteClusters?: string) => {
+  async (http: HttpStart, remoteClusters?: string, signal?: AbortSignal) => {
     const query = remoteClusters ? { remoteClusters } : {};
 
     const result = await http.get<IndicesAutocompleteResult>(
       '/internal/esql/autocomplete/join/indices',
-      { query }
+      { query, signal }
     );
 
     return result;
   },
-  (http: HttpStart, remoteClusters?: string) => remoteClusters || '',
+  (http: HttpStart, remoteClusters?: string, _signal?: AbortSignal) => remoteClusters || '',
   1000 * 60 * 5, // Keep the value in cache for 5 minutes
   1000 * 15 // Refresh the cache in the background only if 15 seconds passed since the last call
 );
@@ -38,13 +38,15 @@ const getLookupIndices = cacheParametrizedAsyncFunction(
 export const getJoinIndices = async (
   query: string,
   http: HttpStart,
-  cacheOptions?: { forceRefresh?: boolean }
+  cacheOptions?: { forceRefresh?: boolean },
+  signal?: AbortSignal
 ) => {
   const remoteClusters = getRemoteClustersFromESQLQuery(query);
   const result = await getLookupIndices.call(
     { forceRefresh: cacheOptions?.forceRefresh },
     http,
-    remoteClusters?.join(',')
+    remoteClusters?.join(','),
+    signal
   );
   return result;
 };

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/policies.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/policies.ts
@@ -17,11 +17,14 @@ type EsqlPolicy = Omit<SerializedEnrichPolicy, 'type' | 'query'>;
  * @param http The HTTP service to use for the request.
  * @returns A promise that resolves to an array of EsqlPolicy objects.
  */
-export const getEsqlPolicies = async (http: HttpStart): Promise<EsqlPolicy[]> => {
+export const getEsqlPolicies = async (
+  http: HttpStart,
+  signal?: AbortSignal
+): Promise<EsqlPolicy[]> => {
   try {
-    const policies = (await http.get(
-      `/internal/index_management/enrich_policies`
-    )) as SerializedEnrichPolicy[];
+    const policies = (await http.get(`/internal/index_management/enrich_policies`, {
+      signal,
+    })) as SerializedEnrichPolicy[];
 
     return policies.map(({ type, query: policyQuery, ...rest }) => rest);
   } catch (error) {

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/timeseries_indices.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/timeseries_indices.ts
@@ -12,14 +12,15 @@ import type { IndicesAutocompleteResult } from '@kbn/esql-types';
 import { cacheParametrizedAsyncFunction } from './utils/cache';
 
 export const getTimeseriesIndices = cacheParametrizedAsyncFunction(
-  async (http: HttpStart) => {
+  async (http: HttpStart, signal?: AbortSignal) => {
     const result = await http.get<IndicesAutocompleteResult>(
-      '/internal/esql/autocomplete/timeseries/indices'
+      '/internal/esql/autocomplete/timeseries/indices',
+      { signal }
     );
 
     return result;
   },
-  (http: HttpStart) => 'timeseries',
+  (http: HttpStart, _signal?: AbortSignal) => 'timeseries',
   1000 * 60 * 5, // Keep the value in cache for 5 minutes
   1000 * 15 // Refresh the cache in the background only if 15 seconds passed since the last call
 );

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/views.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/views.ts
@@ -18,16 +18,16 @@ import { cacheParametrizedAsyncFunction } from './utils/cache';
  * @returns A promise that resolves to the views list.
  */
 export const getViews = cacheParametrizedAsyncFunction(
-  async (http: HttpStart) => {
+  async (http: HttpStart, signal?: AbortSignal) => {
     try {
-      const result = await http.get<EsqlViewsResult>(VIEWS_ROUTE);
+      const result = await http.get<EsqlViewsResult>(VIEWS_ROUTE, { signal });
       return result ?? { views: [] };
     } catch {
       // API may be unavailable (e.g. 404 in FTR when ES plugin route is not registered)
       return { views: [] };
     }
   },
-  (http: HttpStart) => 'views',
+  (http: HttpStart, _signal?: AbortSignal) => 'views',
   1000 * 60 * 5, // Keep the value in cache for 5 minutes
   1000 * 15 // Refresh the cache in the background only if 15 seconds passed since the last call
 );

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/code_action_provider.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/code_action_provider.ts
@@ -18,15 +18,18 @@ export function getCodeActionProvider(
   deps?: ESQLDependencies
 ): monaco.languages.CodeActionProvider {
   return {
-    async provideCodeActions(model, _range, context, _token) {
+    async provideCodeActions(model, _range, context, token) {
+      const modelDeps = deps?.getModelDependencies?.(model);
+      const resolvedDeps = modelDeps ? { ...deps, ...modelDeps } : deps;
+
       return createMonacoProvider({
         model,
-        run: async (safeModel) => {
+        callbacks: resolvedDeps,
+        token,
+        run: async (safeModel, cancellableDeps) => {
           const actions: monaco.languages.CodeAction[] = [];
-          const modelDeps = deps?.getModelDependencies?.(model);
-          const resolvedDeps = modelDeps ? { ...deps, ...modelDeps } : deps;
 
-          const editorMessages = resolvedDeps?.getEditorMessages?.();
+          const editorMessages = cancellableDeps?.getEditorMessages?.();
           const allMessages = editorMessages
             ? [...editorMessages.errors, ...editorMessages.warnings]
             : [];
@@ -40,7 +43,7 @@ export function getCodeActionProvider(
               const quickFix = await getQuickFixForMessage({
                 queryString,
                 message,
-                callbacks: resolvedDeps,
+                callbacks: cancellableDeps,
               });
 
               if (quickFix) {

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/document_highlight_provider.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/document_highlight_provider.ts
@@ -18,10 +18,11 @@ export function getDocumentHighlightProvider(): monaco.languages.DocumentHighlig
     provideDocumentHighlights(
       model: monaco.editor.ITextModel,
       position: monaco.Position,
-      _token: monaco.CancellationToken
+      token: monaco.CancellationToken
     ) {
       return createMonacoProvider({
         model,
+        token,
         run: (safeModel) => {
           const fullText = safeModel.getValue();
           const offset = monacoPositionToOffset(fullText, position);

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/hover_provider.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/hover_provider.ts
@@ -17,10 +17,16 @@ export function getHoverProvider(deps?: ESQLDependencies): monaco.languages.Hove
   let lastHoveredWord: string;
 
   return {
-    async provideHover(model: monaco.editor.ITextModel, position: monaco.Position) {
+    async provideHover(
+      model: monaco.editor.ITextModel,
+      position: monaco.Position,
+      token: monaco.CancellationToken
+    ) {
       return createMonacoProvider({
         model,
-        run: async (safeModel) => {
+        callbacks: deps,
+        token,
+        run: async (safeModel, cancellableDeps) => {
           const fullText = safeModel.getValue();
           const offset = monacoPositionToOffset(fullText, position);
           const hoveredWord = safeModel.getWordAtPosition(position);
@@ -40,7 +46,7 @@ export function getHoverProvider(deps?: ESQLDependencies): monaco.languages.Hove
             }
           }
 
-          return getHoverItem(fullText, offset, deps);
+          return getHoverItem(fullText, offset, cancellableDeps);
         },
         emptyResult: null,
       });

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/inline_completions_provider.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/inline_completions_provider.ts
@@ -20,11 +20,13 @@ export function getInlineCompletionsProvider(
       model: monaco.editor.ITextModel,
       position: monaco.Position,
       _context: monaco.languages.InlineCompletionContext,
-      _token: monaco.CancellationToken
+      token: monaco.CancellationToken
     ) {
       return createMonacoProvider({
         model,
-        run: async (safeModel) => {
+        callbacks,
+        token,
+        run: async (safeModel, cancellableCallbacks) => {
           const fullText = safeModel.getValue();
           const textBeforeCursor = safeModel.getValueInRange({
             startLineNumber: 1,
@@ -40,7 +42,7 @@ export function getInlineCompletionsProvider(
             position.column
           );
 
-          return await inlineSuggest(fullText, textBeforeCursor, range, callbacks);
+          return await inlineSuggest(fullText, textBeforeCursor, range, cancellableCallbacks);
         },
         emptyResult: { items: [] },
       });

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/providers_factory.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/providers_factory.ts
@@ -7,11 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ESQLCallbacks } from '@kbn/esql-types';
 import type { monaco } from '../../../../monaco_imports';
 
-export interface CreateProviderParams<T> {
+export interface MonacoProviderContext {
+  signal: AbortSignal;
+}
+
+export interface CreateProviderParams<T, TCallbacks extends ESQLCallbacks | undefined = undefined> {
   model: monaco.editor.ITextModel;
-  run: (safeModel: monaco.editor.ITextModel) => T | Promise<T>;
+  callbacks?: TCallbacks;
+  token?: monaco.CancellationToken;
+  run: (
+    safeModel: monaco.editor.ITextModel,
+    callbacks: TCallbacks,
+    context: MonacoProviderContext
+  ) => T | Promise<T>;
   emptyResult: T;
 }
 
@@ -31,21 +42,70 @@ export class DisposedModelAccessError extends Error {
  * - Use safeModel for accessing any property or function of the model.
  * - Use the original model if you need to compare instances.
  */
-export async function createMonacoProvider<T>({
-  model,
-  run,
-  emptyResult,
-}: CreateProviderParams<T>): Promise<T> {
+export async function createMonacoProvider<
+  T,
+  TCallbacks extends ESQLCallbacks | undefined = undefined
+>({ model, callbacks, token, run, emptyResult }: CreateProviderParams<T, TCallbacks>): Promise<T> {
   const safeModel = createDisposedSafeModel(model);
+  const abortController = new AbortController();
+  const cancellationListener = token?.onCancellationRequested(() => {
+    abortController.abort();
+  });
+
+  if (token?.isCancellationRequested) {
+    abortController.abort();
+  }
+
   try {
-    const result = await Promise.resolve(run(safeModel));
-    return model.isDisposed() ? emptyResult : result;
+    if (abortController.signal.aborted) {
+      return emptyResult;
+    }
+
+    const cancellableCallbacks = createCancellableCallbacks(
+      callbacks as TCallbacks,
+      abortController.signal
+    );
+    const result = await Promise.resolve(
+      run(safeModel, cancellableCallbacks, {
+        signal: abortController.signal,
+      })
+    );
+    return model.isDisposed() || abortController.signal.aborted ? emptyResult : result;
   } catch (error) {
     if (error instanceof DisposedModelAccessError) {
       return emptyResult;
     }
+    if (abortController.signal.aborted) {
+      return emptyResult;
+    }
     throw error;
+  } finally {
+    cancellationListener?.dispose();
   }
+}
+
+function createCancellableCallbacks<TCallbacks extends ESQLCallbacks | undefined>(
+  callbacks: TCallbacks,
+  signal: AbortSignal
+): TCallbacks {
+  if (!callbacks) {
+    return callbacks;
+  }
+
+  return Object.fromEntries(
+    Object.entries(callbacks).map(([key, value]) => {
+      if (typeof value !== 'function') {
+        return [key, value];
+      }
+
+      return [
+        key,
+        function (this: unknown, ...args: unknown[]) {
+          return value.apply(this, [...args, signal]);
+        },
+      ];
+    })
+  ) as TCallbacks;
 }
 
 /**

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/signature_help_provider.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/signature_help_provider.ts
@@ -21,14 +21,17 @@ export function getSignatureProvider(
     signatureHelpRetriggerCharacters: ['(', ','],
     async provideSignatureHelp(
       model: monaco.editor.ITextModel,
-      position: monaco.Position
+      position: monaco.Position,
+      token: monaco.CancellationToken
     ): Promise<monaco.languages.SignatureHelpResult | null> {
       return createMonacoProvider({
         model,
-        run: async (safeModel) => {
+        callbacks: deps,
+        token,
+        run: async (safeModel, cancellableDeps) => {
           const fullText = safeModel.getValue();
           const offset = monacoPositionToOffset(fullText, position);
-          const signatureHelp = await getSignatureHelp(fullText, offset, deps);
+          const signatureHelp = await getSignatureHelp(fullText, offset, cancellableDeps);
 
           if (!signatureHelp) {
             return null;

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/suggestion_provider.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/suggestion_provider.ts
@@ -35,11 +35,20 @@ export function getSuggestionProvider(
     triggerCharacters: ESQL_AUTOCOMPLETE_TRIGGER_CHARS,
     async provideCompletionItems(
       model: monaco.editor.ITextModel,
-      position: monaco.Position
+      position: monaco.Position,
+      _context: monaco.languages.CompletionContext,
+      token: monaco.CancellationToken
     ): Promise<monaco.languages.CompletionList> {
+      const resolvedCallbacks = deps?.getModelDependencies?.(model) ?? deps;
+      const resolvedDeps = resolvedCallbacks
+        ? ({ ...deps, ...resolvedCallbacks } as ESQLDependencies)
+        : deps;
+
       return createMonacoProvider({
         model,
-        run: async (safeModel) => {
+        callbacks: resolvedDeps,
+        token,
+        run: async (safeModel, cancellableDeps) => {
           // Avoid returning suggestions for unfocused editors sharing the same model.
           const editors = monaco.editor
             .getEditors()
@@ -51,19 +60,15 @@ export function getSuggestionProvider(
             return { suggestions: [] };
           }
 
-          const resolvedCallbacks = deps?.getModelDependencies?.(model) ?? deps;
-          const resolvedDeps = resolvedCallbacks
-            ? ({ ...deps, ...resolvedCallbacks } as ESQLDependencies)
-            : deps;
           const fullText = safeModel.getValue();
           const offset = monacoPositionToOffset(fullText, position);
 
           const computeStart = performance.now();
-          const suggestions = await suggest(fullText, offset, resolvedDeps);
+          const suggestions = await suggest(fullText, offset, cancellableDeps);
 
           const suggestionsWithCustomCommands = filterSuggestionsWithCustomCommands(suggestions);
           if (suggestionsWithCustomCommands.length) {
-            resolvedDeps?.telemetry?.onSuggestionsWithCustomCommandShown?.(
+            cancellableDeps?.telemetry?.onSuggestionsWithCustomCommandShown?.(
               suggestionsWithCustomCommands
             );
           }
@@ -71,7 +76,7 @@ export function getSuggestionProvider(
           const result = wrapAsMonacoSuggestions(suggestions, fullText);
           const computeEnd = performance.now();
 
-          resolvedDeps?.telemetry?.onSuggestionsReady?.(
+          cancellableDeps?.telemetry?.onSuggestionsReady?.(
             computeStart,
             computeEnd,
             safeModel.getValueLength(),
@@ -84,7 +89,7 @@ export function getSuggestionProvider(
           for (const suggestion of result.suggestions) {
             itemContext.set(suggestion, {
               streamNames,
-              getFieldsMetadata: resolvedDeps?.getFieldsMetadata,
+              getFieldsMetadata: cancellableDeps?.getFieldsMetadata,
             });
           }
 

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/validate.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/providers/validate.ts
@@ -17,13 +17,16 @@ export async function esqlValidate(
   model: monaco.editor.ITextModel,
   code?: string,
   callbacks?: ESQLCallbacks,
-  options?: { invalidateColumnsCache?: boolean }
+  options?: { invalidateColumnsCache?: boolean },
+  token?: monaco.CancellationToken
 ) {
   return createMonacoProvider({
     model,
-    run: async (safeModel) => {
+    callbacks,
+    token,
+    run: async (safeModel, cancellableCallbacks) => {
       const text = code ?? safeModel.getValue();
-      const { errors, warnings } = await validateQuery(text, callbacks, options);
+      const { errors, warnings } = await validateQuery(text, cancellableCallbacks, options);
       const monacoErrors = wrapAsMonacoMessages(text, errors);
       const monacoWarnings = wrapAsMonacoMessages(text, warnings);
       return { errors: monacoErrors, warnings: monacoWarnings };


### PR DESCRIPTION
## Summary
This is a PoC for cancelling ongoing requests in our ESQLCallback when we receive a Monaco cancellation signal in a provider.

How it works:
* We use Monaco cancellation token to create an AbortController.
* We wrap all callbacks functions, passing the abort signal to them.
* All callbacks will be aborted when Monaco cancels the invocation of the provider.

