### PR TITLE
poc(entity-store): In-Document History — nested per-EUID first/last seen on entity doc

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/component_templates.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/component_templates.ts
@@ -11,8 +11,30 @@ import type {
   EntityType,
 } from '../../../common/domain/definitions/entity_schema';
 import { ENTITY_BASE_PREFIX, ENTITY_SCHEMA_VERSION_V2 } from '../../../common/domain/entity_index';
+import { ENTITY_RELATIONSHIP_COLLECT_LEAVES } from '../../../common/domain/definitions/common_fields';
 
 type MappingProperties = NonNullable<MappingTypeMapping['properties']>;
+
+// Per-EUID first/last seen history is stored as a nested array next to
+// `entity.relationships.<rel>.ids`. Nested type preserves object identity so
+// DSL nested queries can filter by date range per EUID. ES|QL does not
+// support nested types — analyst temporal investigation lives elsewhere.
+const RELATIONSHIP_HISTORY_MAPPING = {
+  type: 'nested',
+  properties: {
+    euid: { type: 'keyword' },
+    first_seen: { type: 'date', format: 'strict_date_optional_time' },
+    last_seen: { type: 'date', format: 'strict_date_optional_time' },
+  },
+} as const;
+
+const ENTITY_RELATIONSHIP_HISTORY_MAPPINGS: MappingProperties = Object.fromEntries(
+  ENTITY_RELATIONSHIP_COLLECT_LEAVES.map((rel) => [
+    `entity.relationships.${rel}.history`,
+    RELATIONSHIP_HISTORY_MAPPING,
+  ])
+);
+
 const BASE_ENTITY_INDEX_MAPPING = {
   '@timestamp': { type: 'date' },
   'event.ingested': { type: 'date' },
@@ -43,6 +65,7 @@ export const getEntityDefinitionComponentTemplate = (
 const getIndexMappings = (definition: EntityDefinition): MappingTypeMapping => ({
   properties: {
     ...BASE_ENTITY_INDEX_MAPPING,
+    ...ENTITY_RELATIONSHIP_HISTORY_MAPPINGS,
     ...Object.fromEntries(
       definition.fields
         .filter(({ mapping }) => mapping)

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/crud/crud_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/crud/crud_client.ts
@@ -27,6 +27,10 @@ import {
   EntityStoreNotInstalledError,
 } from '../errors';
 import { validateAndTransformDoc } from './utils';
+import {
+  RELATIONSHIP_HISTORY_PAINLESS_SCRIPT,
+  type RelationshipHistoryParams,
+} from './relationship_history_script';
 import { runWithSpan } from '../../telemetry/traces';
 import {
   searchEntitiesV2,
@@ -83,6 +87,11 @@ export interface BulkObjectResponse {
 interface BulkUpdateEntityParams {
   objects: BulkObject[];
   force?: boolean;
+}
+
+interface BulkUpdateEntityWithHistoryParams extends BulkUpdateEntityParams {
+  /** ISO timestamp recorded as the `seen` time for this scan's history entries. */
+  collected: string;
 }
 
 // EntityUpdateClient is the maintainer-safe CRUD surface: all CRUD methods
@@ -332,6 +341,89 @@ export class CRUDClient {
           reason: value.error?.reason,
         } as BulkObjectResponse;
       });
+  }
+
+  /**
+   * Same write contract as `bulkUpdateEntity`, plus an additional bulk Painless
+   * pass that upserts per-EUID `entity.relationships.<rel>.history` records
+   * (preserves `first_seen`, advances `last_seen`) for every entity that
+   * successfully received its `.ids` update.
+   *
+   * History is intentionally NOT written for entities that 404'd in the first
+   * pass — `bulkUpdateEntity` is the only authority on which EUIDs exist in
+   * the store. Callers see the same `BulkObjectResponse[]` error contract; any
+   * errors raised by the history pass are logged but do not surface as caller
+   * errors (the `.ids` update is the source of truth for caller-visible state).
+   */
+  public async bulkUpdateEntityWithHistory({
+    objects,
+    collected,
+    force = false,
+  }: BulkUpdateEntityWithHistoryParams): Promise<BulkObjectResponse[]> {
+    const idsErrors = await this.bulkUpdateEntity({ objects, force });
+
+    const failedHashes = new Set(idsErrors.map((e) => e._id));
+    const historyOps: object[] = [];
+    for (const { type: entityType, doc } of objects) {
+      const generatedId = getEuidFromObject(entityType, doc);
+      const valid = validateAndTransformDoc(
+        'update',
+        entityType,
+        this.namespace,
+        doc,
+        generatedId,
+        force
+      );
+      const docId = hashEuid(valid.id);
+      if (failedHashes.has(docId)) continue;
+
+      // Extract { relType: [euid, ...] } from the doc's relationships shape.
+      const docRels = (valid.doc as { entity?: { relationships?: Record<string, unknown> } })
+        ?.entity?.relationships;
+      if (!docRels || typeof docRels !== 'object') continue;
+      const updates: Record<string, string[]> = {};
+      for (const [relType, val] of Object.entries(docRels)) {
+        const ids = (val as { ids?: unknown })?.ids;
+        if (Array.isArray(ids) && ids.length > 0) {
+          updates[relType] = ids.filter((x): x is string => typeof x === 'string');
+        }
+      }
+      if (Object.keys(updates).length === 0) continue;
+
+      const params: RelationshipHistoryParams = { collected, updates };
+      historyOps.push(
+        { update: { _id: docId, retry_on_conflict: RETRY_ON_CONFLICT } },
+        {
+          script: {
+            source: RELATIONSHIP_HISTORY_PAINLESS_SCRIPT,
+            lang: 'painless',
+            params,
+          },
+        }
+      );
+    }
+
+    if (historyOps.length > 0) {
+      try {
+        const histResp = await this.esClient.bulk({
+          index: getLatestEntitiesIndexName(this.namespace),
+          operations: historyOps,
+          refresh: false,
+        });
+        if (histResp.errors) {
+          const histErrCount = histResp.items.filter((it) => it.update?.error).length;
+          this.logger.warn(
+            `Bulk relationship history upsert produced ${histErrCount} errors out of ${
+              historyOps.length / 2
+            } operations`
+          );
+        }
+      } catch (err) {
+        this.logger.error(`Bulk relationship history upsert failed: ${err}`);
+      }
+    }
+
+    return idsErrors;
   }
 
   // createEntity generates EUID and creates the entity in the LATEST index

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/crud/relationship_history_script.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/crud/relationship_history_script.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Painless script that upserts per-EUID first/last seen records into
+ * `entity.relationships.<relType>.history` for an entity document.
+ *
+ * For each EUID in params.updates[relType]:
+ *  - if a history entry already exists for that EUID, advance `last_seen` to
+ *    params.collected (preserves existing `first_seen`);
+ *  - otherwise append a new entry with `first_seen` and `last_seen` both set
+ *    to params.collected.
+ *
+ * `.ids` is intentionally NOT touched here — it is managed by the entity
+ * store collect_values retention on the bulkUpdateEntity write path that
+ * runs before this script.
+ *
+ * params shape:
+ * {
+ *   collected: "2026-05-14T10:30:00.000Z",
+ *   updates: {
+ *     accesses_frequently: ["host:laptopA", "host:laptopB"],
+ *     owns: ["device:1"]
+ *   }
+ * }
+ */
+export const RELATIONSHIP_HISTORY_PAINLESS_SCRIPT = `
+  String collected = params.collected;
+  def updates = params.updates;
+
+  if (ctx._source.entity == null) { ctx._source.entity = [:]; }
+  if (ctx._source.entity.relationships == null) { ctx._source.entity.relationships = [:]; }
+  def rels = ctx._source.entity.relationships;
+
+  for (def relEntry : updates.entrySet()) {
+    String relType = relEntry.getKey();
+    def euids = relEntry.getValue();
+
+    if (rels[relType] == null) { rels[relType] = [:]; }
+    if (rels[relType].history == null) { rels[relType].history = []; }
+    def history = rels[relType].history;
+
+    for (String euid : euids) {
+      boolean found = false;
+      for (int i = 0; i < history.size(); i++) {
+        if (history[i].euid == euid) {
+          history[i].last_seen = collected;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        history.add([
+          'euid': euid,
+          'first_seen': collected,
+          'last_seen': collected
+        ]);
+      }
+    }
+  }
+`;
+
+export interface RelationshipHistoryParams {
+  collected: string;
+  updates: Record<string, string[]>;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -23,6 +23,7 @@ import type { ObservedEntityData } from '../shared/components/observed_entity/ty
 import type { EntityRiskScore, HostItem } from '../../../../common/search_strategy';
 import { VisualizationsSection } from '../shared/components/right/visualizations_section';
 import { ResolutionSection } from '../../../entity_analytics/components/entity_resolution/resolution_section';
+import { RelationshipHistorySection } from '../shared/components/right/relationship_history_section';
 
 type ObservedHostData = Omit<ObservedEntityData<HostItem>, 'anomalies'>;
 
@@ -101,6 +102,11 @@ export const HostPanelContent = ({
             openDetailsPanel={openDetailsPanel}
           />
           <EuiHorizontalRule margin="m" />
+          <RelationshipHistorySection
+            relationships={
+              entityRecord?.entity?.relationships as unknown as Record<string, unknown> | undefined
+            }
+          />
         </>
       )}
       {entityStoreEntityId && !isPreviewMode && hasEntityResolutionLicense && (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/right/relationship_history_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/right/relationship_history_section.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiAccordion,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiBadge,
+  EuiText,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { PreferenceFormattedDate } from '../../../../../common/components/formatted_date';
+
+// Local shape — the OpenAPI-generated Entity type still has relationships
+// as `string[]` keyed by relType. The actual stored shape is now
+// `{ ids: string[], history: [{ euid, first_seen, last_seen }, ...] }`.
+// Schema regeneration is intentionally deferred (out of scope for POC).
+interface HistoryEntry {
+  euid: string;
+  first_seen: string;
+  last_seen: string;
+}
+
+interface RelationshipShape {
+  ids?: string[];
+  history?: HistoryEntry[];
+}
+
+interface Props {
+  relationships: Record<string, unknown> | undefined;
+}
+
+const REL_TYPE_LABELS: Record<string, string> = {
+  accesses_frequently: 'Accesses Frequently',
+  accesses_infrequently: 'Accesses Infrequently',
+  owns: 'Owns',
+  owns_inferred: 'Owns (inferred)',
+  supervises: 'Supervises',
+  communicates_with: 'Communicates With',
+  depends_on: 'Depends On',
+  administers: 'Administers',
+};
+
+const isHistoryEntry = (val: unknown): val is HistoryEntry =>
+  typeof val === 'object' &&
+  val !== null &&
+  typeof (val as HistoryEntry).euid === 'string' &&
+  typeof (val as HistoryEntry).first_seen === 'string' &&
+  typeof (val as HistoryEntry).last_seen === 'string';
+
+const extractHistory = (rel: unknown): HistoryEntry[] => {
+  const history = (rel as RelationshipShape | undefined)?.history;
+  if (!Array.isArray(history)) return [];
+  return history.filter(isHistoryEntry);
+};
+
+export const RelationshipHistorySection = ({ relationships }: Props) => {
+  if (!relationships) return null;
+
+  const entries = Object.entries(relationships)
+    .map(([relType, rel]) => [relType, extractHistory(rel)] as const)
+    .filter(([, history]) => history.length > 0);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <EuiAccordion
+      id="relationship-history-section"
+      buttonContent={
+        <EuiTitle size="xs">
+          <h3>{'Relationships'}</h3>
+        </EuiTitle>
+      }
+      initialIsOpen
+    >
+      <EuiSpacer size="s" />
+      {entries.map(([relType, history]) => (
+        <div key={relType}>
+          <EuiText size="xs" color="subdued">
+            <strong>{REL_TYPE_LABELS[relType] ?? relType.replace(/_/g, ' ')}</strong>
+          </EuiText>
+          <EuiSpacer size="xs" />
+          {[...history]
+            .sort((a, b) => b.last_seen.localeCompare(a.last_seen))
+            .map((record) => (
+              <EuiFlexGroup key={record.euid} alignItems="center" gutterSize="s" wrap>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">{record.euid}</EuiBadge>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {'First: '}
+                    <PreferenceFormattedDate value={new Date(record.first_seen)} />
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {'Last: '}
+                    <PreferenceFormattedDate value={new Date(record.last_seen)} />
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            ))}
+          <EuiSpacer size="s" />
+        </div>
+      ))}
+    </EuiAccordion>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -24,6 +24,7 @@ import type { ObservedEntityData } from '../shared/components/observed_entity/ty
 import type { EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
 import { VisualizationsSection } from '../shared/components/right/visualizations_section';
 import { ResolutionSection } from '../../../entity_analytics/components/entity_resolution/resolution_section';
+import { RelationshipHistorySection } from '../shared/components/right/relationship_history_section';
 
 export type ObservedUserData = Omit<ObservedEntityData<UserItem>, 'anomalies'> & {
   entityRecord?: EntityStoreRecord | null;
@@ -104,6 +105,11 @@ export const UserPanelContent = ({
             openDetailsPanel={openDetailsPanel}
           />
           <EuiHorizontalRule margin="m" />
+          <RelationshipHistorySection
+            relationships={
+              entityRecord?.entity?.relationships as unknown as Record<string, unknown> | undefined
+            }
+          />
         </>
       )}
       {entityStoreEntityId && !isPreviewMode && hasEntityResolutionLicense && (

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.test.ts
@@ -47,7 +47,7 @@ const makeCrudClient = (
   errors: Array<{ status: number }> = []
 ): { crudClient: EntityUpdateClient; bulkUpdate: jest.Mock } => {
   const bulkUpdate = jest.fn().mockResolvedValue(errors);
-  const crudClient = { bulkUpdateEntity: bulkUpdate } as unknown as EntityUpdateClient;
+  const crudClient = { bulkUpdateEntityWithHistory: bulkUpdate } as unknown as EntityUpdateClient;
   return { crudClient, bulkUpdate };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.test.ts
@@ -12,7 +12,7 @@ import type { EntityRelationshipRecord } from './types';
 
 const makeCrudClient = (errors: Array<{ status: number }> = []): EntityUpdateClient =>
   ({
-    bulkUpdateEntity: jest.fn().mockResolvedValue(errors),
+    bulkUpdateEntityWithHistory: jest.fn().mockResolvedValue(errors),
   } as unknown as EntityUpdateClient);
 
 describe('writeEntityIds', () => {
@@ -20,7 +20,7 @@ describe('writeEntityIds', () => {
     const crudClient = makeCrudClient();
     const result = await writeEntityIds(crudClient, loggerMock.create(), []);
     expect(result).toEqual({ updated: 0, notFound: 0, errors: 0 });
-    expect(crudClient.bulkUpdateEntity).not.toHaveBeenCalled();
+    expect(crudClient.bulkUpdateEntityWithHistory).not.toHaveBeenCalled();
   });
 
   it('skips records with null entityId', async () => {
@@ -34,7 +34,7 @@ describe('writeEntityIds', () => {
     ];
     const result = await writeEntityIds(crudClient, loggerMock.create(), records);
     expect(result).toEqual({ updated: 0, notFound: 0, errors: 0 });
-    expect(crudClient.bulkUpdateEntity).not.toHaveBeenCalled();
+    expect(crudClient.bulkUpdateEntityWithHistory).not.toHaveBeenCalled();
   });
 
   it('skips records where all relationship arrays are empty', async () => {
@@ -51,10 +51,10 @@ describe('writeEntityIds', () => {
     ];
     const result = await writeEntityIds(crudClient, loggerMock.create(), records);
     expect(result).toEqual({ updated: 0, notFound: 0, errors: 0 });
-    expect(crudClient.bulkUpdateEntity).not.toHaveBeenCalled();
+    expect(crudClient.bulkUpdateEntityWithHistory).not.toHaveBeenCalled();
   });
 
-  it('calls bulkUpdateEntity with ids array per relType', async () => {
+  it('calls bulkUpdateEntityWithHistory with ids array per relType', async () => {
     const crudClient = makeCrudClient();
     const records: EntityRelationshipRecord[] = [
       {
@@ -67,7 +67,7 @@ describe('writeEntityIds', () => {
       },
     ];
     await writeEntityIds(crudClient, loggerMock.create(), records);
-    const [call] = (crudClient.bulkUpdateEntity as jest.Mock).mock.calls;
+    const [call] = (crudClient.bulkUpdateEntityWithHistory as jest.Mock).mock.calls;
     const { objects } = call[0];
     expect(objects).toHaveLength(1);
     const doc = objects[0].doc.entity.relationships;
@@ -90,7 +90,7 @@ describe('writeEntityIds', () => {
       },
     ];
     await writeEntityIds(crudClient, loggerMock.create(), records);
-    const [call] = (crudClient.bulkUpdateEntity as jest.Mock).mock.calls;
+    const [call] = (crudClient.bulkUpdateEntityWithHistory as jest.Mock).mock.calls;
     const { objects } = call[0];
     expect(objects).toHaveLength(1);
     expect(objects[0].doc.entity.relationships.communicates_with.ids.sort()).toEqual([
@@ -175,7 +175,7 @@ describe('writeEntityIds', () => {
     expect(logger.error).toHaveBeenCalled();
   });
 
-  it('calls bulkUpdateEntity with force: true', async () => {
+  it('calls bulkUpdateEntityWithHistory with force: true', async () => {
     const crudClient = makeCrudClient();
     const records: EntityRelationshipRecord[] = [
       {
@@ -185,7 +185,7 @@ describe('writeEntityIds', () => {
       },
     ];
     await writeEntityIds(crudClient, loggerMock.create(), records);
-    const [call] = (crudClient.bulkUpdateEntity as jest.Mock).mock.calls;
+    const [call] = (crudClient.bulkUpdateEntityWithHistory as jest.Mock).mock.calls;
     expect(call[0].force).toBe(true);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.ts
@@ -67,7 +67,8 @@ export interface WriteEntityIdsResult {
 export const writeEntityIds = async (
   crudClient: EntityUpdateClient,
   logger: Logger,
-  records: EntityRelationshipRecord[]
+  records: EntityRelationshipRecord[],
+  collected: string = new Date().toISOString()
 ): Promise<WriteEntityIdsResult> => {
   if (records.length === 0) return { updated: 0, notFound: 0, errors: 0 };
 
@@ -101,7 +102,11 @@ export const writeEntityIds = async (
   if (objects.length === 0) return { updated: 0, notFound: 0, errors: 0 };
 
   logger.info(`Writing relationship ids for ${objects.length} entity records`);
-  const responseErrors = await crudClient.bulkUpdateEntity({ objects, force: true });
+  const responseErrors = await crudClient.bulkUpdateEntityWithHistory({
+    objects,
+    collected,
+    force: true,
+  });
 
   const missingErrors = responseErrors.filter((e) => e.status === 404);
   const realErrors = responseErrors.filter((e) => e.status !== 404);


### PR DESCRIPTION
## Summary

**In-Document History.** Stores per-EUID `first_seen`/`last_seen` as a `nested` array under `entity.relationships.{rel}.history` on the entity document, next to the existing `.ids`. Flyout reads directly from the entity record — no new API call.

- New `CRUDClient.bulkUpdateEntityWithHistory({ objects, collected, force })` owns the full write: existing `bulkUpdateEntity` pass for `.ids`, then a single bulk Painless pass for `.history`, scoped only to entities that did not 404. The entity store remains the sole authority on EUID existence; the maintainer never reaches into the entity index.
- Component template (`entity_store` plugin) now declares `entity.relationships.{rel}.history` as `nested` (with `euid` keyword + `first_seen` / `last_seen` date) for every `rel` in `ENTITY_RELATIONSHIP_COLLECT_LEAVES`.
- Maintainer change is minimal: one method name swap. No `esClient` plumbing, no Painless import, no hashing on the maintainer side.
- `RelationshipHistorySection` flyout component renders first/last seen per EUID, sorted by `last_seen` desc, grouped by relationship type.

## Motivation

Part of the investigation into [security-team#17214](https://github.com/elastic/security-team/issues/17214) — comparing **In-Document History** against **Event-Log History** ([#269369](https://github.com/elastic/kibana/pull/269369)). This PR validates the in-document/`nested` approach end-to-end so we can compare trade-offs empirically.

## Architectural rule enforced

> The security_solution maintainer must not reach into the entity index directly. All entity-index operations (writes, existence checks, `.history` upserts) live in the entity_store CRUD client.

This is why `bulkUpdateEntityWithHistory` is on `CRUDClient` and not in security_solution. The maintainer calls one CRUD method per write; the entity store handles everything below that.

## Known limitations vs Event-Log History

- **ES|QL has no support for `nested` type** — analyst temporal investigation queries (`WHERE history.first_seen > X`) are blocked entirely. Event-Log History (#269369) covers that use case.
- **Breaking schema change** — `entity.relationships.{rel}` goes from `keyword[]` to `{ ids, history }` object. Dev: delete and recreate the latest index. Production: out of scope for the POC (full re-index migration required).
- **Unbounded growth** — `.history` array grows once per new EUID per relationship; no eviction tied to `.ids`'s `collect_values` retention.
- **O(N × M) Painless write cost** — upsert iterates the existing array to find a matching `euid`.

## Test plan

- [x] Maintainer runs end-to-end; `entity.relationships.{rel}.history` populated with `{euid, first_seen, last_seen}` for every EUID present in `.ids`
- [x] Cardinality matches: N ids → N history entries, no positional mismatch (verified on entities with 3+ EUIDs)
- [x] Sibling fields (`entity.relationships.resolution.resolved_to`) are unchanged after the new write path
- [x] Unit tests pass: `update_entities.test.ts` (10/10), `run_relationship_maintainer.test.ts` (31/31), `crud_client.test.ts` (3/3)
- [ ] Re-run maintainer; confirm `first_seen` is preserved and `last_seen` advances for existing EUIDs; new EUIDs get added with `first_seen === last_seen`
- [ ] Open user/host flyout with entity store v2 enabled; Relationships section renders first/last seen per EUID
- [ ] DSL nested query with `range` on `history.first_seen` returns expected `inner_hits`
- [ ] Confirm ES|QL cannot query `history.*` (the documented limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
