### PR TITLE
[PoC] [Agent Builder] workflows sml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ src/platform/plugins/shared/console/packaging/react/translations
 
 # Batched commits marker, e.g.: from quick checks
 .collect_commits_marker
+claude.md
+.claude

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -197,8 +197,12 @@ export class WorkflowsManagementApi {
     return this.workflowsService.getWorkflowsSubscribedToTrigger(triggerId, spaceId);
   }
 
-  public async getWorkflow(id: string, spaceId: string): Promise<WorkflowDetailDto | null> {
-    return this.workflowsService.getWorkflow(id, spaceId);
+  public async getWorkflow(
+    id: string,
+    spaceId: string,
+    options?: { includeDeleted?: boolean }
+  ): Promise<WorkflowDetailDto | null> {
+    return this.workflowsService.getWorkflow(id, spaceId, options);
   }
 
   public async getWorkflowsByIds(ids: string[], spaceId: string): Promise<WorkflowDetailDto[]> {

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EMPTY, firstValueFrom, lastValueFrom, of, toArray } from 'rxjs';
+import type { Span } from '@opentelemetry/api';
+import type { ChatEvent } from '@kbn/agent-builder-common';
+import { withConverseSpan } from './with_converse_span';
+
+const mockWithActiveInferenceSpan = jest.fn();
+
+jest.mock('@kbn/inference-tracing', () => ({
+  withActiveInferenceSpan: (
+    name: string,
+    opts: { attributes?: Record<string, unknown> },
+    fn: (span?: Span) => unknown
+  ) => {
+    mockWithActiveInferenceSpan(name, opts);
+    return fn(undefined);
+  },
+  ElasticGenAIAttributes: {
+    InferenceSpanKind: 'elastic.inference.span.kind',
+    AgentId: 'elastic.agent.id',
+    AgentConversationId: 'elastic.agent.conversationId',
+  },
+  GenAISemanticConventions: {
+    GenAIConversationId: 'gen_ai.conversation.id',
+  },
+}));
+
+describe('withConverseSpan', () => {
+  beforeEach(() => {
+    mockWithActiveInferenceSpan.mockClear();
+  });
+
+  it('creates a Converse inference span with CHAIN kind and the expected base attributes', async () => {
+    await firstValueFrom(
+      withConverseSpan({ agentId: 'agent-1', conversationId: 'conv-1' }, () => of({} as ChatEvent))
+    );
+
+    expect(mockWithActiveInferenceSpan).toHaveBeenCalledTimes(1);
+    const [name, opts] = mockWithActiveInferenceSpan.mock.calls[0];
+    expect(name).toBe('Converse');
+    expect(opts.attributes).toMatchObject({
+      'elastic.inference.span.kind': 'CHAIN',
+      'elastic.agent.id': 'agent-1',
+      'elastic.agent.conversationId': 'conv-1',
+      'gen_ai.conversation.id': 'conv-1',
+    });
+  });
+
+  it('stamps user.id and user.name attributes when provided', async () => {
+    await firstValueFrom(
+      withConverseSpan(
+        {
+          agentId: 'agent-1',
+          conversationId: 'conv-1',
+          userId: 'profile-uid-123',
+          userName: 'alice',
+        },
+        () => of({} as ChatEvent)
+      )
+    );
+
+    const [, opts] = mockWithActiveInferenceSpan.mock.calls[0];
+    expect(opts.attributes).toMatchObject({
+      'user.id': 'profile-uid-123',
+      'user.name': 'alice',
+    });
+  });
+
+  it('leaves user.id and user.name unset when not provided', async () => {
+    await lastValueFrom(
+      withConverseSpan({ agentId: 'agent-1', conversationId: 'conv-1' }, () => EMPTY).pipe(
+        toArray()
+      )
+    );
+
+    const [, opts] = mockWithActiveInferenceSpan.mock.calls[0];
+    expect(opts.attributes['user.id']).toBeUndefined();
+    expect(opts.attributes['user.name']).toBeUndefined();
+  });
+
+  it('supports stamping just user.name (no profile UID available)', async () => {
+    await firstValueFrom(
+      withConverseSpan({ agentId: 'agent-1', conversationId: 'conv-1', userName: 'bob' }, () =>
+        of({} as ChatEvent)
+      )
+    );
+
+    const [, opts] = mockWithActiveInferenceSpan.mock.calls[0];
+    expect(opts.attributes['user.id']).toBeUndefined();
+    expect(opts.attributes['user.name']).toBe('bob');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/constants.ts
@@ -7,3 +7,61 @@
 
 export const internalApiPath = '/internal/agent_context_layer';
 export const smlSearchPath = `${internalApiPath}/sml/_search`;
+
+/**
+ * Routes powering the ACL management UI. They proxy to the workflows
+ * management API and restrict scope to workflows carrying the
+ * {@link SML_SYSTEM_WORKFLOW_TAG} tag (set by the install routine).
+ */
+export const systemWorkflowsListPath = `${internalApiPath}/system_workflows`;
+export const systemWorkflowsInstallPath = `${internalApiPath}/system_workflows/_install`;
+export const systemWorkflowItemPath = `${internalApiPath}/system_workflows/{id}`;
+export const systemWorkflowStartPath = `${internalApiPath}/system_workflows/{id}/_start`;
+export const systemWorkflowCancelExecutionPath = `${internalApiPath}/system_workflows/{id}/executions/{executionId}/_cancel`;
+export const systemWorkflowResumeExecutionPath = `${internalApiPath}/system_workflows/{id}/executions/{executionId}/_resume`;
+export const systemWorkflowExecutionsPath = `${internalApiPath}/system_workflows/{id}/executions`;
+
+/**
+ * Tag applied to every SML-owned workflow when installed. The ACL admin
+ * page filters workflows by this tag (since Elasticsearch disallows prefix
+ * queries on the `_id` meta field, we use a tag instead of an id namespace).
+ */
+export const SML_SYSTEM_WORKFLOW_TAG = 'sml-system';
+
+/**
+ * Stable ids for the bundled SML system workflows. Used both for installation
+ * (`installSystemWorkflows`) and for matching against runtime executions when
+ * the ACL admin page builds per-workflow progress summaries.
+ */
+export const SML_INDEX_AUGMENTATION_WORKFLOW_ID = 'workflow-sml-index-augmentation';
+export const SML_INDEX_CRAWL_WORKFLOW_ID = 'workflow-sml-index-crawl';
+
+/**
+ * Step id inside the bundled `workflow-sml-index-crawl` workflow whose output
+ * provides the total index count for the progress summary. Kept in shared
+ * constants so it never drifts from the YAML template.
+ */
+export const SML_INDEX_CRAWL_LIST_STEP = 'list_indices';
+
+/**
+ * Shape of the per-execution progress summary returned alongside each running
+ * workflow in the ACL admin list response. `kind` is keyed on the bundled
+ * workflow id so the UI can render the right label.
+ */
+export type SmlSystemWorkflowProgress =
+  | {
+      kind: 'crawl';
+      /** Total indices to process. `null` until `list_indices` produces output. */
+      total: number | null;
+      /** Number of child augmentations that have finished (any terminal state). */
+      completed: number;
+      /** Index whose augmentation is currently in flight, when known. */
+      currentIndex: string | null;
+    }
+  | {
+      kind: 'augmentation';
+      /** Resolved value of the `indexPattern` workflow input. */
+      indexPattern: string | null;
+      /** Step id of the most recent in-flight step, or the last completed one. */
+      currentStep: string | null;
+    };

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/features.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/features.ts
@@ -6,7 +6,21 @@
  */
 
 export const AGENT_CONTEXT_LAYER_FEATURE_ID = 'agentContextLayer';
+export const AGENT_CONTEXT_LAYER_APP_ID = 'agent_context_layer';
+export const AGENT_CONTEXT_LAYER_BASE_PATH = '/app/agent_context_layer';
 
 export const apiPrivileges = {
   readAgentContextLayer: `${AGENT_CONTEXT_LAYER_FEATURE_ID}:read`,
+  /**
+   * Operator-level capability that gates the ACL management page and the
+   * ability to start / stop / restart bundled `sml--` system workflows.
+   * Granted independently because it has higher blast radius (it implicitly
+   * runs workflows as the Kibana service account).
+   */
+  manageSystemWorkflows: `${AGENT_CONTEXT_LAYER_FEATURE_ID}:manageSystemWorkflows`,
+};
+
+export const uiCapabilities = {
+  /** UI gate for the ACL management app and its actions. */
+  manageSystemWorkflows: 'manageSystemWorkflows' as const,
 };

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/features.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/features.ts
@@ -12,6 +12,18 @@ export const AGENT_CONTEXT_LAYER_BASE_PATH = '/app/agent_context_layer';
 export const apiPrivileges = {
   readAgentContextLayer: `${AGENT_CONTEXT_LAYER_FEATURE_ID}:read`,
   /**
+   * Required to write into the SML index. Checked by
+   * {@link AgentContextLayerPluginStart.indexAttachment} so every
+   * **user-driven** write path (workflow steps, future HTTP endpoints, …)
+   * requires it. The crawler bypasses the start contract and runs as the
+   * Kibana service account, so it is not subject to this privilege.
+   *
+   * The privilege only controls *whether* a user may write at all — per-
+   * `originId` access (spaces, permissions tagged on chunks) is enforced
+   * separately by the registered SML type's `resolveOriginAccess` hook.
+   */
+  writeAgentContextLayer: `${AGENT_CONTEXT_LAYER_FEATURE_ID}:write`,
+  /**
    * Operator-level capability that gates the ACL management page and the
    * ability to start / stop / restart bundled `sml--` system workflows.
    * Granted independently because it has higher blast radius (it implicitly

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
@@ -29,6 +29,16 @@ import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
  */
 export const SmlIndexAttachmentStepTypeId = 'agentContextLayer.smlIndexAttachment';
 
+/**
+ * Per-chunk input for the step.
+ *
+ * `permissions` is intentionally **not** exposed here. The SML indexer
+ * derives the effective `permissions` (and `spaces`) for every chunk from
+ * the registered type's `resolveOriginAccess(originId, ctx, spaceId)` hook,
+ * which is the sole source of truth for chunk authorization. Letting
+ * workflow authors set permissions directly would let a workflow forge
+ * privileges or bypass the cross-space write guard.
+ */
 const ChunkSchema = z.object({
   type: z.string().min(1).describe('Chunk type (e.g., "visualization", "dashboard").'),
   title: z.string().min(1).describe('Display title for the chunk.'),
@@ -36,10 +46,6 @@ const ChunkSchema = z.object({
   description: z.string().optional().describe('Optional longer summary indexed as semantic_text.'),
   user_id: z.string().optional().describe('Optional owner/last-modifier user id.'),
   references: z.array(z.string()).optional().describe('Optional list of referenced SML chunk ids.'),
-  permissions: z
-    .array(z.string())
-    .optional()
-    .describe('Optional Kibana privilege strings required to view the chunk later.'),
 });
 
 /**

--- a/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/common/workflow_steps/sml_index_attachment_step.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { i18n } from '@kbn/i18n';
+import { StepCategory } from '@kbn/workflows';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+
+/**
+ * Workflow step type id for the SML index-attachment step.
+ *
+ * We deliberately avoid the `kibana.*` prefix: the workflow execution engine
+ * (`nodes_factory.create`) routes any `kibana.*` step type straight to the
+ * HTTP-based `KibanaActionStepImpl`, which then asks the
+ * `kibana_request_builder` to derive an HTTP method/path from a registered
+ * Kibana API connector. There is no such connector for this step (it runs
+ * an in-process handler against the SML start contract), so prefixing it
+ * with `kibana.` made the engine throw
+ * "No connector definition found for kibana.agentContextLayer.smlIndexAttachment".
+ *
+ * Use a plugin-scoped namespace instead, following the convention of other
+ * extension steps (e.g. cases plugin: `cases.getCase`, agent builder:
+ * `ai.agent`). The engine's `kibana.*` shortcut is bypassed and the step is
+ * resolved via `workflowsExtensions.getStepDefinition`.
+ */
+export const SmlIndexAttachmentStepTypeId = 'agentContextLayer.smlIndexAttachment';
+
+const ChunkSchema = z.object({
+  type: z.string().min(1).describe('Chunk type (e.g., "visualization", "dashboard").'),
+  title: z.string().min(1).describe('Display title for the chunk.'),
+  content: z.string().min(1).describe('Searchable content (indexed as semantic_text).'),
+  description: z.string().optional().describe('Optional longer summary indexed as semantic_text.'),
+  user_id: z.string().optional().describe('Optional owner/last-modifier user id.'),
+  references: z.array(z.string()).optional().describe('Optional list of referenced SML chunk ids.'),
+  permissions: z
+    .array(z.string())
+    .optional()
+    .describe('Optional Kibana privilege strings required to view the chunk later.'),
+});
+
+/**
+ * Workflow step input.
+ *
+ * The HTTP/workflow surface always indexes via direct content (no
+ * `getSmlData`). Chunks are required for `create`/`update`, forbidden for
+ * `delete`.
+ */
+export const SmlIndexAttachmentInputSchema = z.discriminatedUnion('action', [
+  z.object({
+    originId: z
+      .string()
+      .min(1)
+      .describe('Stable identifier for the source object (e.g., saved object id).'),
+    attachmentType: z.string().min(1).describe('SML attachment type id (chunk namespace).'),
+    action: z.literal('create'),
+    chunks: z.array(ChunkSchema).min(1).max(100),
+  }),
+  z.object({
+    originId: z.string().min(1),
+    attachmentType: z.string().min(1),
+    action: z.literal('update'),
+    chunks: z.array(ChunkSchema).min(1).max(100),
+  }),
+  z.object({
+    originId: z.string().min(1),
+    attachmentType: z.string().min(1),
+    action: z.literal('delete'),
+  }),
+]);
+
+export const SmlIndexAttachmentOutputSchema = z.object({
+  originId: z.string(),
+  attachmentType: z.string(),
+  action: z.enum(['create', 'update', 'delete']),
+  spaceId: z.string(),
+  chunkCount: z.number().int().nonnegative(),
+  acknowledged: z.literal(true),
+});
+
+export type SmlIndexAttachmentStepInputSchema = typeof SmlIndexAttachmentInputSchema;
+export type SmlIndexAttachmentStepOutputSchema = typeof SmlIndexAttachmentOutputSchema;
+
+export const smlIndexAttachmentStepCommonDefinition: CommonStepDefinition<
+  SmlIndexAttachmentStepInputSchema,
+  SmlIndexAttachmentStepOutputSchema
+> = {
+  id: SmlIndexAttachmentStepTypeId,
+  category: StepCategory.Kibana,
+  label: i18n.translate('xpack.agentContextLayer.workflowSteps.smlIndexAttachment.label', {
+    defaultMessage: 'Index SML attachment',
+  }),
+  description: i18n.translate(
+    'xpack.agentContextLayer.workflowSteps.smlIndexAttachment.description',
+    {
+      defaultMessage:
+        'Index or remove an attachment in the Agent Context Layer (Semantic Metadata Layer) using caller-supplied chunks.',
+    }
+  ),
+  documentation: {
+    details: i18n.translate(
+      'xpack.agentContextLayer.workflowSteps.smlIndexAttachment.documentation.details',
+      {
+        defaultMessage:
+          'Indexes chunks directly (no `getSmlData` hook is invoked). For `create`/`update` the workflow author supplies the `chunks` array. For `delete` only `originId` and `attachmentType` are needed.',
+      }
+    ),
+    examples: [
+      `## Index a custom summary
+\`\`\`yaml
+- name: index_summary
+  type: ${SmlIndexAttachmentStepTypeId}
+  with:
+    originId: "doc-42"
+    attachmentType: "custom"
+    action: "create"
+    chunks:
+      - type: "custom"
+        title: "Quarterly summary"
+        content: "Revenue grew 12% across all regions ..."
+        description: "Auto-generated quarterly summary"
+\`\`\``,
+
+      `## Remove a previously indexed attachment
+\`\`\`yaml
+- name: remove_from_sml
+  type: ${SmlIndexAttachmentStepTypeId}
+  with:
+    originId: "doc-42"
+    attachmentType: "custom"
+    action: "delete"
+\`\`\``,
+    ],
+  },
+  inputSchema: SmlIndexAttachmentInputSchema,
+  outputSchema: SmlIndexAttachmentOutputSchema,
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_context_layer/kibana.jsonc
@@ -8,7 +8,8 @@
     "id": "agentContextLayer",
     "server": true,
     "browser": true,
-    "requiredPlugins": ["features", "taskManager"],
-    "optionalPlugins": ["security", "spaces"]
+    "requiredPlugins": ["features", "management", "taskManager", "workflowsManagement"],
+    "optionalPlugins": ["security", "spaces", "workflowsExtensions"],
+    "requiredBundles": ["kibanaReact", "workflowsExtensions"]
   }
 }

--- a/x-pack/platform/plugins/shared/agent_context_layer/public/index.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/public/index.ts
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import type { PluginInitializer } from '@kbn/core-plugins-browser';
+import type { PluginInitializer, PluginInitializerContext } from '@kbn/core-plugins-browser';
+import {
+  AgentContextLayerPublicPlugin,
+  type AgentContextLayerPublicPluginSetup,
+  type AgentContextLayerPublicPluginSetupDeps,
+  type AgentContextLayerPublicPluginStart,
+  type AgentContextLayerPublicPluginStartDeps,
+} from './plugin';
 
 export { smlSearchPath, internalApiPath } from '../common/constants';
 export { SML_HTTP_SEARCH_QUERY_MAX_LENGTH, SmlSearchFilterType } from '../common/http_api/sml';
@@ -15,8 +22,9 @@ export type {
   SmlSearchHttpResultItem,
 } from '../common/http_api/sml';
 
-export const plugin: PluginInitializer<{}, {}> = () => ({
-  setup: () => ({}),
-  start: () => ({}),
-  stop: () => {},
-});
+export const plugin: PluginInitializer<
+  AgentContextLayerPublicPluginSetup,
+  AgentContextLayerPublicPluginStart,
+  AgentContextLayerPublicPluginSetupDeps,
+  AgentContextLayerPublicPluginStartDeps
+> = (context: PluginInitializerContext) => new AgentContextLayerPublicPlugin(context);

--- a/x-pack/platform/plugins/shared/agent_context_layer/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/public/plugin.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type {
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  PluginInitializerContext,
+} from '@kbn/core/public';
+import type { ManagementApp, ManagementSetup } from '@kbn/management-plugin/public';
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+import {
+  AGENT_CONTEXT_LAYER_APP_ID,
+  AGENT_CONTEXT_LAYER_FEATURE_ID,
+  uiCapabilities,
+} from '../common/features';
+import { registerAgentContextLayerWorkflowSteps } from './workflow_steps';
+
+export interface AgentContextLayerPublicPluginSetupDeps {
+  management: ManagementSetup;
+  workflowsExtensions?: WorkflowsExtensionsPublicPluginSetup;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AgentContextLayerPublicPluginStartDeps {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AgentContextLayerPublicPluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AgentContextLayerPublicPluginStart {}
+
+export class AgentContextLayerPublicPlugin
+  implements
+    Plugin<
+      AgentContextLayerPublicPluginSetup,
+      AgentContextLayerPublicPluginStart,
+      AgentContextLayerPublicPluginSetupDeps,
+      AgentContextLayerPublicPluginStartDeps
+    >
+{
+  private managementApp?: ManagementApp;
+
+  constructor(_context: PluginInitializerContext) {}
+
+  public setup(
+    core: CoreSetup<AgentContextLayerPublicPluginStartDeps, AgentContextLayerPublicPluginStart>,
+    deps: AgentContextLayerPublicPluginSetupDeps
+  ): AgentContextLayerPublicPluginSetup {
+    if (deps.workflowsExtensions) {
+      registerAgentContextLayerWorkflowSteps(deps.workflowsExtensions);
+    }
+
+    // Surface the Agent Context Layer admin page under Stack Management →
+    // AI. Listing it here (rather than as a top-level Kibana app) reflects
+    // its operator-oriented nature: it is gated by an independent
+    // `manageSystemWorkflows` sub-feature privilege and exposes start /
+    // stop / cancel controls for `sml--` system workflows that run as the
+    // Kibana service account.
+    this.managementApp = deps.management.sections.section.ai.registerApp({
+      id: AGENT_CONTEXT_LAYER_APP_ID,
+      title: i18n.translate('xpack.agentContextLayer.management.title', {
+        defaultMessage: 'Agent Context Layer',
+      }),
+      order: 5,
+      keywords: ['agent', 'context', 'sml', 'workflows', 'ai'],
+      async mount(params) {
+        const [coreStart] = await core.getStartServices();
+        const canManage =
+          coreStart.application.capabilities?.[AGENT_CONTEXT_LAYER_FEATURE_ID]?.[
+            uiCapabilities.manageSystemWorkflows
+          ] === true;
+        const { renderApp } = await import('./system_workflows/render_app');
+        return renderApp({ coreStart, params, canManage });
+      },
+    });
+
+    // Disable by default — `start()` re-enables it once we have confirmed
+    // the user holds the `manageSystemWorkflows` UI capability. Without
+    // this gate, every user with any Stack Management access would see
+    // the entry, even though hitting it would return the unauthorized
+    // empty prompt.
+    this.managementApp.disable();
+
+    return {};
+  }
+
+  public start(
+    coreStart: CoreStart,
+    _deps: AgentContextLayerPublicPluginStartDeps
+  ): AgentContextLayerPublicPluginStart {
+    const canManage =
+      coreStart.application.capabilities?.[AGENT_CONTEXT_LAYER_FEATURE_ID]?.[
+        uiCapabilities.manageSystemWorkflows
+      ] === true;
+    if (this.managementApp && canManage) {
+      this.managementApp.enable();
+    }
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/platform/plugins/shared/agent_context_layer/public/system_workflows/app.tsx
+++ b/x-pack/platform/plugins/shared/agent_context_layer/public/system_workflows/app.tsx
@@ -1,0 +1,662 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiButton,
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiCode,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPageHeader,
+  EuiPanel,
+  EuiProgress,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { ApplicationStart, HttpStart, NotificationsStart } from '@kbn/core/public';
+import type { WorkflowListDto, WorkflowListItemDto } from '@kbn/workflows';
+import {
+  systemWorkflowCancelExecutionPath,
+  systemWorkflowsInstallPath,
+  systemWorkflowStartPath,
+  systemWorkflowsListPath,
+  type SmlSystemWorkflowProgress,
+} from '../../common/constants';
+
+/**
+ * Local extension of `WorkflowListItemDto`. The ACL list route hydrates each
+ * running row with a per-execution progress summary; the upstream
+ * `WorkflowListItemDto` doesn't know about it.
+ */
+type SmlSystemWorkflowListItem = WorkflowListItemDto & {
+  progress?: SmlSystemWorkflowProgress;
+};
+
+/**
+ * How often to refetch the list while at least one workflow is actively
+ * running. Five seconds matches the workflows app's own detail-page polling
+ * cadence and keeps the load on the workflows API negligible (we issue at
+ * most two extra `getWorkflowExecution` calls per refresh).
+ */
+const PROGRESS_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * History-entry statuses that mean "this execution is still in flight" and
+ * therefore worth polling for live progress updates.
+ *
+ * MUST stay in sync with `ACTIVE_HISTORY_STATUSES` in
+ * `server/routes/system_workflows.ts` — otherwise the client either polls
+ * for rows the server doesn't enrich (cheap noise) or, worse, stops polling
+ * while the server still has live data to send. In particular, a parent
+ * crawl execution sits in `waiting` (not `running`) while its spawned child
+ * augmentation runs, so omitting `waiting` would silently break refresh for
+ * the very workflow most likely to be in progress.
+ */
+const ACTIVE_HISTORY_STATUSES = new Set([
+  'running',
+  'pending',
+  'waiting',
+  'waiting_for_input',
+]);
+
+interface InstallResult {
+  created: string[];
+  skipped: string[];
+  updated: string[];
+  reinstalled: string[];
+  failed: Array<{ id: string; reason: string }>;
+}
+
+export interface SystemWorkflowsAppProps {
+  http: HttpStart;
+  application: ApplicationStart;
+  notifications: NotificationsStart;
+  canManage: boolean;
+}
+
+export const SystemWorkflowsApp = ({
+  http,
+  application,
+  notifications,
+  canManage,
+}: SystemWorkflowsAppProps) => {
+  const [data, setData] = useState<WorkflowListDto | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [installing, setInstalling] = useState<boolean>(false);
+
+  /**
+   * Refetch the list. `silent` skips the spinner so the polling refresh
+   * doesn't make the table flicker between renders.
+   */
+  const fetchList = useCallback(
+    async ({ silent = false }: { silent?: boolean } = {}) => {
+      if (!silent) setLoading(true);
+      setError(null);
+      try {
+        const response = await http.get<WorkflowListDto>(systemWorkflowsListPath);
+        setData(response);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!silent) setLoading(false);
+      }
+    },
+    [http]
+  );
+
+  useEffect(() => {
+    if (canManage) {
+      fetchList().catch(() => {
+        /* state already captured */
+      });
+    } else {
+      setLoading(false);
+    }
+  }, [fetchList, canManage]);
+
+  // While at least one workflow row is still in flight we poll the list so
+  // the progress column ticks live. We watch the latest history entry per
+  // row using the *same* status set the server uses to decide whether to
+  // enrich `progress` — keeping the two in lockstep guarantees that "the
+  // server has live data" and "the client is polling" stay aligned.
+  const hasActiveRun = useMemo(() => {
+    if (!data?.results) return false;
+    return data.results.some((item) => {
+      const latest = item.history?.[0];
+      return !!latest && ACTIVE_HISTORY_STATUSES.has(latest.status);
+    });
+  }, [data]);
+
+  useEffect(() => {
+    if (!canManage || !hasActiveRun) return undefined;
+    const handle = setInterval(() => {
+      fetchList({ silent: true }).catch(() => {
+        /* surfaced via state */
+      });
+    }, PROGRESS_POLL_INTERVAL_MS);
+    return () => clearInterval(handle);
+  }, [canManage, hasActiveRun, fetchList]);
+
+  const onStart = useCallback(
+    async (item: WorkflowListItemDto) => {
+      setBusyId(item.id);
+      try {
+        const path = systemWorkflowStartPath.replace('{id}', encodeURIComponent(item.id));
+        const result = await http.post<{ executionId: string }>(path, {
+          body: JSON.stringify({ inputs: {} }),
+        });
+        notifications.toasts.addSuccess({
+          title: i18n.translate('xpack.agentContextLayer.app.startSuccess', {
+            defaultMessage: 'Started "{name}"',
+            values: { name: item.name ?? item.id },
+          }),
+          text: i18n.translate('xpack.agentContextLayer.app.startSuccessSubtitle', {
+            defaultMessage: 'Execution id: {id}',
+            values: { id: result.executionId },
+          }),
+        });
+        await fetchList();
+      } catch (err) {
+        notifications.toasts.addError(err instanceof Error ? err : new Error(String(err)), {
+          title: i18n.translate('xpack.agentContextLayer.app.startError', {
+            defaultMessage: 'Failed to start "{name}"',
+            values: { name: item.name ?? item.id },
+          }),
+        });
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [fetchList, http, notifications]
+  );
+
+  const onCancelLast = useCallback(
+    async (item: WorkflowListItemDto) => {
+      const latestRunning = (item.history ?? []).find((entry) =>
+        ACTIVE_HISTORY_STATUSES.has(entry.status)
+      );
+      if (!latestRunning) {
+        notifications.toasts.addWarning(
+          i18n.translate('xpack.agentContextLayer.app.cancelNoRunning', {
+            defaultMessage: 'No active execution to cancel for "{name}".',
+            values: { name: item.name ?? item.id },
+          })
+        );
+        return;
+      }
+      setBusyId(item.id);
+      try {
+        const path = systemWorkflowCancelExecutionPath
+          .replace('{id}', encodeURIComponent(item.id))
+          .replace('{executionId}', encodeURIComponent(latestRunning.id));
+        await http.post(path);
+        notifications.toasts.addSuccess(
+          i18n.translate('xpack.agentContextLayer.app.cancelSuccess', {
+            defaultMessage: 'Requested cancellation for "{name}".',
+            values: { name: item.name ?? item.id },
+          })
+        );
+        await fetchList();
+      } catch (err) {
+        notifications.toasts.addError(err instanceof Error ? err : new Error(String(err)), {
+          title: i18n.translate('xpack.agentContextLayer.app.cancelError', {
+            defaultMessage: 'Failed to cancel execution for "{name}"',
+            values: { name: item.name ?? item.id },
+          }),
+        });
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [fetchList, http, notifications]
+  );
+
+  const onEdit = useCallback(
+    (item: WorkflowListItemDto) => {
+      application.navigateToApp('workflows', { path: `/${encodeURIComponent(item.id)}` });
+    },
+    [application]
+  );
+
+  const onInstall = useCallback(async () => {
+    setInstalling(true);
+    try {
+      const result = await http.post<InstallResult>(systemWorkflowsInstallPath);
+      const { created, skipped, updated, reinstalled, failed } = result;
+      if (failed.length > 0) {
+        notifications.toasts.addWarning({
+          title: i18n.translate('xpack.agentContextLayer.app.installPartialTitle', {
+            defaultMessage: 'Some workflows failed to install',
+          }),
+          text: failed.map((f) => `${f.id}: ${f.reason}`).join('\n'),
+        });
+      } else {
+        notifications.toasts.addSuccess(
+          i18n.translate('xpack.agentContextLayer.app.installSuccess', {
+            defaultMessage:
+              'Installed {createdCount}; refreshed {updatedCount}; reinstalled {reinstalledCount}; {skippedCount} already up to date.',
+            values: {
+              createdCount: created.length,
+              updatedCount: updated.length,
+              reinstalledCount: reinstalled.length,
+              skippedCount: skipped.length,
+            },
+          })
+        );
+      }
+      await fetchList();
+    } catch (err) {
+      notifications.toasts.addError(err instanceof Error ? err : new Error(String(err)), {
+        title: i18n.translate('xpack.agentContextLayer.app.installError', {
+          defaultMessage: 'Failed to install system workflows',
+        }),
+      });
+    } finally {
+      setInstalling(false);
+    }
+  }, [fetchList, http, notifications]);
+
+  const columns = useMemo<Array<EuiBasicTableColumn<SmlSystemWorkflowListItem>>>(
+    () => [
+      {
+        field: 'name',
+        name: i18n.translate('xpack.agentContextLayer.app.column.name', {
+          defaultMessage: 'Name',
+        }),
+        render: (name: string, item: SmlSystemWorkflowListItem) => (
+          <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                <strong>{name ?? item.id}</strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {item.id}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
+      },
+      {
+        field: 'enabled',
+        name: i18n.translate('xpack.agentContextLayer.app.column.enabled', {
+          defaultMessage: 'Enabled',
+        }),
+        width: '120px',
+        render: (enabled: boolean) =>
+          enabled ? (
+            <EuiBadge color="success">
+              <FormattedMessage
+                id="xpack.agentContextLayer.app.column.enabledBadge"
+                defaultMessage="Enabled"
+              />
+            </EuiBadge>
+          ) : (
+            <EuiBadge color="hollow">
+              <FormattedMessage
+                id="xpack.agentContextLayer.app.column.disabledBadge"
+                defaultMessage="Disabled"
+              />
+            </EuiBadge>
+          ),
+      },
+      {
+        field: 'history',
+        name: i18n.translate('xpack.agentContextLayer.app.column.lastRun', {
+          defaultMessage: 'Last run',
+        }),
+        width: '180px',
+        render: (_history: unknown, item: SmlSystemWorkflowListItem) => {
+          const last = item.history?.[0];
+          if (!last) {
+            return (
+              <EuiText size="s" color="subdued">
+                <FormattedMessage
+                  id="xpack.agentContextLayer.app.column.noLastRun"
+                  defaultMessage="—"
+                />
+              </EuiText>
+            );
+          }
+          return (
+            <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiBadge color={lastRunBadgeColor(last.status)}>{last.status}</EuiBadge>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs" color="subdued">
+                  {last.finishedAt ?? last.startedAt}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          );
+        },
+      },
+      {
+        field: 'progress',
+        name: i18n.translate('xpack.agentContextLayer.app.column.progress', {
+          defaultMessage: 'Progress',
+        }),
+        width: '220px',
+        render: (_progress: unknown, item: SmlSystemWorkflowListItem) => (
+          <ProgressCell item={item} />
+        ),
+      },
+      {
+        name: i18n.translate('xpack.agentContextLayer.app.column.actions', {
+          defaultMessage: 'Actions',
+        }),
+        width: '180px',
+        render: (item: SmlSystemWorkflowListItem) => {
+          const isBusy = busyId === item.id;
+          const hasActive = (item.history ?? []).some((entry) =>
+            ACTIVE_HISTORY_STATUSES.has(entry.status)
+          );
+          return (
+            <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiToolTip
+                  content={i18n.translate('xpack.agentContextLayer.app.actions.startTooltip', {
+                    defaultMessage: 'Start workflow now',
+                  })}
+                >
+                  <EuiButtonIcon
+                    iconType="play"
+                    aria-label="Start"
+                    isDisabled={isBusy || !canManage}
+                    onClick={() => onStart(item)}
+                  />
+                </EuiToolTip>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiToolTip
+                  content={i18n.translate('xpack.agentContextLayer.app.actions.cancelTooltip', {
+                    defaultMessage: 'Cancel latest active execution',
+                  })}
+                >
+                  <EuiButtonIcon
+                    iconType="cross"
+                    aria-label="Cancel"
+                    color="danger"
+                    isDisabled={isBusy || !canManage || !hasActive}
+                    onClick={() => onCancelLast(item)}
+                  />
+                </EuiToolTip>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiToolTip
+                  content={i18n.translate('xpack.agentContextLayer.app.actions.editTooltip', {
+                    defaultMessage: 'Edit in workflows management',
+                  })}
+                >
+                  <EuiButtonIcon iconType="pencil" aria-label="Edit" onClick={() => onEdit(item)} />
+                </EuiToolTip>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          );
+        },
+      },
+    ],
+    [busyId, canManage, onCancelLast, onEdit, onStart]
+  );
+
+  if (!canManage) {
+    return (
+      <EuiPanel paddingSize="l">
+        <EuiEmptyPrompt
+          iconType="lock"
+          title={
+            <h2>
+              <FormattedMessage
+                id="xpack.agentContextLayer.app.unauthorizedTitle"
+                defaultMessage="Restricted page"
+              />
+            </h2>
+          }
+          body={
+            <p>
+              <FormattedMessage
+                id="xpack.agentContextLayer.app.unauthorizedBody"
+                defaultMessage="You do not have the 'Manage system workflows' privilege required to view this page."
+              />
+            </p>
+          }
+        />
+      </EuiPanel>
+    );
+  }
+
+  return (
+    <EuiPanel paddingSize="l">
+      <EuiPageHeader
+        pageTitle={i18n.translate('xpack.agentContextLayer.app.title', {
+          defaultMessage: 'Agent Context Layer',
+        })}
+        description={i18n.translate('xpack.agentContextLayer.app.description', {
+          defaultMessage:
+            'Manage the SML system workflows that maintain the Agent Context Layer. Workflows run as the user who starts them; the user must hold the workflow execution privilege.',
+        })}
+        rightSideItems={[
+          <EuiButton
+            key="install"
+            iconType="download"
+            onClick={onInstall}
+            isLoading={installing}
+            data-test-subj="aclInstallSystemWorkflowsButton"
+          >
+            <FormattedMessage
+              id="xpack.agentContextLayer.app.install"
+              defaultMessage="Install default workflows"
+            />
+          </EuiButton>,
+          <EuiButton
+            key="refresh"
+            iconType="refresh"
+            onClick={() => {
+              fetchList().catch(() => {
+                /* surfaced via state */
+              });
+            }}
+            isLoading={loading}
+          >
+            <FormattedMessage id="xpack.agentContextLayer.app.refresh" defaultMessage="Refresh" />
+          </EuiButton>,
+        ]}
+      />
+      <EuiSpacer size="l" />
+      {error && (
+        <>
+          <EuiCallOut
+            color="danger"
+            iconType="error"
+            title={i18n.translate('xpack.agentContextLayer.app.loadErrorTitle', {
+              defaultMessage: 'Failed to load system workflows',
+            })}
+          >
+            {error.message}
+          </EuiCallOut>
+          <EuiSpacer />
+        </>
+      )}
+      {loading ? (
+        <EuiFlexGroup alignItems="center" justifyContent="center">
+          <EuiFlexItem grow={false}>
+            <EuiLoadingSpinner size="xl" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : (data?.results?.length ?? 0) === 0 ? (
+        <EuiEmptyPrompt
+          iconType="indexOpen"
+          title={
+            <h2>
+              <FormattedMessage
+                id="xpack.agentContextLayer.app.emptyStateTitle"
+                defaultMessage="No system workflows installed"
+              />
+            </h2>
+          }
+          body={
+            <p>
+              <FormattedMessage
+                id="xpack.agentContextLayer.app.emptyStateBody"
+                defaultMessage="Install the bundled SML maintenance workflows to surface them here. You can edit or remove them later from the standard workflows management page."
+              />
+            </p>
+          }
+          actions={
+            <EuiButton
+              fill
+              iconType="download"
+              onClick={onInstall}
+              isLoading={installing}
+              data-test-subj="aclInstallSystemWorkflowsEmptyStateButton"
+            >
+              <FormattedMessage
+                id="xpack.agentContextLayer.app.installEmptyState"
+                defaultMessage="Install default workflows"
+              />
+            </EuiButton>
+          }
+        />
+      ) : (
+        <EuiBasicTable
+          tableLayout="auto"
+          itemId="id"
+          items={(data?.results ?? []) as SmlSystemWorkflowListItem[]}
+          columns={columns}
+          rowProps={() => ({ 'data-test-subj': 'aclSystemWorkflowRow' })}
+          noItemsMessage={i18n.translate('xpack.agentContextLayer.app.noWorkflows', {
+            defaultMessage: 'No system workflows found.',
+          })}
+        />
+      )}
+    </EuiPanel>
+  );
+};
+
+const lastRunBadgeColor = (status: string): 'success' | 'warning' | 'danger' | 'hollow' => {
+  switch (status) {
+    case 'completed':
+    case 'succeeded':
+      return 'success';
+    case 'failed':
+    case 'cancelled':
+      return 'danger';
+    case 'running':
+    case 'pending':
+      return 'warning';
+    default:
+      return 'hollow';
+  }
+};
+
+/**
+ * Per-row progress renderer. We intentionally keep the cell terse and
+ * status-dependent: the column is wedged between "Last run" and "Actions" so
+ * verbose copy would push the buttons off-screen.
+ *
+ *   - Crawl: `EuiProgress(value/total) + "indexing <currentIndex>"` while
+ *     `total` is known. When `list_indices` hasn't produced output yet the
+ *     bar degrades to an indeterminate spinner.
+ *   - Augmentation: `<indexPattern>` + the current step id beneath. The
+ *     index pattern matters most because the crawl spawns many augmentation
+ *     children identified only by their input.
+ *   - Anything else: em-dash so the column stays vertically aligned with
+ *     completed/idle rows.
+ */
+const ProgressCell: React.FC<{ item: SmlSystemWorkflowListItem }> = ({ item }) => {
+  const progress = item.progress;
+  if (!progress) {
+    return (
+      <EuiText size="s" color="subdued">
+        <FormattedMessage id="xpack.agentContextLayer.app.column.noProgress" defaultMessage="—" />
+      </EuiText>
+    );
+  }
+
+  if (progress.kind === 'crawl') {
+    const totalLabel =
+      progress.total !== null ? `${progress.completed}/${progress.total}` : `${progress.completed}/?`;
+    const subline = progress.currentIndex
+      ? i18n.translate('xpack.agentContextLayer.app.progress.crawlCurrent', {
+          defaultMessage: 'Augmenting {indexPattern}',
+          values: { indexPattern: progress.currentIndex },
+        })
+      : i18n.translate('xpack.agentContextLayer.app.progress.crawlIdle', {
+          defaultMessage: 'Waiting for the next index…',
+        });
+    return (
+      <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <FormattedMessage
+              id="xpack.agentContextLayer.app.progress.crawlSummary"
+              defaultMessage="{count} indices augmented"
+              values={{ count: <strong>{totalLabel}</strong> }}
+            />
+          </EuiText>
+        </EuiFlexItem>
+        {progress.total !== null && progress.total > 0 && (
+          <EuiFlexItem grow={false}>
+            <EuiProgress
+              size="xs"
+              max={progress.total}
+              value={Math.min(progress.completed, progress.total)}
+              color="primary"
+            />
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            {subline}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiText size="s">
+          {progress.indexPattern ? (
+            <strong>{progress.indexPattern}</strong>
+          ) : (
+            <FormattedMessage
+              id="xpack.agentContextLayer.app.progress.augmentationUnknownIndex"
+              defaultMessage="Index pattern unresolved"
+            />
+          )}
+        </EuiText>
+      </EuiFlexItem>
+      {progress.currentStep && (
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            <FormattedMessage
+              id="xpack.agentContextLayer.app.progress.augmentationStep"
+              defaultMessage="Step: {stepId}"
+              values={{ stepId: <EuiCode>{progress.currentStep}</EuiCode> }}
+            />
+          </EuiText>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/public/system_workflows/render_app.tsx
+++ b/x-pack/platform/plugins/shared/agent_context_layer/public/system_workflows/render_app.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { i18n } from '@kbn/i18n';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { CoreStart } from '@kbn/core/public';
+import type { ManagementAppMountParams } from '@kbn/management-plugin/public';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { SystemWorkflowsApp } from './app';
+
+export interface RenderAppParams {
+  coreStart: CoreStart;
+  params: ManagementAppMountParams;
+  canManage: boolean;
+}
+
+export const renderApp = ({ coreStart, params, canManage }: RenderAppParams) => {
+  params.setBreadcrumbs([
+    {
+      text: i18n.translate('xpack.agentContextLayer.management.breadcrumb', {
+        defaultMessage: 'Agent Context Layer',
+      }),
+    },
+  ]);
+
+  ReactDOM.render(
+    <KibanaContextProvider services={coreStart}>
+      <I18nProvider>
+        <SystemWorkflowsApp
+          http={coreStart.http}
+          application={coreStart.application}
+          notifications={coreStart.notifications}
+          canManage={canManage}
+        />
+      </I18nProvider>
+    </KibanaContextProvider>,
+    params.element
+  );
+
+  return () => {
+    ReactDOM.unmountComponentAtNode(params.element);
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/public/workflow_steps/index.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/public/workflow_steps/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+import { smlIndexAttachmentStepDefinition } from './sml_index_attachment_step';
+
+export const registerAgentContextLayerWorkflowSteps = (
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup
+) => {
+  workflowsExtensions.registerStepDefinition(smlIndexAttachmentStepDefinition);
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/public/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/public/workflow_steps/sml_index_attachment_step.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { smlIndexAttachmentStepCommonDefinition } from '../../common/workflow_steps/sml_index_attachment_step';
+
+export const smlIndexAttachmentStepDefinition = createPublicStepDefinition({
+  ...smlIndexAttachmentStepCommonDefinition,
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/memory').then(({ icon }) => ({ default: icon }))
+  ),
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/features.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/features.ts
@@ -33,7 +33,7 @@ export const registerFeatures = ({ features }: { features: FeaturesPluginSetup }
     privileges: {
       all: {
         app: [AGENT_CONTEXT_LAYER_APP_ID],
-        api: [apiPrivileges.readAgentContextLayer],
+        api: [apiPrivileges.readAgentContextLayer, apiPrivileges.writeAgentContextLayer],
         catalogue: [AGENT_CONTEXT_LAYER_APP_ID],
         // The base privileges grant API access to read/write SML data; the
         // management page itself is gated by the independent

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/features.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/features.ts
@@ -8,7 +8,12 @@
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import { AGENT_CONTEXT_LAYER_FEATURE_ID, apiPrivileges } from '../common/features';
+import {
+  AGENT_CONTEXT_LAYER_APP_ID,
+  AGENT_CONTEXT_LAYER_FEATURE_ID,
+  apiPrivileges,
+  uiCapabilities,
+} from '../common/features';
 
 export const registerFeatures = ({ features }: { features: FeaturesPluginSetup }) => {
   features.registerKibanaFeature({
@@ -18,14 +23,22 @@ export const registerFeatures = ({ features }: { features: FeaturesPluginSetup }
     }),
     minimumLicense: 'enterprise',
     order: 1001,
-    category: DEFAULT_APP_CATEGORIES.kibana,
-    app: [],
-    catalogue: [],
+    category: DEFAULT_APP_CATEGORIES.management,
+    // The admin UI lives under Stack Management → AI. Listing the app id
+    // here (and in each privilege below) is what surfaces the entry in the
+    // management sidebar for users granted the relevant privilege.
+    app: [AGENT_CONTEXT_LAYER_APP_ID],
+    catalogue: [AGENT_CONTEXT_LAYER_APP_ID],
+    management: { ai: [AGENT_CONTEXT_LAYER_APP_ID] },
     privileges: {
       all: {
-        app: [],
+        app: [AGENT_CONTEXT_LAYER_APP_ID],
         api: [apiPrivileges.readAgentContextLayer],
-        catalogue: [],
+        catalogue: [AGENT_CONTEXT_LAYER_APP_ID],
+        // The base privileges grant API access to read/write SML data; the
+        // management page itself is gated by the independent
+        // `manage_system_workflows` sub-feature privilege below.
+        management: { ai: [] },
         savedObject: {
           all: [],
           read: [],
@@ -33,9 +46,10 @@ export const registerFeatures = ({ features }: { features: FeaturesPluginSetup }
         ui: [],
       },
       read: {
-        app: [],
+        app: [AGENT_CONTEXT_LAYER_APP_ID],
         api: [apiPrivileges.readAgentContextLayer],
-        catalogue: [],
+        catalogue: [AGENT_CONTEXT_LAYER_APP_ID],
+        management: { ai: [] },
         savedObject: {
           all: [],
           read: [],
@@ -43,5 +57,38 @@ export const registerFeatures = ({ features }: { features: FeaturesPluginSetup }
         ui: [],
       },
     },
+    subFeatures: [
+      {
+        name: i18n.translate('xpack.agentContextLayer.feature.subFeatureName.manageSystem', {
+          defaultMessage: 'System workflows',
+        }),
+        privilegeGroups: [
+          {
+            groupType: 'independent',
+            privileges: [
+              {
+                id: 'manage_system_workflows',
+                name: i18n.translate(
+                  'xpack.agentContextLayer.feature.subFeature.manageSystemWorkflows',
+                  {
+                    defaultMessage: 'Manage system workflows',
+                  }
+                ),
+                // Not granted by default in `all`; operators must explicitly
+                // assign this sub-feature because it implicitly runs
+                // workflows as the Kibana service account. Granting this
+                // privilege also unlocks the Stack Management → AI entry
+                // for the management page.
+                includeIn: 'none',
+                savedObject: { all: [], read: [] },
+                api: [apiPrivileges.manageSystemWorkflows],
+                management: { ai: [AGENT_CONTEXT_LAYER_APP_ID] },
+                ui: [uiCapabilities.manageSystemWorkflows],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   });
 };

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
@@ -7,6 +7,7 @@
 
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
+import { apiPrivileges } from '../common/features';
 import type {
   AgentContextLayerPluginSetup,
   AgentContextLayerPluginStart,
@@ -151,6 +152,8 @@ export class AgentContextLayerPlugin
       this.logger.error(`Failed to schedule SML crawler tasks: ${error.message}`);
     });
 
+    const securityAuthz = security?.authz;
+
     const startContract: AgentContextLayerPluginStart = {
       search: smlService.search,
       checkItemsAccess: smlService.checkItemsAccess,
@@ -158,6 +161,26 @@ export class AgentContextLayerPlugin
       getTypeDefinition: smlService.getTypeDefinition,
       resolveSmlAttachItems: (params) => resolveSmlAttachItems({ ...params, sml: smlService }),
       indexAttachment: async (params) => {
+        // Gate every user-driven write on the `sml:write` API privilege.
+        // The crawler bypasses this start contract (it talks to the
+        // internal SmlService directly as the Kibana service account),
+        // so internal background indexing is unaffected.
+        if (securityAuthz) {
+          const checkPrivileges = securityAuthz.checkPrivilegesDynamicallyWithRequest(
+            params.request
+          );
+          const { hasAllRequested } = await checkPrivileges({
+            kibana: [
+              securityAuthz.actions.api.get(apiPrivileges.writeAgentContextLayer),
+            ],
+          });
+          if (!hasAllRequested) {
+            throw new Error(
+              `Forbidden: caller is missing the '${apiPrivileges.writeAgentContextLayer}' privilege required to index SML attachments.`
+            );
+          }
+        }
+
         const soClient = savedObjects.getScopedClient(params.request, {
           ...(params.includedHiddenTypes?.length
             ? { includedHiddenTypes: params.includedHiddenTypes }
@@ -169,7 +192,12 @@ export class AgentContextLayerPlugin
           originId: params.originId,
           attachmentType: params.attachmentType,
           action: params.action,
+          // For direct mode (chunks supplied) the indexer derives the
+          // effective spaces from `resolveOriginAccess` and ignores
+          // this value, so passing the caller's space here is just a
+          // sensible default for resolved-mode fallbacks.
           spaces: [spaceId],
+          spaceId,
           esClient: elasticsearch.client.asInternalUser,
           savedObjectsClient: soClient,
           logger: this.logger.get('sml'),

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
@@ -16,6 +16,7 @@ import type {
 import { registerFeatures } from './features';
 import { registerUISettings } from './ui_settings';
 import { registerSearchRoute } from './routes/search';
+import { registerSystemWorkflowsRoutes } from './routes/system_workflows';
 import { createSmlService, type SmlServiceInstance } from './services/sml/sml_service';
 import {
   registerSmlCrawlerTaskDefinition,
@@ -23,6 +24,8 @@ import {
 } from './services/sml/sml_task_definitions';
 import { resolveSmlAttachItems } from './services/sml/execute_sml_attach_items';
 import type { SmlService } from './services/sml/types';
+import { registerAgentContextLayerWorkflowSteps } from './workflow_steps';
+import { indexKpiSmlType } from './sml_types';
 
 export class AgentContextLayerPlugin
   implements
@@ -36,6 +39,9 @@ export class AgentContextLayerPlugin
   private logger: Logger;
   private smlServiceInstance: SmlServiceInstance;
   private smlService?: SmlService;
+  private startContract?: AgentContextLayerPluginStart;
+  private spaces?: AgentContextLayerStartDependencies['spaces'];
+  private workflowsManagementApi?: AgentContextLayerSetupDependencies['workflowsManagement']['management'];
 
   constructor(context: PluginInitializerContext) {
     this.logger = context.logger.get();
@@ -49,7 +55,14 @@ export class AgentContextLayerPlugin
     registerFeatures({ features: setupDeps.features });
     registerUISettings({ uiSettings: coreSetup.uiSettings });
 
+    this.workflowsManagementApi = setupDeps.workflowsManagement.management;
+
     const smlSetup = this.smlServiceInstance.setup({ logger: this.logger.get('sml') });
+
+    // Built-in SML types owned by this plugin. The `index_kpi` type backs the
+    // bundled `workflow-sml-index-augmentation` workflow, which writes chunks
+    // directly via the `agentContextLayer.smlIndexAttachment` step.
+    smlSetup.registerType(indexKpiSmlType);
 
     registerSmlCrawlerTaskDefinition({
       taskManager: setupDeps.taskManager,
@@ -82,6 +95,34 @@ export class AgentContextLayerPlugin
       logger: this.logger,
       getSmlService,
     });
+    registerSystemWorkflowsRoutes({
+      router,
+      coreSetup,
+      logger: this.logger.get('system_workflows'),
+      getWorkflowsManagementApi: () => {
+        if (!this.workflowsManagementApi) {
+          throw new Error(
+            'Workflows management API not available — Agent Context Layer setup did not complete.'
+          );
+        }
+        return this.workflowsManagementApi;
+      },
+    });
+
+    if (setupDeps.workflowsExtensions) {
+      registerAgentContextLayerWorkflowSteps({
+        workflowsExtensions: setupDeps.workflowsExtensions,
+        getStartContract: () => {
+          if (!this.startContract) {
+            throw new Error(
+              'Agent Context Layer start contract is not available — plugin has not started'
+            );
+          }
+          return this.startContract;
+        },
+        getSpaces: () => this.spaces,
+      });
+    }
 
     return {
       registerType: smlSetup.registerType,
@@ -98,6 +139,7 @@ export class AgentContextLayerPlugin
       logger: this.logger.get('sml'),
       securityAuthz: security?.authz,
     });
+    this.spaces = spaces;
 
     const smlService = this.smlService;
 
@@ -109,7 +151,7 @@ export class AgentContextLayerPlugin
       this.logger.error(`Failed to schedule SML crawler tasks: ${error.message}`);
     });
 
-    return {
+    const startContract: AgentContextLayerPluginStart = {
       search: smlService.search,
       checkItemsAccess: smlService.checkItemsAccess,
       getDocuments: smlService.getDocuments,
@@ -131,9 +173,15 @@ export class AgentContextLayerPlugin
           esClient: elasticsearch.client.asInternalUser,
           savedObjectsClient: soClient,
           logger: this.logger.get('sml'),
+          chunks: params.chunks,
+          source: params.source,
         });
       },
     };
+
+    this.startContract = startContract;
+
+    return startContract;
   }
 
   stop() {}

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/search.test.ts
@@ -89,6 +89,7 @@ describe('registerSearchRoute', () => {
         updated_at: '2024-01-02',
         spaces: ['test-space'],
         permissions: [],
+        source: 'resolved',
         score: 1.5,
       },
     ];
@@ -123,6 +124,7 @@ describe('registerSearchRoute', () => {
         updated_at: '2024-01-02',
         spaces: ['test-space'],
         permissions: [],
+        source: 'resolved',
         score: 1.5,
       },
     ];

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/system_workflows.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/system_workflows.test.ts
@@ -1,0 +1,394 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup } from '@kbn/core/server';
+import { coreMock, httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { spacesMock } from '@kbn/spaces-plugin/server/mocks';
+import { registerSystemWorkflowsRoutes } from './system_workflows';
+import type {
+  AgentContextLayerPluginStart,
+  AgentContextLayerStartDependencies,
+  WorkflowsManagementApiContract,
+} from '../types';
+
+interface CapturedRoute {
+  handler: (...args: any[]) => Promise<any>;
+}
+
+const createMockApi = () =>
+  ({
+    isWorkflowsAvailable: true,
+    getWorkflow: jest.fn(),
+    getWorkflows: jest.fn(),
+    createWorkflow: jest.fn(),
+    updateWorkflow: jest.fn(),
+    deleteWorkflows: jest.fn().mockResolvedValue({ total: 0, deleted: 0, failures: [] }),
+    runWorkflow: jest.fn(),
+    cancelWorkflowExecution: jest.fn(),
+    resumeWorkflowExecution: jest.fn(),
+    getWorkflowExecutions: jest.fn(),
+    getWorkflowExecution: jest.fn().mockResolvedValue(null),
+  } as unknown as jest.Mocked<WorkflowsManagementApiContract>);
+
+const buildSystemWorkflowDetail = (overrides: { id?: string; tags?: string[] } = {}) => ({
+  id: overrides.id ?? 'workflow-sml-index-augmentation',
+  name: 'Index augmentation',
+  enabled: true,
+  definition: {
+    name: 'index_augmentation',
+    triggers: [],
+    steps: [],
+    version: '1',
+    tags: overrides.tags ?? ['sml-system', 'sml'],
+  } as any,
+  yaml: '',
+});
+
+describe('Agent Context Layer — system workflows routes', () => {
+  let routes: Record<string, CapturedRoute>;
+  let mockApi: jest.Mocked<WorkflowsManagementApiContract>;
+
+  beforeEach(() => {
+    routes = {};
+    mockApi = createMockApi();
+    const captureRoute = (method: string) => (config: { path: string }, handler: any) => {
+      routes[`${method}:${config.path}`] = { handler };
+    };
+    const router = {
+      get: jest.fn().mockImplementation(captureRoute('GET')),
+      post: jest.fn().mockImplementation(captureRoute('POST')),
+    } as any;
+
+    const coreSetup = coreMock.createSetup();
+    const spacesStart = spacesMock.createStart();
+    spacesStart.spacesService.getSpaceId = jest.fn().mockReturnValue('default');
+    (coreSetup.getStartServices as jest.Mock).mockResolvedValue([
+      coreMock.createStart(),
+      { spaces: spacesStart } as Partial<AgentContextLayerStartDependencies>,
+      {} as AgentContextLayerPluginStart,
+    ]);
+
+    registerSystemWorkflowsRoutes({
+      router,
+      coreSetup: coreSetup as unknown as CoreSetup<
+        AgentContextLayerStartDependencies,
+        AgentContextLayerPluginStart
+      >,
+      logger: loggingSystemMock.createLogger(),
+      getWorkflowsManagementApi: () => mockApi,
+    });
+  });
+
+  it("list route filters by the 'sml-system' tag", async () => {
+    mockApi.getWorkflows.mockResolvedValue({ page: 1, size: 50, total: 0, results: [] });
+    const request = httpServerMock.createKibanaRequest({
+      query: { page: 1, size: 50 },
+    });
+    const response = httpServerMock.createResponseFactory();
+
+    await routes['GET:/internal/agent_context_layer/system_workflows'].handler(
+      {},
+      request,
+      response
+    );
+
+    expect(mockApi.getWorkflows).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: ['sml-system'], page: 1, size: 50 }),
+      'default',
+      { includeExecutionHistory: true }
+    );
+    expect(response.ok).toHaveBeenCalled();
+  });
+
+  it('list route overrides history with the truly latest execution and enriches progress', async () => {
+    // Upstream `getWorkflows` returns history sorted by `finishedAt desc`,
+    // so a brand-new running execution lands behind older completed ones.
+    // We mock that explicitly so the test fails if the route ever blindly
+    // trusts `history[0]` again.
+    mockApi.getWorkflows.mockResolvedValue({
+      page: 1,
+      size: 50,
+      total: 2,
+      results: [
+        {
+          id: 'workflow-sml-index-crawl',
+          name: 'Crawl',
+          description: '',
+          enabled: true,
+          definition: null,
+          createdAt: '2026-05-12T09:00:00.000Z',
+          valid: true,
+          history: [
+            {
+              id: 'exec-crawl-old',
+              status: 'completed',
+              startedAt: '2026-05-12T09:00:00.000Z',
+              finishedAt: '2026-05-12T09:05:00.000Z',
+              duration: 300_000,
+            },
+          ],
+        },
+        {
+          id: 'workflow-sml-index-augmentation',
+          name: 'Augment',
+          description: '',
+          enabled: true,
+          definition: null,
+          createdAt: '2026-05-12T09:00:00.000Z',
+          valid: true,
+          history: [
+            {
+              id: 'exec-aug-old',
+              status: 'completed',
+              startedAt: '2026-05-12T09:00:00.000Z',
+              finishedAt: '2026-05-12T09:05:00.000Z',
+              duration: 300_000,
+            },
+          ],
+        },
+      ],
+    } as any);
+    (mockApi.getWorkflowExecutions as jest.Mock).mockImplementation(async ({ workflowId }) => {
+      if (workflowId === 'workflow-sml-index-crawl') {
+        return {
+          page: 1,
+          size: 1,
+          total: 2,
+          results: [
+            {
+              id: 'exec-crawl-new',
+              workflowId,
+              workflowName: 'Crawl',
+              status: 'running',
+              startedAt: '2026-05-12T10:00:00.000Z',
+              finishedAt: '',
+              duration: null,
+            },
+          ],
+        };
+      }
+      return {
+        page: 1,
+        size: 1,
+        total: 1,
+        results: [
+          {
+            id: 'exec-aug-old',
+            workflowId,
+            workflowName: 'Augment',
+            status: 'completed',
+            startedAt: '2026-05-12T09:00:00.000Z',
+            finishedAt: '2026-05-12T09:05:00.000Z',
+            duration: 300_000,
+          },
+        ],
+      };
+    });
+    mockApi.getWorkflowExecution.mockResolvedValue({
+      id: 'exec-crawl-new',
+      workflowId: 'workflow-sml-index-crawl',
+      status: 'running',
+      stepExecutions: [
+        {
+          id: 'list-step',
+          stepId: 'list_indices',
+          status: 'completed',
+          startedAt: '2026-05-12T10:00:01.000Z',
+          output: [{ index: 'a' }, { index: 'b' }, { index: 'c' }],
+        },
+        {
+          id: 'run-1',
+          stepId: 'run_augmentation',
+          stepType: 'workflow.execute',
+          status: 'completed',
+          startedAt: '2026-05-12T10:00:02.000Z',
+          input: { inputs: { indexPattern: 'a' } },
+        },
+        {
+          id: 'run-2',
+          stepId: 'run_augmentation',
+          stepType: 'workflow.execute',
+          status: 'waiting',
+          startedAt: '2026-05-12T10:00:30.000Z',
+          input: { inputs: { indexPattern: 'b' } },
+        },
+      ],
+      context: {},
+    } as any);
+
+    const request = httpServerMock.createKibanaRequest({ query: { page: 1, size: 50 } });
+    const response = httpServerMock.createResponseFactory();
+
+    await routes['GET:/internal/agent_context_layer/system_workflows'].handler(
+      {},
+      request,
+      response
+    );
+
+    // The freshest run is the one we re-fetch — not the stale `history[0]`.
+    // The route MUST request both input and output — without them the
+    // workflows API strips `list_indices.output` and the `workflow.execute`
+    // step `input`, which would blank out total/currentIndex.
+    expect(mockApi.getWorkflowExecution).toHaveBeenCalledTimes(1);
+    expect(mockApi.getWorkflowExecution).toHaveBeenCalledWith('exec-crawl-new', 'default', {
+      includeInput: true,
+      includeOutput: true,
+    });
+
+    const body = (response.ok as jest.Mock).mock.calls[0][0].body;
+    expect(body.results[0]).toMatchObject({
+      id: 'workflow-sml-index-crawl',
+      // history is overwritten with the newer running execution so the
+      // "Last run" column reflects reality.
+      history: [
+        expect.objectContaining({ id: 'exec-crawl-new', status: 'running' }),
+      ],
+      progress: {
+        kind: 'crawl',
+        total: 3,
+        completed: 1,
+        currentIndex: 'b',
+      },
+    });
+    expect(body.results[1].progress).toBeUndefined();
+    expect(body.results[1].history[0]).toMatchObject({ id: 'exec-aug-old', status: 'completed' });
+  });
+
+  it('list route silently degrades when progress enrichment fails', async () => {
+    mockApi.getWorkflows.mockResolvedValue({
+      page: 1,
+      size: 50,
+      total: 1,
+      results: [
+        {
+          id: 'workflow-sml-index-augmentation',
+          name: 'Aug',
+          enabled: true,
+          history: [],
+        } as any,
+      ],
+    } as any);
+    (mockApi.getWorkflowExecutions as jest.Mock).mockResolvedValue({
+      page: 1,
+      size: 1,
+      total: 1,
+      results: [
+        {
+          id: 'exec-fail',
+          workflowId: 'workflow-sml-index-augmentation',
+          workflowName: 'Aug',
+          status: 'running',
+          startedAt: '2026-05-12T10:00:00.000Z',
+          finishedAt: '',
+          duration: null,
+        },
+      ],
+    });
+    mockApi.getWorkflowExecution.mockRejectedValue(new Error('timeout'));
+
+    const request = httpServerMock.createKibanaRequest({ query: { page: 1, size: 50 } });
+    const response = httpServerMock.createResponseFactory();
+
+    await routes['GET:/internal/agent_context_layer/system_workflows'].handler(
+      {},
+      request,
+      response
+    );
+
+    const body = (response.ok as jest.Mock).mock.calls[0][0].body;
+    expect(body.results[0].progress).toBeUndefined();
+    // History fallback still surfaces the running run even when the
+    // step-level fetch fails — the UI needs *something* to render.
+    expect(body.results[0].history[0]).toMatchObject({
+      id: 'exec-fail',
+      status: 'running',
+    });
+    expect(response.ok).toHaveBeenCalled();
+  });
+
+  it("start route rejects workflows that are not tagged 'sml-system'", async () => {
+    mockApi.getWorkflow.mockResolvedValue(
+      buildSystemWorkflowDetail({ id: 'workflow-other', tags: ['other'] }) as any
+    );
+    const request = httpServerMock.createKibanaRequest({
+      params: { id: 'workflow-other' },
+      body: { inputs: {} },
+    });
+    const response = httpServerMock.createResponseFactory();
+
+    await routes['POST:/internal/agent_context_layer/system_workflows/{id}/_start'].handler(
+      {},
+      request,
+      response
+    );
+
+    expect(mockApi.runWorkflow).not.toHaveBeenCalled();
+    expect(response.customError).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
+  });
+
+  it("start route invokes runWorkflow when the workflow is tagged 'sml-system'", async () => {
+    mockApi.getWorkflow.mockResolvedValue(buildSystemWorkflowDetail() as any);
+    mockApi.runWorkflow.mockResolvedValue('exec-123');
+
+    const request = httpServerMock.createKibanaRequest({
+      params: { id: 'workflow-sml-index-augmentation' },
+      body: { inputs: {} },
+    });
+    const response = httpServerMock.createResponseFactory();
+
+    await routes['POST:/internal/agent_context_layer/system_workflows/{id}/_start'].handler(
+      {},
+      request,
+      response
+    );
+
+    expect(mockApi.runWorkflow).toHaveBeenCalled();
+    const [, , , , triggeredBy] = mockApi.runWorkflow.mock.calls[0];
+    expect(triggeredBy).toBe('agent_context_layer:management_page');
+    expect(response.ok).toHaveBeenCalledWith({ body: { executionId: 'exec-123' } });
+  });
+
+  it("cancel route refuses workflows that are not tagged 'sml-system'", async () => {
+    mockApi.getWorkflow.mockResolvedValue(
+      buildSystemWorkflowDetail({ id: 'evil', tags: [] }) as any
+    );
+    const request = httpServerMock.createKibanaRequest({
+      params: { id: 'evil', executionId: 'exec-1' },
+    });
+    const response = httpServerMock.createResponseFactory();
+
+    await routes[
+      'POST:/internal/agent_context_layer/system_workflows/{id}/executions/{executionId}/_cancel'
+    ].handler({}, request, response);
+
+    expect(mockApi.cancelWorkflowExecution).not.toHaveBeenCalled();
+    expect(response.customError).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
+  });
+
+  it('install route delegates to installSystemWorkflows and returns the result', async () => {
+    mockApi.getWorkflow.mockResolvedValue(null);
+    (mockApi as any).createWorkflow.mockResolvedValue({ id: 'workflow-sml-x' } as any);
+
+    const request = httpServerMock.createKibanaRequest({});
+    const response = httpServerMock.createResponseFactory();
+
+    await routes['POST:/internal/agent_context_layer/system_workflows/_install'].handler(
+      {},
+      request,
+      response
+    );
+
+    expect((mockApi as any).createWorkflow).toHaveBeenCalled();
+    expect(response.ok).toHaveBeenCalledWith({
+      body: expect.objectContaining({
+        created: expect.any(Array),
+        skipped: expect.any(Array),
+        failed: expect.any(Array),
+      }),
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/routes/system_workflows.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/routes/system_workflows.ts
@@ -1,0 +1,453 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { CoreSetup, IRouter, KibanaRequest, Logger } from '@kbn/core/server';
+import type { RouteSecurity } from '@kbn/core-http-server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type {
+  WorkflowDetailDto,
+  WorkflowExecutionEngineModel,
+  WorkflowExecutionHistoryModel,
+  WorkflowExecutionListItemDto,
+  WorkflowListDto,
+  WorkflowListItemDto,
+} from '@kbn/workflows';
+import type { WorkflowsManagementApiContract } from '../types';
+import { apiPrivileges } from '../../common/features';
+import {
+  SML_SYSTEM_WORKFLOW_TAG,
+  systemWorkflowCancelExecutionPath,
+  systemWorkflowExecutionsPath,
+  systemWorkflowItemPath,
+  systemWorkflowResumeExecutionPath,
+  systemWorkflowStartPath,
+  systemWorkflowsInstallPath,
+  systemWorkflowsListPath,
+  type SmlSystemWorkflowProgress,
+} from '../../common/constants';
+import type { AgentContextLayerPluginStart, AgentContextLayerStartDependencies } from '../types';
+import { installSystemWorkflows } from '../system_workflows/install_system_workflows';
+import { computeSmlWorkflowProgress } from '../system_workflows/compute_progress';
+
+const SYSTEM_WORKFLOW_MANAGE_SECURITY: RouteSecurity = {
+  authz: { requiredPrivileges: [apiPrivileges.manageSystemWorkflows] },
+};
+
+const ID_PARAM = schema.object({
+  id: schema.string({ minLength: 1, meta: { description: 'Workflow id.' } }),
+});
+
+const ID_AND_EXECUTION_PARAMS = schema.object({
+  id: schema.string({ minLength: 1 }),
+  executionId: schema.string({ minLength: 1 }),
+});
+
+const ensureSystemTaggedWorkflow = (workflow: WorkflowDetailDto): void => {
+  const definitionTags = workflow.definition?.tags;
+  const isSystemTagged =
+    Array.isArray(definitionTags) && definitionTags.includes(SML_SYSTEM_WORKFLOW_TAG);
+  if (!isSystemTagged) {
+    throw new ApiError(
+      400,
+      `Workflow '${workflow.id}' is not an SML system workflow (must be tagged '${SML_SYSTEM_WORKFLOW_TAG}').`
+    );
+  }
+};
+
+class ApiError extends Error {
+  constructor(public readonly statusCode: number, message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Registers the HTTP routes powering the ACL management page.
+ *
+ * Every route is gated by the `agentContextLayer:manageSystemWorkflows`
+ * sub-feature privilege and proxies to the workflows management server
+ * contract. The list route scopes to workflows tagged
+ * {@link SML_SYSTEM_WORKFLOW_TAG}; per-id routes verify the resolved
+ * workflow carries the same tag before operating on it.
+ */
+export const registerSystemWorkflowsRoutes = ({
+  router,
+  coreSetup,
+  logger,
+  getWorkflowsManagementApi,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<AgentContextLayerStartDependencies, AgentContextLayerPluginStart>;
+  logger: Logger;
+  getWorkflowsManagementApi: () => WorkflowsManagementApiContract;
+}) => {
+  const resolveSpaceId = async (request: KibanaRequest): Promise<string> => {
+    const [, startDeps] = await coreSetup.getStartServices();
+    const spaces: SpacesPluginStart | undefined = startDeps.spaces;
+    return spaces?.spacesService?.getSpaceId(request) ?? 'default';
+  };
+
+  router.get(
+    {
+      path: systemWorkflowsListPath,
+      security: SYSTEM_WORKFLOW_MANAGE_SECURITY,
+      validate: {
+        query: schema.object({
+          size: schema.number({ defaultValue: 50, min: 1, max: 500 }),
+          page: schema.number({ defaultValue: 1, min: 1 }),
+          query: schema.maybe(schema.string()),
+          enabled: schema.maybe(schema.boolean()),
+        }),
+      },
+    },
+    async (_context, request, response) => {
+      try {
+        const spaceId = await resolveSpaceId(request);
+        const api = getWorkflowsManagementApi();
+        const list: WorkflowListDto = await api.getWorkflows(
+          {
+            size: request.query.size,
+            page: request.query.page,
+            query: request.query.query,
+            tags: [SML_SYSTEM_WORKFLOW_TAG],
+            enabled:
+              typeof request.query.enabled === 'boolean' ? [request.query.enabled] : undefined,
+          },
+          spaceId,
+          { includeExecutionHistory: true }
+        );
+        const enrichedResults = await Promise.all(
+          list.results.map((item) => enrichWithProgress({ api, item, spaceId, logger }))
+        );
+        return response.ok({
+          body: { ...list, results: enrichedResults },
+        });
+      } catch (error) {
+        return handleError(response, logger, error, 'list-system-workflows');
+      }
+    }
+  );
+
+  router.post(
+    {
+      path: systemWorkflowsInstallPath,
+      security: SYSTEM_WORKFLOW_MANAGE_SECURITY,
+      validate: false,
+    },
+    async (_context, request, response) => {
+      try {
+        const spaceId = await resolveSpaceId(request);
+        const api = getWorkflowsManagementApi();
+        const result = await installSystemWorkflows({
+          workflowsManagementApi: api,
+          request,
+          spaceId,
+          logger,
+        });
+        return response.ok({ body: result });
+      } catch (error) {
+        return handleError(response, logger, error, 'install-system-workflows');
+      }
+    }
+  );
+
+  router.get(
+    {
+      path: systemWorkflowItemPath,
+      security: SYSTEM_WORKFLOW_MANAGE_SECURITY,
+      validate: { params: ID_PARAM },
+    },
+    async (_context, request, response) => {
+      try {
+        const spaceId = await resolveSpaceId(request);
+        const api = getWorkflowsManagementApi();
+        const workflow = await api.getWorkflow(request.params.id, spaceId);
+        if (!workflow) {
+          return response.notFound({ body: { message: 'Workflow not found.' } });
+        }
+        ensureSystemTaggedWorkflow(workflow);
+        return response.ok({ body: workflow });
+      } catch (error) {
+        return handleError(response, logger, error, 'get-system-workflow');
+      }
+    }
+  );
+
+  router.post(
+    {
+      path: systemWorkflowStartPath,
+      security: SYSTEM_WORKFLOW_MANAGE_SECURITY,
+      validate: {
+        params: ID_PARAM,
+        body: schema.object({
+          inputs: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),
+        }),
+      },
+    },
+    async (_context, request, response) => {
+      try {
+        const spaceId = await resolveSpaceId(request);
+        const api = getWorkflowsManagementApi();
+        const workflow = await api.getWorkflow(request.params.id, spaceId);
+        if (!workflow) {
+          return response.notFound({ body: { message: 'Workflow not found.' } });
+        }
+        ensureSystemTaggedWorkflow(workflow);
+        const executionId = await api.runWorkflow(
+          toEngineModel(workflow),
+          spaceId,
+          request.body.inputs,
+          request,
+          'agent_context_layer:management_page'
+        );
+        return response.ok({ body: { executionId } });
+      } catch (error) {
+        return handleError(response, logger, error, 'start-system-workflow');
+      }
+    }
+  );
+
+  router.post(
+    {
+      path: systemWorkflowCancelExecutionPath,
+      security: SYSTEM_WORKFLOW_MANAGE_SECURITY,
+      validate: { params: ID_AND_EXECUTION_PARAMS },
+    },
+    async (_context, request, response) => {
+      try {
+        const spaceId = await resolveSpaceId(request);
+        const api = getWorkflowsManagementApi();
+        const workflow = await api.getWorkflow(request.params.id, spaceId);
+        if (!workflow) {
+          return response.notFound({ body: { message: 'Workflow not found.' } });
+        }
+        ensureSystemTaggedWorkflow(workflow);
+        await api.cancelWorkflowExecution(request.params.executionId, spaceId);
+        return response.ok({ body: { ok: true } });
+      } catch (error) {
+        return handleError(response, logger, error, 'cancel-system-workflow-execution');
+      }
+    }
+  );
+
+  router.post(
+    {
+      path: systemWorkflowResumeExecutionPath,
+      security: SYSTEM_WORKFLOW_MANAGE_SECURITY,
+      validate: {
+        params: ID_AND_EXECUTION_PARAMS,
+        body: schema.object({
+          inputs: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),
+        }),
+      },
+    },
+    async (_context, request, response) => {
+      try {
+        const spaceId = await resolveSpaceId(request);
+        const api = getWorkflowsManagementApi();
+        const workflow = await api.getWorkflow(request.params.id, spaceId);
+        if (!workflow) {
+          return response.notFound({ body: { message: 'Workflow not found.' } });
+        }
+        ensureSystemTaggedWorkflow(workflow);
+        await api.resumeWorkflowExecution(
+          request.params.executionId,
+          spaceId,
+          request.body.inputs,
+          request
+        );
+        return response.ok({ body: { ok: true } });
+      } catch (error) {
+        return handleError(response, logger, error, 'resume-system-workflow-execution');
+      }
+    }
+  );
+
+  router.get(
+    {
+      path: systemWorkflowExecutionsPath,
+      security: SYSTEM_WORKFLOW_MANAGE_SECURITY,
+      validate: {
+        params: ID_PARAM,
+        query: schema.object({
+          size: schema.number({ defaultValue: 20, min: 1, max: 200 }),
+          page: schema.number({ defaultValue: 1, min: 1 }),
+        }),
+      },
+    },
+    async (_context, request, response) => {
+      try {
+        const spaceId = await resolveSpaceId(request);
+        const api = getWorkflowsManagementApi();
+        const workflow = await api.getWorkflow(request.params.id, spaceId);
+        if (!workflow) {
+          return response.notFound({ body: { message: 'Workflow not found.' } });
+        }
+        ensureSystemTaggedWorkflow(workflow);
+        const executions = await api.getWorkflowExecutions(
+          {
+            workflowId: request.params.id,
+            size: request.query.size,
+            page: request.query.page,
+          },
+          spaceId
+        );
+        return response.ok({ body: executions });
+      } catch (error) {
+        return handleError(response, logger, error, 'list-system-workflow-executions');
+      }
+    }
+  );
+};
+
+const toEngineModel = (workflow: WorkflowDetailDto): WorkflowExecutionEngineModel => ({
+  id: workflow.id,
+  name: workflow.name,
+  enabled: workflow.enabled,
+  definition: workflow.definition!,
+  yaml: workflow.yaml,
+});
+
+/**
+ * Wrapper around `WorkflowListItemDto` we ship to the ACL admin page. We
+ * extend, not replace, the upstream dto so the React table keeps using its
+ * existing fields (`name`, `enabled`, `history`, ...). Extra fields are
+ * silently dropped if the client doesn't know about them.
+ */
+type SmlSystemWorkflowListItem = WorkflowListItemDto & {
+  /**
+   * Best-effort progress summary for the latest execution. Populated only
+   * while the most recent history entry is still running (or pending). The
+   * client uses it to render a richer status column for the two bundled
+   * workflows; absence means "no live progress to display".
+   */
+  progress?: SmlSystemWorkflowProgress;
+};
+
+/**
+ * Active history-entry statuses. We only enrich progress for these because
+ * computing it requires an extra `getWorkflowExecution` round trip per row —
+ * there's no value in paying that cost for completed/failed runs whose final
+ * state is already visible in the "Last run" column.
+ */
+const ACTIVE_HISTORY_STATUSES = new Set(['running', 'pending', 'waiting_for_input', 'waiting']);
+
+/**
+ * Project a `WorkflowExecutionListItemDto` (returned by
+ * `getWorkflowExecutions`) onto the smaller `WorkflowExecutionHistoryModel`
+ * shape the table's "Last run" column understands. We only need the fields
+ * the upstream `getRecentExecutionsForWorkflows` would have populated.
+ */
+const toHistoryEntry = (
+  execution: WorkflowExecutionListItemDto
+): WorkflowExecutionHistoryModel => ({
+  id: execution.id,
+  workflowId: execution.workflowId,
+  workflowName: execution.workflowName,
+  status: execution.status,
+  startedAt: execution.startedAt,
+  finishedAt: execution.finishedAt,
+  duration: execution.duration ?? null,
+});
+
+/**
+ * Hydrate a list item with the *truly* latest execution and a `progress`
+ * summary when that execution is still in flight.
+ *
+ * Why we re-fetch instead of trusting `item.history[0]`: the upstream
+ * `getWorkflows({ includeExecutionHistory: true })` populates history via a
+ * `top_hits` aggregation sorted by `finishedAt desc`. Running executions
+ * have no `finishedAt`, so they sort last — the array ends up showing the
+ * most-recently-finished run while a brand-new run is invisibly in
+ * progress. We call `getWorkflowExecutions({ size: 1 })` (default sort
+ * `createdAt desc`) to surface the actual newest execution and overwrite
+ * `history[0]` so the "Last run" column reflects reality.
+ *
+ * Returns the row unchanged (no enrichment) when:
+ *   - The workflow has never been executed.
+ *   - The latest execution is already in a terminal state.
+ *   - Lookups fail (permissions, transient ES hiccup, ...). Progress and
+ *     the override are purely informational, so we swallow errors rather
+ *     than failing the whole list response.
+ *
+ * `getWorkflowExecution` is called with `includeInput`/`includeOutput`
+ * because the workflows API strips both by default — without them the
+ * crawl can't derive `total` (from `list_indices.output`) or
+ * `currentIndex` (from the in-flight `workflow.execute` step's resolved
+ * `inputs.indexPattern`).
+ */
+const enrichWithProgress = async ({
+  api,
+  item,
+  spaceId,
+  logger,
+}: {
+  api: WorkflowsManagementApiContract;
+  item: WorkflowListItemDto;
+  spaceId: string;
+  logger: Logger;
+}): Promise<SmlSystemWorkflowListItem> => {
+  let latest: WorkflowExecutionHistoryModel | undefined;
+  try {
+    const latestList = await api.getWorkflowExecutions(
+      { workflowId: item.id, size: 1, page: 1 },
+      spaceId
+    );
+    const newest = latestList.results[0];
+    if (newest) latest = toHistoryEntry(newest);
+  } catch (error) {
+    logger.debug(
+      `Agent Context Layer failed to fetch latest execution for '${item.id}': ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  // Fall back to the upstream-provided history when re-fetch failed, so
+  // rows still render something meaningful instead of going blank.
+  const baseItem: WorkflowListItemDto = latest
+    ? { ...item, history: [latest] }
+    : item;
+  const activeLatest = latest ?? item.history?.[0];
+  if (!activeLatest || !ACTIVE_HISTORY_STATUSES.has(activeLatest.status)) {
+    return baseItem;
+  }
+  try {
+    const execution = await api.getWorkflowExecution(activeLatest.id, spaceId, {
+      includeInput: true,
+      includeOutput: true,
+    });
+    if (!execution) return baseItem;
+    const progress = computeSmlWorkflowProgress({ execution });
+    if (!progress) return baseItem;
+    return { ...baseItem, progress };
+  } catch (error) {
+    logger.debug(
+      `Agent Context Layer progress enrichment skipped for '${item.id}' (execution '${activeLatest.id}'): ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return baseItem;
+  }
+};
+
+const handleError = (
+  response: Parameters<Parameters<IRouter['post']>[1]>[2],
+  logger: Logger,
+  error: unknown,
+  op: string
+) => {
+  if (error instanceof ApiError) {
+    return response.customError({
+      statusCode: error.statusCode,
+      body: { message: error.message },
+    });
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  logger.error(`Agent Context Layer ${op} failed: ${message}`);
+  return response.customError({ statusCode: 500, body: { message } });
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/execute_sml_attach_items.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/execute_sml_attach_items.test.ts
@@ -39,6 +39,7 @@ const createSmlDoc = (overrides: Partial<SmlDocument> = {}): SmlDocument => ({
   updated_at: '2024-01-02',
   spaces: ['default'],
   permissions: [],
+  source: 'resolved',
   ...overrides,
 });
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_crawler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_crawler.test.ts
@@ -406,6 +406,9 @@ describe('SmlCrawlerImpl', () => {
           attachmentType: 'test-type',
           action: 'create',
           spaces: ['default'],
+          // Crawler must label its writes as resolved so direct-mode writes
+          // override them (and vice versa, the indexer skips when direct exists).
+          source: 'resolved',
         })
       );
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_crawler.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_crawler.ts
@@ -372,6 +372,9 @@ export class SmlCrawlerImpl implements SmlCrawler {
                 esClient,
                 savedObjectsClient,
                 logger: this.logger,
+                // Crawler operations are always resolved-mode: they use the
+                // type's `getSmlData` hook and must yield to direct chunks.
+                source: 'resolved',
               });
 
               if (action === 'delete') {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.test.ts
@@ -29,9 +29,16 @@ jest.mock('./sml_service', () => ({
 
 jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
 
-const createMockEsClient = (): jest.Mocked<ElasticsearchClient> =>
+const createMockEsClient = (
+  overrides: Partial<{
+    deleteByQuery: jest.Mock;
+    count: jest.Mock;
+  }> = {}
+): jest.Mocked<ElasticsearchClient> =>
   ({
-    deleteByQuery: jest.fn().mockResolvedValue({ deleted: 0 }),
+    deleteByQuery: overrides.deleteByQuery ?? jest.fn().mockResolvedValue({ deleted: 0 }),
+    // Default to "no direct chunks exist".
+    count: overrides.count ?? jest.fn().mockResolvedValue({ count: 0 }),
   } as unknown as jest.Mocked<ElasticsearchClient>);
 
 const createMockLogger = () => {
@@ -162,6 +169,7 @@ describe('createSmlIndexer', () => {
         updated_at: expect.any(String),
         spaces: ['default', 'space-2'],
         permissions: ['perm1'],
+        source: 'resolved',
       });
     });
 
@@ -404,6 +412,384 @@ describe('createSmlIndexer', () => {
 
       const bulkCall = bulkMock.mock.calls[0][0];
       expect(bulkCall.operations[0].index.document.permissions).toEqual([]);
+    });
+
+    describe('direct mode (caller-supplied chunks)', () => {
+      it('uses caller-supplied chunks and does NOT call getSmlData', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-1',
+            attachmentType: 'lens',
+            action: 'create',
+            spaces: ['s1'],
+            esClient,
+            logger,
+          }),
+          chunks: [
+            {
+              type: 'lens',
+              title: 'Direct title',
+              content: 'Direct content',
+              permissions: ['perm-x'],
+            },
+          ],
+        });
+
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+        const op = bulkMock.mock.calls[0][0].operations[0];
+        expect(op.index._id).toBe('lens:direct-1:mock-uuid');
+        expect(op.index.document).toEqual({
+          id: 'lens:direct-1:mock-uuid',
+          type: 'lens',
+          title: 'Direct title',
+          origin_id: 'direct-1',
+          content: 'Direct content',
+          created_at: expect.any(String),
+          updated_at: expect.any(String),
+          spaces: ['s1'],
+          permissions: ['perm-x'],
+          source: 'direct',
+        });
+      });
+
+      it('indexes direct chunks even when the type is NOT registered', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const registry = createMockRegistry(undefined);
+        registry.list.mockReturnValue([]);
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-2',
+            attachmentType: 'unregistered',
+            action: 'create',
+            esClient,
+            logger,
+          }),
+          chunks: [{ type: 'unregistered', title: 't', content: 'c' }],
+        });
+
+        expect(registry.get).not.toHaveBeenCalled();
+        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('type definition'));
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('treats an empty chunks array as a soft delete', async () => {
+        const bulkMock = jest.fn();
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-3',
+            attachmentType: 'lens',
+            action: 'update',
+            esClient,
+            logger,
+          }),
+          chunks: [],
+        });
+
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+        expect(bulkMock).not.toHaveBeenCalled();
+      });
+
+      it('ignores caller-supplied chunks for the delete action (always deletes)', async () => {
+        const bulkMock = jest.fn();
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-4',
+            attachmentType: 'lens',
+            action: 'delete',
+            esClient,
+            logger,
+          }),
+          chunks: [{ type: 'lens', title: 'ignored', content: 'ignored' }],
+        });
+
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(bulkMock).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('source-based mutual exclusion (direct vs resolved)', () => {
+      it('resolved create: skips when direct chunks already exist for the origin', async () => {
+        const bulkMock = jest.fn();
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn().mockResolvedValue({
+          chunks: [{ type: 'lens', title: 'crawler', content: 'c' }],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        // direct chunks exist for this origin
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 2 }),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment(
+          createIndexerParams({
+            originId: 'mixed-1',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          })
+        );
+
+        expect(esClient.count).toHaveBeenCalledTimes(1);
+        const countCall = (esClient.count as jest.Mock).mock.calls[0][0];
+        expect(countCall.query.bool.filter).toEqual(
+          expect.arrayContaining([
+            { term: { origin_id: 'mixed-1' } },
+            { term: { source: 'direct' } },
+          ])
+        );
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).not.toHaveBeenCalled();
+        expect(bulkMock).not.toHaveBeenCalled();
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.stringContaining('skipping resolved-mode index')
+        );
+      });
+
+      it('resolved delete: skips when direct chunks already exist for the origin', async () => {
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 1 }),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment(
+          createIndexerParams({
+            originId: 'mixed-2',
+            attachmentType: 'lens',
+            action: 'delete',
+            esClient,
+            logger,
+          })
+        );
+
+        expect(esClient.count).toHaveBeenCalledTimes(1);
+        expect(esClient.deleteByQuery).not.toHaveBeenCalled();
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.stringContaining('skipping resolved-mode delete')
+        );
+      });
+
+      it("explicit source='resolved' is respected (skips when direct exists)", async () => {
+        const bulkMock = jest.fn();
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn().mockResolvedValue({
+          chunks: [{ type: 'lens', title: 't', content: 'c' }],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 3 }),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'mixed-3',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          }),
+          source: 'resolved',
+        });
+
+        expect(getSmlData).not.toHaveBeenCalled();
+        expect(bulkMock).not.toHaveBeenCalled();
+      });
+
+      it('direct create: overrides existing resolved chunks without checking', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn();
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        // even with existing direct chunks (e.g. user re-indexing), direct should override
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 5 }),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'override-1',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          }),
+          chunks: [{ type: 'lens', title: 'override', content: 'new' }],
+        });
+
+        // No precedence check needed in direct mode — direct always wins.
+        expect(esClient.count).not.toHaveBeenCalled();
+        expect(getSmlData).not.toHaveBeenCalled();
+        // deleteByQuery wipes everything for the origin (regardless of source).
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+        expect(esClient.deleteByQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: { term: { origin_id: 'override-1' } },
+          })
+        );
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+        const op = bulkMock.mock.calls[0][0].operations[0];
+        expect(op.index.document.source).toBe('direct');
+      });
+
+      it('direct delete: wipes all chunks regardless of crawler state', async () => {
+        const esClient = createMockEsClient({
+          count: jest.fn().mockResolvedValue({ count: 0 }),
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData: jest.fn() })
+        );
+        const logger = createMockLogger();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'override-2',
+            attachmentType: 'lens',
+            action: 'delete',
+            esClient,
+            logger,
+          }),
+          source: 'direct',
+        });
+
+        expect(esClient.count).not.toHaveBeenCalled();
+        expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
+      });
+
+      it('resolved create: proceeds when no direct chunks exist', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn().mockResolvedValue({
+          chunks: [{ type: 'lens', title: 't', content: 'c' }],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient(); // count defaults to 0
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment(
+          createIndexerParams({
+            originId: 'resolved-only',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          })
+        );
+
+        expect(esClient.count).toHaveBeenCalledTimes(1);
+        expect(getSmlData).toHaveBeenCalledTimes(1);
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+        const op = bulkMock.mock.calls[0][0].operations[0];
+        expect(op.index.document.source).toBe('resolved');
+      });
+
+      it('resolved create: fails open when the precedence check throws non-404', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const getSmlData = jest.fn().mockResolvedValue({
+          chunks: [{ type: 'lens', title: 't', content: 'c' }],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient({
+          count: jest.fn().mockRejectedValue(new Error('cluster_block_exception')),
+        });
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment(
+          createIndexerParams({
+            originId: 'fail-open-1',
+            attachmentType: 'lens',
+            action: 'create',
+            esClient,
+            logger,
+          })
+        );
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('failed to check for direct chunks')
+        );
+        // Failing open means the resolved write proceeds.
+        expect(getSmlData).toHaveBeenCalledTimes(1);
+        expect(bulkMock).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.test.ts
@@ -54,6 +54,15 @@ const createMockSmlTypeDefinition = (
   list: jest.fn(),
   getSmlData: jest.fn(),
   toAttachment: jest.fn(),
+  // Permissive default: grants access in the caller's space with no extra
+  // permission requirements. Individual tests override this when they need
+  // to exercise rejection paths (missing hook, cross-space, etc).
+  resolveOriginAccess: jest
+    .fn()
+    .mockImplementation(async (_id: string, _ctx: unknown, spaceId: string) => ({
+      spaces: [spaceId],
+      permissions: [],
+    })),
   ...overrides,
 });
 
@@ -70,6 +79,7 @@ const createIndexerParams = (
     attachmentType: string;
     action: 'create' | 'update' | 'delete';
     spaces: string[];
+    spaceId: string;
     esClient: jest.Mocked<ElasticsearchClient>;
     logger: ReturnType<typeof createMockLogger>;
   }> = {}
@@ -78,6 +88,10 @@ const createIndexerParams = (
   attachmentType: 'lens',
   action: 'create' as const,
   spaces: ['default'],
+  // `spaceId` is required by the indexer's direct-mode access gate.
+  // Resolved-mode tests don't read it, so providing a default here keeps
+  // both modes simple.
+  spaceId: 'default',
   esClient: createMockEsClient(),
   savedObjectsClient: {} as unknown as ISavedObjectsRepository,
   logger: createMockLogger(),
@@ -415,14 +429,21 @@ describe('createSmlIndexer', () => {
     });
 
     describe('direct mode (caller-supplied chunks)', () => {
-      it('uses caller-supplied chunks and does NOT call getSmlData', async () => {
+      it('overrides caller-supplied spaces/permissions with values from resolveOriginAccess', async () => {
         const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
         const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
         (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
 
         const getSmlData = jest.fn();
+        // resolveOriginAccess is the authoritative source: it grants the
+        // caller's space and a fixed permission, ignoring whatever the
+        // caller passed.
+        const resolveOriginAccess = jest.fn().mockResolvedValue({
+          spaces: ['default'],
+          permissions: ['saved_object:dashboard/get'],
+        });
         const registry = createMockRegistry(
-          createMockSmlTypeDefinition({ id: 'lens', getSmlData })
+          createMockSmlTypeDefinition({ id: 'lens', getSmlData, resolveOriginAccess })
         );
         const logger = createMockLogger();
         const esClient = createMockEsClient();
@@ -433,7 +454,10 @@ describe('createSmlIndexer', () => {
             originId: 'direct-1',
             attachmentType: 'lens',
             action: 'create',
+            // Caller TRIES to write to a space that doesn't match the
+            // origin — must be ignored in favor of resolveOriginAccess.
             spaces: ['s1'],
+            spaceId: 'default',
             esClient,
             logger,
           }),
@@ -442,12 +466,19 @@ describe('createSmlIndexer', () => {
               type: 'lens',
               title: 'Direct title',
               content: 'Direct content',
+              // Caller also tries to set its own permissions — must be
+              // overridden by the hook.
               permissions: ['perm-x'],
             },
           ],
         });
 
         expect(getSmlData).not.toHaveBeenCalled();
+        expect(resolveOriginAccess).toHaveBeenCalledWith(
+          'direct-1',
+          expect.objectContaining({ esClient }),
+          'default'
+        );
         expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
         expect(bulkMock).toHaveBeenCalledTimes(1);
         const op = bulkMock.mock.calls[0][0].operations[0];
@@ -460,37 +491,218 @@ describe('createSmlIndexer', () => {
           content: 'Direct content',
           created_at: expect.any(String),
           updated_at: expect.any(String),
-          spaces: ['s1'],
-          permissions: ['perm-x'],
+          // Hook-derived, not caller-supplied.
+          spaces: ['default'],
+          permissions: ['saved_object:dashboard/get'],
           source: 'direct',
         });
       });
 
-      it('indexes direct chunks even when the type is NOT registered', async () => {
-        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
-        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
-        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
-
+      it('rejects direct writes for unregistered types', async () => {
         const registry = createMockRegistry(undefined);
         registry.list.mockReturnValue([]);
         const logger = createMockLogger();
         const esClient = createMockEsClient();
         const indexer = createSmlIndexer({ registry, logger });
 
+        await expect(
+          indexer.indexAttachment({
+            ...createIndexerParams({
+              originId: 'direct-2',
+              attachmentType: 'unregistered',
+              action: 'create',
+              esClient,
+              logger,
+            }),
+            chunks: [{ type: 'unregistered', title: 't', content: 'c' }],
+          })
+        ).rejects.toThrow(/Unknown SML attachment type/);
+        expect(esClient.deleteByQuery).not.toHaveBeenCalled();
+      });
+
+      it('rejects direct writes when the type does not implement resolveOriginAccess', async () => {
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({
+            id: 'lens',
+            getSmlData: jest.fn(),
+            resolveOriginAccess: undefined,
+          })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await expect(
+          indexer.indexAttachment({
+            ...createIndexerParams({
+              originId: 'direct-3',
+              attachmentType: 'lens',
+              action: 'create',
+              esClient,
+              logger,
+            }),
+            chunks: [{ type: 'lens', title: 't', content: 'c' }],
+          })
+        ).rejects.toThrow(/not direct-writable/);
+      });
+
+      it('rejects direct writes when no caller space is provided', async () => {
+        const registry = createMockRegistry(createMockSmlTypeDefinition({ id: 'lens' }));
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await expect(
+          indexer.indexAttachment({
+            ...createIndexerParams({
+              originId: 'direct-4',
+              attachmentType: 'lens',
+              action: 'create',
+              esClient,
+              logger,
+            }),
+            spaceId: undefined,
+            chunks: [{ type: 'lens', title: 't', content: 'c' }],
+          })
+        ).rejects.toThrow(/requires a spaceId/);
+      });
+
+      it('rejects direct writes when resolveOriginAccess returns undefined', async () => {
+        const resolveOriginAccess = jest.fn().mockResolvedValue(undefined);
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', resolveOriginAccess })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await expect(
+          indexer.indexAttachment({
+            ...createIndexerParams({
+              originId: 'direct-5',
+              attachmentType: 'lens',
+              action: 'create',
+              esClient,
+              logger,
+            }),
+            chunks: [{ type: 'lens', title: 't', content: 'c' }],
+          })
+        ).rejects.toThrow(/not accessible from space/);
+      });
+
+      it('rejects cross-space writes when caller space is not in the origin spaces', async () => {
+        const resolveOriginAccess = jest.fn().mockResolvedValue({
+          spaces: ['other-space'],
+          permissions: [],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', resolveOriginAccess })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await expect(
+          indexer.indexAttachment({
+            ...createIndexerParams({
+              originId: 'direct-6',
+              attachmentType: 'lens',
+              action: 'create',
+              spaceId: 'default',
+              esClient,
+              logger,
+            }),
+            chunks: [{ type: 'lens', title: 't', content: 'c' }],
+          })
+        ).rejects.toThrow(/Cross-space write blocked/);
+      });
+
+      it('accepts writes when the origin lives in multiple spaces including the caller space', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const resolveOriginAccess = jest.fn().mockResolvedValue({
+          spaces: ['default', 'marketing'],
+          permissions: ['perm'],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', resolveOriginAccess })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
         await indexer.indexAttachment({
           ...createIndexerParams({
-            originId: 'direct-2',
-            attachmentType: 'unregistered',
+            originId: 'direct-7',
+            attachmentType: 'lens',
             action: 'create',
+            spaceId: 'default',
             esClient,
             logger,
           }),
-          chunks: [{ type: 'unregistered', title: 't', content: 'c' }],
+          chunks: [{ type: 'lens', title: 't', content: 'c' }],
         });
 
-        expect(registry.get).not.toHaveBeenCalled();
-        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('type definition'));
-        expect(bulkMock).toHaveBeenCalledTimes(1);
+        const op = bulkMock.mock.calls[0][0].operations[0];
+        expect(op.index.document.spaces).toEqual(['default', 'marketing']);
+        expect(op.index.document.permissions).toEqual(['perm']);
+      });
+
+      it('accepts writes when the origin spaces include the wildcard', async () => {
+        const bulkMock = jest.fn().mockResolvedValue({ errors: false, items: [] });
+        const getClientMock = jest.fn().mockReturnValue({ bulk: bulkMock });
+        (createSmlStorage as jest.Mock).mockReturnValue({ getClient: getClientMock });
+
+        const resolveOriginAccess = jest.fn().mockResolvedValue({
+          spaces: ['*'],
+          permissions: [],
+        });
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', resolveOriginAccess })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await indexer.indexAttachment({
+          ...createIndexerParams({
+            originId: 'direct-8',
+            attachmentType: 'lens',
+            action: 'create',
+            spaceId: 'default',
+            esClient,
+            logger,
+          }),
+          chunks: [{ type: 'lens', title: 't', content: 'c' }],
+        });
+
+        const op = bulkMock.mock.calls[0][0].operations[0];
+        expect(op.index.document.spaces).toEqual(['*']);
+      });
+
+      it('treats a thrown resolveOriginAccess as a deny', async () => {
+        const resolveOriginAccess = jest.fn().mockRejectedValue(new Error('boom'));
+        const registry = createMockRegistry(
+          createMockSmlTypeDefinition({ id: 'lens', resolveOriginAccess })
+        );
+        const logger = createMockLogger();
+        const esClient = createMockEsClient();
+        const indexer = createSmlIndexer({ registry, logger });
+
+        await expect(
+          indexer.indexAttachment({
+            ...createIndexerParams({
+              originId: 'direct-9',
+              attachmentType: 'lens',
+              action: 'create',
+              esClient,
+              logger,
+            }),
+            chunks: [{ type: 'lens', title: 't', content: 'c' }],
+          })
+        ).rejects.toThrow(/Failed to resolve access/);
       });
 
       it('treats an empty chunks array as a soft delete', async () => {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.ts
@@ -13,7 +13,7 @@ import type {
 } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
 import type { SmlTypeRegistry } from './sml_type_registry';
-import type { SmlIndexAction, SmlContext, SmlDocument } from './types';
+import type { SmlChunk, SmlIndexAction, SmlContext, SmlDocument, SmlDocumentSource } from './types';
 import { createSmlStorage, smlIndexName } from './sml_storage';
 import { isNotFoundError } from './sml_service';
 
@@ -25,6 +25,25 @@ export interface SmlIndexerDeps {
 export interface SmlIndexer {
   /**
    * Index, update, or delete SML data for a specific item.
+   *
+   * The operation runs in one of two modes:
+   *  - **`direct`**: caller supplies `chunks` (or sets `source: 'direct'`
+   *    explicitly). The indexer wipes any pre-existing chunks for `originId`
+   *    (regardless of source) and writes the supplied chunks tagged with
+   *    `source: 'direct'`. For `action: 'delete'` all chunks for the origin
+   *    are wiped.
+   *  - **`resolved`**: caller omits `chunks` (or sets `source: 'resolved'`).
+   *    The indexer looks up the registered type, calls its `getSmlData(originId)`
+   *    hook, and writes the result tagged with `source: 'resolved'`. If chunks
+   *    tagged `source: 'direct'` already exist for this origin, the operation
+   *    is **skipped** to preserve the user's override. The same protection
+   *    applies to `action: 'delete'` in resolved mode.
+   *
+   * `source` is inferred when not provided: `'direct'` if `chunks` is set,
+   * otherwise `'resolved'`.
+   *
+   * Per-`originId` invariant: the index never holds both `resolved` and
+   * `direct` chunks at the same time.
    */
   indexAttachment: (params: {
     originId: string;
@@ -34,6 +53,10 @@ export interface SmlIndexer {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
+    /** Pre-computed chunks (direct mode for `create`/`update`). */
+    chunks?: SmlChunk[];
+    /** Explicit source; defaults to inferred (direct if chunks else resolved). */
+    source?: SmlDocumentSource;
   }) => Promise<void>;
 }
 
@@ -58,6 +81,8 @@ class SmlIndexerImpl implements SmlIndexer {
     esClient,
     savedObjectsClient,
     logger: contextLogger,
+    chunks: directChunks,
+    source: explicitSource,
   }: {
     originId: string;
     attachmentType: string;
@@ -66,54 +91,98 @@ class SmlIndexerImpl implements SmlIndexer {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
+    chunks?: SmlChunk[];
+    source?: SmlDocumentSource;
   }): Promise<void> {
+    const source: SmlDocumentSource =
+      explicitSource ?? (directChunks !== undefined ? 'direct' : 'resolved');
     this.logger.info(
-      `SML indexer: indexAttachment called — originId='${originId}', type='${attachmentType}', action='${action}', spaces=[${spaces.join(
+      `SML indexer: indexAttachment called — originId='${originId}', type='${attachmentType}', action='${action}', source='${source}', spaces=[${spaces.join(
         ', '
       )}]`
     );
 
-    const definition = this.registry.get(attachmentType);
-    if (!definition) {
-      this.logger.warn(
-        `SML indexer: type definition '${attachmentType}' not found — skipping indexing for '${originId}'. Registered types: [${this.registry
-          .list()
-          .map((t) => t.id)
-          .join(', ')}]`
-      );
-      return;
-    }
-
     if (action === 'delete') {
+      if (source === 'resolved') {
+        const hasDirect = await this.hasDirectChunks({ originId, esClient });
+        if (hasDirect) {
+          this.logger.info(
+            `SML indexer: skipping resolved-mode delete for origin '${originId}' — direct chunks exist and take precedence`
+          );
+          return;
+        }
+      }
       this.logger.info(`SML indexer: deleting chunks for origin '${originId}'`);
       await this.deleteChunks({ originId, esClient });
       return;
     }
 
-    const context: SmlContext = {
-      esClient,
-      savedObjectsClient,
-      logger: contextLogger,
-    };
-
-    this.logger.info(
-      `SML indexer: calling getSmlData for origin '${originId}' of type '${attachmentType}'`
-    );
-    const smlData = await definition.getSmlData(originId, context);
-    if (!smlData || smlData.chunks.length === 0) {
+    let chunks: SmlChunk[];
+    if (source === 'direct') {
+      if (directChunks === undefined) {
+        this.logger.warn(
+          `SML indexer: source='direct' but no chunks supplied for origin '${originId}' — treating as delete`
+        );
+        await this.deleteChunks({ originId, esClient });
+        return;
+      }
+      if (directChunks.length === 0) {
+        this.logger.info(
+          `SML indexer: direct mode received empty chunks for origin '${originId}' — deleting existing chunks`
+        );
+        await this.deleteChunks({ originId, esClient });
+        return;
+      }
+      chunks = directChunks;
       this.logger.info(
-        `SML indexer: no SML data returned for origin '${originId}' of type '${attachmentType}' — deleting existing chunks`
+        `SML indexer: direct mode — using ${chunks.length} caller-supplied chunk(s) for origin '${originId}' (will override any existing chunks)`
       );
-      await this.deleteChunks({ originId, esClient });
-      return;
+    } else {
+      const hasDirect = await this.hasDirectChunks({ originId, esClient });
+      if (hasDirect) {
+        this.logger.info(
+          `SML indexer: skipping resolved-mode index for origin '${originId}' — direct chunks exist and take precedence`
+        );
+        return;
+      }
+
+      const definition = this.registry.get(attachmentType);
+      if (!definition) {
+        this.logger.warn(
+          `SML indexer: type definition '${attachmentType}' not found — skipping indexing for '${originId}'. Registered types: [${this.registry
+            .list()
+            .map((t) => t.id)
+            .join(', ')}]`
+        );
+        return;
+      }
+
+      const context: SmlContext = {
+        esClient,
+        savedObjectsClient,
+        logger: contextLogger,
+      };
+
+      this.logger.info(
+        `SML indexer: calling getSmlData for origin '${originId}' of type '${attachmentType}'`
+      );
+      const smlData = await definition.getSmlData(originId, context);
+      if (!smlData || smlData.chunks.length === 0) {
+        this.logger.info(
+          `SML indexer: no SML data returned for origin '${originId}' of type '${attachmentType}' — deleting existing chunks`
+        );
+        await this.deleteChunks({ originId, esClient });
+        return;
+      }
+      chunks = smlData.chunks;
     }
 
     this.logger.info(
-      `SML indexer: getSmlData returned ${
-        smlData.chunks.length
-      } chunk(s) for origin '${originId}'. First chunk title: '${
-        smlData.chunks[0]?.title
-      }', content length: ${smlData.chunks[0]?.content?.length ?? 0}`
+      `SML indexer: indexing ${
+        chunks.length
+      } chunk(s) for origin '${originId}' (source='${source}'). First chunk title: '${
+        chunks[0]?.title
+      }', content length: ${chunks[0]?.content?.length ?? 0}`
     );
 
     await this.deleteChunks({ originId, esClient });
@@ -122,7 +191,7 @@ class SmlIndexerImpl implements SmlIndexer {
     const smlClient = storage.getClient();
 
     const now = new Date().toISOString();
-    const bulkOps = smlData.chunks.map((chunk) => {
+    const bulkOps = chunks.map((chunk) => {
       const chunkId = `${attachmentType}:${originId}:${uuidv4()}`;
       const document: SmlDocument = {
         id: chunkId,
@@ -134,6 +203,7 @@ class SmlIndexerImpl implements SmlIndexer {
         updated_at: now,
         spaces,
         permissions: chunk.permissions ?? [],
+        source,
       };
       if (chunk.description !== undefined) {
         document.description = chunk.description;
@@ -171,7 +241,7 @@ class SmlIndexerImpl implements SmlIndexer {
           );
         } else {
           this.logger.info(
-            `SML indexer: successfully indexed ${smlData.chunks.length} chunk(s) for origin '${originId}'`
+            `SML indexer: successfully indexed ${chunks.length} chunk(s) for origin '${originId}'`
           );
         }
       } catch (error) {
@@ -182,6 +252,48 @@ class SmlIndexerImpl implements SmlIndexer {
         );
         throw error;
       }
+    }
+  }
+
+  /**
+   * Check whether any chunks tagged `source: 'direct'` exist for the given
+   * `originId`. Used to enforce the per-origin mutual-exclusion invariant:
+   * resolved writes are skipped when direct chunks exist.
+   *
+   * Safe to call before the index has been created.
+   */
+  private async hasDirectChunks({
+    originId,
+    esClient,
+  }: {
+    originId: string;
+    esClient: ElasticsearchClient;
+  }): Promise<boolean> {
+    try {
+      const result = await esClient.count({
+        index: smlIndexName,
+        ignore_unavailable: true,
+        allow_no_indices: true,
+        query: {
+          bool: {
+            filter: [{ term: { origin_id: originId } }, { term: { source: 'direct' } }],
+          },
+        },
+      });
+      return (result.count ?? 0) > 0;
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return false;
+      }
+      this.logger.warn(
+        `SML indexer: failed to check for direct chunks for origin '${originId}': ${
+          (error as Error).message
+        }`
+      );
+      // Fail open: treat as no direct chunks rather than blocking the
+      // resolved-mode write. The next direct write will re-establish the
+      // override.
+      return false;
     }
   }
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_indexer.ts
@@ -28,16 +28,25 @@ export interface SmlIndexer {
    *
    * The operation runs in one of two modes:
    *  - **`direct`**: caller supplies `chunks` (or sets `source: 'direct'`
-   *    explicitly). The indexer wipes any pre-existing chunks for `originId`
-   *    (regardless of source) and writes the supplied chunks tagged with
-   *    `source: 'direct'`. For `action: 'delete'` all chunks for the origin
-   *    are wiped.
+   *    explicitly). The indexer calls the registered type's
+   *    `resolveOriginAccess(originId, ctx, spaceId)` hook to determine the
+   *    effective `spaces` and `permissions` for the write. The hook also
+   *    acts as the cross-space gate: if it returns `undefined`, or if
+   *    `spaceId` is not in the returned `spaces`, the operation is rejected
+   *    with {@link SmlAccessError}. On success, the indexer wipes any
+   *    pre-existing chunks for `originId` (regardless of source) and writes
+   *    the supplied chunks tagged with `source: 'direct'`, the resolved
+   *    `spaces`, and the resolved per-chunk `permissions`. For
+   *    `action: 'delete'` all chunks for the origin are wiped after the
+   *    same access check.
    *  - **`resolved`**: caller omits `chunks` (or sets `source: 'resolved'`).
    *    The indexer looks up the registered type, calls its `getSmlData(originId)`
    *    hook, and writes the result tagged with `source: 'resolved'`. If chunks
    *    tagged `source: 'direct'` already exist for this origin, the operation
    *    is **skipped** to preserve the user's override. The same protection
-   *    applies to `action: 'delete'` in resolved mode.
+   *    applies to `action: 'delete'` in resolved mode. `resolveOriginAccess`
+   *    is NOT consulted in resolved mode — the crawler is trusted, and
+   *    `spaces`/`permissions` come from the caller / `getSmlData`.
    *
    * `source` is inferred when not provided: `'direct'` if `chunks` is set,
    * otherwise `'resolved'`.
@@ -49,7 +58,17 @@ export interface SmlIndexer {
     originId: string;
     attachmentType: string;
     action: SmlIndexAction;
+    /**
+     * Target spaces for resolved writes. Ignored in direct mode — the
+     * effective spaces come from `resolveOriginAccess`.
+     */
     spaces: string[];
+    /**
+     * Caller's current space. Required for direct mode (used to call
+     * `resolveOriginAccess` and validate cross-space writes). Optional /
+     * unused for resolved writes.
+     */
+    spaceId?: string;
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
@@ -58,6 +77,22 @@ export interface SmlIndexer {
     /** Explicit source; defaults to inferred (direct if chunks else resolved). */
     source?: SmlDocumentSource;
   }) => Promise<void>;
+}
+
+/**
+ * Error thrown by the indexer when a direct-mode write is rejected for an
+ * authorization reason (origin doesn't resolve, type doesn't support direct
+ * writes, caller is writing into a space the origin doesn't live in, ...).
+ *
+ * Separate from generic indexing failures so upstream surfaces (route
+ * handlers, workflow steps) can map it to a 403/forbidden-style response
+ * rather than a 500.
+ */
+export class SmlAccessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SmlAccessError';
+  }
 }
 
 export const createSmlIndexer = ({ registry, logger }: SmlIndexerDeps): SmlIndexer => {
@@ -78,6 +113,7 @@ class SmlIndexerImpl implements SmlIndexer {
     attachmentType,
     action,
     spaces,
+    spaceId,
     esClient,
     savedObjectsClient,
     logger: contextLogger,
@@ -88,6 +124,7 @@ class SmlIndexerImpl implements SmlIndexer {
     attachmentType: string;
     action: SmlIndexAction;
     spaces: string[];
+    spaceId?: string;
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
@@ -101,6 +138,35 @@ class SmlIndexerImpl implements SmlIndexer {
         ', '
       )}]`
     );
+
+    // Direct-mode access gate.
+    //
+    // For every direct-mode operation (create / update / delete / empty
+    // chunks) we resolve the origin's access metadata via the type's
+    // `resolveOriginAccess` hook BEFORE touching the index. This is the
+    // only point at which:
+    //   - cross-space writes are rejected (callerSpaceId must be one of
+    //     the origin's spaces, or `*`),
+    //   - per-chunk `permissions` and write `spaces` are derived from the
+    //     origin's authoritative metadata (overriding whatever the caller
+    //     supplied).
+    //
+    // Resolved-mode (crawler) writes skip this — the crawler is trusted
+    // and supplies spaces from `SmlListItem` + permissions from `getSmlData`.
+    let effectiveSpaces: string[] = spaces;
+    let effectivePermissions: string[] | undefined;
+    if (source === 'direct') {
+      const access = await this.resolveDirectAccess({
+        originId,
+        attachmentType,
+        spaceId,
+        esClient,
+        savedObjectsClient,
+        contextLogger,
+      });
+      effectiveSpaces = access.spaces;
+      effectivePermissions = access.permissions;
+    }
 
     if (action === 'delete') {
       if (source === 'resolved') {
@@ -201,8 +267,12 @@ class SmlIndexerImpl implements SmlIndexer {
         content: chunk.content,
         created_at: now,
         updated_at: now,
-        spaces,
-        permissions: chunk.permissions ?? [],
+        spaces: effectiveSpaces,
+        // In direct mode `effectivePermissions` is the authoritative value
+        // returned by `resolveOriginAccess` — it overrides any per-chunk
+        // permissions the caller may have supplied. In resolved mode we
+        // keep `chunk.permissions` (set by the type's `getSmlData` hook).
+        permissions: effectivePermissions ?? chunk.permissions ?? [],
         source,
       };
       if (chunk.description !== undefined) {
@@ -253,6 +323,91 @@ class SmlIndexerImpl implements SmlIndexer {
         throw error;
       }
     }
+  }
+
+  /**
+   * Run the direct-mode access gate for a write/delete.
+   *
+   * Resolves the origin's authoritative `{ spaces, permissions }` via the
+   * registered type's `resolveOriginAccess` hook. Throws
+   * {@link SmlAccessError} when:
+   *   - `spaceId` wasn't provided (direct mode always needs a caller space),
+   *   - the type isn't registered,
+   *   - the type doesn't implement `resolveOriginAccess` (it isn't direct-
+   *     writable by design),
+   *   - the hook returns `undefined` (origin doesn't exist or isn't reachable
+   *     from `spaceId`),
+   *   - the returned `spaces` don't include `spaceId` (and aren't `['*']`).
+   */
+  private async resolveDirectAccess({
+    originId,
+    attachmentType,
+    spaceId,
+    esClient,
+    savedObjectsClient,
+    contextLogger,
+  }: {
+    originId: string;
+    attachmentType: string;
+    spaceId: string | undefined;
+    esClient: ElasticsearchClient;
+    savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
+    contextLogger: Logger;
+  }): Promise<{ spaces: string[]; permissions: string[] }> {
+    if (!spaceId) {
+      throw new SmlAccessError(
+        `Direct-mode write for origin '${originId}' requires a spaceId — refusing to index without a caller space.`
+      );
+    }
+    const definition = this.registry.get(attachmentType);
+    if (!definition) {
+      throw new SmlAccessError(
+        `Unknown SML attachment type '${attachmentType}' for origin '${originId}'`
+      );
+    }
+    if (!definition.resolveOriginAccess) {
+      throw new SmlAccessError(
+        `SML type '${attachmentType}' is not direct-writable (no resolveOriginAccess hook)`
+      );
+    }
+
+    const context: SmlContext = {
+      esClient,
+      savedObjectsClient: savedObjectsClient as SavedObjectsClientContract,
+      logger: contextLogger,
+    };
+
+    let access: { spaces: string[]; permissions: string[] } | undefined;
+    try {
+      access = await definition.resolveOriginAccess(originId, context, spaceId);
+    } catch (error) {
+      // Treat hook errors as a deny — the type's resolver failed, we can't
+      // safely auto-derive permissions, so reject the write.
+      this.logger.warn(
+        `SML indexer: resolveOriginAccess threw for origin '${originId}' (type '${attachmentType}'): ${
+          (error as Error).message
+        } — denying direct write`
+      );
+      throw new SmlAccessError(
+        `Failed to resolve access for origin '${originId}' of type '${attachmentType}': ${
+          (error as Error).message
+        }`
+      );
+    }
+
+    if (!access) {
+      throw new SmlAccessError(
+        `Origin '${originId}' of type '${attachmentType}' is not accessible from space '${spaceId}'`
+      );
+    }
+    if (!access.spaces.includes(spaceId) && !access.spaces.includes('*')) {
+      throw new SmlAccessError(
+        `Cross-space write blocked: origin '${originId}' of type '${attachmentType}' belongs to spaces [${access.spaces.join(
+          ', '
+        )}] which does not include caller space '${spaceId}'`
+      );
+    }
+    return access;
   }
 
   /**

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.test.ts
@@ -357,6 +357,8 @@ describe('SmlService', () => {
         updated_at: '2024-01-02',
         spaces: ['default'],
         permissions: ['saved_object:lens/get'],
+        // Hit had no `source` (pre-`source` doc) — service defaults to 'resolved'.
+        source: 'resolved',
         score: 1.5,
       });
       expect(result.total).toBe(1);
@@ -848,6 +850,8 @@ describe('SmlService', () => {
         updated_at: '2024-01-02',
         spaces: ['default'],
         permissions: [],
+        // Hit had no `source` (pre-`source` doc) — service defaults to 'resolved'.
+        source: 'resolved',
       });
       expect(result.get('doc-2')).toEqual({
         id: 'doc-2',
@@ -862,6 +866,7 @@ describe('SmlService', () => {
         updated_at: '2024-01-02',
         spaces: ['default'],
         permissions: [],
+        source: 'resolved',
       });
     });
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -114,6 +114,7 @@ class SmlServiceImpl implements SmlServiceInstance {
           attachmentType: params.attachmentType,
           action: params.action,
           spaces: params.spaces,
+          spaceId: params.spaceId,
           esClient: params.esClient,
           savedObjectsClient: params.savedObjectsClient,
           logger: params.logger,

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_service.ts
@@ -109,7 +109,17 @@ class SmlServiceImpl implements SmlServiceInstance {
         });
       },
       indexAttachment: async (params) => {
-        return this.getIndexer().indexAttachment(params);
+        return this.getIndexer().indexAttachment({
+          originId: params.originId,
+          attachmentType: params.attachmentType,
+          action: params.action,
+          spaces: params.spaces,
+          esClient: params.esClient,
+          savedObjectsClient: params.savedObjectsClient,
+          logger: params.logger,
+          chunks: params.chunks,
+          source: params.source,
+        });
       },
       getDocuments: async ({ ids, spaceId, esClient }) => {
         return getDocumentsByIds({ ids, spaceId, esClient, logger });
@@ -488,6 +498,9 @@ const searchSml = async ({
           spaces: source.spaces ?? [],
           permissions: source.permissions ?? [],
           user_id: source.user_id,
+          // Pre-`source` docs in the index default to `resolved` (the crawler
+          // was the only writer before this field existed).
+          source: source.source ?? 'resolved',
           score: hit._score ?? 0,
         };
       });
@@ -556,6 +569,8 @@ const getDocumentsByIds = async ({
         updated_at: source.updated_at ?? '',
         spaces: source.spaces ?? [],
         permissions: source.permissions ?? [],
+        // Pre-`source` docs in the index default to `resolved`.
+        source: source.source ?? 'resolved',
       };
       if (source.description !== undefined) {
         doc.description = source.description;

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_storage.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/sml_storage.ts
@@ -33,6 +33,12 @@ const smlStorageSchemaProperties = {
   updated_at: types.date({}),
   spaces: types.keyword({}),
   permissions: types.keyword({}),
+  /**
+   * How this chunk was produced. `resolved` = crawler / `getSmlData` hook;
+   * `direct` = caller supplied chunks (HTTP, workflow step, ...). Used to
+   * enforce the per-origin-id mutual-exclusion invariant.
+   */
+  source: types.keyword({}),
 };
 
 export const storageSettings = {

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
@@ -105,6 +105,40 @@ export interface SmlTypeDefinition {
   ) => Promise<AttachmentInput<string, unknown> | undefined>;
 
   /**
+   * Resolve "who can see chunks for this `originId`, and in which spaces?"
+   *
+   * This hook is the **sole** source of truth for chunk auth metadata when
+   * chunks are written via direct mode (e.g. through the SML index-attachment
+   * workflow step). The indexer:
+   *
+   *   1. Calls this hook with the caller's current `spaceId`.
+   *   2. Rejects the write when the hook returns `undefined` (origin doesn't
+   *      exist or isn't accessible from `spaceId` — this is also how
+   *      cross-space writes are prevented).
+   *   3. Tags every produced chunk with the returned `spaces` (overwriting
+   *      whatever the caller passed) and `permissions` (overwriting any
+   *      per-chunk values the caller may have supplied).
+   *
+   * Implementations should:
+   *   - Be cheap (one saved-object `get` or equivalent).
+   *   - Return `undefined` (rather than throwing) when the origin can't be
+   *     resolved — the indexer interprets that as "deny this write".
+   *   - Only return `spaces` that include `spaceId`, otherwise the indexer
+   *     will reject the write as cross-space.
+   *
+   * Resolved mode (crawler) does **not** call this hook — it uses the chunks
+   * and permissions returned by `getSmlData`, and the spaces returned by
+   * `list`. The hook is therefore optional: types that are never written via
+   * direct mode (e.g. crawler-only types) can omit it, in which case any
+   * attempt to direct-write the type is rejected.
+   */
+  resolveOriginAccess?: (
+    originId: string,
+    context: SmlContext,
+    spaceId: string
+  ) => Promise<{ spaces: string[]; permissions: string[] } | undefined>;
+
+  /**
    * Optional: custom crawl interval for the crawler.
    * Defaults to '10m' if not provided.
    */
@@ -243,10 +277,13 @@ export interface SmlService {
    * Index a single attachment (event-driven).
    *
    * Behavior depends on the effective `source`:
-   * - `direct`: caller supplies `chunks`. The indexer wipes any pre-existing
-   *   chunks for `originId` (regardless of source) and writes the supplied
-   *   chunks tagged with `source: 'direct'`. For `action: 'delete'` it wipes
-   *   all chunks for the origin.
+   * - `direct`: caller supplies `chunks` (and **must** supply `spaceId`).
+   *   The indexer calls the type's `resolveOriginAccess(originId, ctx,
+   *   spaceId)` hook to determine the effective `spaces` and `permissions`,
+   *   wipes any pre-existing chunks for `originId` (regardless of source),
+   *   and writes the supplied chunks tagged with `source: 'direct'`. For
+   *   `action: 'delete'` it wipes all chunks for the origin after the same
+   *   access check.
    * - `resolved`: the indexer calls `getSmlData(originId)` via the registered
    *   type. If chunks tagged `source: 'direct'` already exist for this origin,
    *   the operation is **skipped** to preserve the user's override.
@@ -258,7 +295,18 @@ export interface SmlService {
     originId: string;
     attachmentType: string;
     action: SmlIndexAction;
+    /**
+     * Target spaces for **resolved** writes (typically supplied by the
+     * crawler from `SmlListItem.spaces`). Ignored in direct mode — the
+     * effective spaces are read from `resolveOriginAccess` instead.
+     */
     spaces: string[];
+    /**
+     * Caller's current space. Required for **direct** writes — used to call
+     * `resolveOriginAccess` and to reject cross-space attempts. Optional /
+     * unused for resolved writes.
+     */
+    spaceId?: string;
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract;
     logger: Logger;

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/services/sml/types.ts
@@ -112,6 +112,20 @@ export interface SmlTypeDefinition {
 }
 
 /**
+ * Where a chunk was produced.
+ *
+ * - `resolved`: produced by the crawler or any caller relying on the registered
+ *   type's `getSmlData(originId)` hook.
+ * - `direct`: produced by a caller that supplied chunks directly (HTTP API,
+ *   workflow step, ...).
+ *
+ * The two modes are mutually exclusive per `origin_id`: a `direct` write
+ * overrides any existing chunks, and a `resolved` write is skipped when
+ * `direct` chunks already exist.
+ */
+export type SmlDocumentSource = 'resolved' | 'direct';
+
+/**
  * An SML document as stored in the system index.
  */
 export interface SmlDocument {
@@ -139,6 +153,8 @@ export interface SmlDocument {
   spaces: string[];
   /** Permissions required to access the underlying element */
   permissions: string[];
+  /** How this chunk was produced. See {@link SmlDocumentSource}. */
+  source: SmlDocumentSource;
 }
 
 /**
@@ -223,7 +239,21 @@ export interface SmlService {
     request: KibanaRequest;
   }) => Promise<Map<string, boolean>>;
 
-  /** Index a single attachment (event-driven) */
+  /**
+   * Index a single attachment (event-driven).
+   *
+   * Behavior depends on the effective `source`:
+   * - `direct`: caller supplies `chunks`. The indexer wipes any pre-existing
+   *   chunks for `originId` (regardless of source) and writes the supplied
+   *   chunks tagged with `source: 'direct'`. For `action: 'delete'` it wipes
+   *   all chunks for the origin.
+   * - `resolved`: the indexer calls `getSmlData(originId)` via the registered
+   *   type. If chunks tagged `source: 'direct'` already exist for this origin,
+   *   the operation is **skipped** to preserve the user's override.
+   *
+   * `source` is inferred when not provided: `'direct'` if `chunks` is set,
+   * otherwise `'resolved'`.
+   */
   indexAttachment: (params: {
     originId: string;
     attachmentType: string;
@@ -232,6 +262,8 @@ export interface SmlService {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract;
     logger: Logger;
+    chunks?: SmlChunk[];
+    source?: SmlDocumentSource;
   }) => Promise<void>;
 
   /** Fetch SML documents by their chunk IDs, scoped to a space */

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/index.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { INDEX_KPI_SML_TYPE, indexKpiSmlType } from './index_kpi';

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/index_kpi.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/index_kpi.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SmlTypeDefinition } from '../services/sml/types';
+
+/**
+ * SML attachment type id for KPIs that describe an Elasticsearch index.
+ *
+ * The bundled `workflow-sml-index-augmentation` workflow writes documents of
+ * this type via the `agentContextLayer.smlIndexAttachment` step.
+ *
+ * Origin ids are composite — `<indexPattern>::<kpiName>` — so each KPI is its
+ * own chunk and can be surfaced individually in semantic search results.
+ */
+export const INDEX_KPI_SML_TYPE = 'index_kpi';
+
+/**
+ * SML type definition for `index_kpi`.
+ *
+ * The type is fed exclusively through direct writes from the index-augmentation
+ * workflow (using `source: 'direct'`). It therefore implements:
+ *   - `list`: a no-op async iterable (the crawler has nothing to enumerate).
+ *   - `getSmlData`: returns `undefined` (no resolver path; direct chunks win).
+ *   - `toAttachment`: returns `undefined` (agents see the chunk content from
+ *     semantic search; no dedicated attachment renderer is registered yet).
+ *
+ * These hooks are mandatory on `SmlTypeDefinition`; keeping them no-op is the
+ * canonical pattern for workflow-fed types.
+ */
+export const indexKpiSmlType: SmlTypeDefinition = {
+  id: INDEX_KPI_SML_TYPE,
+
+  async *list() {
+    // Workflow-fed only — nothing to enumerate.
+  },
+
+  getSmlData: async () => undefined,
+
+  toAttachment: async () => undefined,
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/index_kpi.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/sml_types/index_kpi.ts
@@ -27,6 +27,8 @@ export const INDEX_KPI_SML_TYPE = 'index_kpi';
  *   - `getSmlData`: returns `undefined` (no resolver path; direct chunks win).
  *   - `toAttachment`: returns `undefined` (agents see the chunk content from
  *     semantic search; no dedicated attachment renderer is registered yet).
+ *   - `resolveOriginAccess`: scopes each KPI to the caller's space with no
+ *     additional permission requirements (see notes below).
  *
  * These hooks are mandatory on `SmlTypeDefinition`; keeping them no-op is the
  * canonical pattern for workflow-fed types.
@@ -41,4 +43,26 @@ export const indexKpiSmlType: SmlTypeDefinition = {
   getSmlData: async () => undefined,
 
   toAttachment: async () => undefined,
+
+  /**
+   * Direct-mode access for `index_kpi`.
+   *
+   * `index_kpi` origins are synthetic (`<indexPattern>::<kpiName>`) — there
+   * is no underlying saved object to look up. We therefore scope each KPI
+   * to the **caller's current space** and require no extra permissions
+   * beyond the platform-level `agentContextLayer:write` check that the
+   * start contract already enforces.
+   *
+   * Consequences:
+   *  - Cross-space write protection is naturally enforced: the indexer
+   *    only writes chunks tagged with the caller's space, so a workflow in
+   *    space `default` can never produce a chunk visible in space `marketing`.
+   *  - Per-index read permissions are NOT checked here. Tightening this
+   *    (e.g. requiring `read` on the underlying index pattern) is a future
+   *    enhancement; the current model trusts space membership.
+   */
+  resolveOriginAccess: async (_originId, _context, spaceId) => ({
+    spaces: [spaceId],
+    permissions: [],
+  }),
 };

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/compute_progress.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/compute_progress.test.ts
@@ -1,0 +1,332 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  ExecutionStatus,
+  WorkflowExecutionDto,
+  WorkflowStepExecutionDto,
+} from '@kbn/workflows';
+import {
+  SML_INDEX_AUGMENTATION_WORKFLOW_ID,
+  SML_INDEX_CRAWL_LIST_STEP,
+  SML_INDEX_CRAWL_WORKFLOW_ID,
+} from '../../common/constants';
+import { computeSmlWorkflowProgress } from './compute_progress';
+
+/**
+ * `ExecutionStatus` is a string enum union; the fixtures here use string
+ * literals for readability. Funnel everything through a tiny cast helper so
+ * a future widening of `ExecutionStatus` continues to compile without
+ * sprinkling `as ExecutionStatus` across every fixture call site.
+ */
+type StepOverrides = Omit<Partial<WorkflowStepExecutionDto>, 'status'> & { status?: string };
+type ExecutionOverrides = Omit<Partial<WorkflowExecutionDto>, 'status'> & { status?: string };
+
+const buildStep = (overrides: StepOverrides = {}): WorkflowStepExecutionDto => {
+  const { status: rawStatus, ...rest } = overrides;
+  return {
+    id: 'step-exec-1',
+    stepId: 'unknown',
+    workflowRunId: 'run-1',
+    workflowId: 'wf',
+    status: (rawStatus ?? 'completed') as ExecutionStatus,
+    startedAt: '2026-05-12T10:00:00.000Z',
+    finishedAt: '2026-05-12T10:00:01.000Z',
+    topologicalIndex: 0,
+    globalExecutionIndex: 0,
+    stepExecutionIndex: 0,
+    scopeStack: [],
+    ...rest,
+  } as unknown as WorkflowStepExecutionDto;
+};
+
+const buildExecution = (overrides: ExecutionOverrides = {}): WorkflowExecutionDto => {
+  const { status: rawStatus, ...rest } = overrides;
+  return {
+    spaceId: 'default',
+    id: 'exec-1',
+    status: (rawStatus ?? 'running') as ExecutionStatus,
+    isTestRun: false,
+    startedAt: '2026-05-12T10:00:00.000Z',
+    error: null,
+    finishedAt: '',
+    workflowId: 'unknown',
+    workflowDefinition: { name: 'unknown', triggers: [], steps: [], version: '1' as const },
+    stepExecutions: [],
+    duration: null,
+    yaml: '',
+    ...rest,
+  } as unknown as WorkflowExecutionDto;
+};
+
+describe('computeSmlWorkflowProgress', () => {
+  describe('unknown workflow', () => {
+    it('returns undefined for executions that are not SML system workflows', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: buildExecution({ workflowId: 'some-user-workflow' }),
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when workflowId is missing', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: buildExecution({ workflowId: undefined }),
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('crawl workflow', () => {
+    const crawlExecution = (stepOverrides: StepOverrides[] = []): WorkflowExecutionDto =>
+      buildExecution({
+        workflowId: SML_INDEX_CRAWL_WORKFLOW_ID,
+        stepExecutions: stepOverrides.map(buildStep),
+      });
+
+    it('returns total=null and completed=0 before list_indices has run', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: crawlExecution([]),
+      });
+      expect(result).toEqual({
+        kind: 'crawl',
+        total: null,
+        completed: 0,
+        currentIndex: null,
+      });
+    });
+
+    it('derives total from the list_indices step output length', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: crawlExecution([
+          {
+            stepId: SML_INDEX_CRAWL_LIST_STEP,
+            status: 'completed',
+            output: [
+              { index: 'logs-app-1' },
+              { index: 'logs-app-2' },
+              { index: 'logs-app-3' },
+            ],
+          },
+        ]),
+      });
+      expect(result).toEqual({
+        kind: 'crawl',
+        total: 3,
+        completed: 0,
+        currentIndex: null,
+      });
+    });
+
+    it('returns total=null if list_indices output is not an array (e.g. error body)', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: crawlExecution([
+          {
+            stepId: SML_INDEX_CRAWL_LIST_STEP,
+            status: 'completed',
+            output: { error: 'boom' } as unknown as never,
+          },
+        ]),
+      });
+      expect(result?.kind).toBe('crawl');
+      expect((result as { total: number | null }).total).toBeNull();
+    });
+
+    it('counts terminal workflow.execute step executions toward `completed`', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: crawlExecution([
+          {
+            stepId: SML_INDEX_CRAWL_LIST_STEP,
+            status: 'completed',
+            output: [
+              { index: 'idx-1' },
+              { index: 'idx-2' },
+              { index: 'idx-3' },
+              { index: 'idx-4' },
+            ],
+          },
+          {
+            stepId: 'run_augmentation',
+            stepType: 'workflow.execute',
+            status: 'completed',
+            input: { inputs: { indexPattern: 'idx-1' } },
+          },
+          {
+            stepId: 'run_augmentation',
+            stepType: 'workflow.execute',
+            status: 'failed',
+            input: { inputs: { indexPattern: 'idx-2' } },
+          },
+          {
+            stepId: 'run_augmentation',
+            stepType: 'workflow.execute',
+            status: 'running',
+            input: { inputs: { indexPattern: 'idx-3' } },
+          },
+        ]),
+      });
+      // 'completed' + 'failed' are terminal; 'running' is not.
+      expect(result).toMatchObject({ kind: 'crawl', total: 4, completed: 2 });
+    });
+
+    it('reports the in-flight workflow.execute step input as currentIndex', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: crawlExecution([
+          {
+            stepId: SML_INDEX_CRAWL_LIST_STEP,
+            status: 'completed',
+            output: [{ index: 'a' }, { index: 'b' }],
+          },
+          {
+            stepId: 'run_augmentation',
+            stepType: 'workflow.execute',
+            status: 'completed',
+            input: { inputs: { indexPattern: 'a' } },
+            startedAt: '2026-05-12T10:00:01.000Z',
+          },
+          {
+            // `waiting` is the typical status while the spawned child runs.
+            stepId: 'run_augmentation',
+            stepType: 'workflow.execute',
+            status: 'waiting',
+            input: { inputs: { indexPattern: 'logs-active' } },
+            startedAt: '2026-05-12T10:00:05.000Z',
+          },
+        ]),
+      });
+      expect(result).toMatchObject({
+        kind: 'crawl',
+        total: 2,
+        completed: 1,
+        currentIndex: 'logs-active',
+      });
+    });
+
+    it('falls back to null currentIndex when no workflow.execute step is in flight', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: crawlExecution([
+          {
+            stepId: 'run_augmentation',
+            stepType: 'workflow.execute',
+            status: 'completed',
+            input: { inputs: { indexPattern: 'a' } },
+          },
+        ]),
+      });
+      expect((result as { currentIndex: string | null }).currentIndex).toBeNull();
+    });
+
+    it('uses the most recently started list_indices step when there are retries', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: crawlExecution([
+          {
+            stepId: SML_INDEX_CRAWL_LIST_STEP,
+            status: 'failed',
+            startedAt: '2026-05-12T10:00:00.000Z',
+            output: undefined,
+          },
+          {
+            stepId: SML_INDEX_CRAWL_LIST_STEP,
+            status: 'completed',
+            startedAt: '2026-05-12T10:00:05.000Z',
+            output: [{ index: 'a' }, { index: 'b' }],
+          },
+        ]),
+      });
+      expect(result).toMatchObject({ kind: 'crawl', total: 2 });
+    });
+  });
+
+  describe('augmentation workflow', () => {
+    const augmentation = (
+      ctx: Record<string, unknown> | undefined,
+      stepOverrides: StepOverrides[] = []
+    ): WorkflowExecutionDto =>
+      buildExecution({
+        workflowId: SML_INDEX_AUGMENTATION_WORKFLOW_ID,
+        context: ctx,
+        stepExecutions: stepOverrides.map(buildStep),
+      });
+
+    it('returns the indexPattern from context.inputs', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: augmentation({ inputs: { indexPattern: 'logs-app-*' } }),
+      });
+      expect(result).toMatchObject({
+        kind: 'augmentation',
+        indexPattern: 'logs-app-*',
+        currentStep: null,
+      });
+    });
+
+    it('falls back to context.workflow.inputs.indexPattern', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: augmentation({ workflow: { inputs: { indexPattern: 'metrics-*' } } }),
+      });
+      expect((result as { indexPattern: string | null }).indexPattern).toBe('metrics-*');
+    });
+
+    it('falls back to step input when context is empty', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: augmentation({}, [
+          {
+            stepId: 'enterWorkflow',
+            input: { inputs: { indexPattern: 'traces-*' } },
+          },
+        ]),
+      });
+      expect((result as { indexPattern: string | null }).indexPattern).toBe('traces-*');
+    });
+
+    it('returns null indexPattern when nothing is resolvable', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: augmentation(undefined),
+      });
+      expect((result as { indexPattern: string | null }).indexPattern).toBeNull();
+    });
+
+    it('prefers an active step over a completed one for currentStep', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: augmentation({ inputs: { indexPattern: 'x' } }, [
+          {
+            stepId: 'get_index_mappings',
+            status: 'completed',
+            startedAt: '2026-05-12T10:00:00.000Z',
+          },
+          {
+            stepId: 'extract_kpis',
+            status: 'running',
+            startedAt: '2026-05-12T10:00:01.000Z',
+          },
+        ]),
+      });
+      expect((result as { currentStep: string | null }).currentStep).toBe('extract_kpis');
+    });
+
+    it('falls back to the most recently started step when nothing is active', () => {
+      const result = computeSmlWorkflowProgress({
+        execution: augmentation({ inputs: { indexPattern: 'x' } }, [
+          {
+            stepId: 'get_index_mappings',
+            status: 'completed',
+            startedAt: '2026-05-12T10:00:00.000Z',
+          },
+          {
+            stepId: 'extract_kpis',
+            status: 'completed',
+            startedAt: '2026-05-12T10:00:01.000Z',
+          },
+          {
+            stepId: 'index_each_kpi',
+            status: 'completed',
+            startedAt: '2026-05-12T10:00:02.000Z',
+          },
+        ]),
+      });
+      expect((result as { currentStep: string | null }).currentStep).toBe('index_each_kpi');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/compute_progress.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/compute_progress.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowExecutionDto, WorkflowStepExecutionDto } from '@kbn/workflows';
+import {
+  SML_INDEX_AUGMENTATION_WORKFLOW_ID,
+  SML_INDEX_CRAWL_LIST_STEP,
+  SML_INDEX_CRAWL_WORKFLOW_ID,
+  type SmlSystemWorkflowProgress,
+} from '../../common/constants';
+
+/**
+ * Step type used by `workflow.execute` (synchronous child workflow
+ * invocation). The crawl's `foreach` spawns one of these per index — counting
+ * them gives `completed` / detecting the in-flight one gives `currentIndex`.
+ *
+ * Hard-coded rather than imported from `@kbn/workflows` to keep this helper
+ * free of cross-package dependencies; the literal is stable (it's the YAML
+ * step `type:` users write in their workflows).
+ */
+const WORKFLOW_EXECUTE_STEP_TYPE = 'workflow.execute';
+
+/**
+ * Step execution statuses that mean "this step is no longer running" — used
+ * to count completed augmentations in the crawl workflow's progress summary.
+ *
+ * We treat `failed`, `cancelled`, and `skipped` as completed because the
+ * crawl explicitly opts into `iteration-on-failure: continue: true` and we
+ * don't want a single failing index to forever pin the counter at "N/M
+ * completed" with N stuck below total. The UI surfaces the workflow's
+ * overall status separately.
+ */
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled', 'skipped']);
+
+/**
+ * In-flight status set (anything that's actively executing or about to). Used
+ * to find "the current step" in an augmentation workflow and "the current
+ * index" in a crawl workflow. Includes `waiting` because a parent
+ * `workflow.execute` step sits in that state while its spawned child runs.
+ */
+const ACTIVE_STATUSES = new Set(['running', 'pending', 'waiting_for_input', 'waiting']);
+
+/**
+ * Compute a progress payload for one of the bundled SML system workflow
+ * executions, or `undefined` if the execution does not correspond to a known
+ * SML workflow (e.g. user replaced the document at the same id with a
+ * different YAML).
+ *
+ * The two strategies are intentionally distinct:
+ *
+ *  - **Crawl** progress derives entirely from the parent's *own* step
+ *    executions: the foreach iterations show up as repeated
+ *    `workflow.execute` step entries, so counting their statuses gives an
+ *    accurate `completed / total` ratio. `total` comes from the
+ *    `list_indices` Elasticsearch step output once it has produced one.
+ *    `currentIndex` is read from the rendered `input.inputs.indexPattern`
+ *    of whichever `workflow.execute` step is still in flight.
+ *
+ *  - **Augmentation** progress reports the resolved `indexPattern` (so the
+ *    crawl's child runs are individually identifiable in the UI) and the
+ *    step id of the most recent in-flight step (best-effort fallback to the
+ *    most recently *started* step if every step is already terminal).
+ *
+ * The function is total: every code path must return either a typed
+ * `SmlSystemWorkflowProgress` or `undefined`. It must never throw — the route
+ * handler treats progress as best-effort metadata, not a critical payload.
+ *
+ * Note: the caller MUST request `getWorkflowExecution(..., { includeInput:
+ * true, includeOutput: true })`. Without those flags the workflows API
+ * strips step `input` and `output`, leaving `total`/`currentIndex` blank
+ * even though the workflow is making progress.
+ */
+export const computeSmlWorkflowProgress = ({
+  execution,
+}: {
+  execution: WorkflowExecutionDto;
+}): SmlSystemWorkflowProgress | undefined => {
+  const workflowId = execution.workflowId;
+  if (workflowId === SML_INDEX_CRAWL_WORKFLOW_ID) {
+    return computeCrawlProgress(execution);
+  }
+  if (workflowId === SML_INDEX_AUGMENTATION_WORKFLOW_ID) {
+    return computeAugmentationProgress(execution);
+  }
+  return undefined;
+};
+
+const computeCrawlProgress = (execution: WorkflowExecutionDto): SmlSystemWorkflowProgress => {
+  const steps = execution.stepExecutions ?? [];
+  const total = readListIndicesTotal(steps);
+
+  // Each foreach iteration spawns one `workflow.execute` step execution on
+  // the parent. We don't filter by stepId here — that would require knowing
+  // the user-defined name (`run_augmentation`) — because filtering by
+  // stepType is more robust against future template renames.
+  const executeSteps = steps.filter((step) => step.stepType === WORKFLOW_EXECUTE_STEP_TYPE);
+  const completed = executeSteps.filter((step) => TERMINAL_STATUSES.has(step.status)).length;
+
+  // Pick the most-recently started in-flight `workflow.execute` step (there
+  // is usually only one, but workflows can opt into parallel foreach
+  // iterations). Its rendered `input.inputs.indexPattern` is the index
+  // currently being augmented.
+  const inFlight = executeSteps
+    .filter((step) => ACTIVE_STATUSES.has(step.status))
+    .sort(compareStarted);
+  const currentStep = inFlight.length ? inFlight[inFlight.length - 1] : undefined;
+  const currentIndex = currentStep ? readStepIndexPattern(currentStep) : null;
+
+  return {
+    kind: 'crawl',
+    total,
+    completed,
+    currentIndex,
+  };
+};
+
+const computeAugmentationProgress = (
+  execution: WorkflowExecutionDto
+): SmlSystemWorkflowProgress => {
+  const indexPattern = readAugmentationIndexPattern(execution);
+  const currentStep = pickCurrentStepId(execution.stepExecutions);
+  return {
+    kind: 'augmentation',
+    indexPattern,
+    currentStep,
+  };
+};
+
+/**
+ * Read the index pattern an augmentation execution is processing.
+ *
+ * The workflow declares a single `indexPattern` input, so the resolved value
+ * is the most reliable source. Different code paths land it in slightly
+ * different places depending on how the execution was scheduled:
+ *
+ *   - Manual run from the SML admin page → `context.inputs.indexPattern`.
+ *   - Spawned by the crawl via `workflow.execute` → also
+ *     `context.inputs.indexPattern`, but during early scheduling the parent
+ *     may have only populated `context.workflow.inputs` instead. We probe
+ *     both.
+ *
+ * Falls back to scanning any `with.inputs.indexPattern` value found in the
+ * step executions (e.g. on the synthetic `enterWorkflow` step) before giving
+ * up and returning `null`.
+ */
+const readAugmentationIndexPattern = (execution: WorkflowExecutionDto): string | null => {
+  const ctx = execution.context as Record<string, unknown> | undefined;
+  const direct = pickString(ctx?.inputs, 'indexPattern');
+  if (direct !== null) return direct;
+  const nested = pickString(
+    (ctx?.workflow as Record<string, unknown> | undefined)?.inputs,
+    'indexPattern'
+  );
+  if (nested !== null) return nested;
+  for (const step of execution.stepExecutions ?? []) {
+    const fromInput = readStepIndexPattern(step);
+    if (fromInput !== null) return fromInput;
+  }
+  return null;
+};
+
+/**
+ * Read `inputs.indexPattern` from a step execution's rendered input. Returns
+ * `null` when the step has no `input.inputs.indexPattern` (e.g. when the
+ * input has been stripped because the caller forgot `includeInput: true`).
+ */
+const readStepIndexPattern = (step: WorkflowStepExecutionDto): string | null => {
+  const input = step.input as Record<string, unknown> | undefined;
+  return pickString(input?.inputs, 'indexPattern');
+};
+
+/**
+ * Read `list_indices.output.length` when that step has produced an array
+ * output. Returns `null` if the list step has not run yet (or produced a
+ * non-array body, e.g. an error response) so the UI can render `?/—` until
+ * the total becomes known.
+ */
+const readListIndicesTotal = (
+  stepExecutions: WorkflowStepExecutionDto[] | undefined
+): number | null => {
+  if (!stepExecutions) return null;
+  // The foreach iteration counter would also work, but `list_indices.output`
+  // is authoritative whether or not iterations have started. We pick the
+  // most-recently started `list_indices` step to be robust against retries.
+  let chosen: WorkflowStepExecutionDto | undefined;
+  for (const step of stepExecutions) {
+    if (step.stepId !== SML_INDEX_CRAWL_LIST_STEP) continue;
+    if (!chosen || compareStarted(step, chosen) > 0) {
+      chosen = step;
+    }
+  }
+  if (!chosen) return null;
+  const output = chosen.output;
+  if (Array.isArray(output)) return output.length;
+  return null;
+};
+
+/**
+ * Pick the step id to display as "currently running" in an augmentation
+ * workflow:
+ *
+ *   1. Latest active step (`running`/`pending`/`waiting*`) if any.
+ *   2. Otherwise the most recently started step.
+ *
+ * Returns `null` for fresh executions with no recorded step executions yet.
+ */
+const pickCurrentStepId = (
+  stepExecutions: WorkflowStepExecutionDto[] | undefined
+): string | null => {
+  if (!stepExecutions?.length) return null;
+  const active = stepExecutions
+    .filter((s) => ACTIVE_STATUSES.has(s.status))
+    .sort(compareStarted);
+  if (active.length) return active[active.length - 1].stepId;
+  const mostRecent = [...stepExecutions].sort(compareStarted);
+  return mostRecent.length ? mostRecent[mostRecent.length - 1].stepId : null;
+};
+
+/**
+ * Stable, ISO-timestamp comparator. Newer steps sort later. Falls back to
+ * `globalExecutionIndex` when `startedAt` is missing or identical so retries
+ * within the same millisecond still order deterministically.
+ */
+const compareStarted = (a: WorkflowStepExecutionDto, b: WorkflowStepExecutionDto): number => {
+  const aStart = a.startedAt ?? '';
+  const bStart = b.startedAt ?? '';
+  if (aStart !== bStart) return aStart < bStart ? -1 : 1;
+  return (a.globalExecutionIndex ?? 0) - (b.globalExecutionIndex ?? 0);
+};
+
+/** Read a string value at `bag[key]`, returning `null` when missing or non-string. */
+const pickString = (bag: unknown, key: string): string | null => {
+  if (!bag || typeof bag !== 'object') return null;
+  const value = (bag as Record<string, unknown>)[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/install_system_workflows.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/install_system_workflows.test.ts
@@ -1,0 +1,345 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { installSystemWorkflows } from './install_system_workflows';
+import { SML_SYSTEM_WORKFLOW_TEMPLATES } from './templates';
+import type { WorkflowsManagementApiContract } from '../types';
+
+const createMockApi = (overrides: Partial<WorkflowsManagementApiContract> = {}) =>
+  ({
+    isWorkflowsAvailable: true,
+    getWorkflow: jest.fn().mockResolvedValue(null),
+    createWorkflow: jest.fn().mockResolvedValue({ id: 'x' }),
+    updateWorkflow: jest.fn().mockResolvedValue({ id: 'x' }),
+    deleteWorkflows: jest.fn().mockResolvedValue({ total: 1, deleted: 1, failures: [] }),
+    getWorkflows: jest.fn(),
+    runWorkflow: jest.fn(),
+    cancelWorkflowExecution: jest.fn(),
+    resumeWorkflowExecution: jest.fn(),
+    getWorkflowExecutions: jest.fn(),
+    getWorkflowExecution: jest.fn().mockResolvedValue(null),
+    getChildWorkflowExecutions: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as jest.Mocked<WorkflowsManagementApiContract>);
+
+describe('installSystemWorkflows', () => {
+  it('skips when workflows feature is not available', async () => {
+    const api = createMockApi({ isWorkflowsAvailable: false });
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request: httpServerMock.createKibanaRequest(),
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+    expect(result).toEqual({
+      created: [],
+      reinstalled: [],
+      skipped: [],
+      updated: [],
+      failed: [],
+    });
+    expect(api.createWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('creates every bundled template that does not already exist', async () => {
+    const api = createMockApi();
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request: httpServerMock.createKibanaRequest(),
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(api.createWorkflow).toHaveBeenCalledTimes(SML_SYSTEM_WORKFLOW_TEMPLATES.length);
+    expect(result.created).toEqual(SML_SYSTEM_WORKFLOW_TEMPLATES.map((t) => t.id));
+    expect(result.skipped).toEqual([]);
+    expect(result.reinstalled).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(api.deleteWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('skips a live, SML-owned workflow whose YAML matches the template', async () => {
+    const [firstTemplate] = SML_SYSTEM_WORKFLOW_TEMPLATES;
+    const api = createMockApi({
+      getWorkflow: jest
+        .fn()
+        .mockImplementation(async (id: string, _spaceId: string, options?: any) => {
+          if (id !== firstTemplate.id) return null;
+          // Live workflow — YAML matches the bundled template byte-for-byte.
+          return { id, yaml: firstTemplate.yaml };
+        }),
+    });
+
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request: httpServerMock.createKibanaRequest(),
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(result.skipped).toContain(firstTemplate.id);
+    expect(result.created).not.toContain(firstTemplate.id);
+    expect(result.updated).not.toContain(firstTemplate.id);
+    expect(api.createWorkflow).toHaveBeenCalledTimes(SML_SYSTEM_WORKFLOW_TEMPLATES.length - 1);
+    expect(api.updateWorkflow).not.toHaveBeenCalled();
+    expect(api.deleteWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('refreshes a live SML-owned workflow whose YAML differs from the template', async () => {
+    const [firstTemplate] = SML_SYSTEM_WORKFLOW_TEMPLATES;
+    // Stored YAML: clearly stale but still carries the `sml-system` tag, so
+    // ownership is recognisable even though the bundled YAML has changed.
+    const staleYaml = [
+      "version: '1'",
+      'name: stale',
+      'tags:',
+      '  - sml-system',
+      '  - sml',
+      'triggers:',
+      '  - type: manual',
+      'steps:',
+      '  - name: noop',
+      '    type: console',
+      '    with:',
+      '      message: hi',
+      '',
+    ].join('\n');
+    const api = createMockApi({
+      getWorkflow: jest.fn().mockImplementation(async (id: string) => {
+        if (id !== firstTemplate.id) return null;
+        return { id, yaml: staleYaml, definition: null };
+      }),
+    });
+
+    const request = httpServerMock.createKibanaRequest();
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request,
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(result.updated).toEqual([firstTemplate.id]);
+    expect(result.skipped).not.toContain(firstTemplate.id);
+    expect(api.updateWorkflow).toHaveBeenCalledWith(
+      firstTemplate.id,
+      { yaml: firstTemplate.yaml },
+      'default',
+      request
+    );
+    expect(api.createWorkflow).toHaveBeenCalledTimes(SML_SYSTEM_WORKFLOW_TEMPLATES.length - 1);
+  });
+
+  it('leaves a live workflow untouched when it is no longer SML-owned (no sml-system tag)', async () => {
+    const [firstTemplate] = SML_SYSTEM_WORKFLOW_TEMPLATES;
+    const userYaml = [
+      "version: '1'",
+      'name: my custom workflow',
+      'triggers:',
+      '  - type: manual',
+      'steps:',
+      '  - name: noop',
+      '    type: console',
+      '    with:',
+      '      message: hi',
+      '',
+    ].join('\n');
+    const api = createMockApi({
+      getWorkflow: jest.fn().mockImplementation(async (id: string) => {
+        if (id !== firstTemplate.id) return null;
+        return { id, yaml: userYaml, definition: { name: 'my custom workflow' } };
+      }),
+    });
+
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request: httpServerMock.createKibanaRequest(),
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(result.skipped).toContain(firstTemplate.id);
+    expect(result.updated).not.toContain(firstTemplate.id);
+    expect(api.updateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('hard-deletes the tombstone and reinstalls when only a soft-deleted record exists', async () => {
+    const [firstTemplate] = SML_SYSTEM_WORKFLOW_TEMPLATES;
+    const api = createMockApi({
+      getWorkflow: jest
+        .fn()
+        .mockImplementation(async (id: string, _spaceId: string, options?: any) => {
+          if (id !== firstTemplate.id) return null;
+          // Live lookup returns null; includeDeleted lookup finds the tombstone.
+          return options?.includeDeleted ? { id, deleted_at: '2026-05-11T00:00:00.000Z' } : null;
+        }),
+    });
+
+    const request = httpServerMock.createKibanaRequest();
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request,
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(api.deleteWorkflows).toHaveBeenCalledWith([firstTemplate.id], 'default', request, {
+      force: true,
+    });
+    expect(result.reinstalled).toEqual([firstTemplate.id]);
+    expect(result.created).toEqual(SML_SYSTEM_WORKFLOW_TEMPLATES.slice(1).map((t) => t.id));
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(api.createWorkflow).toHaveBeenCalledTimes(SML_SYSTEM_WORKFLOW_TEMPLATES.length);
+  });
+
+  it('records a failure when the tombstone cannot be purged', async () => {
+    const [firstTemplate] = SML_SYSTEM_WORKFLOW_TEMPLATES;
+    const api = createMockApi({
+      getWorkflow: jest
+        .fn()
+        .mockImplementation(async (id: string, _spaceId: string, options?: any) => {
+          if (id !== firstTemplate.id) return null;
+          return options?.includeDeleted ? { id, deleted_at: '2026-05-11T00:00:00.000Z' } : null;
+        }),
+      deleteWorkflows: jest.fn().mockResolvedValue({
+        total: 1,
+        deleted: 0,
+        failures: [{ id: firstTemplate.id, error: 'es down' }],
+      }),
+    });
+
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request: httpServerMock.createKibanaRequest(),
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(result.failed).toEqual([
+      {
+        id: firstTemplate.id,
+        reason: expect.stringContaining('failed to purge soft-deleted tombstone'),
+      },
+    ]);
+    expect(result.reinstalled).toEqual([]);
+    // The first template's createWorkflow must NOT have been called because
+    // purge failed; the remaining templates still proceed.
+    const createIds = (api.createWorkflow as jest.Mock).mock.calls.map((c) => c[0].id);
+    expect(createIds).not.toContain(firstTemplate.id);
+    expect(createIds).toEqual(SML_SYSTEM_WORKFLOW_TEMPLATES.slice(1).map((t) => t.id));
+  });
+
+  it('recovers from a cross-space tombstone conflict by force-deleting and retrying', async () => {
+    const [firstTemplate] = SML_SYSTEM_WORKFLOW_TEMPLATES;
+    // Live + tombstone lookups in *this* space both return null (the
+    // tombstone lives in a different space), so the installer can't detect it
+    // up front. createWorkflow then throws because the global _id check
+    // catches the cross-space tombstone. The defensive retry forcibly deletes
+    // and tries again.
+    let createCalls = 0;
+    const conflictError = Object.assign(new Error("Workflow with id 'X' already exists"), {
+      name: 'WorkflowConflictError',
+    });
+    const api = createMockApi({
+      getWorkflow: jest.fn().mockResolvedValue(null),
+      createWorkflow: jest.fn().mockImplementation(async (cmd: { id?: string }) => {
+        if (cmd.id !== firstTemplate.id) return { id: cmd.id };
+        createCalls += 1;
+        if (createCalls === 1) {
+          throw conflictError;
+        }
+        return { id: cmd.id };
+      }),
+      deleteWorkflows: jest.fn().mockResolvedValue({ total: 1, deleted: 1, failures: [] }),
+    });
+
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request: httpServerMock.createKibanaRequest(),
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(api.deleteWorkflows).toHaveBeenCalledWith(
+      [firstTemplate.id],
+      'default',
+      expect.anything(),
+      { force: true }
+    );
+    expect(result.reinstalled).toEqual([firstTemplate.id]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('surfaces a clear error when conflict is genuinely cross-space (force-delete found nothing)', async () => {
+    const [firstTemplate] = SML_SYSTEM_WORKFLOW_TEMPLATES;
+    const conflictError = Object.assign(new Error("Workflow with id 'X' already exists"), {
+      name: 'WorkflowConflictError',
+    });
+    const api = createMockApi({
+      getWorkflow: jest.fn().mockResolvedValue(null),
+      createWorkflow: jest.fn().mockImplementation(async (cmd: { id?: string }) => {
+        if (cmd.id === firstTemplate.id) throw conflictError;
+        return { id: cmd.id };
+      }),
+      deleteWorkflows: jest.fn().mockResolvedValue({ total: 1, deleted: 0, failures: [] }),
+    });
+
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request: httpServerMock.createKibanaRequest(),
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(result.failed).toEqual([
+      {
+        id: firstTemplate.id,
+        reason: expect.stringContaining('already in use'),
+      },
+    ]);
+    expect(result.reinstalled).toEqual([]);
+  });
+
+  it('records create failures and continues with remaining templates', async () => {
+    const [firstTemplate] = SML_SYSTEM_WORKFLOW_TEMPLATES;
+    const api = createMockApi({
+      createWorkflow: jest.fn().mockImplementation(async (cmd: { id?: string }) => {
+        if (cmd.id === firstTemplate.id) {
+          throw new Error('boom');
+        }
+        return { id: cmd.id };
+      }),
+    });
+
+    const result = await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request: httpServerMock.createKibanaRequest(),
+      spaceId: 'default',
+      logger: loggingSystemMock.createLogger(),
+    });
+
+    expect(result.failed).toEqual([{ id: firstTemplate.id, reason: 'boom' }]);
+    expect(result.created).toHaveLength(SML_SYSTEM_WORKFLOW_TEMPLATES.length - 1);
+  });
+
+  it('uses the caller request and the supplied spaceId', async () => {
+    const api = createMockApi();
+    const request = httpServerMock.createKibanaRequest();
+    await installSystemWorkflows({
+      workflowsManagementApi: api,
+      request,
+      spaceId: 'custom-space',
+      logger: loggingSystemMock.createLogger(),
+    });
+    for (const call of (api.createWorkflow as jest.Mock).mock.calls) {
+      expect(call[1]).toBe('custom-space');
+      expect(call[2]).toBe(request);
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/install_system_workflows.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/install_system_workflows.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import type { CreateWorkflowCommand } from '@kbn/workflows';
+import { SML_SYSTEM_WORKFLOW_TAG } from '../../common/constants';
+import type { WorkflowsManagementApiContract } from '../types';
+import { SML_SYSTEM_WORKFLOW_TEMPLATES } from './templates';
+
+/**
+ * Recognises the "Workflow with id 'X' already exists" conflict raised by
+ * `WorkflowCrudService.createWorkflow` so the installer can decide whether to
+ * attempt recovery. We match on the error name first (the workflows_management
+ * plugin uses a `WorkflowConflictError` class) and fall back to the canonical
+ * message shape for robustness against future error refactors.
+ */
+const isConflictError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'WorkflowConflictError') return true;
+  return /already exists/i.test(error.message);
+};
+
+export interface InstallSystemWorkflowsResult {
+  /** Workflow ids created during this invocation. */
+  created: string[];
+  /**
+   * Workflow ids that already existed (live, not deleted) AND whose YAML
+   * already matches the bundled template — left untouched.
+   */
+  skipped: string[];
+  /**
+   * Workflow ids that already existed (live, not deleted) but whose YAML
+   * differed from the bundled template — refreshed in place via
+   * `updateWorkflow`. Used to repair the broken-template case where an older
+   * install left a workflow with stale (or invalid) YAML.
+   */
+  updated: string[];
+  /**
+   * Workflow ids whose soft-deleted tombstone was found and purged before
+   * recreating the workflow from the bundled template.
+   */
+  reinstalled: string[];
+  /** Workflow ids whose creation failed, paired with the failure message. */
+  failed: Array<{ id: string; reason: string }>;
+}
+
+/**
+ * Installs the bundled SML system workflows.
+ *
+ * Triggered from a route handler (the ACL admin page "Install default
+ * workflows" action). Uses the caller's `KibanaRequest` to drive the standard
+ * `workflowsManagement.createWorkflow` API — matching the convention used by
+ * the streams plugin's `createContinuousKiExtractionWorkflowService`.
+ *
+ * Three branches per template:
+ *
+ *   1. **Live workflow exists, still tagged `sml-system`** — its YAML is
+ *      compared against the bundled template. If equal, skipped (operator
+ *      edits limited to non-YAML fields are preserved). If different, the
+ *      YAML is refreshed in place via `updateWorkflow`. This repairs the
+ *      "first install crashed with invalid YAML, leaving an Untitled
+ *      workflow" case without requiring the operator to manually delete
+ *      anything. A live workflow that has lost the `sml-system` tag is
+ *      treated as user-owned and left untouched.
+ *   2. **Soft-deleted tombstone exists** — the workflows_management plugin
+ *      enforces global `_id` uniqueness across spaces *and* across soft-
+ *      deleted tombstones, so a vanilla `createWorkflow` call would fail with
+ *      `Workflow with id 'X' already exists`. The installer instead
+ *      hard-deletes the tombstone via `deleteWorkflows({ force: true })` and
+ *      then creates a fresh document. Reported under `reinstalled`.
+ *   3. **Nothing exists** — straight create. Reported under `created`.
+ *
+ * The user invoking this function must hold the `workflowsManagement:create`
+ * (and, for the tombstone branch, `workflowsManagement:delete`) privileges in
+ * addition to the ACL feature privilege that gates access to the admin page.
+ */
+export const installSystemWorkflows = async ({
+  workflowsManagementApi,
+  request,
+  spaceId,
+  logger,
+}: {
+  workflowsManagementApi: WorkflowsManagementApiContract;
+  request: KibanaRequest;
+  spaceId: string;
+  logger: Logger;
+}): Promise<InstallSystemWorkflowsResult> => {
+  const result: InstallSystemWorkflowsResult = {
+    created: [],
+    skipped: [],
+    updated: [],
+    reinstalled: [],
+    failed: [],
+  };
+
+  if (!workflowsManagementApi.isWorkflowsAvailable) {
+    logger.debug('Workflows feature is not available; skipping SML system workflow install.');
+    return result;
+  }
+
+  for (const template of SML_SYSTEM_WORKFLOW_TEMPLATES) {
+    try {
+      const live = await workflowsManagementApi.getWorkflow(template.id, spaceId);
+      if (live) {
+        // `WorkflowDetailDto` doesn't expose `tags` directly (only `yaml` +
+        // parsed `definition`). For invalid stored YAML `definition` is null,
+        // so we sniff the raw YAML text for the SML ownership tag. This
+        // catches the "broken Untitled workflow from a previous install"
+        // case where `definition` is null but the stored YAML still carries
+        // our `sml-system` tag.
+        const liveYaml = (live as { yaml?: string }).yaml ?? '';
+        const liveTags = (live as { definition?: { tags?: string[] } }).definition?.tags ?? [];
+        const isSmlOwned =
+          liveTags.includes(SML_SYSTEM_WORKFLOW_TAG) ||
+          /(^|\n)\s*-\s*sml-system\s*(?:#|$)/m.test(liveYaml);
+        if (!isSmlOwned) {
+          result.skipped.push(template.id);
+          continue;
+        }
+        if (normaliseYaml(liveYaml) === normaliseYaml(template.yaml)) {
+          result.skipped.push(template.id);
+          continue;
+        }
+        logger.info(
+          `Refreshing SML system workflow '${template.id}' to match the bundled template.`
+        );
+        await workflowsManagementApi.updateWorkflow(
+          template.id,
+          { yaml: template.yaml },
+          spaceId,
+          request
+        );
+        result.updated.push(template.id);
+        continue;
+      }
+
+      // No live workflow — check for a soft-deleted tombstone. The
+      // workflows_management plugin keeps the ES `_id` reserved even for
+      // soft-deleted docs, so a subsequent `createWorkflow` would otherwise
+      // fail with a confusing "already exists" error.
+      const tombstone = await workflowsManagementApi.getWorkflow(template.id, spaceId, {
+        includeDeleted: true,
+      });
+      let isReinstall = false;
+      if (tombstone) {
+        logger.info(
+          `Found soft-deleted tombstone for SML system workflow '${template.id}' — hard-deleting before reinstall.`
+        );
+        const purge = await workflowsManagementApi.deleteWorkflows(
+          [template.id],
+          spaceId,
+          request,
+          { force: true }
+        );
+        const failure = purge.failures.find((f) => f.id === template.id);
+        if (failure) {
+          throw new Error(
+            `failed to purge soft-deleted tombstone for '${template.id}': ${failure.error}`
+          );
+        }
+        isReinstall = true;
+      }
+
+      const command: CreateWorkflowCommand = { yaml: template.yaml, id: template.id };
+      try {
+        await workflowsManagementApi.createWorkflow(command, spaceId, request);
+      } catch (createError) {
+        // Defensive recovery: the create-conflict check is GLOBAL (across
+        // spaces and across soft-deleted tombstones — see
+        // `WorkflowCrudService.checkExistingIds`), but `getWorkflow` is
+        // space-scoped. If a tombstone (or stale doc) lives in a different
+        // space than the install context, the lookup above misses it but the
+        // create still fails. As a last resort try a forced delete in the
+        // current space and retry once; if that delete reports no rows then
+        // the conflict is genuinely cross-space and we surface a clearer
+        // error so the operator can deal with it manually.
+        if (!isConflictError(createError)) {
+          throw createError;
+        }
+        const purge = await workflowsManagementApi.deleteWorkflows(
+          [template.id],
+          spaceId,
+          request,
+          { force: true }
+        );
+        if (purge.deleted === 0) {
+          throw new Error(
+            `Workflow id '${template.id}' is already in use by another workflow that is not visible in this space. ` +
+              `Hard-delete it from its owning space (or via the workflows management UI with force=true) and retry.`
+          );
+        }
+        await workflowsManagementApi.createWorkflow(command, spaceId, request);
+        isReinstall = true;
+      }
+
+      if (isReinstall) {
+        logger.info(`Reinstalled SML system workflow '${template.id}'.`);
+        result.reinstalled.push(template.id);
+      } else {
+        logger.info(`Installed SML system workflow '${template.id}'.`);
+        result.created.push(template.id);
+      }
+    } catch (error) {
+      const reason = (error as Error).message;
+      result.failed.push({ id: template.id, reason });
+      logger.error(`Failed to install SML system workflow '${template.id}': ${reason}`);
+    }
+  }
+
+  logger.info(
+    `SML system workflow install finished — created: ${result.created.length}, updated: ${result.updated.length}, reinstalled: ${result.reinstalled.length}, skipped: ${result.skipped.length}, failed: ${result.failed.length}.`
+  );
+  return result;
+};
+
+/** Normalise YAML for equality checks: trim trailing whitespace and EOL. */
+const normaliseYaml = (yaml: string | undefined | null): string => {
+  if (!yaml) return '';
+  return yaml.replace(/\s+$/gm, '').replace(/\r\n/g, '\n').trim();
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/templates.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/templates.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { WorkflowSchema } from '@kbn/workflows';
+import { JsonModelSchema } from '@kbn/workflows/spec/schema/common/json_model_schema';
+import { parseWorkflowYamlToJSON } from '@kbn/workflows-yaml';
+import { SML_SYSTEM_WORKFLOW_TEMPLATES } from './templates';
+
+describe('SML system workflow templates', () => {
+  it('ships an index-augmentation template and an index-crawl template', () => {
+    const ids = SML_SYSTEM_WORKFLOW_TEMPLATES.map((t) => t.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(['workflow-sml-index-augmentation', 'workflow-sml-index-crawl'])
+    );
+  });
+
+  it.each(SML_SYSTEM_WORKFLOW_TEMPLATES.map((t) => [t.id, t]))(
+    'parses %s YAML against the WorkflowSchema',
+    (_id, template) => {
+      const result = parseWorkflowYamlToJSON(template.yaml, WorkflowSchema);
+      if (!result.success) {
+        throw new Error(`Failed to parse '${template.id}': ${result.error.message}`);
+      }
+      expect(result.success).toBe(true);
+    }
+  );
+
+  it('tags every template with sml-system and sml', () => {
+    for (const template of SML_SYSTEM_WORKFLOW_TEMPLATES) {
+      const result = parseWorkflowYamlToJSON(template.yaml, WorkflowSchema);
+      if (!result.success) {
+        throw new Error(`Failed to parse '${template.id}'`);
+      }
+      const tags = (result.data as { tags?: string[] }).tags ?? [];
+      expect(tags).toEqual(expect.arrayContaining(['sml-system', 'sml']));
+    }
+  });
+
+  /**
+   * Regression: `ai.agent`'s `schema:` parameter is validated against
+   * `JsonModelRootShapeSchema`, which only allows `type: object` at the root.
+   * If we accidentally used `type: array` (or omitted it) the strict zod
+   * schema used by `createWorkflow` would silently drop the parsed workflow
+   * and fall back to a `name: 'Untitled workflow'` placeholder in storage.
+   */
+  it('uses a root-`object` JSON Schema for every ai.agent schema parameter', () => {
+    for (const template of SML_SYSTEM_WORKFLOW_TEMPLATES) {
+      const result = parseWorkflowYamlToJSON(template.yaml, WorkflowSchema);
+      if (!result.success) {
+        throw new Error(`Failed to parse '${template.id}'`);
+      }
+      const schemas = collectAiAgentSchemas((result.data as { steps?: unknown[] }).steps);
+      for (const schema of schemas) {
+        const validation = JsonModelSchema.safeParse(schema);
+        if (!validation.success) {
+          throw new Error(
+            `ai.agent schema in '${template.id}' is not a valid JsonModelSchema: ` +
+              JSON.stringify(validation.error.issues)
+          );
+        }
+      }
+    }
+  });
+
+});
+
+const collectAiAgentSchemas = (steps: unknown): unknown[] => {
+  if (!Array.isArray(steps)) return [];
+  const out: unknown[] = [];
+  for (const step of steps) {
+    if (!step || typeof step !== 'object') continue;
+    const s = step as { type?: string; with?: { schema?: unknown }; steps?: unknown };
+    if (s.type === 'ai.agent' && s.with?.schema !== undefined) {
+      out.push(s.with.schema);
+    }
+    if (Array.isArray(s.steps)) {
+      out.push(...collectAiAgentSchemas(s.steps));
+    }
+  }
+  return out;
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/templates.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/templates.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import INDEX_AUGMENTATION_YAML from './templates/index_augmentation.yaml';
+import INDEX_CRAWL_YAML from './templates/index_crawl.yaml';
+
+/**
+ * Bundled SML system workflow templates installed by the Agent Context Layer
+ * admin page.
+ *
+ * The templates are NOT seeded at plugin start. The ACL admin page exposes an
+ * "Install default workflows" action which calls
+ * {@link installSystemWorkflows}; this is invoked from a route handler so the
+ * standard `workflowsManagement.createWorkflow` API can be used with the
+ * caller's `KibanaRequest` (matching the streams plugin convention — see
+ * `x-pack/platform/plugins/shared/streams/server/lib/workflows/continuous_extraction_workflow.ts`).
+ *
+ * Workflows are tagged with `SML_SYSTEM_WORKFLOW_TAG` so the admin page can
+ * list them with `getWorkflows({ tags: ['sml-system'] })`. Their ids use plain
+ * `workflow-*` slugs (no reserved namespace) so they are valid through the
+ * regular workflow id validator.
+ *
+ * The bundled templates ship a complete, runnable implementation of the SML
+ * default workflows:
+ *
+ *  - `workflow-sml-index-augmentation` — inspects a single Elasticsearch index
+ *    (mappings + 10 sample docs), asks an Agent Builder agent for a structured
+ *    list of KPIs, and writes one SML chunk per KPI via the
+ *    `agentContextLayer.smlIndexAttachment` step.
+ *
+ *  - `workflow-sml-index-crawl` — lists every open, non-hidden Elasticsearch
+ *    index and runs the index augmentation workflow on each one. Ships
+ *    disabled by default because the LLM cost scales with the number of
+ *    indices; operators opt-in by enabling it or triggering it manually.
+ *
+ * Operators can edit the bundled YAML through the standard workflows
+ * management UI; subsequent installs are idempotent and never overwrite local
+ * edits.
+ */
+export interface SmlSystemWorkflowTemplate {
+  /**
+   * Fixed workflow id used as the `_id` of the stored document. Must be a
+   * valid workflow id (lowercase alphanumeric + hyphens) and NOT use a
+   * reserved namespace prefix.
+   */
+  id: string;
+  /** Human-friendly description shown in the ACL admin page. */
+  description: string;
+  /** Workflow YAML definition. */
+  yaml: string;
+}
+
+const INDEX_AUGMENTATION_TEMPLATE: SmlSystemWorkflowTemplate = {
+  id: 'workflow-sml-index-augmentation',
+  description:
+    'Inspect an Elasticsearch index (mappings + 10 sample documents), ask an LLM via Agent Builder to extract KPIs, and index those KPIs into the Semantic Metadata Layer.',
+  yaml: INDEX_AUGMENTATION_YAML,
+};
+
+const INDEX_CRAWL_TEMPLATE: SmlSystemWorkflowTemplate = {
+  id: 'workflow-sml-index-crawl',
+  description:
+    'Discover every open Elasticsearch index visible to the caller and run the SML index augmentation workflow on each one. Ships disabled-by-default; trigger it manually after reviewing the cost implications.',
+  yaml: INDEX_CRAWL_YAML,
+};
+
+export const SML_SYSTEM_WORKFLOW_TEMPLATES: readonly SmlSystemWorkflowTemplate[] = [
+  INDEX_AUGMENTATION_TEMPLATE,
+  INDEX_CRAWL_TEMPLATE,
+];

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/templates/index_augmentation.yaml
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/templates/index_augmentation.yaml
@@ -1,0 +1,136 @@
+# SML — Index augmentation workflow.
+#
+# Given an Elasticsearch index name or pattern, this workflow:
+#   1. Loads the index mappings.
+#   2. Pulls 10 sample documents.
+#   3. Calls an Agent Builder agent with a structured-output schema and asks it
+#      to propose a small set of high-value KPIs for the index.
+#   4. Writes one SML chunk per KPI via the
+#      `agentContextLayer.smlIndexAttachment` step.
+#
+# Each KPI is stored as its own SML attachment so semantic search can surface
+# individual KPIs. Origin ids follow the convention
+# `<indexPattern>::<kpiName>` and use the registered `index_kpi` SML type.
+#
+# Triggered manually from the SML admin page or via the workflows management
+# UI. Also intended to be invoked by `workflow-sml-index-crawl` once per
+# discovered index.
+version: '1'
+name: 'SML — Index augmentation'
+description: 'Inspect an Elasticsearch index, ask an LLM to extract KPIs, and index those KPIs into the Semantic Metadata Layer.'
+enabled: true
+tags:
+  - sml-system
+  - sml
+inputs:
+  - name: indexPattern
+    type: string
+    required: true
+    description: 'Elasticsearch index name or pattern to augment (e.g. "kibana_sample_data_logs" or "logs-app-*").'
+triggers:
+  - type: manual
+steps:
+  - name: get_index_mappings
+    type: elasticsearch.request
+    with:
+      method: GET
+      path: '/{{ inputs.indexPattern }}/_mapping'
+    on-failure:
+      retry:
+        max-attempts: 3
+        delay: '5s'
+        strategy: exponential
+
+  - name: get_sample_documents
+    type: elasticsearch.search
+    with:
+      index: '{{ inputs.indexPattern }}'
+      size: 10
+      query:
+        match_all: {}
+    on-failure:
+      retry:
+        max-attempts: 3
+        delay: '5s'
+        strategy: exponential
+
+  - name: extract_kpis
+    type: ai.agent
+    with:
+      message: |
+        You are an analytics expert. Inspect the Elasticsearch index "{{ inputs.indexPattern }}" and propose between 3 and 8 KPIs that downstream agents can use to summarize, monitor, or visualize this dataset.
+
+        Use the field types from the mappings and the values in the sample documents to decide which KPIs are realistic.
+
+        Index mappings:
+        {{ steps.get_index_mappings.output | json }}
+
+        Sample documents (up to 10):
+        {{ steps.get_sample_documents.output.hits.hits | json }}
+
+        Return a JSON object with a `kpis` array. For each KPI include: a snake_case `name`, a short human `title`, a 1-2 sentence `description`, the `aggregation_type` (count, sum, avg, max, min, cardinality, terms, date_histogram, ...), the `fields` it relies on, and an optional `sample_esql` snippet that computes it.
+      # NOTE: the workflows JSON-model schema (used by `ai.agent`'s `schema:`
+      # parameter) enforces `type: object` at the root, so the KPI list is
+      # wrapped in a top-level `kpis` array property. The foreach below
+      # iterates `steps.extract_kpis.output.structured_output.kpis`.
+      schema:
+        type: object
+        properties:
+          kpis:
+            type: array
+            description: 'Proposed KPIs for the index.'
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: 'Snake_case identifier for the KPI.'
+                title:
+                  type: string
+                  description: 'Short, human-readable title.'
+                description:
+                  type: string
+                  description: 'One or two sentences explaining what the KPI measures.'
+                aggregation_type:
+                  type: string
+                  description: 'High-level aggregation kind (count, sum, avg, cardinality, terms, ...).'
+                fields:
+                  type: array
+                  items:
+                    type: string
+                  description: 'Field paths the KPI relies on.'
+                sample_esql:
+                  type: string
+                  description: 'Optional ES|QL snippet that computes the KPI.'
+              required:
+                - name
+                - title
+                - description
+                - aggregation_type
+                - fields
+        required:
+          - kpis
+
+  - name: index_each_kpi
+    type: foreach
+    foreach: '${{ steps.extract_kpis.output.structured_output.kpis }}'
+    iteration-on-failure:
+      continue: true
+    steps:
+      - name: index_kpi_chunk
+        type: agentContextLayer.smlIndexAttachment
+        with:
+          originId: '{{ inputs.indexPattern }}::{{ foreach.item.name }}'
+          attachmentType: 'index_kpi'
+          action: 'create'
+          chunks:
+            - type: 'index_kpi'
+              title: '{{ foreach.item.title }} — {{ inputs.indexPattern }}'
+              content: |
+                KPI: {{ foreach.item.title }}
+                Index: {{ inputs.indexPattern }}
+                Aggregation: {{ foreach.item.aggregation_type }}
+                Fields: {{ foreach.item.fields | join: ', ' }}
+                Sample ES|QL: {{ foreach.item.sample_esql }}
+                Description: {{ foreach.item.description }}
+              description: '{{ foreach.item.description }}'

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/templates/index_crawl.yaml
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/system_workflows/templates/index_crawl.yaml
@@ -1,0 +1,46 @@
+# SML — Index crawl workflow.
+#
+# Discovers every open, non-hidden Elasticsearch index reachable to the user
+# running the workflow and triggers the `workflow-sml-index-augmentation`
+# workflow for each one. Hidden / system indices are excluded server-side via
+# `expand_wildcards=open` on the `_cat/indices` call.
+#
+# Iteration-level failures do not abort the crawl — each augmentation runs
+# independently so that one slow or broken index never blocks the rest.
+#
+# The crawl is potentially expensive (one LLM round-trip per index) and ships
+# disabled-by-default; operators can opt in by enabling the workflow or
+# triggering it manually from the workflows management UI.
+version: '1'
+name: 'SML — Index crawl'
+description: 'List every open Elasticsearch index visible to the caller and run the SML index augmentation workflow on each.'
+enabled: false
+tags:
+  - sml-system
+  - sml
+triggers:
+  - type: manual
+steps:
+  - name: list_indices
+    type: elasticsearch.request
+    with:
+      method: GET
+      path: '/_cat/indices?expand_wildcards=open&h=index&format=json&s=index'
+    on-failure:
+      retry:
+        max-attempts: 3
+        delay: '5s'
+        strategy: exponential
+
+  - name: augment_each_index
+    type: foreach
+    foreach: '${{ steps.list_indices.output }}'
+    iteration-on-failure:
+      continue: true
+    steps:
+      - name: run_augmentation
+        type: workflow.execute
+        with:
+          workflow-id: 'workflow-sml-index-augmentation'
+          inputs:
+            indexPattern: '{{ foreach.item.index }}'

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/types.ts
@@ -16,18 +16,126 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import type {
+  CreateWorkflowCommand,
+  WorkflowDetailDto,
+  WorkflowExecutionDto,
+  WorkflowExecutionEngineModel,
+  WorkflowExecutionListDto,
+  WorkflowListDto,
+  WorkflowsSearchParams,
+} from '@kbn/workflows';
 import type {
   SmlTypeDefinition,
   SmlSearchResult,
   SmlSearchFilters,
   SmlDocument,
   SmlIndexAction,
+  SmlChunk,
+  SmlDocumentSource,
 } from './services/sml/types';
 import type { SmlResolvedItemResult } from './services/sml/execute_sml_attach_items';
+
+/**
+ * Minimal projection of `WorkflowsManagementApi` used by the Agent Context
+ * Layer. We define it locally instead of importing
+ * `@kbn/workflows-management-plugin/server` so we avoid a TypeScript project
+ * reference cycle (workflows_management already depends on
+ * `@kbn/agent-context-layer-plugin/server` for its SML notify types).
+ *
+ * Stays structurally compatible with the real `WorkflowsManagementApi`
+ * surface — at runtime the value is the same `management` object the
+ * workflows_management plugin returns from its setup contract.
+ */
+export interface WorkflowsManagementApiContract {
+  isWorkflowsAvailable: boolean;
+  getWorkflows(
+    params: WorkflowsSearchParams,
+    spaceId: string,
+    options?: { includeExecutionHistory?: boolean }
+  ): Promise<WorkflowListDto>;
+  getWorkflow(
+    id: string,
+    spaceId: string,
+    options?: { includeDeleted?: boolean }
+  ): Promise<WorkflowDetailDto | null>;
+  createWorkflow(
+    workflow: CreateWorkflowCommand,
+    spaceId: string,
+    request: KibanaRequest
+  ): Promise<WorkflowDetailDto>;
+  /**
+   * Partial update for an existing workflow document. Used by the SML
+   * installer to refresh built-in workflow YAML when the template ships an
+   * updated version.
+   */
+  updateWorkflow(
+    id: string,
+    workflow: Partial<{ name: string; description: string; yaml: string; enabled: boolean }>,
+    spaceId: string,
+    request: KibanaRequest
+  ): Promise<{ id: string }>;
+  /**
+   * Delete workflows by id. Defaults to soft-delete (sets `deleted_at`); pass
+   * `{ force: true }` to permanently purge the document so its `_id` becomes
+   * available for reuse.
+   */
+  deleteWorkflows(
+    workflowIds: string[],
+    spaceId: string,
+    request: KibanaRequest,
+    options?: { force?: boolean }
+  ): Promise<{
+    total: number;
+    deleted: number;
+    failures: Array<{ id: string; error: string }>;
+  }>;
+  runWorkflow(
+    workflow: WorkflowExecutionEngineModel,
+    spaceId: string,
+    inputs: Record<string, unknown>,
+    request: KibanaRequest,
+    triggeredBy?: string
+  ): Promise<string>;
+  cancelWorkflowExecution(executionId: string, spaceId: string): Promise<void>;
+  resumeWorkflowExecution(
+    executionId: string,
+    spaceId: string,
+    input: Record<string, unknown>,
+    request: KibanaRequest
+  ): Promise<void>;
+  getWorkflowExecutions(
+    params: { workflowId: string; size?: number; page?: number },
+    spaceId: string
+  ): Promise<WorkflowExecutionListDto>;
+  /**
+   * Fetch a single execution detail (including `stepExecutions`) so the SML
+   * admin page can show per-step progress for running workflows (current
+   * index for `workflow-sml-index-augmentation`, completion counter for
+   * `workflow-sml-index-crawl`).
+   *
+   * Pass `{ includeInput: true, includeOutput: true }` when progress needs
+   * the rendered step `input` (e.g. `inputs.indexPattern`) or `output` (e.g.
+   * the `list_indices` array) — those fields are stripped by default to
+   * keep the response small for the workflow list view.
+   */
+  getWorkflowExecution(
+    executionId: string,
+    spaceId: string,
+    options?: { includeInput?: boolean; includeOutput?: boolean }
+  ): Promise<WorkflowExecutionDto | null>;
+}
+
+export interface WorkflowsManagementSetupContract {
+  management: WorkflowsManagementApiContract;
+}
 
 export interface AgentContextLayerSetupDependencies {
   features: FeaturesPluginSetup;
   taskManager: TaskManagerSetupContract;
+  workflowsManagement: WorkflowsManagementSetupContract;
+  workflowsExtensions?: WorkflowsExtensionsServerPluginSetup;
 }
 
 export interface AgentContextLayerStartDependencies {
@@ -85,4 +193,19 @@ export interface SmlIndexAttachmentParams {
   action: SmlIndexAction;
   spaceId?: string;
   includedHiddenTypes?: string[];
+  /**
+   * Optional pre-computed chunks. When provided (for `create`/`update`), the
+   * SML service skips the registered type's `getSmlData` hook and indexes the
+   * supplied chunks directly. Ignored for `action: 'delete'`.
+   */
+  chunks?: SmlChunk[];
+  /**
+   * Explicit source for this operation. When not provided, defaults to
+   * `'direct'` if `chunks` is set, otherwise `'resolved'`.
+   *
+   * `direct` writes override any existing chunks for the `originId`.
+   * `resolved` writes are skipped when `direct` chunks already exist for the
+   * `originId` (preserving the user's override).
+   */
+  source?: SmlDocumentSource;
 }

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/index.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { AgentContextLayerPluginStart } from '../types';
+import { createSmlIndexAttachmentStepDefinition } from './sml_index_attachment_step';
+
+export const registerAgentContextLayerWorkflowSteps = ({
+  workflowsExtensions,
+  getStartContract,
+  getSpaces,
+}: {
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
+  getStartContract: () => AgentContextLayerPluginStart;
+  getSpaces: () => SpacesPluginStart | undefined;
+}) => {
+  workflowsExtensions.registerStepDefinition(
+    createSmlIndexAttachmentStepDefinition({ getStartContract, getSpaces })
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.test.ts
@@ -31,7 +31,6 @@ type StepInput =
         description?: string;
         user_id?: string;
         references?: string[];
-        permissions?: string[];
       }>;
     }
   | { originId: string; attachmentType: string; action: 'delete' };

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.test.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.test.ts
@@ -1,0 +1,248 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import type { AgentContextLayerPluginStart } from '../types';
+import { createSmlIndexAttachmentStepDefinition } from './sml_index_attachment_step';
+
+const buildStartContract = (): jest.Mocked<AgentContextLayerPluginStart> => ({
+  search: jest.fn(),
+  checkItemsAccess: jest.fn(),
+  getDocuments: jest.fn(),
+  // Default: treat any type as registered. Individual tests can override.
+  getTypeDefinition: jest.fn().mockImplementation((id: string) => ({ id } as any)),
+  resolveSmlAttachItems: jest.fn(),
+  indexAttachment: jest.fn().mockResolvedValue(undefined),
+});
+
+type StepInput =
+  | {
+      originId: string;
+      attachmentType: string;
+      action: 'create' | 'update';
+      chunks: Array<{
+        type: string;
+        title: string;
+        content: string;
+        description?: string;
+        user_id?: string;
+        references?: string[];
+        permissions?: string[];
+      }>;
+    }
+  | { originId: string; attachmentType: string; action: 'delete' };
+
+const buildHandlerContext = (input: StepInput, request = httpServerMock.createKibanaRequest()) => ({
+  input,
+  config: {},
+  rawInput: input,
+  contextManager: {
+    getContext: jest.fn(),
+    getScopedEsClient: jest.fn(),
+    renderInputTemplate: jest.fn((value: unknown) => value),
+    getFakeRequest: jest.fn().mockReturnValue(request),
+  },
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  abortSignal: new AbortController().signal,
+  stepId: 'test-step',
+  stepType: 'agentContextLayer.smlIndexAttachment',
+});
+
+describe('createSmlIndexAttachmentStepDefinition', () => {
+  it('exposes the expected step type id and schemas', () => {
+    const definition = createSmlIndexAttachmentStepDefinition({
+      getStartContract: () => buildStartContract(),
+      getSpaces: () => undefined,
+    });
+    expect(definition.id).toBe('agentContextLayer.smlIndexAttachment');
+    expect(definition.inputSchema).toBeDefined();
+    expect(definition.outputSchema).toBeDefined();
+    expect(typeof definition.handler).toBe('function');
+  });
+
+  it('forwards caller-supplied chunks to the start contract for create', async () => {
+    const startContract = buildStartContract();
+    const spacesService = { getSpaceId: jest.fn().mockReturnValue('test-space') };
+    const definition = createSmlIndexAttachmentStepDefinition({
+      getStartContract: () => startContract,
+      getSpaces: () => ({ spacesService } as any),
+    });
+
+    const request = httpServerMock.createKibanaRequest();
+    const context = buildHandlerContext(
+      {
+        originId: 'doc-42',
+        attachmentType: 'custom',
+        action: 'create',
+        chunks: [
+          {
+            type: 'custom',
+            title: 'My title',
+            content: 'My content',
+            description: 'desc',
+          },
+        ],
+      },
+      request
+    );
+
+    const result = await definition.handler(context as any);
+
+    expect(startContract.indexAttachment).toHaveBeenCalledWith({
+      request,
+      originId: 'doc-42',
+      attachmentType: 'custom',
+      action: 'create',
+      chunks: [
+        {
+          type: 'custom',
+          title: 'My title',
+          content: 'My content',
+          description: 'desc',
+        },
+      ],
+      // Workflow step is always a "direct" write — overrides any crawler chunks.
+      source: 'direct',
+    });
+    expect(result).toEqual({
+      output: {
+        originId: 'doc-42',
+        attachmentType: 'custom',
+        action: 'create',
+        spaceId: 'test-space',
+        chunkCount: 1,
+        acknowledged: true,
+      },
+    });
+  });
+
+  it('strips optional chunk fields when not provided', async () => {
+    const startContract = buildStartContract();
+    const definition = createSmlIndexAttachmentStepDefinition({
+      getStartContract: () => startContract,
+      getSpaces: () => undefined,
+    });
+
+    const context = buildHandlerContext({
+      originId: 'doc-1',
+      attachmentType: 'custom',
+      action: 'update',
+      chunks: [{ type: 'custom', title: 't', content: 'c' }],
+    });
+
+    await definition.handler(context as any);
+    const callArgs = startContract.indexAttachment.mock.calls[0][0];
+    expect(callArgs.chunks).toEqual([{ type: 'custom', title: 't', content: 'c' }]);
+    expect(Object.keys(callArgs.chunks![0])).toEqual(['type', 'title', 'content']);
+  });
+
+  it('supports delete without chunks and reports chunkCount = 0', async () => {
+    const startContract = buildStartContract();
+    const definition = createSmlIndexAttachmentStepDefinition({
+      getStartContract: () => startContract,
+      getSpaces: () => undefined,
+    });
+
+    const context = buildHandlerContext({
+      originId: 'doc-1',
+      attachmentType: 'custom',
+      action: 'delete',
+    });
+
+    const result = await definition.handler(context as any);
+
+    expect(startContract.indexAttachment).toHaveBeenCalledWith({
+      request: expect.anything(),
+      originId: 'doc-1',
+      attachmentType: 'custom',
+      action: 'delete',
+      // Workflow-driven deletes are direct: they wipe everything for the origin.
+      source: 'direct',
+    });
+    expect(startContract.indexAttachment.mock.calls[0][0].chunks).toBeUndefined();
+    expect(result).toEqual({
+      output: expect.objectContaining({
+        action: 'delete',
+        spaceId: 'default',
+        chunkCount: 0,
+        acknowledged: true,
+      }),
+    });
+  });
+
+  it('returns an error result when the attachment_type is not registered', async () => {
+    const startContract = buildStartContract();
+    startContract.getTypeDefinition.mockReturnValueOnce(undefined);
+    const definition = createSmlIndexAttachmentStepDefinition({
+      getStartContract: () => startContract,
+      getSpaces: () => undefined,
+    });
+
+    const context = buildHandlerContext({
+      originId: 'doc-1',
+      attachmentType: 'unknown',
+      action: 'create',
+      chunks: [{ type: 'unknown', title: 't', content: 'c' }],
+    });
+
+    const result = await definition.handler(context as any);
+    expect(result.output).toBeUndefined();
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toBe("Unknown SML attachment type: 'unknown'");
+    expect(startContract.indexAttachment).not.toHaveBeenCalled();
+  });
+
+  it('returns an error result and logs when indexAttachment throws', async () => {
+    const startContract = buildStartContract();
+    startContract.indexAttachment.mockRejectedValueOnce(new Error('ES write failed'));
+    const definition = createSmlIndexAttachmentStepDefinition({
+      getStartContract: () => startContract,
+      getSpaces: () => undefined,
+    });
+
+    const context = buildHandlerContext({
+      originId: 'doc-1',
+      attachmentType: 'custom',
+      action: 'create',
+      chunks: [{ type: 'custom', title: 't', content: 'c' }],
+    });
+
+    const result = await definition.handler(context as any);
+    expect(result.output).toBeUndefined();
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toBe('ES write failed');
+    expect(context.logger.error).toHaveBeenCalledWith(
+      'SML index_attachment workflow step failed',
+      expect.any(Error)
+    );
+  });
+
+  it('returns an error when the start contract is not yet available', async () => {
+    const definition = createSmlIndexAttachmentStepDefinition({
+      getStartContract: () => {
+        throw new Error('start contract not ready');
+      },
+      getSpaces: () => undefined,
+    });
+
+    const context = buildHandlerContext({
+      originId: 'doc-1',
+      attachmentType: 'custom',
+      action: 'create',
+      chunks: [{ type: 'custom', title: 't', content: 'c' }],
+    });
+
+    const result = await definition.handler(context as any);
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toBe('start contract not ready');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { smlIndexAttachmentStepCommonDefinition } from '../../common/workflow_steps/sml_index_attachment_step';
+import type { SmlChunk } from '../services/sml/types';
+import type { AgentContextLayerPluginStart } from '../types';
+
+/**
+ * Factory for the SML "index attachment" workflow step.
+ *
+ * Always uses **direct mode** — the workflow author supplies `chunks`
+ * (for `create`/`update`), and the start contract's `indexAttachment`
+ * forwards them to the indexer, bypassing the registered type's
+ * `getSmlData` hook. `delete` only requires the origin/type identifiers.
+ *
+ * The handler defers resolving the AGL start contract until execution time,
+ * so the step can be registered during plugin `setup()` and still call into
+ * the service after `start()` has run.
+ */
+export const createSmlIndexAttachmentStepDefinition = ({
+  getStartContract,
+  getSpaces,
+}: {
+  getStartContract: () => AgentContextLayerPluginStart;
+  getSpaces: () => SpacesPluginStart | undefined;
+}) =>
+  createServerStepDefinition({
+    ...smlIndexAttachmentStepCommonDefinition,
+    handler: async (context) => {
+      try {
+        const input = context.input;
+        const { originId, attachmentType, action } = input;
+        const request = context.contextManager.getFakeRequest();
+
+        const startContract = getStartContract();
+
+        if (!startContract.getTypeDefinition(attachmentType)) {
+          return {
+            error: new Error(`Unknown SML attachment type: '${attachmentType}'`),
+          };
+        }
+
+        if (action === 'delete') {
+          // Workflow surface is always a `direct` operation: workflow-driven
+          // deletes wipe any chunks for the origin regardless of crawler state.
+          await startContract.indexAttachment({
+            request,
+            originId,
+            attachmentType,
+            action: 'delete',
+            source: 'direct',
+          });
+        } else {
+          const chunks: SmlChunk[] = input.chunks.map((chunk) => ({
+            type: chunk.type,
+            title: chunk.title,
+            content: chunk.content,
+            ...(chunk.description !== undefined ? { description: chunk.description } : {}),
+            ...(chunk.user_id !== undefined ? { user_id: chunk.user_id } : {}),
+            ...(chunk.references !== undefined ? { references: chunk.references } : {}),
+            ...(chunk.permissions !== undefined ? { permissions: chunk.permissions } : {}),
+          }));
+
+          await startContract.indexAttachment({
+            request,
+            originId,
+            attachmentType,
+            action,
+            chunks,
+            source: 'direct',
+          });
+        }
+
+        const spaceId = getSpaces()?.spacesService?.getSpaceId(request) ?? 'default';
+        const chunkCount = action === 'delete' ? 0 : input.chunks.length;
+
+        return {
+          output: {
+            originId,
+            attachmentType,
+            action,
+            spaceId,
+            chunkCount,
+            acknowledged: true as const,
+          },
+        };
+      } catch (error) {
+        context.logger.error(
+          'SML index_attachment workflow step failed',
+          error instanceof Error ? error : new Error(String(error))
+        );
+        return {
+          error: new Error(
+            error instanceof Error ? error.message : 'Failed to index SML attachment'
+          ),
+        };
+      }
+    },
+  });

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/workflow_steps/sml_index_attachment_step.ts
@@ -57,6 +57,10 @@ export const createSmlIndexAttachmentStepDefinition = ({
             source: 'direct',
           });
         } else {
+          // We deliberately do NOT forward `permissions` — the indexer
+          // derives the authoritative `permissions` (and `spaces`) for each
+          // chunk from the registered type's `resolveOriginAccess` hook.
+          // See `SmlTypeDefinition.resolveOriginAccess` for the rationale.
           const chunks: SmlChunk[] = input.chunks.map((chunk) => ({
             type: chunk.type,
             title: chunk.title,
@@ -64,7 +68,6 @@ export const createSmlIndexAttachmentStepDefinition = ({
             ...(chunk.description !== undefined ? { description: chunk.description } : {}),
             ...(chunk.user_id !== undefined ? { user_id: chunk.user_id } : {}),
             ...(chunk.references !== undefined ? { references: chunk.references } : {}),
-            ...(chunk.permissions !== undefined ? { permissions: chunk.permissions } : {}),
           }));
 
           await startContract.indexAttachment({

--- a/x-pack/platform/plugins/shared/agent_context_layer/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_context_layer/tsconfig.json
@@ -17,6 +17,7 @@
     "@kbn/core-saved-objects-api-server",
     "@kbn/core-ui-settings-server",
     "@kbn/features-plugin",
+    "@kbn/management-plugin",
     "@kbn/task-manager-plugin",
     "@kbn/spaces-plugin",
     "@kbn/security-plugin-types-server",
@@ -26,6 +27,14 @@
     "@kbn/agent-builder-server",
     "@kbn/core-http-server-mocks",
     "@kbn/core-logging-server-mocks",
-    "@kbn/logging-mocks"
+    "@kbn/logging-mocks",
+    "@kbn/workflows-extensions",
+    "@kbn/workflows",
+    "@kbn/workflows-execution-engine",
+    "@kbn/workflows-yaml",
+    "@kbn/zod",
+    "@kbn/kibana-react-plugin",
+    "@kbn/i18n-react",
+    "@kbn/core-http-server-utils"
   ]
 }


### PR DESCRIPTION
## Summary

PoC for https://github.com/elastic/search-team/issues/14477

- updates schema with `source: 'resolved' | 'direct'` to differentiate between entries indexed by crawler / by user
- expands indexAttachment method on server contract with ability to index `direct` entries
- exposes workflow step that allow to index `direct` entries (for users with `sml:write` permissions)
- adds management page from which one can install default workflows, run them and monitor their progress

-- any user with `sml:write` permissions can overwrite any item in sml index

<img width="2392" height="1236" alt="image" src="https://github.com/user-attachments/assets/6020fa32-924f-4362-9f80-5de4453ec4d4" />
