### PR TITLE
[ci] Validate agentic workflow locks on PRs

### DIFF
--- a/.github/workflows/validate-agentic-workflow-locks.yml
+++ b/.github/workflows/validate-agentic-workflow-locks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.md'
+      - '.github/workflows/*.lock.yml'
+      - '.github/aw/actions-lock.json'
 
 permissions:
   contents: read

--- a/.github/workflows/validate-agentic-workflow-locks.yml
+++ b/.github/workflows/validate-agentic-workflow-locks.yml
@@ -1,0 +1,71 @@
+name: Validate agentic workflow locks
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/*.md'
+
+permissions:
+  contents: read
+
+# GitHub Actions does not allow expressions in `uses:` refs, so the
+# github/gh-aw/actions/setup-cli ref below must be updated alongside this value.
+# It must also match the github/gh-aw-actions/setup entry in
+# .github/aw/actions-lock.json; the verify step below enforces that.
+env:
+  GH_AW_VERSION: v0.71.5
+
+concurrency:
+  group: validate-agentic-workflow-locks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-locks:
+    name: Validate agentic workflow locks
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify pinned gh-aw version matches actions-lock.json
+        run: |
+          set -euo pipefail
+          version=$(jq -er '
+            [.entries[] | select(.repo == "github/gh-aw-actions/setup") | .version]
+            | unique
+            | if length == 1 then .[0]
+              else error("expected exactly one github/gh-aw-actions/setup version in .github/aw/actions-lock.json")
+              end
+          ' .github/aw/actions-lock.json)
+          echo "Pinned gh-aw version: ${version}"
+          if [[ "${version}" != "${GH_AW_VERSION}" ]]; then
+            echo "::error::actions-lock.json pins gh-aw ${version} but this workflow installs github/gh-aw/actions/setup-cli@${GH_AW_VERSION}. Update both refs to match."
+            exit 1
+          fi
+
+      - name: Install gh-aw CLI
+        uses: github/gh-aw/actions/setup-cli@v0.71.5
+        with:
+          version: ${{ env.GH_AW_VERSION }}
+
+      - name: Compile and validate all agentic workflows
+        run: gh aw compile --purge --validate --no-check-update
+
+      - name: Verify generated outputs are up to date
+        run: |
+          set -euo pipefail
+          status=$(git status --porcelain -- '.github/workflows/*.lock.yml' '.github/aw/actions-lock.json')
+          if [[ -n "${status}" ]]; then
+            echo "::error::Compiled output is out of date. Run 'gh aw compile --purge --validate' with gh-aw ${GH_AW_VERSION} and commit the resulting lock changes."
+            echo "Files that differ:"
+            echo "${status}"
+            echo
+            echo "Tracked diff:"
+            git --no-pager diff -- '.github/workflows/*.lock.yml' '.github/aw/actions-lock.json'
+            exit 1
+          fi
+          echo "All compiled lock files are in sync with the source markdown."

--- a/.github/workflows/validate-agentic-workflow-locks.yml
+++ b/.github/workflows/validate-agentic-workflow-locks.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/*.md'
       - '.github/workflows/*.lock.yml'
       - '.github/aw/actions-lock.json'
+      - '.github/workflows/validate-agentic-workflow-locks.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/validate-agentic-workflow-locks.yml
+++ b/.github/workflows/validate-agentic-workflow-locks.yml
@@ -10,10 +10,9 @@ on:
 permissions:
   contents: read
 
-# GitHub Actions does not allow expressions in `uses:` refs, so the
-# github/gh-aw/actions/setup-cli ref below must be updated alongside this value.
-# It must also match the github/gh-aw-actions/setup entry in
-# .github/aw/actions-lock.json; the verify step below enforces that.
+# gh-aw CLI version installed by setup-cli below. Must match the
+# github/gh-aw-actions/setup entry in .github/aw/actions-lock.json;
+# the verify step below enforces that.
 env:
   GH_AW_VERSION: v0.71.5
 
@@ -45,12 +44,12 @@ jobs:
           ' .github/aw/actions-lock.json)
           echo "Pinned gh-aw version: ${version}"
           if [[ "${version}" != "${GH_AW_VERSION}" ]]; then
-            echo "::error::actions-lock.json pins gh-aw ${version} but this workflow installs github/gh-aw/actions/setup-cli@${GH_AW_VERSION}. Update both refs to match."
+            echo "::error::actions-lock.json pins gh-aw ${version} but this workflow installs gh-aw ${GH_AW_VERSION} (set via GH_AW_VERSION). Update one of them so they match."
             exit 1
           fi
 
       - name: Install gh-aw CLI
-        uses: github/gh-aw/actions/setup-cli@v0.71.5
+        uses: github/gh-aw/actions/setup-cli@489dbab88cc78e35506b5ccbf08a4037166824ac # v0.72.1
         with:
           version: ${{ env.GH_AW_VERSION }}
 


### PR DESCRIPTION
## Summary

Adds a GH workflow that validates there is not drift in Agentic Workflows between the `.md` file and the `.lock.yml` file so contributors can't merge a `.md` change without the matching recompiled lock files. This also validates that it was compiled with the proper `gh aw` version in `.github/aw/actions-lock.json`. The job only triggers when `.github/workflows/*.md` changes. The `--purge` flag covers the orphan-lock-file case when an agentic source is deleted and not the lock file.

### Testing
https://github.com/elastic/kibana/actions/runs/25899997761/job/76121136619?pr=269414

Verified locally with [`act`](https://github.com/nektos/act) using:

#### Successful run
```
All compiled lock files are in sync with the source markdown.
✅  Success - Main Verify generated outputs are up to date [331.930094ms]
```

#### Failure run
```
::error::Compiled output is out of date. Run 'gh aw compile --purge --validate' with gh-aw v0.71.5 and commit the resulting lock changes.
Files that differ:
 M .github/workflows/failed-test-investigator.lock.yml
diff --git a/.github/workflows/failed-test-investigator.lock.yml b/.github/workflows/failed-test-investigator.lock.yml
…
- timeout-minutes: 20
+ timeout-minutes: 21
…
- GH_AW_TIMEOUT_MINUTES: "20"
+ GH_AW_TIMEOUT_MINUTES: "21"
```
