### PR TITLE
[9.4] [ObsPresentation][Infra] Migrate Hosts View FTR tests to Scout + OTel coverage (#265509)

### DIFF
--- a/src/platform/packages/shared/kbn-synthtrace-client/src/lib/infra/semconv_host.ts
+++ b/src/platform/packages/shared/kbn-synthtrace-client/src/lib/infra/semconv_host.ts
@@ -31,13 +31,13 @@ export interface SemconvHostMetricsDocument extends SemconvHostDocument {
   'metricset.name'?: string;
   state?: string;
   direction?: string;
-  'system.cpu.utilization'?: number;
-  'system.cpu.logical.count'?: number;
-  'system.cpu.load_average.1m'?: number;
+  'metrics.system.cpu.utilization'?: number;
+  'metrics.system.cpu.logical.count'?: number;
+  'metrics.system.cpu.load_average.1m'?: number;
   'system.memory.utilization'?: number;
   'system.memory.usage'?: number;
   'metrics.system.filesystem.usage'?: number;
-  'system.network.io'?: number;
+  'metrics.system.network.io'?: number;
   'device.keyword'?: string;
 }
 
@@ -45,21 +45,21 @@ class SemconvHostMetrics extends Serializable<SemconvHostMetricsDocument> {}
 
 export class SemconvHost extends Entity<SemconvHostDocument> {
   cpu() {
-    const idle = 0.3 + Math.random() * 0.4;
-    const wait = Math.random() * 0.1;
+    const loadAvg1m = 1 + Math.random() * 3;
     return [
-      { state: 'idle', 'system.cpu.utilization': idle },
-      { state: 'wait', 'system.cpu.utilization': wait },
-      { state: 'user', 'system.cpu.utilization': Math.random() * 0.3 },
-      { state: 'system', 'system.cpu.utilization': Math.random() * 0.2 },
+      { state: 'idle', utilization: 0.3 + Math.random() * 0.4 },
+      { state: 'wait', utilization: Math.random() * 0.1 },
+      { state: 'user', utilization: Math.random() * 0.3 },
+      { state: 'system', utilization: Math.random() * 0.2 },
     ].map(
-      (cpu) =>
+      ({ state, utilization }) =>
         new SemconvHostMetrics({
           ...this.fields,
-          ...cpu,
+          state,
           'metricset.name': 'cpu',
-          'system.cpu.logical.count': 4,
-          'system.cpu.load_average.1m': 1 + Math.random() * 3,
+          'metrics.system.cpu.utilization': utilization,
+          'metrics.system.cpu.logical.count': 4,
+          'metrics.system.cpu.load_average.1m': loadAvg1m,
         })
     );
   }
@@ -69,34 +69,23 @@ export class SemconvHost extends Entity<SemconvHostDocument> {
     const used = total * (0.4 + Math.random() * 0.3);
     const free = total - used;
     return [
-      { state: 'used', 'system.memory.utilization': used / total, 'system.memory.usage': used },
-      { state: 'free', 'system.memory.utilization': free / total, 'system.memory.usage': free },
-      {
-        state: 'cached',
-        'system.memory.utilization': 0.1,
-        'system.memory.usage': total * 0.1,
-      },
-      {
-        state: 'buffered',
-        'system.memory.utilization': 0.05,
-        'system.memory.usage': total * 0.05,
-      },
-      {
-        state: 'slab_reclaimable',
-        'system.memory.utilization': 0.02,
-        'system.memory.usage': total * 0.02,
-      },
-      {
-        state: 'slab_unreclaimable',
-        'system.memory.utilization': 0.01,
-        'system.memory.usage': total * 0.01,
-      },
+      { state: 'used', utilization: used / total, usage: used },
+      { state: 'free', utilization: free / total, usage: free },
+      { state: 'cached', utilization: 0.1, usage: total * 0.1 },
+      { state: 'buffered', utilization: 0.05, usage: total * 0.05 },
+      { state: 'slab_reclaimable', utilization: 0.02, usage: total * 0.02 },
+      { state: 'slab_unreclaimable', utilization: 0.01, usage: total * 0.01 },
     ].map(
-      (mem) =>
+      ({ state, utilization, usage }) =>
         new SemconvHostMetrics({
           ...this.fields,
-          ...mem,
+          state,
           'metricset.name': 'memory',
+          // The semconv `memoryUsage` Lens formula targets `system.memory.utilization`
+          // (no `metrics.` prefix) to match how real OTel collectors land that field;
+          // the `metrics.*` variants are kept for the formulas that do use the prefix.
+          'system.memory.utilization': utilization,
+          'system.memory.usage': usage,
         })
     );
   }
@@ -121,15 +110,16 @@ export class SemconvHost extends Entity<SemconvHostDocument> {
 
   network() {
     return [
-      { direction: 'transmit', 'system.network.io': Math.floor(Math.random() * 1e9) },
-      { direction: 'receive', 'system.network.io': Math.floor(Math.random() * 1e9) },
+      { direction: 'transmit', io: Math.floor(Math.random() * 1e9) },
+      { direction: 'receive', io: Math.floor(Math.random() * 1e9) },
     ].map(
-      (net) =>
+      ({ direction, io }) =>
         new SemconvHostMetrics({
           ...this.fields,
-          ...net,
+          direction,
           'metricset.name': 'network',
           'device.keyword': 'eth0',
+          'metrics.system.network.io': io,
         })
     );
   }

--- a/src/platform/packages/shared/kbn-synthtrace/src/lib/infra/infra_synthtrace_es_client.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/lib/infra/infra_synthtrace_es_client.ts
@@ -8,7 +8,11 @@
  */
 
 import type { Client } from '@elastic/elasticsearch';
-import type { ESDocumentWithOperation, InfraDocument } from '@kbn/synthtrace-client';
+import type {
+  ESDocumentWithOperation,
+  InfraDocument,
+  SynthtraceGenerator,
+} from '@kbn/synthtrace-client';
 import type { Readable } from 'stream';
 import { pipeline, Transform } from 'stream';
 import type { SynthtraceEsClient, SynthtraceEsClientOptions } from '../shared/base_client';
@@ -48,7 +52,75 @@ export class InfraSynthtraceEsClientImpl
       'metrics-kubernetes*',
       'metrics-docker*',
       'metrics-aws*',
+      'metrics-hostmetricsreceiver.otel*',
     ];
+  }
+
+  private otelTemplateCreated = false;
+
+  override async index(
+    streamOrGenerator:
+      | (Readable | SynthtraceGenerator<InfraDocument>)
+      | Array<Readable | SynthtraceGenerator<InfraDocument>>,
+    pipelineCallback?: (base: Readable) => NodeJS.WritableStream
+  ): Promise<void> {
+    if (!this.otelTemplateCreated) {
+      await this.ensureOtelDataStreamTemplate();
+      this.otelTemplateCreated = true;
+    }
+    return super.index(streamOrGenerator, pipelineCallback);
+  }
+
+  private async ensureOtelDataStreamTemplate() {
+    const templateName = 'metrics-hostmetricsreceiver.otel';
+    try {
+      await this.client.indices.putIndexTemplate({
+        name: templateName,
+        index_patterns: ['metrics-hostmetricsreceiver.otel-*'],
+        data_stream: {},
+        priority: 500,
+        template: {
+          mappings: {
+            dynamic: true,
+            dynamic_templates: [
+              {
+                strings_as_keyword: {
+                  match_mapping_type: 'string',
+                  mapping: { type: 'keyword', ignore_above: 1024 },
+                },
+              },
+            ],
+            properties: {
+              '@timestamp': { type: 'date' },
+              host: {
+                properties: {
+                  name: { type: 'keyword' },
+                  hostname: { type: 'keyword' },
+                  ip: { type: 'ip' },
+                  os: { properties: { name: { type: 'keyword' } } },
+                },
+              },
+              cloud: {
+                properties: {
+                  provider: { type: 'keyword' },
+                  region: { type: 'keyword' },
+                },
+              },
+              data_stream: {
+                properties: {
+                  dataset: { type: 'keyword' },
+                  type: { type: 'keyword' },
+                  namespace: { type: 'keyword' },
+                },
+              },
+            },
+          },
+        },
+      });
+      this.logger.info(`Created index template "${templateName}"`);
+    } catch (error) {
+      this.logger.warning(`Failed to create index template "${templateName}": ${error}`);
+    }
   }
 
   async initializePackage(opts?: { version?: string; skipInstallation?: boolean }) {
@@ -104,6 +176,13 @@ function getRoutingTransform() {
   return new Transform({
     objectMode: true,
     transform(document: ESDocumentWithOperation<InfraDocument>, encoding, callback) {
+      const dataset = document['data_stream.dataset'];
+      if (typeof dataset === 'string' && dataset.includes('otel')) {
+        document._index = `metrics-${dataset}-default`;
+        callback(null, document);
+        return;
+      }
+
       const metricset = document['metricset.name'];
 
       if (metricset === 'cpu') {

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/components/kpis/host_kpi_charts.test.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/components/kpis/host_kpi_charts.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { TimeRange } from '@kbn/es-query';
+import { HostKpiCharts } from './host_kpi_charts';
+import { useHostKpiCharts } from '../../hooks/use_host_metrics_charts';
+
+jest.mock('../../hooks/use_host_metrics_charts');
+jest.mock('./kpi', () => ({
+  // Kibana config sets Testing Library's testIdAttribute to `data-test-subj`,
+  // so `screen.getByTestId()` queries that attribute (not `data-testid`).
+  Kpi: ({ id }: { id: string }) => <div data-test-subj={`kpi-${id}`} />,
+}));
+
+const useHostKpiChartsMock = useHostKpiCharts as jest.MockedFunction<typeof useHostKpiCharts>;
+
+const dateRange: TimeRange = {
+  from: '2023-03-28T18:20:00.000Z',
+  to: '2023-03-28T18:21:00.000Z',
+};
+
+const renderWithI18n = (node: React.ReactElement) => render(<I18nProvider>{node}</I18nProvider>);
+
+describe('HostKpiCharts', () => {
+  beforeEach(() => {
+    useHostKpiChartsMock.mockReturnValue([
+      { id: 'cpuUsage' },
+      { id: 'normalizedLoad1m' },
+      { id: 'memoryUsage' },
+      { id: 'diskUsage' },
+    ] as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders KPI panels when loading', () => {
+    renderWithI18n(<HostKpiCharts dateRange={dateRange} loading />);
+
+    expect(screen.getByTestId('kpi-cpuUsage')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-normalizedLoad1m')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-memoryUsage')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-diskUsage')).toBeInTheDocument();
+  });
+
+  it('renders empty placeholders when hasData is false', () => {
+    renderWithI18n(<HostKpiCharts dateRange={dateRange} hasData={false} />);
+
+    expect(screen.getAllByText('No results found')).toHaveLength(4);
+  });
+
+  it('renders error placeholders when error is provided', () => {
+    renderWithI18n(
+      <HostKpiCharts dateRange={dateRange} error={{ message: 'boom' } as any} loading={false} />
+    );
+
+    expect(screen.getAllByText('boom')).toHaveLength(4);
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -107,9 +107,26 @@ export const DATE_WITH_POD_DATA = '04/01/2023 6:20:59 PM';
 export const POD_COUNT = 1;
 export const POD_NAMES = Array.from({ length: POD_COUNT }, (_, i) => `pod-${i}`);
 
+export const SEMCONV_HOST1_NAME = 'semconv-host-1';
+export const SEMCONV_HOST2_NAME = 'semconv-host-2';
+
+export const SEMCONV_HOSTS = [{ hostName: SEMCONV_HOST1_NAME }, { hostName: SEMCONV_HOST2_NAME }];
+
+export const DATE_WITH_SEMCONV_DATA_FROM = '2023-04-02T18:20:00.000Z';
+export const DATE_WITH_SEMCONV_DATA_TO = '2023-04-02T18:21:00.000Z';
+
 export const DATE_WITHOUT_DATA = '04/01/2024 6:20:59 PM';
 
 export const EXTENDED_TIMEOUT = 45000; // 45 seconds
+
+/**
+ * Budget for waiting on KPI Lens charts (the `.echMetricText__value`
+ * signal). Under CI contention, the first Lens + elastic-charts render on a
+ * worker can exceed `EXTENDED_TIMEOUT`; a 90s budget covers that variance
+ * while staying well under the `test.slow()` test-timeout (180s) these
+ * KPI-heavy suites opt into.
+ */
+export const KPI_RENDER_TIMEOUT = 90000;
 
 export const KUBERNETES_TOUR_STORAGE_KEY = 'isKubernetesTourSeen';
 export const KUBERNETES_CARD_DISMISSED_STORAGE_KEY = 'infra.inventory.k8sCardDismissed';

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/asset_details.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/asset_details.ts
@@ -11,6 +11,8 @@ import { OverviewTab } from './overview_tab';
 import { MetadataTab } from './metadata_tab';
 import { MetricsTab } from './metrics_tab';
 import { LogsTab } from './logs_tab';
+import { ProcessesTab } from './processes_tab';
+import { DashboardsTab } from './dashboards_tab';
 
 export class AssetDetailsPage {
   public readonly hostOverviewTab: OverviewTab;
@@ -22,6 +24,10 @@ export class AssetDetailsPage {
   public readonly dockerMetricsTab: MetricsTab;
 
   public readonly logsTag: LogsTab;
+
+  public readonly processesTab: ProcessesTab;
+
+  public readonly dashboardsTab: DashboardsTab;
 
   public readonly openAsPageButton: Locator;
   public readonly returnButton: Locator;
@@ -36,6 +42,10 @@ export class AssetDetailsPage {
     this.dockerMetricsTab = createLazyPageObject(MetricsTab, this.page, this.kbnUrl, 'Docker');
 
     this.logsTag = createLazyPageObject(LogsTab, this.page, this.kbnUrl);
+
+    this.processesTab = createLazyPageObject(ProcessesTab, this.page, this.kbnUrl);
+
+    this.dashboardsTab = createLazyPageObject(DashboardsTab, this.page, this.kbnUrl);
 
     this.openAsPageButton = this.page.getByTestId('infraAssetDetailsOpenAsPageButton');
     this.returnButton = this.page.getByTestId('infraAssetDetailsReturnButton');

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/asset_details_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/asset_details_tab.ts
@@ -15,7 +15,8 @@ export type AssetDetailsPageTabName =
   | 'Profiling'
   | 'Logs'
   | 'Anomalies'
-  | 'Osquery';
+  | 'Osquery'
+  | 'Dashboards';
 
 export abstract class AssetDetailsTab {
   public abstract readonly tabName: AssetDetailsPageTabName;

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/dashboards_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/dashboards_tab.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+import type { AssetDetailsPageTabName } from './asset_details_tab';
+import { AssetDetailsTab } from './asset_details_tab';
+
+export class DashboardsTab extends AssetDetailsTab {
+  public readonly tabName: AssetDetailsPageTabName = 'Dashboards';
+  public readonly tab: Locator;
+
+  public readonly addDashboardButton: Locator;
+
+  constructor(page: ScoutPage, kbnUrl: KibanaUrl) {
+    super(page, kbnUrl);
+    this.tab = this.page.getByTestId(`infraAssetDetails${this.tabName}Tab`);
+
+    this.addDashboardButton = this.page.getByTestId('infraAddDashboard');
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/overview_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/overview_tab.ts
@@ -9,10 +9,13 @@ import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
 import type { AssetDetailsPageTabName } from './asset_details_tab';
 import { AssetDetailsTab } from './asset_details_tab';
 
+const KPI_METRICS = ['cpuUsage', 'normalizedLoad1m', 'memoryUsage', 'diskUsage'] as const;
+
 export class OverviewTab extends AssetDetailsTab {
   public readonly tabName: AssetDetailsPageTabName = 'Overview';
   public readonly tab: Locator;
 
+  public readonly kpiGrid: Locator;
   public readonly kpiCpuUsageChart: Locator;
   public readonly kpiNormalizedLoadChart: Locator;
   public readonly kpiMemoryUsageChart: Locator;
@@ -67,10 +70,11 @@ export class OverviewTab extends AssetDetailsTab {
     super(page, kbnUrl);
     this.tab = this.page.getByTestId(`infraAssetDetails${this.tabName}Tab`);
 
-    this.kpiCpuUsageChart = this.page.getByTestId('infraAssetDetailsKPIcpuUsage');
-    this.kpiNormalizedLoadChart = this.page.getByTestId('infraAssetDetailsKPInormalizedLoad1m');
-    this.kpiMemoryUsageChart = this.page.getByTestId('infraAssetDetailsKPImemoryUsage');
-    this.kpiDiskUsageChart = this.page.getByTestId('infraAssetDetailsKPIdiskUsage');
+    this.kpiGrid = this.page.getByTestId('infraAssetDetailsKPIGrid');
+    this.kpiCpuUsageChart = this.kpiGrid.getByTestId('infraAssetDetailsKPIcpuUsage');
+    this.kpiNormalizedLoadChart = this.kpiGrid.getByTestId('infraAssetDetailsKPInormalizedLoad1m');
+    this.kpiMemoryUsageChart = this.kpiGrid.getByTestId('infraAssetDetailsKPImemoryUsage');
+    this.kpiDiskUsageChart = this.kpiGrid.getByTestId('infraAssetDetailsKPIdiskUsage');
 
     this.metadataSection = this.page
       .getByTestId('infraAssetDetailsCollapseExpandSection')
@@ -176,5 +180,70 @@ export class OverviewTab extends AssetDetailsTab {
     this.metricsDiskIOChart = this.metricsDiskSection.getByTestId(
       'infraAssetDetailsMetricChartdiskIOReadWrite'
     );
+  }
+
+  private getKPIValueSelector(kpiPanelTestId: string): string {
+    // Relative to `kpiGrid` — do not repeat `infraAssetDetailsKPIGrid` here or
+    // Playwright will nest the selector twice (grid + grid + KPI).
+    return `[data-test-subj="${kpiPanelTestId}"] .echMetricText__value`;
+  }
+
+  public getKPIValue(metric: string): Locator {
+    const kpiPanelTestId = `infraAssetDetailsKPI${metric}`;
+    return this.kpiGrid.locator(this.getKPIValueSelector(kpiPanelTestId));
+  }
+
+  private getKPILoadingIndicator(metric: string): Locator {
+    return this.kpiGrid
+      .getByTestId(`infraAssetDetailsKPI${metric}`)
+      .getByRole('progressbar', { name: 'Loading' });
+  }
+
+  /**
+   * Lens embeddable error panel shown when a KPI fails to render.
+   * `data-test-subj="embeddableError"` is defined by the shared embeddable panel error component.
+   */
+  public getKPIEmbeddableError(metric: string): Locator {
+    return this.kpiGrid.getByTestId(`infraAssetDetailsKPI${metric}`).getByTestId('embeddableError');
+  }
+
+  public async waitForKPILoadingToFinish(timeout?: number) {
+    await this.getKPILoadingIndicator('cpuUsage').waitFor({ state: 'hidden', timeout });
+  }
+
+  private async waitForKPIValueTitleToBeSet(metric: string, timeout?: number) {
+    await this.getKPIValue(metric).waitFor({ state: 'attached', timeout });
+    const kpiPanelTestId = `infraAssetDetailsKPI${metric}`;
+    const selector = `[data-test-subj="infraAssetDetailsKPIGrid"] ${this.getKPIValueSelector(
+      kpiPanelTestId
+    )}`;
+
+    await this.page.waitForFunction(
+      ({ sel }) => {
+        const valueEl = document.querySelector(sel);
+        const title = valueEl?.getAttribute('title');
+        return typeof title === 'string' && title.trim().length > 0;
+      },
+      { sel: selector },
+      { timeout }
+    );
+  }
+
+  /**
+   * Waits for all KPI Lens charts to finish rendering in parallel. The
+   * `.echMetricText__value` element only appears once elastic-charts has
+   * painted, so it's a sufficient single signal: it implies the outer panel
+   * dropped `-loading`, Lens attributes resolved, and the chart didn't end up
+   * in the `-error` state. Running the waits concurrently shares the budget
+   * across all 4 charts instead of cascading it.
+   */
+  public async waitForKPIChartsToLoad(timeout?: number) {
+    await this.kpiGrid.scrollIntoViewIfNeeded();
+
+    await this.waitForKPILoadingToFinish(timeout);
+
+    for (const metric of KPI_METRICS) {
+      await this.waitForKPIValueTitleToBeSet(metric, timeout);
+    }
   }
 }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/processes_tab.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/asset_details/processes_tab.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+import type { AssetDetailsPageTabName } from './asset_details_tab';
+import { AssetDetailsTab } from './asset_details_tab';
+
+export class ProcessesTab extends AssetDetailsTab {
+  public readonly tabName: AssetDetailsPageTabName = 'Processes';
+  public readonly tab: Locator;
+
+  public readonly content: Locator;
+  public readonly table: Locator;
+  public readonly searchBar: Locator;
+  public readonly searchInputError: Locator;
+
+  constructor(page: ScoutPage, kbnUrl: KibanaUrl) {
+    super(page, kbnUrl);
+    this.tab = this.page.getByTestId(`infraAssetDetails${this.tabName}Tab`);
+
+    this.content = this.page.getByTestId('infraAssetDetailsProcessesTabContent');
+    this.table = this.page.getByTestId('infraAssetDetailsProcessesTable');
+    this.searchBar = this.page.getByTestId('infraAssetDetailsProcessesSearchBarInput');
+    this.searchInputError = this.page.getByTestId('infraAssetDetailsProcessesSearchInputError');
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/hosts_page.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/hosts_page.ts
@@ -8,21 +8,59 @@
 import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
 import { EXTENDED_TIMEOUT } from '../constants';
 
+type PreferredSchema = 'ecs' | 'semconv' | null;
+
 export class HostsPage {
   public readonly tableLoaded: Locator;
+  public readonly tableLoading: Locator;
   public readonly tableRows: Locator;
+  public readonly tableNoData: Locator;
   public readonly searchBar: Locator;
+  public readonly querySubmitButton: Locator;
+  public readonly errorCallout: Locator;
+
+  public readonly metricsTab: Locator;
   public readonly logsTab: Locator;
+  public readonly alertsTab: Locator;
+  public readonly alertsTabCountBadge: Locator;
+
   public readonly logsSearchBar: Locator;
   public readonly excludeButton: Locator;
 
+  public readonly kpiGrid: Locator;
+  public readonly metricsChartsContainer: Locator;
+
+  public readonly tablePageSizeSelector: Locator;
+  public readonly selectedHostsFilterButton: Locator;
+  public readonly addFilterButton: Locator;
+  public readonly noDataPage: Locator;
+  public readonly noDataPageActionButton: Locator;
+
   constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
     this.tableLoaded = this.page.getByTestId('hostsView-table-loaded');
+    this.tableLoading = this.page.getByTestId('hostsView-table-loading');
     this.tableRows = this.page.getByTestId('hostsView-tableRow');
+    this.tableNoData = this.page.getByTestId('hostsViewTableNoData');
     this.searchBar = this.page.getByTestId('queryInput');
+    this.querySubmitButton = this.page.getByTestId('querySubmitButton');
+    this.errorCallout = this.page.getByTestId('hostsViewErrorCallout');
+
+    this.metricsTab = this.page.getByTestId('hostsView-tabs-metrics');
     this.logsTab = this.page.getByTestId('hostsView-tabs-logs');
+    this.alertsTab = this.page.getByTestId('hostsView-tabs-alerts');
+    this.alertsTabCountBadge = this.page.getByTestId('hostsView-tabs-alerts-count');
+
     this.logsSearchBar = this.page.getByTestId('hostsView-logs-text-field-search');
     this.excludeButton = this.page.getByTestId('optionsList__excludeResults');
+
+    this.kpiGrid = this.page.getByTestId('hostsViewKPIGrid');
+    this.metricsChartsContainer = this.page.getByTestId('hostsView-metricChart');
+
+    this.tablePageSizeSelector = this.page.getByTestId('tablePaginationPopoverButton');
+    this.selectedHostsFilterButton = this.page.getByTestId('hostsViewTableSelectHostsFilterButton');
+    this.addFilterButton = this.page.getByTestId('hostsViewTableAddFilterButton');
+    this.noDataPage = this.page.getByTestId('kbnNoDataPage');
+    this.noDataPageActionButton = this.noDataPage.getByTestId('noDataDefaultActionButton');
   }
 
   private async waitForTableToLoad() {
@@ -36,26 +74,234 @@ export class HostsPage {
     await this.waitForTableToLoad();
   }
 
-  public async goToPage({ from, to }: { from: string; to: string }) {
-    const baseUrl = this.kbnUrl.app('metrics');
-    const risonState = `(dateRange:(from:'${from}',to:'${to}'),filters:!(),limit:100,panelFilters:!(),preferredSchema:!n,query:(language:kuery,query:''))`;
-    await this.page.goto(`${baseUrl}/hosts?_a=${risonState}`);
+  public async submitQuery(query: string) {
+    await this.searchBar.clear();
+    await this.searchBar.fill(query);
+    await this.querySubmitButton.click();
     await this.waitForTableToLoad();
   }
 
+  public async goToPage({
+    from,
+    to,
+    preferredSchema = null,
+    skipLoadWait = false,
+  }: {
+    from: string;
+    to: string;
+    preferredSchema?: PreferredSchema;
+    skipLoadWait?: boolean;
+  }) {
+    const baseUrl = this.kbnUrl.app('metrics');
+    const schemaPart =
+      preferredSchema === null ? 'preferredSchema:!n' : `preferredSchema:${preferredSchema}`;
+    const risonState = `(dateRange:(from:'${from}',to:'${to}'),filters:!(),limit:100,panelFilters:!(),${schemaPart},query:(language:kuery,query:''))`;
+    await this.page.goto(`${baseUrl}/hosts?_a=${risonState}`);
+    if (!skipLoadWait) {
+      await this.waitForTableToLoad();
+    }
+  }
+
+  public async goToHostsPage(opts: { skipLoadWait?: boolean } = {}) {
+    const baseUrl = this.kbnUrl.app('metrics');
+    await this.page.goto(`${baseUrl}/hosts`);
+    if (!opts.skipLoadWait) {
+      await this.waitForTableToLoad();
+    }
+  }
+
+  public async clickNoDataPageAddDataButton() {
+    await this.noDataPageActionButton.click();
+  }
+
+  public getHostRow(hostName: string) {
+    return this.tableRows.filter({
+      has: this.page
+        .getByTestId('hostsViewTableEntryTitleLink')
+        .getByText(hostName, { exact: true }),
+    });
+  }
+
   public async openHostFlyout(hostName: string) {
-    const row = this.tableRows.filter({ hasText: hostName });
+    const row = this.getHostRow(hostName);
     await row.getByTestId('hostsView-flyout-button').click();
-    await this.page
-      .getByRole('dialog')
-      .getByRole('heading', { name: hostName })
-      .waitFor({ timeout: EXTENDED_TIMEOUT });
+    await this.page.getByTestId('infraAssetDetailsFlyout').waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   public async closeFlyout() {
     await this.page.getByTestId('euiFlyoutCloseButton').click();
     await this.waitForTableToLoad();
   }
+
+  public async closeFlyoutWithEscape() {
+    await this.page.keyboard.press('Escape');
+    await this.waitForTableToLoad();
+  }
+
+  // Table helpers
+
+  public getHostDetailLinks() {
+    return this.page.getByTestId('hostsViewTableEntryTitleLink');
+  }
+
+  public getCellContentLocator(row: Locator, cellTestId: string): Locator {
+    return row.getByTestId(cellTestId).locator('.euiTableCellContent');
+  }
+
+  public getRowDataLocators(row: Locator) {
+    return {
+      alertsCount: this.getCellContentLocator(row, 'hostsView-tableRow-alertsCount'),
+      title: row.getByTestId('hostsViewTableEntryTitleLink'),
+      cpuUsage: this.getCellContentLocator(row, 'hostsView-tableRow-cpuUsage'),
+      normalizedLoad: this.getCellContentLocator(row, 'hostsView-tableRow-normalizedLoad1m'),
+      memoryUsage: this.getCellContentLocator(row, 'hostsView-tableRow-memoryUsage'),
+      memoryFree: this.getCellContentLocator(row, 'hostsView-tableRow-memoryFree'),
+      diskSpaceUsage: this.getCellContentLocator(row, 'hostsView-tableRow-diskSpaceUsage'),
+      rx: this.getCellContentLocator(row, 'hostsView-tableRow-rx'),
+      tx: this.getCellContentLocator(row, 'hostsView-tableRow-tx'),
+    };
+  }
+
+  public async clickHostCheckbox(hostId: string, os: string) {
+    await this.page.getByTestId(`checkboxSelectRow-${hostId}-${os}`).click();
+  }
+
+  public async clickSelectedHostsButton() {
+    await this.selectedHostsFilterButton.click();
+  }
+
+  public async clickAddFilterButton() {
+    await this.addFilterButton.click();
+  }
+
+  // KPI helpers
+
+  private getHostKPIValueSelector(kpiPanelTestId: string): string {
+    // Relative to `kpiGrid` — do not repeat `hostsViewKPIGrid` here or Playwright
+    // will nest the selector twice (grid + grid + KPI).
+    return `[data-test-subj="${kpiPanelTestId}"] .echMetricText__value`;
+  }
+
+  private async waitForHostKPIValueTitleToBeSet(metric: string, timeout?: number) {
+    await this.getHostKPIChartValueLocator(metric).waitFor({ state: 'attached', timeout });
+    const kpiPanelTestId = `infraAssetDetailsKPI${metric}`;
+    const selector = `[data-test-subj="hostsViewKPIGrid"] ${this.getHostKPIValueSelector(
+      kpiPanelTestId
+    )}`;
+
+    await this.page.waitForFunction(
+      ({ sel }) => {
+        const valueEl = document.querySelector(sel);
+        const title = valueEl?.getAttribute('title');
+        return typeof title === 'string' && title.trim().length > 0;
+      },
+      { sel: selector },
+      { timeout }
+    );
+  }
+
+  public getKPITileValueLocator(type: string) {
+    return this.kpiGrid.getByTestId(`hostsViewKPI-${type}`).locator('.echMetricText__value');
+  }
+
+  /**
+   * Value locator for the shared host KPI tiles (`cpuUsage`, `normalizedLoad1m`,
+   * `memoryUsage`, `diskUsage`) rendered via `HostKpiCharts`. They use the
+   * `infraAssetDetailsKPI*` prefix in both the hosts page grid and the flyout;
+   * scoping to the hosts page `kpiGrid` disambiguates when both are on screen.
+   */
+  public getHostKPIChartValueLocator(metric: string) {
+    return this.kpiGrid
+      .getByTestId(`infraAssetDetailsKPI${metric}`)
+      .locator('.echMetricText__value');
+  }
+
+  /**
+   * Lens embeddable error panel shown when a KPI fails to render.
+   * `data-test-subj="embeddableError"` is defined by the shared embeddable panel error component.
+   */
+  public getHostKPIEmbeddableError(metric: string) {
+    return this.kpiGrid.getByTestId(`infraAssetDetailsKPI${metric}`).getByTestId('embeddableError');
+  }
+
+  /**
+   * Waits for the shared host KPI tiles to finish rendering. Uses parallel
+   * `waitFor` calls so the budget is shared across charts instead of compounding
+   * when one takes longer to render than the others (a common CI flake source).
+   */
+  public async waitForHostKPIChartsToLoad(metrics: readonly string[], timeout?: number) {
+    await this.waitForKPILoadingToFinish(timeout);
+    for (const metric of metrics) {
+      await this.waitForHostKPIValueTitleToBeSet(metric, timeout);
+    }
+  }
+
+  /**
+   * Waits for the KPI loading spinner to disappear. Complements
+   * `waitForHostKPIChartsToLoad` (which waits for the value element to appear)
+   * and is useful in `beforeEach` blocks that just need the page-ready signal
+   * before assertions begin, without waiting on every individual chart value.
+   */
+  public async waitForKPILoadingToFinish(timeout?: number) {
+    await this.kpiGrid
+      .getByTestId('infraAssetDetailsKPIcpuUsage')
+      .getByRole('progressbar', { name: 'Loading' })
+      .waitFor({ state: 'hidden', timeout });
+  }
+
+  // Metrics tab
+
+  public async visitMetricsTab() {
+    await this.metricsTab.scrollIntoViewIfNeeded();
+    await this.metricsTab.click();
+  }
+
+  public getMetricsCharts() {
+    return this.metricsChartsContainer.locator(
+      '[data-test-subj*="hostsView-metricChart-"]:not([data-test-subj*="hover-actions"])'
+    );
+  }
+
+  public async clickMetricChartAction(chartTestId: string) {
+    const element = this.page.getByTestId(chartTestId);
+    await element.hover();
+    const button = element.getByTestId('embeddablePanelToggleMenuIcon');
+    await button.click();
+    const menu = this.page.getByTestId('presentationPanelContextMenuItems');
+    await menu.hover();
+  }
+
+  // Logs tab
+
+  public async visitLogsTab() {
+    await this.logsTab.scrollIntoViewIfNeeded();
+    await this.logsTab.click();
+  }
+
+  // Pagination
+
+  public async changePageSize(pageSize: number) {
+    await this.tablePageSizeSelector.click();
+    await this.page.getByTestId(`tablePagination-${pageSize}-rows`).click();
+  }
+
+  public async paginateTo(pageNumber: number) {
+    await this.page.getByTestId(`pagination-button-${pageNumber - 1}`).click();
+  }
+
+  // Sorting
+
+  public async sortByCpuUsage() {
+    const cpuHeader = this.page.getByTestId('tableHeaderCell_cpuV2_2');
+    await cpuHeader.getByTestId('tableHeaderSortButton').click();
+  }
+
+  public async sortByTitle() {
+    const titleHeader = this.page.getByTestId('tableHeaderCell_title_1');
+    await titleHeader.getByTestId('tableHeaderSortButton').click();
+  }
+
+  // Filter controls
 
   public async openFilterControl(fieldName: string) {
     const controlTestId = `optionsList-control-${fieldName}`;

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/sequential_hosts_synthtrace.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/sequential_hosts_synthtrace.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Sequential `tests/` UI specs do not run `parallel_tests/global.setup.ts`.
+ *
+ * Payloads mirror `global.setup.ts`, but ingestion must call `getSynthtraceClient`
+ * with `{ skipInstallation: true }` so fixed-date docs are not rejected by TSDS —
+ * unlike `globalSetupHook`, the default `synthtraceFixture` `infraSynthtraceEsClient`
+ * does not skip Fleet install. Global setup never used that default path.
+ */
+
+import type { EsClient, KibanaUrl, ScoutLogger, ScoutTestConfig } from '@kbn/scout-oblt';
+import { getSynthtraceClient } from '@kbn/scout-synthtrace';
+import type {
+  ApmFields,
+  InfraDocument,
+  LogDocument,
+  SynthtraceGenerator,
+} from '@kbn/synthtrace-client';
+import { Readable } from 'stream';
+import {
+  DATE_WITH_HOSTS_DATA_FROM,
+  DATE_WITH_HOSTS_DATA_TO,
+  DATE_WITH_SEMCONV_DATA_FROM,
+  DATE_WITH_SEMCONV_DATA_TO,
+  HOST_NAME_WITH_SERVICES,
+  HOSTS,
+  SEMCONV_HOSTS,
+  SERVICE_PER_HOST_COUNT,
+} from './constants';
+import { generateAddServicesToExistingHost } from './synthtrace/add_services_to_existing_hosts';
+import { generateHostData } from './synthtrace/host_data';
+import { generateLogsDataForHostsOrContainers } from './synthtrace/logs_data_for_hosts_or_containers';
+import { generateSemconvHostData } from './synthtrace/semconv_host_data';
+
+const skipFleetForFixedDates = { skipInstallation: true as const };
+
+export interface SequentialSynthtraceWorkerDeps {
+  esClient: EsClient;
+  kbnUrl: KibanaUrl;
+  log: ScoutLogger;
+  config: ScoutTestConfig;
+}
+
+type SynthtraceClientName = 'infraEsClient' | 'logsEsClient' | 'apmEsClient';
+
+const unwrapSynthtraceClient = <TClientName extends SynthtraceClientName, TClient>(
+  clientName: TClientName,
+  value: unknown
+): TClient => {
+  // `getSynthtraceClient` caches instances and returns inconsistent shapes:
+  // - first call: { [clientName]: client }
+  // - subsequent calls: client
+  // Normalize so sequential suites can safely call index + clean.
+  if (value && typeof value === 'object' && clientName in (value as Record<string, unknown>)) {
+    return (value as Record<TClientName, TClient>)[clientName];
+  }
+
+  return value as TClient;
+};
+
+const indexInfra = async (
+  deps: SequentialSynthtraceWorkerDeps,
+  events: SynthtraceGenerator<InfraDocument>
+) => {
+  const result = await getSynthtraceClient(
+    'infraEsClient',
+    {
+      esClient: deps.esClient,
+      kbnUrl: deps.kbnUrl.get(),
+      log: deps.log,
+      config: deps.config,
+    },
+    skipFleetForFixedDates
+  );
+  const infraEsClient = unwrapSynthtraceClient<
+    'infraEsClient',
+    { index: (s: Readable) => Promise<void> }
+  >('infraEsClient', result);
+  await infraEsClient.index(Readable.from(Array.from(events)));
+};
+
+const indexLogs = async (
+  deps: SequentialSynthtraceWorkerDeps,
+  events: SynthtraceGenerator<LogDocument>
+) => {
+  const result = await getSynthtraceClient(
+    'logsEsClient',
+    {
+      esClient: deps.esClient,
+      log: deps.log,
+      config: deps.config,
+    },
+    skipFleetForFixedDates
+  );
+  const logsEsClient = unwrapSynthtraceClient<
+    'logsEsClient',
+    { index: (s: Readable) => Promise<void> }
+  >('logsEsClient', result);
+  await logsEsClient.index(Readable.from(Array.from(events)));
+};
+
+const indexApm = async (
+  deps: SequentialSynthtraceWorkerDeps,
+  events: SynthtraceGenerator<ApmFields>
+) => {
+  const result = await getSynthtraceClient(
+    'apmEsClient',
+    {
+      esClient: deps.esClient,
+      kbnUrl: deps.kbnUrl.get(),
+      log: deps.log,
+      config: deps.config,
+    },
+    skipFleetForFixedDates
+  );
+  const apmEsClient = unwrapSynthtraceClient<
+    'apmEsClient',
+    { index: (s: Readable) => Promise<void> }
+  >('apmEsClient', result);
+  await apmEsClient.index(Readable.from(Array.from(events)));
+};
+
+export const ingestHostsFlyoutSynthtraceData = async (
+  deps: SequentialSynthtraceWorkerDeps
+): Promise<void> => {
+  await indexInfra(
+    deps,
+    generateHostData({
+      from: DATE_WITH_HOSTS_DATA_FROM,
+      to: DATE_WITH_HOSTS_DATA_TO,
+      hosts: HOSTS,
+    })
+  );
+
+  await indexLogs(
+    deps,
+    generateLogsDataForHostsOrContainers({
+      from: DATE_WITH_HOSTS_DATA_FROM,
+      to: DATE_WITH_HOSTS_DATA_TO,
+      hostNames: HOSTS.map((host) => host.hostName),
+    })
+  );
+
+  await indexApm(
+    deps,
+    generateAddServicesToExistingHost({
+      from: DATE_WITH_HOSTS_DATA_FROM,
+      to: DATE_WITH_HOSTS_DATA_TO,
+      hostName: HOST_NAME_WITH_SERVICES,
+      servicesPerHost: SERVICE_PER_HOST_COUNT,
+    })
+  );
+};
+
+export const cleanHostsFlyoutSynthtraceData = async (
+  deps: SequentialSynthtraceWorkerDeps
+): Promise<void> => {
+  const infraResult = await getSynthtraceClient(
+    'infraEsClient',
+    {
+      esClient: deps.esClient,
+      kbnUrl: deps.kbnUrl.get(),
+      log: deps.log,
+      config: deps.config,
+    },
+    skipFleetForFixedDates
+  );
+  const infraEsClient = unwrapSynthtraceClient<'infraEsClient', { clean: () => Promise<void> }>(
+    'infraEsClient',
+    infraResult
+  );
+  await infraEsClient.clean();
+
+  const logsResult = await getSynthtraceClient(
+    'logsEsClient',
+    {
+      esClient: deps.esClient,
+      log: deps.log,
+      config: deps.config,
+    },
+    skipFleetForFixedDates
+  );
+  const logsEsClient = unwrapSynthtraceClient<'logsEsClient', { clean: () => Promise<void> }>(
+    'logsEsClient',
+    logsResult
+  );
+  await logsEsClient.clean();
+
+  const apmResult = await getSynthtraceClient(
+    'apmEsClient',
+    {
+      esClient: deps.esClient,
+      kbnUrl: deps.kbnUrl.get(),
+      log: deps.log,
+      config: deps.config,
+    },
+    skipFleetForFixedDates
+  );
+  const apmEsClient = unwrapSynthtraceClient<'apmEsClient', { clean: () => Promise<void> }>(
+    'apmEsClient',
+    apmResult
+  );
+  await apmEsClient.clean();
+};
+
+export const ingestSemconvHostsSynthtraceData = async (
+  deps: SequentialSynthtraceWorkerDeps
+): Promise<void> => {
+  await indexInfra(
+    deps,
+    generateSemconvHostData({
+      from: DATE_WITH_SEMCONV_DATA_FROM,
+      to: DATE_WITH_SEMCONV_DATA_TO,
+      hosts: SEMCONV_HOSTS,
+    })
+  );
+};
+
+export const cleanSemconvHostsSynthtraceData = async (
+  deps: SequentialSynthtraceWorkerDeps
+): Promise<void> => {
+  const result = await getSynthtraceClient(
+    'infraEsClient',
+    {
+      esClient: deps.esClient,
+      kbnUrl: deps.kbnUrl.get(),
+      log: deps.log,
+      config: deps.config,
+    },
+    skipFleetForFixedDates
+  );
+  const infraEsClient = unwrapSynthtraceClient<'infraEsClient', { clean: () => Promise<void> }>(
+    'infraEsClient',
+    result
+  );
+  await infraEsClient.clean();
+};

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/semconv_host_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/semconv_host_data.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { infra, timerange } from '@kbn/synthtrace-client';
+
+export function generateSemconvHostData({
+  from,
+  to,
+  hosts,
+}: {
+  from: string;
+  to: string;
+  hosts: Array<{ hostName: string }>;
+}) {
+  const range = timerange(from, to);
+  const hostList = hosts.map(({ hostName }) => infra.semconvHost(hostName));
+
+  return range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) =>
+      hostList.flatMap((host) => {
+        // Stagger by 1 ms per doc — TSDB derives _id from dimensions that exclude
+        // `state`/`direction`, so identical @timestamp + metricset = duplicate _id.
+        const docs = [...host.cpu(), ...host.memory(), ...host.filesystem(), ...host.network()];
+        return docs.map((doc, i) => doc.timestamp(timestamp + i));
+      })
+    );
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
@@ -20,10 +20,13 @@ import {
   DATE_WITH_K8S_HOSTS_DATA_TO,
   DATE_WITH_POD_DATA_FROM,
   DATE_WITH_POD_DATA_TO,
+  DATE_WITH_SEMCONV_DATA_FROM,
+  DATE_WITH_SEMCONV_DATA_TO,
   HOST_NAME_WITH_SERVICES,
   HOSTS,
   HOSTS_WITHOUT_DATA,
   POD_COUNT,
+  SEMCONV_HOSTS,
   SERVICE_PER_HOST_COUNT,
 } from '../fixtures/constants';
 import { generateHostsWithK8sNodeData } from '../fixtures/synthtrace/hosts_with_k8s_node_data';
@@ -31,6 +34,7 @@ import { generatePodsData } from '../fixtures/synthtrace/pods_data';
 import { generateLogsDataForHostsOrContainers } from '../fixtures/synthtrace/logs_data_for_hosts_or_containers';
 import { generateAddServicesToExistingHost } from '../fixtures/synthtrace/add_services_to_existing_hosts';
 import { generateDockerContainersData } from '../fixtures/synthtrace/docker_containers_data';
+import { generateSemconvHostData } from '../fixtures/synthtrace/semconv_host_data';
 import { globalSetupHook } from '../fixtures';
 
 globalSetupHook(
@@ -108,5 +112,14 @@ globalSetupHook(
       })
     );
     log.info('Logs data for containers indexed');
+
+    await infraSynthtraceEsClient.index(
+      generateSemconvHostData({
+        from: DATE_WITH_SEMCONV_DATA_FROM,
+        to: DATE_WITH_SEMCONV_DATA_TO,
+        hosts: SEMCONV_HOSTS,
+      })
+    );
+    log.info('Semconv host data indexed');
   }
 );

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_content.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_content.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import {
+  HOSTS,
+  HOST1_NAME,
+  DATE_WITH_HOSTS_DATA_FROM,
+  DATE_WITH_HOSTS_DATA_TO,
+  EXTENDED_TIMEOUT,
+} from '../../fixtures/constants';
+
+test.describe(
+  'Hosts Page - Content',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth, pageObjects: { hostsPage } }) => {
+      await browserAuth.loginAsViewer();
+      await hostsPage.goToPage({
+        from: DATE_WITH_HOSTS_DATA_FROM,
+        to: DATE_WITH_HOSTS_DATA_TO,
+        preferredSchema: 'ecs',
+      });
+
+      await test.step('wait for table and KPIs to load', async () => {
+        await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+        await hostsPage.waitForKPILoadingToFinish(EXTENDED_TIMEOUT);
+      });
+    });
+
+    test('should render the correct page title', async ({ page }) => {
+      await expect(page).toHaveTitle(/Hosts - Infrastructure - Observability - Elastic/);
+    });
+
+    test('should maintain the selected date range when navigating to host details', async ({
+      pageObjects: { hostsPage },
+      page,
+    }) => {
+      await test.step('click a host link to navigate to host details', async () => {
+        const hostLink = hostsPage.getHostDetailLinks();
+        await expect(hostLink).not.toHaveCount(0);
+        const linkRow = hostsPage.getHostRow(HOST1_NAME);
+        await linkRow.getByTestId('hostsViewTableEntryTitleLink').click();
+      });
+
+      await test.step('verify the date picker preserves the selected time range', async () => {
+        const datePicker = page.getByTestId('superDatePickerstartDatePopoverButton');
+        await expect(datePicker).toBeVisible({ timeout: EXTENDED_TIMEOUT });
+        await expect(datePicker).toContainText('Mar 28, 2023');
+      });
+    });
+
+    test('should load 11 lens metric charts in the Metrics tab', async ({
+      pageObjects: { hostsPage },
+      page,
+    }) => {
+      await hostsPage.visitMetricsTab();
+
+      await test.step('verify 11 metric charts are rendered', async () => {
+        const charts = hostsPage.getMetricsCharts();
+        await expect(charts).toHaveCount(11, { timeout: EXTENDED_TIMEOUT });
+      });
+
+      await test.step('verify the Lens action menu is available', async () => {
+        await hostsPage.clickMetricChartAction('hostsView-metricChart-tx');
+        await expect(page.getByTestId('embeddablePanelAction-openInLens')).toBeVisible();
+        await page.keyboard.press('Escape');
+      });
+    });
+
+    test('should load the Logs tab with embedded saved search', async ({
+      pageObjects: { hostsPage },
+      page,
+    }) => {
+      await hostsPage.visitLogsTab();
+
+      await test.step('verify the embedded saved search table is visible', async () => {
+        await expect(page.getByTestId('embeddedSavedSearchDocTable')).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+      });
+
+      await test.step('verify the correct column headers', async () => {
+        const table = page.getByTestId('embeddedSavedSearchDocTable');
+        await expect(table.getByRole('columnheader', { name: '@timestamp' })).toBeVisible();
+        await expect(table.getByRole('columnheader', { name: 'Summary' })).toBeVisible();
+      });
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_metadata_filter.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_metadata_filter.spec.ts
@@ -25,6 +25,7 @@ test.describe(
       await hostsPage.goToPage({
         from: DATE_WITH_HOSTS_DATA_FROM,
         to: DATE_WITH_HOSTS_DATA_TO,
+        preferredSchema: 'ecs',
       });
     });
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_search.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_search.spec.ts
@@ -26,15 +26,12 @@ test.describe(
       await hostsPage.goToPage({
         from: DATE_WITH_HOSTS_DATA_FROM,
         to: DATE_WITH_HOSTS_DATA_TO,
+        preferredSchema: 'ecs',
       });
 
       await test.step('verify all hosts are visible before filtering', async () => {
         await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
-        await expect(
-          page
-            .getByTestId('infraAssetDetailsKPIcpuUsage')
-            .getByRole('progressbar', { name: 'Loading' })
-        ).toBeHidden({ timeout: EXTENDED_TIMEOUT });
+        await hostsPage.waitForKPILoadingToFinish(EXTENDED_TIMEOUT);
         await expect(
           page.getByRole('listitem').getByRole('heading', { name: 'CPU Usage' })
         ).toBeVisible({ timeout: EXTENDED_TIMEOUT });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_table.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_table.spec.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import {
+  HOST1_NAME,
+  HOST2_NAME,
+  HOST3_NAME,
+  HOST5_NAME,
+  HOST6_NAME,
+  HOSTS,
+  DATE_WITH_HOSTS_DATA_FROM,
+  DATE_WITH_HOSTS_DATA_TO,
+  KPI_RENDER_TIMEOUT,
+} from '../../fixtures/constants';
+
+const EXPECTED_HOST_COUNT = HOSTS.length;
+
+test.describe(
+  'Hosts Page - Table',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth, pageObjects: { hostsPage } }) => {
+      // The hosts table suite waits on Lens + elastic-charts KPI rendering in
+      // beforeEach; under CI contention first-load timing exceeds Scout's 60s
+      // default. Extend the budget to 180s.
+      test.setTimeout(180_000);
+      await browserAuth.loginAsViewer();
+      await hostsPage.goToPage({
+        from: DATE_WITH_HOSTS_DATA_FROM,
+        to: DATE_WITH_HOSTS_DATA_TO,
+        preferredSchema: 'ecs',
+      });
+
+      await test.step('wait for table and KPIs to load', async () => {
+        await expect(hostsPage.tableRows).toHaveCount(EXPECTED_HOST_COUNT);
+        await hostsPage.waitForKPILoadingToFinish(KPI_RENDER_TIMEOUT);
+      });
+    });
+
+    test('should render a table with the correct number of hosts', async ({
+      pageObjects: { hostsPage },
+    }) => {
+      await expect(hostsPage.tableRows).toHaveCount(EXPECTED_HOST_COUNT);
+    });
+
+    test('should render metric values for each host entry', async ({
+      pageObjects: { hostsPage },
+    }) => {
+      for (const host of HOSTS) {
+        const row = hostsPage.getHostRow(host.hostName);
+        await expect(row).toBeVisible();
+        const rowData = hostsPage.getRowDataLocators(row);
+        await expect(rowData.title).toHaveText(host.hostName);
+        await expect(rowData.cpuUsage).not.toHaveText('');
+        await expect(rowData.cpuUsage).not.toHaveText('N/A');
+      }
+    });
+
+    test('should select and filter hosts inside the table', async ({
+      pageObjects: { hostsPage },
+      page,
+    }) => {
+      await test.step('verify selected hosts button is not visible initially', async () => {
+        await expect(hostsPage.selectedHostsFilterButton).toBeHidden();
+      });
+
+      await test.step('select two hosts via checkboxes', async () => {
+        await hostsPage.clickHostCheckbox(HOST1_NAME, 'Linux');
+        await hostsPage.clickHostCheckbox(HOST2_NAME, 'Linux');
+        await expect(hostsPage.selectedHostsFilterButton).toBeVisible();
+      });
+
+      await test.step('apply the selected hosts filter', async () => {
+        await hostsPage.clickSelectedHostsButton();
+        await hostsPage.clickAddFilterButton();
+        await expect(hostsPage.tableRows).toHaveCount(2);
+      });
+
+      await test.step('remove the filter and verify all hosts return', async () => {
+        const deleteFilterButton = page.locator(
+          `[title="Delete host.name: ${HOST1_NAME} OR host.name: ${HOST2_NAME}"]`
+        );
+        await deleteFilterButton.click();
+        await expect(hostsPage.tableRows).toHaveCount(EXPECTED_HOST_COUNT);
+      });
+    });
+
+    test('should display correct KPI tile values', async ({ pageObjects: { hostsPage } }) => {
+      await test.step('verify hosts count KPI', async () => {
+        await expect(hostsPage.getKPITileValueLocator('hostsCount')).toHaveAttribute(
+          'title',
+          String(EXPECTED_HOST_COUNT)
+        );
+      });
+
+      const kpiTiles = ['cpuUsage', 'memoryUsage', 'normalizedLoad1m', 'diskUsage'];
+
+      await hostsPage.waitForHostKPIChartsToLoad(kpiTiles, KPI_RENDER_TIMEOUT);
+
+      for (const metric of kpiTiles) {
+        await test.step(`verify ${metric} KPI is present`, async () => {
+          await expect(hostsPage.getHostKPIChartValueLocator(metric)).toHaveAttribute(
+            'title',
+            /.+/
+          );
+        });
+      }
+    });
+
+    test('should paginate to 5 rows per page and navigate to the last page', async ({
+      pageObjects: { hostsPage },
+    }) => {
+      await test.step('change page size to 5', async () => {
+        await hostsPage.changePageSize(5);
+        await expect(hostsPage.tableRows).toHaveCount(5);
+      });
+
+      await test.step('navigate to the second page and verify 1 row', async () => {
+        await hostsPage.paginateTo(2);
+        await expect(hostsPage.tableRows).toHaveCount(1);
+      });
+    });
+
+    test('should show all hosts when page size is increased', async ({
+      pageObjects: { hostsPage },
+    }) => {
+      await test.step('change page size to 5 first', async () => {
+        await hostsPage.changePageSize(5);
+        await expect(hostsPage.tableRows).toHaveCount(5);
+      });
+
+      await test.step('change page size to 10 and verify all hosts', async () => {
+        await hostsPage.changePageSize(10);
+        await expect(hostsPage.tableRows).toHaveCount(EXPECTED_HOST_COUNT);
+      });
+    });
+
+    test('should sort by CPU usage ascending', async ({ pageObjects: { hostsPage } }) => {
+      await hostsPage.changePageSize(5);
+
+      await test.step('sort ascending and verify lowest CPU host is on first page', async () => {
+        await hostsPage.sortByCpuUsage();
+        const lowestCpuRow = hostsPage.getHostRow(HOST5_NAME);
+        await expect(lowestCpuRow).toBeVisible();
+      });
+
+      await test.step('navigate to last page and verify highest CPU host', async () => {
+        await hostsPage.paginateTo(2);
+        const highestCpuRow = hostsPage.getHostRow(HOST3_NAME);
+        await expect(highestCpuRow).toBeVisible();
+      });
+    });
+
+    test('should sort by CPU usage descending', async ({ pageObjects: { hostsPage } }) => {
+      await hostsPage.changePageSize(5);
+
+      await test.step('sort descending and verify highest CPU host is on first page', async () => {
+        await hostsPage.sortByCpuUsage();
+        await hostsPage.sortByCpuUsage();
+        const highestCpuRow = hostsPage.getHostRow(HOST3_NAME);
+        await expect(highestCpuRow).toBeVisible();
+      });
+
+      await test.step('navigate to last page and verify lowest CPU host', async () => {
+        await hostsPage.paginateTo(2);
+        const lowestCpuRow = hostsPage.getHostRow(HOST5_NAME);
+        await expect(lowestCpuRow).toBeVisible();
+      });
+    });
+
+    test('should sort by title ascending', async ({ pageObjects: { hostsPage } }) => {
+      await hostsPage.changePageSize(5);
+
+      await test.step('sort ascending and verify host-1 is on first page', async () => {
+        await hostsPage.sortByTitle();
+        const firstHostRow = hostsPage.getHostRow(HOST1_NAME);
+        await expect(firstHostRow).toBeVisible();
+      });
+
+      await test.step('navigate to last page and verify host-6', async () => {
+        await hostsPage.paginateTo(2);
+        const lastHostRow = hostsPage.getHostRow(HOST6_NAME);
+        await expect(lastHostRow).toBeVisible();
+      });
+    });
+
+    test('should sort by title descending', async ({ pageObjects: { hostsPage } }) => {
+      await hostsPage.changePageSize(5);
+
+      await test.step('sort descending and verify host-6 is on first page', async () => {
+        await hostsPage.sortByTitle();
+        await hostsPage.sortByTitle();
+        const lastHostRow = hostsPage.getHostRow(HOST6_NAME);
+        await expect(lastHostRow).toBeVisible();
+      });
+
+      await test.step('navigate to last page and verify host-1', async () => {
+        await hostsPage.paginateTo(2);
+        const firstHostRow = hostsPage.getHostRow(HOST1_NAME);
+        await expect(firstHostRow).toBeVisible();
+      });
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_flyout.spec.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import {
+  HOST1_NAME,
+  HOSTS,
+  SERVICE_PER_HOST_COUNT,
+  DATE_WITH_HOSTS_DATA_FROM,
+  DATE_WITH_HOSTS_DATA_TO,
+  EXTENDED_TIMEOUT,
+} from '../../fixtures/constants';
+import {
+  cleanHostsFlyoutSynthtraceData,
+  ingestHostsFlyoutSynthtraceData,
+} from '../../fixtures/sequential_hosts_synthtrace';
+
+const CUSTOM_DASHBOARDS_SETTING = 'observability:enableInfrastructureAssetCustomDashboards';
+
+test.describe(
+  'Hosts Page - Flyout',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeAll(async ({ esClient, kbnUrl, log, config }) => {
+      log.info('Sequential suite: ingesting ECS hosts + logs + APM services for flyout tests');
+      await ingestHostsFlyoutSynthtraceData({ esClient, kbnUrl, log, config });
+    });
+
+    test.beforeEach(async ({ browserAuth, pageObjects: { hostsPage } }) => {
+      // Flyout suites open Lens + elastic-charts in the host overview tab.
+      // Under CI contention the cumulative cost of navigation, flyout init,
+      // and first-time chart rendering can exceed Scout's default 60s test
+      // timeout. Now that this spec runs sequentially, a smaller budget is
+      // sufficient while still covering first-render variance.
+      test.setTimeout(120_000);
+      await browserAuth.loginAsViewer();
+      await hostsPage.goToPage({
+        from: DATE_WITH_HOSTS_DATA_FROM,
+        to: DATE_WITH_HOSTS_DATA_TO,
+        preferredSchema: 'ecs',
+      });
+      await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+    });
+
+    test.afterEach(async ({ kbnClient }) => {
+      // Reset the custom-dashboards setting after every test so cleanup runs
+      // even if the test times out. No-op for tests that didn't toggle it.
+      await kbnClient.uiSettings.update({ [CUSTOM_DASHBOARDS_SETTING]: false });
+    });
+
+    test.afterAll(async ({ esClient, kbnUrl, log, config }) => {
+      log.info('Sequential suite: cleaning synthtrace data for flyout tests');
+      await cleanHostsFlyoutSynthtraceData({ esClient, kbnUrl, log, config });
+    });
+
+    test('Overview Tab - KPI charts and collapsible sections', async ({
+      pageObjects: { hostsPage, assetDetailsPage },
+    }) => {
+      await hostsPage.openHostFlyout(HOST1_NAME);
+
+      await test.step('verify KPI charts are rendered', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.kpiGrid).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+        await expect(
+          assetDetailsPage.hostOverviewTab.getKPIEmbeddableError('cpuUsage')
+        ).toHaveCount(0);
+        await expect(
+          assetDetailsPage.hostOverviewTab.getKPIEmbeddableError('normalizedLoad1m')
+        ).toHaveCount(0);
+        await expect(
+          assetDetailsPage.hostOverviewTab.getKPIEmbeddableError('memoryUsage')
+        ).toHaveCount(0);
+        await expect(
+          assetDetailsPage.hostOverviewTab.getKPIEmbeddableError('diskUsage')
+        ).toHaveCount(0);
+      });
+
+      await test.step('verify collapsible sections exist', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.metadataSectionCollapsible).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.alertsSectionCollapsible).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsSectionCollapsible).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.servicesSectionCollapsible).toBeVisible();
+      });
+
+      await test.step('verify metrics chart sections', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.metricsCpuUsageChart).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsCpuNormalizedLoadChart).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsMemoryUsageChart).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsDiskUsageChart).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsDiskIOChart).toBeVisible();
+        await expect(assetDetailsPage.hostOverviewTab.metricsNetworkChart).toBeVisible();
+      });
+    });
+
+    test('Overview Tab - Services section', async ({
+      pageObjects: { hostsPage, assetDetailsPage },
+    }) => {
+      await hostsPage.openHostFlyout(HOST1_NAME);
+
+      await test.step('verify services section is visible with correct count', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.servicesContainer).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+        const serviceLinks = assetDetailsPage.hostOverviewTab.servicesContainer.getByRole('link');
+        await expect(serviceLinks).toHaveCount(SERVICE_PER_HOST_COUNT);
+      });
+    });
+
+    test('Metadata Tab', async ({ pageObjects: { hostsPage, assetDetailsPage } }) => {
+      await hostsPage.openHostFlyout(HOST1_NAME);
+
+      await test.step('navigate to metadata tab', async () => {
+        await assetDetailsPage.metadataTab.clickTab();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('verify metadata table is visible', async () => {
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+      });
+    });
+
+    test('Metrics Tab', async ({ pageObjects: { hostsPage, assetDetailsPage } }) => {
+      await hostsPage.openHostFlyout(HOST1_NAME);
+
+      await test.step('navigate to metrics tab', async () => {
+        await assetDetailsPage.hostMetricsTab.clickTab();
+        await expect(assetDetailsPage.hostMetricsTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('verify metrics content is visible', async () => {
+        await expect(assetDetailsPage.hostMetricsTab.cpuUsageChart).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+      });
+    });
+
+    test('Processes Tab', async ({ pageObjects: { hostsPage, assetDetailsPage } }) => {
+      await hostsPage.openHostFlyout(HOST1_NAME);
+
+      await test.step('navigate to processes tab', async () => {
+        await assetDetailsPage.processesTab.clickTab();
+        await expect(assetDetailsPage.processesTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('verify processes content is visible', async () => {
+        await expect(assetDetailsPage.processesTab.content).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+      });
+    });
+
+    test('Logs Tab', async ({ pageObjects: { hostsPage, assetDetailsPage } }) => {
+      await hostsPage.openHostFlyout(HOST1_NAME);
+
+      await test.step('navigate to logs tab', async () => {
+        await assetDetailsPage.logsTag.clickTab();
+        await expect(assetDetailsPage.logsTag.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('verify logs content is visible', async () => {
+        await expect(assetDetailsPage.logsTag.table).toBeVisible({ timeout: EXTENDED_TIMEOUT });
+      });
+    });
+
+    test('Open as page and return', async ({
+      pageObjects: { hostsPage, assetDetailsPage },
+      page,
+    }) => {
+      await hostsPage.openHostFlyout(HOST1_NAME);
+
+      await test.step('click open as page', async () => {
+        await assetDetailsPage.openAsPageButton.click();
+        const url = new URL(page.url());
+        expect(url.pathname).toBe(`/app/metrics/detail/host/${encodeURIComponent(HOST1_NAME)}`);
+      });
+
+      await test.step('verify date range is preserved', async () => {
+        const datePicker = page.getByTestId('superDatePickerstartDatePopoverButton');
+        await expect(datePicker).toBeVisible({ timeout: EXTENDED_TIMEOUT });
+        await expect(datePicker).toContainText('Mar 28, 2023');
+      });
+
+      await test.step('return to hosts view', async () => {
+        await expect(assetDetailsPage.returnButton).toBeVisible({ timeout: EXTENDED_TIMEOUT });
+        await assetDetailsPage.returnButton.click();
+        await expect(
+          page.getByRole('dialog').getByRole('heading', { name: HOST1_NAME })
+        ).toBeVisible();
+      });
+    });
+
+    test('Dashboards Tab', async ({ pageObjects: { hostsPage, assetDetailsPage }, kbnClient }) => {
+      await kbnClient.uiSettings.update({ [CUSTOM_DASHBOARDS_SETTING]: true });
+      // Re-navigate so the page picks up the enabled setting (the beforeEach
+      // navigation happened with the setting still off).
+      await hostsPage.goToPage({
+        from: DATE_WITH_HOSTS_DATA_FROM,
+        to: DATE_WITH_HOSTS_DATA_TO,
+        preferredSchema: 'ecs',
+      });
+      await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+      await hostsPage.openHostFlyout(HOST1_NAME);
+
+      await test.step('navigate to dashboards tab', async () => {
+        await assetDetailsPage.dashboardsTab.clickTab();
+        await expect(assetDetailsPage.dashboardsTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('verify dashboards splash screen is visible', async () => {
+        await expect(assetDetailsPage.dashboardsTab.addDashboardButton).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+      });
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_page_empty_state.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_page_empty_state.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import { EXTENDED_TIMEOUT } from '../../fixtures/constants';
+
+test.describe(
+  'Hosts Page - Empty State',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeEach(async ({ browserAuth, pageObjects: { hostsPage } }) => {
+      await browserAuth.loginAsViewer();
+      await hostsPage.goToHostsPage({ skipLoadWait: true });
+    });
+
+    test('should show onboarding page when no data is present', async ({
+      page,
+      pageObjects: { hostsPage },
+    }) => {
+      await test.step('display empty state', async () => {
+        await expect(hostsPage.noDataPage).toBeVisible({ timeout: EXTENDED_TIMEOUT });
+        await expect(hostsPage.noDataPageActionButton).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+      });
+
+      await test.step('redirect to onboarding page when clicking on the add data button', async () => {
+        await hostsPage.clickNoDataPageAddDataButton();
+        await expect(page.getByTestId('obltOnboardingHomeTitle')).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+      });
+    });
+  }
+);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_page_semconv.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_page_semconv.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/ui';
+import { test } from '../../fixtures';
+import {
+  SEMCONV_HOSTS,
+  SEMCONV_HOST1_NAME,
+  DATE_WITH_SEMCONV_DATA_FROM,
+  DATE_WITH_SEMCONV_DATA_TO,
+  EXTENDED_TIMEOUT,
+  KPI_RENDER_TIMEOUT,
+} from '../../fixtures/constants';
+import {
+  cleanSemconvHostsSynthtraceData,
+  ingestSemconvHostsSynthtraceData,
+} from '../../fixtures/sequential_hosts_synthtrace';
+
+test.describe(
+  'Hosts Page - OTel Semconv Data',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    test.beforeAll(async ({ esClient, kbnUrl, log, config }) => {
+      log.info('Sequential suite: ingesting semconv host metrics');
+      await ingestSemconvHostsSynthtraceData({ esClient, kbnUrl, log, config });
+    });
+
+    test.beforeEach(async ({ browserAuth, pageObjects: { hostsPage } }) => {
+      // Semconv KPI + flyout suites rely on Lens + elastic-charts rendering
+      // on top of the OTel data stream; first-load timing in CI exceeds
+      // Scout's 60s default. Now that this spec runs sequentially, a smaller
+      // budget is sufficient while still covering first-render variance.
+      test.setTimeout(120_000);
+      await browserAuth.loginAsViewer();
+      await hostsPage.goToPage({
+        from: DATE_WITH_SEMCONV_DATA_FROM,
+        to: DATE_WITH_SEMCONV_DATA_TO,
+        preferredSchema: 'semconv',
+      });
+      await expect(hostsPage.tableRows).toHaveCount(SEMCONV_HOSTS.length);
+    });
+
+    test.afterEach(() => {
+      // `playwright/prefer-hooks-in-order`: `afterEach` before `afterAll`.
+    });
+
+    test.afterAll(async ({ esClient, kbnUrl, log, config }) => {
+      log.info('Sequential suite: cleaning semconv host metrics');
+      await cleanSemconvHostsSynthtraceData({ esClient, kbnUrl, log, config });
+    });
+
+    test('should display semconv hosts in the table', async ({ pageObjects: { hostsPage } }) => {
+      await test.step('verify host count KPI', async () => {
+        await expect(hostsPage.kpiGrid.getByTestId('hostsViewKPI-hostsCount')).toContainText(
+          String(SEMCONV_HOSTS.length)
+        );
+      });
+
+      await test.step('verify all semconv hosts are listed', async () => {
+        for (const host of SEMCONV_HOSTS) {
+          await expect(hostsPage.getHostRow(host.hostName)).toBeVisible();
+        }
+      });
+    });
+
+    test('should display KPI metrics for semconv data', async ({ pageObjects: { hostsPage } }) => {
+      const kpiTiles = ['cpuUsage', 'normalizedLoad1m', 'memoryUsage', 'diskUsage'];
+
+      await hostsPage.waitForHostKPIChartsToLoad(kpiTiles, KPI_RENDER_TIMEOUT);
+
+      for (const metric of kpiTiles) {
+        await test.step(`verify ${metric} KPI tile has a value`, async () => {
+          await expect(hostsPage.getHostKPIChartValueLocator(metric)).toHaveAttribute(
+            'title',
+            /.+/
+          );
+        });
+      }
+    });
+
+    test('should show metric values in table rows (not N/A)', async ({
+      pageObjects: { hostsPage },
+    }) => {
+      const metricCells = [
+        'hostsView-tableRow-cpuUsage',
+        'hostsView-tableRow-normalizedLoad1m',
+        'hostsView-tableRow-memoryUsage',
+        'hostsView-tableRow-memoryFree',
+        'hostsView-tableRow-diskSpaceUsage',
+      ];
+
+      for (const host of SEMCONV_HOSTS) {
+        await test.step(`verify ${host.hostName} has metric values`, async () => {
+          const row = hostsPage.getHostRow(host.hostName);
+
+          for (const cellTestId of metricCells) {
+            const cell = hostsPage.getCellContentLocator(row, cellTestId);
+            await expect(cell).not.toHaveText('N/A');
+            await expect(cell).not.toHaveText('');
+          }
+        });
+      }
+    });
+
+    test('should hide rx and tx columns for semconv data', async ({ page }) => {
+      await expect(page.getByTestId('hostsView-tableRow-rx')).toHaveCount(0);
+      await expect(page.getByTestId('hostsView-tableRow-tx')).toHaveCount(0);
+    });
+
+    test('should open flyout for a semconv host', async ({
+      pageObjects: { hostsPage, assetDetailsPage },
+    }) => {
+      await hostsPage.openHostFlyout(SEMCONV_HOST1_NAME);
+
+      await test.step('verify overview tab loads with KPI charts', async () => {
+        await expect(assetDetailsPage.hostOverviewTab.kpiGrid).toBeVisible({
+          timeout: EXTENDED_TIMEOUT,
+        });
+        await expect(
+          assetDetailsPage.hostOverviewTab.getKPIEmbeddableError('cpuUsage')
+        ).toHaveCount(0);
+      });
+    });
+  }
+);

--- a/x-pack/solutions/observability/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/hosts_view.ts
@@ -7,35 +7,12 @@
 
 import moment from 'moment';
 import expect from '@kbn/expect';
-import type {
-  ApmSynthtraceEsClient,
-  InfraSynthtraceEsClient,
-  LogsSynthtraceEsClient,
-} from '@kbn/synthtrace';
-import { enableInfrastructureAssetCustomDashboards } from '@kbn/observability-plugin/common';
 import { ALERT_STATUS_ACTIVE, ALERT_STATUS_RECOVERED } from '@kbn/rule-data-utils';
-import type { WebElementWrapper } from '@kbn/ftr-common-functional-ui-services';
 import type { FtrProviderContext } from '../../ftr_provider_context';
-import {
-  DATES,
-  HOSTS_LINK_LOCAL_STORAGE_KEY,
-  HOSTS_VIEW_PATH,
-  DATE_PICKER_FORMAT,
-  DATE_WITH_HOSTS_DATA_FROM,
-  DATE_WITH_HOSTS_DATA_TO,
-} from './constants';
-import {
-  generateAddServicesToExistingHost,
-  generateHostData,
-  generateLogsDataForHosts,
-} from './helpers';
+import { DATES, HOSTS_VIEW_PATH, DATE_PICKER_FORMAT } from './constants';
 
 const START_DATE = moment.utc(DATES.metricsAndLogs.hosts.min);
 const END_DATE = moment.utc(DATES.metricsAndLogs.hosts.max);
-
-// synthtrace data dates
-const START_SYNTHTRACE_DATE = moment.utc(DATE_WITH_HOSTS_DATA_FROM);
-const END_SYNTHTRACE_DATE = moment.utc(DATE_WITH_HOSTS_DATA_TO);
 
 const tableEntries = [
   {
@@ -106,129 +83,20 @@ const tableEntries = [
   },
 ];
 
-const synthtraceHostsTableEntries = [
-  {
-    title: 'host-1',
-    cpuUsage: '90%',
-    normalizedLoad: '18.8%',
-    memoryUsage: '35%',
-    memoryFree: '44.7 GB',
-    diskSpaceUsage: '1,223%',
-    rx: '1.5 Mbit/s',
-    tx: '1.5 Mbit/s',
-  },
-  {
-    title: 'host-2',
-    cpuUsage: '70%',
-    normalizedLoad: '18.8%',
-    memoryUsage: '35%',
-    memoryFree: '44.7 GB',
-    diskSpaceUsage: '1,223%',
-    rx: '1.5 Mbit/s',
-    tx: '1.5 Mbit/s',
-  },
-  {
-    title: 'host-3',
-    cpuUsage: '50%',
-    normalizedLoad: '18.8%',
-    memoryUsage: '35%',
-    memoryFree: '44.7 GB',
-    diskSpaceUsage: '1,223%',
-    rx: '1.5 Mbit/s',
-    tx: '1.5 Mbit/s',
-  },
-  {
-    title: 'host-4',
-    cpuUsage: '40%',
-    normalizedLoad: '18.8%',
-    memoryUsage: '35%',
-    memoryFree: '44.7 GB',
-    diskSpaceUsage: '1,223%',
-    rx: '1.5 Mbit/s',
-    tx: '1.5 Mbit/s',
-  },
-  {
-    title: 'host-5',
-    cpuUsage: '30%',
-    normalizedLoad: '18.8%',
-    memoryUsage: '35%',
-    memoryFree: '44.7 GB',
-    diskSpaceUsage: '1,223%',
-    rx: '1.5 Mbit/s',
-    tx: '1.5 Mbit/s',
-  },
-  {
-    title: 'host-6',
-    cpuUsage: '10%',
-    normalizedLoad: '18.8%',
-    memoryUsage: '35%',
-    memoryFree: '44.7 GB',
-    diskSpaceUsage: '1,223%',
-    rx: '1.5 Mbit/s',
-    tx: '1.5 Mbit/s',
-  },
-];
-
-const SYNTH_HOSTS = [
-  {
-    hostName: 'host-1',
-    cpuValue: 0.9,
-  },
-  {
-    hostName: 'host-2',
-    cpuValue: 0.7,
-  },
-  {
-    hostName: 'host-3',
-    cpuValue: 0.5,
-  },
-  {
-    hostName: 'host-4',
-    cpuValue: 0.4,
-  },
-  {
-    hostName: 'host-5',
-    cpuValue: 0.3,
-  },
-  {
-    hostName: 'host-6',
-    cpuValue: 0.1,
-  },
-];
-
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const browser = getService('browser');
   const esArchiver = getService('esArchiver');
-  const find = getService('find');
-  const kibanaServer = getService('kibanaServer');
   const observability = getService('observability');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
-  const synthtraceClient = getService('synthtrace');
 
   const pageObjects = getPageObjects([
     'assetDetails',
     'common',
-    'infraHome',
     'timePicker',
     'infraHostsView',
-    'security',
-    'settings',
     'header',
-    'discover',
   ]);
-
-  // Helpers
-  const setCustomDashboardsEnabled = (value: boolean = true) =>
-    kibanaServer.uiSettings.update({ [enableInfrastructureAssetCustomDashboards]: value });
-
-  const returnTo = async (path: string, timeout = 2000) =>
-    retry.waitForWithTimeout('returned to hosts view', timeout, async () => {
-      await browser.goBack();
-      await pageObjects.header.waitUntilLoadingHasFinished();
-      const currentUrl = await browser.getCurrentUrl();
-      return !!currentUrl.match(path);
-    });
 
   const waitForPageToLoad = async () =>
     await retry.waitFor(
@@ -239,732 +107,191 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     );
 
   describe('Hosts View', function () {
-    let synthEsInfraClient: InfraSynthtraceEsClient;
-    let synthEsLogsClient: LogsSynthtraceEsClient;
-    let synthtraceApmClient: ApmSynthtraceEsClient;
-
-    before(async () => {
-      const clients = await synthtraceClient.getClients([
-        'infraEsClient',
-        'logsEsClient',
-        'apmEsClient',
-      ]);
-
-      synthEsInfraClient = clients.infraEsClient;
-      synthEsLogsClient = clients.logsEsClient;
-      synthtraceApmClient = clients.apmEsClient;
-
-      await synthtraceApmClient.initializePackage({ skipInstallation: false });
-
-      return Promise.all([
-        synthtraceApmClient.clean(),
-        synthEsInfraClient.clean(),
-        synthEsLogsClient.clean(),
-      ]);
-    });
-
-    after(async () => {
-      return Promise.all([
-        synthtraceApmClient.uninstallPackage(),
-        synthtraceApmClient.clean(),
-        synthEsInfraClient.clean(),
-        synthEsLogsClient.clean(),
-      ]);
-    });
-
-    describe('#Onboarding', function () {
+    describe('#Page Content with alerts', () => {
       before(async () => {
-        await pageObjects.common.navigateToApp(HOSTS_VIEW_PATH);
-      });
-
-      it('should show hosts no data page and redirect onboarding page', async () => {
-        await pageObjects.infraHome.noDataPromptExists();
-        await pageObjects.infraHome.noDataPromptAddDataClick();
-
-        await retry.tryForTime(5000, async () => {
-          const currentUrl = await browser.getCurrentUrl();
-          const parsedUrl = new URL(currentUrl);
-          const baseUrl = `${parsedUrl.protocol}//${parsedUrl.host}`;
-          const expectedUrlPattern = `${baseUrl}/app/observabilityOnboarding/?category=host`;
-          expect(currentUrl).to.equal(expectedUrlPattern);
-        });
-      });
-    });
-
-    describe('#With data', function () {
-      before(async () => {
-        const hosts = generateHostData({
-          from: DATE_WITH_HOSTS_DATA_FROM,
-          to: DATE_WITH_HOSTS_DATA_TO,
-          hosts: SYNTH_HOSTS,
-        });
-
-        const services = generateAddServicesToExistingHost({
-          from: DATE_WITH_HOSTS_DATA_FROM,
-          to: DATE_WITH_HOSTS_DATA_TO,
-          hostName: 'host-1',
-          servicesPerHost: 3,
-        });
-
-        const logs = generateLogsDataForHosts({
-          from: DATE_WITH_HOSTS_DATA_FROM,
-          to: DATE_WITH_HOSTS_DATA_TO,
-          hosts: SYNTH_HOSTS,
-        });
-
-        await browser.setWindowSize(1600, 1200);
-
-        await Promise.all([
-          synthEsInfraClient.index(hosts),
-          synthtraceApmClient.index(services),
-          synthEsLogsClient.index(logs),
+        return Promise.all([
+          esArchiver.load('x-pack/solutions/observability/test/fixtures/es_archives/infra/alerts'),
+          esArchiver.load(
+            'x-pack/solutions/observability/test/fixtures/es_archives/infra/metrics_and_logs'
+          ),
         ]);
       });
 
       after(async () => {
-        return browser.removeLocalStorageItem(HOSTS_LINK_LOCAL_STORAGE_KEY);
+        return Promise.all([
+          esArchiver.unload(
+            'x-pack/solutions/observability/test/fixtures/es_archives/infra/alerts'
+          ),
+          esArchiver.unload(
+            'x-pack/solutions/observability/test/fixtures/es_archives/infra/metrics_and_logs'
+          ),
+        ]);
       });
 
-      describe('#Single Host Flyout', () => {
-        before(async () => {
-          await setCustomDashboardsEnabled(true);
-          await pageObjects.common.navigateToApp(HOSTS_VIEW_PATH);
-          await pageObjects.header.waitUntilLoadingHasFinished();
-        });
+      describe('Alerts Tab', () => {
+        const ACTIVE_ALERTS = 6;
+        const RECOVERED_ALERTS = 4;
+        const ALL_ALERTS = ACTIVE_ALERTS + RECOVERED_ALERTS;
+        const COLUMNS = 12;
 
-        describe('Tabs', () => {
-          before(async () => {
-            await retry.waitFor(
-              'date picker to be visible before setting range',
-              async () => await pageObjects.timePicker.timePickerExists()
-            );
-            await pageObjects.timePicker.setAbsoluteRange(
-              START_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT),
-              END_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT)
-            );
-
-            await waitForPageToLoad();
-
-            await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-          });
-
-          after(async () => {
-            await pageObjects.infraHome.closeFlyoutWithEscape();
-          });
-
-          describe('Overview Tab', () => {
-            before(async () => {
-              await pageObjects.infraHome.closeFlyoutWithEscape();
-              await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-              await pageObjects.assetDetails.clickOverviewTab();
-            });
-
-            [
-              { metric: 'cpuUsage', value: '48.3%' },
-              { metric: 'normalizedLoad1m', value: '18.8%' },
-              { metric: 'memoryUsage', value: '35.0%' },
-              { metric: 'diskUsage', value: '1,223.0%' },
-            ].forEach(({ metric, value }) => {
-              it(`${metric} tile should show ${value}`, async () => {
-                await retry.tryForTime(5000, async () => {
-                  expect(await pageObjects.assetDetails.getAssetDetailsKPITileValue(metric)).to.eql(
-                    value
-                  );
-                });
-              });
-            });
-
-            [
-              { metric: 'cpu', chartsCount: 2 },
-              { metric: 'memory', chartsCount: 1 },
-              { metric: 'disk', chartsCount: 2 },
-              { metric: 'network', chartsCount: 1 },
-            ].forEach(({ metric, chartsCount }) => {
-              it(`should render ${chartsCount} ${metric} chart(s) in the Metrics section`, async () => {
-                const hosts = await pageObjects.assetDetails.getOverviewTabHostMetricCharts(metric);
-                expect(hosts.length).to.equal(chartsCount);
-              });
-            });
-
-            it('should show all section as collapsible', async () => {
-              await pageObjects.assetDetails.metadataSectionCollapsibleExist();
-              await pageObjects.assetDetails.alertsSectionCollapsibleExist();
-              await pageObjects.assetDetails.metricsSectionCollapsibleExist();
-              await pageObjects.assetDetails.servicesSectionCollapsibleExist();
-            });
-
-            it('should show alerts', async () => {
-              await pageObjects.header.waitUntilLoadingHasFinished();
-              await pageObjects.assetDetails.overviewAlertsTitleExists();
-            });
-
-            it('should show 3 services each with an icon, service name, and url', async () => {
-              await pageObjects.assetDetails.servicesSectionCollapsibleExist();
-
-              const services =
-                await pageObjects.assetDetails.getAssetDetailsServicesWithIconsAndNames();
-
-              expect(services.length).to.equal(3);
-
-              const currentUrl = await browser.getCurrentUrl();
-              const parsedUrl = new URL(currentUrl);
-              const baseUrl = `${parsedUrl.protocol}//${parsedUrl.host}`;
-
-              services.forEach((service, index) => {
-                expect(service.serviceName).to.equal(`service-${index}`);
-                expect(service.iconSrc).to.not.be.empty();
-                const expectedUrlPattern = `${baseUrl}/app/apm/services/service-${index}/overview?rangeFrom=${DATES.metricsAndLogs.hosts.processesDataStartDate}&rangeTo=${DATES.metricsAndLogs.hosts.processesDataEndDate}`;
-                expect(service.serviceUrl).to.equal(expectedUrlPattern);
-              });
-            });
-          });
-
-          describe('Metadata Tab', () => {
-            before(async () => {
-              await pageObjects.infraHome.closeFlyoutWithEscape();
-              await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-              await pageObjects.assetDetails.clickMetadataTab();
-            });
-
-            it('should show metadata table', async () => {
-              await pageObjects.assetDetails.metadataTableExists();
-            });
-
-            it('should render metadata tab, add and remove filter', async () => {
-              // Add Filter
-              await pageObjects.assetDetails.clickAddMetadataFilter();
-              await pageObjects.header.waitUntilLoadingHasFinished();
-
-              const addedFilter = await pageObjects.assetDetails.getMetadataAppliedFilter();
-              expect(addedFilter).to.contain('host.name: host-1');
-              const removeFilterExists =
-                await pageObjects.assetDetails.metadataRemoveFilterExists();
-              expect(removeFilterExists).to.be(true);
-
-              // Remove filter
-              await pageObjects.assetDetails.clickRemoveMetadataFilter();
-              await pageObjects.header.waitUntilLoadingHasFinished();
-              const removeFilterShouldNotExist =
-                await pageObjects.assetDetails.metadataRemovePinExists();
-              expect(removeFilterShouldNotExist).to.be(false);
-            });
-          });
-
-          describe('Metrics Tab', () => {
-            before(async () => {
-              await pageObjects.infraHome.closeFlyoutWithEscape();
-              await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-              await pageObjects.assetDetails.clickMetricsTab();
-            });
-
-            it('should show metrics content', async () => {
-              await pageObjects.assetDetails.metricsChartsContentExists();
-            });
-          });
-
-          describe('Processes Tab', () => {
-            before(async () => {
-              await pageObjects.infraHome.closeFlyoutWithEscape();
-              await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-              await pageObjects.assetDetails.clickProcessesTab();
-            });
-
-            it('should show processes content', async () => {
-              await pageObjects.assetDetails.processesContentExist();
-            });
-          });
-
-          describe('Logs Tab', () => {
-            before(async () => {
-              await pageObjects.infraHome.closeFlyoutWithEscape();
-              await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-              await pageObjects.assetDetails.clickLogsTab();
-            });
-
-            it('should render logs tab', async () => {
-              await pageObjects.assetDetails.logsExists();
-            });
-          });
-
-          describe('Dashboards Tab', () => {
-            before(async () => {
-              await pageObjects.infraHome.closeFlyoutWithEscape();
-              await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-              await pageObjects.assetDetails.clickDashboardsTab();
-            });
-
-            it('should render dashboards tab splash screen with option to add dashboard', async () => {
-              await pageObjects.assetDetails.addDashboardExists();
-            });
-          });
-
-          describe('Flyout links', () => {
-            before(async () => {
-              await pageObjects.infraHome.closeFlyoutWithEscape();
-              await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-            });
-
-            it('should navigate to Host Details page after click', async () => {
-              await pageObjects.assetDetails.clickOpenAsPageLink();
-              const dateRange = await pageObjects.timePicker.getTimeConfigAsAbsoluteTimes();
-              expect(dateRange.start).to.equal(START_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT));
-              expect(dateRange.end).to.equal(END_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT));
-
-              await returnTo(HOSTS_VIEW_PATH);
-            });
-          });
-        });
-      });
-
-      describe('#Page Content without alerts', () => {
         before(async () => {
           await pageObjects.common.navigateToApp(HOSTS_VIEW_PATH);
           await pageObjects.header.waitUntilLoadingHasFinished();
           await pageObjects.timePicker.setAbsoluteRange(
-            START_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT),
-            END_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT)
+            START_DATE.format(DATE_PICKER_FORMAT),
+            END_DATE.format(DATE_PICKER_FORMAT)
           );
 
           await waitForPageToLoad();
-        });
-
-        it('should render the correct page title', async () => {
-          const documentTitle = await browser.getTitle();
-          expect(documentTitle).to.contain('Hosts - Infrastructure - Observability - Elastic');
-        });
-
-        describe('Hosts table', () => {
-          let hostRows: WebElementWrapper[] = [];
-
-          before(async () => {
-            hostRows = await pageObjects.infraHostsView.getHostsTableData();
-          });
-
-          it('should render a table with 6 hosts', async () => {
-            expect(hostRows.length).to.equal(6);
-          });
-
-          it('should render the computed metrics for each host entry', async () => {
-            for (let i = 0; i < hostRows.length; i++) {
-              const hostRowData = await pageObjects.infraHostsView.getHostsRowData(hostRows[i]);
-              expect(hostRowData).to.eql(synthtraceHostsTableEntries[i]);
-            }
-          });
-
-          it('should select and filter hosts inside the table', async () => {
-            const selectHostsButtonExistsOnLoad =
-              await pageObjects.infraHostsView.selectedHostsButtonExist();
-            expect(selectHostsButtonExistsOnLoad).to.be(false);
-
-            await pageObjects.infraHostsView.clickHostCheckbox('host-1', 'Linux');
-            await pageObjects.infraHostsView.clickHostCheckbox('host-2', 'Linux');
-
-            const selectHostsButtonExistsOnSelection =
-              await pageObjects.infraHostsView.selectedHostsButtonExist();
-            expect(selectHostsButtonExistsOnSelection).to.be(true);
-
-            await pageObjects.infraHostsView.clickSelectedHostsButton();
-            await pageObjects.infraHostsView.clickSelectedHostsAddFilterButton();
-
-            await pageObjects.header.waitUntilLoadingHasFinished();
-            const hostRowsAfterFilter = await pageObjects.infraHostsView.getHostsTableData();
-            expect(hostRowsAfterFilter.length).to.equal(2);
-
-            const deleteFilterButton = await find.byCssSelector(
-              `[title="Delete host.name: host-1 OR host.name: host-2"]`
-            );
-            await deleteFilterButton.click();
-            await pageObjects.header.waitUntilLoadingHasFinished();
-            const hostRowsAfterRemovingFilter =
-              await pageObjects.infraHostsView.getHostsTableData();
-            expect(hostRowsAfterRemovingFilter.length).to.equal(6);
-          });
-        });
-
-        describe('Host details page navigation', () => {
-          after(async () => {
-            await pageObjects.common.navigateToApp(HOSTS_VIEW_PATH);
-            await pageObjects.header.waitUntilLoadingHasFinished();
-            await pageObjects.timePicker.setAbsoluteRange(
-              START_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT),
-              END_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT)
-            );
-
-            await waitForPageToLoad();
-          });
-
-          it('should maintain the selected date range when navigating to the individual host details', async () => {
-            const start = START_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT);
-            const end = END_SYNTHTRACE_DATE.format(DATE_PICKER_FORMAT);
-
-            await pageObjects.timePicker.setAbsoluteRange(start, end);
-
-            await waitForPageToLoad();
-
-            const hostDetailLinks = await pageObjects.infraHostsView.getAllHostDetailLinks();
-            expect(hostDetailLinks.length).not.to.equal(0);
-
-            await hostDetailLinks[0].click();
-
-            expect(await pageObjects.timePicker.timePickerExists()).to.be(true);
-
-            const datePickerValue = await pageObjects.timePicker.getTimeConfig();
-            expect(datePickerValue.start).to.equal(start);
-            expect(datePickerValue.end).to.equal(end);
-          });
-        });
-
-        describe('KPIs', () => {
-          [
-            { metric: 'hostsCount', value: '6' },
-            { metric: 'cpuUsage', value: '48.3%' },
-            { metric: 'normalizedLoad1m', value: '18.8%' },
-            { metric: 'memoryUsage', value: '35.0%' },
-            { metric: 'diskUsage', value: '1,223.0%' },
-          ].forEach(({ metric, value }) => {
-            it(`${metric} tile should show ${value}`, async () => {
-              await retry.tryForTime(5000, async () => {
-                const tileValue =
-                  metric === 'hostsCount'
-                    ? await pageObjects.infraHostsView.getKPITileValue(metric)
-                    : await pageObjects.assetDetails.getAssetDetailsKPITileValue(metric);
-
-                expect(tileValue).to.eql(value);
-              });
-            });
-          });
-        });
-
-        describe('Metrics Tab', () => {
-          before(async () => {
-            await browser.scrollTop();
-            await pageObjects.infraHostsView.visitMetricsTab();
-          });
-
-          after(async () => {
-            await browser.scrollTop();
-          });
-
-          it('should load 11 lens metric charts', async () => {
-            const metricCharts = await pageObjects.infraHostsView.getAllMetricsCharts();
-            expect(metricCharts.length).to.equal(11);
-          });
-
-          // flaky, the option is not visible
-          it('should have an option to open the chart in lens', async () => {
-            await retry.tryForTime(5000, async () => {
-              await pageObjects.infraHostsView.clickAndValidateMetricChartActionOptions();
-              await browser.pressKeys(browser.keys.ESCAPE);
-            });
-          });
-        });
-
-        describe('Logs Tab', () => {
-          before(async () => {
-            await browser.scrollTop();
-            await pageObjects.infraHostsView.visitLogsTab();
-          });
-
-          after(async () => {
-            await browser.scrollTop();
-          });
-
-          it('should load the Logs tab section when clicking on it', async () => {
-            await testSubjects.existOrFail('embeddedSavedSearchDocTable');
-          });
-
-          it('should load the Logs tab with the right columns', async () => {
-            await retry.tryForTime(5000, async () => {
-              const columnHeaders = await pageObjects.discover.getDocHeader();
-
-              expect(columnHeaders).to.have.string('@timestamp');
-              expect(columnHeaders).to.have.string('Summary');
-            });
-          });
-        });
-
-        describe('Pagination and Sorting', () => {
-          before(async () => {
-            await browser.scrollTop();
-          });
-
-          after(async () => {
-            await browser.scrollTop();
-          });
-
-          beforeEach(async () => {
-            await retry.tryForTime(5000, async () => {
-              await pageObjects.infraHostsView.changePageSize(5);
-            });
-          });
-
-          it('should show 5 rows on the first page', async () => {
-            const hostRows = await pageObjects.infraHostsView.getHostsTableData();
-
-            for (let i = 0; i < hostRows.length; i++) {
-              const hostRowData = await pageObjects.infraHostsView.getHostsRowData(hostRows[i]);
-              expect(hostRowData).to.eql(synthtraceHostsTableEntries[i]);
-            }
-          });
-
-          it('should paginate to the last page', async () => {
-            await pageObjects.infraHostsView.paginateTo(2);
-            const hostRows = await pageObjects.infraHostsView.getHostsTableData();
-
-            expect(hostRows.length).to.equal(1);
-
-            const hostRowData = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostRowData).to.eql(synthtraceHostsTableEntries[5]);
-          });
-
-          it('should show all hosts on the same page', async () => {
-            await pageObjects.infraHostsView.changePageSize(10);
-            const hostRows = await pageObjects.infraHostsView.getHostsTableData();
-
-            for (let i = 0; i < hostRows.length; i++) {
-              const hostRowData = await pageObjects.infraHostsView.getHostsRowData(hostRows[i]);
-              expect(hostRowData).to.eql(synthtraceHostsTableEntries[i]);
-            }
-          });
-
-          it('should sort by a numeric field asc', async () => {
-            await pageObjects.infraHostsView.sortByCpuUsage();
-            let hostRows = await pageObjects.infraHostsView.getHostsTableData();
-            const hostDataFirtPage = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostDataFirtPage).to.eql(synthtraceHostsTableEntries[5]);
-
-            await pageObjects.infraHostsView.paginateTo(2);
-            hostRows = await pageObjects.infraHostsView.getHostsTableData();
-            const hostDataLastPage = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostDataLastPage).to.eql(synthtraceHostsTableEntries[0]);
-          });
-
-          it('should sort by a numeric field desc', async () => {
-            await pageObjects.infraHostsView.sortByCpuUsage();
-            let hostRows = await pageObjects.infraHostsView.getHostsTableData();
-            const hostDataFirtPage = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostDataFirtPage).to.eql(synthtraceHostsTableEntries[0]);
-
-            await pageObjects.infraHostsView.paginateTo(2);
-            hostRows = await pageObjects.infraHostsView.getHostsTableData();
-            const hostDataLastPage = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostDataLastPage).to.eql(synthtraceHostsTableEntries[5]);
-          });
-
-          it('should sort by text field asc', async () => {
-            await pageObjects.infraHostsView.sortByTitle();
-            let hostRows = await pageObjects.infraHostsView.getHostsTableData();
-            const hostDataFirtPage = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostDataFirtPage).to.eql(synthtraceHostsTableEntries[0]);
-
-            await pageObjects.infraHostsView.paginateTo(2);
-            hostRows = await pageObjects.infraHostsView.getHostsTableData();
-            const hostDataLastPage = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostDataLastPage).to.eql(synthtraceHostsTableEntries[5]);
-          });
-
-          it('should sort by text field desc', async () => {
-            await pageObjects.infraHostsView.sortByTitle();
-            let hostRows = await pageObjects.infraHostsView.getHostsTableData();
-            const hostDataFirtPage = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostDataFirtPage).to.eql(synthtraceHostsTableEntries[5]);
-
-            await pageObjects.infraHostsView.paginateTo(2);
-            hostRows = await pageObjects.infraHostsView.getHostsTableData();
-            const hostDataLastPage = await pageObjects.infraHostsView.getHostsRowData(hostRows[0]);
-            expect(hostDataLastPage).to.eql(synthtraceHostsTableEntries[0]);
-          });
-        });
-      });
-
-      describe('#Page Content with alerts', () => {
-        before(async () => {
-          return Promise.all([
-            esArchiver.load(
-              'x-pack/solutions/observability/test/fixtures/es_archives/infra/alerts'
-            ),
-            esArchiver.load(
-              'x-pack/solutions/observability/test/fixtures/es_archives/infra/metrics_and_logs'
-            ),
-          ]);
+          await browser.scrollTop();
+          await pageObjects.infraHostsView.visitAlertTab();
         });
 
         after(async () => {
-          return Promise.all([
-            esArchiver.unload(
-              'x-pack/solutions/observability/test/fixtures/es_archives/infra/alerts'
-            ),
-            esArchiver.unload(
-              'x-pack/solutions/observability/test/fixtures/es_archives/infra/metrics_and_logs'
-            ),
-          ]);
+          await browser.scrollTop();
         });
 
-        describe('Alerts Tab', () => {
-          const ACTIVE_ALERTS = 6;
-          const RECOVERED_ALERTS = 4;
-          const ALL_ALERTS = ACTIVE_ALERTS + RECOVERED_ALERTS;
-          const COLUMNS = 12;
+        it('should correctly load the Alerts tab section when clicking on it', async () => {
+          await testSubjects.existOrFail('hostsView-alerts');
+        });
 
-          before(async () => {
-            await pageObjects.common.navigateToApp(HOSTS_VIEW_PATH);
-            await pageObjects.header.waitUntilLoadingHasFinished();
-            await pageObjects.timePicker.setAbsoluteRange(
-              START_DATE.format(DATE_PICKER_FORMAT),
-              END_DATE.format(DATE_PICKER_FORMAT)
-            );
+        it('should correctly render a badge with the active alerts count', async () => {
+          const alertsCount = await pageObjects.infraHostsView.getAlertsCount();
 
-            await waitForPageToLoad();
-            await browser.scrollTop();
-            await pageObjects.infraHostsView.visitAlertTab();
-          });
+          expect(alertsCount).to.be('6');
+        });
 
-          after(async () => {
-            await browser.scrollTop();
-          });
-
-          it('should correctly load the Alerts tab section when clicking on it', async () => {
-            await testSubjects.existOrFail('hostsView-alerts');
-          });
-
-          it('should correctly render a badge with the active alerts count', async () => {
-            const alertsCount = await pageObjects.infraHostsView.getAlertsCount();
-
-            expect(alertsCount).to.be('6');
-          });
-
-          describe('#FilterButtonGroup', () => {
-            it('can be filtered to only show "all" alerts using the filter button', async () => {
-              await pageObjects.infraHostsView.setAlertStatusFilter();
-              await retry.tryForTime(5000, async () => {
-                const tableRows = await observability.alerts.common.getTableCellsInRows();
-                expect(tableRows.length).to.be(ALL_ALERTS);
-              });
-            });
-
-            it('can be filtered to only show "active" alerts using the filter button', async () => {
-              await pageObjects.infraHostsView.setAlertStatusFilter(ALERT_STATUS_ACTIVE);
-              await retry.tryForTime(5000, async () => {
-                const tableRows = await observability.alerts.common.getTableCellsInRows();
-                expect(tableRows.length).to.be(ACTIVE_ALERTS);
-              });
-            });
-
-            it('can be filtered to only show "recovered" alerts using the filter button', async () => {
-              await pageObjects.infraHostsView.setAlertStatusFilter(ALERT_STATUS_RECOVERED);
-              await retry.tryForTime(5000, async () => {
-                const tableRows = await observability.alerts.common.getTableCellsInRows();
-                expect(tableRows.length).to.be(RECOVERED_ALERTS);
-              });
+        describe('#FilterButtonGroup', () => {
+          it('can be filtered to only show "all" alerts using the filter button', async () => {
+            await pageObjects.infraHostsView.setAlertStatusFilter();
+            await retry.tryForTime(5000, async () => {
+              const tableRows = await observability.alerts.common.getTableCellsInRows();
+              expect(tableRows.length).to.be(ALL_ALERTS);
             });
           });
 
-          describe('#AlertsTable', () => {
-            it('should correctly render', async () => {
-              await observability.alerts.common.getTableOrFail();
+          it('can be filtered to only show "active" alerts using the filter button', async () => {
+            await pageObjects.infraHostsView.setAlertStatusFilter(ALERT_STATUS_ACTIVE);
+            await retry.tryForTime(5000, async () => {
+              const tableRows = await observability.alerts.common.getTableCellsInRows();
+              expect(tableRows.length).to.be(ACTIVE_ALERTS);
             });
+          });
 
-            it('should renders the correct number of cells', async () => {
-              await pageObjects.infraHostsView.setAlertStatusFilter();
-              await retry.tryForTime(5000, async () => {
-                const cells = await observability.alerts.common.getTableCells();
-                expect(cells.length).to.be(ALL_ALERTS * COLUMNS);
-              });
+          it('can be filtered to only show "recovered" alerts using the filter button', async () => {
+            await pageObjects.infraHostsView.setAlertStatusFilter(ALERT_STATUS_RECOVERED);
+            await retry.tryForTime(5000, async () => {
+              const tableRows = await observability.alerts.common.getTableCellsInRows();
+              expect(tableRows.length).to.be(RECOVERED_ALERTS);
             });
           });
         });
 
-        describe('Search Query', () => {
-          const filtererEntries = tableEntries.slice(0, 3);
-
-          const query = filtererEntries.map((entry) => `host.name :"${entry.title}"`).join(' or ');
-
-          before(async () => {
-            await pageObjects.common.navigateToApp(HOSTS_VIEW_PATH);
-            await pageObjects.header.waitUntilLoadingHasFinished();
-            await pageObjects.timePicker.setAbsoluteRange(
-              START_DATE.format(DATE_PICKER_FORMAT),
-              END_DATE.format(DATE_PICKER_FORMAT)
-            );
-
-            await waitForPageToLoad();
-            await browser.scrollTop();
-            await pageObjects.infraHostsView.submitQuery(query);
-            await await waitForPageToLoad();
+        describe('#AlertsTable', () => {
+          it('should correctly render', async () => {
+            await observability.alerts.common.getTableOrFail();
           });
 
-          after(async () => {
-            await browser.scrollTop();
-            await pageObjects.infraHostsView.submitQuery('');
-          });
-
-          it('should filter the table content on a search submit', async () => {
-            const hostRows = await pageObjects.infraHostsView.getHostsTableData();
-
-            expect(hostRows.length).to.equal(3);
-
-            for (let i = 0; i < hostRows.length; i++) {
-              const hostRowData = await pageObjects.infraHostsView.getHostsRowDataWithAlerts(
-                hostRows[i]
-              );
-              expect(hostRowData).to.eql(filtererEntries[i]);
-            }
-          });
-
-          it('should update the KPIs content on a search submit', async () => {
-            await Promise.all(
-              [
-                { metric: 'hostsCount', value: '3' },
-                { metric: 'cpuUsage', value: 'N/A' },
-                { metric: 'normalizedLoad1m', value: '0.2%' },
-                { metric: 'memoryUsage', value: '17.5%' },
-                { metric: 'diskUsage', value: '35.7%' },
-              ].map(async ({ metric, value }) => {
-                await retry.tryForTime(5000, async () => {
-                  const tileValue =
-                    metric === 'hostsCount'
-                      ? await pageObjects.infraHostsView.getKPITileValue(metric)
-                      : await pageObjects.assetDetails.getAssetDetailsKPITileValue(metric);
-                  expect(tileValue).to.eql(value);
-                });
-              })
-            );
-          });
-
-          it('should update the alerts count on a search submit', async () => {
-            const alertsCount = await pageObjects.infraHostsView.getAlertsCount();
-
-            expect(alertsCount).to.be('6');
-          });
-
-          it('should update the alerts table content on a search submit', async () => {
-            const ACTIVE_ALERTS = 6;
-            const RECOVERED_ALERTS = 4;
-            const ALL_ALERTS = ACTIVE_ALERTS + RECOVERED_ALERTS;
-            const COLUMNS = 12;
-
-            await pageObjects.infraHostsView.visitAlertTab();
-
+          it('should renders the correct number of cells', async () => {
             await pageObjects.infraHostsView.setAlertStatusFilter();
             await retry.tryForTime(5000, async () => {
               const cells = await observability.alerts.common.getTableCells();
               expect(cells.length).to.be(ALL_ALERTS * COLUMNS);
             });
           });
+        });
+      });
 
-          it('should show an error message when an invalid KQL is submitted', async () => {
-            await pageObjects.infraHostsView.submitQuery('cloud.provider="gcp" A');
-            await testSubjects.existOrFail('hostsViewErrorCallout');
+      describe('Search Query', () => {
+        const filtererEntries = tableEntries.slice(0, 3);
+
+        const query = filtererEntries.map((entry) => `host.name :"${entry.title}"`).join(' or ');
+
+        before(async () => {
+          await pageObjects.common.navigateToApp(HOSTS_VIEW_PATH);
+          await pageObjects.header.waitUntilLoadingHasFinished();
+          await pageObjects.timePicker.setAbsoluteRange(
+            START_DATE.format(DATE_PICKER_FORMAT),
+            END_DATE.format(DATE_PICKER_FORMAT)
+          );
+
+          await waitForPageToLoad();
+          await browser.scrollTop();
+          await pageObjects.infraHostsView.submitQuery(query);
+          await waitForPageToLoad();
+        });
+
+        after(async () => {
+          await browser.scrollTop();
+          await pageObjects.infraHostsView.submitQuery('');
+        });
+
+        it('should filter the table content on a search submit', async () => {
+          const hostRows = await pageObjects.infraHostsView.getHostsTableData();
+
+          expect(hostRows.length).to.equal(3);
+
+          for (let i = 0; i < hostRows.length; i++) {
+            const hostRowData = await pageObjects.infraHostsView.getHostsRowDataWithAlerts(
+              hostRows[i]
+            );
+            expect(hostRowData).to.eql(filtererEntries[i]);
+          }
+        });
+
+        it('should update the KPIs content on a search submit', async () => {
+          await Promise.all(
+            [
+              { metric: 'hostsCount', value: '3' },
+              { metric: 'cpuUsage', value: 'N/A' },
+              { metric: 'normalizedLoad1m', value: '0.2%' },
+              { metric: 'memoryUsage', value: '17.5%' },
+              { metric: 'diskUsage', value: '35.7%' },
+            ].map(async ({ metric, value }) => {
+              await retry.tryForTime(5000, async () => {
+                const tileValue =
+                  metric === 'hostsCount'
+                    ? await pageObjects.infraHostsView.getKPITileValue(metric)
+                    : await pageObjects.assetDetails.getAssetDetailsKPITileValue(metric);
+                expect(tileValue).to.eql(value);
+              });
+            })
+          );
+        });
+
+        it('should update the alerts count on a search submit', async () => {
+          const alertsCount = await pageObjects.infraHostsView.getAlertsCount();
+
+          expect(alertsCount).to.be('6');
+        });
+
+        it('should update the alerts table content on a search submit', async () => {
+          const ACTIVE_ALERTS = 6;
+          const RECOVERED_ALERTS = 4;
+          const ALL_ALERTS = ACTIVE_ALERTS + RECOVERED_ALERTS;
+          const COLUMNS = 12;
+
+          await pageObjects.infraHostsView.visitAlertTab();
+
+          await pageObjects.infraHostsView.setAlertStatusFilter();
+          await retry.tryForTime(5000, async () => {
+            const cells = await observability.alerts.common.getTableCells();
+            expect(cells.length).to.be(ALL_ALERTS * COLUMNS);
           });
+        });
 
-          it('should show no data message in the table content', async () => {
-            await pageObjects.infraHostsView.submitQuery('host.name : "foo"');
+        it('should show an error message when an invalid KQL is submitted', async () => {
+          await pageObjects.infraHostsView.submitQuery('cloud.provider="gcp" A');
+          await testSubjects.existOrFail('hostsViewErrorCallout');
+        });
 
-            await waitForPageToLoad();
+        it('should show no data message in the table content', async () => {
+          await pageObjects.infraHostsView.submitQuery('host.name : "foo"');
 
-            await retry.tryForTime(5000, async () => {
-              await testSubjects.exists('hostsViewTableNoData');
-            });
+          await waitForPageToLoad();
+
+          await retry.tryForTime(5000, async () => {
+            await testSubjects.exists('hostsViewTableNoData');
           });
         });
       });

--- a/x-pack/solutions/observability/test/functional/page_objects/infra_hosts_view.ts
+++ b/x-pack/solutions/observability/test/functional/page_objects/infra_hosts_view.ts
@@ -212,7 +212,7 @@ export function InfraHostsViewProvider({ getService }: FtrProviderContext) {
       await browser.execute('arguments[0].click();', alertsTab);
     },
 
-    setAlertStatusFilter(alertStatus?: PublicAlertStatus) {
+    async setAlertStatusFilter(alertStatus?: PublicAlertStatus) {
       const buttons: Record<PublicAlertStatus | 'all', string> = {
         active: 'hostsView-alert-status-filter-active-button',
         recovered: 'hostsView-alert-status-filter-recovered-button',
@@ -222,7 +222,13 @@ export function InfraHostsViewProvider({ getService }: FtrProviderContext) {
 
       const buttonSubject = alertStatus ? buttons[alertStatus] : buttons.all;
 
-      return testSubjects.click(buttonSubject);
+      // Use a scrollIntoView + JS click to bypass overlap detection: the alerts
+      // tab renders the filter button group above an async AlertSummaryWidget,
+      // and the sticky hosts filter header can also sit above the button once
+      // scrolled into view. Mirrors the pattern used by `visitAlertTab`.
+      const button = await testSubjects.find(buttonSubject);
+      await button.scrollIntoViewIfNecessary();
+      await browser.execute('arguments[0].click();', button);
     },
 
     // Query Bar


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ObsPresentation][Infra] Migrate Hosts View FTR tests to Scout + OTel coverage (#265509)](https://github.com/elastic/kibana/pull/265509)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miriam","email":"31922082+MiriamAparicio@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-30T14:27:51Z","message":"[ObsPresentation][Infra] Migrate Hosts View FTR tests to Scout + OTel coverage (#265509)\n\nCloses [#254902](https://github.com/elastic/kibana/issues/254902)\n\n## Summary\n\nMigrates the Hosts View FTR tests to Scout (Playwright) and adds\nOTel/semconv coverage, as tracked in #254902.\n\nThis PR supersedes https://github.com/elastic/kibana/pull/263136, which\nhad a noisy commit history from iterating on flaky tests. Same code,\nclean history.\n\n### What was migrated\n\nAll non-alert Hosts View FTR tests have been migrated to Scout,\norganized into focused parallel spec files:\n\n- **`hosts_page_empty_state.spec.ts`** (sequential) — Verifies the empty\nstate when no hosts match the selected time range (0 hosts KPI, no-data\nmessage in table).\n- **`hosts_page_table.spec.ts`** — Table rendering, per-host metric\nvalues, host selection/filtering, KPI tiles, pagination (page size 5 →\n10), and sorting (by CPU usage and title, asc/desc).\n- **`hosts_page_content.spec.ts`** — Page title, host details navigation\nwith date range preservation, page-level Metrics tab (11 Lens charts),\nand Logs tab (column headers).\n- **`hosts_flyout.spec.ts`** — Single host flyout: Overview tab (KPI\ntiles, metric charts, collapsible sections, services count), Metadata\ntab (table, add/remove filter), Metrics tab, Processes tab, Logs tab,\nDashboards tab (feature-flagged via `kbnClient.uiSettings`), and \"open\nas page\" with date range preservation.\n- **`hosts_page_semconv.spec.ts`** — OTel semconv-specific coverage:\nsemconv hosts displayed in table, KPI metrics with values, metric values\nin table rows (not N/A), rx/tx columns hidden for semconv data, and\nflyout overview for semconv hosts.\n\n### What remains in FTR\n\nThe `#Page Content with alerts` block stays in FTR (`hosts_view.ts`)\nbecause it depends on `esArchiver` data for alerts and processes that\ncan't yet be replicated with Synthtrace (tracked in #192571). All\nsynthtrace dependencies were removed from the FTR file since the\nremaining tests only use archived data.\n\n## Bug fixes\n\n- **Inventory schema filter** — The infrastructure inventory was showing\nhosts from all schemas regardless of the selected schema in the UI.\nSelecting \"ECS\" or \"OpenTelemetry\" now properly filters the displayed\nnodes.\n- **`semconv_host.ts` (`kbn-synthtrace-client`)** — Fixed a field-name\nmismatch that caused KPIs to render blank for semconv data.\n\n## FTR cleanup\n\nRemoved ~670 lines from `hosts_view.ts`:\n\n- Deleted the `#Onboarding`, `#Single Host Flyout`, and `#Page Content\nwithout alerts` describe blocks.\n- Removed all synthtrace client setup/teardown and the `#With data`\nwrapper.\n- Cleaned up unused imports, constants, helpers, services, and page\nobjects.\n- Fixed a pre-existing `await await` double-await bug.\n- Adjusted `setAlertStatusFilter` in `infra_hosts_view.ts` to\nscroll-into-view + JS click, working around an intermittent\n`ElementClickInterceptedError` that surfaced once the surrounding suites\nwere removed.\n\n## Flake mitigation\n\nKPI-heavy suites use `test.setTimeout(180_000)` and a\n`KPI_RENDER_TIMEOUT` constant (90s) to absorb Lens + elastic-charts\nfirst-render variance under CI contention. Both have inline comments\nexplaining the rationale, and they sit comfortably under the extended\ntest budget. Confirmed with the Scout flaky test runner (see links\nbelow).\n\n## How to test\n\n### Run the new Scout suites\n\n```sh\nnode scripts/scout.js run-tests \\\n  --arch stateful --domain classic \\\n  --config x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel.playwright.config.ts\n```\n\n### Run the trimmed FTR suite (alerts tab still here)\n\n```sh\nnode scripts/functional_tests \\\n  --config x-pack/solutions/observability/test/functional/apps/infra/config.ts\n```","sha":"d91c236af68732e07d9330cba624dfa5e8ed5f39","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-presentation","v9.5.0"],"title":"[ObsPresentation][Infra] Migrate Hosts View FTR tests to Scout + OTel coverage","number":265509,"url":"https://github.com/elastic/kibana/pull/265509","mergeCommit":{"message":"[ObsPresentation][Infra] Migrate Hosts View FTR tests to Scout + OTel coverage (#265509)\n\nCloses [#254902](https://github.com/elastic/kibana/issues/254902)\n\n## Summary\n\nMigrates the Hosts View FTR tests to Scout (Playwright) and adds\nOTel/semconv coverage, as tracked in #254902.\n\nThis PR supersedes https://github.com/elastic/kibana/pull/263136, which\nhad a noisy commit history from iterating on flaky tests. Same code,\nclean history.\n\n### What was migrated\n\nAll non-alert Hosts View FTR tests have been migrated to Scout,\norganized into focused parallel spec files:\n\n- **`hosts_page_empty_state.spec.ts`** (sequential) — Verifies the empty\nstate when no hosts match the selected time range (0 hosts KPI, no-data\nmessage in table).\n- **`hosts_page_table.spec.ts`** — Table rendering, per-host metric\nvalues, host selection/filtering, KPI tiles, pagination (page size 5 →\n10), and sorting (by CPU usage and title, asc/desc).\n- **`hosts_page_content.spec.ts`** — Page title, host details navigation\nwith date range preservation, page-level Metrics tab (11 Lens charts),\nand Logs tab (column headers).\n- **`hosts_flyout.spec.ts`** — Single host flyout: Overview tab (KPI\ntiles, metric charts, collapsible sections, services count), Metadata\ntab (table, add/remove filter), Metrics tab, Processes tab, Logs tab,\nDashboards tab (feature-flagged via `kbnClient.uiSettings`), and \"open\nas page\" with date range preservation.\n- **`hosts_page_semconv.spec.ts`** — OTel semconv-specific coverage:\nsemconv hosts displayed in table, KPI metrics with values, metric values\nin table rows (not N/A), rx/tx columns hidden for semconv data, and\nflyout overview for semconv hosts.\n\n### What remains in FTR\n\nThe `#Page Content with alerts` block stays in FTR (`hosts_view.ts`)\nbecause it depends on `esArchiver` data for alerts and processes that\ncan't yet be replicated with Synthtrace (tracked in #192571). All\nsynthtrace dependencies were removed from the FTR file since the\nremaining tests only use archived data.\n\n## Bug fixes\n\n- **Inventory schema filter** — The infrastructure inventory was showing\nhosts from all schemas regardless of the selected schema in the UI.\nSelecting \"ECS\" or \"OpenTelemetry\" now properly filters the displayed\nnodes.\n- **`semconv_host.ts` (`kbn-synthtrace-client`)** — Fixed a field-name\nmismatch that caused KPIs to render blank for semconv data.\n\n## FTR cleanup\n\nRemoved ~670 lines from `hosts_view.ts`:\n\n- Deleted the `#Onboarding`, `#Single Host Flyout`, and `#Page Content\nwithout alerts` describe blocks.\n- Removed all synthtrace client setup/teardown and the `#With data`\nwrapper.\n- Cleaned up unused imports, constants, helpers, services, and page\nobjects.\n- Fixed a pre-existing `await await` double-await bug.\n- Adjusted `setAlertStatusFilter` in `infra_hosts_view.ts` to\nscroll-into-view + JS click, working around an intermittent\n`ElementClickInterceptedError` that surfaced once the surrounding suites\nwere removed.\n\n## Flake mitigation\n\nKPI-heavy suites use `test.setTimeout(180_000)` and a\n`KPI_RENDER_TIMEOUT` constant (90s) to absorb Lens + elastic-charts\nfirst-render variance under CI contention. Both have inline comments\nexplaining the rationale, and they sit comfortably under the extended\ntest budget. Confirmed with the Scout flaky test runner (see links\nbelow).\n\n## How to test\n\n### Run the new Scout suites\n\n```sh\nnode scripts/scout.js run-tests \\\n  --arch stateful --domain classic \\\n  --config x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel.playwright.config.ts\n```\n\n### Run the trimmed FTR suite (alerts tab still here)\n\n```sh\nnode scripts/functional_tests \\\n  --config x-pack/solutions/observability/test/functional/apps/infra/config.ts\n```","sha":"d91c236af68732e07d9330cba624dfa5e8ed5f39"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265509","number":265509,"mergeCommit":{"message":"[ObsPresentation][Infra] Migrate Hosts View FTR tests to Scout + OTel coverage (#265509)\n\nCloses [#254902](https://github.com/elastic/kibana/issues/254902)\n\n## Summary\n\nMigrates the Hosts View FTR tests to Scout (Playwright) and adds\nOTel/semconv coverage, as tracked in #254902.\n\nThis PR supersedes https://github.com/elastic/kibana/pull/263136, which\nhad a noisy commit history from iterating on flaky tests. Same code,\nclean history.\n\n### What was migrated\n\nAll non-alert Hosts View FTR tests have been migrated to Scout,\norganized into focused parallel spec files:\n\n- **`hosts_page_empty_state.spec.ts`** (sequential) — Verifies the empty\nstate when no hosts match the selected time range (0 hosts KPI, no-data\nmessage in table).\n- **`hosts_page_table.spec.ts`** — Table rendering, per-host metric\nvalues, host selection/filtering, KPI tiles, pagination (page size 5 →\n10), and sorting (by CPU usage and title, asc/desc).\n- **`hosts_page_content.spec.ts`** — Page title, host details navigation\nwith date range preservation, page-level Metrics tab (11 Lens charts),\nand Logs tab (column headers).\n- **`hosts_flyout.spec.ts`** — Single host flyout: Overview tab (KPI\ntiles, metric charts, collapsible sections, services count), Metadata\ntab (table, add/remove filter), Metrics tab, Processes tab, Logs tab,\nDashboards tab (feature-flagged via `kbnClient.uiSettings`), and \"open\nas page\" with date range preservation.\n- **`hosts_page_semconv.spec.ts`** — OTel semconv-specific coverage:\nsemconv hosts displayed in table, KPI metrics with values, metric values\nin table rows (not N/A), rx/tx columns hidden for semconv data, and\nflyout overview for semconv hosts.\n\n### What remains in FTR\n\nThe `#Page Content with alerts` block stays in FTR (`hosts_view.ts`)\nbecause it depends on `esArchiver` data for alerts and processes that\ncan't yet be replicated with Synthtrace (tracked in #192571). All\nsynthtrace dependencies were removed from the FTR file since the\nremaining tests only use archived data.\n\n## Bug fixes\n\n- **Inventory schema filter** — The infrastructure inventory was showing\nhosts from all schemas regardless of the selected schema in the UI.\nSelecting \"ECS\" or \"OpenTelemetry\" now properly filters the displayed\nnodes.\n- **`semconv_host.ts` (`kbn-synthtrace-client`)** — Fixed a field-name\nmismatch that caused KPIs to render blank for semconv data.\n\n## FTR cleanup\n\nRemoved ~670 lines from `hosts_view.ts`:\n\n- Deleted the `#Onboarding`, `#Single Host Flyout`, and `#Page Content\nwithout alerts` describe blocks.\n- Removed all synthtrace client setup/teardown and the `#With data`\nwrapper.\n- Cleaned up unused imports, constants, helpers, services, and page\nobjects.\n- Fixed a pre-existing `await await` double-await bug.\n- Adjusted `setAlertStatusFilter` in `infra_hosts_view.ts` to\nscroll-into-view + JS click, working around an intermittent\n`ElementClickInterceptedError` that surfaced once the surrounding suites\nwere removed.\n\n## Flake mitigation\n\nKPI-heavy suites use `test.setTimeout(180_000)` and a\n`KPI_RENDER_TIMEOUT` constant (90s) to absorb Lens + elastic-charts\nfirst-render variance under CI contention. Both have inline comments\nexplaining the rationale, and they sit comfortably under the extended\ntest budget. Confirmed with the Scout flaky test runner (see links\nbelow).\n\n## How to test\n\n### Run the new Scout suites\n\n```sh\nnode scripts/scout.js run-tests \\\n  --arch stateful --domain classic \\\n  --config x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel.playwright.config.ts\n```\n\n### Run the trimmed FTR suite (alerts tab still here)\n\n```sh\nnode scripts/functional_tests \\\n  --config x-pack/solutions/observability/test/functional/apps/infra/config.ts\n```","sha":"d91c236af68732e07d9330cba624dfa5e8ed5f39"}}]}] BACKPORT-->