### PR TITLE
[UII] Set loading state on enrollment tokens confirmation modal

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/confirm_action_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/confirm_action_modal.tsx
@@ -9,18 +9,25 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiConfirmModal, EuiCallOut, useGeneratedHtmlId } from '@elastic/eui';
 
-interface BulkActionModalProps {
+interface ConfirmActionModalProps {
   count: number;
   onCancel: () => void;
   onConfirm: () => void;
+  isLoading?: boolean;
 }
 
-export const ConfirmRevokeModal = ({ count, onCancel, onConfirm }: BulkActionModalProps) => {
+export const ConfirmRevokeModal = ({
+  count,
+  onCancel,
+  onConfirm,
+  isLoading,
+}: ConfirmActionModalProps) => {
   const modalTitleId = useGeneratedHtmlId();
 
   return (
     <EuiConfirmModal
       aria-labelledby={modalTitleId}
+      isLoading={isLoading}
       title={
         count === 1
           ? i18n.translate('xpack.fleet.enrollmentTokenBulkRevokeModal.titleSingle', {
@@ -59,12 +66,18 @@ export const ConfirmRevokeModal = ({ count, onCancel, onConfirm }: BulkActionMod
   );
 };
 
-export const ConfirmDeleteModal = ({ count, onCancel, onConfirm }: BulkActionModalProps) => {
+export const ConfirmDeleteModal = ({
+  count,
+  onCancel,
+  onConfirm,
+  isLoading,
+}: ConfirmActionModalProps) => {
   const modalTitleId = useGeneratedHtmlId();
 
   return (
     <EuiConfirmModal
       aria-labelledby={modalTitleId}
+      isLoading={isLoading}
       title={
         count === 1
           ? i18n.translate('xpack.fleet.enrollmentTokenBulkDeleteModal.titleSingle', {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/token_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/token_actions.tsx
@@ -14,7 +14,7 @@ import { useStartServices, sendDeleteOneEnrollmentAPIKey } from '../../../../hoo
 import { HierarchicalActionsMenu } from '../../components';
 import type { MenuItem } from '../../components';
 
-import { ConfirmRevokeModal, ConfirmDeleteModal } from './confirm_bulk_action_modal';
+import { ConfirmRevokeModal, ConfirmDeleteModal } from './confirm_action_modal';
 
 export type BulkAction = 'delete' | 'revoke';
 
@@ -37,27 +37,34 @@ export const TokenActions: React.FunctionComponent<{
 }> = ({ apiKey, refresh }) => {
   const { notifications } = useStartServices();
   const [pendingAction, setPendingAction] = useState<BulkAction | null>(null);
+  const [isActionInProgress, setIsActionInProgress] = useState(false);
 
   const onCancelAction = () => setPendingAction(null);
 
   const onConfirmRevoke = async () => {
+    if (isActionInProgress) return;
+    setIsActionInProgress(true);
     try {
       const res = await sendDeleteOneEnrollmentAPIKey(apiKey.id);
       if (res.error) throw res.error;
     } catch (err) {
       notifications.toasts.addError(err as Error, { title: 'Error' });
     }
+    setIsActionInProgress(false);
     setPendingAction(null);
     refresh();
   };
 
   const onConfirmDelete = async () => {
+    if (isActionInProgress) return;
+    setIsActionInProgress(true);
     try {
       const res = await sendDeleteOneEnrollmentAPIKey(apiKey.id, { forceDelete: true });
       if (res.error) throw res.error;
     } catch (err) {
       notifications.toasts.addError(err as Error, { title: 'Error' });
     }
+    setIsActionInProgress(false);
     setPendingAction(null);
     refresh();
   };
@@ -65,10 +72,20 @@ export const TokenActions: React.FunctionComponent<{
   return (
     <>
       {pendingAction === 'revoke' && (
-        <ConfirmRevokeModal count={1} onCancel={onCancelAction} onConfirm={onConfirmRevoke} />
+        <ConfirmRevokeModal
+          count={1}
+          onCancel={onCancelAction}
+          onConfirm={onConfirmRevoke}
+          isLoading={isActionInProgress}
+        />
       )}
       {pendingAction === 'delete' && (
-        <ConfirmDeleteModal count={1} onCancel={onCancelAction} onConfirm={onConfirmDelete} />
+        <ConfirmDeleteModal
+          count={1}
+          onCancel={onCancelAction}
+          onConfirm={onConfirmDelete}
+          isLoading={isActionInProgress}
+        />
       )}
       <HierarchicalActionsMenu
         items={getTokenActionItems({

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/index.tsx
@@ -41,7 +41,7 @@ import { DefaultLayout } from '../../../layouts';
 import { AgentPolicyFilter } from '../agent_list_page/components/filter_bar/agent_policy_filter';
 import { HierarchicalActionsMenu } from '../components';
 
-import { ConfirmRevokeModal, ConfirmDeleteModal } from './components/confirm_bulk_action_modal';
+import { ConfirmRevokeModal, ConfirmDeleteModal } from './components/confirm_action_modal';
 import { Divider, getTokenActionItems } from './components/token_actions';
 import { getColumns } from './components/columns';
 import { useBulkActions } from './hooks/use_bulk_actions';


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/269299. This PR sets loading state on confirmation modal for enrollment token actions so that `Confirm` can't be double clicked.

This also removes `bulk` from some of the naming here, since this component is used for both single & bulk actions.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.