### PR TITLE
[ES|QL] Clear getSources cache with the correct key

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -200,11 +200,11 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
 // refresh the esql cache entry after 10 minutes
 const CACHE_INVALIDATE_DELAY = 10 * 60 * 1000;
 
-export const clearCacheWhenOld = (cache: MapCache, esqlQuery: string) => {
-  if (cache.has(esqlQuery)) {
-    const cacheEntry = cache.get(esqlQuery);
+export const clearCacheWhenOld = (cache: MapCache, key: string) => {
+  if (cache.has(key)) {
+    const cacheEntry = cache.get(key);
     if (Date.now() - cacheEntry.timestamp > CACHE_INVALIDATE_DELAY) {
-      cache.delete(esqlQuery);
+      cache.delete(key);
     }
   }
 };

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -198,7 +198,9 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
 };
 
 // refresh the esql cache entry after 10 minutes
-const CACHE_INVALIDATE_DELAY = 10 * 60 * 1000;
+export const CACHE_INVALIDATE_DELAY = 10 * 60 * 1000;
+export const DATA_SOURCES_CACHE_KEY = 'dataSources';
+export const HISTORY_STARRED_ITEMS_CACHE_KEY = 'historyStarredItems';
 
 export const clearCacheWhenOld = (cache: MapCache, key: string) => {
   if (cache.has(key)) {

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.test.ts
@@ -11,6 +11,7 @@ import { renderHook } from '@testing-library/react';
 import type { CoreStart } from '@kbn/core/public';
 import type { MapCache } from 'lodash';
 import type { FavoritesClient } from '@kbn/content-management-favorites-public';
+import { CACHE_INVALIDATE_DELAY, DATA_SOURCES_CACHE_KEY } from '../helpers';
 import { useEsqlCallbacks } from './use_esql_callbacks';
 import type { StarredQueryMetadata } from '../editor_footer/esql_starred_queries_service';
 
@@ -86,6 +87,51 @@ const createDefaultParams = () => {
 };
 
 describe('useEsqlCallbacks', () => {
+  describe('getSources', () => {
+    it('cleans correctly the dataSourcesCache when getSources is called after invalidate time', async () => {
+      const params = createDefaultParams();
+      const staleTimestamp = Date.now() - (CACHE_INVALIDATE_DELAY + 1);
+      params.dataSourcesCache.set(DATA_SOURCES_CACHE_KEY, {
+        timestamp: staleTimestamp,
+        result: Promise.resolve([]),
+      });
+
+      (params.memoizedSources as unknown as jest.Mock).mockReturnValue({
+        timestamp: Date.now(),
+        result: Promise.resolve([]),
+      });
+
+      const { result } = renderHook(() => useEsqlCallbacks(params));
+
+      await result.current.getSources!();
+
+      expect(params.dataSourcesCache.delete).toHaveBeenCalledWith(DATA_SOURCES_CACHE_KEY);
+      expect(params.dataSourcesCache.has(DATA_SOURCES_CACHE_KEY)).toBe(false);
+    });
+
+    it('do not clean the dataSourcesCache when getSources is called before invalidate time', async () => {
+      const params = createDefaultParams();
+      const cacheEntry = {
+        timestamp: Date.now(),
+        result: Promise.resolve([]),
+      };
+      params.dataSourcesCache.set(DATA_SOURCES_CACHE_KEY, cacheEntry);
+
+      (params.memoizedSources as unknown as jest.Mock).mockReturnValue({
+        timestamp: Date.now(),
+        result: Promise.resolve([]),
+      });
+
+      const { result } = renderHook(() => useEsqlCallbacks(params));
+
+      await result.current.getSources!();
+
+      expect(params.dataSourcesCache.delete).not.toHaveBeenCalled();
+      expect(params.dataSourcesCache.has(DATA_SOURCES_CACHE_KEY)).toBe(true);
+      expect(params.dataSourcesCache.get(DATA_SOURCES_CACHE_KEY)).toBe(cacheEntry);
+    });
+  });
+
   describe('getColumnsFor', () => {
     it('aborts the in-flight request when the editor unmounts', async () => {
       const params = createDefaultParams();

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.ts
@@ -33,6 +33,7 @@ import type { ESQLEditorDeps } from '../types';
 import type { StarredQueryMetadata } from '../editor_footer/esql_starred_queries_service';
 import { useCanCreateLookupIndex } from '../lookup_join';
 import { useCanSuggestResourceBrowser } from '../resource_browser/use_can_suggest_resource_browser';
+import { ESQL_SOURCES_CACHE_KEY, HISTORY_STARRED_ITEMS_CACHE_KEY } from './use_memoized_caches';
 
 type MemoizedFn<TArgs extends unknown[], TResult> = (...args: TArgs) => {
   timestamp: number;
@@ -110,12 +111,12 @@ export const useEsqlCallbacks = ({
   const previousColumnsQueryRef = useRef<string | undefined>(undefined);
 
   const getSources = useCallback(async () => {
-    clearCacheWhenOld(dataSourcesCache, minimalQueryRef.current);
+    clearCacheWhenOld(dataSourcesCache, ESQL_SOURCES_CACHE_KEY);
     const getLicense = esqlService?.getLicense;
     const enrichSources = esqlService?.enrichSources;
     const sources = await memoizedSources(core, getLicense, enrichSources).result;
     return sources;
-  }, [dataSourcesCache, minimalQueryRef, memoizedSources, core, esqlService]);
+  }, [dataSourcesCache, memoizedSources, core, esqlService]);
 
   const getColumnsFor = useCallback(
     async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
@@ -262,7 +263,7 @@ export const useEsqlCallbacks = ({
   const getActiveProduct = useCallback(() => core.pricing.getActiveProduct(), [core.pricing]);
 
   const getHistoryStarredItems = useCallback(async () => {
-    clearCacheWhenOld(historyStarredItemsCache, 'historyStarredItems');
+    clearCacheWhenOld(historyStarredItemsCache, HISTORY_STARRED_ITEMS_CACHE_KEY);
     return await memoizedHistoryStarredItems(getHistoryItems, favoritesClient).result;
   }, [historyStarredItemsCache, memoizedHistoryStarredItems, favoritesClient]);
 

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_esql_callbacks.ts
@@ -33,7 +33,7 @@ import type { ESQLEditorDeps } from '../types';
 import type { StarredQueryMetadata } from '../editor_footer/esql_starred_queries_service';
 import { useCanCreateLookupIndex } from '../lookup_join';
 import { useCanSuggestResourceBrowser } from '../resource_browser/use_can_suggest_resource_browser';
-import { ESQL_SOURCES_CACHE_KEY, HISTORY_STARRED_ITEMS_CACHE_KEY } from './use_memoized_caches';
+import { DATA_SOURCES_CACHE_KEY, HISTORY_STARRED_ITEMS_CACHE_KEY } from '../helpers';
 
 type MemoizedFn<TArgs extends unknown[], TResult> = (...args: TArgs) => {
   timestamp: number;
@@ -111,7 +111,7 @@ export const useEsqlCallbacks = ({
   const previousColumnsQueryRef = useRef<string | undefined>(undefined);
 
   const getSources = useCallback(async () => {
-    clearCacheWhenOld(dataSourcesCache, ESQL_SOURCES_CACHE_KEY);
+    clearCacheWhenOld(dataSourcesCache, DATA_SOURCES_CACHE_KEY);
     const getLicense = esqlService?.getLicense;
     const enrichSources = esqlService?.enrichSources;
     const sources = await memoizedSources(core, getLicense, enrichSources).result;

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_memoized_caches.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_memoized_caches.ts
@@ -25,6 +25,9 @@ import {
 import type { getHistoryItems } from '../history_local_storage';
 import type { StarredQueryMetadata } from '../editor_footer/esql_starred_queries_service';
 
+export const ESQL_SOURCES_CACHE_KEY = 'esqlSources';
+export const HISTORY_STARRED_ITEMS_CACHE_KEY = 'historyStarredItems';
+
 interface UseMemoizedCachesParams {
   code: string;
   core: CoreStart;
@@ -66,7 +69,7 @@ export const useMemoizedCaches = ({
   const effectiveProjectRouting = setProjectRouting ?? pickerProjectRouting;
 
   const { cache: dataSourcesCache, memoizedSources } = useMemo(() => {
-    // Keying on effectiveProjectRouting ensures a fresh cache (and therefore a fresh fetch)
+    // effectiveProjectRouting as a useMemo dependency ensures a fresh cache (and therefore a fresh fetch)
     // whenever either the SET statement or the picker selection changes.
     const fn = memoize(
       (
@@ -78,7 +81,8 @@ export const useMemoizedCaches = ({
       ) => ({
         timestamp: Date.now(),
         result: getESQLSources(...args, undefined, effectiveProjectRouting),
-      })
+      }),
+      () => ESQL_SOURCES_CACHE_KEY
     );
 
     return { cache: fn.cache, memoizedSources: fn };
@@ -115,7 +119,7 @@ export const useMemoizedCaches = ({
         })(),
       }),
       // Constant key: single cache entry, invalidated via cache.clear() in clearCacheWhenOld()
-      () => 'historyStarredItems'
+      () => HISTORY_STARRED_ITEMS_CACHE_KEY
     );
 
     return { cache: fn.cache, memoizedHistoryStarredItems: fn };

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_memoized_caches.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_memoized_caches.ts
@@ -24,9 +24,7 @@ import {
 } from '@kbn/esql-utils';
 import type { getHistoryItems } from '../history_local_storage';
 import type { StarredQueryMetadata } from '../editor_footer/esql_starred_queries_service';
-
-export const ESQL_SOURCES_CACHE_KEY = 'esqlSources';
-export const HISTORY_STARRED_ITEMS_CACHE_KEY = 'historyStarredItems';
+import { DATA_SOURCES_CACHE_KEY, HISTORY_STARRED_ITEMS_CACHE_KEY } from '../helpers';
 
 interface UseMemoizedCachesParams {
   code: string;
@@ -82,7 +80,7 @@ export const useMemoizedCaches = ({
         timestamp: Date.now(),
         result: getESQLSources(...args, undefined, effectiveProjectRouting),
       }),
-      () => ESQL_SOURCES_CACHE_KEY
+      () => DATA_SOURCES_CACHE_KEY
     );
 
     return { cache: fn.cache, memoizedSources: fn };


### PR DESCRIPTION
## Summary
Fixes some issues with regard `dataSourcesCache`.

* It was using a CoreStart instance as cache key, changed it for a constant key, similar to `historyStarredCache`.
* `clearCacheWhenOld` call was not doing nothing as it was called with the query string and the key never matched.