### PR TITLE
[SLO] Improve structured server-side error logging

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/delete_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/delete_slo.ts
@@ -35,7 +35,8 @@ export const deleteSLORoute = createSloServerRoute({
       transformManager,
       summaryTransformManager,
       scopedClusterClient,
-      rulesClient
+      rulesClient,
+      logger
     );
 
     await deleteSLO.execute(params.path.id);

--- a/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
@@ -108,15 +108,29 @@ export class CreateSLO {
         this.summaryTransformManager.start(summaryTransformId),
       ]);
     } catch (err) {
-      this.logger.debug(
-        `Cannot create the SLO [id: ${slo.id}, revision: ${slo.revision}]. Rolling back. ${err}`
-      );
+      this.logger.warn('Cannot create the SLO. Rolling back.', {
+        service: { name: 'create_slo' },
+        labels: {
+          slo_id: slo.id,
+          indicator_type: slo.indicator.type,
+          error_type: 'creation_failed',
+        },
+        error: err,
+      });
 
       await asyncForEach(rollbackOperations.reverse(), async (operation) => {
         try {
           await operation();
         } catch (rollbackErr) {
-          this.logger.debug(`Rollback operation failed. ${rollbackErr}`);
+          this.logger.warn('Rollback operation failed.', {
+            service: { name: 'create_slo' },
+            labels: {
+              slo_id: slo.id,
+              indicator_type: slo.indicator.type,
+              error_type: 'rollback_failed',
+            },
+            error: rollbackErr,
+          });
         }
       });
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.test.ts
@@ -7,8 +7,10 @@
 
 import { rulesClientMock } from '@kbn/alerting-plugin/server/rules_client.mock';
 import type { RulesClientApi } from '@kbn/alerting-plugin/server/types';
+import type { MockedLogger } from '@kbn/logging-mocks';
 import type { ScopedClusterClientMock } from '@kbn/core/server/mocks';
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { DeleteSLO } from './delete_slo';
 import { createAPMTransactionErrorRateIndicator, createSLO } from './fixtures/slo';
 import {
@@ -25,6 +27,7 @@ describe('DeleteSLO', () => {
   let mockSummaryTransformManager: jest.Mocked<TransformManager>;
   let mockScopedClusterClient: ScopedClusterClientMock;
   let mockRulesClient: jest.Mocked<RulesClientApi>;
+  let mockLogger: MockedLogger;
   let deleteSLO: DeleteSLO;
 
   beforeEach(() => {
@@ -33,12 +36,14 @@ describe('DeleteSLO', () => {
     mockSummaryTransformManager = createSummaryTransformManagerMock();
     mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
     mockRulesClient = rulesClientMock.create();
+    mockLogger = loggingSystemMock.createLogger();
     deleteSLO = new DeleteSLO(
       mockRepository,
       mockTransformManager,
       mockSummaryTransformManager,
       mockScopedClusterClient,
-      mockRulesClient
+      mockRulesClient,
+      mockLogger
     );
   });
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
@@ -7,7 +7,7 @@
 
 import { addTransactionLabels } from '@kbn/apm-utils';
 import type { RulesClientApi } from '@kbn/alerting-plugin/server/types';
-import type { IScopedClusterClient } from '@kbn/core/server';
+import type { IScopedClusterClient, Logger } from '@kbn/core/server';
 import {
   SLI_DESTINATION_INDEX_PATTERN,
   SUMMARY_DESTINATION_INDEX_PATTERN,
@@ -33,6 +33,7 @@ export class DeleteSLO {
     private summaryTransformManager: TransformManager,
     private scopedClusterClient: IScopedClusterClient,
     private rulesClient: RulesClientApi,
+    private logger: Logger,
     private abortController: AbortController = new AbortController()
   ) {}
 
@@ -127,6 +128,7 @@ export class DeleteSLO {
       { signal: this.abortController.signal }
     );
   }
+
   private async deleteAssociatedRules(sloId: string, skip: boolean): Promise<void> {
     if (skip) {
       return;
@@ -137,7 +139,11 @@ export class DeleteSLO {
         filter: `alert.attributes.params.sloId:${sloId}`,
       });
     } catch (err) {
-      // no-op
+      this.logger.warn('Failed to delete associated rules for SLO.', {
+        service: { name: 'delete_slo' },
+        labels: { slo_id: sloId, error_type: 'cleanup_failed' },
+        error: err,
+      });
     }
   }
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
@@ -81,9 +81,15 @@ export class ResetSLO {
     } catch (err) {
       // Any errors here should not prevent moving forward.
       // Worst case we keep rolling up data for the orignal SLO
-      this.logger.debug(
-        `Deletion of the original SLO resources failed while resetting it: ${err}.`
-      );
+      this.logger.warn('Deletion of the original SLO resources failed while resetting it.', {
+        service: { name: 'reset_slo' },
+        labels: {
+          slo_id: slo.id,
+          indicator_type: slo.indicator.type,
+          error_type: 'cleanup_failed',
+        },
+        error: err,
+      });
     }
   }
 
@@ -165,15 +171,29 @@ export class ResetSLO {
         this.summaryTransformManager.start(summaryTransformId),
       ]);
     } catch (err) {
-      this.logger.debug(
-        `Cannot reset the SLO [id: ${slo.id}, revision: ${slo.revision}]. Rolling back. ${err}`
-      );
+      this.logger.warn('Cannot reset the SLO. Rolling back.', {
+        service: { name: 'reset_slo' },
+        labels: {
+          slo_id: slo.id,
+          indicator_type: slo.indicator.type,
+          error_type: 'reset_failed',
+        },
+        error: err,
+      });
 
       await asyncForEach(rollbackOperations.reverse(), async (operation) => {
         try {
           await operation();
         } catch (rollbackErr) {
-          this.logger.debug(`Rollback operation failed. ${rollbackErr}`);
+          this.logger.warn('Rollback operation failed.', {
+            service: { name: 'reset_slo' },
+            labels: {
+              slo_id: slo.id,
+              indicator_type: slo.indicator.type,
+              error_type: 'rollback_failed',
+            },
+            error: rollbackErr,
+          });
         }
       });
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/bulk_delete/bulk_delete_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/bulk_delete/bulk_delete_task.ts
@@ -83,6 +83,7 @@ export class BulkDeleteTask {
                 summaryTransformManager,
                 scopedClusterClient,
                 rulesClient,
+                this.logger,
                 abortController
               );
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
@@ -35,7 +35,14 @@ export class DefaultTransformManager implements TransformManager {
   async install(slo: SLODefinition): Promise<TransformId> {
     const generator = this.generators[slo.indicator.type];
     if (!generator) {
-      this.logger.debug(`No transform generator found for indicator type [${slo.indicator.type}]`);
+      this.logger.debug('No transform generator found for indicator type.', {
+        service: { name: 'transform_manager' },
+        labels: {
+          slo_id: slo.id,
+          indicator_type: slo.indicator.type,
+          error_type: 'unsupported_indicator_type',
+        },
+      });
       throw new Error(`Unsupported indicator type [${slo.indicator.type}]`);
     }
 
@@ -49,9 +56,15 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.debug(
-        `Cannot create SLO transform for indicator type [${slo.indicator.type}]. ${err}`
-      );
+      this.logger.warn('Cannot install SLO transform.', {
+        service: { name: 'transform_manager' },
+        labels: {
+          slo_id: slo.id,
+          indicator_type: slo.indicator.type,
+          error_type: 'transform_install_failed',
+        },
+        error: err,
+      });
       if (err.meta?.body?.error?.type === 'security_exception') {
         throw new SecurityException(err.meta.body.error.reason);
       }
@@ -83,7 +96,11 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.debug(`Cannot preview SLO transform [${transformId}]. ${err}`);
+      this.logger.warn('Cannot preview SLO transform.', {
+        service: { name: 'transform_manager' },
+        labels: { transform_id: transformId, error_type: 'transform_preview_failed' },
+        error: err,
+      });
       throw err;
     }
   }
@@ -100,7 +117,11 @@ export class DefaultTransformManager implements TransformManager {
       );
       await this.scheduleNowTransform(transformId);
     } catch (err) {
-      this.logger.debug(`Cannot start SLO transform [${transformId}]. ${err}`);
+      this.logger.warn('Cannot start SLO transform.', {
+        service: { name: 'transform_manager' },
+        labels: { transform_id: transformId, error_type: 'transform_start_failed' },
+        error: err,
+      });
       throw err;
     }
   }
@@ -121,7 +142,11 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.debug(`Cannot stop SLO transform [${transformId}]. ${err}`);
+      this.logger.warn('Cannot stop SLO transform.', {
+        service: { name: 'transform_manager' },
+        labels: { transform_id: transformId, error_type: 'transform_stop_failed' },
+        error: err,
+      });
       throw err;
     }
   }
@@ -137,7 +162,11 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.debug(`Cannot delete SLO transform [${transformId}]. ${err}`);
+      this.logger.warn('Cannot uninstall SLO transform.', {
+        service: { name: 'transform_manager' },
+        labels: { transform_id: transformId, error_type: 'transform_uninstall_failed' },
+        error: err,
+      });
       throw err;
     }
   }
@@ -163,7 +192,11 @@ export class DefaultTransformManager implements TransformManager {
         return undefined;
       }
 
-      this.logger.debug(`Cannot retrieve SLO transform version [${transformId}]. ${err}`);
+      this.logger.warn('Cannot retrieve SLO transform version.', {
+        service: { name: 'transform_manager' },
+        labels: { transform_id: transformId, error_type: 'transform_get_version_failed' },
+        error: err,
+      });
       throw err;
     }
   }
@@ -175,7 +208,11 @@ export class DefaultTransformManager implements TransformManager {
         this.logger.debug(`SLO transform [${transformId}] scheduled now successfully`);
       })
       .catch((e) => {
-        this.logger.debug(`Cannot schedule now SLO transform [${transformId}]. ${e}`);
+        this.logger.warn('Cannot schedule now SLO transform.', {
+          service: { name: 'transform_manager' },
+          labels: { transform_id: transformId, error_type: 'transform_schedule_failed' },
+          error: e,
+        });
       });
   }
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
@@ -385,9 +385,7 @@ describe('UpdateSLO', () => {
       const warnMessages = mockLogger.warn.mock.calls.map(([msg]) => String(msg));
       expect(warnMessages).toEqual(
         expect.arrayContaining([
-          expect.stringContaining(
-            `previous revision of SLO [id=${slo.id}, revision=${slo.revision}]`
-          ),
+          expect.stringContaining('Failed to clean up resources for previous SLO revision.'),
         ])
       );
     });

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -92,15 +92,29 @@ export class UpdateSLO {
           getSummaryPipelineTemplate(updatedSlo, this.spaceId, this.basePath)
         );
       } catch (err) {
-        this.logger.debug(
-          `Cannot update the SLO summary pipeline [id: ${updatedSlo.id}, revision: ${updatedSlo.revision}]. ${err}`
-        );
+        this.logger.warn('Cannot update the SLO summary pipeline. Rolling back.', {
+          service: { name: 'update_slo' },
+          labels: {
+            slo_id: updatedSlo.id,
+            indicator_type: updatedSlo.indicator.type,
+            error_type: 'update_failed',
+          },
+          error: err,
+        });
 
         await asyncForEach(rollbackOperations.reverse(), async (operation) => {
           try {
             await operation();
           } catch (rollbackErr) {
-            this.logger.debug(`Rollback operation failed. ${rollbackErr}`);
+            this.logger.warn('Rollback operation failed.', {
+              service: { name: 'update_slo' },
+              labels: {
+                slo_id: updatedSlo.id,
+                indicator_type: updatedSlo.indicator.type,
+                error_type: 'rollback_failed',
+              },
+              error: rollbackErr,
+            });
           }
         });
 
@@ -157,15 +171,29 @@ export class UpdateSLO {
         this.summaryTransformManager.start(updatedSummaryTransformId),
       ]);
     } catch (err) {
-      this.logger.debug(
-        `Cannot update the SLO [id: ${updatedSlo.id}, revision: ${updatedSlo.revision}]. Rolling back. ${err}`
-      );
+      this.logger.warn('Cannot update the SLO. Rolling back.', {
+        service: { name: 'update_slo' },
+        labels: {
+          slo_id: updatedSlo.id,
+          indicator_type: updatedSlo.indicator.type,
+          error_type: 'update_failed',
+        },
+        error: err,
+      });
 
       await asyncForEach(rollbackOperations.reverse(), async (operation) => {
         try {
           await operation();
         } catch (rollbackErr) {
-          this.logger.debug(`Rollback operation failed. ${rollbackErr}`);
+          this.logger.warn('Rollback operation failed.', {
+            service: { name: 'update_slo' },
+            labels: {
+              slo_id: updatedSlo.id,
+              indicator_type: updatedSlo.indicator.type,
+              error_type: 'rollback_failed',
+            },
+            error: rollbackErr,
+          });
         }
       });
 
@@ -211,13 +239,17 @@ export class UpdateSLO {
 
       await Promise.all([this.deleteRollupData(slo), this.deleteSummaryData(slo)]);
     } catch (err) {
-      // Don't block the update on cleanup failures, but surface them in logs so
-      // stale transforms and orphan summary documents become diagnosable.
-      // SDH #6202.
       this.logger.warn(
-        `Failed to clean up resources for previous revision of SLO ` +
-          `[id=${slo.id}, revision=${slo.revision}]. ` +
-          `Old resources may continue producing data. ${err}`
+        'Failed to clean up resources for previous SLO revision. Old resources may continue producing data.',
+        {
+          service: { name: 'update_slo' },
+          labels: {
+            slo_id: slo.id,
+            indicator_type: slo.indicator.type,
+            error_type: 'cleanup_failed',
+          },
+          error: err,
+        }
       );
     }
   }


### PR DESCRIPTION

## Summary

Closes #269381

- Upgrades all error `logger.debug` calls in core SLO services to `logger.warn` with ECS-compatible structured metadata (`labels: {}` with `slo_id`, `indicator_type`, `error_type`, `transform_id`)
- Uses semantically correct `error_type` values per catch site (`cleanup_failed`, `rollback_failed`, `reset_failed`, `update_failed`, `transform_*_failed`, `unsupported_indicator_type`)
- Adds `Logger` to `DeleteSLO` constructor (route + bulk-delete task wired in)

## Motivation

Part of the SLO self-observability initiative. Structured labels are a prerequisite for log-pattern-issue-tracker team config queries like `labels.error_type : "transform_install_failed"` and for meta-SLO error-rate dashboards.



## Test plan

- [x] `node scripts/jest delete_slo.test.ts update_slo.test.ts` — 25 tests pass
- [x] `node scripts/type_check --project x-pack/solutions/observability/plugins/slo/tsconfig.json` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)