### PR TITLE
poc(entity-store): Event-Log History — separate index with append-only seen events

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/get_relationship_history.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/get_relationship_history.schema.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.0
+info:
+  title: Get Entity Relationship History
+  version: '1'
+paths:
+  /api/entity_store/entities/{entityId}/relationship_history:
+    get:
+      operationId: GetEntityRelationshipHistory
+      summary: Get relationship history for an entity
+      tags:
+        - Entity Store
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The entity store ID (e.g. "user:john")
+      responses:
+        '200':
+          description: Relationship history records
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - records
+                properties:
+                  records:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/RelationshipHistorySummary'
+components:
+  schemas:
+    RelationshipHistorySummary:
+      type: object
+      required:
+        - entity_id
+        - rel_type
+        - target_euid
+        - first_seen
+        - last_seen
+        - seen_count
+      properties:
+        entity_id:
+          type: string
+        rel_type:
+          type: string
+        target_euid:
+          type: string
+        first_seen:
+          type: string
+          format: date-time
+        last_seen:
+          type: string
+          format: date-time
+        seen_count:
+          type: integer

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -23,6 +23,7 @@ import type { ObservedEntityData } from '../shared/components/observed_entity/ty
 import type { EntityRiskScore, HostItem } from '../../../../common/search_strategy';
 import { VisualizationsSection } from '../shared/components/right/visualizations_section';
 import { ResolutionSection } from '../../../entity_analytics/components/entity_resolution/resolution_section';
+import { RelationshipHistorySection } from '../shared/components/right/relationship_history_section';
 
 type ObservedHostData = Omit<ObservedEntityData<HostItem>, 'anomalies'>;
 
@@ -101,6 +102,7 @@ export const HostPanelContent = ({
             openDetailsPanel={openDetailsPanel}
           />
           <EuiHorizontalRule margin="m" />
+          <RelationshipHistorySection entityId={entityStoreEntityId} />
         </>
       )}
       {entityStoreEntityId && !isPreviewMode && hasEntityResolutionLicense && (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/right/relationship_history_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/right/relationship_history_section.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiAccordion,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiBadge,
+  EuiText,
+  EuiSpacer,
+  EuiTitle,
+  EuiLoadingSpinner,
+} from '@elastic/eui';
+import { PreferenceFormattedDate } from '../../../../../common/components/formatted_date';
+import { useRelationshipHistory } from '../../hooks/use_relationship_history';
+
+interface Props {
+  entityId: string | undefined;
+}
+
+const REL_TYPE_LABELS: Record<string, string> = {
+  Accesses_frequently: 'Accesses Frequently',
+  Owns: 'Owns',
+  Supervises: 'Supervises',
+  Supervised_by: 'Supervised By',
+  Communicates_with: 'Communicates With',
+  Depends_on: 'Depends On',
+  Dependent_of: 'Dependent Of',
+  Owned_by: 'Owned By',
+  Accessed_frequently_by: 'Accessed Frequently By',
+};
+
+export const RelationshipHistorySection = ({ entityId }: Props) => {
+  const { data, isLoading, isError } = useRelationshipHistory(entityId);
+
+  if (!entityId) return null;
+
+  if (isLoading) {
+    return <EuiLoadingSpinner size="m" />;
+  }
+
+  if (isError) {
+    return (
+      <EuiText size="xs" color="danger">
+        {'Failed to load relationship history'}
+      </EuiText>
+    );
+  }
+
+  const entries = Object.entries(data ?? {}).filter(([, records]) => records.length > 0);
+  if (entries.length === 0) return null;
+
+  return (
+    <EuiAccordion
+      id="relationship-history-section"
+      buttonContent={
+        <EuiTitle size="xs">
+          <h3>{'Relationships'}</h3>
+        </EuiTitle>
+      }
+      initialIsOpen
+    >
+      <EuiSpacer size="s" />
+      {entries.map(([relType, records]) => (
+        <div key={relType}>
+          <EuiText size="xs" color="subdued">
+            <strong>{REL_TYPE_LABELS[relType] ?? relType.replace(/_/g, ' ')}</strong>
+          </EuiText>
+          <EuiSpacer size="xs" />
+          {[...records]
+            .sort((a, b) => b.last_seen.localeCompare(a.last_seen))
+            .map((record) => (
+              <EuiFlexGroup key={record.target_euid} alignItems="center" gutterSize="s" wrap>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">{record.target_euid}</EuiBadge>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {'First: '}
+                    <PreferenceFormattedDate value={new Date(record.first_seen)} />
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {'Last: '}
+                    <PreferenceFormattedDate value={new Date(record.last_seen)} />
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            ))}
+          <EuiSpacer size="s" />
+        </div>
+      ))}
+    </EuiAccordion>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_relationship_history.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_relationship_history.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { useKibana } from '../../../../common/lib/kibana';
+import { API_VERSIONS } from '../../../../../common/entity_analytics/constants';
+
+export interface RelationshipHistorySummary {
+  entity_id: string;
+  rel_type: string;
+  target_euid: string;
+  first_seen: string;
+  last_seen: string;
+  seen_count: number;
+}
+
+export type RelationshipHistoryByType = Record<string, RelationshipHistorySummary[]>;
+
+interface RelationshipHistoryResponse {
+  records: RelationshipHistorySummary[];
+}
+
+export const useRelationshipHistory = (entityId: string | undefined) => {
+  const { http } = useKibana().services;
+
+  return useQuery({
+    queryKey: ['relationship-history', entityId],
+    enabled: !!entityId,
+    queryFn: async (): Promise<RelationshipHistoryByType> => {
+      const response = await http.fetch<RelationshipHistoryResponse>(
+        `/api/entity_store/entities/${encodeURIComponent(entityId!)}/relationship_history`,
+        { version: API_VERSIONS.public.v1, method: 'GET' }
+      );
+      const grouped: RelationshipHistoryByType = {};
+      for (const record of response.records) {
+        if (!grouped[record.rel_type]) {
+          grouped[record.rel_type] = [];
+        }
+        grouped[record.rel_type].push(record);
+      }
+      return grouped;
+    },
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -24,6 +24,7 @@ import type { ObservedEntityData } from '../shared/components/observed_entity/ty
 import type { EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
 import { VisualizationsSection } from '../shared/components/right/visualizations_section';
 import { ResolutionSection } from '../../../entity_analytics/components/entity_resolution/resolution_section';
+import { RelationshipHistorySection } from '../shared/components/right/relationship_history_section';
 
 export type ObservedUserData = Omit<ObservedEntityData<UserItem>, 'anomalies'> & {
   entityRecord?: EntityStoreRecord | null;
@@ -104,6 +105,7 @@ export const UserPanelContent = ({
             openDetailsPanel={openDetailsPanel}
           />
           <EuiHorizontalRule margin="m" />
+          <RelationshipHistorySection entityId={entityStoreEntityId} />
         </>
       )}
       {entityStoreEntityId && !isPreviewMode && hasEntityResolutionLicense && (

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/relationship_history/relationship_history_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/relationship_history/relationship_history_client.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { RELATIONSHIP_HISTORY_INDEX } from './relationship_history_index';
+
+/** Shape of each raw event written to the index (append-only). */
+interface RelationshipHistoryEvent {
+  entity_id: string;
+  rel_type: string;
+  target_euid: string;
+  seen: string;
+}
+
+/** Aggregated summary returned by the API — first/last seen derived at query time. */
+export interface RelationshipHistorySummary {
+  entity_id: string;
+  rel_type: string;
+  target_euid: string;
+  first_seen: string;
+  last_seen: string;
+  seen_count: number;
+}
+
+export interface AppendBatch {
+  entityId: string;
+  relType: string;
+  euids: string[];
+  seen: string;
+}
+
+export class RelationshipHistoryClient {
+  constructor(
+    private readonly esClient: ElasticsearchClient,
+    private readonly logger: Logger
+  ) {}
+
+  /** Appends one event per entity×rel_type×EUID for this scan. */
+  async appendBatch(batches: AppendBatch[]): Promise<void> {
+    if (batches.length === 0) return;
+
+    const operations = batches.flatMap(({ entityId, relType, euids, seen }) =>
+      euids.flatMap((targetEuid) => [
+        { index: { _index: RELATIONSHIP_HISTORY_INDEX } },
+        { entity_id: entityId, rel_type: relType, target_euid: targetEuid, seen } satisfies RelationshipHistoryEvent,
+      ])
+    );
+
+    try {
+      const result = await this.esClient.bulk({ operations, refresh: true });
+      if (result.errors) {
+        const errors = result.items.filter((item) => item.index?.error);
+        this.logger.warn(`[POC B] ${errors.length} bulk errors appending relationship history`);
+      }
+    } catch (err) {
+      this.logger.error(`[POC B] Failed to append relationship history: ${err}`);
+    }
+  }
+
+  /**
+   * Aggregates raw events for an entity and returns one summary per
+   * rel_type×target_euid with first_seen (MIN) and last_seen (MAX).
+   */
+  async getHistoryForEntity(entityId: string): Promise<RelationshipHistorySummary[]> {
+    const result = await this.esClient.search({
+      index: RELATIONSHIP_HISTORY_INDEX,
+      size: 0,
+      query: { term: { entity_id: entityId } },
+      aggs: {
+        by_rel_type: {
+          terms: { field: 'rel_type', size: 20 },
+          aggs: {
+            by_target: {
+              terms: { field: 'target_euid', size: 200 },
+              aggs: {
+                first_seen: { min: { field: 'seen' } },
+                last_seen: { max: { field: 'seen' } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const summaries: RelationshipHistorySummary[] = [];
+    const byRelType = (result.aggregations?.by_rel_type as any)?.buckets ?? [];
+
+    for (const relTypeBucket of byRelType) {
+      const relType: string = relTypeBucket.key;
+      const byTarget = relTypeBucket.by_target?.buckets ?? [];
+
+      for (const targetBucket of byTarget) {
+        summaries.push({
+          entity_id: entityId,
+          rel_type: relType,
+          target_euid: targetBucket.key,
+          first_seen: targetBucket.first_seen.value_as_string ?? targetBucket.first_seen.value,
+          last_seen: targetBucket.last_seen.value_as_string ?? targetBucket.last_seen.value,
+          seen_count: targetBucket.doc_count,
+        });
+      }
+    }
+
+    return summaries;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/relationship_history/relationship_history_index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/relationship_history/relationship_history_index.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+export const RELATIONSHIP_HISTORY_INDEX = 'entity-relationship-history';
+
+export const RELATIONSHIP_HISTORY_MAPPING = {
+  mappings: {
+    properties: {
+      entity_id: { type: 'keyword' as const },
+      rel_type: { type: 'keyword' as const },
+      target_euid: { type: 'keyword' as const },
+      seen: { type: 'date' as const, format: 'strict_date_optional_time' },
+    },
+  },
+  settings: {
+    number_of_shards: 1,
+    number_of_replicas: 0,
+  },
+};
+
+export async function createRelationshipHistoryIndex(esClient: ElasticsearchClient) {
+  const exists = await esClient.indices.exists({ index: RELATIONSHIP_HISTORY_INDEX });
+  if (!exists) {
+    await esClient.indices.create({
+      index: RELATIONSHIP_HISTORY_INDEX,
+      ...RELATIONSHIP_HISTORY_MAPPING,
+    });
+  }
+}
+
+export async function deleteRelationshipHistoryIndex(esClient: ElasticsearchClient) {
+  await esClient.indices.delete({
+    index: RELATIONSHIP_HISTORY_INDEX,
+    ignore_unavailable: true,
+  });
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/entities/get_relationship_history.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/entities/get_relationship_history.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { IKibanaResponse, Logger } from '@kbn/core/server';
+import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
+import { transformError } from '@kbn/securitysolution-es-utils';
+
+import { APP_ID } from '../../../../../../common';
+import { API_VERSIONS } from '../../../../../../common/entity_analytics/constants';
+import type { ITelemetryEventsSender } from '../../../../telemetry/sender';
+import type { EntityAnalyticsRoutesDeps } from '../../../types';
+import { RelationshipHistoryClient } from '../../relationship_history/relationship_history_client';
+
+export const getRelationshipHistoryRoute = (
+  router: EntityAnalyticsRoutesDeps['router'],
+  telemetry: ITelemetryEventsSender,
+  logger: Logger
+) => {
+  router.versioned
+    .get({
+      access: 'public',
+      path: '/api/entity_store/entities/{entityId}/relationship_history',
+      security: {
+        authz: {
+          requiredPrivileges: ['securitySolution', `${APP_ID}-entity-analytics`],
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.public.v1,
+        validate: {
+          request: {
+            params: schema.object({ entityId: schema.string() }),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse> => {
+        const siemResponse = buildSiemResponse(response);
+        try {
+          const { entityId } = request.params;
+          const esClient = (await context.core).elasticsearch.client.asCurrentUser;
+          const historyClient = new RelationshipHistoryClient(esClient, logger);
+          const records = await historyClient.getHistoryForEntity(entityId);
+          return response.ok({ body: { records } });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({ statusCode: error.statusCode, body: error.message });
+        }
+      }
+    );
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/register_entity_store_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/register_entity_store_routes.ts
@@ -20,6 +20,7 @@ import { enableEntityStoreRoute } from './enablement';
 import { upsertEntity } from './entity_crud/upsert_entity';
 import { upsertEntitiesBulk } from './entity_crud/upsert_entities_bulk';
 import { deleteEntity } from './entity_crud/delete_entity';
+import { getRelationshipHistoryRoute } from './entities/get_relationship_history';
 
 export const registerEntityStoreRoutes = ({
   router,
@@ -43,4 +44,5 @@ export const registerEntityStoreRoutes = ({
   upsertEntity(router, telemetry, logger);
   upsertEntitiesBulk(router, telemetry, logger);
   deleteEntity(router, telemetry, logger);
+  getRelationshipHistoryRoute(router, telemetry, logger);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.ts
@@ -23,6 +23,8 @@ import { parseTargetsPerActorRows } from './parse_targets_per_actor_rows';
 import { writeEntityIds, type WriteEntityIdsResult } from './update_entities';
 import { LOOKBACK_WINDOW, MAX_ITERATIONS } from './constants';
 import { assertValidNamespace } from './validate_namespace';
+import { RelationshipHistoryClient } from '../../entity_store/relationship_history/relationship_history_client';
+import { createRelationshipHistoryIndex } from '../../entity_store/relationship_history/relationship_history_index';
 
 interface CompositeAggregations {
   users: {
@@ -219,7 +221,9 @@ async function runIntegration(
 
   // Stream per-integration: write this integration's records before
   // returning so memory does not accumulate across the outer loop.
-  const write = await writeEntityIds(crudClient, logger, records);
+  await createRelationshipHistoryIndex(esClient);
+  const historyClient = new RelationshipHistoryClient(esClient, logger);
+  const write = await writeEntityIds(crudClient, logger, records, historyClient);
   return { buckets: totalBuckets, recordsCount: records.length, write };
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.ts
@@ -5,11 +5,17 @@
  * 2.0.
  */
 
+import { createHash } from 'crypto';
 import type { Logger } from '@kbn/logging';
 import type { EntityUpdateClient, BulkObject } from '@kbn/entity-store/server';
 import type { Entity } from '@kbn/entity-store/common/domain/definitions/entity.gen';
 
 import type { ProcessedEngineRecord } from './types';
+import type { RelationshipHistoryClient } from '../../entity_store/relationship_history/relationship_history_client';
+
+function hashEntityId(id: string): string {
+  return createHash('sha256').update(id).digest('hex');
+}
 
 type ValidRecord = ProcessedEngineRecord & { entityId: string };
 
@@ -67,7 +73,9 @@ export interface WriteEntityIdsResult {
 export const writeEntityIds = async (
   crudClient: EntityUpdateClient,
   logger: Logger,
-  records: ProcessedEngineRecord[]
+  records: ProcessedEngineRecord[],
+  historyClient?: RelationshipHistoryClient,
+  seen: string = new Date().toISOString()
 ): Promise<WriteEntityIdsResult> => {
   if (records.length === 0) return { updated: 0, notFound: 0, errors: 0 };
 
@@ -77,6 +85,9 @@ export const writeEntityIds = async (
   const merged = mergeRecords(valid);
 
   const objects: BulkObject[] = [];
+  // Maps hashEuid(entityId) → entityId so we can identify which entities
+  // failed from bulkUpdateEntity's error responses (which carry _id = hash).
+  const hashToEntityId = new Map<string, string>();
   for (const [entityId, mergedRels] of merged) {
     const relationships: Record<string, { ids: string[] }> = {};
     for (const [relType, idSet] of Object.entries(mergedRels)) {
@@ -85,6 +96,7 @@ export const writeEntityIds = async (
       }
     }
     if (Object.keys(relationships).length > 0) {
+      hashToEntityId.set(hashEntityId(entityId), entityId);
       // TODO(follow-up): entity type hardcoded to 'user' — use actorEntityType from config.
       objects.push({
         type: 'user',
@@ -122,5 +134,22 @@ export const writeEntityIds = async (
   }
 
   logger.info(`Wrote relationship ids for ${updated} entities`);
+
+  if (historyClient) {
+    const failedEntityIds = new Set(
+      responseErrors.map((e) => hashToEntityId.get(e._id)).filter((id): id is string => !!id)
+    );
+    const batches = [];
+    for (const [entityId, mergedRels] of merged) {
+      if (failedEntityIds.has(entityId)) continue;
+      for (const [relType, idSet] of Object.entries(mergedRels)) {
+        if (idSet.size > 0) {
+          batches.push({ entityId, relType, euids: Array.from(idSet), seen });
+        }
+      }
+    }
+    await historyClient.appendBatch(batches);
+  }
+
   return { updated, notFound: missingErrors.length, errors: realErrors.length };
 };


### PR DESCRIPTION
## Summary

**Event-Log History.** Appends one event per entity×rel_type×EUID×scan to a new `entity-relationship-history` index with a single `seen` date field (no calculated fields — `first_seen`/`last_seen` derived at query time via MIN/MAX aggregation).

- Relationship maintainer appends one event per entity×rel_type×EUID×scan after each successful entity store write; 404 actors excluded via `hashEuid` reverse-map on `bulkUpdateEntity` errors
- New `GET /api/entity_store/entities/{entityId}/relationship_history` route aggregates and returns `first_seen`, `last_seen`, `seen_count` per rel_type×target_euid
- `RelationshipHistorySection` component surfaces relationship history in the user and host entity flyouts (entity store v2 only)

## Motivation

Part of the investigation into [security-team#17214](https://github.com/elastic/security-team/issues/17214) — comparing **Event-Log History** against **In-Document History** ([#269383](https://github.com/elastic/kibana/pull/269383)). The key advantage over the in-document approach: native date fields enable per-EUID range queries and ES|QL temporal investigation queries — e.g. "who first accessed this host after date X".

## Architecture decision

The index stores raw scan events with a single `seen` date. Calculated fields (`first_seen`, `last_seen`, `scan_count`) are intentionally absent from the stored document — they are derived at query time. This keeps the write path simple (bulk index, no Painless script) and avoids update conflicts under concurrent runs.

## Known follow-ups before this could go to production

- Logic currently lives in `security_solution` — needs to move into `entity_store` plugin (the maintainer should not reach into the entity index directly; see In-Document History PR for the architectural rule)
- ILM / retention policy required (index is append-only)
- Index template / data stream (currently lazy-created with hardcoded settings)
- Cross-namespace support (index name is global)
- Security model for non-superuser roles
- Cleanup semantics on entity delete

## Test plan

- [x] Start Kibana dev, trigger relationship maintainer, verify documents appear in `entity-relationship-history` index with only `entity_id`, `rel_type`, `target_euid`, `seen` fields
- [x] Run maintainer a second time, verify multiple `seen` events exist per entity×rel_type×EUID pair
- [x] Call `GET /api/entity_store/entities/{entityId}/relationship_history` and verify aggregated `first_seen`/`last_seen`/`seen_count` are correct
- [x] Open user/host entity flyout with entity store v2 enabled, verify Relationships section appears
- [x] Run ES|QL investigation query against the history index — full per-EUID temporal queries work (the differentiator vs In-Document History)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
