### PR TITLE
[Alerting v2] Fix splitQuery heuristic for queries without STATS

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_heuristic_split.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_heuristic_split.test.ts
@@ -25,13 +25,49 @@ describe('splitQuery', () => {
   });
 
   describe('no STATS segment', () => {
-    it('returns none confidence and puts the whole query as alertBlock when there is no STATS', () => {
-      const query = 'FROM logs-* | WHERE count > 0';
+    it('returns base = full query when no STATS and no WHERE', () => {
+      const query = 'FROM logs-* | LIMIT 100';
       const result = splitQuery(query);
       expect(result.confidence).toBe('none');
       expect(result.reason).toBe('no_stats');
-      expect(result.alertBlock).toBe(query.trim());
-      expect(result.base).toBe('');
+      expect(result.base).toBe(query.trim());
+      expect(result.alertBlock).toBe('');
+    });
+
+    it('splits after the last non-WHERE before the trailing WHERE', () => {
+      const query = 'FROM logs-* | WHERE status_code >= 500';
+      const result = splitQuery(query);
+      expect(result.confidence).toBe('low');
+      expect(result.reason).toBe('where_without_stats');
+      expect(result.base).toBe('FROM logs-*');
+      expect(result.alertBlock).toBe('| WHERE status_code >= 500');
+    });
+
+    it('groups consecutive trailing WHEREs into the alert block', () => {
+      const query = 'FROM logs-* | WHERE a > 1 | WHERE b > 2 | WHERE c > 3';
+      const result = splitQuery(query);
+      expect(result.confidence).toBe('low');
+      expect(result.reason).toBe('where_without_stats');
+      expect(result.base).toBe('FROM logs-*');
+      expect(result.alertBlock).toBe('| WHERE a > 1 | WHERE b > 2 | WHERE c > 3');
+    });
+
+    it('splits after the last non-WHERE when a non-WHERE precedes the trailing chain', () => {
+      const query = 'FROM logs-* | WHERE env == "prod" | EVAL x = 1 | WHERE error_rate > 0.05';
+      const result = splitQuery(query);
+      expect(result.confidence).toBe('low');
+      expect(result.reason).toBe('where_without_stats');
+      expect(result.base).toBe('FROM logs-* | WHERE env == "prod" | EVAL x = 1');
+      expect(result.alertBlock).toBe('| WHERE error_rate > 0.05');
+    });
+
+    it('returns no base when all commands are WHERE', () => {
+      const query = 'FROM logs-* | WHERE x > 1';
+      const result = splitQuery(query);
+      expect(result.confidence).toBe('low');
+      expect(result.reason).toBe('where_without_stats');
+      expect(result.base).toBe('FROM logs-*');
+      expect(result.alertBlock).toBe('| WHERE x > 1');
     });
   });
 
@@ -104,11 +140,13 @@ describe('splitQuery', () => {
   });
 
   describe('reason field', () => {
-    it('reason is no_stats when no STATS found', () => {
-      // FROM logs-* has no pipe at all so tokeniseSegments yields one segment (FROM) with no STATS
+    it('reason is no_stats when neither STATS nor WHERE found', () => {
       expect(splitQuery('FROM logs-*').reason).toBe('no_stats');
-      // FROM logs-* | WHERE x > 1 has a WHERE but still no STATS
-      expect(splitQuery('FROM logs-* | WHERE x > 1').reason).toBe('no_stats');
+      expect(splitQuery('FROM logs-* | LIMIT 10').reason).toBe('no_stats');
+    });
+
+    it('reason is where_without_stats when WHERE but no STATS', () => {
+      expect(splitQuery('FROM logs-* | WHERE x > 1').reason).toBe('where_without_stats');
     });
 
     it('reason is no_where when STATS present but no WHERE', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_heuristic_split.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_heuristic_split.test.ts
@@ -61,13 +61,22 @@ describe('splitQuery', () => {
       expect(result.alertBlock).toBe('| WHERE error_rate > 0.05');
     });
 
-    it('returns no base when all commands are WHERE', () => {
+    it('preserves FROM as base when the only piped command is WHERE', () => {
       const query = 'FROM logs-* | WHERE x > 1';
       const result = splitQuery(query);
       expect(result.confidence).toBe('low');
       expect(result.reason).toBe('where_without_stats');
       expect(result.base).toBe('FROM logs-*');
       expect(result.alertBlock).toBe('| WHERE x > 1');
+    });
+
+    it('sweeps a trailing non-WHERE (LIMIT) into the alert block when it follows a WHERE', () => {
+      const query = 'FROM logs-* | WHERE x > 1 | LIMIT 10';
+      const result = splitQuery(query);
+      expect(result.confidence).toBe('low');
+      expect(result.reason).toBe('where_without_stats');
+      expect(result.base).toBe('FROM logs-*');
+      expect(result.alertBlock).toBe('| WHERE x > 1 | LIMIT 10');
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_heuristic_split.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_heuristic_split.ts
@@ -17,23 +17,31 @@ export interface SplitResult {
    * Machine-readable reason for the confidence level, useful for downstream
    * branching without string-matching the human-readable messages.
    *
-   * - 'no_stats'        — no STATS segment found; cannot identify a base query
-   * - 'no_where'        — STATS found but no WHERE after it; alert block is absent
-   * - 'split_succeeded' — both STATS and a post-STATS WHERE were found
+   * - 'no_stats'           — no STATS and no WHERE; entire query is base
+   * - 'no_where'           — STATS found but no WHERE after it; alert block is absent
+   * - 'split_succeeded'    — both STATS and a post-STATS WHERE were found
+   * - 'where_without_stats' — no STATS but a WHERE exists; split at the last WHERE
    */
-  reason: 'no_stats' | 'no_where' | 'split_succeeded';
+  reason: 'no_stats' | 'no_where' | 'split_succeeded' | 'where_without_stats';
 }
 
 /**
  * Splits an ES|QL query into a base portion and an alert-condition block
  * using the ANTLR-based AST parser from `@elastic/esql`.
  *
- * Strategy: find the last STATS command and the first WHERE after it.
- * Everything up to and including STATS is the base query. Everything from
- * that WHERE onward is the alert block (including its leading pipe).
+ * Heuristic (three rules, evaluated in order):
  *
- * Because splitting is performed against the real AST, pipes inside string
- * literals, comments, or other lexical contexts are handled correctly.
+ * 1. If there is at least one WHERE after a STATS, split directly before
+ *    the first WHERE after the last STATS.
+ * 2. If there is at least one WHERE but no STATS, split directly after
+ *    the last non-WHERE command that precedes the last WHERE. Consecutive
+ *    trailing WHEREs all become part of the alert block.
+ * 3. Otherwise (no WHERE, or only WHEREs before a STATS), we cannot
+ *    determine the split — the entire query is the base, alert block is
+ *    empty.
+ *
+ * Parsing uses the real AST, so pipes inside string literals, comments,
+ * or other lexical contexts are handled correctly.
  */
 export function splitQuery(query: string): SplitResult {
   if (!query.trim()) {
@@ -56,7 +64,46 @@ export function splitQuery(query: string): SplitResult {
   }
 
   if (lastStatsIdx === -1) {
-    return { base: '', alertBlock: query.trim(), confidence: 'none', reason: 'no_stats' };
+    // No STATS — find the last non-WHERE command that precedes the last WHERE.
+    // All commands from that point onward (a trailing chain of WHEREs, possibly
+    // interspersed with SORT/LIMIT/EVAL tail commands) become the alert block.
+    let lastWhereIdx = -1;
+    for (let j = commands.length - 1; j >= 0; j--) {
+      if (commands[j].name === 'where') {
+        lastWhereIdx = j;
+        break;
+      }
+    }
+
+    if (lastWhereIdx === -1) {
+      return { base: query.trim(), alertBlock: '', confidence: 'none', reason: 'no_stats' };
+    }
+
+    // Walk backwards from the last WHERE to find the last non-WHERE before it.
+    let splitAfterIdx = -1;
+    for (let j = lastWhereIdx - 1; j >= 0; j--) {
+      if (commands[j].name !== 'where') {
+        splitAfterIdx = j;
+        break;
+      }
+    }
+
+    // If every command up to the last WHERE is also a WHERE, there's no base.
+    if (splitAfterIdx === -1) {
+      return { base: '', alertBlock: query.trim(), confidence: 'none', reason: 'no_stats' };
+    }
+
+    // Split directly after the last non-WHERE command preceding the trailing WHERE chain.
+    const firstAlertCmd = commands[splitAfterIdx + 1];
+    const splitPos = query.lastIndexOf('|', firstAlertCmd.location.min);
+    const cutAt = splitPos >= 0 ? splitPos : firstAlertCmd.location.min;
+
+    return {
+      base: query.slice(0, cutAt).trim(),
+      alertBlock: query.slice(cutAt).trim(),
+      confidence: 'low',
+      reason: 'where_without_stats',
+    };
   }
 
   let firstWhereAfterStats = -1;


### PR DESCRIPTION
## Summary

Fixes the `splitQuery` heuristic so that ES|QL queries without a `STATS` command are handled correctly when enabling tracking in the Compose Discover flyout.

**Bug:** When a user enables tracking on a query like `FROM logs-* | WHERE status > 400`, the entire query was placed in the alert condition block with an empty base — making it impossible to define a meaningful recovery condition.

### The fix

Refines the three-rule heuristic in `splitQuery`:

1. **Has `STATS`**: split before the first `WHERE` after the last `STATS` (unchanged)
2. **No `STATS` but has `WHERE`**: split after the last non-`WHERE` command that precedes the trailing chain of `WHERE` clauses. The base gets everything up to that point; consecutive trailing `WHERE`s become the alert block.
3. **No `STATS`, no trailing `WHERE`**: entire query becomes the base, alert block is empty

### Examples

| Query | Base | Alert block | Rule |
|---|---|---|---|
| `FROM logs \| STATS count() BY host \| WHERE count > 5` | `FROM logs \| STATS count() BY host` | `WHERE count > 5` | 1 |
| `FROM logs \| WHERE status > 400` | `FROM logs` | `WHERE status > 400` | 2 |
| `FROM logs \| WHERE env = "prod" \| WHERE status > 400` | `FROM logs` | `WHERE env = "prod" \| WHERE status > 400` | 2 |
| `FROM logs \| LIMIT 100` | `FROM logs \| LIMIT 100` | *(empty)* | 3 |

## Test plan

- [x] Unit tests updated for all three heuristic rules
- [ ] Manual: open Compose Discover, enter `FROM logs-* | WHERE status > 400`, enable tracking — base and alert block split correctly

Closes #269400