### PR TITLE
[Security Solution] add staleness warning for AT

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-endpoint/evals/automatic_troubleshooting/automatic_troubleshooting.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-endpoint/evals/automatic_troubleshooting/automatic_troubleshooting.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../../src/data_generators/endpoint_data';
 import { cleanupSeededData } from '../../src/data_generators/cleanup';
 
-const SKILL_PATH = 'skills/security/endpoint/elastic_defend_configuration_troubleshooting/SKILL.md';
+const SKILL_PATH = 'skills/security/endpoint/elastic-defend-configuration-troubleshooting/SKILL.md';
 const UNITED_TRANSFORM_WILDCARD = `${METADATA_UNITED_TRANSFORM}*`;
 
 evaluate.describe('Automatic Troubleshooting', { tag: tags.stateful.classic }, () => {

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/is_endpoint_package_stale.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/is_endpoint_package_stale.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import semverLt from 'semver/functions/lt';
+
+export const STALE_ENDPOINT_PACKAGE_MESSAGE =
+  'Your Elastic Defend integration ({installedVersion}) is older than the latest available version ({latestVersion}). Troubleshooting recommendations may be outdated.';
+
+export const isEndpointPackageStale = (
+  installedVersion: string | null,
+  latestVersion: string | null
+): boolean => {
+  if (!installedVersion || !latestVersion) return false;
+  try {
+    return semverLt(installedVersion, latestVersion);
+  } catch {
+    return false;
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/components/stale_endpoint_package_banner.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/components/stale_endpoint_package_banner.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StaleEndpointPackageBanner } from './stale_endpoint_package_banner';
+
+jest.mock('../../../../hooks/insights/use_fetch_endpoint_package_freshness', () => ({
+  useFetchEndpointPackageFreshness: jest.fn(),
+}));
+
+const mockUseFetchEndpointPackageFreshness = jest.requireMock(
+  '../../../../hooks/insights/use_fetch_endpoint_package_freshness'
+).useFetchEndpointPackageFreshness;
+
+const STORAGE_KEY_PREFIX =
+  'securitySolution.endpointHosts.workflowInsightsAB.stalePackageBannerDismissed';
+
+describe('StaleEndpointPackageBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders nothing while data is undefined', () => {
+    mockUseFetchEndpointPackageFreshness.mockReturnValue({ data: undefined });
+    const { container } = render(<StaleEndpointPackageBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when package is fresh', () => {
+    mockUseFetchEndpointPackageFreshness.mockReturnValue({
+      data: { installedVersion: '9.4.0', latestVersion: '9.4.0', stale: false },
+    });
+    const { container } = render(<StaleEndpointPackageBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the callout when package is stale', () => {
+    mockUseFetchEndpointPackageFreshness.mockReturnValue({
+      data: { installedVersion: '9.3.0', latestVersion: '9.4.0', stale: true },
+    });
+    render(<StaleEndpointPackageBanner />);
+    expect(screen.getByText(/9\.3\.0/)).toBeInTheDocument();
+    expect(screen.getByText(/9\.4\.0/)).toBeInTheDocument();
+  });
+
+  it('hides the callout and persists dismissal when closed', () => {
+    mockUseFetchEndpointPackageFreshness.mockReturnValue({
+      data: { installedVersion: '9.3.0', latestVersion: '9.4.0', stale: true },
+    });
+    render(<StaleEndpointPackageBanner />);
+
+    fireEvent.click(screen.getByTestId('euiDismissCalloutButton'));
+
+    expect(localStorage.getItem(`${STORAGE_KEY_PREFIX}.9.4.0`)).toBe('true');
+    expect(screen.queryByText(/9\.3\.0/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when storage indicates previously dismissed for this version', () => {
+    localStorage.setItem(`${STORAGE_KEY_PREFIX}.9.4.0`, 'true');
+    mockUseFetchEndpointPackageFreshness.mockReturnValue({
+      data: { installedVersion: '9.3.0', latestVersion: '9.4.0', stale: true },
+    });
+    const { container } = render(<StaleEndpointPackageBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('re-shows when latestVersion changes to a version not yet dismissed', () => {
+    localStorage.setItem(`${STORAGE_KEY_PREFIX}.9.4.0`, 'true');
+
+    mockUseFetchEndpointPackageFreshness.mockReturnValue({
+      data: { installedVersion: '9.3.0', latestVersion: '9.4.0', stale: true },
+    });
+    const { rerender } = render(<StaleEndpointPackageBanner />);
+    expect(screen.queryByText(/9\.3\.0/)).not.toBeInTheDocument();
+
+    mockUseFetchEndpointPackageFreshness.mockReturnValue({
+      data: { installedVersion: '9.3.0', latestVersion: '9.5.0', stale: true },
+    });
+    rerender(<StaleEndpointPackageBanner />);
+    expect(screen.getByText(/9\.5\.0/)).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/components/stale_endpoint_package_banner.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/components/stale_endpoint_package_banner.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { useFetchEndpointPackageFreshness } from '../../../../hooks/insights/use_fetch_endpoint_package_freshness';
+import { WORKFLOW_INSIGHTS } from '../../../../translations';
+
+const STORAGE_KEY_PREFIX =
+  'securitySolution.endpointHosts.workflowInsightsAB.stalePackageBannerDismissed';
+
+export const StaleEndpointPackageBanner = () => {
+  const { data } = useFetchEndpointPackageFreshness();
+
+  const latestVersion = data?.latestVersion ?? 'unknown';
+  const storageKey = `${STORAGE_KEY_PREFIX}.${latestVersion}`;
+
+  const [dismissed, setDismissed] = useLocalStorage<boolean>(storageKey, false);
+
+  if (data === undefined || !data.stale || dismissed) {
+    return null;
+  }
+
+  return (
+    <>
+      <EuiCallOut
+        title={WORKFLOW_INSIGHTS.stalePackageBanner.title}
+        color="warning"
+        iconType="warning"
+        onDismiss={() => setDismissed(true)}
+      >
+        <p>
+          {WORKFLOW_INSIGHTS.stalePackageBanner.description(
+            data.installedVersion ?? '',
+            data.latestVersion ?? ''
+          )}
+        </p>
+      </EuiCallOut>
+      <EuiSpacer size="m" />
+    </>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_ab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_ab.tsx
@@ -19,6 +19,7 @@ import { useFetchInsightsAB } from '../../../hooks/insights/use_fetch_insights_a
 import { WORKFLOW_INSIGHTS } from '../../../translations';
 import { WorkflowInsightsResults } from './workflow_insights_results';
 import { WorkflowInsightsScanSectionAB } from './workflow_insights_scan_ab';
+import { StaleEndpointPackageBanner } from './components/stale_endpoint_package_banner';
 
 interface WorkflowInsightsABProps {
   endpointId: string;
@@ -205,6 +206,7 @@ export const WorkflowInsightsAB = ({ endpointId }: WorkflowInsightsABProps) => {
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />
+      <StaleEndpointPackageBanner />
       <WorkflowInsightsScanSectionAB
         isScanButtonDisabled={isScanRunning || isTriggerLoading || isUserScanLoading}
         isLoading={showScanLoading}

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_fetch_endpoint_package_freshness.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_fetch_endpoint_package_freshness.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useFetchEndpointPackageFreshness } from './use_fetch_endpoint_package_freshness';
+
+const mockHttpGet = jest.fn();
+
+jest.mock('../../../../../../common/lib/kibana', () => ({
+  useKibana: () => ({
+    services: { http: { get: mockHttpGet } },
+  }),
+}));
+
+jest.mock('@kbn/react-query', () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock('../../../../../services/policies/ingest', () => ({
+  sendGetEndpointSecurityPackage: jest.fn(),
+}));
+
+const mockUseQuery = jest.requireMock('@kbn/react-query').useQuery;
+const mockSendGetEndpointSecurityPackage = jest.requireMock(
+  '../../../../../services/policies/ingest'
+).sendGetEndpointSecurityPackage;
+
+describe('useFetchEndpointPackageFreshness', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseQuery.mockImplementation((_key: unknown, queryFn: unknown) => {
+      if (typeof queryFn === 'function') {
+        queryFn().catch(() => {});
+      }
+      return { data: undefined, isSuccess: false, isLoading: true };
+    });
+  });
+
+  it('uses namespaced query key', () => {
+    renderHook(() => useFetchEndpointPackageFreshness());
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      ['workflowInsights', 'endpointPackageFreshness'],
+      expect.any(Function),
+      expect.any(Object)
+    );
+  });
+
+  it('returns stale: true when installed is behind latest', async () => {
+    mockSendGetEndpointSecurityPackage.mockResolvedValue({
+      installationInfo: { version: '9.3.0' },
+      latestVersion: '9.4.0',
+    });
+
+    let capturedResult: unknown;
+    mockUseQuery.mockImplementation((_key: unknown, queryFn: unknown) => {
+      if (typeof queryFn === 'function') {
+        capturedResult = queryFn();
+      }
+      return { data: undefined, isSuccess: false };
+    });
+
+    renderHook(() => useFetchEndpointPackageFreshness());
+    const result = await capturedResult;
+
+    expect(result).toEqual({
+      installedVersion: '9.3.0',
+      latestVersion: '9.4.0',
+      stale: true,
+    });
+  });
+
+  it('returns stale: false when installed equals latest', async () => {
+    mockSendGetEndpointSecurityPackage.mockResolvedValue({
+      installationInfo: { version: '9.4.0' },
+      latestVersion: '9.4.0',
+    });
+
+    let capturedResult: unknown;
+    mockUseQuery.mockImplementation((_key: unknown, queryFn: unknown) => {
+      if (typeof queryFn === 'function') {
+        capturedResult = queryFn();
+      }
+      return { data: undefined, isSuccess: false };
+    });
+
+    renderHook(() => useFetchEndpointPackageFreshness());
+    const result = await capturedResult;
+
+    expect(result).toEqual({
+      installedVersion: '9.4.0',
+      latestVersion: '9.4.0',
+      stale: false,
+    });
+  });
+
+  it('returns stale: false when package is not installed', async () => {
+    mockSendGetEndpointSecurityPackage.mockResolvedValue({
+      installationInfo: undefined,
+      latestVersion: '9.4.0',
+    });
+
+    let capturedResult: unknown;
+    mockUseQuery.mockImplementation((_key: unknown, queryFn: unknown) => {
+      if (typeof queryFn === 'function') {
+        capturedResult = queryFn();
+      }
+      return { data: undefined, isSuccess: false };
+    });
+
+    renderHook(() => useFetchEndpointPackageFreshness());
+    const result = await capturedResult;
+
+    expect(result).toMatchObject({ installedVersion: null, stale: false });
+  });
+
+  it('returns stale: false when version strings are invalid semver', async () => {
+    mockSendGetEndpointSecurityPackage.mockResolvedValue({
+      installationInfo: { version: 'not-semver' },
+      latestVersion: 'also-not-semver',
+    });
+
+    let capturedResult: unknown;
+    mockUseQuery.mockImplementation((_key: unknown, queryFn: unknown) => {
+      if (typeof queryFn === 'function') {
+        capturedResult = queryFn();
+      }
+      return { data: undefined, isSuccess: false };
+    });
+
+    renderHook(() => useFetchEndpointPackageFreshness());
+    const result = await capturedResult;
+
+    expect(result).toMatchObject({ stale: false });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_fetch_endpoint_package_freshness.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_fetch_endpoint_package_freshness.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseQueryResult } from '@kbn/react-query';
+import { useQuery } from '@kbn/react-query';
+import { useKibana } from '../../../../../../common/lib/kibana';
+import { sendGetEndpointSecurityPackage } from '../../../../../services/policies/ingest';
+import { isEndpointPackageStale } from '../../../../../../../common/endpoint/utils/is_endpoint_package_stale';
+
+export interface EndpointPackageFreshness {
+  installedVersion: string | null;
+  latestVersion: string | null;
+  stale: boolean;
+}
+
+export const useFetchEndpointPackageFreshness = (): UseQueryResult<
+  EndpointPackageFreshness,
+  Error
+> => {
+  const { http } = useKibana().services;
+
+  return useQuery<EndpointPackageFreshness, Error>(
+    ['workflowInsights', 'endpointPackageFreshness'],
+    async () => {
+      const info = await sendGetEndpointSecurityPackage(http);
+      const installedVersion = info.installationInfo?.version ?? null;
+      const latestVersion = info.latestVersion ?? info.version ?? null;
+      return {
+        installedVersion,
+        latestVersion,
+        stale: isEndpointPackageStale(installedVersion, latestVersion),
+      };
+    },
+    { refetchOnWindowFocus: false, staleTime: 5 * 60 * 1000 }
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/translations.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { STALE_ENDPOINT_PACKAGE_MESSAGE } from '../../../../../common/endpoint/utils/is_endpoint_package_stale';
 
 export const OVERVIEW = i18n.translate('xpack.securitySolution.endpointDetails.overview', {
   defaultMessage: 'Overview',
@@ -59,6 +60,20 @@ export const WORKFLOW_INSIGHTS = {
         defaultMessage: 'Learn more',
       }
     ),
+  },
+  stalePackageBanner: {
+    title: i18n.translate(
+      'xpack.securitySolution.endpointDetails.workflowInsights.stalePackageBanner.title',
+      { defaultMessage: 'Endpoint integration update available' }
+    ),
+    description: (installedVersion: string, latestVersion: string) =>
+      i18n.translate(
+        'xpack.securitySolution.endpointDetails.workflowInsights.stalePackageBanner.description',
+        {
+          defaultMessage: STALE_ENDPOINT_PACKAGE_MESSAGE,
+          values: { installedVersion, latestVersion },
+        }
+      ),
   },
   issues: {
     title: i18n.translate('xpack.securitySolution.endpointDetails.workflowInsights.issues.title', {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.test.ts
@@ -24,7 +24,7 @@ describe('createAutomaticTroubleshootingSkill', () => {
 
       expect(skill).toBeDefined();
       expect(skill.id).toBe('automatic_troubleshooting');
-      expect(skill.name).toBe('elastic_defend_configuration_troubleshooting');
+      expect(skill.name).toBe('elastic-defend-configuration-troubleshooting');
       expect(skill.basePath).toBe('skills/security/endpoint');
       expect(skill.description).toContain(
         'Troubleshoot Elastic Defend endpoint configuration issues'
@@ -69,13 +69,13 @@ describe('createAutomaticTroubleshootingSkill', () => {
   });
 
   describe('getInlineTools', () => {
-    it('returns two inline tools', () => {
+    it('returns three inline tools', () => {
       const skill = createAutomaticTroubleshootingSkill(mockEndpointAppContextService);
 
       const inlineTools = skill.getInlineTools?.();
 
       expect(inlineTools).toBeDefined();
-      expect(inlineTools).toHaveLength(2);
+      expect(inlineTools).toHaveLength(3);
     });
 
     it('includes get_package_configurations tool', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/index.ts
@@ -10,17 +10,25 @@ import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definitio
 import { platformCoreTools } from '@kbn/agent-builder-common';
 
 import type { EndpointAppContextService } from '../../../endpoint/endpoint_app_context_services';
-import { getPackageConfigurationsTool, generateInsightTool } from './tools';
+import {
+  getPackageConfigurationsTool,
+  generateInsightTool,
+  checkEndpointPackageFreshnessTool,
+} from './tools';
 import { AVAILABLE_INDICES } from './data_sources';
+import { STALE_ENDPOINT_PACKAGE_MESSAGE } from '../../../../common/endpoint/utils/is_endpoint_package_stale';
 
 const ID = 'automatic_troubleshooting';
-const NAME = 'elastic_defend_configuration_troubleshooting';
+const NAME = 'elastic-defend-configuration-troubleshooting';
 const BASE_PATH = 'skills/security/endpoint';
 function toolName(name: string) {
   return `${ID}.${name}`;
 }
 export const GET_PACKAGE_CONFIGURATIONS_TOOL_ID = toolName('get_package_configurations');
 export const GENERATE_INSIGHT_TOOL_ID = toolName('generate_insight');
+export const CHECK_ENDPOINT_PACKAGE_FRESHNESS_TOOL_ID = toolName(
+  'check_endpoint_package_freshness'
+);
 
 export const createAutomaticTroubleshootingSkill = (
   endpointAppContextService: EndpointAppContextService
@@ -49,6 +57,7 @@ Reference './available_indices' for the list of indices available for troublesho
 
 ## Troubleshooting Tools
 
+- **${CHECK_ENDPOINT_PACKAGE_FRESHNESS_TOOL_ID}** - Check if the Elastic Defend integration package is up to date (call this FIRST)
 - **${platformCoreTools.integrationKnowledge}** - Retrieve Elastic Defend knowledge base context to inform the analysis
 - **${platformCoreTools.search}** - Query raw data from available indices for troubleshooting evidence
 - **${platformCoreTools.getDocumentById}** - Retrieve full document content by ID from query results
@@ -57,10 +66,11 @@ Reference './available_indices' for the list of indices available for troublesho
 
 ## Troubleshooting Approach
 
-1. **Gather context** - Use ${platformCoreTools.integrationKnowledge} to retrieve relevant Elastic Defend knowledge that informs the analysis approach.
-2. **Investigate data** - Use ${platformCoreTools.search} to query relevant indices for evidence of errors, warnings, misconfigurations, or incompatibilities. Use ${platformCoreTools.getDocumentById} to retrieve full documents when needed. Use ${GET_PACKAGE_CONFIGURATIONS_TOOL_ID} to inspect Elastic Defend package configuration if relevant.
-3. **Iterate** - Continue querying and gathering context until the root cause or relevant findings are understood.
-4. **Persist findings** - Call ${GENERATE_INSIGHT_TOOL_ID} with a clear problem description, actionable remediation steps, affected endpoint IDs, and relevant raw documents.
+1. **Check package freshness** - Call ${CHECK_ENDPOINT_PACKAGE_FRESHNESS_TOOL_ID} first. If \`stale: true\`, output this exact line before anything else, substituting the version values: "⚠️ ${STALE_ENDPOINT_PACKAGE_MESSAGE}" Do not add to or rephrase this line. Then continue the investigation. If the check fails or the package is fresh, proceed without comment.
+2. **Gather context** - Use ${platformCoreTools.integrationKnowledge} to retrieve relevant Elastic Defend knowledge that informs the analysis approach.
+3. **Investigate data** - Use ${platformCoreTools.search} to query relevant indices for evidence of errors, warnings, misconfigurations, or incompatibilities. Use ${platformCoreTools.getDocumentById} to retrieve full documents when needed. Use ${GET_PACKAGE_CONFIGURATIONS_TOOL_ID} to inspect Elastic Defend package configuration if relevant.
+4. **Iterate** - Continue querying and gathering context until the root cause or relevant findings are understood.
+5. **Persist findings** - Call ${GENERATE_INSIGHT_TOOL_ID} with a clear problem description, actionable remediation steps, affected endpoint IDs, and relevant raw documents.
 
 ## Response format (CRITICAL)
 
@@ -106,7 +116,11 @@ Reference './available_indices' for the list of indices available for troublesho
       platformCoreTools.integrationKnowledge,
     ],
     getInlineTools: () => {
-      return [getPackageConfigurationsTool(endpointAppContextService), generateInsightTool()];
+      return [
+        checkEndpointPackageFreshnessTool(endpointAppContextService),
+        getPackageConfigurationsTool(endpointAppContextService),
+        generateInsightTool(),
+      ];
     },
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/check_endpoint_package_freshness/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/check_endpoint_package_freshness/index.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToolHandlerContext } from '@kbn/agent-builder-server/tools';
+import type { PackageClient } from '@kbn/fleet-plugin/server';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+
+import type { EndpointAppContextService } from '../../../../../endpoint/endpoint_app_context_services';
+import { createMockEndpointAppContext } from '../../../../../endpoint/mocks';
+import { CHECK_ENDPOINT_PACKAGE_FRESHNESS_TOOL_ID } from '../..';
+import { checkEndpointPackageFreshnessTool } from '.';
+
+const mockLogger = { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
+const mockContext = { logger: mockLogger } as unknown as ToolHandlerContext;
+
+describe('checkEndpointPackageFreshnessTool', () => {
+  let mockEndpointAppContextService: EndpointAppContextService;
+  let mockPackageClient: jest.Mocked<PackageClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEndpointAppContextService = createMockEndpointAppContext().service;
+    mockPackageClient = mockEndpointAppContextService.getInternalFleetServices()
+      .packages as jest.Mocked<PackageClient>;
+  });
+
+  describe('tool definition', () => {
+    it('returns a valid builtin tool definition', () => {
+      const tool = checkEndpointPackageFreshnessTool(mockEndpointAppContextService);
+      expect(tool.type).toBe(ToolType.builtin);
+      expect(tool.id).toBe(CHECK_ENDPOINT_PACKAGE_FRESHNESS_TOOL_ID);
+      expect(tool.description).toContain('stale');
+    });
+
+    it('has correct tool id format', () => {
+      expect(CHECK_ENDPOINT_PACKAGE_FRESHNESS_TOOL_ID).toBe(
+        'automatic_troubleshooting.check_endpoint_package_freshness'
+      );
+    });
+  });
+
+  describe('handler', () => {
+    let tool: ReturnType<typeof checkEndpointPackageFreshnessTool>;
+
+    beforeEach(() => {
+      tool = checkEndpointPackageFreshnessTool(mockEndpointAppContextService);
+    });
+
+    it('returns stale: false when installed version equals latest', async () => {
+      mockPackageClient.getInstallation.mockResolvedValue({ version: '9.4.0' } as Awaited<
+        ReturnType<typeof mockPackageClient.getInstallation>
+      >);
+      mockPackageClient.getLatestPackageInfo.mockResolvedValue({ version: '9.4.0' } as Awaited<
+        ReturnType<typeof mockPackageClient.getLatestPackageInfo>
+      >);
+
+      const result = await tool.handler({}, mockContext);
+
+      if ('results' in result) {
+        expect(result.results[0].type).toBe(ToolResultType.other);
+        expect(result.results[0].data).toMatchObject({
+          installedVersion: '9.4.0',
+          latestVersion: '9.4.0',
+          stale: false,
+        });
+      }
+    });
+
+    it('returns stale: true when installed version is behind latest', async () => {
+      mockPackageClient.getInstallation.mockResolvedValue({ version: '9.3.0' } as Awaited<
+        ReturnType<typeof mockPackageClient.getInstallation>
+      >);
+      mockPackageClient.getLatestPackageInfo.mockResolvedValue({ version: '9.4.0' } as Awaited<
+        ReturnType<typeof mockPackageClient.getLatestPackageInfo>
+      >);
+
+      const result = await tool.handler({}, mockContext);
+
+      if ('results' in result) {
+        expect(result.results[0].data).toMatchObject({
+          installedVersion: '9.3.0',
+          latestVersion: '9.4.0',
+          stale: true,
+        });
+      }
+    });
+
+    it('returns stale: false when package is not installed', async () => {
+      mockPackageClient.getInstallation.mockResolvedValue(undefined);
+      mockPackageClient.getLatestPackageInfo.mockResolvedValue({ version: '9.4.0' } as Awaited<
+        ReturnType<typeof mockPackageClient.getLatestPackageInfo>
+      >);
+
+      const result = await tool.handler({}, mockContext);
+
+      if ('results' in result) {
+        expect(result.results[0].data).toMatchObject({
+          installedVersion: null,
+          latestVersion: '9.4.0',
+          stale: false,
+        });
+      }
+    });
+
+    it('returns an error result when Fleet call throws', async () => {
+      mockPackageClient.getInstallation.mockRejectedValue(new Error('registry unavailable'));
+
+      const result = await tool.handler({}, mockContext);
+
+      if ('results' in result) {
+        expect(result.results[0].type).toBe(ToolResultType.error);
+      }
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('returns stale: false when version strings are invalid semver', async () => {
+      mockPackageClient.getInstallation.mockResolvedValue({ version: 'not-semver' } as Awaited<
+        ReturnType<typeof mockPackageClient.getInstallation>
+      >);
+      mockPackageClient.getLatestPackageInfo.mockResolvedValue({
+        version: 'also-not-semver',
+      } as Awaited<ReturnType<typeof mockPackageClient.getLatestPackageInfo>>);
+
+      const result = await tool.handler({}, mockContext);
+
+      if ('results' in result) {
+        expect(result.results[0].data).toMatchObject({ stale: false });
+      }
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/check_endpoint_package_freshness/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/check_endpoint_package_freshness/index.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
+import { z } from '@kbn/zod/v4';
+import { ToolResultType, ToolType } from '@kbn/agent-builder-common';
+import { FLEET_ENDPOINT_PACKAGE } from '@kbn/fleet-plugin/common';
+import { getToolResultId } from '@kbn/agent-builder-server/tools';
+
+import type { EndpointAppContextService } from '../../../../../endpoint/endpoint_app_context_services';
+import { isEndpointPackageStale } from '../../../../../../common/endpoint/utils/is_endpoint_package_stale';
+import { CHECK_ENDPOINT_PACKAGE_FRESHNESS_TOOL_ID } from '../..';
+
+export const checkEndpointPackageFreshnessTool = (
+  endpointAppContextService: EndpointAppContextService
+): BuiltinSkillBoundedTool => {
+  return {
+    id: CHECK_ENDPOINT_PACKAGE_FRESHNESS_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Returns the installed version, the latest available version, and whether the Elastic Defend endpoint integration package is stale (installed version behind latest).`,
+    schema: z.object({}),
+    handler: async (_, { logger }) => {
+      try {
+        const packageClient = endpointAppContextService.getInternalFleetServices().packages;
+        const [installation, latestInfo] = await Promise.all([
+          packageClient.getInstallation(FLEET_ENDPOINT_PACKAGE),
+          packageClient.getLatestPackageInfo(FLEET_ENDPOINT_PACKAGE),
+        ]);
+
+        const installedVersion = installation?.version ?? null;
+        const latestVersion = latestInfo.version ?? null;
+
+        return {
+          results: [
+            {
+              tool_result_id: getToolResultId(),
+              type: ToolResultType.other,
+              data: {
+                installedVersion,
+                latestVersion,
+                stale: isEndpointPackageStale(installedVersion, latestVersion),
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(error);
+        return {
+          results: [
+            {
+              tool_result_id: getToolResultId(),
+              type: ToolResultType.error,
+              data: { message: `Error checking endpoint package freshness: ${error.message}` },
+            },
+          ],
+        };
+      }
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/index.ts
@@ -7,3 +7,4 @@
 
 export { getPackageConfigurationsTool } from './get_package_configurations';
 export { generateInsightTool } from './generate_insight';
+export { checkEndpointPackageFreshnessTool } from './check_endpoint_package_freshness';


### PR DESCRIPTION
## Summary

Adds a staleness warning for Automatic Troubleshooting in 2 places:
* banner on the host details flyout on the endpoint list page
* small instruction in AT skill for agent to warn

Also renames the skill from `elastic_defend_configuration_troubleshooting` to `elastic-defend-configuration-troubleshooting` to be consistent with other Agent Builder skills.

This is only intended as a best effort warning so intentionally not adding to evals.

Endpoint list page flyout:
<img width="1146" height="626" alt="Screenshot 2026-05-13 at 9 48 37 PM" src="https://github.com/user-attachments/assets/3cb029b0-11a4-4702-9b50-33e4deff82d5" />

Agent warning:
<img width="849" height="606" alt="Screenshot 2026-05-14 at 6 39 24 PM" src="https://github.com/user-attachments/assets/3031bb16-ae15-4676-8c01-401273e4b12b" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios