### PR TITLE
[Fleet]: run cluster_id sync and agentless deployment sync independently 

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.test.ts
@@ -659,6 +659,48 @@ describe('Agentless Deployment Sync', () => {
       );
     });
 
+    it('runs cluster_id sync and deployment update independently in the same pass', async () => {
+      const { logger, agentlessAgentService } = mockDependencies();
+      agentlessAgentService.listAgentlessDeployments.mockResolvedValueOnce({
+        deployments: [{ policy_id: 'policy1', revision_idx: 9, cluster_id: 'cluster-abc' }],
+      });
+
+      jest.mocked(agentPolicyService.getByIds).mockResolvedValueOnce([
+        {
+          id: 'policy1',
+          name: 'Agentless policy policy1',
+          is_managed: true,
+          revision: 10,
+          keep_monitoring_alive: true,
+          monitoring_enabled: [],
+          agentless: {},
+        },
+      ] as unknown as AgentPolicy[]);
+      jest.mocked(agentPolicyService.list).mockReset();
+      jest.mocked(agentPolicyService.list).mockResolvedValueOnce({
+        items: [] as AgentPolicy[],
+        total: 0,
+        page: 0,
+        perPage: 100,
+      });
+
+      await syncAgentlessDeployments({ logger, agentlessAgentService });
+
+      expect(agentPolicyService.update).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'policy1',
+        { agentless: { cluster_id: 'cluster-abc' } },
+        { bumpRevision: false }
+      );
+      expect(agentlessAgentService.createAgentlessAgent).toHaveBeenCalledTimes(1);
+      expect(agentlessAgentService.createAgentlessAgent).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'policy1' })
+      );
+    });
+
     it('logs error when cluster_id update fails', async () => {
       const { logger, agentlessAgentService } = mockDependencies();
       agentlessAgentService.listAgentlessDeployments.mockResolvedValueOnce({

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.ts
@@ -107,25 +107,10 @@ export async function syncAgentlessDeployments(
                   );
                 });
             }
-          } else if (
-            !agentPolicy.keep_monitoring_alive ||
-            (agentPolicy.monitoring_enabled?.length ?? 0) > 0
-          ) {
-            const esClient = appContextService.getInternalUserESClient();
-            const spacedScopedSoClient = appContextService.getInternalUserSOClientForSpaceId(
-              agentPolicy.namespace || undefined
-            );
-            logger.info(
-              `[Agentless Deployment Sync]${dryRunTag(
-                opts?.dryRun
-              )} Updating agentless policy monitoring settings ${agentPolicy.id}`
-            );
-            await agentPolicyService.update(spacedScopedSoClient, esClient, agentPolicy.id, {
-              // Ensure agentless policies keep monitoring alive so http monitoring server continue to work even without monitoring enabled
-              keep_monitoring_alive: true,
-              monitoring_enabled: [],
-            });
-          } else if (
+            return;
+          }
+
+          if (
             deployment.cluster_id &&
             deployment.cluster_id !== agentPolicy.agentless?.cluster_id
           ) {
@@ -159,6 +144,26 @@ export async function syncAgentlessDeployments(
                   );
                 });
             }
+          }
+
+          if (
+            !agentPolicy.keep_monitoring_alive ||
+            (agentPolicy.monitoring_enabled?.length ?? 0) > 0
+          ) {
+            const esClient = appContextService.getInternalUserESClient();
+            const spacedScopedSoClient = appContextService.getInternalUserSOClientForSpaceId(
+              agentPolicy.namespace || undefined
+            );
+            logger.info(
+              `[Agentless Deployment Sync]${dryRunTag(
+                opts?.dryRun
+              )} Updating agentless policy monitoring settings ${agentPolicy.id}`
+            );
+            await agentPolicyService.update(spacedScopedSoClient, esClient, agentPolicy.id, {
+              // Ensure agentless policies keep monitoring alive so http monitoring server continue to work even without monitoring enabled
+              keep_monitoring_alive: true,
+              monitoring_enabled: [],
+            });
           } else if (
             deployment.revision_idx === undefined ||
             deployment.revision_idx < agentPolicy.revision


### PR DESCRIPTION
## Summary

Previously, the cluster_id sync and the revision-based deployment sync  (`revision_idx`) were in a single else if chain, meaning only one could  execute per sync pass. This change converts them to independent if   blocks so both can apply in the same run, avoiding an unnecessary extra c cycle when a policy's cluster_id and revision are both out of  date.


cc @rubenruizdegauna 

