### PR TITLE
fix(fleet): resolve connector health correctly in OTel collector pipeline view

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.test.tsx
@@ -79,6 +79,48 @@ describe('CollectorDetailHealth', () => {
     expect(panel.textContent).toContain('connection refused');
   });
 
+  it('resolves connector health when an exporter id appears in config.connectors', () => {
+    const connectorConfig: OTelCollectorConfig = {
+      receivers: { otlp: {} },
+      processors: { batch: {} },
+      connectors: { 'forward/connector': {} },
+      exporters: { 'elasticsearch/default': {} },
+      service: {
+        pipelines: {
+          'logs/default': {
+            receivers: ['otlp'],
+            processors: ['batch'],
+            exporters: ['forward/connector'],
+          },
+        },
+      },
+    };
+
+    const health: ComponentHealth = {
+      healthy: true,
+      status: 'StatusOK',
+      component_health_map: {
+        'pipeline:logs/default': {
+          healthy: true,
+          status: 'StatusOK',
+          component_health_map: {
+            'receiver:otlp': { healthy: true, status: 'StatusOK' },
+            'processor:batch': { healthy: true, status: 'StatusOK' },
+            // health is keyed as connector, not exporter
+            'connector:forward/connector': { healthy: true, status: 'StatusOK' },
+          },
+        },
+      },
+    };
+
+    const result = testRenderer.render(
+      <CollectorDetailHealth health={health} config={connectorConfig} />
+    );
+
+    const pipeline = result.getByTestId('collectorHealthPipeline-logs/default');
+    expect(pipeline.textContent).toContain('3 healthy');
+  });
+
   it('renders pipeline component breakdown when config is provided', () => {
     const health: ComponentHealth = {
       healthy: true,

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/collector_detail/collector_detail_health.tsx
@@ -144,6 +144,7 @@ const PipelineAccordion: React.FC<{
     (sum, g) => sum + g.components.filter((c) => c.status === 'healthy').length,
     0
   );
+
   const unhealthyCount = totalComponents - healthyCount;
 
   return (
@@ -304,6 +305,17 @@ const ComponentHealthSectionHeader: React.FC<{
   );
 };
 
+const resolveComponentType = (
+  componentId: string,
+  componentType: string,
+  config: OTelCollectorConfig
+): OTelComponentType => {
+  if (config.connectors && componentId in config.connectors) {
+    return 'connector';
+  }
+  return componentType as OTelComponentType;
+};
+
 export const CollectorDetailHealth: React.FC<CollectorDetailHealthProps> = ({
   health,
   config,
@@ -333,8 +345,8 @@ export const CollectorDetailHealth: React.FC<CollectorDetailHealthProps> = ({
             type,
             components: componentIds.map((id) => {
               const componentHealth =
-                findComponentHealth(pipelineHealth, type, id) ??
-                findComponentHealth(health, type, id);
+                findComponentHealth(pipelineHealth, resolveComponentType(id, type, config), id) ??
+                findComponentHealth(health, resolveComponentType(id, type, config), id);
               return {
                 id,
                 health: componentHealth,


### PR DESCRIPTION
## Summary

OTel reports connector health under the `connector:<id>` key, but connectors can appear in a pipeline's exporter list. Previously the health lookup always used the pipeline slot type (`exporter`), so connector health was never found and always rendered as unknown.

The fix introduces a `resolveComponentType` helper that checks `config.connectors` and returns `'connector'` when the component id is declared there, ensuring the correct health map key is used for the lookup.

## Test plan

You can add an opamp agent with a connector, routing is easy to add and see his health correctly resolved

Before 

<img width="1000" alt="Screenshot 2026-05-14 at 3 02 11 PM" src="https://github.com/user-attachments/assets/e0bb3b05-c3b8-40ea-b3fe-bd078b97d48f" />

After


<img width="1000" alt="Screenshot 2026-05-14 at 3 02 25 PM" src="https://github.com/user-attachments/assets/21056b7a-ed50-4a57-8439-8b8cdfc08f02" />






