### PR TITLE
[9.3] Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/actionable-obs-team` files (#268803)

### DIFF
--- a/x-pack/solutions/observability/packages/alert-details/src/components/alert_annotation.tsx
+++ b/x-pack/solutions/observability/packages/alert-details/src/components/alert_annotation.tsx
@@ -44,7 +44,7 @@ export function AlertAnnotation({ alertStart, color, dateFormat, id }: Props) {
           opacity: 1,
         },
       }}
-      marker={<EuiIcon type="warning" color={color} />}
+      marker={<EuiIcon type="warning" color={color} aria-hidden={true} />}
       markerPosition={Position.Top}
     />
   );

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/components/series_color_picker.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/components/series_color_picker.tsx
@@ -42,7 +42,7 @@ export function SeriesColorPicker({ seriesId, series }: { seriesId: number; seri
         onClick={() => setIsOpen((prevState) => !prevState)}
         flush="both"
       >
-        <EuiIcon type="stopFilled" size="l" color={color} />
+        <EuiIcon type="stopFilled" size="l" color={color} aria-hidden={true} />
       </EuiButtonEmpty>
     </EuiToolTip>
   );

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/chart_type_select.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/chart_type_select.tsx
@@ -48,7 +48,11 @@ export function SeriesChartTypes({ seriesId, series, seriesConfig }: Props) {
             flush="both"
           >
             {icon && (
-              <EuiIcon type={(data ?? []).find(({ id }) => id === seriesType)?.icon!} size="l" />
+              <EuiIcon
+                type={(data ?? []).find(({ id }) => id === seriesType)?.icon!}
+                size="l"
+                aria-hidden={true}
+              />
             )}
           </EuiButtonEmpty>
         </EuiToolTip>

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/chart_types.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/chart_types.tsx
@@ -89,7 +89,7 @@ export function XYChartTypesSelect({
     const LabelWithIcon = (
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
-          <EuiIcon type={icon} />
+          <EuiIcon type={icon} aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem>{fullLabel || label}</EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/components/labels_filter.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/components/labels_filter.tsx
@@ -57,7 +57,7 @@ export function LabelsFieldFilter(props: FilterProps) {
     return {
       label: field.name,
       searchableLabel: field.name,
-      append: <EuiIcon type="arrowRight" />,
+      append: <EuiIcon type="arrowRight" aria-hidden={true} />,
       showIcons: false,
     };
   });

--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/error_rate/error_rate_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/error_rate/error_rate_panel.tsx
@@ -83,7 +83,7 @@ export function ErrorRatePanel({ alert, slo, isLoading }: Props) {
                 data-test-subj="o11yErrorRatePanelSloDetailsLink"
                 href={http.basePath.prepend(alert.link!)}
               >
-                <EuiIcon type="sortRight" style={{ marginRight: '4px' }} />
+                <EuiIcon type="sortRight" style={{ marginRight: '4px' }} aria-hidden={true} />
                 <FormattedMessage
                   id="xpack.slo.burnRateRule.alertDetailsAppSection.burnRate.sloDetailsLink"
                   defaultMessage="SLO details"
@@ -112,7 +112,7 @@ export function ErrorRatePanel({ alert, slo, isLoading }: Props) {
                         'xpack.slo.burnRateRule.alertDetailsAppSection.burnRate.thresholdBreachedTitle',
                         { defaultMessage: 'Threshold breached' }
                       )}
-                      <EuiIcon type="warning" style={{ marginLeft: '4px' }} />
+                      <EuiIcon type="warning" style={{ marginLeft: '4px' }} aria-hidden={true} />
                     </span>
                   </EuiText>
                 </EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/slo/public/components/slo/simple_burn_rate/burn_rate.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/slo/simple_burn_rate/burn_rate.tsx
@@ -49,7 +49,7 @@ export function SimpleBurnRate({ slo, duration, lastRefreshTime }: Props) {
         description={
           <EuiTextColor color="subdued">
             <span>
-              <EuiIcon type="clock" color={'subdued'} /> {durationLabel}
+              <EuiIcon type="clock" color={'subdued'} aria-hidden={true} /> {durationLabel}
             </span>
           </EuiTextColor>
         }
@@ -84,14 +84,14 @@ export function SimpleBurnRate({ slo, duration, lastRefreshTime }: Props) {
           <EuiToolTip position="top" content={timeToExhaustLabel}>
             <EuiTextColor color={color}>
               <span>
-                <EuiIcon type="clock" color={color} /> {durationLabel}
+                <EuiIcon type="clock" color={color} aria-hidden={true} /> {durationLabel}
               </span>
             </EuiTextColor>
           </EuiToolTip>
         ) : (
           <EuiTextColor color={color}>
             <span>
-              <EuiIcon type="clock" color={color} /> {durationLabel}
+              <EuiIcon type="clock" color={color} aria-hidden={true} /> {durationLabel}
             </span>
           </EuiTextColor>
         )

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_overview_grid.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_overview_grid.tsx
@@ -62,7 +62,7 @@ const getSloChartData = ({
         }}
       />
     ),
-    icon: () => <EuiIcon type="visGauge" size="l" />,
+    icon: () => <EuiIcon type="visGauge" size="l" aria-hidden={true} />,
     color: cardColor,
   };
 };

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/header_control.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/header_control.tsx
@@ -201,6 +201,7 @@ export function HeaderControl({ slo }: Props) {
     <EuiIcon
       type="popout"
       size="s"
+      aria-hidden={true}
       css={{
         marginLeft: '10px',
       }}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/health_callout/content_with_inspect_cta.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/health_callout/content_with_inspect_cta.tsx
@@ -32,7 +32,7 @@ export function ContentWithInspectCta({
             responsive={false}
           >
             <EuiFlexItem grow={false}>
-              <EuiIcon type="inspect" color="danger" />
+              <EuiIcon type="inspect" color="danger" aria-hidden={true} />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiText size={textSize} color="danger">

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/advanced_settings/advanced_settings.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/advanced_settings/advanced_settings.tsx
@@ -36,7 +36,7 @@ export function AdvancedSettings() {
       buttonContent={
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiIcon type="controlsVertical" size="m" />
+            <EuiIcon type="controlsVertical" size="m" aria-hidden={true} />
           </EuiFlexItem>
 
           <EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_bulk_actions.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_bulk_actions.tsx
@@ -102,7 +102,7 @@ export function SloManagementBulkActions({ items, setSelectedItems }: Props) {
             defaultMessage: 'Selected {count} {count, plural, =1 {SLO} other {SLOs}}',
             values: { count: items.length },
           })}{' '}
-          <EuiIcon type="arrowDown" size="s" />
+          <EuiIcon type="arrowDown" size="s" aria-hidden={true} />
         </EuiButtonEmpty>
       }
       isOpen={isOpen}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_outdated_filter_callout.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_management/components/slo_management_outdated_filter_callout.tsx
@@ -19,7 +19,7 @@ export function SloOutdatedFilterCallout() {
   return (
     <EuiCallOut color="primary">
       <EuiText>
-        <EuiIcon type="info" />{' '}
+        <EuiIcon type="info" aria-hidden={true} />{' '}
         {i18n.translate('xpack.slo.outdatedSloFilterCallout.title', {
           defaultMessage:
             "You're currently viewing only outdated SLOs. You can reset them from the action menu to bring them up to date.",

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/card_view/slo_card_item.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/card_view/slo_card_item.tsx
@@ -244,7 +244,7 @@ export function SloCardChart({
                   }}
                 />
               ),
-              icon: () => <EuiIcon type="visGauge" size="l" />,
+              icon: () => <EuiIcon type="visGauge" size="l" aria-hidden={true} />,
               color: cardColor,
               body: badges,
             },

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/compact_view/slo_list_compact_view.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/compact_view/slo_list_compact_view.tsx
@@ -107,6 +107,7 @@ export function SloListCompactView({ sloList, loading, error }: Props) {
         <EuiIcon
           type="popout"
           size="s"
+          aria-hidden={true}
           css={{
             marginLeft: '10px',
           }}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_item_actions.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_item_actions.tsx
@@ -171,6 +171,7 @@ export function SloItemActions({
     <EuiIcon
       type="popout"
       size="s"
+      aria-hidden={true}
       css={{
         marginLeft: '10px',
       }}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/location_status_badges.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/location_status_badges.tsx
@@ -118,7 +118,7 @@ const MonitorDetailLinkForLocation = ({
 
   return (
     <EuiBadge
-      iconType={() => <EuiIcon size="m" type="dot" color={color} />}
+      iconType={() => <EuiIcon size="m" type="dot" color={color} aria-hidden={true} />}
       color="hollow"
       href={monitorDetailLinkUrl ?? '/'}
       aria-label={i18n.translate('xpack.synthetics.management.location.ariaLabel', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_location_select.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_location_select.tsx
@@ -64,7 +64,8 @@ export const MonitorLocationSelect = ({
           onClick={openLocationList}
           disabled={isDisabled}
         >
-          {selectedLocation.label} {!isDisabled ? <EuiIcon type="arrowDown" aria-hidden={true} /> : null}
+          {selectedLocation.label}{' '}
+          {!isDisabled ? <EuiIcon type="arrowDown" aria-hidden={true} /> : null}
         </EuiLink>
       );
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_location_select.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_location_select.tsx
@@ -64,13 +64,19 @@ export const MonitorLocationSelect = ({
           onClick={openLocationList}
           disabled={isDisabled}
         >
-          {selectedLocation.label} {!isDisabled ? <EuiIcon type="arrowDown" /> : null}
+          {selectedLocation.label} {!isDisabled ? <EuiIcon type="arrowDown" aria-hidden={true} /> : null}
         </EuiLink>
       );
 
       const menuItems =
         loadingLocationsStatus && !locationsStatus
-          ? [<span key="loading">Loading...</span>]
+          ? [
+              <span key="loading">
+                {i18n.translate('xpack.synthetics.locationList.span.loadingLabel', {
+                  defaultMessage: 'Loading...',
+                })}
+              </span>,
+            ]
           : locationsStatus
               .map((location) => {
                 return (

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/empty_thumbnail.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/screenshot/empty_thumbnail.tsx
@@ -95,6 +95,7 @@ export const EmptyThumbnail = ({
             data-test-subj="stepScreenshotNotAvailable"
             type="eyeClosed"
             color={euiTheme.colors.textDisabled}
+            aria-hidden={true}
           />
 
           {unavailableMessage ? (

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/monitor_type_radio_group.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/monitor_type_radio_group.tsx
@@ -59,7 +59,7 @@ export const MonitorType = ({
       isSelected={isSelected}
       data-test-subj={dataTestSubj}
     >
-      <EuiIcon type={icon} />
+      <EuiIcon type={icon} aria-hidden={true} />
     </EuiKeyPadMenuItem>
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -1345,7 +1345,7 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
         id="xpack.synthetics.monitorConfig.throttlingDisabled.label"
         defaultMessage="Connection profile ( {icon} Important information about throttling: {link})"
         values={{
-          icon: <EuiIcon type="alert" color="warning" size="s" />,
+          icon: <EuiIcon type="alert" color="warning" size="s" aria-hidden={true} />,
           link: (
             <EuiLink
               data-test-subj="syntheticsFIELDNoticeLink"

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/monitor_details_portal.tsx
@@ -63,7 +63,7 @@ const MonitorDetailsLink = ({ name, configId }: Props) => {
 const MonitorLink = ({ href, name }: { href: string; name: string }) => {
   return (
     <EuiLink data-test-subj="syntheticsMonitorDetailsLinkLink" href={href}>
-      <EuiIcon type="arrowLeft" /> {name}
+      <EuiIcon type="arrowLeft" aria-hidden={true} /> {name}
     </EuiLink>
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/errors_icon.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/errors_icon.tsx
@@ -11,5 +11,5 @@ import { useMonitorErrors } from '../hooks/use_monitor_errors';
 export const MonitorErrorsIcon = () => {
   const { hasActiveError } = useMonitorErrors();
 
-  return hasActiveError ? <EuiIcon type="warning" color="danger" /> : null;
+  return hasActiveError ? <EuiIcon type="warning" color="danger" aria-hidden={true} /> : null;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/monitor_errors.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_errors/monitor_errors.tsx
@@ -70,7 +70,7 @@ const EmptyErrors = () => {
     <EuiFlexGroup alignItems="center" justifyContent="center" style={{ height: '65vh' }}>
       <EuiFlexItem grow={false} style={{ textAlign: 'center' }}>
         <span>
-          <EuiIcon type="checkInCircleFilled" color="success" size="xl" />
+          <EuiIcon type="checkInCircleFilled" color="success" size="xl" aria-hidden={true} />
         </span>
         <EuiSpacer size="m" />
         <EuiTitle size="m">

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_legend.tsx
@@ -34,7 +34,7 @@ export const MonitorStatusLegend = ({ brushable }: { brushable: boolean }) => {
         }}
         grow={false}
       >
-        <EuiIcon type={iconType} color={color} />
+        <EuiIcon type={iconType} color={color} aria-hidden={true} />
         <EuiText size="xs">{label}</EuiText>
       </EuiFlexItem>
     );

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/route_config.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/route_config.tsx
@@ -98,7 +98,7 @@ export const getMonitorDetailsRoute = (
 const getMonitorsBreadcrumb = (syntheticsPath: string) => ({
   text: (
     <>
-      <EuiIcon size="s" type="arrowLeft" />{' '}
+      <EuiIcon size="s" type="arrowLeft" aria-hidden={true} />{' '}
       <FormattedMessage
         id="xpack.synthetics.monitorSummaryRoute.monitorBreadcrumb"
         defaultMessage="Monitors"

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
@@ -66,7 +66,11 @@ export const RunTestManuallyContextItem = () => {
       >
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           <EuiFlexItem grow={false}>
-            {testInProgress ? <EuiLoadingSpinner size="s" /> : <EuiIcon type="beaker" size="s" aria-hidden={true} />}
+            {testInProgress ? (
+              <EuiLoadingSpinner size="s" />
+            ) : (
+              <EuiIcon type="beaker" size="s" aria-hidden={true} />
+            )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>{<span>{RUN_TEST_LABEL}</span>}</EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/run_test_manually.tsx
@@ -66,7 +66,7 @@ export const RunTestManuallyContextItem = () => {
       >
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
           <EuiFlexItem grow={false}>
-            {testInProgress ? <EuiLoadingSpinner size="s" /> : <EuiIcon type="beaker" size="s" />}
+            {testInProgress ? <EuiLoadingSpinner size="s" /> : <EuiIcon type="beaker" size="s" aria-hidden={true} />}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>{<span>{RUN_TEST_LABEL}</span>}</EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/alerting_defaults/hooks/use_alerting_defaults.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/alerting_defaults/hooks/use_alerting_defaults.tsx
@@ -37,6 +37,7 @@ export const useAlertingDefaults = () => {
         <EuiIcon
           type={actionTypeRegistry.get(connectorAction.actionTypeId as string).iconClass}
           size="s"
+          aria-hidden={true}
         />
       ),
     }));

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/data_retention/unprivileged.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/data_retention/unprivileged.tsx
@@ -19,7 +19,7 @@ export const Unprivileged = ({ hideIlmMessage = false }: { hideIlmMessage?: bool
     <EuiEmptyPrompt
       data-test-subj="syntheticsUnprivileged"
       color="plain"
-      icon={<EuiIcon type="logoObservability" size="xl" />}
+      icon={<EuiIcon type="logoObservability" size="xl" aria-hidden={true} />}
       title={
         <h2>
           <FormattedMessage

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_objects/color_palette.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_objects/color_palette.tsx
@@ -96,9 +96,14 @@ export const ColorPalette = ({
         <EuiFlexItem grow={false} style={{ width: 40 }}>
           <EuiToolTip content={getToolTipContent()}>
             {hasDelta ? (
-              <EuiIcon type={delta > 0 ? 'sortUp' : 'sortDown'} size="m" color={getColor()} />
+              <EuiIcon
+                type={delta > 0 ? 'sortUp' : 'sortDown'}
+                size="m"
+                color={getColor()}
+                aria-hidden={true}
+              />
             ) : (
-              <EuiIcon type="minus" size="m" color="subdued" />
+              <EuiIcon type="minus" size="m" color="subdued" aria-hidden={true} />
             )}
           </EuiToolTip>
         </EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_header/waterfall_legend_item.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_header/waterfall_legend_item.tsx
@@ -53,7 +53,7 @@ export function WaterfallLegendItem<T = string>({
         onClick?.(id);
       }}
     >
-      <EuiIcon color={color} size="m" type={isBoxFilled ? 'stopFilled' : 'stopSlash'} />
+      <EuiIcon color={color} size="m" type={isBoxFilled ? 'stopFilled' : 'stopSlash'} aria-hidden={true} />
 
       <EuiText size="xs">{label}</EuiText>
     </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_header/waterfall_legend_item.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_header/waterfall_legend_item.tsx
@@ -53,7 +53,12 @@ export function WaterfallLegendItem<T = string>({
         onClick?.(id);
       }}
     >
-      <EuiIcon color={color} size="m" type={isBoxFilled ? 'stopFilled' : 'stopSlash'} aria-hidden={true} />
+      <EuiIcon
+        color={color}
+        size="m"
+        type={isBoxFilled ? 'stopFilled' : 'stopSlash'}
+        aria-hidden={true}
+      />
 
       <EuiText size="xs">{label}</EuiText>
     </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_header/waterfall_tick_axis.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_header/waterfall_tick_axis.tsx
@@ -70,6 +70,7 @@ export const WaterfallTickAxis = ({
                       <EuiIcon
                         type={showOnlyHighlightedNetworkRequests ? 'eyeClosed' : 'eye'}
                         size="s"
+                        aria-hidden={true}
                       />
                       <EuiText size="xs">
                         <FormattedMessage

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_synthetics_priviliges.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_synthetics_priviliges.tsx
@@ -72,7 +72,7 @@ const Unprivileged = ({ unprivilegedIndices }: { unprivilegedIndices: string[] }
   <EuiEmptyPrompt
     data-test-subj="syntheticsUnprivileged"
     color="plain"
-    icon={<EuiIcon type="logoObservability" size="xl" />}
+    icon={<EuiIcon type="logoObservability" size="xl" aria-hidden={true} />}
     title={
       <h2>
         <FormattedMessage

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/fleet_package/deprecate_notice_modal.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/fleet_package/deprecate_notice_modal.tsx
@@ -21,7 +21,7 @@ export const DeprecateNoticeModal = ({ onCancel }: { onCancel: () => void }) => 
       titleProps={{ id: modalTitleId }}
       title={
         <>
-          {HEADER_TEXT} <EuiIcon type="cheer" />
+          {HEADER_TEXT} <EuiIcon type="cheer" aria-hidden={true} />
         </>
       }
       onCancel={onCancel}

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/ml/manage_ml_job.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/ml/manage_ml_job.tsx
@@ -94,7 +94,7 @@ export const ManageMLJobComponent = ({ hasMLJob, onEnableJob, onJobDelete }: Pro
       items: [
         {
           name: labels.EXPLORE_IN_ML_APP,
-          icon: <EuiIcon type="dataVisualizer" size="m" />,
+          icon: <EuiIcon type="dataVisualizer" size="m" aria-hidden={true} />,
           href: getMLJobLinkHref({
             basePath,
             monitorId,
@@ -129,7 +129,7 @@ export const ManageMLJobComponent = ({ hasMLJob, onEnableJob, onJobDelete }: Pro
         {
           name: labels.DISABLE_ANOMALY_DETECTION,
           'data-test-subj': 'uptimeDeleteMLJobBtn',
-          icon: <EuiIcon type="trash" size="m" />,
+          icon: <EuiIcon type="trash" size="m" aria-hidden={true} />,
           onClick: () => {
             setIsPopOverOpen(false);
             onJobDelete();

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/status_details/__snapshots__/ssl_certificate.test.tsx.snap
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/status_details/__snapshots__/ssl_certificate.test.tsx.snap
@@ -29,6 +29,7 @@ Array [
           tabindex="0"
         >
           <span
+            aria-hidden="true"
             color="success"
             data-euiicon-type="lock"
           />

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/columns/cert_status_column.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/columns/cert_status_column.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 import styled from 'styled-components';
 import { EuiIcon, EuiText, EuiToolTip } from '@elastic/eui';
@@ -42,7 +43,7 @@ export const CertStatusColumn: React.FC<Props> = ({ expiry, boldStyle = false })
     return (
       <EuiToolTip content={moment(notAfter).format('L LT')}>
         <EuiText size="s" tabIndex={0}>
-          <EuiIcon color={color} type="lock" size="s" />
+          <EuiIcon color={color} type="lock" size="s" aria-hidden={true} />
           {boldStyle ? (
             <H4Text>
               {text} {relativeDate}
@@ -64,5 +65,11 @@ export const CertStatusColumn: React.FC<Props> = ({ expiry, boldStyle = false })
     return <CertStatus color="danger" text={EXPIRED} />;
   }
 
-  return certStatus ? <CertStatus color="success" text={EXPIRES} /> : <span>--</span>;
+  return certStatus ? (
+    <CertStatus color="success" text={EXPIRES} />
+  ) : (
+    <span>
+      {i18n.translate('xpack.uptime.certStatusColumn.span.Label', { defaultMessage: '--' })}
+    </span>
+  );
 };

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/settings/alert_defaults_form.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/settings/alert_defaults_form.tsx
@@ -108,7 +108,7 @@ export const AlertDefaultsForm: React.FC<SettingsFormProps> = ({
     const { actionTypeId: type } = data?.find((dt) => dt.id === value) ?? {};
     return (
       <ConnectorSpan>
-        <EuiIcon type={actionTypeRegistry.get(type as string).iconClass} />
+        <EuiIcon type={actionTypeRegistry.get(type as string).iconClass} aria-hidden={true} />
         <span>{label}</span>
       </ConnectorSpan>
     );

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/synthetics/step_screenshot_display.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/synthetics/step_screenshot_display.tsx
@@ -177,7 +177,7 @@ export const StepScreenshotDisplay: FC<StepScreenshotDisplayProps> = ({
           data-test-subj="stepScreenshotImageUnavailable"
         >
           <EuiFlexItem grow={false}>
-            <EuiIcon color="subdued" size="xxl" type="image" />
+            <EuiIcon color="subdued" size="xxl" type="image" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/actionable-obs-team` files (#268803)](https://github.com/elastic/kibana/pull/268803)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-12T12:24:14Z","message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/actionable-obs-team` files (#268803)\n\nFixes 44 `@elastic/eui/icon-accessibility-rules` violations across 39\nfiles owned by `@elastic/actionable-obs-team`.\n\nAll icons are decorative (adjacent to visible text conveying the same\nmeaning), so each receives `aria-hidden={true}` per the accessibility\nskill guidance.\n\n```tsx\n// Before\n<EuiIcon type=\"warning\" color=\"danger\" />\n\n// After\n<EuiIcon type=\"warning\" color=\"danger\" aria-hidden={true} />\n```\n\n### Scope\n- **SLO plugin** — clock, chartGauge, external link, warning, info,\ninspect, controls, chevron icons\n- **Synthetics plugin** — dot, chevron, eyeSlash, flask,\ncheckCircleFill, eye, logoObservability, warning, connector type icons\n- **Uptime plugin** — popper, dataVisualizer, trash, lock, connector\ntype, image icons\n- **Exploratory View plugin** — stopFill, chart type, chevron icons\n- **Alert Details package** — warning annotation marker icon\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2\nt/webkit-2272/minibrowser-gtk/MiniBrowser` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node\nscripts/check_changes.ts bin/ldd ldd s/li\u0004\u0018` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"de0231e7ed82a2cddfaa4da0ca839076ca93fc6c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","💝community","backport:version","a11y:agent-pr","v9.5.0","v9.3.5","v9.4.1"],"title":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/actionable-obs-team` files","number":268803,"url":"https://github.com/elastic/kibana/pull/268803","mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/actionable-obs-team` files (#268803)\n\nFixes 44 `@elastic/eui/icon-accessibility-rules` violations across 39\nfiles owned by `@elastic/actionable-obs-team`.\n\nAll icons are decorative (adjacent to visible text conveying the same\nmeaning), so each receives `aria-hidden={true}` per the accessibility\nskill guidance.\n\n```tsx\n// Before\n<EuiIcon type=\"warning\" color=\"danger\" />\n\n// After\n<EuiIcon type=\"warning\" color=\"danger\" aria-hidden={true} />\n```\n\n### Scope\n- **SLO plugin** — clock, chartGauge, external link, warning, info,\ninspect, controls, chevron icons\n- **Synthetics plugin** — dot, chevron, eyeSlash, flask,\ncheckCircleFill, eye, logoObservability, warning, connector type icons\n- **Uptime plugin** — popper, dataVisualizer, trash, lock, connector\ntype, image icons\n- **Exploratory View plugin** — stopFill, chart type, chevron icons\n- **Alert Details package** — warning annotation marker icon\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2\nt/webkit-2272/minibrowser-gtk/MiniBrowser` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node\nscripts/check_changes.ts bin/ldd ldd s/li\u0004\u0018` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"de0231e7ed82a2cddfaa4da0ca839076ca93fc6c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/268803","number":268803,"mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across `@elastic/actionable-obs-team` files (#268803)\n\nFixes 44 `@elastic/eui/icon-accessibility-rules` violations across 39\nfiles owned by `@elastic/actionable-obs-team`.\n\nAll icons are decorative (adjacent to visible text conveying the same\nmeaning), so each receives `aria-hidden={true}` per the accessibility\nskill guidance.\n\n```tsx\n// Before\n<EuiIcon type=\"warning\" color=\"danger\" />\n\n// After\n<EuiIcon type=\"warning\" color=\"danger\" aria-hidden={true} />\n```\n\n### Scope\n- **SLO plugin** — clock, chartGauge, external link, warning, info,\ninspect, controls, chevron icons\n- **Synthetics plugin** — dot, chevron, eyeSlash, flask,\ncheckCircleFill, eye, logoObservability, warning, connector type icons\n- **Uptime plugin** — popper, dataVisualizer, trash, lock, connector\ntype, image icons\n- **Exploratory View plugin** — stopFill, chart type, chevron icons\n- **Alert Details package** — warning annotation marker icon\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2\nt/webkit-2272/minibrowser-gtk/MiniBrowser` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node\nscripts/check_changes.ts bin/ldd ldd s/li\u0004\u0018` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 0.8.2\nche/ms-playwright/firefox-1511/firefox/libnspr4.so` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"de0231e7ed82a2cddfaa4da0ca839076ca93fc6c"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->