### PR TITLE
[Fleet] Fix flaky policy_secrets integration tests

### DIFF
--- a/x-pack/platform/test/fleet_api_integration/apis/policy_secrets.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/policy_secrets.ts
@@ -747,10 +747,16 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       it('should have correctly deleted unused secrets after update', async () => {
-        const searchRes = await getSecrets();
-        expect(searchRes.hits.hits.length).to.eql(5); // should have created 2 and deleted 2 docs
+        // Secret deletion is async — retry until the expected count is reached
+        let searchRes: Awaited<ReturnType<typeof getSecrets>> | undefined;
+        for (let i = 0; i < 5; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          searchRes = await getSecrets();
+          if (searchRes.hits.hits.length === 5) break;
+        }
+        expect(searchRes!.hits.hits.length).to.eql(5); // should have created 2 and deleted 2 docs
 
-        const secretValuesById = searchRes.hits.hits.reduce((acc: any, secret: any) => {
+        const secretValuesById = searchRes!.hits.hits.reduce((acc: any, secret: any) => {
           acc[secret._id] = secret._source.value;
           return acc;
         }, {});
@@ -911,13 +917,15 @@ export default function (providerContext: FtrProviderContext) {
           .set('kbn-xsrf', 'xxxx')
           .expect(200);
 
-        // sleep to allow for secrets to be deleted
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        // Secret deletion is async — retry until the expected count is reached
+        for (let i = 0; i < 5; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          const searchRes = await getSecrets();
+          // should have deleted new_package_secret_val_2 and new_package_multi_secret_val_3/4
+          if (searchRes.hits.hits.length === 5) return;
+        }
 
-        const searchRes = await getSecrets();
-
-        // should have deleted new_package_secret_val_2 and new_package_multi_secret_val_3/4
-        expect(searchRes.hits.hits.length).to.eql(5);
+        throw new Error('Secrets not deleted to expected count of 5');
       });
     });
 
@@ -964,9 +972,14 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('fleet server version requirements', () => {
       afterEach(async () => {
-        await cleanupAgents();
-        await cleanupPolicies();
-        await cleanupSecrets();
+        await pRetry(
+          async () => {
+            await cleanupAgents();
+            await cleanupPolicies();
+            await cleanupSecrets();
+          },
+          { retries: 3 }
+        );
       });
       it('should not store secrets if fleet server does not meet minimum version', async () => {
         const { fleetServerAgentPolicy } = await createFleetServerAgentPolicy();


### PR DESCRIPTION
## Summary
Fixes flaky failures in `policy_secrets.ts` FTR integration tests across two root causes:

**1. `afterEach` hook failures** — the `fleet server version requirements` describe block's cleanup (`cleanupAgents` → `cleanupPolicies` → `cleanupSecrets`) was failing intermittently due to transient 409 conflicts. Wrapped in `pRetry({ retries: 3 })`.

**2. Async secret deletion races** — two tests asserted secret counts immediately after a delete/update operation, before the async deletion completed. Applied the same retry loop (5 × 1s) already used in the `delete package policy` test.

Closes #266407, #257724, #247484, #239701, #236967, #230676

## Issues
- fixes #266407 — update: deleted unused secrets after update
- fixes #257724 — afterEach hook: "should store secrets if there are no fleet servers"
- fixes #247484 — copy: should not delete used secrets on delete of duplicated package policy
- fixes #239701 — afterEach hook: "should not revert to plaintext values if the user adds an out of date fleet server"
- fixes #236967 — delete: should delete all secrets on package policy delete
- fixes #230676 — afterEach hook: "should store secrets if additional fleet server does not meet minimum version, but is unenrolled"