### PR TITLE
[ci] Use GCS for test run order

### DIFF
--- a/.buildkite/scripts/steps/code_coverage/jest_parallel.sh
+++ b/.buildkite/scripts/steps/code_coverage/jest_parallel.sh
@@ -19,7 +19,7 @@ fi
 
 export TEST_TYPE
 echo "--- downloading jest test run order"
-download_artifact jest_run_order.json .
+download_tmp_artifact jest_run_order.json . "$BUILDKITE_BUILD_ID"
 configs=$(jq -r 'getpath([env.TEST_TYPE]) | .groups[env.JOB | tonumber].names | .[]' jest_run_order.json)
 
 echo "--- KIBANA_DIR: $KIBANA_DIR"

--- a/.buildkite/scripts/steps/test/ftr_configs.sh
+++ b/.buildkite/scripts/steps/test/ftr_configs.sh
@@ -35,7 +35,7 @@ fi
 
 if [ "$configs" == "" ] && [ "$FTR_CONFIG_GROUP_KEY" != "" ]; then
   echo "--- downloading ftr test run order"
-  download_artifact ftr_run_order.json .
+  download_tmp_artifact ftr_run_order.json . "$BUILDKITE_BUILD_ID"
   configs=$(jq -r '.[env.FTR_CONFIG_GROUP_KEY].names[]' ftr_run_order.json)
 fi
 

--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -28,7 +28,7 @@ export TEST_TYPE
 
 if [ "$configs" == "" ]; then
   echo "--- downloading jest test run order"
-  download_artifact jest_run_order.json .
+  download_tmp_artifact jest_run_order.json . "$BUILDKITE_BUILD_ID"
   configs=$(jq -r 'getpath([env.TEST_TYPE]) | .groups[env.JOB | tonumber].names | .[]' jest_run_order.json)
 fi
 

--- a/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
+++ b/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
@@ -10,3 +10,12 @@ source .buildkite/scripts/bootstrap.sh
 
 echo '--- Pick Test Group Run Order'
 ts-node "$(dirname "${0}")/pick_test_group_run_order.ts"
+
+echo '--- Upload test run order artifacts to GCS'
+if [[ -f jest_run_order.json ]]; then
+  upload_tmp_artifact jest_run_order.json jest_run_order.json "$BUILDKITE_BUILD_ID"
+fi
+
+if [[ -f ftr_run_order.json ]]; then
+  upload_tmp_artifact ftr_run_order.json ftr_run_order.json "$BUILDKITE_BUILD_ID"
+fi

--- a/.buildkite/scripts/steps/test/scout/configs.sh
+++ b/.buildkite/scripts/steps/test/scout/configs.sh
@@ -58,7 +58,7 @@ module_data=""
 SCHEDULED_MANIFEST="scout_playwright_configs_scheduled.json"
 if [ "$SCOUT_CONFIG_GROUP_KEY" != "" ]; then
   echo "--- Downloading Scout Test Configuration"
-  download_artifact "$SCHEDULED_MANIFEST" .
+  download_tmp_artifact "$SCHEDULED_MANIFEST" . "$BUILDKITE_BUILD_ID"
 
   # Extract module and its configs
   module_data=$(jq -c ".[] | select(.name == env.SCOUT_CONFIG_GROUP_KEY)" "$SCHEDULED_MANIFEST")

--- a/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
@@ -30,6 +30,7 @@ echo "--- Discover Playwright Configs (target=$SCOUT_DISCOVERY_TARGET)"
 node scripts/scout discover-playwright-configs --include-custom-servers --target "$SCOUT_DISCOVERY_TARGET" --save
 cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
 buildkite-agent artifact upload "scout_playwright_configs.json"
+upload_tmp_artifact scout_playwright_configs.json scout_playwright_configs.json "$BUILDKITE_BUILD_ID"
 
 echo '--- Plan and upload Scout flaky steps'
 ts-node .buildkite/pipelines/flaky_tests/pick_scout_flaky_run_order.ts

--- a/.buildkite/scripts/steps/test/scout/discover_playwright_configs.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_playwright_configs.sh
@@ -17,4 +17,5 @@ cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.js
 # directly from disk in the same step (see discover_and_plan_flaky.sh) and does
 # not depend on the artifact name.
 buildkite-agent artifact upload "scout_playwright_configs.json"
+upload_tmp_artifact scout_playwright_configs.json scout_playwright_configs.json "$BUILDKITE_BUILD_ID"
 

--- a/.buildkite/scripts/steps/test/scout/run_test_lane.sh
+++ b/.buildkite/scripts/steps/test/scout/run_test_lane.sh
@@ -33,7 +33,7 @@ check_required_env_vars() {
 # Download the test lane loads artifact produced by uploadAllScoutTestLaneSteps()
 download_test_lane_loads() {
   echo "--- Downloading test lane loads file"
-  download_artifact "$SCOUT_TEST_LANE_LOADS_PATH" .
+  download_tmp_artifact "$SCOUT_TEST_LANE_LOADS_PATH" . "$BUILDKITE_BUILD_ID"
 }
 
 # Read the comma-separated list of previously passed load indices from Buildkite metadata

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -111,9 +111,19 @@ else
     --save
   cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
   buildkite-agent artifact upload "scout_playwright_configs.json"
+  upload_tmp_artifact scout_playwright_configs.json scout_playwright_configs.json "$BUILDKITE_BUILD_ID"
 fi
 
 source .buildkite/scripts/steps/test/scout/upload_report_events.sh
 
 echo '--- Producing Scout Test Execution Steps'
 ts-node "$(dirname "${0}")/test_run_builder.ts"
+
+echo '--- Upload scout test run order artifacts to GCS'
+if [[ -f scout_playwright_configs_scheduled.json ]]; then
+  upload_tmp_artifact scout_playwright_configs_scheduled.json scout_playwright_configs_scheduled.json "$BUILDKITE_BUILD_ID"
+fi
+
+if [[ -f .scout/test_lane_loads.json ]]; then
+  upload_tmp_artifact .scout/test_lane_loads.json .scout/test_lane_loads.json "$BUILDKITE_BUILD_ID"
+fi


### PR DESCRIPTION
Part of an effort to move shared files between build agents to temporary storage on GCS, where we can more closely manage regions and lifecycles.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->