### PR TITLE
[9.4] [Security Solution][Detection Engine][O11y] Attach rule execution outcome to APM (#268289)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -6,6 +6,7 @@
  */
 
 import { omitBy } from 'lodash';
+import agent from 'elastic-apm-node';
 import type { Logger } from '@kbn/core/server';
 import { addSpanLabels } from '@kbn/apm-utils';
 import type {
@@ -31,7 +32,10 @@ import {
   LogLevelSetting,
   logLevelToNumber,
 } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
-import { SECURITY_RULE_STATUS } from '../../../../rule_types/utils/apm_field_names';
+import {
+  SECURITY_EXECUTION_OUTCOME,
+  SECURITY_RULE_STATUS,
+} from '../../../../rule_types/utils/apm_field_names';
 import type {
   ExecutionResult,
   IRuleExecutionLogForExecutors,
@@ -165,6 +169,17 @@ export function createRuleExecutionLogClientForExecutors(
             message: truncateValue(executionResult.message) ?? '',
             userError: executionResult.userError,
           };
+
+          agent.setCustomContext({
+            [SECURITY_EXECUTION_OUTCOME]: {
+              status: normalizedExecutionResult.status,
+              message: normalizedExecutionResult.message,
+              user_error: normalizedExecutionResult.userError,
+              errors: executionResultBuffer.errors,
+              warnings: executionResultBuffer.warnings,
+              metrics: executionResultBuffer.metrics,
+            },
+          });
 
           writeStatusChangeToEventLog(normalizedExecutionResult);
           writeMetricsToEventLog(executionResultBuffer.metrics);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/apm_field_names.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/apm_field_names.ts
@@ -41,6 +41,13 @@ export const SECURITY_RULE_ID = 'security_rule_id';
  */
 export const SECURITY_RULE_STATUS = 'security_rule_status';
 
+/**
+ * APM custom context key under which the full execution-outcome diagnostics document is
+ * attached to the rule-execution transaction. Written as custom context (not labels) to
+ * avoid the indexing cost of dozens of low-cardinality fields.
+ */
+export const SECURITY_EXECUTION_OUTCOME = 'security_execution_outcome';
+
 // Schema field names and descriptions for APM custom context set by security rule executors
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution][Detection Engine][O11y] Attach rule execution outcome to APM (#268289)](https://github.com/elastic/kibana/pull/268289)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Brooks","email":"hannah.brooks@elastic.co"},"sourceCommit":{"committedDate":"2026-05-13T13:01:45Z","message":"[Security Solution][Detection Engine][O11y] Attach rule execution outcome to APM (#268289)\n\n## Summary\n\nAddresses\n[#16304](https://github.com/elastic/security-team/issues/16304).\n\nAdds a `setCustomContext` call at the end of rule execution so the full\nexecution result + metrics are attached to the rule's APM transaction\nand viewable alongside the existing performance instrumentation. Extra\nfields that are mentioned in original issue have been taken care of by\nthe metrics.","sha":"0b0648702cb14324098b1ccbf744dce77158754b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Detection Engine","backport:previous-minor","v9.5.0"],"title":"[Security Solution][Detection Engine][O11y] Attach rule execution outcome to APM","number":268289,"url":"https://github.com/elastic/kibana/pull/268289","mergeCommit":{"message":"[Security Solution][Detection Engine][O11y] Attach rule execution outcome to APM (#268289)\n\n## Summary\n\nAddresses\n[#16304](https://github.com/elastic/security-team/issues/16304).\n\nAdds a `setCustomContext` call at the end of rule execution so the full\nexecution result + metrics are attached to the rule's APM transaction\nand viewable alongside the existing performance instrumentation. Extra\nfields that are mentioned in original issue have been taken care of by\nthe metrics.","sha":"0b0648702cb14324098b1ccbf744dce77158754b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/268289","number":268289,"mergeCommit":{"message":"[Security Solution][Detection Engine][O11y] Attach rule execution outcome to APM (#268289)\n\n## Summary\n\nAddresses\n[#16304](https://github.com/elastic/security-team/issues/16304).\n\nAdds a `setCustomContext` call at the end of rule execution so the full\nexecution result + metrics are attached to the rule's APM transaction\nand viewable alongside the existing performance instrumentation. Extra\nfields that are mentioned in original issue have been taken care of by\nthe metrics.","sha":"0b0648702cb14324098b1ccbf744dce77158754b"}}]}] BACKPORT-->