### PR TITLE
[Security][Agent Builder] RFC: API-driven alert-analysis skill (v2)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_alert_analysis_api/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_alert_analysis_api/stateful/classic.stateful.config.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as evalsTracingConfig } from '../../evals_tracing/stateful/classic.stateful.config';
+
+export const servers: ScoutServerConfig = {
+  ...evalsTracingConfig,
+  kbnTestServer: {
+    ...evalsTracingConfig.kbnTestServer,
+    serverArgs: [
+      ...evalsTracingConfig.kbnTestServer.serverArgs,
+      `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+        'alertAnalysisApiDrivenSkill',
+      ])}`,
+      '--uiSettings.overrides.agentBuilder:experimentalFeatures=true',
+    ],
+  },
+};

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/security_skills.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/security_skills.spec.ts
@@ -190,6 +190,24 @@ evaluate.describe(
                   expectedOnlyToolId: 'security.entity_risk_score',
                 },
               },
+              {
+                input: {
+                  question:
+                    'Correlate related alerts for alert id "test-alert-id-123" over the last 24 hours and summarize shared entities I should investigate.',
+                },
+                output: {
+                  expected:
+                    'I will call the related alerts internal API for alert test-alert-id-123 and summarize correlated entities from the last 24 hours.',
+                },
+                metadata: {
+                  query_intent: 'Alert Correlation',
+                  expectedSkill: 'alert-analysis',
+                  expectedToolId: 'platform.workflows.workflow_execute_step',
+                  expectedWorkflowRequestPath:
+                    '/internal/security_solution/alert_analysis/related_alerts',
+                  expectedWorkflowStepType: 'kibana.request',
+                },
+              },
             ],
           },
         });

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.ts
@@ -48,6 +48,50 @@ interface DatasetExample extends Example {
   };
 }
 
+const WORKFLOW_EXECUTE_STEP_TOOL_ID = 'platform.workflows.workflow_execute_step';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const matchesWorkflowRequestExpectation = ({
+  params,
+  expectedPath,
+  expectedStepType,
+}: {
+  params: unknown;
+  expectedPath: string;
+  expectedStepType: string;
+}): boolean => {
+  if (!isRecord(params)) return false;
+
+  const yaml = params.yaml;
+  if (typeof yaml === 'string') {
+    const hasPath = yaml.includes(expectedPath);
+    const hasStepType = yaml.includes(`type: ${expectedStepType}`);
+    if (hasPath && hasStepType) return true;
+  }
+
+  const step = params.step;
+  if (!isRecord(step)) return false;
+
+  const stepType = step.type;
+  const withArgs = step.with;
+  if (!isRecord(withArgs)) return false;
+
+  return stepType === expectedStepType && withArgs.path === expectedPath;
+};
+
+const extractWorkflowExecuteParams = (output: TaskOutput): unknown[] => {
+  const steps = (output as { steps?: unknown[] }).steps;
+  if (!Array.isArray(steps)) return [];
+
+  return steps
+    .filter((step): step is Record<string, unknown> => isRecord(step))
+    .filter((step) => step.type === 'tool_call' && step.tool_id === WORKFLOW_EXECUTE_STEP_TOOL_ID)
+    .map((step) => step.params)
+    .filter((params) => params != null);
+};
+
 export type EvaluateDataset = ({
   dataset: { name, description, examples },
 }: {
@@ -122,18 +166,89 @@ function configureExperiment({
 
   const selectedEvaluators = selectEvaluators([
     {
+      name: 'ExpectedWorkflowRequest',
+      kind: 'CODE' as const,
+      evaluate: async ({ output, metadata }) => {
+        const expectedPath = getStringMeta(metadata, 'expectedWorkflowRequestPath');
+        if (!expectedPath) return { score: 1 };
+
+        const expectedStepType =
+          getStringMeta(metadata, 'expectedWorkflowStepType') ?? 'kibana.request';
+        const workflowParams = extractWorkflowExecuteParams(output as TaskOutput);
+        if (workflowParams.length === 0) {
+          return {
+            score: 0,
+            metadata: {
+              reason: 'No workflow execute step calls found',
+              expectedPath,
+              expectedStepType,
+            },
+          };
+        }
+
+        const matched = workflowParams.some((params) =>
+          matchesWorkflowRequestExpectation({
+            params,
+            expectedPath,
+            expectedStepType,
+          })
+        );
+
+        return {
+          score: matched ? 1 : 0,
+          metadata: {
+            expectedPath,
+            expectedStepType,
+            workflowCallCount: workflowParams.length,
+          },
+        };
+      },
+    },
+    {
+      name: 'ExpectedToolCalled',
+      kind: 'CODE' as const,
+      evaluate: async ({ output, metadata }) => {
+        const expectedToolId = getStringMeta(metadata, 'expectedToolId');
+        if (!expectedToolId) return { score: 1 };
+
+        const toolCalls = getToolCallSteps(output as TaskOutput);
+        if (toolCalls.length === 0) {
+          return { score: 0, metadata: { reason: 'No tool calls found', expectedToolId } };
+        }
+
+        const usedToolIds = toolCalls.map((t) => t.tool_id).filter(Boolean);
+        const invoked = usedToolIds.includes(expectedToolId);
+
+        return {
+          score: invoked ? 1 : 0,
+          metadata: { expectedToolId, usedToolIds },
+        };
+      },
+    },
+    {
       name: 'ToolUsageOnly',
       kind: 'CODE' as const,
       evaluate: async ({ output, metadata }) => {
         const expectedOnlyToolId = getStringMeta(metadata, 'expectedOnlyToolId');
         if (!expectedOnlyToolId) return { score: 1 };
 
+        // Exclude infrastructure/framework tools that are always called regardless of user intent.
+        // filestore.read is the skill-file loader — it's not a domain tool choice.
+        const INFRA_TOOL_IDS = new Set(['filestore.read']);
+
         const toolCalls = getToolCallSteps(output as TaskOutput);
-        if (toolCalls.length === 0) {
-          return { score: 0, metadata: { reason: 'No tool calls found', expectedOnlyToolId } };
+        const domainToolCalls = toolCalls.filter(
+          (t) => t.tool_id && !INFRA_TOOL_IDS.has(t.tool_id)
+        );
+
+        if (domainToolCalls.length === 0) {
+          return {
+            score: 0,
+            metadata: { reason: 'No domain tool calls found', expectedOnlyToolId },
+          };
         }
 
-        const usedToolIds = toolCalls.map((t) => t.tool_id).filter(Boolean);
+        const usedToolIds = domainToolCalls.map((t) => t.tool_id).filter(Boolean);
         const hasExpected = usedToolIds.includes(expectedOnlyToolId);
         const allExpected = usedToolIds.every((id) => id === expectedOnlyToolId);
 
@@ -218,7 +333,7 @@ function configureExperiment({
         }
 
         const query = `FROM traces-*
-| WHERE trace.id == "${traceId}"
+| WHERE trace_id == "${traceId}"
 | STATS skill_invoked = COUNT(
     CASE(
       attributes.gen_ai.tool.name == "filestore.read"

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/index.ts
@@ -25,3 +25,4 @@ export const plugin: PluginInitializer<
 };
 
 export { config } from './config';
+export { WORKFLOW_EXECUTE_STEP_TOOL_ID } from './tools/workflow_execute_step_tool';

--- a/x-pack/solutions/security/plugins/security_solution/common/api/alert_analysis/related_alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/alert_analysis/related_alerts.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+
+export const ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH =
+  '/internal/security_solution/alert_analysis/related_alerts';
+
+export const relatedAlertsRequestSchema = z.object({
+  alertId: z.string().describe('The _id of the alert to correlate'),
+  timeWindowHours: z.number().min(1).max(168).default(24),
+  maxResults: z.number().min(1).max(100).default(25),
+  hostNames: z.array(z.string()).optional(),
+  userNames: z.array(z.string()).optional(),
+  sourceIps: z.array(z.string()).optional(),
+  destIps: z.array(z.string()).optional(),
+});
+
+export type RelatedAlertsRequest = z.infer<typeof relatedAlertsRequestSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -247,6 +247,12 @@ export const allowedExperimentalValues = Object.freeze({
   entityAnalyticsEntityStoreV2: false,
 
   /**
+   * Enables API-driven alert-analysis skill registration.
+   * When disabled, the legacy inline implementation is used.
+   */
+  alertAnalysisApiDrivenSkill: false,
+
+  /**
    * Enables the deprecated prebuilt rules UI
    * Release: 9.4
    */

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_api_driven.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_api_driven.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateSkillDefinition } from '@kbn/agent-builder-server/skills/type_definition';
+import { ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH } from '../../../../common/api/alert_analysis/related_alerts';
+import {
+  alertAnalysisApiDrivenSkill,
+  WORKFLOW_EXECUTE_STEP_TOOL_ID,
+} from './alert_analysis_skill_api_driven';
+
+describe('alertAnalysisApiDrivenSkill', () => {
+  it('has stable skill identity', () => {
+    expect(alertAnalysisApiDrivenSkill.id).toBe('alert-analysis');
+    expect(alertAnalysisApiDrivenSkill.name).toBe('alert-analysis');
+    expect(alertAnalysisApiDrivenSkill.basePath).toBe('skills/security/alerts');
+  });
+
+  it('validates successfully', async () => {
+    await expect(validateSkillDefinition(alertAnalysisApiDrivenSkill)).resolves.toBeDefined();
+  });
+
+  it('registers workflow execute step tool for kibana.request invocation', () => {
+    const tools = alertAnalysisApiDrivenSkill.getRegistryTools?.();
+    expect(tools).toBeDefined();
+    expect(tools).toContain(WORKFLOW_EXECUTE_STEP_TOOL_ID);
+  });
+
+  it('does not define inline tools', () => {
+    expect(alertAnalysisApiDrivenSkill.getInlineTools).toBeUndefined();
+  });
+
+  it('documents the related-alerts internal API path', () => {
+    expect(alertAnalysisApiDrivenSkill.content).toContain(
+      ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH
+    );
+  });
+
+  it('documents that Elasticsearch lookups are not proxied through kibana.request', () => {
+    expect(alertAnalysisApiDrivenSkill.content).toContain(
+      'Do **NOT** proxy standard Elasticsearch reads through `kibana.request`'
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_api_driven.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_api_driven.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { WORKFLOW_EXECUTE_STEP_TOOL_ID } from '@kbn/agent-builder-workflows-plugin/server';
+import {
+  SECURITY_ALERTS_TOOL_ID,
+  SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+  SECURITY_LABS_SEARCH_TOOL_ID,
+} from '../../tools';
+import { ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH } from '../../../../common/api/alert_analysis/related_alerts';
+
+export { WORKFLOW_EXECUTE_STEP_TOOL_ID };
+
+export const alertAnalysisApiDrivenSkill = defineSkillType({
+  id: 'alert-analysis',
+  name: 'alert-analysis',
+  basePath: 'skills/security/alerts',
+  description:
+    'API-driven alert triage and investigation: fetch alerts, correlate related alerts through internal APIs, ' +
+    'enrich with Security Labs intelligence, and assess entity risk to determine disposition.',
+  content: `# Alert Analysis Guide (API-Driven)
+
+## When to Use This Skill
+
+Use this skill when:
+- Triaging a specific security alert to determine disposition
+- Correlating related alerts across shared entities (host, user, source.ip, destination.ip)
+- Enriching alert context with Security Labs threat intelligence
+- Prioritizing investigation using entity risk signals
+
+## Required Step Selection Policy
+
+- Use \`kibana.request\` (via \`platform.workflows.workflow_execute_step\`) for internal Security Solution API calls.
+- Use Elasticsearch steps (\`elasticsearch.search\`, \`elasticsearch.esql.query\`, etc.) for Elasticsearch lookups.
+- Do **NOT** proxy standard Elasticsearch reads through \`kibana.request\`.
+
+## Recommended Investigation Flow
+
+1. Fetch alert context with \`security.alerts\`
+2. Correlate related alerts by calling internal API path \`${ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH}\` with \`kibana.request\`
+3. Query threat intelligence with \`security.security_labs_search\`
+4. Check host/user risk with \`security.entity_risk_score\`
+5. Synthesize disposition and next actions
+
+## Tool Selection Guardrails
+
+- For list/prioritization questions (for example: "high/critical alerts in last 24h"), use only \`security.alerts\` unless explicit correlation by \`alertId\` is requested.
+- For Security Labs intel questions (for example: "Lazarus Group techniques"), use only \`security.security_labs_search\`.
+- For risk score questions (for example: "risk score for host DC01"), use only \`security.entity_risk_score\`.
+- For correlation requests that include an \`alertId\`, call \`platform.workflows.workflow_execute_step\` with step type \`kibana.request\` and path \`${ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH}\`.
+- Do NOT use \`platform.core.search\` for related-alert correlation when an \`alertId\` is available.
+- Do NOT use workflow status/inspection tools as a substitute for executing the related-alert request.
+- If the workflow call fails or is blocked, report that clearly and include the returned error details.
+
+## Internal API Contract (Related Alerts)
+
+Call \`platform.workflows.workflow_execute_step\` with inline workflow YAML and a \`stepName\`:
+
+- **method**: \`POST\`
+- **path**: \`${ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH}\`
+- **body**:
+  - \`alertId\` (required)
+  - \`timeWindowHours\` (optional, default 24, max 168)
+  - \`hostNames\`, \`userNames\`, \`sourceIps\`, \`destIps\` (optional arrays; pass when already known)
+  - \`maxResults\` (optional, bounded server-side for token efficiency)
+
+When \`alertId\` is present, use this exact shape:
+\`\`\`
+tool_id: platform.workflows.workflow_execute_step
+params:
+  stepName: get_related_alerts
+  yaml: |
+    version: "1"
+    name: alert_analysis_related_alerts
+    triggers:
+      - type: manual
+    steps:
+      - name: get_related_alerts
+        type: kibana.request
+        with:
+          method: POST
+          path: ${ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH}
+          body:
+            alertId: "<alert-id>"
+            timeWindowHours: 24
+\`\`\`
+
+The API response is token-budgeted and may include truncation metadata.`,
+  getRegistryTools: () => [
+    SECURITY_ALERTS_TOOL_ID,
+    SECURITY_LABS_SEARCH_TOOL_ID,
+    SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+    WORKFLOW_EXECUTE_STEP_TOOL_ID,
+  ],
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { alertAnalysisSkill } from './alert_analysis_skill';
+export { alertAnalysisApiDrivenSkill } from './alert_analysis_skill_api_driven';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { alertAnalysisSkill } from './alert_analysis';
+export { alertAnalysisApiDrivenSkill } from './alert_analysis/alert_analysis_skill_api_driven';
 export { threatHuntingSkill } from './threat_hunting';
 export { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 export { pciComplianceSkill } from './pci_compliance';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ExperimentalFeatures } from '../../../common/experimental_features';
+import { registerSkills } from './register_skills';
+
+jest.mock('./alert_analysis', () => ({
+  alertAnalysisSkill: { id: 'alert-analysis-legacy' },
+}));
+
+jest.mock('./alert_analysis/alert_analysis_skill_api_driven', () => ({
+  alertAnalysisApiDrivenSkill: { id: 'alert-analysis-api-driven' },
+}));
+
+jest.mock('./threat_hunting', () => ({
+  threatHuntingSkill: { id: 'threat-hunting' },
+}));
+
+jest.mock('./automatic_troubleshooting', () => ({
+  createAutomaticTroubleshootingSkill: jest.fn(() => ({ id: 'automatic-troubleshooting' })),
+}));
+
+jest.mock('./detection_rule_edit', () => ({
+  getDetectionRuleEditSkill: jest.fn(() => ({ id: 'detection-rule-edit' })),
+}));
+
+jest.mock('./entity_analytics', () => ({
+  getEntityAnalyticsSkill: jest.fn(() => ({ id: 'entity-analytics' })),
+}));
+
+jest.mock('./find_security_ml_jobs', () => ({
+  findSecurityMlJobsSkill: jest.fn(() => ({ id: 'find-security-ml-jobs' })),
+}));
+
+jest.mock('./pci_compliance', () => ({
+  pciComplianceSkill: { id: 'pci-compliance' },
+}));
+
+describe('registerSkills', () => {
+  const register = jest.fn(async () => undefined);
+
+  const baseArgs = {
+    agentBuilder: { skills: { register } },
+    getStartServices: jest.fn(),
+    kibanaVersion: '9.9.9',
+    logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    ml: undefined,
+    options: { endpointAppContextService: {} },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers legacy alert-analysis skill when API-driven flag is disabled', async () => {
+    const experimentalFeatures = {
+      alertAnalysisApiDrivenSkill: false,
+      automaticTroubleshootingSkill: false,
+      entityAnalyticsEntityStoreV2: false,
+      pciComplianceAgentBuilder: false,
+    } as ExperimentalFeatures;
+
+    await registerSkills({
+      ...baseArgs,
+      experimentalFeatures,
+    });
+
+    const ids = register.mock.calls.map(([skill]) => skill.id);
+    expect(ids).toContain('alert-analysis-legacy');
+    expect(ids).not.toContain('alert-analysis-api-driven');
+  });
+
+  it('registers API-driven alert-analysis skill when flag is enabled', async () => {
+    const experimentalFeatures = {
+      alertAnalysisApiDrivenSkill: true,
+      automaticTroubleshootingSkill: false,
+      entityAnalyticsEntityStoreV2: false,
+      pciComplianceAgentBuilder: false,
+    } as ExperimentalFeatures;
+
+    await registerSkills({
+      ...baseArgs,
+      experimentalFeatures,
+    });
+
+    const ids = register.mock.calls.map(([skill]) => skill.id);
+    expect(ids).toContain('alert-analysis-api-driven');
+    expect(ids).not.toContain('alert-analysis-legacy');
+    expect(ids).toContain('threat-hunting');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -15,6 +15,7 @@ import { getEntityAnalyticsSkill } from './entity_analytics';
 import { pciComplianceSkill } from './pci_compliance';
 import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
+import { alertAnalysisApiDrivenSkill } from './alert_analysis/alert_analysis_skill_api_driven';
 import type { EntityAnalyticsRoutesDeps } from '../../lib/entity_analytics/types';
 import { findSecurityMlJobsSkill } from './find_security_ml_jobs';
 
@@ -59,7 +60,11 @@ export const registerSkills = async ({
   );
 
   await agentBuilder.skills.register(threatHuntingSkill);
-  await agentBuilder.skills.register(alertAnalysisSkill);
+  await agentBuilder.skills.register(
+    experimentalFeatures.alertAnalysisApiDrivenSkill
+      ? alertAnalysisApiDrivenSkill
+      : alertAnalysisSkill
+  );
 
   if (experimentalFeatures.pciComplianceAgentBuilder) {
     agentBuilder.skills.register(pciComplianceSkill);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/routes/register_alert_analysis_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/routes/register_alert_analysis_routes.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import {
+  ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH,
+  relatedAlertsRequestSchema,
+} from '../../../../common/api/alert_analysis/related_alerts';
+import type { SecuritySolutionPluginRouter } from '../../../types';
+import { findRelatedAlerts } from '../services/find_related_alerts';
+
+export const registerAlertAnalysisRoutes = (router: SecuritySolutionPluginRouter) => {
+  router.versioned
+    .post({
+      path: ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH,
+      access: 'internal',
+      security: {
+        authz: {
+          requiredPrivileges: ['securitySolution'],
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: buildRouteValidationWithZod(relatedAlertsRequestSchema),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const [coreContext, securitySolutionContext] = await Promise.all([
+          context.core,
+          context.securitySolution,
+        ]);
+        const spaceId = securitySolutionContext.getSpaceId();
+        const alertsIndex = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+
+        const result = await findRelatedAlerts(coreContext.elasticsearch.client.asCurrentUser, {
+          alertId: request.body.alertId,
+          alertsIndex,
+          timeWindowHours: request.body.timeWindowHours,
+          maxResults: request.body.maxResults,
+          hostNames: request.body.hostNames,
+          userNames: request.body.userNames,
+          sourceIps: request.body.sourceIps,
+          destIps: request.body.destIps,
+        });
+
+        if (!result.ok) {
+          return response.customError({
+            statusCode: 400,
+            body: { message: result.message },
+          });
+        }
+
+        return response.ok({
+          body: result,
+        });
+      }
+    );
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/services/find_related_alerts.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/services/find_related_alerts.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { findRelatedAlerts } from './find_related_alerts';
+
+describe('findRelatedAlerts', () => {
+  const esClient = {
+    get: jest.fn(),
+    search: jest.fn(),
+  } as unknown as ElasticsearchClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty result when no source entities are present', async () => {
+    (esClient.get as jest.Mock).mockResolvedValue({
+      _source: { 'kibana.alert.rule.name': 'Rule' },
+    });
+
+    const result = await findRelatedAlerts(esClient, {
+      alertId: 'alert-1',
+      alertsIndex: '.alerts-security.alerts-default',
+      timeWindowHours: 24,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.relatedAlerts).toEqual([]);
+      expect(result.returnedCount).toBe(0);
+      expect(result.isTruncated).toBe(false);
+    }
+  });
+
+  it('uses token-budgeted defaults and emits truncation metadata', async () => {
+    (esClient.search as jest.Mock).mockResolvedValue({
+      hits: {
+        total: { value: 99, relation: 'eq' },
+        hits: [
+          {
+            _id: 'related-1',
+            _index: '.alerts-security.alerts-default',
+            _source: { message: 'related' },
+          },
+        ],
+      },
+    });
+
+    const result = await findRelatedAlerts(esClient, {
+      alertId: 'alert-1',
+      alertsIndex: '.alerts-security.alerts-default',
+      timeWindowHours: 24,
+      hostNames: ['host-a'],
+    });
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size: 25,
+        _source: expect.arrayContaining(['@timestamp', 'message', 'host.name']),
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.totalMatched).toBe(99);
+      expect(result.returnedCount).toBe(1);
+      expect(result.isTruncated).toBe(true);
+    }
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/services/find_related_alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/services/find_related_alerts.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+export interface SourceEntities {
+  hostNames: string[];
+  userNames: string[];
+  sourceIps: string[];
+  destIps: string[];
+}
+
+export interface FindRelatedAlertsParams {
+  alertId: string;
+  alertsIndex: string;
+  timeWindowHours: number;
+  maxResults?: number;
+  hostNames?: string[];
+  userNames?: string[];
+  sourceIps?: string[];
+  destIps?: string[];
+}
+
+interface RelatedAlertDocument extends Record<string, unknown> {
+  _id: string;
+  _index: string;
+}
+
+export interface FindRelatedAlertsSuccess {
+  ok: true;
+  message: string;
+  relatedAlerts: RelatedAlertDocument[];
+  sourceEntities: SourceEntities;
+  totalMatched: number;
+  returnedCount: number;
+  isTruncated: boolean;
+}
+
+export interface FindRelatedAlertsError {
+  ok: false;
+  message: string;
+}
+
+export type FindRelatedAlertsResult = FindRelatedAlertsSuccess | FindRelatedAlertsError;
+
+const DEFAULT_MAX_RESULTS = 25;
+
+const RELATED_ALERT_SOURCE_ALLOWLIST = [
+  '@timestamp',
+  'kibana.alert.rule.name',
+  'kibana.alert.severity',
+  'kibana.alert.risk_score',
+  'kibana.alert.workflow_status',
+  'kibana.alert.reason',
+  'kibana.alert.rule.threat',
+  'host.name',
+  'user.name',
+  'source.ip',
+  'destination.ip',
+  'process.name',
+  'process.executable',
+  'file.name',
+  'file.path',
+  'message',
+] as const;
+
+export const findRelatedAlerts = async (
+  esClient: ElasticsearchClient,
+  params: FindRelatedAlertsParams
+): Promise<FindRelatedAlertsResult> => {
+  const {
+    alertId,
+    alertsIndex,
+    timeWindowHours,
+    maxResults = DEFAULT_MAX_RESULTS,
+    hostNames: providedHostNames,
+    userNames: providedUserNames,
+    sourceIps: providedSourceIps,
+    destIps: providedDestIps,
+  } = params;
+
+  const hasProvidedEntities =
+    (Array.isArray(providedHostNames) && providedHostNames.length > 0) ||
+    (Array.isArray(providedUserNames) && providedUserNames.length > 0) ||
+    (Array.isArray(providedSourceIps) && providedSourceIps.length > 0) ||
+    (Array.isArray(providedDestIps) && providedDestIps.length > 0);
+
+  let sourceEntities: SourceEntities;
+
+  try {
+    if (hasProvidedEntities) {
+      sourceEntities = {
+        hostNames: Array.isArray(providedHostNames) ? providedHostNames : [],
+        userNames: Array.isArray(providedUserNames) ? providedUserNames : [],
+        sourceIps: Array.isArray(providedSourceIps) ? providedSourceIps : [],
+        destIps: Array.isArray(providedDestIps) ? providedDestIps : [],
+      };
+    } else {
+      const alertResult = await esClient.get({
+        index: alertsIndex,
+        id: alertId,
+      });
+
+      const alertSource = alertResult._source as Record<string, unknown> | undefined;
+      if (!alertSource) {
+        return {
+          ok: false,
+          message: `Alert ${alertId} not found or has no source data.`,
+        };
+      }
+
+      sourceEntities = {
+        hostNames: getNestedValues(alertSource, 'host.name'),
+        userNames: getNestedValues(alertSource, 'user.name'),
+        sourceIps: getNestedValues(alertSource, 'source.ip'),
+        destIps: getNestedValues(alertSource, 'destination.ip'),
+      };
+    }
+
+    const hasEntities =
+      sourceEntities.hostNames.length > 0 ||
+      sourceEntities.userNames.length > 0 ||
+      sourceEntities.sourceIps.length > 0 ||
+      sourceEntities.destIps.length > 0;
+
+    if (!hasEntities) {
+      return {
+        ok: true,
+        message: 'No entity values found on the source alert to correlate.',
+        sourceEntities,
+        relatedAlerts: [],
+        totalMatched: 0,
+        returnedCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    const shouldClauses: Array<{ terms: Record<string, string[]> }> = [];
+    if (sourceEntities.hostNames.length > 0) {
+      shouldClauses.push({ terms: { 'host.name': sourceEntities.hostNames } });
+    }
+    if (sourceEntities.userNames.length > 0) {
+      shouldClauses.push({ terms: { 'user.name': sourceEntities.userNames } });
+    }
+    if (sourceEntities.sourceIps.length > 0) {
+      shouldClauses.push({ terms: { 'source.ip': sourceEntities.sourceIps } });
+    }
+    if (sourceEntities.destIps.length > 0) {
+      shouldClauses.push({ terms: { 'destination.ip': sourceEntities.destIps } });
+    }
+
+    const size = Math.min(Math.max(maxResults, 1), 100);
+
+    const searchResult = await esClient.search<Record<string, unknown>>({
+      index: alertsIndex,
+      size,
+      track_total_hits: true,
+      query: {
+        bool: {
+          must: [
+            {
+              range: {
+                '@timestamp': {
+                  gte: `now-${timeWindowHours}h`,
+                },
+              },
+            },
+          ],
+          should: shouldClauses,
+          minimum_should_match: 1,
+          must_not: [{ ids: { values: [alertId] } }],
+        },
+      },
+      sort: [{ '@timestamp': 'desc' }],
+      _source: [...RELATED_ALERT_SOURCE_ALLOWLIST],
+      ignore_unavailable: true,
+    });
+
+    const relatedAlerts: RelatedAlertDocument[] = searchResult.hits.hits.map((hit) => ({
+      _id: hit._id,
+      _index: hit._index ?? alertsIndex,
+      ...((hit._source as Record<string, unknown> | undefined) ?? {}),
+    }));
+
+    const totalMatched = getTotalMatched(searchResult.hits.total);
+    const returnedCount = relatedAlerts.length;
+    const isTruncated = totalMatched > returnedCount;
+
+    return {
+      ok: true,
+      message: `Found ${returnedCount} related alerts sharing entities with alert ${alertId}.`,
+      sourceEntities,
+      relatedAlerts,
+      totalMatched,
+      returnedCount,
+      isTruncated,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: `Failed to find related alerts: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+};
+
+const getTotalMatched = (
+  total: number | { relation?: string; value?: number } | undefined
+): number => {
+  if (typeof total === 'number') {
+    return total;
+  }
+  if (total && typeof total.value === 'number') {
+    return total.value;
+  }
+  return 0;
+};
+
+function getNestedValues(obj: Record<string, unknown>, path: string): string[] {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current == null || typeof current !== 'object') {
+      return [];
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  if (typeof current === 'string') {
+    return [current];
+  }
+  if (Array.isArray(current)) {
+    return current.filter((value): value is string => typeof value === 'string');
+  }
+  return [];
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
@@ -60,6 +60,7 @@ import { registerSiemReadinessRoutes } from '../lib/siem_readiness';
 import type { TrialCompanionRoutesDeps } from '../lib/trial_companion/types';
 import { registerDataGeneratorRoutes } from './data_generator/register_data_generator_routes';
 import { registerInitializationRoutes } from '../lib/initialization';
+import { registerAlertAnalysisRoutes } from '../lib/alert_analysis/routes/register_alert_analysis_routes';
 
 export const initRoutes = (
   router: SecuritySolutionPluginRouter,
@@ -167,6 +168,7 @@ export const initRoutes = (
   registerTrialCompanionRoutes(trialCompanionDeps);
 
   registerInitializationRoutes({ router, logger });
+  registerAlertAnalysisRoutes(router);
 
   if (enableDataGeneratorRoutes) {
     registerDataGeneratorRoutes(router, getStartServices);


### PR DESCRIPTION
## Ask

Should engineers building Agent Builder skills prefer **building tools**, or using **`workflow_execute_step`** with **internal HTTP via `kibana.request`**? This PR investigates that pattern for the existing **alert-analysis** skill.

## Our Findings

The `workflow_execute_step` / YAML approach works—it correctly routes to the internal API every time—but it costs **~28% more input tokens** and produces measurably worse Factuality and Relevance scores compared to the legacy inline-tool path. **We do not recommend it as the default pattern for new skills**; building a focused inline tool remains the better trade-off until a structured wrapper can eliminate the YAML authoring overhead.

## What this PR does

- Duplicates the `alert-analysis` skill behind a feature flag: the experimental variant uses **`platform.workflows.workflow_execute_step`** with a **`kibana.request`** step to call the related-alerts internal API, instead of the legacy skill’s inline **`security.alert-analysis.get-related-alerts`** tool for related alerts.
- Moves **related alerts** logic to its own internal API (implemented by `findRelatedAlerts`) + route + tests
- Toggle **`alertAnalysisApiDrivenSkill`** via `xpack.securitySolution.enableExperimental` to choose API-driven vs legacy **`alert-analysis`** (see `register_skills.ts`)
- Scout **`evals_alert_analysis_api`** for local runs
- Eval helpers (`ExpectedToolCalled`, `ExpectedWorkflowRequest`, `ToolUsageOnly` infra exclusions) so we can assert the correlation path calls `workflow_execute_step` with the related-alerts route and so `filestore.read` (skill loading) does not fail “single tool” checks as if it were a stray domain tool.

## Evals (local, paired settings)

|                   |                                                                      |
| ----------------- | -------------------------------------------------------------------- |
| Suite             | `agent-builder`, `--grep "Alert Analysis"`                           |
| Model / connector | Sonnet (`pmeClaudeV45SonnetUsEast1` example)                         |
| Repetitions       | 3                                                                    |
| Runs              | `alert-analysis-old-skill-clean` vs `alert-analysis-new-skill-clean` |

**Tokens (trace-backed evaluators, same runs as above)**

|                      | Legacy skill | API-driven | Change   |
| -------------------- | -----------: | ---------: | -------- |
| Input tokens (mean)  |      152,385 |    195,751 | **+28%** |
| Output tokens (mean) |        2,399 |      2,694 | **+12%** |

**Judge metrics**

| Evaluator         | Legacy skill | API-driven | Note                                                                                  |
| ----------------- | -----------: | ---------: | ------------------------------------------------------------------------------------- |
| Factuality        |         0.20 |       0.13 | API-driven spends more tokens on YAML scaffolding, leaving less budget for grounded claims; also n=3 so variance is high |
| Groundedness      |         0.86 |       0.89 | ↑ slight improvement                                                                  |
| Relevance         |         0.45 |       0.31 | Extra workflow boilerplate in the response dilutes relevance scoring vs the reference |
| Sequence accuracy |         1.00 |       1.00 | Both paths call tools in the expected order                                           |
| ToolUsageOnly     |         0.60 |       0.53 | `filestore.read` (skill loading) is excluded via infra filter; remaining gap reflects the workflow step producing wider, less-targeted tool output |

**Path-specific (API-driven only; legacy not comparable)**

| Evaluator                                    | API-driven |
| -------------------------------------------- | ---------: |
| ExpectedToolCalled (`workflow_execute_step`) |       1.00 |
| ExpectedWorkflowRequest                      |       1.00 |

## YAML vs token cost

The API-driven skill has the model call **`workflow_execute_step`** and author **workflow YAML** for a **`kibana.request`** to the internal related-alerts route—more scaffolding per turn than a small JSON-only tool.

The **token table above** is the concrete part: on the paired eval runs, API-driven used **substantially higher input tokens** and **moderately higher output tokens** than the legacy skill with the same setup. That is the closest thing we routinely see in evals to a “budget” story (we don’t count “reasoning” directly).

**Follow-up (in progress here: https://github.com/elastic/kibana/pull/269397):** add a **new inline tool** that performs the same internal call as the **`workflow_execute_step` / YAML** path so the model can pass structured params instead of authoring workflow YAML—aimed at **reducing token spend on YAML reasoning** while keeping behavior equivalent.

## Reproducing the Alert Analysis evals

1. **Scout** — from repo root (`yarn kbn bootstrap` if needed):
   - **API-driven skill** (feature flag + Agent Builder experimental):  
     `node scripts/scout.js start-server --arch stateful --domain classic --serverConfigSet evals_alert_analysis_api`  
     That enables **`alertAnalysisApiDrivenSkill`** via `xpack.securitySolution.enableExperimental` and **`agentBuilder:experimentalFeatures=true`** (see [`classic.stateful.config.ts`](src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_alert_analysis_api/stateful/classic.stateful.config.ts)).
   - **Legacy baseline**: `node scripts/evals scout` (wraps **`evals_tracing`**; no `alertAnalysisApiDrivenSkill`).
2. **Manual Kibana** (no Scout): set `xpack.securitySolution.enableExperimental` to include **`alertAnalysisApiDrivenSkill`**, and enable **`agentBuilder:experimentalFeatures`** for the workflow step path—same knobs as the Scout config above.
3. **Run** (adjust host/port to what Scout prints; Kibana is usually **`:5620`** in these configs):

```bash
TRACING_ES_URL=http://elastic:changeme@localhost:9220 \
KIBANA_URL=http://elastic:changeme@localhost:5620 \
EVALUATION_CONNECTOR_ID=<connector> \
EVALUATION_REPETITIONS=3 \
TEST_RUN_ID=my-alert-analysis-run \
node scripts/evals run --suite agent-builder \
  --grep "Alert Analysis" \
  --model pmeClaudeV45SonnetUsEast1
```

`EVALUATION_CONNECTOR_ID` must exist on the target Kibana (see `node scripts/evals run` / vault config). Point **`TRACING_ES_URL`** at the Elasticsearch cluster that actually receives OTLP traces (typically the **same** ES Scout uses, e.g. `:9220`, when EDOT is aligned).

---

_PR developed with Cursor + GPT-5.3-codex + claude-4.6-sonnet-medium-thinking_
