### PR TITLE
ci: declare workflow-level `contents: read` on 6 workflows

### DIFF
--- a/.github/workflows/add-to-apm-project.yml
+++ b/.github/workflows/add-to-apm-project.yml
@@ -3,6 +3,10 @@ on:
   issues:
     types:
       - labeled
+
+permissions:
+  contents: read
+
 jobs:
   add_to_project:
     runs-on: ubuntu-latest

--- a/.github/workflows/alert-failed-test.yml
+++ b/.github/workflows/alert-failed-test.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   issue_alert:
     name: Alert on failed test

--- a/.github/workflows/launchdarkly-code-references.yml
+++ b/.github/workflows/launchdarkly-code-references.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read
+
 jobs:
   launchDarklyCodeReferences:
     name: LaunchDarkly Code References

--- a/.github/workflows/skip-failed-test.yml
+++ b/.github/workflows/skip-failed-test.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   issue_commented:
     name: Skip failed test on comment

--- a/.github/workflows/trigger-flaky.yml
+++ b/.github/workflows/trigger-flaky.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   trigger_flaky:
     name: Trigger flaky test runner on /flaky comment

--- a/.github/workflows/trigger-sync-ci.yml
+++ b/.github/workflows/trigger-sync-ci.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   issue_commented:
     name: sync ci checks on comment


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 6 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `evaluate-dependency-health.yml`, `on-merge.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.