### PR TITLE
[Background search test] Change notifications assertion

### DIFF
--- a/src/platform/test/functional/services/search_sessions.ts
+++ b/src/platform/test/functional/services/search_sessions.ts
@@ -82,6 +82,13 @@ export class SearchSessionsService extends FtrService {
     );
   }
 
+  public async expectCompletedSearchToast() {
+    await this.retry.waitFor(
+      'the toast appears indicating that the search session is completed',
+      () => this.testSubjects.exists('backgroundSearchCompletedToastLink')
+    );
+  }
+
   public async openCompletedSearchFromToast() {
     await this.retry.try(async () => {
       const link = await this.testSubjects.find('backgroundSearchCompletedToastLink');

--- a/x-pack/platform/test/search_sessions_integration/tests/apps/discover/notifications.ts
+++ b/x-pack/platform/test/search_sessions_integration/tests/apps/discover/notifications.ts
@@ -8,10 +8,8 @@
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const retry = getService('retry');
   const monacoEditor = getService('monacoEditor');
   const searchSessions = getService('searchSessions');
-  const toasts = getService('toasts');
   const esArchiver = getService('esArchiver');
 
   const { common, timePicker, discover } = getPageObjects(['common', 'discover', 'timePicker']);
@@ -34,10 +32,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await searchSessions.save({ withRefresh: true });
 
       // Verify the completion toast is shown
-      await retry.waitFor('completion toast is shown', async () => {
-        const toastContent = await toasts.getContentByIndex(1); // 0 is the sent to background toast, 1 is the completion toast
-        return toastContent.includes('Background search completed');
-      });
+      await searchSessions.expectCompletedSearchToast();
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/268710

Instead of assuming that the toast is in the 2nd position this updates it to just look for the link that appears in the completion toast.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->