### PR TITLE
[Content List] Unified actions config: handlers + restrictions per actionId

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_features.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_features.stories.tsx
@@ -123,9 +123,13 @@ const CoreFeaturesWrapper = ({
   const itemConfig = useMemo(
     () => ({
       getHref: (item: ContentListItem) => `#/dashboard/${item.id}`,
-      onEdit: (item: ContentListItem) => alert(`Edit: ${item.title}`),
-      onDelete: async (_items: ContentListItem[]) => {
-        await new Promise((resolve) => setTimeout(resolve, 300));
+      actions: {
+        edit: { onItemAction: (item: ContentListItem) => alert(`Edit: ${item.title}`) },
+        delete: {
+          onBulkAction: async (_items: ContentListItem[]) => {
+            await new Promise((resolve) => setTimeout(resolve, 300));
+          },
+        },
       },
     }),
     []

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/dashboard_listing.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/dashboard_listing.stories.tsx
@@ -96,11 +96,14 @@ const useDashboardProviderProps = ({
   const item = useMemo(
     () => ({
       getHref: (content: ContentListItem) => `#/dashboard/${content.id}`,
-      getEditUrl: (content: ContentListItem) => `#/dashboard/${content.id}?view=edit`,
-      onDelete: async () => {
-        await wait(250);
+      actions: {
+        delete: {
+          onBulkAction: async () => {
+            await wait(250);
+          },
+        },
+        ...(includeInspect && onInspect ? { inspect: { onItemAction: onInspect } } : {}),
       },
-      ...(includeInspect && onInspect ? { onInspect } : {}),
     }),
     [includeInspect, onInspect]
   );
@@ -223,10 +226,148 @@ const ProposalStory = () => {
   );
 };
 
+// =============================================================================
+// Bulk-delete partition: dialog explains, never disables
+// =============================================================================
+
+/**
+ * IDs of dashboards treated as managed for these stories.
+ */
+const MANAGED_DASHBOARD_IDS = new Set(['dashboard-002', 'dashboard-005']);
+
+const MANAGED_DELETE_RESTRICTION = 'Managed dashboards cannot be deleted.';
+const MANAGED_EDIT_RESTRICTION = 'Managed dashboards cannot be edited.';
+
+const decorateAsManaged = (items: typeof MOCK_DASHBOARDS): typeof MOCK_DASHBOARDS =>
+  items.map((dashboard) =>
+    MANAGED_DASHBOARD_IDS.has(dashboard.id) ? { ...dashboard, managed: true } : dashboard
+  );
+
+const restrictManagedDelete = (content: ContentListItem) =>
+  content.managed ? MANAGED_DELETE_RESTRICTION : undefined;
+const restrictManagedEdit = (content: ContentListItem) =>
+  content.managed ? MANAGED_EDIT_RESTRICTION : undefined;
+
+const BulkDeleteStory = () => {
+  const favoritesClient = useMemo(
+    () => createMockFavoritesClient(['dashboard-001', 'dashboard-003', 'dashboard-007']),
+    []
+  );
+
+  const dataSource = useMemo(
+    () => ({
+      debounceMs: 0,
+      findItems: createMockStoryFindItems({
+        items: decorateAsManaged(MOCK_DASHBOARDS),
+        favoritesClient,
+      }),
+    }),
+    [favoritesClient]
+  );
+
+  const features = useMemo(
+    () => ({
+      sorting: {
+        initialSort: { field: 'updatedAt', direction: 'desc' as const },
+        fields: [
+          { field: 'title', name: 'Name' },
+          { field: 'updatedAt', name: 'Last updated' },
+        ],
+      },
+      pagination: { initialPageSize: 20 },
+      tags: createMockTagFacetProvider(MOCK_DASHBOARDS),
+      starred: true as const,
+      userProfiles: createMockUserProfileFacetProvider(MOCK_DASHBOARDS),
+      // Selection enabled so the toolbar's bulk-delete button appears.
+      selection: true,
+    }),
+    []
+  );
+
+  const item = useMemo(
+    () => ({
+      getHref: (content: ContentListItem) => `#/dashboard/${content.id}`,
+      // Handlers and restrictions declared once on the provider.
+      actions: {
+        edit: { onItemAction: () => undefined, restriction: restrictManagedEdit },
+        delete: {
+          onBulkAction: async () => {
+            await wait(250);
+          },
+          restriction: restrictManagedDelete,
+        },
+      },
+    }),
+    []
+  );
+
+  const pageElement = useMemo(
+    () => (
+      <KibanaContentListPage>
+        <KibanaContentListPage.Header
+          title="Dashboards"
+          tabs={[{ label: 'Dashboards', isSelected: true, onClick: () => undefined }]}
+        />
+        <Section>
+          <ContentList emptyState={<DashboardListingEmptyPromptMock />}>
+            <ContentListToolbar>
+              <Filters>
+                <Filters.Starred />
+                <Filters.Tags />
+                <Filters.CreatedBy />
+                <Filters.Sort />
+              </Filters>
+            </ContentListToolbar>
+            <ContentListTable title="Dashboards">
+              <Column.Name showDescription showTags showStarred />
+              <Column.CreatedBy />
+              <Column.UpdatedAt />
+              {/* Actions column default-infers Edit/Delete from itemConfig. */}
+              <Column.Actions />
+            </ContentListTable>
+            <ContentListFooter />
+          </ContentList>
+        </Section>
+      </KibanaContentListPage>
+    ),
+    []
+  );
+
+  return (
+    <ContentListProvider
+      id="dashboard-listing-bulk-delete-partition"
+      labels={labels}
+      services={{
+        favorites: favoritesClient,
+        tags: mockTagsService,
+        userProfiles: mockContentListUserProfilesServices,
+      }}
+      dataSource={dataSource}
+      features={features}
+      item={item}
+    >
+      {pageElement}
+      <EuiSpacer size="m" />
+      <StateDiagnosticPanel element={pageElement} />
+    </ContentListProvider>
+  );
+};
+
 export const Original: StoryObj = {
   render: () => <OriginalStory />,
 };
 
 export const Proposal: StoryObj = {
   render: () => <ProposalStory />,
+};
+
+/**
+ * Demonstrates the bulk-delete partition policy.
+ *
+ * - Selection checkboxes on managed rows are disabled with a tooltip.
+ * - Row-level Delete and Edit icons on managed rows are disabled.
+ * - The toolbar "Delete N dashboards" button is never disabled per-selection.
+ */
+export const BulkDeletePartition: StoryObj = {
+  render: () => <BulkDeleteStory />,
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/files_management.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/files_management.stories.tsx
@@ -107,10 +107,14 @@ const useFilesProviderProps = (onInspect?: (item: ContentListItem) => void) => {
 
   const item = useMemo(
     () => ({
-      onDelete: async () => {
-        await wait(250);
+      actions: {
+        delete: {
+          onBulkAction: async () => {
+            await wait(250);
+          },
+        },
+        ...(onInspect ? { inspect: { onItemAction: onInspect } } : {}),
       },
-      ...(onInspect ? { onInspect } : {}),
     }),
     [onInspect]
   );

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/maps.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/maps.stories.tsx
@@ -82,10 +82,14 @@ const useMapsProviderProps = ({
   const item = useMemo(
     () => ({
       getHref: (content: ContentListItem) => `#/maps/map/${content.id}`,
-      onDelete: async () => {
-        await wait(250);
+      actions: {
+        delete: {
+          onBulkAction: async () => {
+            await wait(250);
+          },
+        },
+        ...(onInspect ? { inspect: { onItemAction: onInspect } } : {}),
       },
-      ...(onInspect ? { onInspect } : {}),
     }),
     [onInspect]
   );

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/builder_panel.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/builder_panel.tsx
@@ -245,28 +245,21 @@ export const BuilderPanel = ({ state, dispatch }: BuilderPanelProps) => {
               onChange={(v) => dispatch({ type: 'SET_ITEM_PROP', key: 'getHref', value: v })}
             />
           </JsxPropDisplay>
-          <JsxPropDisplay name="getEditUrl">
-            <InlineCheckbox
-              id={`${idPrefix}-getEditUrl`}
-              checked={item.getEditUrl}
-              onChange={(v) => dispatch({ type: 'SET_ITEM_PROP', key: 'getEditUrl', value: v })}
-            />
-          </JsxPropDisplay>
-          <JsxPropDisplay name="onEdit">
+          <JsxPropDisplay name="actions.edit">
             <InlineCheckbox
               id={`${idPrefix}-onEdit`}
               checked={item.onEdit}
               onChange={(v) => dispatch({ type: 'SET_ITEM_PROP', key: 'onEdit', value: v })}
             />
           </JsxPropDisplay>
-          <JsxPropDisplay name="onDelete">
+          <JsxPropDisplay name="actions.delete">
             <InlineCheckbox
               id={`${idPrefix}-onDelete`}
               checked={item.onDelete}
               onChange={(v) => dispatch({ type: 'SET_ITEM_PROP', key: 'onDelete', value: v })}
             />
           </JsxPropDisplay>
-          <JsxPropDisplay name="onInspect">
+          <JsxPropDisplay name="actions.inspect">
             <InlineCheckbox
               id={`${idPrefix}-onInspect`}
               checked={item.onInspect}
@@ -409,7 +402,7 @@ export const BuilderPanel = ({ state, dispatch }: BuilderPanelProps) => {
                         !item.onDelete &&
                         !item.onInspect &&
                         !col.actions.some((a) => !['edit', 'delete', 'inspect'].includes(a.type))
-                          ? 'This column is hidden because no item actions (onEdit, onDelete, onInspect) are configured on the provider and no custom actions are present.'
+                          ? 'This column is hidden because no item actions (actions.edit, actions.delete, actions.inspect) are configured on the provider and no custom actions are present.'
                           : undefined
                       }
                     />

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/instructions.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/instructions.md
@@ -19,7 +19,7 @@ All three child components read their state from the provider via context, so th
 
 The JSX-shaped tree on the left mirrors the component hierarchy you are building. Each node has inline controls:
 
-- **Provider props** — toggle features like sorting, pagination, and search; set entity labels; enable item-level callbacks (`getHref`, `getEditUrl`, `onEdit`, `onDelete`).
+- **Provider props** — toggle features like sorting, pagination, and search; set entity labels; enable item-level navigation (`getHref`) and action handlers (`actions.edit`, `actions.delete`, `actions.inspect`).
 - **Columns** — drag to reorder, click the arrow to edit props (`width`, `columnTitle`, etc.), or press ✕ to remove.
 - **Actions** — nested inside `Column.Actions`; drag to reorder or remove.
 - **Filters** — toolbar filter components like `Filters.Sort`.
@@ -43,9 +43,9 @@ Actions are children of `Column.Actions`:
 
 | Component | Description |
 |---|---|
-| `Action.Edit` | Opens the item for editing (requires `onEdit` or `getEditUrl`). |
-| `Action.Delete` | Triggers a delete-confirmation modal (requires `onDelete`). |
-| `Action (Export)` | Custom action example — demonstrates the base `Action` API with an icon and click handler. |
+| `Action.Edit` | Opens the item for editing (requires `actions.edit.onItemAction`). |
+| `Action.Delete` | Triggers a delete-confirmation modal (requires `actions.delete.onBulkAction`). |
+| `Action (Export)` | Custom action example — demonstrates the base `Action` API. Behavior is supplied via `actions.export.onItemAction` on the provider's item config. |
 
 > **Tip:** If `Column.Actions` is present but no item callbacks are enabled on the provider and no custom actions are present, the column is hidden. Look for the ⚠ warning icon in the builder panel.
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_builder.tsx
@@ -185,23 +185,35 @@ const usePreview = (state: PlaygroundState, onInspect?: (item: ContentListItem) 
 
   const providerItemConfig = useMemo(() => {
     const config: Record<string, unknown> = {};
+    const actions: Record<string, unknown> = {};
+
     if (itemConfig.getHref) {
       config.getHref = (i: ContentListItem) => `#/${provider.entity}/${i.id}`;
     }
-    if (itemConfig.getEditUrl) {
-      config.getEditUrl = (i: ContentListItem) => `#/${provider.entity}/${i.id}/edit`;
-    }
     if (itemConfig.onEdit) {
-      config.onEdit = (i: ContentListItem) => alert(`Edit: ${i.title}`);
+      actions.edit = { onItemAction: (i: ContentListItem) => alert(`Edit: ${i.title}`) };
     }
     if (itemConfig.onDelete) {
-      config.onDelete = async () => {
-        await new Promise((resolve) => setTimeout(resolve, 300));
+      actions.delete = {
+        onBulkAction: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 300));
+        },
       };
     }
     if (itemConfig.onInspect && onInspect) {
-      config.onInspect = onInspect;
+      actions.inspect = { onItemAction: onInspect };
     }
+
+    // Sample handler for the custom `'export'` action declared in the
+    // playground's actions column.
+    actions.export = {
+      onItemAction: (item: ContentListItem) => alert(`Export: ${item.title}`),
+    };
+
+    if (Object.keys(actions).length > 0) {
+      config.actions = actions;
+    }
+
     return Object.keys(config).length > 0 ? config : undefined;
   }, [itemConfig, provider.entity, onInspect]);
 
@@ -253,7 +265,6 @@ const usePreview = (state: PlaygroundState, onInspect?: (item: ContentListItem) 
                           id="export"
                           name="Export"
                           icon="exportAction"
-                          onClick={(item) => alert(`Export: ${item.title}`)}
                         />
                       );
                     default:

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
@@ -52,7 +52,6 @@ export interface PlaygroundState {
   };
   item: {
     getHref: boolean;
-    getEditUrl: boolean;
     onEdit: boolean;
     onDelete: boolean;
     onInspect: boolean;
@@ -236,7 +235,6 @@ export const INITIAL_STATE: PlaygroundState = {
   },
   item: {
     getHref: true,
-    getEditUrl: false,
     onEdit: false,
     onDelete: false,
     onInspect: false,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/stories_helpers.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/stories_helpers.tsx
@@ -108,13 +108,14 @@ const InspectFlyout = ({ item, onClose }: { item: ContentListItem; onClose: () =
 /**
  * Hook that manages the open/close state for a mock inspect flyout.
  *
- * Returns an `onInspect` callback suitable for `ContentListItemConfig.onInspect`
- * and a `flyout` element to render in the component tree.
+ * Returns an `onInspect` callback suitable for
+ * `ContentListItemConfig.actions.inspect.onItemAction` and a `flyout`
+ * element to render in the component tree.
  *
  * @example
  * ```tsx
  * const { onInspect, flyout } = useInspectFlyout();
- * // pass onInspect to item config, render {flyout} in JSX
+ * // pass onInspect via `actions.inspect.onItemAction`, render `{flyout}` in JSX
  * ```
  */
 export const useInspectFlyout = (): {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
@@ -121,7 +121,7 @@ Each subfolder is named after the `ContentListClientProvider` field it serves:
 | `createContentInsightsService(opts)` + `<SavedObjectActivityRow>` | `services/content_insights/` | `contentEditor.appendRows`            |
 | `createDuplicateTitleValidator(opts)` | `services/duplicate_title/` | `contentEditor.customValidators.title`|
 | `useRecentlyAccessedDecoration(src)`  | `services/recently_accessed/` | `findItems` decoration + `features.flags` + a closure-bound `RecentsFilter` |
-| `withPerformanceMetrics(fn, opts)`    | `services/performance_metrics/` | wraps `findItems` / `onDelete` |
+| `withPerformanceMetrics(fn, opts)`    | `services/performance_metrics/` | wraps `findItems` / `actions.delete.onBulkAction` |
 
 Each helper is tested in isolation and is independently optional. Use one, several, or none — `ContentListClientProvider` accepts the raw types either way.
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/types.ts
@@ -18,9 +18,9 @@ import type { ContentListItem } from '@kbn/content-list-provider';
  * Content editor configuration for `ContentListClientProvider`.
  *
  * This is the Kibana-specific content editor integration. The base
- * `ContentListProvider` only knows about a simple `onInspect` callback;
- * this config produces that callback by wiring it to the Kibana content
- * editor flyout.
+ * `ContentListProvider` only knows about an `actions.inspect.onItemAction`
+ * callback; this config produces that callback by wiring it to the
+ * Kibana content editor flyout.
  */
 export interface ContentEditorConfig {
   /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/use_content_editor_inspect.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/use_content_editor_inspect.ts
@@ -22,17 +22,12 @@ const MANAGED_READONLY_REASON = i18n.translate(
 );
 
 /**
- * Creates an `onInspect` callback that opens the Kibana content editor flyout.
+ * Creates an inspect callback that opens the Kibana content editor flyout.
  *
- * This hook encapsulates all Kibana-specific content editor logic:
- * - Transforming `ContentListItem` to the content editor's `Item` shape
- * - Forcing managed items into read-only mode with an explanatory reason
- * - Wrapping `onSave` with query invalidation (to trigger refetch) and flyout close
+ * Returns `undefined` when `contentEditor` is not provided.
  *
- * Returns `undefined` when `contentEditor` is not provided, so the base provider's
- * `item.onInspect` remains unset and the inspect action won't render.
- *
- * @internal Used by `ContentListClientProvider`.
+ * @internal Used by `ContentListClientProvider` to populate
+ * `itemConfig.actions.inspect.onItemAction`.
  */
 export const useContentEditorInspect = ({
   contentEditor,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.test.tsx
@@ -331,9 +331,11 @@ describe('ContentListClientProvider', () => {
       const { result } = renderHook(() => useContentListConfig(), {
         wrapper: createWrapper(props),
       });
-      const onInspect = result.current.item?.onInspect;
+      const onInspect = result.current.item?.actions?.inspect?.onItemAction;
       if (!onInspect) {
-        throw new Error('expected provider to expose onInspect when contentEditor is configured');
+        throw new Error(
+          'expected provider to expose actions.inspect.onItemAction when contentEditor is configured'
+        );
       }
       return { onInspect, dataSource: result.current.dataSource };
     };
@@ -425,6 +427,53 @@ describe('ContentListClientProvider', () => {
       // Read-only flyout never receives an onSave to wrap, so the inspect
       // path should not synthesise one.
       expect(params?.onSave).toBeUndefined();
+    });
+  });
+
+  describe('inspect action merge', () => {
+    // The merge spreads the existing config so only `onItemAction` is overridden.
+    it('preserves consumer-provided `actions.inspect.restriction` when injecting the inspect handler', () => {
+      const openContentEditor = jest.fn<() => void, [OpenContentEditorParams]>(() => jest.fn());
+      const restriction = jest.fn(() => 'archived');
+      // Consumer-provided placeholder handler — the discriminated union
+      // requires at least one handler. The client provider's injection
+      // is what actually opens the flyout, so this should be overridden.
+      const consumerOnItemAction = jest.fn();
+
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          contentEditor: { openContentEditor, isReadonly: true },
+          item: {
+            actions: { inspect: { onItemAction: consumerOnItemAction, restriction } },
+          },
+        }),
+      });
+
+      const inspect = result.current.item?.actions?.inspect;
+      expect(inspect?.onItemAction).toEqual(expect.any(Function));
+      // The consumer's placeholder is overridden by the injected handler.
+      expect(inspect?.onItemAction).not.toBe(consumerOnItemAction);
+      // The restriction flows through unchanged.
+      expect(inspect?.restriction).toBe(restriction);
+    });
+
+    it('preserves other consumer-provided `actions[id]` entries unchanged', () => {
+      const openContentEditor = jest.fn<() => void, [OpenContentEditorParams]>(() => jest.fn());
+      const archiveOnBulkAction = jest.fn(async () => {});
+
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          contentEditor: { openContentEditor, isReadonly: true },
+          item: {
+            actions: {
+              archive: { onBulkAction: archiveOnBulkAction },
+            },
+          },
+        }),
+      });
+
+      const archive = result.current.item?.actions?.archive;
+      expect(archive?.onBulkAction).toBe(archiveOnBulkAction);
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.tsx
@@ -128,10 +128,11 @@ export type ContentListClientProviderProps = ContentListCoreConfig & {
   /**
    * Content editor (metadata editing flyout) configuration.
    *
-   * When provided, creates an `onInspect` callback on the item config that opens
-   * the Kibana content editor flyout. The consumer must wrap their component tree
-   * with `ContentEditorKibanaProvider` (from `@kbn/content-management-content-editor`)
-   * above this provider.
+   * When provided, populates `actions.inspect.onItemAction` on the item
+   * config with a handler that opens the Kibana content editor flyout.
+   * The consumer must wrap their component tree with
+   * `ContentEditorKibanaProvider` (from
+   * `@kbn/content-management-content-editor`) above this provider.
    */
   contentEditor?: ContentEditorConfig;
 };
@@ -394,7 +395,7 @@ export const ContentListClientProvider = ({
     };
   }, [contentEditor, onInvalidate]);
 
-  // Create the onInspect callback from the content editor config.
+  // Create the inspect handler from the content editor config.
   const onInspect = useContentEditorInspect({
     contentEditor: contentEditorWithInvalidation,
     entityName: rest.labels.entity,
@@ -402,14 +403,23 @@ export const ContentListClientProvider = ({
     queryKeyScope,
   });
 
-  // Merge onInspect into the item config.
-  const itemConfig = useMemo(
-    () => ({
+  // Merge the inspect handler into the item config, preserving consumer-supplied
+  // fields on `actions.inspect` (e.g. `restriction`). Only `onItemAction` is overridden.
+  const itemConfig = useMemo(() => {
+    if (!onInspect) {
+      return itemConfigProp;
+    }
+    return {
       ...itemConfigProp,
-      ...(onInspect && { onInspect }),
-    }),
-    [itemConfigProp, onInspect]
-  );
+      actions: {
+        ...itemConfigProp?.actions,
+        inspect: {
+          ...itemConfigProp?.actions?.inspect,
+          onItemAction: onInspect,
+        },
+      },
+    };
+  }, [itemConfigProp, onInspect]);
 
   return (
     <ContentListProvider

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/index.ts
@@ -43,5 +43,5 @@ export {
   type RecentlyAccessedHistorySource,
 } from './recently_accessed';
 
-// Helpers for wrapping `findItems` / `onDelete` with EBT performance metrics.
+// Helpers for wrapping `findItems` / `actions.delete.onBulkAction` with EBT performance metrics.
 export { withPerformanceMetrics, type PerformanceMetricsOptions } from './performance_metrics';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
@@ -70,7 +70,14 @@ export { CONTENT_LIST_ACTIONS } from './src/state';
 export type { ContentListAction } from './src/state';
 
 // Types.
-export type { ContentListItem, ContentListItemConfig } from './src/item';
+export type {
+  ContentListItem,
+  ContentListItemConfig,
+  ContentListActions,
+  ActionConfig,
+  ActionId,
+  KnownActionId,
+} from './src/item';
 export type {
   ContentListFeatures,
   ContentListSupports,
@@ -135,3 +142,11 @@ export {
 
 // Utilities.
 export { contentListKeys, contentListQueryClient } from './src/query';
+
+// Bulk actions (per-action restriction predicates and partitioning).
+export type {
+  RegisteredBulkAction,
+  BulkActionPartition,
+  BulkActionSkippedItem,
+} from './src/bulk_actions';
+export { useBulkActionRestrictions, partitionByRestriction } from './src/bulk_actions';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/index.ts
@@ -7,20 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  ContentListItem,
-  ContentListItemConfig,
-  ContentListActions,
-  ActionConfig,
-  ActionId,
-  KnownActionId,
-} from './types';
+export type { RegisteredBulkAction } from './types';
+export { useBulkActionRestrictions } from './use_bulk_action_restrictions';
 export {
-  USER_UID_FIELDS,
-  MANAGED_USER_FILTER,
-  NO_CREATOR_USER_FILTER,
-  MANAGED_USER_LABEL,
-  NO_CREATOR_USER_LABEL,
-  SENTINEL_KEYS,
-  getCreatorKey,
-} from './types';
+  BulkActionRegistryContext,
+  buildRegisteredActions,
+  useBulkActionRegistryContext,
+} from './registry';
+
+export type { BulkActionPartition, BulkActionSkippedItem } from './partition';
+export { partitionByRestriction } from './partition';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/partition.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/partition.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ContentListItem } from '../item';
+import { partitionByRestriction } from './partition';
+
+const item = (id: string, extras: Partial<ContentListItem> = {}): ContentListItem => ({
+  id,
+  title: `Item ${id}`,
+  ...extras,
+});
+
+describe('partitionByRestriction', () => {
+  it('treats every item as permitted when no predicate is supplied', () => {
+    const items = [item('1'), item('2'), item('3')];
+
+    const result = partitionByRestriction(items);
+
+    expect(result.permitted).toEqual(items);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('returns a copy of the input array when no predicate is supplied', () => {
+    const items = [item('1')];
+
+    const result = partitionByRestriction(items);
+
+    expect(result.permitted).not.toBe(items);
+  });
+
+  it('routes items with an `undefined` reason to `permitted`', () => {
+    const items = [item('1'), item('2')];
+
+    const result = partitionByRestriction(items, () => undefined);
+
+    expect(result.permitted).toEqual(items);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('routes items with a string reason to `skipped`', () => {
+    const items = [item('1'), item('2')];
+
+    const result = partitionByRestriction(items, () => 'Restricted');
+
+    expect(result.permitted).toEqual([]);
+    expect(result.skipped).toEqual([
+      { item: items[0], reason: 'Restricted' },
+      { item: items[1], reason: 'Restricted' },
+    ]);
+  });
+
+  it('partitions a mixed selection by the predicate', () => {
+    const items = [
+      item('1', { managed: true }),
+      item('2', { managed: false }),
+      item('3', { managed: true }),
+      item('4', { managed: false }),
+    ];
+
+    const result = partitionByRestriction(items, (i) =>
+      i.managed ? 'Managed dashboards cannot be deleted.' : undefined
+    );
+
+    expect(result.permitted).toEqual([items[1], items[3]]);
+    expect(result.skipped).toEqual([
+      { item: items[0], reason: 'Managed dashboards cannot be deleted.' },
+      { item: items[2], reason: 'Managed dashboards cannot be deleted.' },
+    ]);
+  });
+
+  it('preserves input order within each subset', () => {
+    const items = [
+      item('a', { managed: true }),
+      item('b', { managed: false }),
+      item('c', { managed: true }),
+      item('d', { managed: false }),
+      item('e', { managed: true }),
+    ];
+
+    const result = partitionByRestriction(items, (i) => (i.managed ? 'restricted' : undefined));
+
+    expect(result.permitted.map((i) => i.id)).toEqual(['b', 'd']);
+    expect(result.skipped.map((s) => s.item.id)).toEqual(['a', 'c', 'e']);
+  });
+
+  it('returns empty subsets for an empty input', () => {
+    const result = partitionByRestriction([], () => 'whatever');
+
+    expect(result.permitted).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('lets the predicate return per-item reason strings', () => {
+    const items = [item('1', { managed: true }), item('2', { type: 'system' })];
+
+    const result = partitionByRestriction(items, (i: ContentListItem) => {
+      if (i.managed) {
+        return 'Managed';
+      }
+      if (i.type === 'system') {
+        return 'System';
+      }
+      return undefined;
+    });
+
+    expect(result.permitted).toEqual([]);
+    expect(result.skipped.map((s) => s.reason)).toEqual(['Managed', 'System']);
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/partition.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/partition.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ContentListItem } from '../item';
+
+/**
+ * One row in the `skipped` partition: an item that cannot have the bulk
+ * action applied to it, paired with the human-readable reason returned by
+ * the action's restriction predicate.
+ */
+export interface BulkActionSkippedItem {
+  /** The original item the consumer asked the action to apply to. */
+  item: ContentListItem;
+  /** Reason string from the action's restriction predicate. */
+  reason: string;
+}
+
+/**
+ * The result of partitioning a bulk-action request through one action's
+ * restriction predicate.
+ *
+ * `permitted` is the subset of items the action's confirm dialog will
+ * forward to the action handler if the user confirms; `skipped` is the
+ * subset shown in the dialog's "can't be acted upon" callout so the user
+ * knows up-front that not every requested item will be affected.
+ */
+export interface BulkActionPartition {
+  permitted: ContentListItem[];
+  skipped: BulkActionSkippedItem[];
+}
+
+/**
+ * Partition `items` into permitted and non-permitted subsets using a
+ * single bulk-action restriction predicate.
+ *
+ * Items the predicate marks as restricted are routed to `skipped`
+ * (with reason), and only `permitted` items reach the action handler.
+ * When `restriction` is `undefined`, every item is permitted.
+ */
+export const partitionByRestriction = (
+  items: ContentListItem[],
+  restriction?: (item: ContentListItem) => string | undefined
+): BulkActionPartition => {
+  if (!restriction) {
+    return { permitted: items.slice(), skipped: [] };
+  }
+
+  const permitted: ContentListItem[] = [];
+  const skipped: BulkActionSkippedItem[] = [];
+
+  for (const item of items) {
+    const reason = restriction(item);
+    if (reason === undefined) {
+      permitted.push(item);
+    } else {
+      skipped.push({ item, reason });
+    }
+  }
+
+  return { permitted, skipped };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/registry.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/registry.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createContext, useContext } from 'react';
+import type { ContentListItemConfig } from '../item';
+import type { RegisteredBulkAction } from './types';
+
+/**
+ * Internal registry context value: the current list of registered bulk
+ * actions, derived from `itemConfig.actions`. The registry is a pure
+ * projection of provider config.
+ */
+interface BulkActionRegistryContextValue {
+  /** Latest list of registered bulk actions (keyed by `actionId`). */
+  actions: RegisteredBulkAction[];
+}
+
+/**
+ * Context that exposes the bulk-action registry to consumers (the row
+ * selection bridge and the toolbar's delete-confirmation dialog).
+ *
+ * @internal Provided directly by `ContentListProvider`; readers go
+ * through {@link useBulkActionRestrictions}.
+ */
+export const BulkActionRegistryContext = createContext<BulkActionRegistryContextValue | null>(null);
+
+/**
+ * Build the bulk-action entries that are operative for the current
+ * provider configuration.
+ *
+ * "Operative" means both `onBulkAction` and `restriction` are configured.
+ * Without a handler, the action can't be taken. Without a restriction,
+ * the action is unrestricted.
+ */
+export const buildRegisteredActions = (
+  itemConfig: ContentListItemConfig | undefined
+): RegisteredBulkAction[] => {
+  if (!itemConfig?.actions) {
+    return [];
+  }
+
+  const result: RegisteredBulkAction[] = [];
+
+  for (const [actionId, config] of Object.entries(itemConfig.actions)) {
+    if (typeof config?.onBulkAction === 'function' && typeof config.restriction === 'function') {
+      result.push({ actionId, restriction: config.restriction });
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Internal accessor for the bulk-action registry context.
+ *
+ * Returns `null` when invoked outside `ContentListProvider`, so the
+ * public read hook can degrade gracefully (no registered actions). The
+ * package always wraps consumers in a provider, so `null` only occurs
+ * in test setups that bypass `ContentListProvider`.
+ *
+ * @internal
+ */
+export const useBulkActionRegistryContext = (): BulkActionRegistryContextValue | null => {
+  return useContext(BulkActionRegistryContext);
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/types.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActionId, ContentListItem } from '../item';
+
+/**
+ * Registry entry pairing a bulk action's identifier with its restriction
+ * predicate.
+ *
+ * The registry is a pure projection of `itemConfig.actions`.
+ * `ContentListProvider` registers an entry per action whose `onBulkAction`
+ * handler AND `restriction` predicate are both supplied.
+ */
+export interface RegisteredBulkAction {
+  /** Stable identifier for the bulk action (e.g. `'delete'`). */
+  actionId: ActionId;
+  /** Predicate returning a reason when the action is restricted on `item`. */
+  restriction: (item: ContentListItem) => string | undefined;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/use_bulk_action_restrictions.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/use_bulk_action_restrictions.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { ContentListProvider } from '../context';
+import type { ContentListItem, ContentListItemConfig } from '../item';
+import type { FindItemsResult, FindItemsParams } from '../datasource';
+import { useBulkActionRestrictions } from './use_bulk_action_restrictions';
+
+const mockFindItems = jest.fn(
+  async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+    items: [],
+    total: 0,
+  })
+);
+
+interface WrapperOptions {
+  item?: ContentListItemConfig;
+}
+
+const createWrapper =
+  ({ item }: WrapperOptions = {}) =>
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+        dataSource={{ findItems: mockFindItems }}
+        {...(item ? { item } : {})}
+      >
+        {children}
+      </ContentListProvider>
+    );
+
+const sampleItem = { id: '1', title: 'Item 1' } as ContentListItem;
+
+const restrictManaged = (i: ContentListItem) => (i.managed ? 'managed' : undefined);
+
+describe('useBulkActionRestrictions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty array when no actions are configured', () => {
+    const { result } = renderHook(() => useBulkActionRestrictions(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns an empty array when `actions.delete.onBulkAction` is configured without a `restriction`', () => {
+    // Without a restriction predicate the action is unrestricted.
+    const { result } = renderHook(() => useBulkActionRestrictions(), {
+      wrapper: createWrapper({
+        item: { actions: { delete: { onBulkAction: jest.fn(async () => {}) } } },
+      }),
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns an empty array when only `actions.delete.restriction` is configured (no `onBulkAction`)', () => {
+    // Delete is not bulk-eligible without `onBulkAction`.
+    // Cast through `unknown` to construct the "invalid" config and verify the runtime gate.
+    const invalidItem = {
+      actions: { delete: { restriction: restrictManaged } },
+    } as unknown as ContentListItemConfig;
+
+    const { result } = renderHook(() => useBulkActionRestrictions(), {
+      wrapper: createWrapper({ item: invalidItem }),
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('publishes the delete restriction when both `onBulkAction` and `restriction` are configured', () => {
+    const { result } = renderHook(() => useBulkActionRestrictions(), {
+      wrapper: createWrapper({
+        item: {
+          actions: {
+            delete: { onBulkAction: jest.fn(async () => {}), restriction: restrictManaged },
+          },
+        },
+      }),
+    });
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].actionId).toBe('delete');
+    expect(result.current[0].restriction({ ...sampleItem, managed: true })).toBe('managed');
+    expect(result.current[0].restriction({ ...sampleItem, managed: false })).toBeUndefined();
+  });
+
+  it('does not publish row-only action entries (e.g. `actions.edit`)', () => {
+    const { result } = renderHook(() => useBulkActionRestrictions(), {
+      wrapper: createWrapper({
+        item: {
+          actions: {
+            edit: { onItemAction: jest.fn(), restriction: () => 'cannot edit' },
+            delete: { onBulkAction: jest.fn(async () => {}), restriction: restrictManaged },
+          },
+        },
+      }),
+    });
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].actionId).toBe('delete');
+  });
+
+  it('publishes custom bulk-eligible actions (e.g. `actions.archive`)', () => {
+    // Custom action IDs flow through the same registry pipeline.
+    const restrictArchived = (i: ContentListItem) =>
+      (i as ContentListItem & { archived?: boolean }).archived ? 'already archived' : undefined;
+
+    const { result } = renderHook(() => useBulkActionRestrictions(), {
+      wrapper: createWrapper({
+        item: {
+          actions: {
+            delete: { onBulkAction: jest.fn(async () => {}), restriction: restrictManaged },
+            archive: { onBulkAction: jest.fn(async () => {}), restriction: restrictArchived },
+          },
+        },
+      }),
+    });
+
+    expect(result.current.map((entry) => entry.actionId).sort()).toEqual(['archive', 'delete']);
+  });
+
+  it('preserves array identity across renders when `itemConfig` does not change', () => {
+    const item: ContentListItemConfig = {
+      actions: {
+        delete: { onBulkAction: jest.fn(async () => {}), restriction: restrictManaged },
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useBulkActionRestrictions(), {
+      wrapper: createWrapper({ item }),
+    });
+
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('returns an empty array when used outside a `ContentListProvider`', () => {
+    const { result } = renderHook(() => useBulkActionRestrictions());
+    expect(result.current).toEqual([]);
+  });
+
+  it('serves the same registry to multiple readers under one provider, and one reader unmounting does not affect the other', () => {
+    // With the provider-derived projection there is one source of truth,
+    // so multiple readers see the same array and unmounting any reader
+    // does not perturb others.
+    const item: ContentListItemConfig = {
+      actions: {
+        delete: { onBulkAction: jest.fn(async () => {}), restriction: restrictManaged },
+      },
+    };
+    const wrapper = createWrapper({ item });
+
+    const readerA = renderHook(() => useBulkActionRestrictions(), { wrapper });
+    const readerB = renderHook(() => useBulkActionRestrictions(), { wrapper });
+
+    expect(readerA.result.current).toHaveLength(1);
+    expect(readerB.result.current).toHaveLength(1);
+    expect(readerA.result.current[0].restriction).toBe(item.actions!.delete!.restriction);
+    expect(readerB.result.current[0].restriction).toBe(item.actions!.delete!.restriction);
+
+    readerA.unmount();
+
+    // Reader B's view is unaffected by Reader A's unmount.
+    expect(readerB.result.current).toHaveLength(1);
+    expect(readerB.result.current[0].restriction).toBe(item.actions!.delete!.restriction);
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/use_bulk_action_restrictions.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/bulk_actions/use_bulk_action_restrictions.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useBulkActionRegistryContext } from './registry';
+import type { RegisteredBulkAction } from './types';
+
+const EMPTY: RegisteredBulkAction[] = [];
+
+/**
+ * Read the bulk actions currently registered on the active content list.
+ *
+ * The registry is purely a projection of `itemConfig.actions`, derived
+ * by `ContentListProvider` on every render.
+ *
+ * Returns an empty array when called outside a content list provider.
+ */
+export const useBulkActionRestrictions = (): RegisteredBulkAction[] => {
+  const ctx = useBulkActionRegistryContext();
+  return ctx?.actions ?? EMPTY;
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.component.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.component.tsx
@@ -8,16 +8,35 @@
  */
 
 import React from 'react';
-import { EuiConfirmModal, EuiCallOut, EuiSpacer, useGeneratedHtmlId } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiConfirmModal,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ContentListItem } from '../../item';
+import type { BulkActionSkippedItem } from '../../bulk_actions';
 
 /**
  * Props for the presentational {@link DeleteConfirmationComponent}.
+ *
+ * The component receives a pre-computed {@link BulkActionPartition}
+ * separating items into `permitted` (will be deleted) and `skipped`
+ * (rejected by the restriction predicate, with reasons).
  */
 export interface DeleteConfirmationComponentProps {
-  /** Items being deleted. */
-  items: ContentListItem[];
+  /** Items that will actually be deleted on confirm. */
+  permitted: ContentListItem[];
+  /** Items rejected by the registered delete restriction, with reasons. */
+  skipped: BulkActionSkippedItem[];
   /** Singular entity name (e.g., "dashboard"). */
   entityName: string;
   /** Plural entity name (e.g., "dashboards"). */
@@ -26,21 +45,27 @@ export interface DeleteConfirmationComponentProps {
   isDeleting: boolean;
   /** Error message from the last failed attempt, displayed inline. */
   error?: string | null;
-  /** Called when the user cancels. */
+  /** Called when the user cancels (or closes the informational dialog). */
   onCancel: () => void;
-  /** Called when the user confirms. */
+  /** Called when the user confirms the delete. Never invoked in informational mode. */
   onConfirm: () => void;
 }
 
 /**
- * Presentational confirmation modal for delete operations.
+ * Stateless confirmation/explanation modal for delete operations.
  *
- * Stateless — all data and callbacks are provided via props.
- * Use {@link DeleteConfirmationModal} for the connected version that
- * reads from content list context.
+ * Renders one of two layouts:
+ * - **Confirmable** (`permitted.length > 0`): `EuiConfirmModal` with a
+ *   callout for any skipped items.
+ * - **Informational** (`permitted.length === 0`): `EuiModal` explaining
+ *   why no items can be deleted, with only a "Close" button.
+ *
+ * This dialog explains any partition that survives selection.
+ * Use {@link DeleteConfirmationModal} for the connected version.
  */
 export const DeleteConfirmationComponent = ({
-  items,
+  permitted,
+  skipped,
   entityName,
   entityNamePlural,
   isDeleting,
@@ -49,15 +74,59 @@ export const DeleteConfirmationComponent = ({
   onConfirm,
 }: DeleteConfirmationComponentProps) => {
   const titleId = useGeneratedHtmlId({ prefix: 'contentListDeleteConfirmationTitle' });
-  const itemCount = items.length;
-  const displayEntityName = itemCount === 1 ? entityName : entityNamePlural;
+  const permittedCount = permitted.length;
+  const skippedCount = skipped.length;
+  const permittedEntityName = permittedCount === 1 ? entityName : entityNamePlural;
+  const skippedEntityName = skippedCount === 1 ? entityName : entityNamePlural;
+
+  if (permittedCount === 0) {
+    return (
+      <EuiModal
+        aria-labelledby={titleId}
+        onClose={onCancel}
+        data-test-subj="contentListDeleteConfirmation"
+      >
+        <EuiModalHeader>
+          <EuiModalHeaderTitle id={titleId}>
+            {i18n.translate('contentManagement.contentList.deleteConfirmation.ineligibleTitle', {
+              defaultMessage: "{skippedCount} {skippedEntityName} can't be deleted",
+              values: { skippedCount, skippedEntityName },
+            })}
+          </EuiModalHeaderTitle>
+        </EuiModalHeader>
+        <EuiModalBody>
+          <EuiText size="s">
+            <p>
+              {i18n.translate('contentManagement.contentList.deleteConfirmation.ineligibleBody', {
+                defaultMessage: 'None of the selected {entityNamePlural} can be deleted:',
+                values: { entityNamePlural },
+              })}
+            </p>
+          </EuiText>
+          <EuiSpacer size="s" />
+          <SkippedItemList skipped={skipped} />
+        </EuiModalBody>
+        <EuiModalFooter>
+          <EuiButton
+            onClick={onCancel}
+            fill
+            data-test-subj="contentListDeleteConfirmation-closeButton"
+          >
+            {i18n.translate('contentManagement.contentList.deleteConfirmation.close', {
+              defaultMessage: 'Close',
+            })}
+          </EuiButton>
+        </EuiModalFooter>
+      </EuiModal>
+    );
+  }
 
   return (
     <EuiConfirmModal
       aria-labelledby={titleId}
       title={i18n.translate('contentManagement.contentList.deleteConfirmation.title', {
-        defaultMessage: 'Delete {itemCount} {displayEntityName}?',
-        values: { itemCount, displayEntityName },
+        defaultMessage: 'Delete {permittedCount} {permittedEntityName}?',
+        values: { permittedCount, permittedEntityName },
       })}
       titleProps={{ id: titleId }}
       onCancel={onCancel}
@@ -79,6 +148,28 @@ export const DeleteConfirmationComponent = ({
       isLoading={isDeleting}
       data-test-subj="contentListDeleteConfirmation"
     >
+      {skippedCount > 0 && (
+        <>
+          <EuiCallOut
+            announceOnMount
+            size="s"
+            color="primary"
+            iconType="iInCircle"
+            title={i18n.translate(
+              'contentManagement.contentList.deleteConfirmation.skippedCalloutTitle',
+              {
+                defaultMessage:
+                  "{skippedCount} {skippedEntityName} can't be deleted and will be skipped",
+                values: { skippedCount, skippedEntityName },
+              }
+            )}
+            data-test-subj="contentListDeleteConfirmation-skippedCallout"
+          >
+            <SkippedItemList skipped={skipped} compact />
+          </EuiCallOut>
+          <EuiSpacer size="s" />
+        </>
+      )}
       <p>
         {i18n.translate('contentManagement.contentList.deleteConfirmation.body', {
           defaultMessage: "You can't recover deleted {entityNamePlural}.",
@@ -103,5 +194,48 @@ export const DeleteConfirmationComponent = ({
         </>
       )}
     </EuiConfirmModal>
+  );
+};
+
+/**
+ * Render the list of skipped items inside the dialog.
+ *
+ * When every skipped item shares the same reason, render the reason once
+ * with the items as a bulleted list under it. Otherwise itemise as
+ * `<title> — <reason>` per line so each row carries its own explanation.
+ */
+const SkippedItemList = ({
+  skipped,
+  compact = false,
+}: {
+  skipped: BulkActionSkippedItem[];
+  compact?: boolean;
+}) => {
+  const reasons = new Set(skipped.map((s) => s.reason));
+  const uniformReason = reasons.size === 1 ? skipped[0].reason : undefined;
+
+  return (
+    <EuiText size={compact ? 'xs' : 's'} data-test-subj="contentListDeleteConfirmation-skippedList">
+      {uniformReason ? (
+        <>
+          <p>{uniformReason}</p>
+          <ul>
+            {skipped.map(({ item }) => (
+              <li key={item.id}>{item.title}</li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <ul>
+          {skipped.map(({ item, reason }) => (
+            <li key={item.id}>
+              <strong>{item.title}</strong>
+              {' — '}
+              {reason}
+            </li>
+          ))}
+        </ul>
+      )}
+    </EuiText>
   );
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.test.tsx
@@ -8,11 +8,12 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { ContentListProvider } from '../../context';
 import type { FindItemsResult, FindItemsParams } from '../../datasource';
+import type { ContentListItem } from '../../item';
 import { DeleteConfirmationModal } from './delete_confirmation';
 
 const mockFindItems = jest.fn(
@@ -24,21 +25,31 @@ const mockFindItems = jest.fn(
 
 const mockOnDelete = jest.fn(async () => {});
 
-const createWrapper =
-  (options?: { onDelete?: typeof mockOnDelete }) =>
-  ({ children }: { children: React.ReactNode }) =>
-    (
-      <ContentListProvider
-        id="test-list"
-        labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
-        dataSource={{ findItems: mockFindItems }}
-        item={{ onDelete: options?.onDelete ?? mockOnDelete }}
-      >
-        {children}
-      </ContentListProvider>
-    );
+const createWrapper = (options?: {
+  onDelete?: typeof mockOnDelete;
+  getDeleteRestriction?: (item: ContentListItem) => string | undefined;
+}) => {
+  const item = {
+    actions: {
+      delete: {
+        onBulkAction: options?.onDelete ?? mockOnDelete,
+        ...(options?.getDeleteRestriction && { restriction: options.getDeleteRestriction }),
+      },
+    },
+  };
+  return ({ children }: { children: React.ReactNode }) => (
+    <ContentListProvider
+      id="test-list"
+      labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+      dataSource={{ findItems: mockFindItems }}
+      item={item}
+    >
+      {children}
+    </ContentListProvider>
+  );
+};
 
-const defaultItems = [{ id: '1', title: 'Item 1' }];
+const defaultItems: ContentListItem[] = [{ id: '1', title: 'Item 1' }];
 
 describe('DeleteConfirmationModal', () => {
   beforeEach(() => {
@@ -63,7 +74,7 @@ describe('DeleteConfirmationModal', () => {
     });
 
     it('uses plural entity label for multiple items', () => {
-      const items = [
+      const items: ContentListItem[] = [
         { id: '1', title: 'Item 1' },
         { id: '2', title: 'Item 2' },
         { id: '3', title: 'Item 3' },
@@ -182,6 +193,116 @@ describe('DeleteConfirmationModal', () => {
           )
         ).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('partition by registered delete restriction', () => {
+    const sampleItems: ContentListItem[] = [
+      { id: '1', title: 'Free 1', managed: false },
+      { id: '2', title: 'Managed 1', managed: true },
+      { id: '3', title: 'Free 2', managed: false },
+      { id: '4', title: 'Managed 2', managed: true },
+    ];
+
+    const restrictManaged = (item: ContentListItem) =>
+      item.managed ? 'Managed dashboards cannot be deleted.' : undefined;
+
+    it('uses `permitted` count in the title when some items are skipped', () => {
+      render(<DeleteConfirmationModal items={sampleItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper({ getDeleteRestriction: restrictManaged }),
+      });
+
+      expect(screen.getByText(/Delete 2 dashboards\?/)).toBeInTheDocument();
+    });
+
+    it('renders a callout listing the skipped items and their reason', () => {
+      render(<DeleteConfirmationModal items={sampleItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper({ getDeleteRestriction: restrictManaged }),
+      });
+
+      const callout = screen.getByTestId('contentListDeleteConfirmation-skippedCallout');
+      expect(
+        within(callout).getByText("2 dashboards can't be deleted and will be skipped")
+      ).toBeInTheDocument();
+
+      const list = within(callout).getByTestId('contentListDeleteConfirmation-skippedList');
+      expect(within(list).getByText('Managed dashboards cannot be deleted.')).toBeInTheDocument();
+      expect(within(list).getByText('Managed 1')).toBeInTheDocument();
+      expect(within(list).getByText('Managed 2')).toBeInTheDocument();
+    });
+
+    it('itemises per-row when skipped reasons differ', () => {
+      const restrictMixed = (item: ContentListItem) => {
+        if (item.id === '2') {
+          return 'Managed';
+        }
+        if (item.id === '4') {
+          return 'In use';
+        }
+        return undefined;
+      };
+
+      render(<DeleteConfirmationModal items={sampleItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper({ getDeleteRestriction: restrictMixed }),
+      });
+
+      const list = screen.getByTestId('contentListDeleteConfirmation-skippedList');
+      // Each itemised line includes both title and reason text.
+      expect(list).toHaveTextContent('Managed 1 — Managed');
+      expect(list).toHaveTextContent('Managed 2 — In use');
+    });
+
+    it('passes only `permitted` items to `onDelete` on confirm', async () => {
+      render(<DeleteConfirmationModal items={sampleItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper({ getDeleteRestriction: restrictManaged }),
+      });
+
+      await userEvent.click(screen.getByText('Delete'));
+
+      await waitFor(() => {
+        expect(mockOnDelete).toHaveBeenCalledTimes(1);
+      });
+      expect(mockOnDelete).toHaveBeenCalledWith([sampleItems[0], sampleItems[2]]);
+    });
+
+    it('flips to informational mode when every selected item is restricted', () => {
+      const allManaged: ContentListItem[] = [
+        { id: '2', title: 'Managed 1', managed: true },
+        { id: '4', title: 'Managed 2', managed: true },
+      ];
+
+      render(<DeleteConfirmationModal items={allManaged} onClose={jest.fn()} />, {
+        wrapper: createWrapper({ getDeleteRestriction: restrictManaged }),
+      });
+
+      expect(screen.getByText(/2 dashboards can't be deleted/)).toBeInTheDocument();
+      expect(screen.getByTestId('contentListDeleteConfirmation-closeButton')).toBeInTheDocument();
+      expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    });
+
+    it('closes via the informational `Close` button without invoking `onDelete`', async () => {
+      const onClose = jest.fn();
+      const allManaged: ContentListItem[] = [{ id: '2', title: 'Managed 1', managed: true }];
+
+      render(<DeleteConfirmationModal items={allManaged} onClose={onClose} />, {
+        wrapper: createWrapper({ getDeleteRestriction: restrictManaged }),
+      });
+
+      await userEvent.click(screen.getByTestId('contentListDeleteConfirmation-closeButton'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(mockOnDelete).not.toHaveBeenCalled();
+    });
+
+    it('renders without a skipped callout when no items are restricted', () => {
+      render(<DeleteConfirmationModal items={sampleItems} onClose={jest.fn()} />, {
+        wrapper: createWrapper({ getDeleteRestriction: () => undefined }),
+      });
+
+      expect(
+        screen.queryByTestId('contentListDeleteConfirmation-skippedCallout')
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/Delete 4 dashboards\?/)).toBeInTheDocument();
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/delete_confirmation.tsx
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useRef, useState, useCallback } from 'react';
+import React, { useRef, useState, useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useContentListConfig } from '../../context';
 import { useContentListState } from '../../state/use_content_list_state';
 import { DeleteConfirmationComponent } from './delete_confirmation.component';
-import type { ContentListItem } from '../../item';
+import { partitionByRestriction, useBulkActionRestrictions } from '../../bulk_actions';
+import type { ContentListItem, KnownActionId } from '../../item';
 
 /**
  * Props for the connected {@link DeleteConfirmationModal}.
@@ -27,9 +28,16 @@ export interface DeleteConfirmationModalProps {
 /**
  * Connected confirmation modal for delete operations.
  *
- * Reads `item.onDelete` and entity labels from the provider config, calls
- * `refetch` on success, and manages `isDeleting`/`error` locally.
- * Delegates rendering to {@link DeleteConfirmationComponent}.
+ * Looks up the delete restriction from the bulk-action registry,
+ * partitions the requested `items`, and delegates rendering to
+ * {@link DeleteConfirmationComponent}.
+ *
+ * - When some items are restricted, a callout lists skipped items;
+ *   confirming deletes only the permitted subset.
+ * - When *every* item is restricted, flips to an informational layout.
+ *
+ * Calls `refetch` on successful delete and manages `isDeleting`/`error`
+ * locally.
  *
  * @example
  * ```tsx
@@ -44,13 +52,26 @@ export interface DeleteConfirmationModalProps {
 export const DeleteConfirmationModal = ({ items, onClose }: DeleteConfirmationModalProps) => {
   const { labels, item: itemConfig } = useContentListConfig();
   const { refetch } = useContentListState();
+  const registeredActions = useBulkActionRestrictions();
 
   const deletingRef = useRef(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const deleteRestriction = useMemo(
+    () =>
+      registeredActions.find((a) => a.actionId === ('delete' satisfies KnownActionId))?.restriction,
+    [registeredActions]
+  );
+
+  const partition = useMemo(
+    () => partitionByRestriction(items, deleteRestriction),
+    [items, deleteRestriction]
+  );
+
   const onConfirm = useCallback(async () => {
-    if (!itemConfig?.onDelete || deletingRef.current) {
+    const onBulkDelete = itemConfig?.actions?.delete?.onBulkAction;
+    if (!onBulkDelete || deletingRef.current || partition.permitted.length === 0) {
       return;
     }
 
@@ -59,7 +80,7 @@ export const DeleteConfirmationModal = ({ items, onClose }: DeleteConfirmationMo
     setError(null);
 
     try {
-      await itemConfig.onDelete(items);
+      await onBulkDelete(partition.permitted);
       refetch();
       onClose();
     } catch (e) {
@@ -75,11 +96,14 @@ export const DeleteConfirmationModal = ({ items, onClose }: DeleteConfirmationMo
             })
       );
     }
-  }, [itemConfig, items, labels.entityPlural, refetch, onClose]);
+  }, [itemConfig, partition, labels.entityPlural, refetch, onClose]);
 
   return (
     <DeleteConfirmationComponent
-      {...{ items, isDeleting, error }}
+      permitted={partition.permitted}
+      skipped={partition.skipped}
+      isDeleting={isDeleting}
+      error={error}
       entityName={labels.entity}
       entityNamePlural={labels.entityPlural}
       onCancel={onClose}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/use_delete_confirmation.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/use_delete_confirmation.test.tsx
@@ -32,7 +32,7 @@ const createWrapper =
         id="test-list"
         labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
         dataSource={{ findItems: mockFindItems }}
-        item={{ onDelete: mockOnDelete }}
+        item={{ actions: { delete: { onBulkAction: mockOnDelete } } }}
       >
         {children}
       </ContentListProvider>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/use_delete_confirmation.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/components/delete/use_delete_confirmation.tsx
@@ -36,9 +36,13 @@ export interface UseDeleteConfirmationReturn {
 /**
  * Encapsulates the open/close state for a {@link DeleteConfirmationModal}.
  *
- * Consumers call `requestDelete(items)` to open the modal and render
- * `deleteModal` in their JSX. The modal handles confirmation, deletion
- * (via the provider's `onDelete`), loading, and error display internally.
+ * Consumers call `requestDelete(items)` and render `deleteModal` in their JSX.
+ * The modal partitions items into deletable and non-deletable subsets using
+ * `actions.delete.restriction`, shows the partition to the user, and invokes
+ * `actions.delete.onBulkAction` on the deletable subset.
+ *
+ * The partition acts as a defensive backstop for programmatic selection or
+ * multi-action scenarios where a row is selectable but not deletable.
  *
  * @example Row-level delete (table)
  * ```tsx

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.tsx
@@ -16,6 +16,7 @@ import type { DataSourceConfig } from '../datasource';
 import { ProfileCache, ProfileCacheContext } from '../services';
 import { ContentListStateProvider } from '../state';
 import { QueryClientProvider, contentListQueryClient } from '../query';
+import { BulkActionRegistryContext, buildRegisteredActions } from '../bulk_actions';
 
 /**
  * Internal context value type.
@@ -151,10 +152,20 @@ export const ContentListProvider = ({
     [labels, item, isReadOnly, id, queryKeyScope, dataSource, features, supports, services]
   );
 
+  // Bulk-action registry: a pure projection of `item`. Provided
+  // alongside `ContentListContext` so every table's selection bridge
+  // and the toolbar's delete-confirmation dialog share one consistent,
+  // provider-scoped registry. The registry has no setter — multiple
+  // tables under the same provider therefore see the same derived
+  // entries, and unmounting any table never clears the registry.
+  const bulkActionRegistry = useMemo(() => ({ actions: buildRegisteredActions(item) }), [item]);
+
   // Build the provider tree bottom-up (innermost → outermost).
   let content: React.ReactNode = (
     <ContentListContext.Provider value={value}>
-      <ContentListStateProvider>{children}</ContentListStateProvider>
+      <BulkActionRegistryContext.Provider value={bulkActionRegistry}>
+        <ContentListStateProvider>{children}</ContentListStateProvider>
+      </BulkActionRegistryContext.Provider>
     </ContentListContext.Provider>
   );
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
@@ -98,6 +98,72 @@ export type ContentListItem<T = Record<string, unknown>> = T & {
 };
 
 /**
+ * Action identifiers known to the package.
+ *
+ * The package owns built-in action presets keyed by these IDs (`Action.Edit`,
+ * `Action.Delete`, `Action.Inspect`). Consumers may also invent custom IDs;
+ * see {@link ActionId}.
+ */
+export type KnownActionId = 'edit' | 'delete' | 'inspect';
+
+/**
+ * Identifier for an action.
+ *
+ * `KnownActionId | (string & {})` keeps IDE autocomplete on the known
+ * IDs while still accepting any consumer-invented string (e.g.
+ * `'archive'`). The opaque `string & {}` is the standard TypeScript
+ * trick that prevents the union from collapsing to plain `string`.
+ */
+export type ActionId = KnownActionId | (string & {});
+
+interface ActionConfigBase {
+  /**
+   * Per-item restriction. Returns a reason string when the action is
+   * not permitted on the item; `undefined` otherwise. Drives row icon
+   * disabling, selection-checkbox gating (when `onBulkAction` is set),
+   * and the dialog partition.
+   */
+  restriction?: (item: ContentListItem) => string | undefined;
+}
+
+/**
+ * Configuration for a single action.
+ *
+ * At least one of `onItemAction` or `onBulkAction` must be supplied.
+ * Presence of `onBulkAction` makes the action bulk-eligible.
+ */
+export type ActionConfig =
+  | (ActionConfigBase & {
+      /** Single-item handler. */
+      onItemAction: (item: ContentListItem) => void;
+      /** Optional bulk handler. */
+      onBulkAction?: (items: ContentListItem[]) => Promise<void>;
+    })
+  | (ActionConfigBase & {
+      /** Optional single-item handler. */
+      onItemAction?: (item: ContentListItem) => void;
+      /** Bulk handler. */
+      onBulkAction: (items: ContentListItem[]) => Promise<void>;
+    });
+
+/**
+ * Action configuration map.
+ *
+ * Known IDs (`edit`/`delete`/`inspect`) are first-class fields;
+ * consumers can also add custom action IDs via the index signature.
+ */
+export interface ContentListActions {
+  /** Row-level edit. */
+  edit?: ActionConfig;
+  /** Bulk-eligible delete. */
+  delete?: ActionConfig;
+  /** Row-level inspect ("View details"). */
+  inspect?: ActionConfig;
+  /** Custom actions, identified by a consumer-chosen string ID. */
+  [customId: string]: ActionConfig | undefined;
+}
+
+/**
  * Per-item configuration for link behavior and actions.
  */
 export interface ContentListItemConfig {
@@ -108,42 +174,7 @@ export interface ContentListItemConfig {
   getHref?: (item: ContentListItem) => string;
 
   /**
-   * Function to generate the edit URL for an item.
-   * When provided, the edit action renders as an `<a>` link with this `href`,
-   * preserving native link behavior (right-click, middle-click, screen reader
-   * announcement).
-   *
-   * Composable with `onEdit`: when both are provided, the action renders as a
-   * link (`href`) and also calls `onEdit` on click (e.g., for analytics tracking).
+   * Action handlers and per-item restrictions, keyed by action ID.
    */
-  getEditUrl?: (item: ContentListItem) => string;
-
-  /**
-   * Callback invoked when the edit action is clicked.
-   * Use this for side effects such as opening a flyout, tracking analytics,
-   * or programmatic navigation.
-   *
-   * When provided alone, the action renders as a button with an `onClick` handler.
-   * When provided alongside `getEditUrl`, both are applied: the action renders
-   * as a link and the callback fires on click.
-   */
-  onEdit?: (item: ContentListItem) => void;
-
-  /**
-   * Callback invoked to delete one or more items.
-   * When provided, enables the delete action on rows and the bulk-delete flow.
-   * The callback should handle the actual deletion and return a resolved promise on success.
-   */
-  onDelete?: (items: ContentListItem[]) => Promise<void>;
-
-  /**
-   * Callback invoked to inspect an item (view/edit its metadata).
-   * When provided, enables the "View details" row action.
-   *
-   * This is a simple, UI-agnostic callback — the implementation decides what
-   * happens when the action fires (e.g., opening a flyout, navigating to a
-   * detail page). The Kibana content editor integration is handled by
-   * `ContentListClientProvider` in `@kbn/content-list-provider-client`.
-   */
-  onInspect?: (item: ContentListItem) => void;
+  actions?: ContentListActions;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
@@ -17,7 +17,7 @@ const onDelete = jest.fn();
 
 const defaultContext: ActionBuilderContext = {
   itemConfig: {
-    onDelete: jest.fn(async () => {}),
+    actions: { delete: { onBulkAction: jest.fn(async () => {}) } },
   },
   isReadOnly: false,
   entityName: 'dashboard',
@@ -39,7 +39,7 @@ describe('delete action builder', () => {
   });
 
   describe('buildDeleteAction', () => {
-    it('returns an action with defaults when props are empty and `onDelete` is configured', () => {
+    it('returns an action with defaults when props are empty and `actions.delete.onBulkAction` is configured', () => {
       const result = buildDeleteAction({}, defaultContext);
 
       expect(result).toMatchObject({
@@ -62,7 +62,7 @@ describe('delete action builder', () => {
       expect(result).toBeUndefined();
     });
 
-    it('returns `undefined` when no `onDelete` handler is configured', () => {
+    it('returns `undefined` when no bulk-delete handler is configured', () => {
       const context: ActionBuilderContext = {
         ...defaultContext,
         itemConfig: {},
@@ -99,18 +99,96 @@ describe('delete action builder', () => {
       expect(onDelete).toHaveBeenCalledWith([item]);
     });
 
-    it('does not call `itemConfig.onDelete` directly', () => {
-      const itemOnDelete = jest.fn();
+    it('does not call `itemConfig.actions.delete.onBulkAction` directly', () => {
+      const onBulkAction = jest.fn(async () => {});
       const context: ActionBuilderContext = {
         ...defaultContext,
-        itemConfig: { onDelete: itemOnDelete },
+        itemConfig: { actions: { delete: { onBulkAction } } },
       };
       const result = buildDeleteAction({}, context);
       const item = { id: '1', title: 'Test' };
 
       result?.onClick?.(item, {} as React.MouseEvent);
 
-      expect(itemOnDelete).not.toHaveBeenCalled();
+      expect(onBulkAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with `itemConfig.actions.delete.restriction`', () => {
+    const freeItem = { id: '1', title: 'Free', managed: false };
+    const managedItem = { id: '2', title: 'Managed', managed: true };
+
+    const restrictManaged = (item: { managed?: boolean }) =>
+      item.managed ? 'Managed dashboards cannot be deleted.' : undefined;
+
+    const contextWithRestriction = (
+      restriction: (item: { managed?: boolean }) => string | undefined
+    ): ActionBuilderContext => ({
+      ...defaultContext,
+      itemConfig: {
+        actions: {
+          delete: { onBulkAction: jest.fn(async () => {}), restriction },
+        },
+      },
+    });
+
+    it('disables the row icon when the item has a restriction reason', () => {
+      const result = buildDeleteAction({}, contextWithRestriction(restrictManaged));
+
+      // EUI's `enabled` predicate: `false` => disabled.
+      expect((result!.enabled as (item: typeof managedItem) => boolean)(managedItem)).toBe(false);
+      expect((result!.enabled as (item: typeof freeItem) => boolean)(freeItem)).toBe(true);
+    });
+
+    it('surfaces the restriction reason as the per-row tooltip via `description`', () => {
+      const result = buildDeleteAction({}, contextWithRestriction(restrictManaged));
+      const description = result!.description as (item: typeof managedItem) => string;
+
+      expect(description(managedItem)).toBe('Managed dashboards cannot be deleted.');
+      // Default description (the i18n action description) is used for unrestricted items.
+      expect(description(freeItem)).toEqual(expect.any(String));
+      expect(description(freeItem)).not.toBe('Managed dashboards cannot be deleted.');
+    });
+
+    it('lets the consumer `enabled` further narrow but never expand the auto verdict', () => {
+      // Auto-derivation says `freeItem` is OK; consumer says no -> result is no.
+      const result = buildDeleteAction(
+        { enabled: (item) => item.id !== '1' },
+        contextWithRestriction(restrictManaged)
+      );
+      const enabled = result!.enabled as (item: typeof freeItem) => boolean;
+
+      expect(enabled(freeItem)).toBe(false);
+      expect(enabled(managedItem)).toBe(false);
+    });
+
+    it('keeps the icon enabled when no restriction predicate is configured', () => {
+      const result = buildDeleteAction({}, defaultContext);
+      const enabled = result!.enabled as (item: typeof freeItem) => boolean;
+
+      expect(enabled(freeItem)).toBe(true);
+      expect(enabled(managedItem)).toBe(true);
+    });
+
+    it('keeps the static description when no restriction predicate is configured', () => {
+      const result = buildDeleteAction({}, defaultContext);
+      expect(typeof result?.description).toBe('string');
+    });
+
+    it('ignores `actions.edit.restriction` when building the delete action', () => {
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: {
+          actions: {
+            delete: { onBulkAction: jest.fn(async () => {}) },
+            edit: { onItemAction: jest.fn(), restriction: () => 'Cannot edit' },
+          },
+        },
+      };
+
+      const result = buildDeleteAction({}, context);
+
+      expect(typeof result?.description).toBe('string');
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.tsx
@@ -11,6 +11,7 @@ import React, { useLayoutEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { EuiTextColor, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import type { ContentListItem } from '@kbn/content-list-provider';
 import type { DeleteActionProps, ActionOutput, ActionBuilderContext } from '../types';
 
 /**
@@ -64,12 +65,11 @@ const DEFAULT_DELETE_DESCRIPTION = i18n.translate(
 /**
  * Build a `DefaultItemAction` for the delete action preset.
  *
- * Returns `undefined` when:
- * - The table is in read-only mode.
- * - No delete handler (`onDelete`) is configured on the item config.
+ * Returns `undefined` when read-only or when `onBulkAction` is not configured.
+ * The `onClick` handler opens the table-level delete confirmation modal.
  *
- * The `onClick` handler calls {@link BuilderContextActions.onDelete} to open
- * the delete confirmation modal at the table level.
+ * Composes `enabled` and `description` with `actions.delete.restriction` to
+ * disable the icon and surface the reason when restricted.
  *
  * @param attributes - The declarative attributes from the parsed `Action.Delete` element.
  * @param context - Builder context with provider configuration.
@@ -84,21 +84,43 @@ export const buildDeleteAction = (
   if (isReadOnly) {
     return undefined;
   }
-  if (typeof itemConfig?.onDelete !== 'function') {
+
+  const deleteConfig = itemConfig?.actions?.delete;
+  if (typeof deleteConfig?.onBulkAction !== 'function') {
     return undefined;
   }
 
   const label = attributes.label ?? DEFAULT_DELETE_LABEL;
+  const { enabled: consumerEnabled } = attributes;
+  const restriction = deleteConfig.restriction;
+
+  const enabled = (item: ContentListItem): boolean => {
+    if (restriction && restriction(item) !== undefined) {
+      return false;
+    }
+    return consumerEnabled ? consumerEnabled(item) : true;
+  };
+
+  // EUI surfaces `description` as the icon's tooltip. When a restriction
+  // predicate is configured we forward a function so the tooltip can carry
+  // the per-item reason; otherwise we keep the static string (preserves the
+  // EUI fast-path for static descriptions).
+  const description = restriction
+    ? (item: ContentListItem): string => {
+        const reason = restriction(item);
+        return reason ?? DEFAULT_DELETE_DESCRIPTION;
+      }
+    : DEFAULT_DELETE_DESCRIPTION;
 
   return {
     name: <DangerActionName>{label}</DangerActionName>,
-    description: DEFAULT_DELETE_DESCRIPTION,
+    description,
     icon: 'trash',
     type: 'icon',
     color: 'danger',
     isPrimary: true,
     onClick: (item) => actions?.onDelete?.([item]),
-    ...(attributes.enabled && { enabled: attributes.enabled }),
+    enabled,
     'data-test-subj': 'content-list-table-action-delete',
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
@@ -13,7 +13,7 @@ import { buildEditAction } from './edit_action';
 
 const defaultContext: ActionBuilderContext = {
   itemConfig: {
-    getEditUrl: (item) => `/edit/${item.id}`,
+    actions: { edit: { onItemAction: jest.fn() } },
   },
   isReadOnly: false,
   entityName: 'dashboard',
@@ -30,7 +30,7 @@ const defaultContext: ActionBuilderContext = {
 
 describe('edit action builder', () => {
   describe('buildEditAction', () => {
-    it('returns an action with defaults when props are empty and `getEditUrl` is configured', () => {
+    it('returns an action with defaults when props are empty and `actions.edit.onItemAction` is configured', () => {
       const result = buildEditAction({}, defaultContext);
 
       expect(result).toMatchObject({
@@ -77,74 +77,102 @@ describe('edit action builder', () => {
       expect(result).toMatchObject({ name: 'Modify' });
     });
 
-    it('provides `href` when `getEditUrl` is configured', () => {
+    it('provides `onClick` and no `href`', () => {
       const result = buildEditAction({}, defaultContext);
-
-      expect(result).toHaveProperty('href');
-      expect(result).not.toHaveProperty('onClick');
-    });
-
-    it('generates correct href for an item', () => {
-      const result = buildEditAction({}, defaultContext);
-      const href = (result?.href as (item: { id: string }) => string)({ id: '123' });
-
-      expect(href).toBe('/edit/123');
-    });
-
-    it('provides `onClick` when only `onEdit` is configured (no `getEditUrl`)', () => {
-      const onEdit = jest.fn();
-      const context: ActionBuilderContext = {
-        ...defaultContext,
-        itemConfig: { onEdit },
-      };
-      const result = buildEditAction({}, context);
 
       expect(result).toHaveProperty('onClick');
       expect(result).not.toHaveProperty('href');
     });
 
-    it('calls `onEdit` when onClick is triggered', () => {
-      const onEdit = jest.fn();
+    it('calls `actions.edit.onItemAction` when onClick is triggered', () => {
+      const onItemAction = jest.fn();
       const context: ActionBuilderContext = {
         ...defaultContext,
-        itemConfig: { onEdit },
+        itemConfig: { actions: { edit: { onItemAction } } },
       };
       const result = buildEditAction({}, context);
       const item = { id: '1', title: 'Test' };
 
       result?.onClick?.(item, {} as React.MouseEvent);
-      expect(onEdit).toHaveBeenCalledWith(item);
+      expect(onItemAction).toHaveBeenCalledWith(item);
     });
 
-    it('composes both `href` and `onClick` when `getEditUrl` and `onEdit` are provided', () => {
-      const onEdit = jest.fn();
-      const context: ActionBuilderContext = {
-        ...defaultContext,
-        itemConfig: {
-          getEditUrl: (item) => `/edit/${item.id}`,
-          onEdit,
-        },
-      };
-      const result = buildEditAction({}, context);
+    describe('with `itemConfig.actions.edit.restriction`', () => {
+      const managedItem = { id: 'm', title: 'Managed', managed: true };
+      const freeItem = { id: 'f', title: 'Free', managed: false };
 
-      expect(result).toHaveProperty('href');
-      expect(result).toHaveProperty('onClick');
-    });
+      const restrictManaged = (item: { managed?: boolean }) =>
+        item.managed ? 'Managed dashboards cannot be edited.' : undefined;
 
-    it('calls `onEdit` on click even when `getEditUrl` is also provided', () => {
-      const onEdit = jest.fn();
-      const context: ActionBuilderContext = {
-        ...defaultContext,
-        itemConfig: {
-          getEditUrl: (item) => `/edit/${item.id}`,
-          onEdit,
-        },
-      };
-      const result = buildEditAction({}, context);
-      const item = { id: '1', title: 'Test' };
+      it('disables the icon and surfaces the reason as a description function', () => {
+        const context: ActionBuilderContext = {
+          ...defaultContext,
+          itemConfig: {
+            actions: { edit: { onItemAction: jest.fn(), restriction: restrictManaged } },
+          },
+        };
 
-      result?.onClick?.(item, {} as React.MouseEvent);
-      expect(onEdit).toHaveBeenCalledWith(item);
+        const result = buildEditAction({}, context);
+
+        expect(typeof result?.enabled).toBe('function');
+        expect(result?.enabled?.(freeItem)).toBe(true);
+        expect(result?.enabled?.(managedItem)).toBe(false);
+
+        expect(typeof result?.description).toBe('function');
+        const description = result?.description as (item: typeof freeItem) => string;
+        expect(description(freeItem)).toBe('Edit this item');
+        expect(description(managedItem)).toBe('Managed dashboards cannot be edited.');
+      });
+
+      it('keeps the static description when no restriction is configured', () => {
+        const result = buildEditAction({}, defaultContext);
+        expect(typeof result?.description).toBe('string');
+      });
+
+      it("doesn't expand the consumer's `enabled` predicate", () => {
+        // Consumer disallows everything; restriction allows everything;
+        // composed verdict is `false` (consumer narrows, restriction
+        // can't expand).
+        const context: ActionBuilderContext = {
+          ...defaultContext,
+          itemConfig: {
+            actions: { edit: { onItemAction: jest.fn(), restriction: () => undefined } },
+          },
+        };
+
+        const result = buildEditAction({ enabled: () => false }, context);
+
+        expect(result?.enabled?.(freeItem)).toBe(false);
+      });
+
+      it('disables the icon when the restriction returns a reason even if `enabled` is true', () => {
+        const context: ActionBuilderContext = {
+          ...defaultContext,
+          itemConfig: {
+            actions: { edit: { onItemAction: jest.fn(), restriction: () => 'restricted' } },
+          },
+        };
+
+        const result = buildEditAction({ enabled: () => true }, context);
+
+        expect(result?.enabled?.(freeItem)).toBe(false);
+      });
+
+      it('ignores `actions.delete.restriction` when building the edit action', () => {
+        const context: ActionBuilderContext = {
+          ...defaultContext,
+          itemConfig: {
+            actions: {
+              edit: { onItemAction: jest.fn() },
+              delete: { onBulkAction: jest.fn(async () => {}), restriction: () => 'Cannot delete' },
+            },
+          },
+        };
+
+        const result = buildEditAction({}, context);
+
+        expect(typeof result?.description).toBe('string');
+      });
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.tsx
@@ -8,6 +8,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import type { ContentListItem } from '@kbn/content-list-provider';
 import type { EditActionProps, ActionOutput, ActionBuilderContext } from '../types';
 
 /** Default i18n-translated label for the edit action. */
@@ -24,13 +25,10 @@ const DEFAULT_EDIT_DESCRIPTION = i18n.translate(
 /**
  * Build a `DefaultItemAction` for the edit action preset.
  *
- * Returns `undefined` when:
- * - The table is in read-only mode.
- * - No edit handler (`onEdit`) or edit URL generator (`getEditUrl`) is configured.
- *
- * When both `getEditUrl` and `onEdit` are provided, the action renders as a link
- * (`href`) and also fires `onEdit` on click. This enables composable behavior
- * such as navigating to an edit page while also tracking analytics.
+ * Returns `undefined` when read-only or when no `actions.edit.onItemAction`
+ * is configured. Composes `enabled` and `description` with
+ * `actions.edit.restriction` to disable the icon and surface the reason
+ * when restricted.
  *
  * @param attributes - The declarative attributes from the parsed `Action.Edit` element.
  * @param context - Builder context with provider configuration.
@@ -46,23 +44,43 @@ export const buildEditAction = (
     return undefined;
   }
 
-  const { getEditUrl, onEdit } = itemConfig;
+  const editConfig = itemConfig.actions?.edit;
+  const onItemAction = editConfig?.onItemAction;
 
-  if (!getEditUrl && !onEdit) {
+  if (!onItemAction) {
     return undefined;
   }
 
   const label = attributes.label ?? DEFAULT_EDIT_LABEL;
+  const { enabled: consumerEnabled } = attributes;
+  const restriction = editConfig?.restriction;
+
+  const enabled = (item: ContentListItem): boolean => {
+    if (restriction && restriction(item) !== undefined) {
+      return false;
+    }
+    return consumerEnabled ? consumerEnabled(item) : true;
+  };
+
+  // EUI surfaces `description` as the icon's tooltip. When a restriction
+  // predicate is configured we forward a function so the tooltip can carry
+  // the per-item reason; otherwise we keep the static string (preserves
+  // EUI's fast-path for static descriptions).
+  const description = restriction
+    ? (item: ContentListItem): string => {
+        const reason = restriction(item);
+        return reason ?? DEFAULT_EDIT_DESCRIPTION;
+      }
+    : DEFAULT_EDIT_DESCRIPTION;
 
   return {
     name: label,
-    description: DEFAULT_EDIT_DESCRIPTION,
+    description,
     icon: 'pencil',
     type: 'icon',
     isPrimary: true,
-    ...(getEditUrl && { href: (item) => getEditUrl(item) }),
-    ...(onEdit && { onClick: (item) => onEdit(item) }),
-    ...(attributes.enabled && { enabled: attributes.enabled }),
+    onClick: (item) => onItemAction(item),
+    enabled,
     'data-test-subj': 'content-list-table-action-edit',
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.test.tsx
@@ -15,7 +15,7 @@ const onInspect = jest.fn();
 
 const defaultContext: ActionBuilderContext = {
   itemConfig: {
-    onInspect,
+    actions: { inspect: { onItemAction: onInspect } },
   },
   isReadOnly: false,
   entityName: 'dashboard',
@@ -84,6 +84,62 @@ describe('inspect action builder', () => {
       const result = buildInspectAction({ label: 'Details' }, defaultContext);
 
       expect(result).toMatchObject({ name: 'Details' });
+    });
+  });
+
+  describe('with `itemConfig.actions.inspect.restriction`', () => {
+    const freeItem = { id: '1', title: 'Free', managed: false };
+    const managedItem = { id: '2', title: 'Managed', managed: true };
+
+    const restrictManaged = (item: { managed?: boolean }) =>
+      item.managed ? 'Managed items cannot be inspected.' : undefined;
+
+    const contextWithRestriction = (
+      restriction: (item: { managed?: boolean }) => string | undefined
+    ): ActionBuilderContext => ({
+      ...defaultContext,
+      itemConfig: {
+        actions: { inspect: { onItemAction: onInspect, restriction } },
+      },
+    });
+
+    it('disables the row icon when the item has a restriction reason', () => {
+      const result = buildInspectAction({}, contextWithRestriction(restrictManaged));
+
+      expect((result!.enabled as (item: typeof managedItem) => boolean)(managedItem)).toBe(false);
+      expect((result!.enabled as (item: typeof freeItem) => boolean)(freeItem)).toBe(true);
+    });
+
+    it('surfaces the restriction reason as the per-row tooltip via `description`', () => {
+      const result = buildInspectAction({}, contextWithRestriction(restrictManaged));
+      const description = result!.description as (item: typeof managedItem) => string;
+
+      expect(description(managedItem)).toBe('Managed items cannot be inspected.');
+      expect(description(freeItem)).toBe('View details');
+    });
+
+    it('lets the consumer `enabled` further narrow but never expand the auto verdict', () => {
+      const result = buildInspectAction(
+        { enabled: (item) => item.id !== '1' },
+        contextWithRestriction(restrictManaged)
+      );
+      const enabled = result!.enabled as (item: typeof freeItem) => boolean;
+
+      expect(enabled(freeItem)).toBe(false);
+      expect(enabled(managedItem)).toBe(false);
+    });
+
+    it('keeps the icon enabled when no restriction predicate is configured', () => {
+      const result = buildInspectAction({}, defaultContext);
+      const enabled = result!.enabled as (item: typeof freeItem) => boolean;
+
+      expect(enabled(freeItem)).toBe(true);
+      expect(enabled(managedItem)).toBe(true);
+    });
+
+    it('keeps the static description when no restriction predicate is configured', () => {
+      const result = buildInspectAction({}, defaultContext);
+      expect(typeof result?.description).toBe('string');
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.tsx
@@ -8,16 +8,12 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import type { ContentListItem } from '@kbn/content-list-provider';
 import type { InspectActionProps, ActionOutput, ActionBuilderContext } from '../types';
 
 /**
  * Default i18n-translated label for the inspect action.
- *
- * Used as both the `name` (visible text / aria-label) and `description`
- * (tooltip) on the underlying `DefaultItemAction` so the action reads as
- * a simple "View details" affordance rather than per-item phrasing like
- * "View {itemTitle} details". Override with the `label` prop on
- * `Action.Inspect` when an item-aware label is desired.
+ * Used as both `name` and `description` (tooltip).
  */
 const DEFAULT_INSPECT_LABEL = i18n.translate(
   'contentManagement.contentList.table.action.inspect.label',
@@ -27,7 +23,9 @@ const DEFAULT_INSPECT_LABEL = i18n.translate(
 /**
  * Build a `DefaultItemAction` for the inspect (view details) action preset.
  *
- * Returns `undefined` when no `onInspect` handler is configured on the item config.
+ * Returns `undefined` when no `actions.inspect.onItemAction` is configured.
+ * Composes `enabled` and `description` with `actions.inspect.restriction` to
+ * disable the icon and surface the reason when restricted.
  *
  * @param attributes - The declarative attributes from the parsed `Action.Inspect` element.
  * @param context - Builder context with provider configuration.
@@ -37,19 +35,38 @@ export const buildInspectAction = (
   attributes: InspectActionProps,
   context: ActionBuilderContext
 ): ActionOutput | undefined => {
-  if (!context.itemConfig?.onInspect) {
+  const inspectConfig = context.itemConfig?.actions?.inspect;
+  const onItemAction = inspectConfig?.onItemAction;
+  if (!onItemAction) {
     return undefined;
   }
 
-  const { onInspect } = context.itemConfig;
   const label = attributes.label ?? DEFAULT_INSPECT_LABEL;
+  const { enabled: consumerEnabled } = attributes;
+  const restriction = inspectConfig?.restriction;
+
+  const enabled = (item: ContentListItem): boolean => {
+    if (restriction && restriction(item) !== undefined) {
+      return false;
+    }
+    return consumerEnabled ? consumerEnabled(item) : true;
+  };
+
+  // EUI surfaces `description` as the icon's tooltip. When a restriction
+  // predicate is configured we forward a function so the tooltip can
+  // carry the per-item reason; otherwise we keep the static string
+  // (preserves EUI's fast-path for static descriptions).
+  const description = restriction
+    ? (item: ContentListItem): string => restriction(item) ?? DEFAULT_INSPECT_LABEL
+    : DEFAULT_INSPECT_LABEL;
 
   return {
     name: label,
-    description: DEFAULT_INSPECT_LABEL,
+    description,
     icon: 'inspect',
     type: 'icon',
-    onClick: (item) => onInspect(item),
+    onClick: (item) => onItemAction(item),
+    enabled,
     'data-test-subj': 'content-list-table-action-inspect',
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/part.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ContentListItem } from '@kbn/content-list-provider';
 import { table } from '../assembly';
 import type {
   EditActionProps,
@@ -37,8 +38,14 @@ export const action = table.definePart<ActionPresets, ActionOutput, ActionBuilde
 /**
  * Build a `DefaultItemAction` from a custom (non-preset) action.
  *
- * Registered as the fallback resolver via `createComponent({ resolve })`.
- * Custom actions are identified by `props.id` rather than a preset name.
+ * Custom actions are identified by `props.id` and resolved against
+ * `itemConfig.actions?.[id]`:
+ *
+ * - Prefers `onItemAction`, falls back to `onBulkAction([item])`.
+ * - Returns `undefined` if no handler exists, skipping the action
+ *   to prevent EUI crashes.
+ * - Composes `enabled` and `description` with `restriction` to
+ *   disable the icon and surface the reason when restricted.
  */
 const resolveCustomAction = (
   {
@@ -48,32 +55,71 @@ const resolveCustomAction = (
     icon,
     type: actionType,
     color,
-    onClick,
-    href,
-    enabled,
+    enabled: consumerEnabled,
     available,
     'data-test-subj': dataTestSubj,
   }: ActionProps,
-  _context: ActionBuilderContext
-): ActionOutput => {
+  { itemConfig }: ActionBuilderContext
+): ActionOutput | undefined => {
+  const actionConfig = itemConfig?.actions?.[id];
+  const onItemAction = actionConfig?.onItemAction;
+  const onBulkAction = actionConfig?.onBulkAction;
+
+  // Row click: prefer the explicit single-item handler; fall back to
+  // invoking the bulk handler with a singleton when only it is defined.
+  const onClick: ((item: ContentListItem) => void) | undefined = onItemAction
+    ? (item) => onItemAction(item)
+    : onBulkAction
+    ? (item) => {
+        void onBulkAction([item]);
+      }
+    : undefined;
+
+  // EUI's `DefaultItemAction` requires either `onClick` or `href` and
+  // throws at render otherwise. Custom actions never set `href` (no
+  // navigation slot in `ActionProps`), so the absence of a handler in
+  // `itemConfig.actions[id]` means there's nothing safe to emit. Skip
+  // the action — the table simply won't render an icon for this `id`.
+  if (!onClick) {
+    return undefined;
+  }
+
   // Default `type` to `'icon'` when an icon is provided, ensuring the object
   // satisfies EUI's discriminated union (`DefaultItemIconButtonAction` requires
   // both `icon` and `type`). Without this, the conditional spread loses the
   // discriminant and requires a cast.
   const resolvedType = actionType ?? (icon ? 'icon' : undefined);
 
+  const restriction = actionConfig?.restriction;
+
+  const composedEnabled = restriction
+    ? (item: ContentListItem): boolean => {
+        if (restriction(item) !== undefined) {
+          return false;
+        }
+        return consumerEnabled ? consumerEnabled(item) : true;
+      }
+    : consumerEnabled;
+
+  // EUI surfaces `description` as the icon's tooltip. When a restriction
+  // is configured we forward a function so the tooltip can carry the
+  // per-item reason; otherwise we keep the static string when one was
+  // provided (preserves EUI's fast-path for static descriptions).
+  const composedDescription = restriction
+    ? (item: ContentListItem): string | undefined => restriction(item) ?? description
+    : description;
+
   // Cast required: EUI's `DefaultItemAction` is a discriminated union keyed on
   // `icon`. The spread-conditional pattern loses the discriminant, but the
   // `resolvedType` guard above ensures the runtime object is always valid.
   return {
     name,
-    ...(description && { description }),
+    ...(composedDescription !== undefined && { description: composedDescription }),
     ...(icon && { icon }),
     ...(resolvedType && { type: resolvedType }),
     ...(color && { color }),
-    ...(onClick && { onClick }),
-    ...(href && { href }),
-    ...(enabled && { enabled }),
+    onClick,
+    ...(composedEnabled && { enabled: composedEnabled }),
     ...(available && { available }),
     'data-test-subj': dataTestSubj ?? `content-list-table-action-${id}`,
   } as ActionOutput;
@@ -155,7 +201,7 @@ export const InspectAction = action.createPreset({ name: 'inspect', resolve: bui
  *   <Column.Name />
  *   <Column.Actions>
  *     <Action.Edit />
- *     <Action id="duplicate" name="Duplicate" icon="copy" onClick={handleDuplicate} />
+ *     <Action id="duplicate" name="Duplicate" icon="copy" />
  *     <Action.Delete />
  *   </Column.Actions>
  * </ContentListTable>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
@@ -9,7 +9,7 @@
 
 import type { ReactNode } from 'react';
 import type { DefaultItemAction, EuiButtonIconProps } from '@elastic/eui';
-import type { ContentListItem } from '@kbn/content-list-provider';
+import type { ActionId, ContentListItem } from '@kbn/content-list-provider';
 import type { BuilderContext } from '../column/types';
 
 /**
@@ -28,13 +28,17 @@ export type ActionBuilderContext = BuilderContext;
 /**
  * Props for the `Action` component (custom actions).
  *
- * Custom actions are identified by `props.id` and provide their own
- * behavior. Pre-built actions (like `Action.Edit`) have dedicated
- * preset components with their own props interfaces.
+ * Custom actions are purely declarative: behavior is supplied at the
+ * provider level via `itemConfig.actions[id]`. The `id` prop ties the JSX
+ * declaration to the matching config entry.
  */
 export interface ActionProps {
-  /** Unique identifier for the action. */
-  id: string;
+  /**
+   * Unique identifier for the action. Built-in IDs (`'edit'`, `'delete'`,
+   * `'inspect'`) are autocompleted; consumer-defined custom IDs (e.g.
+   * `'archive'`) are also accepted.
+   */
+  id: ActionId;
   /** Display name for the action (shown in menu and tooltip). */
   name: string | ((item: ContentListItem) => ReactNode);
   /** Accessible description for the action. */
@@ -45,10 +49,6 @@ export interface ActionProps {
   type?: 'icon' | 'button';
   /** Icon/button color (matches EUI button color palette). */
   color?: EuiButtonIconProps['color'];
-  /** Click handler. */
-  onClick?: (item: ContentListItem) => void;
-  /** Link href (string or function returning href per item). */
-  href?: string | ((item: ContentListItem) => string);
   /** Whether the action is enabled for a given item. */
   enabled?: (item: ContentListItem) => boolean;
   /** Whether the action is available (visible) for a given item. */
@@ -102,4 +102,6 @@ export interface InspectActionProps {
    * item title to keep the icon-button affordance terse.
    */
   label?: string | ((item: ContentListItem) => ReactNode);
+  /** Per-item guard. When provided, disables the action for items where this returns `false`. */
+  enabled?: (item: ContentListItem) => boolean;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
@@ -8,11 +8,11 @@
  */
 
 import React from 'react';
-import type { EuiTableActionsColumnType } from '@elastic/eui';
+import type { DefaultItemAction, EuiTableActionsColumnType } from '@elastic/eui';
 import type { ContentListItem } from '@kbn/content-list-provider';
 import type { ColumnBuilderContext } from '../types';
 import { buildActionsColumn, type ActionsColumnProps } from './actions_builder';
-import { EditAction, DeleteAction } from '../../action';
+import { Action, EditAction, DeleteAction } from '../../action';
 
 /** Helper to cast the result to the actions column type for assertions. */
 type ActionsColumn = EuiTableActionsColumnType<ContentListItem> & {
@@ -21,8 +21,10 @@ type ActionsColumn = EuiTableActionsColumnType<ContentListItem> & {
 
 const defaultContext: ColumnBuilderContext = {
   itemConfig: {
-    getEditUrl: (item) => `/edit/${item.id}`,
-    onDelete: jest.fn(async () => {}),
+    actions: {
+      edit: { onItemAction: jest.fn() },
+      delete: { onBulkAction: jest.fn(async () => {}) },
+    },
   },
   isReadOnly: false,
   entityName: 'dashboard',
@@ -53,25 +55,10 @@ describe('actions column builder', () => {
         expect(result['data-test-subj']).toBe('content-list-table-column-actions');
       });
 
-      it('includes edit action when `getEditUrl` is configured', () => {
+      it('includes edit action when `actions.edit.onItemAction` is configured', () => {
         const context: ColumnBuilderContext = {
           ...defaultContext,
-          itemConfig: { getEditUrl: (item) => `/edit/${item.id}` },
-        };
-        const result = buildActionsColumn({}, context) as ActionsColumn;
-
-        expect(result).toBeDefined();
-        expect(result.actions).toHaveLength(1);
-        expect(result.actions[0]).toMatchObject({
-          icon: 'pencil',
-          'data-test-subj': 'content-list-table-action-edit',
-        });
-      });
-
-      it('includes edit action when `onEdit` is configured', () => {
-        const context: ColumnBuilderContext = {
-          ...defaultContext,
-          itemConfig: { onEdit: jest.fn() },
+          itemConfig: { actions: { edit: { onItemAction: jest.fn() } } },
         };
         const result = buildActionsColumn({}, context) as ActionsColumn;
 
@@ -82,10 +69,10 @@ describe('actions column builder', () => {
         });
       });
 
-      it('includes delete action when `onDelete` is configured', () => {
+      it('includes delete action when `actions.delete.onBulkAction` is configured', () => {
         const context: ColumnBuilderContext = {
           ...defaultContext,
-          itemConfig: { onDelete: jest.fn(async () => {}) },
+          itemConfig: { actions: { delete: { onBulkAction: jest.fn(async () => {}) } } },
         };
         const result = buildActionsColumn({}, context) as ActionsColumn;
 
@@ -108,7 +95,7 @@ describe('actions column builder', () => {
         expect(result).toBeUndefined();
       });
 
-      it('returns `undefined` in read-only mode when onInspect is not configured', () => {
+      it('returns `undefined` in read-only mode when `actions.inspect.onItemAction` is not configured', () => {
         const context: ColumnBuilderContext = {
           ...defaultContext,
           isReadOnly: true,
@@ -118,11 +105,17 @@ describe('actions column builder', () => {
         expect(result).toBeUndefined();
       });
 
-      it('returns only inspect action in read-only mode when onInspect is configured', () => {
+      it('returns only inspect action in read-only mode when `actions.inspect.onItemAction` is configured', () => {
         const context: ColumnBuilderContext = {
           ...defaultContext,
           isReadOnly: true,
-          itemConfig: { ...defaultContext.itemConfig, onInspect: jest.fn() },
+          itemConfig: {
+            ...defaultContext.itemConfig,
+            actions: {
+              ...defaultContext.itemConfig?.actions,
+              inspect: { onItemAction: jest.fn() },
+            },
+          },
         };
         const result = buildActionsColumn({}, context) as ActionsColumn;
 
@@ -134,10 +127,16 @@ describe('actions column builder', () => {
         });
       });
 
-      it('includes inspect action alongside edit and delete when onInspect is configured', () => {
+      it('includes inspect action alongside edit and delete when `actions.inspect.onItemAction` is configured', () => {
         const context: ColumnBuilderContext = {
           ...defaultContext,
-          itemConfig: { ...defaultContext.itemConfig, onInspect: jest.fn() },
+          itemConfig: {
+            ...defaultContext.itemConfig,
+            actions: {
+              ...defaultContext.itemConfig?.actions,
+              inspect: { onItemAction: jest.fn() },
+            },
+          },
         };
         const result = buildActionsColumn({}, context) as ActionsColumn;
 
@@ -187,6 +186,70 @@ describe('actions column builder', () => {
         expect(result).toBeDefined();
         expect(result.actions).toHaveLength(1);
         expect(result.actions[0]).toMatchObject({ icon: 'trash' });
+      });
+
+      it('renders a custom `<Action>` when its config is wired in `itemConfig.actions[id]`', () => {
+        const onArchive = jest.fn();
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          itemConfig: {
+            actions: { archive: { onItemAction: onArchive } },
+          },
+        };
+
+        const props: ActionsColumnProps = {
+          children: <Action id="archive" name="Archive" icon="folderClosed" />,
+        };
+        const result = buildActionsColumn(props, context) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(1);
+        const action = result.actions[0] as DefaultItemAction<ContentListItem>;
+        expect(action).toMatchObject({
+          name: 'Archive',
+          icon: 'folderClosed',
+          'data-test-subj': 'content-list-table-action-archive',
+        });
+        expect(action.onClick).toEqual(expect.any(Function));
+      });
+
+      it('skips a custom `<Action>` when its `itemConfig.actions[id]` config is missing', () => {
+        // Regression: emitting an action object without `onClick`/`href`
+        // crashes EUI at render. The resolver returns `undefined` so the
+        // missing wiring degrades to a no-op instead of a table crash.
+        const props: ActionsColumnProps = {
+          children: (
+            <>
+              <EditAction />
+              <Action id="archive" name="Archive" icon="folderClosed" />
+            </>
+          ),
+        };
+        const result = buildActionsColumn(props, defaultContext) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(1);
+        expect(result.actions[0]).toMatchObject({ icon: 'pencil' });
+      });
+
+      it('falls back to invoking `onBulkAction([item])` when only the bulk handler is configured', () => {
+        const onBulkAction = jest.fn(async () => {});
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          itemConfig: {
+            actions: { archive: { onBulkAction } },
+          },
+        };
+
+        const props: ActionsColumnProps = {
+          children: <Action id="archive" name="Archive" icon="folderClosed" />,
+        };
+        const result = buildActionsColumn(props, context) as ActionsColumn;
+
+        const item = { id: '1', title: 'Item 1' };
+        const action = result.actions[0] as DefaultItemAction<ContentListItem>;
+        action.onClick?.(item, {} as React.MouseEvent);
+        expect(onBulkAction).toHaveBeenCalledWith([item]);
       });
     });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
@@ -84,8 +84,9 @@ export interface ActionsColumnProps
    *
    * When provided, only the specified actions are rendered in the given order.
    * When omitted, actions are determined automatically from the provider config
-   * (e.g., edit is shown if `getEditUrl` or `onEdit` is configured, delete is
-   * shown if `onDelete` is configured).
+   * (e.g., edit is shown if `actions.edit.onItemAction` is configured, delete
+   * is shown if `actions.delete.onBulkAction` is configured, inspect is shown
+   * if `actions.inspect.onItemAction` is configured).
    */
   children?: ReactNode;
 }
@@ -94,21 +95,21 @@ export interface ActionsColumnProps
  * Build default action parts based on the current context.
  *
  * When `Column.Actions` has no children, this function determines which actions
- * to show based on the provider configuration. For example, edit is included
- * when `getEditUrl` or `onEdit` is configured, and delete is included when
- * `onDelete` is configured.
+ * to show based on the provider configuration: each `actions[id]` entry whose
+ * handler is configured contributes a default action.
  */
 const getDefaultActionParts = (context: ColumnBuilderContext): ParsedPart[] => {
   const parts: ParsedPart[] = [];
   const { itemConfig, isReadOnly } = context;
+  const itemActions = itemConfig?.actions;
 
   // Edit and delete actions are suppressed in read-only mode, but inspect
   // (view details) is always available when the content editor is enabled —
   // matching the existing TableListView behavior where "View details" is
   // shown regardless of read-only state.
   if (!isReadOnly) {
-    const hasEdit = itemConfig?.getEditUrl || itemConfig?.onEdit;
-    const hasDelete = itemConfig?.onDelete;
+    const hasEdit = itemActions?.edit?.onItemAction;
+    const hasDelete = itemActions?.delete?.onBulkAction;
 
     if (hasEdit) {
       parts.push({
@@ -131,7 +132,7 @@ const getDefaultActionParts = (context: ColumnBuilderContext): ParsedPart[] => {
     }
   }
 
-  if (itemConfig?.onInspect) {
+  if (itemActions?.inspect?.onItemAction) {
     parts.push({
       type: 'part',
       part: 'action',
@@ -148,8 +149,7 @@ const getDefaultActionParts = (context: ColumnBuilderContext): ParsedPart[] => {
  * Build an `EuiBasicTableColumn` (actions column) from `Column.Actions` declarative attributes.
  *
  * Parses action children to determine which row actions to render. When no children
- * are provided, defaults are inferred from the provider configuration. Returns
- * `undefined` when no actions are available (e.g., read-only mode, no handlers configured).
+ * are provided, defaults are inferred from the provider configuration.
  *
  * @param attributes - The declarative attributes from the parsed `Column.Actions` element.
  * @param context - Builder context with provider configuration.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.test.tsx
@@ -343,7 +343,7 @@ describe('ContentListTable', () => {
 
       render(
         <LoadingWrapper>
-          {/* Default columns when no item.onEdit/onDelete/onInspect: Name + UpdatedAt (Actions is omitted). */}
+          {/* Default columns when no item.actions handlers: Name + UpdatedAt (Actions is omitted). */}
           <ContentListTable title="Dashboards" />
         </LoadingWrapper>
       );

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_columns.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_columns.test.tsx
@@ -61,7 +61,7 @@ describe('useColumns', () => {
         wrapper: createWrapper(),
       });
 
-      // Actions column is omitted because no onEdit/onDelete is configured.
+      // Actions column is omitted because no edit/delete handlers are configured.
       expect(result.current).toHaveLength(2);
       expect(result.current[0].column).toMatchObject({
         field: 'title',
@@ -78,7 +78,14 @@ describe('useColumns', () => {
     it('includes Actions column when item config has edit/delete handlers', () => {
       const onEdit = jest.fn();
       const onDelete = jest.fn();
-      const wrapper = createWrapper({ item: { onEdit, onDelete } });
+      const wrapper = createWrapper({
+        item: {
+          actions: {
+            edit: { onItemAction: onEdit },
+            delete: { onBulkAction: onDelete },
+          },
+        },
+      });
 
       const { result } = renderHook(() => useColumns(undefined, onDelete), {
         wrapper,
@@ -90,9 +97,11 @@ describe('useColumns', () => {
       expect(result.current[2].column).toMatchObject({ name: 'Actions' });
     });
 
-    it('includes only Edit action when only onEdit is configured', () => {
+    it('includes only Edit action when only `actions.edit.onItemAction` is configured', () => {
       const onEdit = jest.fn();
-      const wrapper = createWrapper({ item: { onEdit } });
+      const wrapper = createWrapper({
+        item: { actions: { edit: { onItemAction: onEdit } } },
+      });
 
       const { result } = renderHook(() => useColumns(undefined), {
         wrapper,
@@ -107,7 +116,15 @@ describe('useColumns', () => {
     it('omits Actions column in read-only mode even with handlers', () => {
       const onEdit = jest.fn();
       const onDelete = jest.fn();
-      const wrapper = createWrapper({ isReadOnly: true, item: { onEdit, onDelete } });
+      const wrapper = createWrapper({
+        isReadOnly: true,
+        item: {
+          actions: {
+            edit: { onItemAction: onEdit },
+            delete: { onBulkAction: onDelete },
+          },
+        },
+      });
 
       const { result } = renderHook(() => useColumns(undefined, onDelete), {
         wrapper,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_selection.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_selection.test.tsx
@@ -29,8 +29,19 @@ describe('useSelection', () => {
   const createWrapper = (options?: {
     selection?: boolean | SelectionConfig;
     isReadOnly?: boolean;
+    getDeleteRestriction?: (item: ContentListItem) => string | undefined;
   }) => {
-    const { selection, isReadOnly } = options ?? {};
+    const { selection, isReadOnly, getDeleteRestriction } = options ?? {};
+    const item = getDeleteRestriction
+      ? {
+          actions: {
+            delete: {
+              onBulkAction: jest.fn(async () => {}),
+              restriction: getDeleteRestriction,
+            },
+          },
+        }
+      : undefined;
 
     return ({ children }: { children: React.ReactNode }) => (
       <ContentListProvider
@@ -41,6 +52,7 @@ describe('useSelection', () => {
         features={{
           ...(selection !== undefined && { selection }),
         }}
+        {...(item && { item })}
       >
         {children}
       </ContentListProvider>
@@ -133,8 +145,6 @@ describe('useSelection', () => {
       // coerced to an empty string so the EUI signature is satisfied.
       expect(forwarded(true, mockItems[0])).toBe('');
       expect(forwarded(false, mockItems[1])).toBe('Dashboard B cannot be selected');
-      expect(selectableMessage).toHaveBeenCalledWith(true, mockItems[0]);
-      expect(selectableMessage).toHaveBeenCalledWith(false, mockItems[1]);
     });
 
     it('falls back to the default `selectable` when none is provided', () => {
@@ -147,12 +157,87 @@ describe('useSelection', () => {
       expect(selectable!(mockItems[1])).toBe(true);
     });
 
-    it('omits `selectableMessage` when none is provided', () => {
+    it('omits `selectableMessage` when no message source is configured', () => {
       const { result } = renderHook(() => useSelection(), {
         wrapper: createWrapper({ selection: {} }),
       });
 
       expect(result.current.selection!).not.toHaveProperty('selectableMessage');
+    });
+  });
+
+  describe('with a registered delete restriction', () => {
+    const restrictedItems: ContentListItem[] = [
+      { id: '1', title: 'Free dashboard', managed: false },
+      { id: '2', title: 'Managed dashboard', managed: true },
+    ];
+
+    const restrictManaged = (item: ContentListItem) =>
+      item.managed ? 'Managed dashboards cannot be deleted.' : undefined;
+
+    it('auto-disables rows whose only bulk action (delete) is restricted', () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper({ getDeleteRestriction: restrictManaged }),
+      });
+
+      const { selectable } = result.current.selection!;
+      expect(selectable!(restrictedItems[0])).toBe(true);
+      expect(selectable!(restrictedItems[1])).toBe(false);
+    });
+
+    it('surfaces the restriction reason as `selectableMessage` for disabled rows', () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper({ getDeleteRestriction: restrictManaged }),
+      });
+
+      const message = result.current.selection!.selectableMessage!;
+      expect(message(true, restrictedItems[0])).toBe('');
+      expect(message(false, restrictedItems[1])).toBe('Managed dashboards cannot be deleted.');
+    });
+
+    it('intersects with the consumer `selectable` predicate (consumer can only narrow)', () => {
+      // Consumer marks Free dashboard non-selectable. The auto-derivation
+      // would have allowed it; the composed verdict respects the consumer.
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper({
+          selection: { selectable: (item) => item.id !== '1' },
+          getDeleteRestriction: restrictManaged,
+        }),
+      });
+
+      const { selectable } = result.current.selection!;
+      expect(selectable!(restrictedItems[0])).toBe(false);
+      expect(selectable!(restrictedItems[1])).toBe(false);
+    });
+
+    it("prefers the consumer's `selectableMessage` over the action restriction reason", () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper({
+          selection: {
+            selectable: (item) => item.id !== '1',
+            selectableMessage: (selectable, item) =>
+              selectable ? undefined : `${item.title} is archived`,
+          },
+          getDeleteRestriction: restrictManaged,
+        }),
+      });
+
+      const message = result.current.selection!.selectableMessage!;
+      // Consumer's predicate wins for id=1, so its message is surfaced.
+      expect(message(false, restrictedItems[0])).toBe('Free dashboard is archived');
+      // For id=2 the consumer's `selectable` would allow the row, so the
+      // restriction reason wins for the message.
+      expect(message(false, restrictedItems[1])).toBe('Managed dashboards cannot be deleted.');
+    });
+
+    it('keeps every row selectable when the registered restriction returns `undefined`', () => {
+      const { result } = renderHook(() => useSelection(), {
+        wrapper: createWrapper({ getDeleteRestriction: () => undefined }),
+      });
+
+      const { selectable } = result.current.selection!;
+      expect(selectable!(restrictedItems[0])).toBe(true);
+      expect(selectable!(restrictedItems[1])).toBe(true);
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_selection.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_selection.ts
@@ -11,6 +11,7 @@ import { useMemo } from 'react';
 import type { EuiTableSelectionType } from '@elastic/eui';
 import {
   isSelectionConfig,
+  useBulkActionRestrictions,
   useContentListConfig,
   useContentListSelection,
   type ContentListItem,
@@ -31,48 +32,117 @@ export interface UseSelectionReturn {
  * Hook to integrate content list selection with `EuiBasicTable`.
  *
  * Bridges the provider's selection state with `EuiBasicTable`'s `selection` prop
- * using **controlled mode** (`selected`). This ensures programmatic selection
- * changes (e.g., clearing after delete) are reflected in the table checkboxes.
+ * using controlled mode (`selected`).
  *
- * When `features.selection` is a {@link SelectionConfig}, its `selectable` and
- * `selectableMessage` callbacks are forwarded to EUI so consumers can gate row
- * checkboxes (e.g. permission checks) and surface a tooltip describing the
- * disablement reason.
+ * Composes two layers of "is this row selectable?":
+ * 1. The union over every registered bulk-action restriction predicate.
+ *    A row is disabled when *every* registered action is restricted for that row.
+ * 2. The consumer's optional `SelectionConfig.selectable` predicate.
+ *
+ * The tooltip (`selectableMessage`) surfaces the consumer's message if they
+ * disabled the row, or the first restriction reason otherwise.
  *
  * @returns Object containing the `selection` prop for `EuiBasicTable`.
  */
 export const useSelection = (): UseSelectionReturn => {
   const { supports, features } = useContentListConfig();
   const { selectedItems, setSelection } = useContentListSelection();
+  const restrictions = useBulkActionRestrictions();
 
   // Pull the user-supplied selectable predicate (if any) from the feature
   // config. `boolean` values default to "all rows selectable".
   const selectionConfig = isSelectionConfig(features.selection) ? features.selection : undefined;
-  const selectablePredicate = selectionConfig?.selectable;
-  const selectableMessage = selectionConfig?.selectableMessage;
+  const consumerSelectable = selectionConfig?.selectable;
+  const consumerSelectableMessage = selectionConfig?.selectableMessage;
 
   const selection: EuiTableSelectionType<ContentListItem> | undefined = useMemo(() => {
     if (!supports.selection) {
       return undefined;
     }
 
-    // Adapt the consumer's `selectableMessage` (which may return `undefined`
-    // for selectable rows) to EUI's stricter `(...) => string` signature. EUI
-    // only consults the message when `selectable` is `false`, so any
-    // `undefined` returned for a selectable row is coerced to an empty
-    // string and never rendered.
-    const adaptedSelectableMessage: EuiTableSelectionType<ContentListItem>['selectableMessage'] =
-      selectableMessage
-        ? (selectable, item) => selectableMessage(selectable, item) ?? ''
-        : undefined;
+    /**
+     * `true` iff at least one registered bulk action permits the item.
+     * With no restrictions registered every item is permitted by default.
+     */
+    const isAnyActionAllowed = (item: ContentListItem): boolean => {
+      if (restrictions.length === 0) {
+        return true;
+      }
+      return restrictions.some(({ restriction }) => restriction(item) === undefined);
+    };
+
+    /**
+     * First reason any registered restriction reports for the item, or
+     * `undefined` if every action permits it. Used for tooltip resolution
+     * when the bridge auto-disabled the row.
+     */
+    const firstRestrictionReason = (item: ContentListItem): string | undefined => {
+      for (const { restriction } of restrictions) {
+        const reason = restriction(item);
+        if (reason !== undefined) {
+          return reason;
+        }
+      }
+      return undefined;
+    };
+
+    /**
+     * Composed selectable verdict. Returns `false` as soon as either layer
+     * objects, so the most-specific reason can be surfaced by the message
+     * adapter below.
+     */
+    const composedSelectable = (item: ContentListItem): boolean => {
+      const consumerOK = consumerSelectable ? consumerSelectable(item) : true;
+      if (!consumerOK) {
+        return false;
+      }
+      return isAnyActionAllowed(item);
+    };
+
+    /**
+     * Composed message. Order matters: when the consumer's predicate marks
+     * a row not-selectable, their message wins (their reason is the more
+     * specific one); otherwise the first registered restriction's reason
+     * is surfaced. EUI only displays the message for non-selectable rows,
+     * so the `selectable === true` branch always returns `''`.
+     */
+    const composedSelectableMessage = (isSelectable: boolean, item: ContentListItem): string => {
+      if (isSelectable) {
+        return '';
+      }
+      const consumerOK = consumerSelectable ? consumerSelectable(item) : true;
+      if (!consumerOK) {
+        const consumerMsg = consumerSelectableMessage?.(false, item);
+        if (consumerMsg) {
+          return consumerMsg;
+        }
+      }
+      const reason = firstRestrictionReason(item);
+      if (reason) {
+        return reason;
+      }
+      return consumerSelectableMessage?.(false, item) ?? '';
+    };
+
+    // Only forward `selectableMessage` when there's a real reason source;
+    // otherwise let EUI fall back to its default behaviour and keep the
+    // pre-existing "no message provided" test contract intact.
+    const hasMessageSource = Boolean(consumerSelectableMessage) || restrictions.length > 0;
 
     return {
       onSelectionChange: setSelection,
       selected: selectedItems,
-      selectable: selectablePredicate ?? (() => true),
-      ...(adaptedSelectableMessage && { selectableMessage: adaptedSelectableMessage }),
+      selectable: composedSelectable,
+      ...(hasMessageSource && { selectableMessage: composedSelectableMessage }),
     };
-  }, [supports.selection, setSelection, selectedItems, selectablePredicate, selectableMessage]);
+  }, [
+    supports.selection,
+    setSelection,
+    selectedItems,
+    consumerSelectable,
+    consumerSelectableMessage,
+    restrictions,
+  ]);
 
   return { selection };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/selection_bar.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/selection_bar.test.tsx
@@ -55,7 +55,7 @@ describe('SelectionBar', () => {
         id="test-list"
         labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
         dataSource={{ findItems: mockFindItems }}
-        item={withOnDelete ? { onDelete: mockOnDelete } : undefined}
+        item={withOnDelete ? { actions: { delete: { onBulkAction: mockOnDelete } } } : undefined}
       >
         {children}
       </ContentListProvider>
@@ -118,7 +118,7 @@ describe('SelectionBar', () => {
     expect(container.innerHTML).toBe('');
   });
 
-  it('returns null when `onDelete` is not configured even with selected items', async () => {
+  it('returns null when `actions.delete.onBulkAction` is not configured even with selected items', async () => {
     const Wrapper = createWrapper({ withOnDelete: false });
     const { container } = render(
       <Wrapper>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/selection_bar.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/selection_bar/selection_bar.tsx
@@ -24,13 +24,18 @@ export interface SelectionBarProps {
 /**
  * Selection actions rendered as `toolsLeft` inside the `EuiSearchBar`.
  *
- * When items are selected and `onDelete` is configured on the provider, renders
- * a danger button labelled "Delete {count} {entity}" matching the existing
- * `TableListView` pattern. Clicking the button opens a {@link DeleteConfirmationModal}
- * that handles the delete lifecycle (confirmation, loading, error, refetch).
- * Clears selection when the modal closes (cancel or success).
+ * When items are selected and `actions.delete.onBulkAction` is
+ * configured, renders a "Delete {count} {entity}" button.
+ * Clicking opens a {@link DeleteConfirmationModal}.
  *
- * Returns `null` when nothing is selected or when `onDelete` is not configured.
+ * Bulk-action policy:
+ * - The toolbar button is *never* disabled based on selected items.
+ *   The dialog handles per-action partitioning.
+ * - Row checkboxes auto-disable when no bulk action can act on the row.
+ * - The confirm dialog partitions the request defensively.
+ *
+ * Returns `null` when nothing is selected or when
+ * `actions.delete.onBulkAction` is not configured.
  *
  * @internal Rendered automatically by {@link ContentListToolbar}.
  */
@@ -53,7 +58,7 @@ export const SelectionBar = ({
     [selectedCount, labels.entity, labels.entityPlural]
   );
 
-  if (selectedCount === 0 || typeof itemConfig?.onDelete !== 'function') {
+  if (selectedCount === 0 || typeof itemConfig?.actions?.delete?.onBulkAction !== 'function') {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Replaces the flat `onEdit` / `onDelete` / `onInspect` handlers and the parallel `restrictions` map on `ContentListItemConfig` with a single `actions: ContentListActions` map keyed by `ActionId` (`'edit'` / `'delete'` / `'inspect'` plus consumer-defined custom IDs). Each entry declares at least one of `onItemAction` (single-item handler) or `onBulkAction` (bulk handler), and may add a `restriction` predicate returning a per-item reason string.

### Why

The pre-policy listing surface had three problems that drove this shape change:

- **Last-writer-wins registry** — the old bulk-action registry was a pub/sub set populated by each `ContentListTable`. Two tables under one provider raced to overwrite each other's entries, and either unmount cleared every subscription. Restriction-aware row icons, selection-checkbox gating, and the dialog partition all silently shared this single point of failure.
- **Implicit, scattered configuration** — restrictions lived in `restrictions[id]`, handlers lived as top-level fields, and `onClick` / `href` on JSX `<Action>` props duplicated the handler concept on the consumer side. There was no obvious place to declare a custom bulk action; the registry hard-coded the `delete` ID.
- **Custom actions could not opt into bulk semantics** — only `delete` was wired through the restriction → checkbox-gating → dialog-partition pipeline, leaving custom actions stuck as row-only.

The unified shape collapses all of that into one declaration site: a provider-derived projection of `itemConfig.actions` drives row icons, checkboxes, and the toolbar dialog from a single source of truth, and custom actions flow through the same registry pipeline by declaring both `onBulkAction` and `restriction`.

### What changes

- New types in `kbn-content-list-provider/src/item/types.ts`: `KnownActionId`, `ActionId`, `ActionConfig` (discriminated union requiring at least one handler), and `ContentListActions` (named fields plus an open index signature for custom IDs).
- `ContentListItemConfig` swaps `onEdit` / `onDelete` / `onInspect` / `restrictions` for `actions?: ContentListActions`. `getEditUrl` and `getHref` remain top-level (navigation, not actions).
- `bulk_actions/registry.tsx` becomes a pure projection of `itemConfig.actions`. `BULK_ACTION_HANDLER_KEYS`, `DELETE_ACTION_ID`, and the `BulkActionRestriction` type alias are removed.
- Preset action builders (`buildEditAction`, `buildDeleteAction`, `buildInspectAction`) and `resolveCustomAction` read handlers and restrictions from the unified map. The custom-action `onClick` falls back to invoking `onBulkAction([item])` when only the bulk handler is configured. JSX `<Action>` props are purely declarative — `onClick` and `href` are gone.
- `kbn-content-list-provider-client` synthesises `actions.inspect.onItemAction` from the content editor wiring, merging into any consumer-supplied `actions.inspect` config (preserving `restriction`).
- Stories, the docs playground, the package READMEs, and JSDoc throughout the four affected packages are updated to the new shape.

## Test plan

- [ ] Unit tests: `node scripts/jest src/platform/packages/shared/content-management/content_list`
- [ ] Type checks: each affected package's `tsconfig.json`
- [ ] Storybook: load the dashboard listing, files, maps, and core stories; verify managed-row gating shows on row icons, selection checkboxes, and the bulk-delete dialog partition.
- [ ] Storybook playground: toggle edit / delete / inspect / custom export actions; verify the generated JSX matches the new declarative shape.