### PR TITLE
[FTR] Replace retry.try* with native WebDriverIO waits

### DIFF
--- a/src/platform/test/functional/page_objects/common_page.ts
+++ b/src/platform/test/functional/page_objects/common_page.ts
@@ -511,10 +511,8 @@ export class CommonPageObject extends FtrService {
 
   async waitForSaveModalToClose() {
     this.log.debug('Waiting for save modal to close');
-    await this.retry.try(async () => {
-      if (await this.testSubjects.exists('savedObjectSaveModal', { timeout: 5000 })) {
-        throw new Error('save modal still open');
-      }
+    await this.testSubjects.missingOrFail('savedObjectSaveModal', {
+      timeout: this.testSubjects.TRY_TIME,
     });
   }
 

--- a/src/platform/test/functional/page_objects/console_page.ts
+++ b/src/platform/test/functional/page_objects/console_page.ts
@@ -452,12 +452,10 @@ export class ConsolePageObject extends FtrService {
   }
 
   async skipTourIfExists() {
-    await this.retry.try(async () => {
-      const tourShown = await this.testSubjects.exists('consoleSkipTourButton');
-      if (tourShown) {
-        await this.clickSkipTour();
-      }
-    });
+    const tourShown = await this.testSubjects.exists('consoleSkipTourButton');
+    if (tourShown) {
+      await this.clickSkipTour();
+    }
   }
 
   public async clickContextMenu() {

--- a/src/platform/test/functional/page_objects/dashboard_page.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page.ts
@@ -244,14 +244,12 @@ export class DashboardPageObject extends FtrService {
       ? 'breadcrumb breadcrumb-deepLinkId-dashboards'
       : 'breadcrumb dashboardListingBreadcrumb first';
     await this.testSubjects.click(breadcrumbLink);
-    await this.retry.try(async () => {
-      const warning = await this.testSubjects.exists('confirmModalTitleText');
-      if (warning) {
-        await this.testSubjects.click(
-          ignorePageLeaveWarning ? 'confirmModalConfirmButton' : 'confirmModalCancelButton'
-        );
-      }
-    });
+    const warning = await this.testSubjects.exists('confirmModalTitleText');
+    if (warning) {
+      await this.testSubjects.click(
+        ignorePageLeaveWarning ? 'confirmModalConfirmButton' : 'confirmModalCancelButton'
+      );
+    }
     await this.expectExistsDashboardLandingPage();
   }
 

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -1100,7 +1100,7 @@ export class DiscoverPageObject extends FtrService {
     await field.focus();
     await this.retry.try(async () => {
       await this.browser.pressKeys(this.browser.keys.ENTER);
-      await this.testSubjects.exists('.domDroppable--active'); // checks if we're in dnd mode and there's any drop target active
+      await this.find.byCssSelector('.domDroppable--active'); // checks if we're in dnd mode and there's any drop target active
     });
     await this.browser.pressKeys(this.browser.keys.RIGHT);
     await this.browser.pressKeys(this.browser.keys.ENTER);

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -1066,12 +1066,7 @@ export class DiscoverPageObject extends FtrService {
   }
 
   private async waitForDropToFinish() {
-    await this.retry.try(async () => {
-      const exists = await this.find.existsByCssSelector('.domDragDrop-isActiveGroup');
-      if (exists) {
-        throw new Error('UI still in drag/drop mode');
-      }
-    });
+    await this.find.waitForDeletedByCssSelector('.domDragDrop-isActiveGroup');
     await this.header.waitUntilLoadingHasFinished();
     await this.waitUntilSearchingHasFinished();
   }

--- a/src/platform/test/functional/page_objects/header_page.ts
+++ b/src/platform/test/functional/page_objects/header_page.ts
@@ -84,13 +84,11 @@ export class HeaderPageObject extends FtrService {
   }
 
   public async onAppLeaveWarning(ignoreWarning = false) {
-    await this.retry.try(async () => {
-      const warning = await this.testSubjects.exists('confirmModalTitleText');
-      if (warning) {
-        await this.testSubjects.click(
-          ignoreWarning ? 'confirmModalConfirmButton' : 'confirmModalCancelButton'
-        );
-      }
-    });
+    const warning = await this.testSubjects.exists('confirmModalTitleText');
+    if (warning) {
+      await this.testSubjects.click(
+        ignoreWarning ? 'confirmModalConfirmButton' : 'confirmModalCancelButton'
+      );
+    }
   }
 }

--- a/src/platform/test/functional/page_objects/time_picker.ts
+++ b/src/platform/test/functional/page_objects/time_picker.ts
@@ -194,10 +194,10 @@ export class TimePickerPageObject extends FtrService {
       if (isShowDatesButton) {
         await this.testSubjects.moveMouseTo('superDatePickerShowDatesButton');
         await this.testSubjects.click('superDatePickerShowDatesButton', 50);
-      }
-      await this.testSubjects.exists('superDatePickerstartDatePopoverButton', { timeout: 1000 });
-      // Close the start date popover which opens automatically if `superDatePickerShowDatesButton` is clicked
-      if (isShowDatesButton) {
+        // Close the start date popover which opens automatically
+        await this.testSubjects.existOrFail('superDatePickerstartDatePopoverButton', {
+          timeout: 1000,
+        });
         await this.testSubjects.click('superDatePickerstartDatePopoverButton');
       }
     });

--- a/src/platform/test/functional/page_objects/visualize_chart_page.ts
+++ b/src/platform/test/functional/page_objects/visualize_chart_page.ts
@@ -154,12 +154,10 @@ export class VisualizeChartPageObject extends FtrService {
   }
 
   private async toggleLegend() {
-    await this.retry.try(async () => {
-      const isVisible = await this.find.existsByCssSelector('.echLegend');
-      if (!isVisible) {
-        await this.testSubjects.click('vislibToggleLegend');
-      }
-    });
+    const isVisible = await this.find.existsByCssSelector('.echLegend');
+    if (!isVisible) {
+      await this.testSubjects.click('vislibToggleLegend');
+    }
   }
 
   public async filterLegend(name: string) {

--- a/x-pack/platform/test/functional/page_objects/lens_page.ts
+++ b/x-pack/platform/test/functional/page_objects/lens_page.ts
@@ -392,7 +392,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       log.debug(`Press ${metaKey} with keyboard`);
       await retry.try(async () => {
         await browser.pressKeys(browserKey);
-        await find.existsByCssSelector(
+        await find.byCssSelector(
           `.domDroppable__extraTarget > [data-test-subj="domDragDrop-dropTarget-${metaToAction[metaKey]}"].domDroppable--hover`
         );
       });
@@ -497,12 +497,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     },
 
     async waitForLensDragDropToFinish() {
-      await retry.try(async () => {
-        const exists = await find.existsByCssSelector('.domDragDrop-isActiveGroup');
-        if (exists) {
-          throw new Error('UI still in drag/drop mode');
-        }
-      });
+      await find.waitForDeletedByCssSelector('.domDragDrop-isActiveGroup');
     },
 
     /**

--- a/x-pack/platform/test/functional/services/ml/common_ui.ts
+++ b/x-pack/platform/test/functional/services/ml/common_ui.ts
@@ -424,7 +424,7 @@ export function MachineLearningCommonUIProvider({
           await this.ensureAllMenuPopoversClosed();
 
           await testSubjects.click(`${rowSelector} > euiCollapsedItemActionsButton`);
-          await find.byCssSelector('euiContextMenuPanel');
+          await find.byCssSelector('.euiContextMenuPanel');
 
           const isEnabled = await testSubjects.isEnabled(actionTestSubject);
 

--- a/x-pack/platform/test/functional/services/ml/common_ui.ts
+++ b/x-pack/platform/test/functional/services/ml/common_ui.ts
@@ -424,7 +424,7 @@ export function MachineLearningCommonUIProvider({
           await this.ensureAllMenuPopoversClosed();
 
           await testSubjects.click(`${rowSelector} > euiCollapsedItemActionsButton`);
-          await find.existsByCssSelector('euiContextMenuPanel');
+          await find.byCssSelector('euiContextMenuPanel');
 
           const isEnabled = await testSubjects.isEnabled(actionTestSubject);
 

--- a/x-pack/platform/test/functional/services/ml/data_visualizer_table.ts
+++ b/x-pack/platform/test/functional/services/ml/data_visualizer_table.ts
@@ -177,7 +177,7 @@ export function MachineLearningDataVisualizerTableProvider(
       await retry.tryForTime(30 * 1000, async () => {
         await this.ensureAllMenuPopoversClosed();
         await testSubjects.click(this.rowSelector(fieldName, 'euiCollapsedItemActionsButton'));
-        await find.byCssSelector('euiContextMenuPanel');
+        await find.byCssSelector('.euiContextMenuPanel');
       });
     }
 

--- a/x-pack/platform/test/functional/services/ml/data_visualizer_table.ts
+++ b/x-pack/platform/test/functional/services/ml/data_visualizer_table.ts
@@ -177,7 +177,7 @@ export function MachineLearningDataVisualizerTableProvider(
       await retry.tryForTime(30 * 1000, async () => {
         await this.ensureAllMenuPopoversClosed();
         await testSubjects.click(this.rowSelector(fieldName, 'euiCollapsedItemActionsButton'));
-        await find.existsByCssSelector('euiContextMenuPanel');
+        await find.byCssSelector('euiContextMenuPanel');
       });
     }
 

--- a/x-pack/platform/test/functional/services/ml/job_annotations_table.ts
+++ b/x-pack/platform/test/functional/services/ml/job_annotations_table.ts
@@ -365,7 +365,7 @@ export function MachineLearningJobAnnotationsProvider({ getService }: FtrProvide
           `mlAnnotationsTableRow row-${annotationId} > euiCollapsedItemActionsButton`,
           30 * 1000
         );
-        await find.existsByCssSelector('euiContextMenuPanel');
+        await find.byCssSelector('euiContextMenuPanel');
       });
     }
 

--- a/x-pack/platform/test/functional/services/ml/job_annotations_table.ts
+++ b/x-pack/platform/test/functional/services/ml/job_annotations_table.ts
@@ -365,7 +365,7 @@ export function MachineLearningJobAnnotationsProvider({ getService }: FtrProvide
           `mlAnnotationsTableRow row-${annotationId} > euiCollapsedItemActionsButton`,
           30 * 1000
         );
-        await find.byCssSelector('euiContextMenuPanel');
+        await find.byCssSelector('.euiContextMenuPanel');
       });
     }
 

--- a/x-pack/platform/test/functional_with_es_ssl/apps/embeddable_alerts_table/embeddable_alerts_table.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/embeddable_alerts_table/embeddable_alerts_table.ts
@@ -117,7 +117,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await toasts.dismissIfExists();
           await dashboardAddPanel.openAddPanelFlyout();
           await dashboardAddPanel.clickAddNewPanelFromUIActionLink('Alerts');
-          await retry.try(() => testSubjects.exists(FILTERS_FORM_SUBJ));
+          await testSubjects.existOrFail(FILTERS_FORM_SUBJ);
           if (solution === 'stack' || solution === 'observability') {
             await testSubjects.missingOrFail(SOLUTION_SELECTOR_SUBJ);
           }
@@ -132,7 +132,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           // Dashboard warnings may appear above the save button
           await toasts.dismissIfExists();
           await testSubjects.click(SAVE_CONFIG_BUTTON_SUBJ);
-          await retry.try(() => testSubjects.exists(DASHBOARD_PANEL_TEST_SUBJ));
+          await testSubjects.existOrFail(DASHBOARD_PANEL_TEST_SUBJ);
           await pageObjects.dashboard.verifyNoRenderErrors();
           const tagsCells = await find.allByCssSelector(
             '[data-gridcell-column-id="kibana.alert.rule.tags"] [data-test-subj="dataGridRowCell"]'
@@ -155,7 +155,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await testSubjects.click(SOLUTION_SELECTOR_SUBJ);
       await find.clickByCssSelector(`button#observability`);
       await testSubjects.click(SAVE_CONFIG_BUTTON_SUBJ);
-      await retry.try(() => testSubjects.exists(DASHBOARD_PANEL_TEST_SUBJ));
+      await testSubjects.existOrFail(DASHBOARD_PANEL_TEST_SUBJ);
       const featureCells = await find.allByCssSelector(
         '[data-gridcell-column-id="kibana.alert.rule.consumer"] [data-test-subj="dataGridRowCell"]'
       );

--- a/x-pack/solutions/observability/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/hosts_view.ts
@@ -290,9 +290,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
           await waitForPageToLoad();
 
-          await retry.tryForTime(5000, async () => {
-            await testSubjects.exists('hostsViewTableNoData');
-          });
+          await testSubjects.existOrFail('hostsViewTableNoData', { timeout: 5000 });
         });
       });
     });

--- a/x-pack/solutions/observability/test/serverless/functional/services/svl_oblt_navigation.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/services/svl_oblt_navigation.ts
@@ -25,7 +25,7 @@ export function SvlObltNavigationServiceProvider({
     async navigateToDiscoverPage() {
       await retry.tryForTime(60 * 1000, async () => {
         await PageObjects.common.navigateToApp('discover');
-        await testSubjects.existOrFail('discoverQueryTotalHits', { timeout: 20_000 });
+        await testSubjects.existOrFail('dscPage', { timeout: 20_000 });
       });
     },
   };

--- a/x-pack/solutions/observability/test/serverless/functional/services/svl_oblt_navigation.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/services/svl_oblt_navigation.ts
@@ -25,7 +25,7 @@ export function SvlObltNavigationServiceProvider({
     async navigateToDiscoverPage() {
       await retry.tryForTime(60 * 1000, async () => {
         await PageObjects.common.navigateToApp('discover');
-        await testSubjects.exists('discoverQueryTotalHits', { timeout: 20_000 });
+        await testSubjects.existOrFail('discoverQueryTotalHits', { timeout: 20_000 });
       });
     },
   };

--- a/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
+++ b/x-pack/solutions/search/test/page_objects/search_synonyms_page.ts
@@ -23,10 +23,11 @@ export function SearchSynonymsPageProvider({ getService }: FtrProviderContext) {
           'searchSynonymsCreateSynonymsSetModalForceWrite',
       },
       async expectSynonymsGetStartedPageComponentsToExist() {
-        // check if exists, refresh and check again for 10 seconds
         await retry.tryForTime(10000, async () => {
-          await testSubjects.exists(this.TEST_IDS.GET_STARTED_BUTTON, { timeout: 2000 });
-          await browser.refresh();
+          if (!(await testSubjects.exists(this.TEST_IDS.GET_STARTED_BUTTON, { timeout: 2000 }))) {
+            await browser.refresh();
+            throw new Error(`${this.TEST_IDS.GET_STARTED_BUTTON} not visible`);
+          }
         });
       },
       async clickCreateSynonymsSetButton() {


### PR DESCRIPTION
Replaces JS-polling anti-patterns in FTR tests with proper browser-native or semantic equivalents:

- `retry.try(() => exists(...))` → `existOrFail` (or `missingOrFail` for absence checks)
- `retry.try(() => existsByCssSelector(...))` → `byCssSelector('.selector')` with correct CSS class selectors
- `retry.try(() => existsByCssSelector('.cls'))` for drag/drop teardown → `waitForDeletedByCssSelector`
- Remove `retry.try` wrappers whose bodies never threw (dead retry logic)
- Use `dscPage` instead of `discoverQueryTotalHits` for Discover load detection (the latter only renders when a query returns results)

This is should improve the performance of tests which use these.

Updates #269385

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->