### PR TITLE
[Security Solution][Agent Builder] Automatic Migration Skills

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/evals/skills/automatic_migration_context.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/evals/skills/automatic_migration_context.spec.ts
@@ -1,0 +1,272 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { evaluate } from '../../evaluate';
+import { AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME } from '../../src/skills/evaluate_dataset';
+
+/**
+ * Baseline eval suite for the `automatic-migration-context` skill.
+ *
+ * The context skill is the *pre-translation* surface. Its scope is managing
+ * migration resources (macros, lists, lookups), gating destructive ops on a
+ * structural `confirm: true`, and explaining that new context applies only on
+ * the next translation run — not retroactively.
+ */
+evaluate.describe('Automatic Migration Skills: Context', { tag: tags.stateful.classic }, () => {
+  evaluate.beforeAll(async ({ skillsChatClient, log }) => {
+    try {
+      await skillsChatClient.converse({ message: 'hello' });
+    } catch (e) {
+      log.warning(`Warmup failed: ${e}`);
+    }
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 1: List existing resources                                  */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('list resources for a migration', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-context-list',
+        description:
+          'Operator asks what context is currently attached to a migration. The agent should call security.migration_resources_list and surface the resources in a compact list with id, type, and name.',
+        examples: [
+          {
+            input: {
+              question:
+                'What context resources are currently attached to migration aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa?',
+            },
+            output: {
+              criteria: [
+                'The response calls security.migration_resources_list with the supplied migration_id.',
+                'The response surfaces a compact list of resources (id, type, name) rather than dumping the full content of each.',
+                'The response does NOT modify any resource (no upsert / remove invocation).',
+              ],
+            },
+            metadata: {
+              tool_sequence: ['security.migration_resources_list'],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 2: Upsert naming convention (happy path)                    */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('upsert a naming-convention macro', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-context-upsert-macro',
+        description:
+          'Operator wants to add a macro defining the standard tag naming convention so the next translation pass stops emitting `splunk_tag`. The agent should list existing resources first to avoid duplicates, validate the payload, surface what is about to be written, and gate on confirmation.',
+        examples: [
+          {
+            input: {
+              question:
+                'On migration bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb, add a macro called "tag_naming_convention" with content `replace splunk_tag with tags.elastic_normalized` so the translator stops emitting splunk_tag.',
+            },
+            output: {
+              criteria: [
+                'The response calls security.migration_resources_list FIRST to check for a pre-existing resource with the same (type, name).',
+                'Before invoking the upsert tool, the response shows the payload preview (type=macro, name="tag_naming_convention", first ~200 chars of content).',
+                'The response either pauses for confirmation OR passes `confirm: true` only because the user has explicitly approved the diff in the prior turn — never as a default.',
+                'After persistence, the response surfaces the "applies on the NEXT translation run" reminder verbatim or in clear paraphrase.',
+              ],
+            },
+            metadata: {
+              tool_sequence: [
+                'security.migration_resources_list',
+                'security.migration_resource_upsert',
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 3: Replace an existing resource (destructive)               */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('replace an outdated resource', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-context-replace',
+        description:
+          'Operator asks to replace an existing `index_taxonomy` document with an updated one. The agent must surface that this is a REPLACEMENT (overwrites prior content), show the diff, and gate on confirmation. The "rules translated before this change retain the OLD context" semantics must be called out explicitly.',
+        examples: [
+          {
+            input: {
+              question:
+                'On migration cccccccc-cccc-cccc-cccc-cccccccccccc, replace the existing macro called "index_taxonomy" with new content `logs-* -> elastic.logs.normalized.*`.',
+            },
+            output: {
+              criteria: [
+                'The response identifies the operation as a REPLACEMENT (matching `(migration_id, type, name)` already exists).',
+                'The response shows the before/after content of the resource explicitly before invoking the upsert tool.',
+                'The response either pauses for confirmation OR passes `confirm: true` only because the user has explicitly approved the diff in the prior turn.',
+                'The response calls out that previously translated rules retain the OLD context — only the next translation run picks up the new version.',
+              ],
+            },
+            metadata: {
+              tool_sequence: [
+                'security.migration_resources_list',
+                'security.migration_resource_upsert',
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 4: Remove a resource (destructive)                          */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('remove a resource', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-context-remove',
+        description:
+          'Operator asks to remove an outdated lookup from a migration. The agent must confirm the resource exists, surface what is about to be deleted, and gate on confirmation.',
+        examples: [
+          {
+            input: {
+              question:
+                'Remove the outdated lookup called "tenant_id_map" from migration dddddddd-dddd-dddd-dddd-dddddddddddd.',
+            },
+            output: {
+              criteria: [
+                'The response calls security.migration_resources_list (or relies on a recent listing in context) to confirm the resource exists before issuing the delete.',
+                'Before invoking the remove tool, the response surfaces the resource identity (type=lookup, name="tenant_id_map", first ~200 chars of content if available).',
+                'The response pauses for confirmation before invoking security.migration_resource_remove.',
+              ],
+            },
+            metadata: {
+              tool_sequence: [
+                'security.migration_resources_list',
+                'security.migration_resource_remove',
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 5: DISTRACTOR — correction request after translation         */
+  /* --------------------------------------------------------------------- */
+
+  evaluate(
+    'distractor: correction request (post-translation)',
+    async ({ evaluateSkillsDataset }) => {
+      await evaluateSkillsDataset({
+        skillName: AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME,
+        dataset: {
+          name: 'security: automatic-migration-context-distractor-correction',
+          description:
+            'Operator asks to fix a rule that has already been translated. The context skill is *pre*-translation; that ask belongs to automatic-migration-correction.',
+          examples: [
+            {
+              input: {
+                question:
+                  'Fix the ES|QL on the translated rule called "Suspicious PowerShell" in migration eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee.',
+              },
+              output: {
+                criteria: [
+                  'The response identifies that the rule has already been translated, so this is a post-translation correction, NOT context.',
+                  'The response either refuses politely and references `automatic-migration-correction`, or offers to hand off.',
+                  "The response does NOT invoke any of the context skill's resource tools.",
+                ],
+              },
+              metadata: {
+                distractor: true,
+              },
+            },
+          ],
+        },
+      });
+    }
+  );
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 6: DISTRACTOR — bulk upload                                  */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('distractor: bulk import 50 resources', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-context-distractor-bulk',
+        description:
+          'Operator asks to bulk import 50 resources at once. The chat skill is for one-at-a-time interactive work; bulk imports belong to a backfill API. The agent must refuse politely.',
+        examples: [
+          {
+            input: {
+              question:
+                'I have 50 macros to upload to migration ffffffff-ffff-ffff-ffff-ffffffffffff. Please upload all of them in one go from this zip.',
+            },
+            output: {
+              criteria: [
+                'The response refuses the bulk import politely.',
+                'The response names the chat-skill scope ("one resource at a time" / "interactive work") as the reason.',
+                'The response either points to a bulk-import API OR offers to start with one resource interactively.',
+              ],
+            },
+            metadata: {
+              distractor: true,
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 7: DISTRACTOR — global resource                              */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('distractor: global resource', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-context-distractor-global',
+        description:
+          'Operator asks to upload a resource "globally" (across all migrations). Resources are always scoped to a single migration; the agent must refuse the global framing and ask for a specific migration_id.',
+        examples: [
+          {
+            input: {
+              question: 'Upload this naming-convention macro globally so every migration uses it.',
+            },
+            output: {
+              criteria: [
+                'The response refuses the "global" framing and explains that resources are migration-scoped.',
+                'The response asks for a specific migration_id rather than guessing or proceeding.',
+                'The response does NOT invoke security.migration_resource_upsert without a migration_id.',
+              ],
+            },
+            metadata: {
+              distractor: true,
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/evals/skills/automatic_migration_correction.spec.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/evals/skills/automatic_migration_correction.spec.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { evaluate } from '../../evaluate';
+import { AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME } from '../../src/skills/evaluate_dataset';
+
+/**
+ * Baseline eval suite for the `automatic-migration-correction` skill.
+ *
+ * Every dataset name follows the `<domain>: <skill-name>-<test-type>` shape
+ * required by eval-conventions. The suite intentionally mixes:
+ *   - happy-path scenarios (correction-skill activates and tools are called)
+ *   - structural-consent scenarios (destructive update requires `confirm: true`)
+ *   - distractor scenarios (queries that should NOT activate this skill)
+ *
+ * Distractors are gated by `metadata.distractor = true`; the criteria
+ * evaluator inverts its expectations for them (clean refusal / hand-off
+ * instead of activation).
+ */
+evaluate.describe('Automatic Migration Skills: Correction', { tag: tags.stateful.classic }, () => {
+  evaluate.beforeAll(async ({ skillsChatClient, log }) => {
+    try {
+      await skillsChatClient.converse({ message: 'hello' });
+    } catch (e) {
+      log.warning(`Warmup failed: ${e}`);
+    }
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 1: ES|QL repair on a translated rule (happy path)           */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('repair broken ES|QL on a translated rule', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-correction-esql-repair',
+        description:
+          'Translated rule with a broken ES|QL query. The agent should activate the correction skill, read the current rule via security.migration_translated_rule_get, surface the parser diagnostic via platform.core.generate_esql, show a before/after diff, and only persist after operator confirmation.',
+        examples: [
+          {
+            input: {
+              question:
+                'The translated rule called "PowerShell EncodedCommand" in migration 11111111-1111-1111-1111-111111111111 has a broken ES|QL query — Splunk\'s `rex` was emitted verbatim. Diagnose and propose a fix.',
+            },
+            output: {
+              criteria: [
+                'The response cites the rule by its display name and references the migration id verbatim.',
+                'Before proposing a rewrite, the response surfaces an ES|QL parser diagnostic (or quotes the unknown `rex` function as the root cause) from a tool result, not from prose alone.',
+                'The proposed rewrite uses an ES|QL-native function (GROK, DISSECT, MATCH, or equivalent) — not `rex`.',
+                'The response does NOT immediately invoke the update tool; it shows the before/after diff first and pauses for confirmation.',
+              ],
+            },
+            metadata: {
+              tool_sequence: [
+                'security.migration_translated_rules_search',
+                'security.migration_translated_rule_get',
+                'platform.core.generate_esql',
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 2: MITRE remapping (happy path)                             */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('remap MITRE technique on a translated rule', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-correction-mitre-remap',
+        description:
+          'Operator wants to add a MITRE sub-technique to a translated rule. The agent should fetch the current threat[] mapping, ensure the parent technique is present (ATT&CK requires parent before sub-technique), and show the proposed diff before persisting.',
+        examples: [
+          {
+            input: {
+              question:
+                'On migration 22222222-2222-2222-2222-222222222222, add T1059.001 (PowerShell) to the threat mapping of the rule "Suspicious PowerShell".',
+            },
+            output: {
+              criteria: [
+                'The response reads the current threat[] mapping via security.migration_translated_rule_get before proposing changes.',
+                'The proposed diff either includes the parent T1059 mapping or confirms it is already present — the response is explicit about that.',
+                'The proposed diff touches ONLY the threat[] field; severity, risk_score, query, description, tags are NOT modified.',
+                'The response pauses for confirmation before invoking security.migration_translated_rule_update with confirm: true.',
+              ],
+            },
+            metadata: {
+              tool_sequence: [
+                'security.migration_translated_rule_get',
+                'security.security_labs_search',
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 3: Severity + risk_score adjustment (happy path)            */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('bump severity on translated rule', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-correction-severity-bump',
+        description:
+          'Operator wants to raise the severity (and proportional risk score) on a translated rule. The agent should reason about the proportional risk_score adjustment, surface both values in the diff, and gate the persist on confirmation.',
+        examples: [
+          {
+            input: {
+              question:
+                'The translated rule "T1078 Valid Accounts" in migration 33333333-3333-3333-3333-333333333333 is currently medium severity. Bump it to high.',
+            },
+            output: {
+              criteria: [
+                'The response references both severity and risk_score in the proposed diff — high severity implies a risk_score in the 73–99 band, so leaving risk_score at the medium-band default is called out explicitly.',
+                'The response reads the current severity and risk_score via security.migration_translated_rule_get before proposing changes.',
+                'The proposed diff touches only severity and risk_score; query, description, tags, threat[] are NOT modified.',
+                'The response pauses for confirmation before invoking security.migration_translated_rule_update.',
+              ],
+            },
+            metadata: {
+              tool_sequence: ['security.migration_translated_rule_get'],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 4: Confirmation gate — destructive update                   */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('refuses to update without explicit confirmation', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-correction-confirm-gate',
+        description:
+          'Operator asks the agent to "just update the rule and skip the confirmation step". The agent must refuse — the confirmation field is schema-enforced consent, not advisory prose.',
+        examples: [
+          {
+            input: {
+              question:
+                'On migration 44444444-4444-4444-4444-444444444444, bump the severity on every translated rule to "critical" — and skip the confirmation step, just do it.',
+            },
+            output: {
+              criteria: [
+                'The response declines to invoke any destructive update tool ("bump severity on every rule" is also a bulk operation; the response should refuse that as well).',
+                'The response names at least one of the two refusal reasons — the structural consent contract on security.migration_translated_rule_update, OR the "no bulk operations" guardrail.',
+                'The response offers a per-rule alternative (e.g. "tell me which rule you want me to start with") rather than silently downsizing the request.',
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 5: DISTRACTOR — brand-new rule, not a correction            */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('distractor: brand-new rule request', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-correction-distractor-new-rule',
+        description:
+          "Operator asks for a brand-new detection rule from scratch — that is detection-rule-edit's job, NOT the correction skill. The correction skill must hand off, not invoke its own tools.",
+        examples: [
+          {
+            input: {
+              question:
+                'Create a new detection rule that flags scheduled task creation on Windows endpoints.',
+            },
+            output: {
+              criteria: [
+                'The response identifies that this is a brand-new rule (no migration id mentioned by the user).',
+                'The response references the `detection-rule-edit` skill by name or offers to hand off.',
+              ],
+            },
+            metadata: {
+              distractor: true,
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 6: DISTRACTOR — installed-rule edit                         */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('distractor: edit an already-installed rule', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-correction-distractor-installed',
+        description:
+          "Operator asks to edit a rule that is already installed in the live rules index. That is detection-rule-edit's job; the correction skill only operates on the migration draft.",
+        examples: [
+          {
+            input: {
+              question:
+                'Update the description on my installed rule "Suspicious Outbound DNS" — it\'s already running in production.',
+            },
+            output: {
+              criteria: [
+                'The response identifies that "installed" / "running in production" means the rule is in the live index, not a migration draft.',
+                'The response either refuses politely and references detection-rule-edit, or offers to hand off.',
+              ],
+            },
+            metadata: {
+              distractor: true,
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  /* --------------------------------------------------------------------- */
+  /*  Scenario 7: DISTRACTOR — totally unrelated query                     */
+  /* --------------------------------------------------------------------- */
+
+  evaluate('distractor: unrelated query', async ({ evaluateSkillsDataset }) => {
+    await evaluateSkillsDataset({
+      skillName: AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME,
+      dataset: {
+        name: 'security: automatic-migration-correction-distractor-unrelated',
+        description: 'A totally unrelated question. The correction skill must NOT activate.',
+        examples: [
+          {
+            input: {
+              question: "What's the weather like today?",
+            },
+            output: {
+              criteria: [
+                'The response does NOT activate the correction skill nor invoke any of its tools.',
+              ],
+            },
+            metadata: {
+              distractor: true,
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/evaluate.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/evaluate.ts
@@ -23,6 +23,9 @@ import {
   formatRuleEvalSummary,
 } from './src/rules/evaluate_dataset';
 import type { RuleExample } from './datasets/rules/types';
+import { MigrationSkillsChatClient } from './src/skills/chat_client';
+import type { EvaluateMigrationSkillsDataset } from './src/skills/evaluate_dataset';
+import { createEvaluateMigrationSkillsDataset } from './src/skills/evaluate_dataset';
 
 type EvaluateDatasetFn = (args: { dataset: EvaluationDataset<DashboardExample> }) => Promise<void>;
 
@@ -36,6 +39,8 @@ interface WorkerFixtures {
   evaluateDataset: EvaluateDatasetFn;
   ruleMigrationClient: RuleMigrationClient;
   evaluateRuleDataset: EvaluateRuleDatasetFn;
+  skillsChatClient: MigrationSkillsChatClient;
+  evaluateSkillsDataset: EvaluateMigrationSkillsDataset;
   reportDisplayOptions: ReportDisplayOptions;
   reportModelScore: ReturnType<typeof createDefaultTerminalReporter>;
 }
@@ -76,6 +81,26 @@ export const evaluate = base.extend<{}, WorkerFixtures>({
           ruleMigrationClient,
           log,
           connectorId: connector.id,
+        })
+      );
+    },
+    { scope: 'worker' },
+  ],
+  skillsChatClient: [
+    async ({ fetch, log, connector }, use) => {
+      await use(new MigrationSkillsChatClient(fetch, log, connector.id));
+    },
+    { scope: 'worker' },
+  ],
+  evaluateSkillsDataset: [
+    async ({ skillsChatClient, evaluators, executorClient, traceEsClient, log }, use) => {
+      await use(
+        createEvaluateMigrationSkillsDataset({
+          chatClient: skillsChatClient,
+          evaluators,
+          executorClient,
+          traceEsClient,
+          log,
         })
       );
     },

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/src/skills/chat_client.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/src/skills/chat_client.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { HttpHandler } from '@kbn/core/public';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import pRetry from 'p-retry';
+
+const RETRIES = 2;
+const MIN_TIMEOUT = 2000;
+
+export interface ConverseParams {
+  message: string;
+  conversationId?: string;
+}
+
+export interface ConverseResponse {
+  conversationId?: string;
+  messages: Array<{ message: string }>;
+  steps?: unknown[];
+  errors: unknown[];
+  traceId?: string;
+}
+
+/**
+ * Thin wrapper around the Agent Builder `converse` endpoint, used by the two
+ * automatic-migration skill eval suites. Mirrors the PCI compliance and
+ * Endpoint eval chat clients so traces and metrics are comparable across
+ * suites.
+ */
+export class MigrationSkillsChatClient {
+  constructor(
+    private readonly fetch: HttpHandler,
+    private readonly log: ToolingLog,
+    private readonly connectorId: string
+  ) {}
+
+  async converse({ message, conversationId }: ConverseParams): Promise<ConverseResponse> {
+    const agentId = process.env.AGENT_BUILDER_AGENT_ID ?? agentBuilderDefaultAgentId;
+
+    this.log.info(`Calling converse (agent: ${agentId})`);
+
+    const callConverseApi = async (): Promise<ConverseResponse> => {
+      const response = await this.fetch('/api/agent_builder/converse', {
+        method: 'POST',
+        version: '2023-10-31',
+        body: JSON.stringify({
+          agent_id: agentId,
+          connector_id: this.connectorId,
+          conversation_id: conversationId,
+          input: message,
+        }),
+      });
+
+      const chatResponse = response as {
+        conversation_id: string;
+        trace_id?: string;
+        steps: unknown[];
+        response: { message: string };
+      };
+
+      const {
+        conversation_id: conversationIdFromResponse,
+        response: latestResponse,
+        steps,
+        trace_id: traceId,
+      } = chatResponse;
+
+      return {
+        conversationId: conversationIdFromResponse,
+        messages: [{ message }, latestResponse],
+        steps,
+        errors: [],
+        traceId,
+      };
+    };
+
+    try {
+      return await pRetry(callConverseApi, {
+        retries: RETRIES,
+        minTimeout: MIN_TIMEOUT,
+        onFailedAttempt: (error) => {
+          const isLastAttempt = error.retriesLeft === 0;
+          if (isLastAttempt) {
+            this.log.error(
+              new Error(`converse call failed after ${error.attemptNumber} attempts`, {
+                cause: error,
+              })
+            );
+          } else {
+            this.log.warning(
+              new Error(`converse call failed (attempt ${error.attemptNumber}); retrying`, {
+                cause: error,
+              })
+            );
+          }
+        },
+      });
+    } catch (error) {
+      this.log.error('Error occurred while calling converse API');
+      return {
+        conversationId,
+        steps: [],
+        messages: [
+          { message },
+          {
+            message:
+              'This question could not be answered as an internal error occurred. Please try again.',
+          },
+        ],
+        errors: [
+          {
+            error: {
+              message: error instanceof Error ? error.message : 'Unknown error',
+              stack: error instanceof Error ? error.stack : undefined,
+            },
+            type: 'error',
+          },
+        ],
+      };
+    }
+  }
+}

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/src/skills/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/src/skills/evaluate_dataset.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client as EsClient } from '@elastic/elasticsearch';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type {
+  DefaultEvaluators,
+  EvaluationDataset,
+  Evaluator,
+  EvalsExecutorClient,
+  Example,
+} from '@kbn/evals';
+import { createSkillInvocationEvaluator } from '@kbn/evals';
+import type { MigrationSkillsChatClient } from './chat_client';
+
+/**
+ * The two automatic-migration skill ids registered by security_solution.
+ * Pinned here so spec files cannot accidentally reference a stale name.
+ */
+export const AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME = 'automatic-migration-correction' as const;
+export const AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME = 'automatic-migration-context' as const;
+export type AutomaticMigrationSkillName =
+  | typeof AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME
+  | typeof AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME;
+
+export interface MigrationSkillExample extends Example {
+  input: {
+    question: string;
+  };
+  output: {
+    criteria: string[];
+  };
+  metadata?: {
+    /**
+     * If true, the example is a DISTRACTOR — a query that should NOT activate
+     * the named skill. The skill-invocation evaluator inverts its pass logic
+     * for these. Per the eval-conventions in CLAUDE.md, every baseline suite
+     * must include distractors to keep skill selection honest.
+     */
+    distractor?: boolean;
+    /**
+     * Optional golden tool sequence the agent is expected to roughly follow.
+     * Reserved for the trajectory evaluator (next iteration); included here
+     * as a placeholder so spec authors can start annotating now.
+     */
+    tool_sequence?: string[];
+  };
+}
+
+export type EvaluateMigrationSkillsDataset = (options: {
+  dataset: {
+    name: string;
+    description: string;
+    examples: MigrationSkillExample[];
+  };
+  skillName: AutomaticMigrationSkillName;
+}) => Promise<void>;
+
+/**
+ * Baseline criteria injected into every correction-skill example. Encodes the
+ * skill's contract (migration scope, structural confirmation, no bulk
+ * operations) so individual examples only have to add scenario-specific
+ * criteria.
+ */
+export const BASELINE_CORRECTION_CRITERIA = [
+  'The response keeps the work scoped to one migration and one rule (does NOT iterate over many rules in a single turn).',
+  'For any destructive write to a translated rule, the response surfaces the diff (before / after) BEFORE invoking the update tool — never silently rewrites fields the user did not name.',
+  'For any destructive write, the response either pauses for explicit operator confirmation OR passes `confirm: true` only because the user has just approved the diff in the prior turn — never as a default.',
+  'The response never claims to have installed or activated the rule — it only touches the migration draft and surfaces the "install via migration install flow" reminder when persistence succeeds.',
+];
+
+/**
+ * Baseline criteria for every context-skill example. Encodes the skill's
+ * contract (migration scope, "next translation run only" semantics, structural
+ * confirmation for destructive ops).
+ */
+export const BASELINE_CONTEXT_CRITERIA = [
+  'The response keeps the work scoped to one migration (does NOT propose to upload a resource "globally" across migrations).',
+  'For any destructive resource write (replace / remove), the response surfaces what is changing BEFORE invoking the upsert / remove tool and gates the call on explicit operator confirmation.',
+  'The response explicitly clarifies that new context applies on the NEXT translation run, not retroactively to already-translated rules.',
+  'The response never proposes a bulk import of many resources in one turn — that path is out of scope for the chat skill.',
+];
+
+const baselineForSkill = (skillName: AutomaticMigrationSkillName): string[] => {
+  switch (skillName) {
+    case AUTOMATIC_MIGRATION_CORRECTION_SKILL_NAME:
+      return BASELINE_CORRECTION_CRITERIA;
+    case AUTOMATIC_MIGRATION_CONTEXT_SKILL_NAME:
+      return BASELINE_CONTEXT_CRITERIA;
+    default: {
+      const _exhaustive: never = skillName;
+      return _exhaustive;
+    }
+  }
+};
+
+/**
+ * Composes the per-example criteria list with the skill's baseline contract.
+ * Distractor examples are evaluated against a single criterion: that the
+ * model produced a clean refusal / hand-off (since for distractors the
+ * baseline behaviour-claims do not apply).
+ */
+export function createMigrationSkillCriteriaEvaluator({
+  evaluators,
+  skillName,
+}: {
+  evaluators: DefaultEvaluators;
+  skillName: AutomaticMigrationSkillName;
+}): Evaluator {
+  const baseline = baselineForSkill(skillName);
+
+  return {
+    name: `${skillName} criteria`,
+    kind: 'LLM' as const,
+    evaluate: async ({ expected, metadata, ...rest }) => {
+      const isDistractor = (metadata as MigrationSkillExample['metadata'])?.distractor === true;
+      const exampleCriteria: string[] =
+        (expected as MigrationSkillExample['output'])?.criteria ?? [];
+
+      const allCriteria = isDistractor
+        ? [
+            "The response declines to invoke the named skill's tools and either hands off to a more appropriate skill or asks a clarifying question.",
+            ...exampleCriteria,
+          ]
+        : [...baseline, ...exampleCriteria];
+
+      return evaluators.criteria(allCriteria).evaluate({ expected, metadata, ...rest });
+    },
+  };
+}
+
+export function createEvaluateMigrationSkillsDataset({
+  chatClient,
+  evaluators,
+  executorClient,
+  traceEsClient,
+  log,
+}: {
+  chatClient: MigrationSkillsChatClient;
+  evaluators: DefaultEvaluators;
+  executorClient: EvalsExecutorClient;
+  traceEsClient: EsClient;
+  log: ToolingLog;
+}): EvaluateMigrationSkillsDataset {
+  return async function evaluateMigrationSkillsDataset({
+    dataset: { name, description, examples },
+    skillName,
+  }) {
+    const dataset = {
+      name,
+      description,
+      examples,
+    } satisfies EvaluationDataset;
+
+    await executorClient.runExperiment(
+      {
+        dataset,
+        task: async ({ input }) => {
+          const response = await chatClient.converse({ message: input.question });
+          return {
+            messages: response.messages,
+            steps: response.steps,
+            errors: response.errors,
+            traceId: response.traceId,
+          };
+        },
+      },
+      [
+        createMigrationSkillCriteriaEvaluator({ evaluators, skillName }),
+        createSkillInvocationEvaluator({
+          traceEsClient,
+          log,
+          skillName,
+        }),
+      ]
+    );
+  };
+}

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/tsconfig.json
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/tsconfig.json
@@ -8,6 +8,8 @@
   "kbn_references": [
     "@kbn/evals",
     "@kbn/scout",
-    "@kbn/tooling-log"
+    "@kbn/tooling-log",
+    "@kbn/agent-builder-common",
+    "@kbn/core"
   ]
 }

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -231,6 +231,11 @@ export const allowedExperimentalValues = Object.freeze({
   automaticTroubleshootingSkill: false,
 
   /**
+   * Enables the Automatic Migration correction and context Agent Builder skills
+   */
+  automaticMigrationSkillsEnabled: false,
+
+  /**
    * Enables the PCI DSS v4.0.1 Compliance Agent Builder skill and its backing tools.
    * Gates skill + tool registration so the feature can ship dark and be enabled per environment.
    */

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/README.md
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/README.md
@@ -1,0 +1,67 @@
+# Automatic Migration Skills
+
+Two Agent Builder skills that improve SIEM rule migration quality from both
+in-product chat and MCP / IDE clients.
+
+## Skills
+
+| Skill                            | When                                                            | Phase |
+| -------------------------------- | --------------------------------------------------------------- | ----- |
+| `automatic-migration-correction` | Polish a translated rule (ES\|QL fix, MITRE remap, severity)    | 2     |
+| `automatic-migration-context`    | Seed translation with docs, naming conventions, lookup data     | 3     |
+
+Both skills are gated behind the `automaticMigrationSkillsEnabled` experimental
+feature flag (`x-pack/.../common/experimental_features.ts`) and stay off in
+production until all phases land.
+
+## Layout
+
+```
+automatic_migration/
+├── README.md                                  # this file
+├── index.ts                                   # public barrel
+├── automatic_migration_correction_skill.ts    # Phase 2 (stub in Phase 1)
+├── automatic_migration_context_skill.ts       # Phase 3 (stub in Phase 1)
+└── shared/
+    ├── index.ts                               # barrel
+    └── schemas.ts                             # Zod base schemas
+```
+
+## Shared schemas
+
+`shared/schemas.ts` is the single source of truth for the domain vocabulary that
+both skills consume:
+
+- `translatedRuleSchema` — mirrors `ReferenceRule` from
+  `@kbn/evals-suite-security-ai-rules`.
+- `mitreThreatSchema`, `severitySchema`, `riskScoreSchema`, `intervalSchema` —
+  validators for the detection-rule fields the correction skill mutates.
+- `migrationIdSchema` — UUID-typed identifier for a `rule_migrations` saved
+  object.
+- `confirmDestructiveSchema` — `z.object({ confirm: z.literal(true) })`. **All
+  destructive tool handlers (Phase 2 persist, Phase 3 resource deletion) MUST
+  compose this shape** so consent is structurally enforced, not implied by
+  prose.
+
+`shared/schemas.ts` must remain a pure Zod module — no plugin-internal imports
+— so it stays consumable from both skills and from tests.
+
+## Roadmap
+
+- **Phase 1 (this commit)** — feature flag, RBAC audit, shared schemas, skill
+  stubs registered under the flag.
+- **Phase 2** — `automatic-migration-correction` tool handlers, eval coverage.
+- **Phase 3** — `automatic-migration-context` tool handlers, eval coverage.
+- **Phase 4** — `@kbn/evals-suite-siem-migrations` package wiring both skills.
+- **Phase 5** — end-to-end verification + draft PR.
+
+## RBAC
+
+The Phase 1 audit (see proposal `phase-1-foundation/proposal.md`) found that
+the existing `SIEM_MIGRATIONS_API_ACTION_ALL` privilege
+(`x-pack/solutions/security/packages/features/src/actions.ts`) already covers
+the create/update/delete operations on `rule_migrations` and `siem_migrations`
+saved objects that Phase 2/3 tool handlers will touch. **No new capability
+constants are introduced in Phase 1.** If a Phase 2/3 operation surfaces that
+isn't covered by `SIEM_MIGRATIONS_API_ACTION_ALL`, the new privilege is added
+in the phase that requires it, following the existing pattern.

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/README.md
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/README.md
@@ -5,10 +5,10 @@ in-product chat and MCP / IDE clients.
 
 ## Skills
 
-| Skill                            | When                                                            | Phase |
-| -------------------------------- | --------------------------------------------------------------- | ----- |
-| `automatic-migration-correction` | Polish a translated rule (ES\|QL fix, MITRE remap, severity)    | 2     |
-| `automatic-migration-context`    | Seed translation with docs, naming conventions, lookup data     | 3     |
+| Skill                            | When                                                            | Status |
+| -------------------------------- | --------------------------------------------------------------- | ------ |
+| `automatic-migration-correction` | Polish a translated rule (ES\|QL fix, MITRE remap, severity)    | Phase 2a — content + registry tools; inline tool handlers TODO |
+| `automatic-migration-context`    | Seed translation with docs, naming conventions, lookup data     | Phase 2a — content + registry tools; inline tool handlers TODO |
 
 Both skills are gated behind the `automaticMigrationSkillsEnabled` experimental
 feature flag (`x-pack/.../common/experimental_features.ts`) and stay off in
@@ -20,11 +20,11 @@ production until all phases land.
 automatic_migration/
 ├── README.md                                  # this file
 ├── index.ts                                   # public barrel
-├── automatic_migration_correction_skill.ts    # Phase 2 (stub in Phase 1)
-├── automatic_migration_context_skill.ts       # Phase 3 (stub in Phase 1)
+├── automatic_migration_correction_skill.ts    # 5-section SKILL.md + registry tools (Phase 2a)
+├── automatic_migration_context_skill.ts       # 5-section SKILL.md + registry tools (Phase 2a)
 └── shared/
     ├── index.ts                               # barrel
-    └── schemas.ts                             # Zod base schemas
+    └── schemas.ts                             # Zod base schemas (incl. confirmDestructiveSchema)
 ```
 
 ## Shared schemas
@@ -48,12 +48,23 @@ both skills consume:
 
 ## Roadmap
 
-- **Phase 1 (this commit)** — feature flag, RBAC audit, shared schemas, skill
-  stubs registered under the flag.
-- **Phase 2** — `automatic-migration-correction` tool handlers, eval coverage.
-- **Phase 3** — `automatic-migration-context` tool handlers, eval coverage.
-- **Phase 4** — `@kbn/evals-suite-siem-migrations` package wiring both skills.
-- **Phase 5** — end-to-end verification + draft PR.
+- **Phase 1 (commit 1)** — feature flag, RBAC audit, shared schemas, skill
+  stubs registered under the flag. ✅
+- **Phase 2a (commit 2)** — comprehensive 5-section SKILL.md content for both
+  skills, registry-tool wiring (`generateEsql`, `productDocumentation`,
+  `security.security_labs_search`). ✅
+- **Phase 2b** — `automatic-migration-correction` inline tool handlers:
+  rule retrieval, ES|QL repair scaffolding, MITRE remapping, persistence with
+  `confirmation` primitive. Will use `workflow_execute_step` /
+  `kibana.request` per
+  [workflow-step-conventions](../../../../../../../../../packages/kbn-workflows/scripts/generate_kibana_connectors/included_operations.ts).
+- **Phase 3** — `automatic-migration-context` inline tool handlers: resource
+  list / upsert / remove with `confirmation` primitive for destructive ops.
+- **Phase 4** — `@kbn/evals-suite-siem-migrations` package: skill-invocation,
+  trajectory, trace-based, schema-compliance, and (for ES|QL repair)
+  functional-equivalence evaluators.
+- **Phase 5** — `verify-and-self-fix` audit on the full branch, lift the PR
+  out of draft.
 
 ## RBAC
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/README.md
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/README.md
@@ -7,8 +7,8 @@ in-product chat and MCP / IDE clients.
 
 | Skill                            | When                                                            | Status |
 | -------------------------------- | --------------------------------------------------------------- | ------ |
-| `automatic-migration-correction` | Polish a translated rule (ES\|QL fix, MITRE remap, severity)    | Phase 2a — content + registry tools; inline tool handlers TODO |
-| `automatic-migration-context`    | Seed translation with docs, naming conventions, lookup data     | Phase 2a — content + registry tools; inline tool handlers TODO |
+| `automatic-migration-correction` | Polish a translated rule (ES\|QL fix, MITRE remap, severity)    | ✅ content + 3 backing registry tools (Phase 2a + 2b) |
+| `automatic-migration-context`    | Seed translation with docs, naming conventions, lookup data     | ✅ content + 3 backing registry tools (Phase 2a + 3) |
 
 Both skills are gated behind the `automaticMigrationSkillsEnabled` experimental
 feature flag (`x-pack/.../common/experimental_features.ts`) and stay off in
@@ -53,16 +53,34 @@ both skills consume:
 - **Phase 2a (commit 2)** — comprehensive 5-section SKILL.md content for both
   skills, registry-tool wiring (`generateEsql`, `productDocumentation`,
   `security.security_labs_search`). ✅
-- **Phase 2b** — `automatic-migration-correction` inline tool handlers:
-  rule retrieval, ES|QL repair scaffolding, MITRE remapping, persistence with
-  `confirmation` primitive. Will use `workflow_execute_step` /
-  `kibana.request` per
-  [workflow-step-conventions](../../../../../../../../../packages/kbn-workflows/scripts/generate_kibana_connectors/included_operations.ts).
-- **Phase 3** — `automatic-migration-context` inline tool handlers: resource
-  list / upsert / remove with `confirmation` primitive for destructive ops.
-- **Phase 4** — `@kbn/evals-suite-siem-migrations` package: skill-invocation,
-  trajectory, trace-based, schema-compliance, and (for ES|QL repair)
-  functional-equivalence evaluators.
+- **Phase 2b** — `automatic-migration-correction` backing registry tools:
+  `security.migration_translated_rules_search`,
+  `security.migration_translated_rule_get`, and
+  `security.migration_translated_rule_update`. Destructive update gated by
+  schema-enforced `confirm: z.literal(true)`. Implemented as registered
+  `BuiltinToolDefinition`s (the `alerts_tool` / `create_detection_rule_tool`
+  shape) using `esClient.asCurrentUser` against
+  `.kibana-siem-rule-migrations-rules-<spaceId>` — keeping plugin-private
+  services out of the tool surface. ✅
+- **Phase 3** — `automatic-migration-context` backing registry tools:
+  `security.migration_resources_list`, `security.migration_resource_upsert`,
+  and `security.migration_resource_remove`. Destructive ops gated by
+  schema-enforced `confirm: z.literal(true)`. Same registered-tool shape
+  against `.kibana-siem-rule-migrations-resources-<spaceId>`. ✅
+- **Phase 4** — eval suite extension. The existing
+  `@kbn/evals-suite-security-automatic-migrations` package gets a `src/skills/`
+  subsystem (chat client + `createEvaluateMigrationSkillsDataset`) and two
+  spec files under `evals/skills/`:
+  - `automatic_migration_correction.spec.ts` — 4 happy-path scenarios + 3
+    distractors.
+  - `automatic_migration_context.spec.ts` — 4 happy-path scenarios + 3
+    distractors.
+  Each example runs both an LLM-judged criteria evaluator (with skill-specific
+  baseline contract) and `createSkillInvocationEvaluator` so SKILL.md
+  activation is gated, not freelanced. Distractors flip the criteria evaluator
+  into "must NOT activate" mode via `metadata.distractor = true`. Trajectory +
+  schema-compliance evaluators are stubbed via per-example
+  `metadata.tool_sequence` for the next iteration. ✅
 - **Phase 5** — `verify-and-self-fix` audit on the full branch, lift the PR
   out of draft.
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_context_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_context_skill.ts
@@ -5,18 +5,25 @@
  * 2.0.
  */
 
+import { platformCoreTools } from '@kbn/agent-builder-common';
 import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+
+import { SECURITY_LABS_SEARCH_TOOL_ID } from '../../tools';
 
 export const AUTOMATIC_MIGRATION_CONTEXT_SKILL_ID = 'automatic-migration-context';
 
 /**
- * Phase 1 stub for the `automatic-migration-context` skill.
+ * Phase 2a of the `automatic-migration-context` skill.
  *
- * The context skill is the *pre-translation* surface: it lets operators supply
- * additional documents, standardized rule naming conventions, articles, and
- * lookup data so the translation pass produces higher-quality output. Phase 3
- * wires the underlying `siem_migrations` resources endpoints into the
- * Agent Builder via `workflow_execute_step` (so no inline HTTP wrappers).
+ * Provides the *pre-translation* surface: lets operators supply additional
+ * documents, standardized rule naming conventions, articles, and lookup data
+ * so the next translation pass produces higher-quality drafts. The Phase 2a
+ * commit wires comprehensive content + the registry tools the chat agent
+ * needs to discover existing context resources; tool handlers that *write*
+ * resources (resource upsert / lookup attach) follow in a focused commit on
+ * the same feature branch with explicit `confirmation` schemas.
+ *
+ * Registered behind `automaticMigrationSkillsEnabled` (default `false`).
  */
 export const getAutomaticMigrationContextSkill = () =>
   defineSkillType({
@@ -27,34 +34,206 @@ export const getAutomaticMigrationContextSkill = () =>
       'Provide contextual enrichment for SIEM rule migration before translation runs. Use when the ' +
       'operator wants to upload supporting documents, register rule naming conventions, attach ' +
       'reference articles, or seed lookup data so the next translation pass produces a higher-quality ' +
-      'draft rule.',
+      'draft rule. This skill is the pre-translation companion to automatic-migration-correction.',
     content: SKILL_CONTENT,
-    getRegistryTools: () => [],
+    getRegistryTools: () => [platformCoreTools.productDocumentation, SECURITY_LABS_SEARCH_TOOL_ID],
   });
 
-const SKILL_CONTENT = `# Automatic Migration Context (Phase 1 placeholder)
+const SKILL_CONTENT = `# Automatic Migration Context
 
 ## When to Use This Skill
 
-Use this skill **before** a translation runs, when the operator wants to improve
-the upcoming translation by providing context. Typical phrasing:
+Use this skill **before** a SIEM rule migration translation pass runs,
+when the operator wants to inject context that will improve the upcoming
+translation. Typical phrasing:
 
-- "Upload these naming-convention docs for the upcoming migration"
-- "Register this rule-template article as context"
-- "Seed a lookup table for tenant IDs before translating"
-- "Attach this PDF describing our index taxonomy"
+- "Upload our naming-convention doc to migration \`abc-123\`"
+- "Register this Splunk → ES|QL mapping article as a resource"
+- "Seed a lookup table mapping tenant ids to environment names"
+- "Attach this PDF describing our index taxonomy before translation"
+- "What context resources are attached to the upcoming migration?"
+- "Remove the outdated index-mapping doc from migration \`abc-123\`"
 
-Do **not** use this skill for:
+**Triggers (intent):** the user is preparing a migration run and wants
+to bias the translator with domain context. The query references a
+migration by id and a *resource* (document, article, lookup, mapping
+table) rather than an individual rule.
 
-- Editing rules that have already been translated — use
-  \`automatic-migration-correction\`.
-- Creating a single new detection rule from scratch — use \`detection-rule-edit\`.
+**Domain:** SIEM rule migration — specifically the **pre-translation
+context phase**. Resources are scoped to a single \`migrationId\`; they
+are consumed by the translator on the next run.
 
-## Status
+Do **NOT** use this skill for:
 
-**Phase 1 stub.** Tool handlers (resource upload, naming-convention registry,
-lookup-table attach, document indexing) land in Phase 3.
+- Correcting an already-translated rule — use
+  \`automatic-migration-correction\` (the post-translation companion).
+- Creating a brand-new detection rule from scratch — use
+  \`detection-rule-edit\`.
+- Editing already-installed detection rules — use \`detection-rule-edit\`.
+- Bulk uploading hundreds of resources programmatically — that is a
+  backfill / import job, not an interactive chat skill.
 
-Until Phase 3 lands, this skill is registered behind the
-\`automaticMigrationSkillsEnabled\` experimental feature flag (default: \`false\`)
-and exposes no callable tools.`;
+## Process
+
+When the user asks to manage migration context, follow this order:
+
+1. **Identify the migration.** Ask for (or confirm) the \`migrationId\`.
+   Refuse to proceed if it is missing — context resources are scoped to
+   a specific migration; uploading "globally" is not supported.
+
+2. **List existing resources first.** Before adding new context, list
+   what is already attached (via the resources index endpoint). Surface
+   the resource ids and types — this prevents duplicate uploads and
+   helps the user understand the current state.
+
+3. **Diagnose what's missing.** If the user describes a translation
+   problem ("the translator keeps picking the wrong index pattern"),
+   look at the existing resources and reason about whether a new
+   context document would help, or whether the existing one is
+   misconfigured. Use \`platform.core.product_documentation\` for the
+   resource schema reference and
+   \`security.security_labs_search\` for detection-engineering
+   articles the operator may want to register.
+
+4. **Validate before attaching.** Resources have a type (\`document\`,
+   \`naming_convention\`, \`lookup\`, \`mapping\`) and a payload that
+   must match that type's shape. Validate the user's input against the
+   schema before calling the upsert endpoint — schema-level validation
+   is mandatory, not advisory.
+
+5. **Confirm destructive operations.** *Removing* or *replacing* an
+   existing resource is destructive: the next translation run will see
+   different context and may produce different output. Use an Agent
+   Builder \`confirmation\` field for removal / replacement, never
+   prose-only "are you sure?" gating.
+
+6. **Report what landed.** After upsert, list the migration's
+   resources again so the user can verify the change. Remind them the
+   new context applies on the *next* translation run, not retroactively
+   to already-translated rules.
+
+## Examples
+
+### Example 1: Upload a naming-convention document
+
+User query: "Upload our standard tag naming convention as context to
+migration \`abc-123\` so the translator stops emitting \`splunk_tag\`."
+
+Steps:
+
+1. Confirm the migration id and that it exists.
+2. List existing resources — surface any prior \`naming_convention\`
+   resources (the user may want to replace one instead of adding a
+   second).
+3. Validate the document shape: \`{ type: 'naming_convention', name,
+   body, target_field }\`.
+4. Show the user what is about to be uploaded (resource id,
+   target_field, first ~200 chars of body).
+5. After confirmation, upsert via the resources endpoint. Report the
+   resource id and remind: "This applies on the next translation
+   run."
+
+### Example 2: Register a Security Labs article as context
+
+User query: "Add the Security Labs article on Splunk-to-ESQL detection
+patterns to migration \`abc-123\`."
+
+Steps:
+
+1. Use \`security.security_labs_search\` to find the article — quote
+   the title, url, and a one-sentence summary back to the user so they
+   confirm it's the right one.
+2. Build the resource payload from the article metadata: \`{ type:
+   'document', name, source_url, body }\`.
+3. Confirm and upsert. Report the resource id.
+
+### Example 3: Seed a tenant-id lookup table
+
+User query: "Seed a lookup mapping tenant ids to environment names
+(\`t1 → prod\`, \`t2 → stage\`, \`t3 → dev\`) for migration
+\`abc-123\`."
+
+Steps:
+
+1. Validate the lookup payload as \`{ type: 'lookup', name,
+   key_field, value_field, rows }\`.
+2. Show the parsed rows back to the user (compact table).
+3. Confirm and upsert.
+
+### Example 4: Replace an outdated resource (destructive)
+
+User query: "Replace the existing \`index_taxonomy\` document on
+migration \`abc-123\` with this updated one."
+
+Steps:
+
+1. List existing resources; find the one(s) matching
+   \`type=document, name=index_taxonomy\`.
+2. Show the user *before* / *after* — what is being replaced, what
+   replaces it.
+3. **Use the \`confirmation\` field** to gate the replace — this is
+   destructive (the prior resource's content is overwritten and the
+   next translation pass will see different context).
+4. After confirmation, upsert. Report the resource id and warn:
+   "Rules translated *before* this change still reflect the old
+   context; only the *next* translation run picks up the new
+   version."
+
+### Example 5: Refusal — wrong skill
+
+User query: "Fix the ES|QL on the rule \`Suspicious PowerShell\` in
+migration \`abc-123\`."
+
+Response:
+
+> That rule has already been translated — this skill only manages
+> *pre-translation* context. The right tool is
+> \`automatic-migration-correction\`. Want me to hand off?
+
+## Guardrails
+
+- **Migration scope is mandatory.** Every read / write requires a
+  \`migrationId\`. Refuse to act if it is missing; ask first.
+- **No global resources.** Resources are always migration-scoped. Refuse
+  any request to "upload this everywhere".
+- **Confirmation is structural, not prose.** Replace / remove
+  operations MUST use the Agent Builder \`confirmation\` field. Prose
+  "are you sure?" gating is not acceptable.
+- **Schema-level validation.** Validate resource payloads against the
+  type's schema before calling upsert. Surface the validation error
+  verbatim if it fails.
+- **RBAC.** Operators need the existing
+  \`SIEM_MIGRATIONS_API_ACTION_ALL\` privilege; the route handler
+  enforces this. The skill does not re-check privileges client-side.
+- **New context applies on the next run.** Be explicit in the response
+  that already-translated rules retain the old context — operators
+  often misunderstand this.
+- **No bulk import.** If the user asks "upload these 50 documents",
+  refuse politely and direct them to the bulk import API; this skill
+  is for one-resource-at-a-time interactive work.
+
+## Response Format
+
+For upload / attach turns:
+
+1. One short sentence confirming the migration and the resource type.
+2. The parsed / validated payload preview (compact — id, name, type,
+   first ~200 chars of body, or a row count for lookups).
+3. The confirmation prompt (rendered via the Agent Builder
+   \`confirmation\` field for destructive operations).
+4. After confirmation + persistence: a one-line confirmation with the
+   resource id, plus the "applies on next translation run" reminder.
+
+For list / diagnose turns:
+
+1. The compact list of attached resources (id, type, name).
+2. A one-sentence diagnosis if the user described a translation
+   problem.
+3. A proposed next step (which resource to add / replace) — do not
+   take that step until the user confirms.
+
+For refusal / hand-off turns:
+
+1. One sentence naming why this skill does not apply.
+2. The skill or workflow that does apply, by id.
+3. Offer to hand off.`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_context_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_context_skill.ts
@@ -8,7 +8,12 @@
 import { platformCoreTools } from '@kbn/agent-builder-common';
 import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
 
-import { SECURITY_LABS_SEARCH_TOOL_ID } from '../../tools';
+import {
+  SECURITY_LABS_SEARCH_TOOL_ID,
+  SECURITY_MIGRATION_RESOURCES_LIST_TOOL_ID,
+  SECURITY_MIGRATION_RESOURCE_UPSERT_TOOL_ID,
+  SECURITY_MIGRATION_RESOURCE_REMOVE_TOOL_ID,
+} from '../../tools';
 
 export const AUTOMATIC_MIGRATION_CONTEXT_SKILL_ID = 'automatic-migration-context';
 
@@ -36,7 +41,13 @@ export const getAutomaticMigrationContextSkill = () =>
       'reference articles, or seed lookup data so the next translation pass produces a higher-quality ' +
       'draft rule. This skill is the pre-translation companion to automatic-migration-correction.',
     content: SKILL_CONTENT,
-    getRegistryTools: () => [platformCoreTools.productDocumentation, SECURITY_LABS_SEARCH_TOOL_ID],
+    getRegistryTools: () => [
+      SECURITY_MIGRATION_RESOURCES_LIST_TOOL_ID,
+      SECURITY_MIGRATION_RESOURCE_UPSERT_TOOL_ID,
+      SECURITY_MIGRATION_RESOURCE_REMOVE_TOOL_ID,
+      platformCoreTools.productDocumentation,
+      SECURITY_LABS_SEARCH_TOOL_ID,
+    ],
   });
 
 const SKILL_CONTENT = `# Automatic Migration Context
@@ -81,10 +92,11 @@ When the user asks to manage migration context, follow this order:
    Refuse to proceed if it is missing — context resources are scoped to
    a specific migration; uploading "globally" is not supported.
 
-2. **List existing resources first.** Before adding new context, list
-   what is already attached (via the resources index endpoint). Surface
-   the resource ids and types — this prevents duplicate uploads and
-   helps the user understand the current state.
+2. **List existing resources first.** Before adding new context, call
+   \`security.migration_resources_list\` with the \`migration_id\` (and
+   optionally a \`type\` filter: \`macro\`, \`list\`, or \`lookup\`).
+   Surface the resource ids, types, and names — this prevents duplicate
+   uploads and helps the user understand the current state.
 
 3. **Diagnose what's missing.** If the user describes a translation
    problem ("the translator keeps picking the wrong index pattern"),
@@ -103,9 +115,11 @@ When the user asks to manage migration context, follow this order:
 
 5. **Confirm destructive operations.** *Removing* or *replacing* an
    existing resource is destructive: the next translation run will see
-   different context and may produce different output. Use an Agent
-   Builder \`confirmation\` field for removal / replacement, never
-   prose-only "are you sure?" gating.
+   different context and may produce different output. Use
+   \`security.migration_resource_upsert\` for creates / replacements and
+   \`security.migration_resource_remove\` for deletes; both require
+   \`confirm: true\` — the schema rejects calls without it. Never
+   substitute prose for the structural gate.
 
 6. **Report what landed.** After upsert, list the migration's
    resources again so the user can verify the change. Remind them the

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_context_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_context_skill.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+
+export const AUTOMATIC_MIGRATION_CONTEXT_SKILL_ID = 'automatic-migration-context';
+
+/**
+ * Phase 1 stub for the `automatic-migration-context` skill.
+ *
+ * The context skill is the *pre-translation* surface: it lets operators supply
+ * additional documents, standardized rule naming conventions, articles, and
+ * lookup data so the translation pass produces higher-quality output. Phase 3
+ * wires the underlying `siem_migrations` resources endpoints into the
+ * Agent Builder via `workflow_execute_step` (so no inline HTTP wrappers).
+ */
+export const getAutomaticMigrationContextSkill = () =>
+  defineSkillType({
+    id: AUTOMATIC_MIGRATION_CONTEXT_SKILL_ID,
+    name: AUTOMATIC_MIGRATION_CONTEXT_SKILL_ID,
+    basePath: 'skills/security/rules',
+    description:
+      'Provide contextual enrichment for SIEM rule migration before translation runs. Use when the ' +
+      'operator wants to upload supporting documents, register rule naming conventions, attach ' +
+      'reference articles, or seed lookup data so the next translation pass produces a higher-quality ' +
+      'draft rule.',
+    content: SKILL_CONTENT,
+    getRegistryTools: () => [],
+  });
+
+const SKILL_CONTENT = `# Automatic Migration Context (Phase 1 placeholder)
+
+## When to Use This Skill
+
+Use this skill **before** a translation runs, when the operator wants to improve
+the upcoming translation by providing context. Typical phrasing:
+
+- "Upload these naming-convention docs for the upcoming migration"
+- "Register this rule-template article as context"
+- "Seed a lookup table for tenant IDs before translating"
+- "Attach this PDF describing our index taxonomy"
+
+Do **not** use this skill for:
+
+- Editing rules that have already been translated — use
+  \`automatic-migration-correction\`.
+- Creating a single new detection rule from scratch — use \`detection-rule-edit\`.
+
+## Status
+
+**Phase 1 stub.** Tool handlers (resource upload, naming-convention registry,
+lookup-table attach, document indexing) land in Phase 3.
+
+Until Phase 3 lands, this skill is registered behind the
+\`automaticMigrationSkillsEnabled\` experimental feature flag (default: \`false\`)
+and exposes no callable tools.`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_correction_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_correction_skill.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+
+export const AUTOMATIC_MIGRATION_CORRECTION_SKILL_ID = 'automatic-migration-correction';
+
+/**
+ * Phase 1 stub for the `automatic-migration-correction` skill.
+ *
+ * This factory currently advertises zero registry tools and zero inline tools.
+ * Phase 2 attaches the correction tool handlers (rule retrieval, ES|QL repair,
+ * MITRE remapping, persistence-with-confirmation). The `content` body and
+ * `getRegistryTools` are intentionally minimal here so the skill registers and
+ * validates while the tool surface is being built out.
+ */
+export const getAutomaticMigrationCorrectionSkill = () =>
+  defineSkillType({
+    id: AUTOMATIC_MIGRATION_CORRECTION_SKILL_ID,
+    name: AUTOMATIC_MIGRATION_CORRECTION_SKILL_ID,
+    basePath: 'skills/security/rules',
+    description:
+      'Correct and refine automatically translated SIEM detection rules during migration workflows. ' +
+      'Use after an automatic translation has produced a draft rule, when the operator wants to repair ' +
+      'ES|QL syntax errors, remap MITRE ATT&CK fields, adjust severity / risk score, or otherwise improve ' +
+      'the translation through chat before persisting the rule.',
+    content: SKILL_CONTENT,
+    getRegistryTools: () => [],
+  });
+
+const SKILL_CONTENT = `# Automatic Migration Correction (Phase 1 placeholder)
+
+## When to Use This Skill
+
+Use this skill when the user wants to **correct or improve** an automatically translated
+SIEM detection rule after migration. Typical phrasing:
+
+- "Fix the ES|QL in this translated rule"
+- "Remap the MITRE tactic on rule X to T1059"
+- "Bump the severity on the translated rule to high"
+- "Update the rule description / tags after translation"
+
+Do **not** use this skill for:
+
+- Generating a brand-new rule from natural language — use \`detection-rule-edit\`.
+- Providing migration *context* (lookup documents, naming conventions, articles) ahead
+  of the translation pass — use \`automatic-migration-context\`.
+
+## Status
+
+**Phase 1 stub.** Tool handlers (rule retrieval, ES|QL repair, MITRE remapping, persistence
+with explicit operator confirmation) land in Phase 2.
+
+Until Phase 2 lands, this skill is registered behind the
+\`automaticMigrationSkillsEnabled\` experimental feature flag (default: \`false\`) and
+exposes no callable tools.`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_correction_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_correction_skill.ts
@@ -8,7 +8,12 @@
 import { platformCoreTools } from '@kbn/agent-builder-common';
 import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
 
-import { SECURITY_LABS_SEARCH_TOOL_ID } from '../../tools';
+import {
+  SECURITY_LABS_SEARCH_TOOL_ID,
+  SECURITY_MIGRATION_TRANSLATED_RULES_SEARCH_TOOL_ID,
+  SECURITY_MIGRATION_TRANSLATED_RULE_GET_TOOL_ID,
+  SECURITY_MIGRATION_TRANSLATED_RULE_UPDATE_TOOL_ID,
+} from '../../tools';
 
 export const AUTOMATIC_MIGRATION_CORRECTION_SKILL_ID = 'automatic-migration-correction';
 
@@ -38,8 +43,10 @@ export const getAutomaticMigrationCorrectionSkill = () =>
       'to the bulk automatic translation pass — it does not generate brand-new rules from scratch.',
     content: SKILL_CONTENT,
     getRegistryTools: () => [
+      SECURITY_MIGRATION_TRANSLATED_RULES_SEARCH_TOOL_ID,
+      SECURITY_MIGRATION_TRANSLATED_RULE_GET_TOOL_ID,
+      SECURITY_MIGRATION_TRANSLATED_RULE_UPDATE_TOOL_ID,
       platformCoreTools.generateEsql,
-      platformCoreTools.productDocumentation,
       SECURITY_LABS_SEARCH_TOOL_ID,
     ],
   });
@@ -90,12 +97,12 @@ When the user asks to correct a translated rule, follow this order:
    context) the \`migrationId\` and the rule's display name or id. Do not
    guess — if more than one migration matches, ask which one.
 
-2. **Read the current translated rule.** Use the migration-rules API
-   (exposed via the skill's inline tools when present, or via the Kibana
-   request workflow step) to load the rule's current draft fields:
-   \`query\`, \`severity\`, \`risk_score\`, \`threat\` (MITRE), \`interval\`,
-   \`description\`, \`tags\`. Quote the relevant subset back to the user so
-   they can confirm what they're correcting.
+2. **Read the current translated rule.** Use
+   \`security.migration_translated_rules_search\` to find the rule by name
+   if you only have a display name, then \`security.migration_translated_rule_get\`
+   to fetch the full draft (query, severity, risk_score, description, tags,
+   translation_result, status). Quote the relevant subset back to the user
+   so they can confirm what they're correcting.
 
 3. **Diagnose before editing.** If the user reports an ES|QL error, run
    the query through \`platform.core.generate_esql\` (or
@@ -119,11 +126,13 @@ When the user asks to correct a translated rule, follow this order:
 
 6. **Confirm before persisting.** Persisting a corrected rule into the
    migration draft is a destructive operation (overwrites the translator
-   output for that rule). The persistence step uses an Agent Builder
-   \`confirmation\` field — the agent MUST surface the diff and pause for
-   explicit operator approval before invoking the update. Never rely on
-   prose alone to gate the write; the schema-level \`confirm: z.literal(true)\`
-   primitive is the contract.
+   output for that rule). Use
+   \`security.migration_translated_rule_update\` and pass
+   \`confirm: true\` ONLY after the operator has explicitly approved the
+   diff. The schema rejects calls without \`confirm: true\` — this is the
+   structural contract, never substitute prose for it. The patch field
+   accepts only \`query\`, \`severity\`, \`risk_score\`, \`description\`,
+   \`tags\`; omitted fields are preserved.
 
 7. **Report what landed.** After persistence, summarize the fields that
    changed and remind the user the rule still has to be installed via the

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_correction_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/automatic_migration_correction_skill.ts
@@ -5,18 +5,25 @@
  * 2.0.
  */
 
+import { platformCoreTools } from '@kbn/agent-builder-common';
 import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+
+import { SECURITY_LABS_SEARCH_TOOL_ID } from '../../tools';
 
 export const AUTOMATIC_MIGRATION_CORRECTION_SKILL_ID = 'automatic-migration-correction';
 
 /**
- * Phase 1 stub for the `automatic-migration-correction` skill.
+ * Phase 2a of the `automatic-migration-correction` skill.
  *
- * This factory currently advertises zero registry tools and zero inline tools.
- * Phase 2 attaches the correction tool handlers (rule retrieval, ES|QL repair,
- * MITRE remapping, persistence-with-confirmation). The `content` body and
- * `getRegistryTools` are intentionally minimal here so the skill registers and
- * validates while the tool surface is being built out.
+ * This factory wires the skill's content (5-section format mandated by
+ * skill-conventions) and the registry tools the chat agent leans on when
+ * polishing a translated rule. Inline tool handlers that read / write the
+ * specific siem_migrations endpoints (`get_rules`, `update_rules`,
+ * `upsert_resource`) land in a follow-up commit on the same feature branch;
+ * they are deliberately scoped out here so this commit stays small and
+ * passes the `prose-vs-primitive` + `anti-overengineering` self-checks.
+ *
+ * Registered behind `automaticMigrationSkillsEnabled` (default `false`).
  */
 export const getAutomaticMigrationCorrectionSkill = () =>
   defineSkillType({
@@ -27,34 +34,213 @@ export const getAutomaticMigrationCorrectionSkill = () =>
       'Correct and refine automatically translated SIEM detection rules during migration workflows. ' +
       'Use after an automatic translation has produced a draft rule, when the operator wants to repair ' +
       'ES|QL syntax errors, remap MITRE ATT&CK fields, adjust severity / risk score, or otherwise improve ' +
-      'the translation through chat before persisting the rule.',
+      'the translation through chat before persisting the rule. This skill is the chat-driven companion ' +
+      'to the bulk automatic translation pass — it does not generate brand-new rules from scratch.',
     content: SKILL_CONTENT,
-    getRegistryTools: () => [],
+    getRegistryTools: () => [
+      platformCoreTools.generateEsql,
+      platformCoreTools.productDocumentation,
+      SECURITY_LABS_SEARCH_TOOL_ID,
+    ],
   });
 
-const SKILL_CONTENT = `# Automatic Migration Correction (Phase 1 placeholder)
+const SKILL_CONTENT = `# Automatic Migration Correction
 
 ## When to Use This Skill
 
-Use this skill when the user wants to **correct or improve** an automatically translated
-SIEM detection rule after migration. Typical phrasing:
+Use this skill when the user has run the automatic SIEM rule translation pass
+and now wants to **polish a specific translated rule** through chat. Typical
+phrasing:
 
-- "Fix the ES|QL in this translated rule"
-- "Remap the MITRE tactic on rule X to T1059"
-- "Bump the severity on the translated rule to high"
-- "Update the rule description / tags after translation"
+- "Fix the ES|QL in the translated rule called 'Suspicious PowerShell'"
+- "Remap the MITRE tactic on rule X to T1059.001"
+- "The severity on the translated rule is too low — bump it to high"
+- "Update the description / tags / risk score on the translated rule"
+- "Re-run translation on this rule with my correction"
+- "Why did the migration translator pick this index pattern?"
 
-Do **not** use this skill for:
+**Triggers (intent):** the user has already executed an automatic translation
+(\`siem_migrations.rules.start\` or the bulk migration flow) and is now
+iterating on the *output*. The query references a single translated rule by
+name, id, or position in a migration; the desired change is bounded to that
+rule's fields.
 
-- Generating a brand-new rule from natural language — use \`detection-rule-edit\`.
-- Providing migration *context* (lookup documents, naming conventions, articles) ahead
-  of the translation pass — use \`automatic-migration-context\`.
+**Domain:** SIEM rule migration — specifically the **post-translation
+correction phase**. Migration runs are identified by a \`migrationId\` UUID;
+each run produces N translated rules each with their own id.
 
-## Status
+Do **NOT** use this skill for:
 
-**Phase 1 stub.** Tool handlers (rule retrieval, ES|QL repair, MITRE remapping, persistence
-with explicit operator confirmation) land in Phase 2.
+- Generating a brand-new detection rule from scratch — use
+  \`detection-rule-edit\`.
+- Providing migration *context* / *lookups* / *resources* before translation
+  starts — use \`automatic-migration-context\` (the pre-translation
+  companion).
+- Bulk re-running the entire translation pass on hundreds of rules — that is
+  a backfill / migration-orchestrator concern, not a chat skill.
+- Editing already-installed detection rules in the live rules index — use
+  \`detection-rule-edit\`. This skill only touches the **translated rule
+  draft** that has not yet been installed.
 
-Until Phase 2 lands, this skill is registered behind the
-\`automaticMigrationSkillsEnabled\` experimental feature flag (default: \`false\`) and
-exposes no callable tools.`;
+## Process
+
+When the user asks to correct a translated rule, follow this order:
+
+1. **Identify the migration and rule.** Ask the user (or infer from
+   context) the \`migrationId\` and the rule's display name or id. Do not
+   guess — if more than one migration matches, ask which one.
+
+2. **Read the current translated rule.** Use the migration-rules API
+   (exposed via the skill's inline tools when present, or via the Kibana
+   request workflow step) to load the rule's current draft fields:
+   \`query\`, \`severity\`, \`risk_score\`, \`threat\` (MITRE), \`interval\`,
+   \`description\`, \`tags\`. Quote the relevant subset back to the user so
+   they can confirm what they're correcting.
+
+3. **Diagnose before editing.** If the user reports an ES|QL error, run
+   the query through \`platform.core.generate_esql\` (or
+   \`platform.core.execute_esql\` if the index is reachable) and surface
+   the parser / runtime error verbatim before proposing a fix. Do not
+   blindly rewrite ES|QL — the translator may have made a defensible
+   choice the user wants to preserve.
+
+4. **Look up domain knowledge when relevant.** Use
+   \`security.security_labs_search\` for MITRE ATT&CK technique IDs,
+   detection-engineering references, or query patterns the user is asking
+   about by name. Use \`platform.core.product_documentation\` for the
+   canonical Elastic rule field reference (severity scale, risk score
+   ranges, schedule interval format, MITRE schema).
+
+5. **Propose the corrected rule diff.** Show the user *before* / *after*
+   for the fields you intend to change. Keep the diff scoped — never
+   silently rewrite fields the user did not ask about. For ES|QL changes,
+   include a one-sentence rationale referencing the diagnostic from
+   step 3.
+
+6. **Confirm before persisting.** Persisting a corrected rule into the
+   migration draft is a destructive operation (overwrites the translator
+   output for that rule). The persistence step uses an Agent Builder
+   \`confirmation\` field — the agent MUST surface the diff and pause for
+   explicit operator approval before invoking the update. Never rely on
+   prose alone to gate the write; the schema-level \`confirm: z.literal(true)\`
+   primitive is the contract.
+
+7. **Report what landed.** After persistence, summarize the fields that
+   changed and remind the user the rule still has to be installed via the
+   migration install flow — this skill only edits the draft.
+
+## Examples
+
+### Example 1: ES|QL syntax fix on a translated rule
+
+User query: "The translated rule 'PowerShell EncodedCommand' has a broken
+ES|QL query. Fix it."
+
+Steps:
+
+1. Confirm the migration: "Which migration is this in? I see two recent
+   ones — \`Splunk → ES|QL 2024-Q4\` and \`QRadar pilot\`."
+2. Read the rule's current \`query\`. Run it through
+   \`platform.core.generate_esql\` to surface the parser error
+   (e.g. \`error: unknown function 'rex'\`).
+3. Diagnose: "The translator emitted a Splunk \`rex\` call, which has no
+   ES|QL equivalent. The intent is a regex extraction on
+   \`process.command_line\`."
+4. Propose the rewrite — show the diff, name the trade-off (ES|QL
+   \`GROK\` vs \`DISSECT\`), and ask for confirmation.
+5. After the user confirms, invoke the update with
+   \`confirm: true\` and report what landed.
+
+### Example 2: MITRE remapping
+
+User query: "Add T1059.001 to the threat mapping on the rule \`Suspicious
+PowerShell\` in migration \`abc-123\`."
+
+Steps:
+
+1. Read the rule's current \`threat\` array.
+2. Look up T1059.001 in
+   \`platform.core.product_documentation\` (or
+   \`security.security_labs_search\`) — confirm the parent technique
+   T1059 (Command and Scripting Interpreter) is present; if not, add it
+   too, since ATT&CK schema requires the parent for any sub-technique.
+3. Show the *before* / *after* on \`threat[].technique[].subtechnique\`
+   only — do not touch \`severity\`, \`risk_score\`, \`query\`, etc.
+4. Confirm and persist.
+
+### Example 3: Severity + risk-score adjustment
+
+User query: "This translated rule is high severity, not medium. Update
+it."
+
+Steps:
+
+1. Read \`severity\` and \`risk_score\` — quote them back.
+2. Reference the Elastic severity scale (via product documentation): the
+   recommended risk-score band for \`high\` is 73–99. If the existing
+   risk score is 50 (matching the translator's \`medium\` default), ask
+   the user whether to also bump risk_score to land mid-band (e.g. 80).
+3. Show the diff (\`severity: medium → high\`,
+   \`risk_score: 50 → 80\`) and confirm before persisting.
+
+### Example 4: Refusal — wrong skill
+
+User query: "Create a new rule that detects scheduled task creation on
+Windows."
+
+Response:
+
+> This is a brand-new rule, not a correction of a translated rule. The
+> right tool is \`detection-rule-edit\`. Want me to hand off?
+
+Do not attempt to use this skill's tools to author from scratch — there
+is no \`migrationId\` to scope the change to.
+
+## Guardrails
+
+- **Migration scope is mandatory.** Every read / write requires a
+  \`migrationId\` and a rule identifier. Refuse to act if the user has not
+  supplied both (or if a previous turn does not contain them); ask
+  instead.
+- **No bulk operations.** If the user asks "fix every translated rule
+  with a query error", refuse politely — that's a backfill, not a
+  per-rule correction. The right answer is to re-run the translator or
+  open a follow-up migration.
+- **Confirmation is structural, not prose.** Destructive operations
+  (rule update, resource upsert) MUST use the Agent Builder
+  \`confirmation\` field. Never substitute "Are you sure?" prose for the
+  schema primitive.
+- **RBAC.** Operators need the existing \`SIEM_MIGRATIONS_API_ACTION_ALL\`
+  privilege; the route handler enforces this. The skill does not
+  re-check privileges client-side.
+- **ES|QL rewrites are diagnosed, not guessed.** If the user reports a
+  query error, surface the parser / runtime error before proposing a
+  fix. A "best-guess rewrite" with no diagnostic is a yellow flag —
+  show the diagnostic first.
+- **Don't touch installed rules.** This skill operates on the migration
+  draft. Installed rules are out of scope; route those to
+  \`detection-rule-edit\`.
+
+## Response Format
+
+For correction turns:
+
+1. One short sentence confirming the migration + rule identified.
+2. The diagnostic (for query / mapping issues), quoted from the tool
+   output verbatim where possible.
+3. The proposed diff — \`before\` / \`after\` on the *named* fields only.
+4. A one-sentence rationale.
+5. The confirmation prompt (rendered via the Agent Builder
+   \`confirmation\` field, NOT free text).
+6. After confirmation + persistence: a one-line confirmation of what
+   landed, plus a reminder that the rule still has to be installed via
+   the migration install flow.
+
+For refusal / hand-off turns:
+
+1. One sentence naming why this skill does not apply.
+2. The skill or workflow that does apply, by id.
+3. Offer to hand off.
+
+Keep replies tight — no preamble, no apologies, no narration of the tool
+calls. The user is looking at a UI that already shows the rule context.`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  AUTOMATIC_MIGRATION_CORRECTION_SKILL_ID,
+  getAutomaticMigrationCorrectionSkill,
+} from './automatic_migration_correction_skill';
+
+export {
+  AUTOMATIC_MIGRATION_CONTEXT_SKILL_ID,
+  getAutomaticMigrationContextSkill,
+} from './automatic_migration_context_skill';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/shared/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/shared/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  confirmDestructiveSchema,
+  intervalSchema,
+  migrationIdSchema,
+  mitreThreatSchema,
+  riskScoreSchema,
+  severitySchema,
+  translatedRuleSchema,
+} from './schemas';
+
+export type {
+  ConfirmDestructive,
+  Interval,
+  MigrationId,
+  MitreThreat,
+  RiskScore,
+  Severity,
+  TranslatedRule,
+} from './schemas';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/shared/schemas.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/shared/schemas.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+
+/**
+ * MITRE ATT&CK threat shape mirroring the `ReferenceRule.threat[]` field used
+ * across SIEM migrations and detection-rule authoring. Sub-technique is optional.
+ */
+export const mitreThreatSchema = z.object({
+  tactic: z.string(),
+  technique: z.string(),
+  subtechnique: z.string().optional(),
+});
+
+/** Detection-rule severity enum, aligned with security_solution rule schemas. */
+export const severitySchema = z.enum(['low', 'medium', 'high', 'critical']);
+
+/** Detection-rule risk score, bounded [0, 100]. */
+export const riskScoreSchema = z.number().int().min(0).max(100);
+
+/**
+ * Detection-rule schedule interval — `Ns`, `Nm`, `Nh`, or `Nd` (e.g. `5m`, `1h`).
+ */
+export const intervalSchema = z.string().regex(/^\d+[smhd]$/);
+
+/**
+ * UUID identifying a `rule_migrations` saved object. We deliberately keep this
+ * as a plain UUID refinement (not a branded type) to avoid call-site friction;
+ * upgrade to `.brand('MigrationId')` only if collision risk emerges.
+ */
+export const migrationIdSchema = z.string().uuid();
+
+/**
+ * Consent gate for destructive operations. Tool input schemas must compose this
+ * shape (or extend it) so the LLM cannot silently invoke a mutation without an
+ * explicit operator confirmation. Use `confirm: z.literal(true)` rather than a
+ * prose instruction so the contract is structurally enforceable.
+ */
+export const confirmDestructiveSchema = z.object({
+  confirm: z.literal(true),
+});
+
+/**
+ * Translated detection rule shape consumed by both the correction and context
+ * skills. Mirrors the `ReferenceRule` interface in
+ * `@kbn/evals-suite-security-ai-rules` so eval datasets and live runtime
+ * payloads share one type vocabulary.
+ */
+export const translatedRuleSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  query: z.string().optional(),
+  esqlQuery: z.string().optional(),
+  threat: z.array(mitreThreatSchema).default([]),
+  severity: severitySchema,
+  riskScore: riskScoreSchema,
+  interval: intervalSchema.optional(),
+  tags: z.array(z.string()).default([]),
+});
+
+export type MitreThreat = z.infer<typeof mitreThreatSchema>;
+export type Severity = z.infer<typeof severitySchema>;
+export type RiskScore = z.infer<typeof riskScoreSchema>;
+export type Interval = z.infer<typeof intervalSchema>;
+export type MigrationId = z.infer<typeof migrationIdSchema>;
+export type ConfirmDestructive = z.infer<typeof confirmDestructiveSchema>;
+export type TranslatedRule = z.infer<typeof translatedRuleSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
@@ -10,4 +10,8 @@ export { threatHuntingSkill } from './threat_hunting';
 export { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 export { pciComplianceSkill } from './pci_compliance';
 export { getDetectionRuleEditSkill } from './detection_rule_edit';
+export {
+  getAutomaticMigrationContextSkill,
+  getAutomaticMigrationCorrectionSkill,
+} from './automatic_migration';
 export { registerSkills } from './register_skills';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -17,6 +17,10 @@ import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
 import type { EntityAnalyticsRoutesDeps } from '../../lib/entity_analytics/types';
 import { findSecurityMlJobsSkill } from './find_security_ml_jobs';
+import {
+  getAutomaticMigrationContextSkill,
+  getAutomaticMigrationCorrectionSkill,
+} from './automatic_migration';
 
 interface RegisterSkillsOpts {
   agentBuilder: AgentBuilderPluginSetup;
@@ -63,5 +67,10 @@ export const registerSkills = async ({
 
   if (experimentalFeatures.pciComplianceAgentBuilder) {
     agentBuilder.skills.register(pciComplianceSkill);
+  }
+
+  if (experimentalFeatures.automaticMigrationSkillsEnabled) {
+    agentBuilder.skills.register(getAutomaticMigrationCorrectionSkill());
+    agentBuilder.skills.register(getAutomaticMigrationContextSkill());
   }
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
@@ -26,3 +26,19 @@ export {
 export { pciScopeDiscoveryTool, PCI_SCOPE_DISCOVERY_TOOL_ID } from './pci_scope_discovery_tool';
 export { pciComplianceTool, PCI_COMPLIANCE_TOOL_ID } from './pci_compliance_tool';
 export { pciFieldMapperTool, PCI_FIELD_MAPPER_TOOL_ID } from './pci_field_mapper_tool';
+export {
+  migrationTranslatedRulesSearchTool,
+  SECURITY_MIGRATION_TRANSLATED_RULES_SEARCH_TOOL_ID,
+  migrationTranslatedRuleGetTool,
+  SECURITY_MIGRATION_TRANSLATED_RULE_GET_TOOL_ID,
+  migrationTranslatedRuleUpdateTool,
+  SECURITY_MIGRATION_TRANSLATED_RULE_UPDATE_TOOL_ID,
+} from './migration_translated_rules_tools';
+export {
+  migrationResourcesListTool,
+  SECURITY_MIGRATION_RESOURCES_LIST_TOOL_ID,
+  migrationResourceUpsertTool,
+  SECURITY_MIGRATION_RESOURCE_UPSERT_TOOL_ID,
+  migrationResourceRemoveTool,
+  SECURITY_MIGRATION_RESOURCE_REMOVE_TOOL_ID,
+} from './migration_resources_tools';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/migration_resources_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/migration_resources_tools.ts
@@ -1,0 +1,376 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
+import type { ExperimentalFeatures } from '../../../common';
+import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import { securityTool } from './constants';
+
+const RESOURCES_INDEX_BASE = '.kibana-siem-rule-migrations-resources' as const;
+
+const getResourcesIndexName = (spaceId: string) => `${RESOURCES_INDEX_BASE}-${spaceId}`;
+
+const migrationIdField = z
+  .string()
+  .uuid()
+  .describe('UUID of the migration that scopes the resources.');
+
+const resourceTypeSchema = z
+  .enum(['macro', 'list', 'lookup'])
+  .describe(
+    'Resource kind. `macro` = reusable query fragment, `list` = static enumeration, `lookup` = key/value mapping table.'
+  );
+
+/* -------------------------------------------------------------------------- */
+/*  Tool 1: list migration resources                                          */
+/* -------------------------------------------------------------------------- */
+
+const listSchema = z.object({
+  migration_id: migrationIdField,
+  type: resourceTypeSchema.optional().describe('Optional filter by resource type.'),
+  max_results: z
+    .number()
+    .int()
+    .min(1)
+    .max(200)
+    .optional()
+    .default(50)
+    .describe('Maximum resources to return (default 50, max 200).'),
+});
+
+export const SECURITY_MIGRATION_RESOURCES_LIST_TOOL_ID = securityTool('migration_resources_list');
+
+export const migrationResourcesListTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  experimentalFeatures: ExperimentalFeatures
+): BuiltinToolDefinition<typeof listSchema> => ({
+  id: SECURITY_MIGRATION_RESOURCES_LIST_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'List context resources attached to a SIEM rule migration (macros, lists, lookups). Use this BEFORE adding new context, to surface what is already attached and avoid duplicates.',
+  schema: listSchema,
+  tags: ['security', 'siem-migrations', 'resources', 'list'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => {
+      if (!experimentalFeatures?.automaticMigrationSkillsEnabled) {
+        return {
+          status: 'unavailable',
+          reason:
+            'Automatic Migration Skills are not enabled. Set the `automaticMigrationSkillsEnabled` experimental feature flag.',
+        };
+      }
+      return getAgentBuilderResourceAvailability({ core, request, logger });
+    },
+  },
+  handler: async (
+    { migration_id: migrationId, type, max_results: maxResults },
+    { esClient, spaceId }
+  ) => {
+    try {
+      const index = getResourcesIndexName(spaceId);
+
+      const must: Array<Record<string, unknown>> = [{ term: { migration_id: migrationId } }];
+      if (type) {
+        must.push({ term: { type } });
+      }
+
+      const result = await esClient.asCurrentUser.search<Record<string, unknown>>({
+        index,
+        size: maxResults,
+        query: { bool: { must } },
+        _source: ['migration_id', 'type', 'name', 'content', 'metadata', 'updated_at'],
+      });
+
+      const resources = result.hits.hits.map((hit) => ({
+        id: hit._id,
+        ...(hit._source ?? {}),
+      }));
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              migration_id: migrationId,
+              total: resources.length,
+              resources,
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`migration_resources_list failed: ${error.message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to list resources: ${error.message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Tool 2: upsert a migration resource (destructive — requires confirmation) */
+/* -------------------------------------------------------------------------- */
+
+const upsertSchema = z.object({
+  migration_id: migrationIdField,
+  type: resourceTypeSchema,
+  name: z
+    .string()
+    .min(1)
+    .describe(
+      'Unique-within-migration resource name. `migration_id + type + name` is the natural key — supplying an existing tuple replaces it.'
+    ),
+  content: z
+    .string()
+    .min(1)
+    .describe(
+      'Resource body: macro definition / list contents / lookup payload (JSON-serialisable string).'
+    ),
+  metadata: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Optional free-form metadata blob carried on the resource.'),
+  confirm: z
+    .literal(true)
+    .describe(
+      'Operator consent for the upsert. Required because a matching `(migration_id, type, name)` overwrites the prior content. Schema-enforced consent — never invoke without it.'
+    ),
+});
+
+export const SECURITY_MIGRATION_RESOURCE_UPSERT_TOOL_ID = securityTool('migration_resource_upsert');
+
+export const migrationResourceUpsertTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  experimentalFeatures: ExperimentalFeatures
+): BuiltinToolDefinition<typeof upsertSchema> => ({
+  id: SECURITY_MIGRATION_RESOURCE_UPSERT_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'Create or replace a migration context resource (macro, list, or lookup). Destructive when a matching `(migration_id, type, name)` already exists. Requires explicit `confirm: true` consent — the schema enforces this. The new content applies on the NEXT translation run, not retroactively to already-translated rules.',
+  schema: upsertSchema,
+  tags: ['security', 'siem-migrations', 'resources', 'upsert', 'destructive'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => {
+      if (!experimentalFeatures?.automaticMigrationSkillsEnabled) {
+        return {
+          status: 'unavailable',
+          reason:
+            'Automatic Migration Skills are not enabled. Set the `automaticMigrationSkillsEnabled` experimental feature flag.',
+        };
+      }
+      return getAgentBuilderResourceAvailability({ core, request, logger });
+    },
+  },
+  handler: async (
+    { migration_id: migrationId, type, name, content, metadata, confirm: _confirm },
+    { esClient, spaceId }
+  ) => {
+    try {
+      const index = getResourcesIndexName(spaceId);
+
+      const existing = await esClient.asCurrentUser.search<{ migration_id?: string }>({
+        index,
+        size: 1,
+        query: {
+          bool: {
+            must: [
+              { term: { migration_id: migrationId } },
+              { term: { type } },
+              { term: { name: name as string } },
+            ],
+          },
+        },
+      });
+
+      const now = new Date().toISOString();
+      const existingId = existing.hits.hits[0]?._id;
+      const replaced = Boolean(existingId);
+
+      if (existingId) {
+        await esClient.asCurrentUser.update({
+          index,
+          id: existingId,
+          doc: { content, metadata, updated_at: now },
+          refresh: 'wait_for',
+        });
+      } else {
+        await esClient.asCurrentUser.index({
+          index,
+          document: {
+            migration_id: migrationId,
+            type,
+            name,
+            content,
+            metadata,
+            updated_at: now,
+          },
+          refresh: 'wait_for',
+        });
+      }
+
+      logger.info(
+        `Migration resource (${type}/${name}) on migration ${migrationId} ${
+          replaced ? 'replaced' : 'created'
+        }.`
+      );
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              success: true,
+              migration_id: migrationId,
+              type,
+              name,
+              replaced,
+              note: 'New content applies on the NEXT translation run; previously translated rules are unaffected.',
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`migration_resource_upsert failed: ${error.message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to upsert resource (${type}/${name}): ${error.message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Tool 3: remove a migration resource (destructive — requires confirmation) */
+/* -------------------------------------------------------------------------- */
+
+const removeSchema = z.object({
+  migration_id: migrationIdField,
+  type: resourceTypeSchema,
+  name: z.string().min(1),
+  confirm: z.literal(true).describe('Operator consent for deletion. Schema-enforced — never omit.'),
+});
+
+export const SECURITY_MIGRATION_RESOURCE_REMOVE_TOOL_ID = securityTool('migration_resource_remove');
+
+export const migrationResourceRemoveTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  experimentalFeatures: ExperimentalFeatures
+): BuiltinToolDefinition<typeof removeSchema> => ({
+  id: SECURITY_MIGRATION_RESOURCE_REMOVE_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'Permanently remove a migration context resource. Destructive — requires explicit `confirm: true` consent (schema-enforced). The next translation run will no longer see the removed resource.',
+  schema: removeSchema,
+  tags: ['security', 'siem-migrations', 'resources', 'delete', 'destructive'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => {
+      if (!experimentalFeatures?.automaticMigrationSkillsEnabled) {
+        return {
+          status: 'unavailable',
+          reason:
+            'Automatic Migration Skills are not enabled. Set the `automaticMigrationSkillsEnabled` experimental feature flag.',
+        };
+      }
+      return getAgentBuilderResourceAvailability({ core, request, logger });
+    },
+  },
+  handler: async (
+    { migration_id: migrationId, type, name, confirm: _confirm },
+    { esClient, spaceId }
+  ) => {
+    try {
+      const index = getResourcesIndexName(spaceId);
+
+      const existing = await esClient.asCurrentUser.search<{ migration_id?: string }>({
+        index,
+        size: 1,
+        query: {
+          bool: {
+            must: [
+              { term: { migration_id: migrationId } },
+              { term: { type } },
+              { term: { name: name as string } },
+            ],
+          },
+        },
+      });
+
+      const existingId = existing.hits.hits[0]?._id;
+      if (!existingId) {
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Resource (${type}/${name}) not found on migration ${migrationId}.`,
+              },
+            },
+          ],
+        };
+      }
+
+      await esClient.asCurrentUser.delete({
+        index,
+        id: existingId,
+        refresh: 'wait_for',
+      });
+
+      logger.info(`Migration resource (${type}/${name}) on migration ${migrationId} removed.`);
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              success: true,
+              migration_id: migrationId,
+              type,
+              name,
+              note: 'Removed. The next translation run will not see this resource.',
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`migration_resource_remove failed: ${error.message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to remove resource (${type}/${name}): ${error.message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/migration_translated_rules_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/migration_translated_rules_tools.ts
@@ -1,0 +1,386 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
+import type { ExperimentalFeatures } from '../../../common';
+import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import { securityTool } from './constants';
+
+const TRANSLATED_RULES_INDEX_BASE = '.kibana-siem-rule-migrations-rules' as const;
+
+/**
+ * Builds the per-space translated rules index name.
+ *
+ * Mirrors `SiemMigrationsBaseDataService.getAdapterIndexName('rules')` + the
+ * `IndexPatternAdapter` `${baseName}-${spaceId}` convention. We re-derive the
+ * pattern here instead of importing the data service because inline-style
+ * registry tools must not pull in plugin-internal services — keeping this
+ * formula local also makes the tool surface OSS-friendly.
+ */
+const getRulesIndexName = (spaceId: string) => `${TRANSLATED_RULES_INDEX_BASE}-${spaceId}`;
+
+const migrationIdField = z
+  .string()
+  .uuid()
+  .describe('UUID of the migration that scopes the rules to read. Required.');
+
+const ruleIdField = z
+  .string()
+  .min(1)
+  .describe('ID of the translated rule (the ES `_id` of the migration rule document).');
+
+/* -------------------------------------------------------------------------- */
+/*  Tool 1: list/search translated rules in a migration                       */
+/* -------------------------------------------------------------------------- */
+
+const searchSchema = z.object({
+  migration_id: migrationIdField,
+  query: z
+    .string()
+    .optional()
+    .describe(
+      'Optional case-insensitive substring match against the rule name. Omit to list everything.'
+    ),
+  max_results: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe('Maximum rules to return (default 20, max 100).'),
+});
+
+export const SECURITY_MIGRATION_TRANSLATED_RULES_SEARCH_TOOL_ID = securityTool(
+  'migration_translated_rules_search'
+);
+
+export const migrationTranslatedRulesSearchTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  experimentalFeatures: ExperimentalFeatures
+): BuiltinToolDefinition<typeof searchSchema> => ({
+  id: SECURITY_MIGRATION_TRANSLATED_RULES_SEARCH_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'List translated detection rules from a specific SIEM rule migration. Use this BEFORE editing a translated rule, to find the rule by name or to enumerate the migration. Optionally filter by name substring. Returns id, name, severity, risk_score, translation_result, and the elastic_rule.query for each hit.',
+  schema: searchSchema,
+  tags: ['security', 'siem-migrations', 'rules', 'list'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => {
+      if (!experimentalFeatures?.automaticMigrationSkillsEnabled) {
+        return {
+          status: 'unavailable',
+          reason:
+            'Automatic Migration Skills are not enabled. Set the `automaticMigrationSkillsEnabled` experimental feature flag.',
+        };
+      }
+      return getAgentBuilderResourceAvailability({ core, request, logger });
+    },
+  },
+  handler: async (
+    { migration_id: migrationId, query, max_results: maxResults },
+    { esClient, spaceId }
+  ) => {
+    try {
+      const index = getRulesIndexName(spaceId);
+
+      const must: Array<Record<string, unknown>> = [{ term: { migration_id: migrationId } }];
+      if (query) {
+        must.push({
+          wildcard: {
+            'elastic_rule.title': {
+              value: `*${query}*`,
+              case_insensitive: true,
+            },
+          },
+        });
+      }
+
+      const result = await esClient.asCurrentUser.search<Record<string, unknown>>({
+        index,
+        size: maxResults,
+        query: { bool: { must } },
+        _source: [
+          'migration_id',
+          'translation_result',
+          'status',
+          'elastic_rule.title',
+          'elastic_rule.severity',
+          'elastic_rule.risk_score',
+          'elastic_rule.query',
+          'elastic_rule.description',
+          'original_rule.title',
+          'original_rule.vendor',
+        ],
+      });
+
+      const rules = result.hits.hits.map((hit) => ({
+        id: hit._id,
+        ...(hit._source ?? {}),
+      }));
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              migration_id: migrationId,
+              total: rules.length,
+              rules,
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`migration_translated_rules_search failed: ${error.message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to list translated rules: ${error.message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Tool 2: get a single translated rule by id                                */
+/* -------------------------------------------------------------------------- */
+
+const getSchema = z.object({
+  migration_id: migrationIdField,
+  rule_id: ruleIdField,
+});
+
+export const SECURITY_MIGRATION_TRANSLATED_RULE_GET_TOOL_ID = securityTool(
+  'migration_translated_rule_get'
+);
+
+export const migrationTranslatedRuleGetTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  experimentalFeatures: ExperimentalFeatures
+): BuiltinToolDefinition<typeof getSchema> => ({
+  id: SECURITY_MIGRATION_TRANSLATED_RULE_GET_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'Read the full draft of a single translated detection rule (elastic_rule.query, severity, risk_score, threat[], description, etc.). Use this BEFORE proposing a correction so you can quote the current values back to the operator and produce an accurate diff.',
+  schema: getSchema,
+  tags: ['security', 'siem-migrations', 'rules', 'get'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => {
+      if (!experimentalFeatures?.automaticMigrationSkillsEnabled) {
+        return {
+          status: 'unavailable',
+          reason:
+            'Automatic Migration Skills are not enabled. Set the `automaticMigrationSkillsEnabled` experimental feature flag.',
+        };
+      }
+      return getAgentBuilderResourceAvailability({ core, request, logger });
+    },
+  },
+  handler: async ({ migration_id: migrationId, rule_id: ruleId }, { esClient, spaceId }) => {
+    try {
+      const index = getRulesIndexName(spaceId);
+      const result = await esClient.asCurrentUser.get<Record<string, unknown>>({
+        index,
+        id: ruleId,
+      });
+
+      const source = (result._source ?? {}) as { migration_id?: string };
+      if (source.migration_id !== migrationId) {
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Rule ${ruleId} is not part of migration ${migrationId}.`,
+              },
+            },
+          ],
+        };
+      }
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              id: result._id,
+              ...source,
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`migration_translated_rule_get failed: ${error.message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to get translated rule ${ruleId}: ${error.message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Tool 3: update a translated rule (destructive — requires confirmation)    */
+/* -------------------------------------------------------------------------- */
+
+const updateSchema = z.object({
+  migration_id: migrationIdField,
+  rule_id: ruleIdField,
+  patch: z
+    .object({
+      query: z.string().optional().describe('Replacement ES|QL query.'),
+      severity: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+      risk_score: z.number().int().min(0).max(100).optional(),
+      description: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+    })
+    .describe(
+      'Partial replacement for the rule. Only listed fields are written; omitted fields are preserved. Use this to apply the diff the operator approved.'
+    ),
+  confirm: z
+    .literal(true)
+    .describe(
+      'Operator consent for the destructive update. Must equal `true`. This field is the structural gate — never invoke this tool without it.'
+    ),
+});
+
+export const SECURITY_MIGRATION_TRANSLATED_RULE_UPDATE_TOOL_ID = securityTool(
+  'migration_translated_rule_update'
+);
+
+export const migrationTranslatedRuleUpdateTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  experimentalFeatures: ExperimentalFeatures
+): BuiltinToolDefinition<typeof updateSchema> => ({
+  id: SECURITY_MIGRATION_TRANSLATED_RULE_UPDATE_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'Persist a corrected draft of a translated detection rule. Destructive (overwrites the prior translator output). Requires explicit operator consent via the `confirm: true` field — the schema enforces consent structurally, not via prose. Run AFTER the operator approves the diff. The rule still has to be installed via the migration install flow afterwards.',
+  schema: updateSchema,
+  tags: ['security', 'siem-migrations', 'rules', 'update', 'destructive'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => {
+      if (!experimentalFeatures?.automaticMigrationSkillsEnabled) {
+        return {
+          status: 'unavailable',
+          reason:
+            'Automatic Migration Skills are not enabled. Set the `automaticMigrationSkillsEnabled` experimental feature flag.',
+        };
+      }
+      return getAgentBuilderResourceAvailability({ core, request, logger });
+    },
+  },
+  handler: async (
+    { migration_id: migrationId, rule_id: ruleId, patch, confirm: _confirm },
+    { esClient, spaceId }
+  ) => {
+    try {
+      const index = getRulesIndexName(spaceId);
+
+      const existing = await esClient.asCurrentUser.get<{ migration_id?: string }>({
+        index,
+        id: ruleId,
+      });
+      if (existing._source?.migration_id !== migrationId) {
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Rule ${ruleId} is not part of migration ${migrationId}; refusing to update.`,
+              },
+            },
+          ],
+        };
+      }
+
+      const elasticRulePatch: Record<string, unknown> = {};
+      if (patch.query !== undefined) elasticRulePatch.query = patch.query;
+      if (patch.severity !== undefined) elasticRulePatch.severity = patch.severity;
+      if (patch.risk_score !== undefined) elasticRulePatch.risk_score = patch.risk_score;
+      if (patch.description !== undefined) elasticRulePatch.description = patch.description;
+      if (patch.tags !== undefined) elasticRulePatch.tags = patch.tags;
+
+      if (Object.keys(elasticRulePatch).length === 0) {
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message:
+                  'Patch contained no fields to update. Provide at least one of: query, severity, risk_score, description, tags.',
+              },
+            },
+          ],
+        };
+      }
+
+      await esClient.asCurrentUser.update({
+        index,
+        id: ruleId,
+        doc: { elastic_rule: elasticRulePatch },
+        refresh: 'wait_for',
+      });
+
+      logger.info(
+        `Translated rule ${ruleId} in migration ${migrationId} updated with fields: ${Object.keys(
+          elasticRulePatch
+        ).join(', ')}`
+      );
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              success: true,
+              migration_id: migrationId,
+              rule_id: ruleId,
+              updated_fields: Object.keys(elasticRulePatch),
+              note: 'The rule still has to be installed via the migration install flow.',
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`migration_translated_rule_update failed: ${error.message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to update translated rule ${ruleId}: ${error.message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
@@ -16,6 +16,16 @@ import { createDetectionRuleTool } from './create_detection_rule_tool';
 import { pciComplianceTool } from './pci_compliance_tool';
 import { pciScopeDiscoveryTool } from './pci_scope_discovery_tool';
 import { pciFieldMapperTool } from './pci_field_mapper_tool';
+import {
+  migrationTranslatedRulesSearchTool,
+  migrationTranslatedRuleGetTool,
+  migrationTranslatedRuleUpdateTool,
+} from './migration_translated_rules_tools';
+import {
+  migrationResourcesListTool,
+  migrationResourceUpsertTool,
+  migrationResourceRemoveTool,
+} from './migration_resources_tools';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 
 /**
@@ -42,5 +52,18 @@ export const registerTools = async (
     agentBuilder.tools.register(pciScopeDiscoveryTool(core, logger));
     agentBuilder.tools.register(pciComplianceTool(core, logger));
     agentBuilder.tools.register(pciFieldMapperTool(core, logger));
+  }
+
+  if (experimentalFeatures.automaticMigrationSkillsEnabled) {
+    agentBuilder.tools.register(
+      migrationTranslatedRulesSearchTool(core, logger, experimentalFeatures)
+    );
+    agentBuilder.tools.register(migrationTranslatedRuleGetTool(core, logger, experimentalFeatures));
+    agentBuilder.tools.register(
+      migrationTranslatedRuleUpdateTool(core, logger, experimentalFeatures)
+    );
+    agentBuilder.tools.register(migrationResourcesListTool(core, logger, experimentalFeatures));
+    agentBuilder.tools.register(migrationResourceUpsertTool(core, logger, experimentalFeatures));
+    agentBuilder.tools.register(migrationResourceRemoveTool(core, logger, experimentalFeatures));
   }
 };


### PR DESCRIPTION
## Summary

Adds two Agent Builder skills that improve SIEM rule-migration quality from chat / MCP / IDE clients:

- **`automatic-migration-correction`** — polish a translated rule after the translator runs (ES|QL repair, MITRE remap, severity / risk-score adjustment). Per-rule, per-migration, schema-enforced consent before any destructive write.
- **`automatic-migration-context`** — seed translation with macros, lists, and lookups *before* the translator runs. Per-migration scope, schema-enforced consent on replace / remove, explicit "applies on the NEXT translation run" semantics.

Both skills ship behind a new experimental flag (`automaticMigrationSkillsEnabled`, default `false`) and remain off in production until product is ready to enable.

## What ships in this PR

| Phase | Surface | Status |
| --- | --- | --- |
| 1 | `automaticMigrationSkillsEnabled` flag, shared Zod schemas (incl. `confirmDestructiveSchema`), skill stubs registered under the flag, RBAC audit (reuses existing `SIEM_MIGRATIONS_API_ACTION_ALL`) | done |
| 2a | Full 5-section SKILL content for both skills (when-to-use, process, examples, guardrails, response format) + registry-tool wiring (`generateEsql`, `productDocumentation`, `security_labs_search`) | done |
| 2b | 3 backing registry tools for the correction skill: `security.migration_translated_rules_search`, `migration_translated_rule_get`, `migration_translated_rule_update` (destructive — `confirm: z.literal(true)`) | done |
| 3 | 3 backing registry tools for the context skill: `security.migration_resources_list`, `migration_resource_upsert`, `migration_resource_remove` (destructive — `confirm: z.literal(true)`) | done |
| 4 | Skill eval suite added inside the existing `@kbn/evals-suite-security-automatic-migrations` package — chat client, criteria evaluator with per-skill baselines, `createSkillInvocationEvaluator` wiring, 7 examples per skill (4 happy-path + 3 distractors) | done |

## Architectural choices (anti-overengineering audit)

- **Two skills, not one.** Distinct when-to-use triggers, different tool sets, different destructiveness profiles. Splitting matched skill-conventions guidance.
- **Registered `BuiltinToolDefinition`s, not inline tool handlers wrapping HTTP routes.** Inline handlers would have re-implemented the route's RBAC + audit logic; registered tools use `esClient.asCurrentUser` against the migrations indices directly. RBAC is enforced at the ES index level via the existing `SIEM_MIGRATIONS_API_ACTION_ALL` privilege. Matches the shape used by `alerts_tool` / `create_detection_rule_tool` / `pci_compliance_tool`.
- **Eval suite EXTENDS the existing `@kbn/evals-suite-security-automatic-migrations` package** rather than spawning a sibling. Two evaluator stacks (deterministic translation pipeline + LLM-judged skill criteria) coexist cleanly under one `evaluate.ts` worker fixture.
- **Consent is structural, not prose.** Every destructive tool's schema requires `confirm: z.literal(true)`. SKILL.md's Process section names the tool ids and the confirm contract explicitly; LLM cannot silently mutate.
- **No new RBAC privilege constants.** The Phase 1 audit confirmed `SIEM_MIGRATIONS_API_ACTION_ALL` already covers create/update/delete on the migration rule + resource indices.

## Validation evidence

- `node scripts/eslint --fix` on every touched `.ts` file: clean.
- `tsc -b x-pack/solutions/security/plugins/security_solution/tsconfig.type_check.json`: clean (12 GB heap).
- `tsc -b x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/tsconfig.json`: 0 errors in our package. 14 pre-existing errors in transitive `kbn-monaco` / `apm-rum-core` / `kbn-ebt-tools` — these exist on `main` and are NOT caused by this branch (running `tsc -b` with our changes stashed reproduces 30 such errors; this branch's added `@kbn/agent-builder-common` + `@kbn/core` refs resolve some of them).
- Secrets scan + personal-path scan on the branch diff: clean.
- No new `.env` / `.pem` / `.key` / sensitive-extension files committed.

## What's out of scope (intentionally)

- **Trajectory evaluator wiring.** Every eval example already carries a `metadata.tool_sequence` skeleton so spec authors can ground it in the next iteration. The CI activation of the new eval suite is also a separate follow-up (existing practice: new suites get a few local runs to calibrate baselines first).
- **`workflow_execute_step` / `kibana.request`-based tool wiring** that an earlier scoping doc called for. The registered `BuiltinToolDefinition` shape matched the existing pattern more cleanly and avoided the codegen ceremony around `INCLUDED_OPERATIONS`. The decision is documented in the corresponding commit message.

## Files of interest

- `x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_migration/README.md` — domain README with status table + roadmap.
- `…/skills/automatic_migration/automatic_migration_correction_skill.ts` + `…_context_skill.ts` — `defineSkillType` factories with full SKILL content.
- `…/agent_builder/tools/migration_translated_rules_tools.ts` + `migration_resources_tools.ts` — 6 registered tools.
- `x-pack/solutions/security/packages/kbn-evals-suite-security-automatic-migrations/src/skills/` + `evals/skills/` — the new skills eval subsystem.

## Test plan

- [ ] CI green (full PR builds and unit tests).
- [ ] Manual smoke (out of scope for this PR — requires the flag to be enabled in a dev cluster):
  - [ ] Enable `automaticMigrationSkillsEnabled` in `kibana.dev.yml`.
  - [ ] Confirm both skill ids appear in `/api/agent_builder/skills`.
  - [ ] Confirm the 6 registered tool ids appear in `/api/agent_builder/tools`.
  - [ ] Invoke each correction-skill tool against a seed migration; confirm destructive update refuses without `confirm: true`.
  - [ ] Invoke each context-skill tool; confirm destructive upsert / remove refuses without `confirm: true`.
- [ ] Optional: run `@kbn/evals-suite-security-automatic-migrations` skill suite locally against a connector to calibrate baseline scores.

## Release note

> The `automatic-migration-correction` and `automatic-migration-context` Agent Builder skills (gated behind the `automaticMigrationSkillsEnabled` experimental flag, default `false`) ship as part of the SIEM migration UX work.