### PR TITLE
[9.3] Fix `@elastic/eui/icon-accessibility-rules` lint violations across @elastic/search-kibana files (#269038)

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/components/github_link.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/github_link.tsx
@@ -20,7 +20,7 @@ export const GithubLink: React.FC<{
   return (
     <EuiFlexGroup alignItems="center" gutterSize="xs" justifyContent="flexEnd">
       <EuiFlexItem grow={false}>
-        <EuiIcon size="s" type={`${assetBasePath}/github.svg`} />
+        <EuiIcon size="s" type={`${assetBasePath}/github.svg`} aria-hidden={true} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiText size="s">

--- a/src/platform/packages/shared/kbn-search-connectors/components/sync_jobs/__snapshots__/documents_panel.test.tsx.snap
+++ b/src/platform/packages/shared/kbn-search-connectors/components/sync_jobs/__snapshots__/documents_panel.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`DocumentsPanel renders 1`] = `
             <React.Fragment>
               Upserted
               <EuiIcon
+                aria-hidden={true}
                 className="eui-alignTop"
                 color="subdued"
                 size="s"
@@ -63,6 +64,7 @@ exports[`DocumentsPanel renders 1`] = `
             <React.Fragment>
               Deleted
               <EuiIcon
+                aria-hidden={true}
                 className="eui-alignTop"
                 color="subdued"
                 size="s"
@@ -95,6 +97,7 @@ exports[`DocumentsPanel renders 1`] = `
             <React.Fragment>
               Volume
               <EuiIcon
+                aria-hidden={true}
                 className="eui-alignTop"
                 color="subdued"
                 size="s"

--- a/src/platform/packages/shared/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
+++ b/src/platform/packages/shared/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
@@ -41,7 +41,13 @@ export const SyncJobDocumentsPanel: React.FC<SyncJobDocumentsPanelProps> = (sync
             {i18n.translate('searchConnectors.index.syncJobs.documents.added', {
               defaultMessage: 'Upserted',
             })}
-            <EuiIcon size="s" type="question" color="subdued" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              type="question"
+              color="subdued"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </>
         </EuiToolTip>
       ),
@@ -62,7 +68,13 @@ export const SyncJobDocumentsPanel: React.FC<SyncJobDocumentsPanelProps> = (sync
             {i18n.translate('searchConnectors.index.syncJobs.documents.removed', {
               defaultMessage: 'Deleted',
             })}
-            <EuiIcon size="s" type="question" color="subdued" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              type="question"
+              color="subdued"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </>
         </EuiToolTip>
       ),
@@ -83,7 +95,13 @@ export const SyncJobDocumentsPanel: React.FC<SyncJobDocumentsPanelProps> = (sync
             {i18n.translate('searchConnectors.index.syncJobs.documents.volume', {
               defaultMessage: 'Volume',
             })}
-            <EuiIcon size="s" type="question" color="subdued" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              type="question"
+              color="subdued"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </>
         </EuiToolTip>
       ),

--- a/src/platform/packages/shared/kbn-search-connectors/components/sync_jobs/sync_jobs_table.tsx
+++ b/src/platform/packages/shared/kbn-search-connectors/components/sync_jobs/sync_jobs_table.tsx
@@ -67,7 +67,13 @@ export const SyncJobsTable: React.FC<SyncJobHistoryTableProps> = ({
             {i18n.translate('searchConnectors.syncJobs.lastSync.columnTitle', {
               defaultMessage: 'Last sync',
             })}
-            <EuiIcon size="s" type="question" color="subdued" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              type="question"
+              color="subdued"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </>
         </EuiToolTip>
       ),
@@ -94,7 +100,13 @@ export const SyncJobsTable: React.FC<SyncJobHistoryTableProps> = ({
             {i18n.translate('searchConnectors.syncJobs.syncDuration.columnTitle', {
               defaultMessage: 'Sync duration',
             })}
-            <EuiIcon size="s" type="question" color="subdued" className="eui-alignTop" />
+            <EuiIcon
+              size="s"
+              type="question"
+              color="subdued"
+              className="eui-alignTop"
+              aria-hidden={true}
+            />
           </>
         </EuiToolTip>
       ),
@@ -119,7 +131,13 @@ export const SyncJobsTable: React.FC<SyncJobHistoryTableProps> = ({
                   {i18n.translate('searchConnectors.searchIndices.addedDocs.columnTitle', {
                     defaultMessage: 'Docs upserted',
                   })}
-                  <EuiIcon size="s" type="question" color="subdued" className="eui-alignTop" />
+                  <EuiIcon
+                    size="s"
+                    type="question"
+                    color="subdued"
+                    className="eui-alignTop"
+                    aria-hidden={true}
+                  />
                 </>
               </EuiToolTip>
             ),
@@ -142,7 +160,13 @@ export const SyncJobsTable: React.FC<SyncJobHistoryTableProps> = ({
                   {i18n.translate('searchConnectors.searchIndices.deletedDocs.columnTitle', {
                     defaultMessage: 'Docs deleted',
                   })}
-                  <EuiIcon size="s" type="question" color="subdued" className="eui-alignTop" />
+                  <EuiIcon
+                    size="s"
+                    type="question"
+                    color="subdued"
+                    className="eui-alignTop"
+                    aria-hidden={true}
+                  />
                 </>
               </EuiToolTip>
             ),

--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/editable_result.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/editable_result.tsx
@@ -120,7 +120,16 @@ export const EditableResult: React.FC<EditableResultProps> = ({
               responsive={false}
             >
               <EuiFlexItem grow={false}>
-                {error && <EuiIcon type="warning" color="danger" />}
+                {error && (
+                  <EuiIcon
+                    type="warning"
+                    color="danger"
+                    aria-label={i18n.translate(
+                      'xpack.sharedKbnSearchIndexDocuments.editableResult.warningIconAriaLabel',
+                      { defaultMessage: 'Error' }
+                    )}
+                  />
+                )}
                 {!error &&
                   hasIndexSelector &&
                   (isLoading ? (
@@ -185,7 +194,7 @@ export const EditableResult: React.FC<EditableResultProps> = ({
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
               <EuiText color="danger" size="xs">
-                <EuiIcon type="warning" />
+                <EuiIcon type="warning" aria-hidden={true} />
                 &nbsp;
                 {error}
               </EuiText>

--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/rich_result_header.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/rich_result_header.tsx
@@ -229,7 +229,7 @@ const Score: React.FC<{ score: MetaDataProps['score'] }> = ({ score }) => {
         gutterSize="s"
       >
         <EuiFlexItem grow>
-          <EuiIcon type="visGauge" size="m" />
+          <EuiIcon type="visGauge" size="m" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow>
           <EuiPanel

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/generated_config_fields.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/generated_config_fields.tsx
@@ -137,7 +137,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
           <EuiFlexItem>
             <EuiFlexGroup responsive={false} gutterSize="xs">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="check" />
+                <EuiIcon type="check" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiText size="s">
@@ -201,7 +201,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
           <EuiFlexItem>
             <EuiFlexGroup responsive={false} gutterSize="xs">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="check" />
+                <EuiIcon type="check" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem>
                 {i18n.translate(
@@ -222,7 +222,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
               <EuiFlexItem>
                 <EuiFlexGroup responsive={false} gutterSize="xs">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="check" />
+                    <EuiIcon type="check" aria-hidden={true} />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     {i18n.translate(

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/run_from_source_step.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/run_from_source_step.tsx
@@ -105,7 +105,7 @@ export const RunFromSourceStep: React.FC<RunFromSourceStepProps> = ({
               })}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="popout" />
+              <EuiIcon type="popout" aria-hidden={true} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiButton>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/run_options_buttons.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/run_options_buttons.tsx
@@ -50,7 +50,7 @@ export const RunOptionsButtons: React.FC<RunOptionsButtonsProps> = ({
               label={
                 <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="logoDocker" size="l" />
+                    <EuiIcon type="logoDocker" size="l" aria-hidden={true} />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiText>
@@ -77,7 +77,7 @@ export const RunOptionsButtons: React.FC<RunOptionsButtonsProps> = ({
               label={
                 <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="logoGithub" size="l" />
+                    <EuiIcon type="logoGithub" size="l" aria-hidden={true} />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiText>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_configuration.tsx
@@ -88,7 +88,7 @@ export const ConnectorConfiguration: React.FC = () => {
           <EuiFlexGroup gutterSize="m" direction="row" alignItems="center">
             {iconPath && (
               <EuiFlexItem grow={false}>
-                <EuiIcon size="xl" type={iconPath} />
+                <EuiIcon size="xl" type={iconPath} aria-hidden={true} />
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_stats.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_stats.tsx
@@ -183,7 +183,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({
             >
               {connectorDefinition && connectorDefinition.iconPath && (
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type={connectorDefinition.iconPath} size="xl" />
+                  <EuiIcon type={connectorDefinition.iconPath} size="xl" aria-hidden={true} />
                 </EuiFlexItem>
               )}
               <EuiFlexItem>
@@ -307,7 +307,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({
               <EuiFlexItem>
                 <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="documents" />
+                    <EuiIcon type="documents" aria-hidden={true} />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiText size="s">

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/native_connector_configuration.tsx
@@ -84,7 +84,7 @@ export const NativeConnectorConfiguration: React.FC = () => {
           <EuiFlexGroup gutterSize="m" direction="row" alignItems="center">
             {iconPath && (
               <EuiFlexItem grow={false}>
-                <EuiIcon size="xl" type={iconPath} />
+                <EuiIcon size="xl" type={iconPath} aria-hidden={true} />
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connector_type.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connector_type.tsx
@@ -28,7 +28,7 @@ export const ConnectorType: React.FC<ConnectorTypeProps> = ({ serviceType }) => 
     <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
       {connector && connector.iconPath && (
         <EuiFlexItem grow={false}>
-          <EuiIcon type={connector.iconPath} size="m" />
+          <EuiIcon type={connector.iconPath} size="m" aria-hidden={true} />
         </EuiFlexItem>
       )}
       <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/choose_connector.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/choose_connector.tsx
@@ -134,7 +134,7 @@ export const ChooseConnector: React.FC<ChooseConnectorSelectableProps> = ({
       }
       return {
         _append,
-        _prepend: <EuiIcon size="l" type={connector.iconPath} />,
+        _prepend: <EuiIcon size="l" type={connector.iconPath} aria-hidden={true} />,
         'aria-label': connector.name + _ariaLabelAppend,
         key: key.toString(),
         label: connector.name,

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/connector_description_popover.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/connector_description_popover.tsx
@@ -29,7 +29,7 @@ const nativePopoverPanels = [
       'xpack.contentConnectors.connectorDescriptionPopover.connectorDescriptionBadge.native.chooseADataSourceLabel',
       { defaultMessage: 'Choose a data source you would like to sync' }
     ),
-    icons: [<EuiIcon size="l" type="documents" />],
+    icons: [<EuiIcon size="l" type="documents" aria-hidden={true} />],
     id: 'native-choose-source',
   },
   {
@@ -37,7 +37,10 @@ const nativePopoverPanels = [
       'xpack.contentConnectors.connectorDescriptionPopover.connectorDescriptionBadge.native.configureConnectorLabel',
       { defaultMessage: 'Configure your connector using our Kibana UI' }
     ),
-    icons: [<EuiIcon size="l" type="plugs" />, <EuiIcon size="l" type="logoElastic" />],
+    icons: [
+      <EuiIcon size="l" type="plugs" aria-hidden={true} />,
+      <EuiIcon size="l" type="logoElastic" aria-hidden={true} />,
+    ],
     id: 'native-configure-connector',
   },
 ];
@@ -48,7 +51,7 @@ const connectorClientPopoverPanels = [
       'xpack.contentConnectors.connectorDescriptionPopover.connectorDescriptionBadge.client.chooseADataSourceLabel',
       { defaultMessage: 'Choose a data source you would like to sync' }
     ),
-    icons: [<EuiIcon size="l" type="documents" />],
+    icons: [<EuiIcon size="l" type="documents" aria-hidden={true} />],
     id: 'client-choose-source',
   },
   {
@@ -60,9 +63,9 @@ const connectorClientPopoverPanels = [
       }
     ),
     icons: [
-      <EuiIcon size="l" type="plugs" />,
-      <EuiIcon size="l" type="sortRight" />,
-      <EuiIcon size="l" type="launch" />,
+      <EuiIcon size="l" type="plugs" aria-hidden={true} />,
+      <EuiIcon size="l" type="sortRight" aria-hidden={true} />,
+      <EuiIcon size="l" type="launch" aria-hidden={true} />,
     ],
     id: 'client-deploy',
   },
@@ -74,11 +77,11 @@ const connectorClientPopoverPanels = [
       }
     ),
     icons: [
-      <EuiIcon size="l" type="documents" />,
-      <EuiIcon size="l" type="sortRight" />,
-      <EuiIcon size="l" type="plugs" />,
-      <EuiIcon size="l" type="sortRight" />,
-      <EuiIcon size="l" type="logoElastic" />,
+      <EuiIcon size="l" type="documents" aria-hidden={true} />,
+      <EuiIcon size="l" type="sortRight" aria-hidden={true} />,
+      <EuiIcon size="l" type="plugs" aria-hidden={true} />,
+      <EuiIcon size="l" type="sortRight" aria-hidden={true} />,
+      <EuiIcon size="l" type="logoElastic" aria-hidden={true} />,
     ],
     id: 'client-configure-connector',
   },

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/create_connector.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/create_connector.tsx
@@ -292,6 +292,7 @@ const CreateConnector: React.FC = () => {
                             <EuiIcon
                               size="l"
                               type={selectedConnector?.iconPath ?? ''}
+                              aria-hidden={true}
                               css={css`
                                 margin-right: ${euiTheme.size.m};
                               `}

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/finish_up_step.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/finish_up_step.tsx
@@ -106,7 +106,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
               <EuiFlexGroup gutterSize="m">
                 <EuiFlexItem>
                   <EuiCard
-                    icon={<EuiIcon size="xxl" type="discoverApp" />}
+                    icon={<EuiIcon size="xxl" type="discoverApp" aria-hidden={true} />}
                     titleSize="s"
                     title={i18n.translate(
                       'xpack.contentConnectors.createConnector.finishUpStep.euiCard.exploreYourDataLabel',
@@ -166,7 +166,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiCard
-                    icon={<EuiIcon size="xxl" type={connectorLogo} />}
+                    icon={<EuiIcon size="xxl" type={connectorLogo} aria-hidden={true} />}
                     titleSize="s"
                     title={i18n.translate(
                       'xpack.contentConnectors.createConnector.finishUpStep.euiCard.manageYourConnectorLabel',
@@ -235,6 +235,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                       `}
                       size="m"
                       type="console"
+                      aria-hidden={true}
                     />
                   }
                   title={i18n.translate(

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx
@@ -61,7 +61,7 @@ export const ElasticManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         gutterSize="s"
                       >
                         <EuiFlexItem grow={false}>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden={true} />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
@@ -89,10 +89,10 @@ export const ElasticManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         justifyContent="center"
                       >
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="web" />
+                          <EuiIcon color="primary" size="l" type="web" aria-hidden={true} />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="logoElastic" />
+                          <EuiIcon color="primary" size="l" type="logoElastic" aria-hidden={true} />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/self_managed_web_crawler_empty_prompt.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/self_managed_web_crawler_empty_prompt.tsx
@@ -54,13 +54,13 @@ export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
                       justifyContent="center"
                     >
                       <EuiFlexItem grow={false}>
-                        <EuiIcon color="primary" size="l" type="web" />
+                        <EuiIcon color="primary" size="l" type="web" aria-hidden={true} />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon size="m" type="sortRight" />
+                        <EuiIcon size="m" type="sortRight" aria-hidden={true} />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon color="primary" size="l" type="launch" />
+                        <EuiIcon color="primary" size="l" type="launch" aria-hidden={true} />
                       </EuiFlexItem>
                     </EuiFlexGroup>
                     <EuiFlexItem>
@@ -113,7 +113,7 @@ export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         gutterSize="s"
                       >
                         <EuiFlexItem grow={false}>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden={true} />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
@@ -142,19 +142,24 @@ export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         justifyContent="center"
                       >
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden={true} />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon size="m" type="sortRight" />
+                          <EuiIcon size="m" type="sortRight" aria-hidden={true} />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="web" />
+                          <EuiIcon color="primary" size="l" type="web" aria-hidden={true} />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon size="m" type="sortRight" />
+                          <EuiIcon size="m" type="sortRight" aria-hidden={true} />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="logoElasticsearch" />
+                          <EuiIcon
+                            color="primary"
+                            size="l"
+                            type="logoElasticsearch"
+                            aria-hidden={true}
+                          />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_empty_prompt/search_empty_prompt.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_empty_prompt/search_empty_prompt.tsx
@@ -58,7 +58,7 @@ export const SearchEmptyPrompt: React.FC<SearchEmptyPromptProps> = ({
         )}
         {icon && (
           <EuiFlexItem>
-            <EuiIcon size="xxl" type={icon} />
+            <EuiIcon size="xxl" type={icon} aria-hidden={true} />
           </EuiFlexItem>
         )}
         <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/access_control_index_selector/access_control_index_selector.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/access_control_index_selector/access_control_index_selector.tsx
@@ -92,7 +92,7 @@ export const AccessControlIndexSelector: React.FC<IndexSelectorProps> = ({
             <EuiFlexGroup direction="row" alignItems="center" gutterSize="m">
               {option.error ? (
                 <EuiFlexItem grow={false} align>
-                  <EuiIcon type={'warning'} />{' '}
+                  <EuiIcon type={'warning'} aria-hidden={true} />{' '}
                 </EuiFlexItem>
               ) : null}
               <EuiFlexGroup direction="column" gutterSize="none">

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/header_actions/syncs_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/header_actions/syncs_context_menu.tsx
@@ -157,7 +157,7 @@ export const SyncsContextMenu: React.FC<SyncsContextMenuProps> = ({ disabled = f
           'data-telemetry-id': `entSearchContent-connector-header-sync-cancelSync`,
           disabled:
             (isCanceling && ingestionStatus !== IngestionStatus.ERROR) || status === Status.LOADING,
-          icon: <EuiIcon type="cross" size="m" color="danger" />,
+          icon: <EuiIcon type="cross" size="m" color="danger" aria-hidden={true} />,
           name: (
             <EuiText color="danger" size="s">
               <p>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_row.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/tables/reorderable_table/draggable_body_row.tsx
@@ -64,7 +64,7 @@ export const DraggableBodyRow = <Item extends object>({
                       { defaultMessage: 'Drag handle' }
                     )}
                   >
-                    <EuiIcon type="grab" />
+                    <EuiIcon type="grab" aria-hidden={true} />
                   </div>
                 )}
               </EuiFlexItem>

--- a/x-pack/solutions/search/packages/shared-ui/src/search_empty_prompt/search_empty_prompt.tsx
+++ b/x-pack/solutions/search/packages/shared-ui/src/search_empty_prompt/search_empty_prompt.tsx
@@ -58,7 +58,7 @@ export const SearchEmptyPrompt: React.FC<SearchEmptyPromptProps> = ({
         )}
         {icon && (
           <EuiFlexItem>
-            <EuiIcon size="xxl" type={icon} />
+            <EuiIcon aria-hidden={true} size="xxl" type={icon} />
           </EuiFlexItem>
         )}
         <EuiFlexItem>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_overview/analytics_collection_metric.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_overview/analytics_collection_metric.tsx
@@ -122,7 +122,7 @@ export const AnalyticsCollectionViewMetric: React.FC<
                 })
               ) : (
                 <>
-                  <EuiIcon type={icon} />
+                  <EuiIcon aria-hidden type={icon} />
                   {displaySecondaryMetric + '%'}
                 </>
               )}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_overview/analytics_collection_card/analytics_collection_card.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_overview/analytics_collection_card/analytics_collection_card.tsx
@@ -158,7 +158,7 @@ export const AnalyticsCollectionCard: React.FC<
                 })
               ) : (
                 <>
-                  <EuiIcon type={CARD_THEME.icon} />
+                  <EuiIcon aria-hidden type={CARD_THEME.icon} />
                   {secondaryMetric}%
                 </>
               )}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/connect/search_application_documentation.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/connect/search_application_documentation.tsx
@@ -162,7 +162,7 @@ export const SearchApplicationDocumentation = () => {
             <EuiPanel grow paddingSize="l">
               <EuiFlexGroup direction="row">
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type="securitySignal" size="l" aria-hidden={true} />
+                  <EuiIcon type="securitySignal" size="l" aria-hidden />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiTitle size="s">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/connect/search_application_documentation.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/connect/search_application_documentation.tsx
@@ -68,7 +68,7 @@ export const SearchApplicationDocumentation = () => {
             <EuiPanel grow paddingSize="l">
               <EuiFlexGroup direction="row">
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type="lock" size="l" />
+                  <EuiIcon aria-hidden type="lock" size="l" />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiTitle size="s">
@@ -115,7 +115,7 @@ export const SearchApplicationDocumentation = () => {
             <EuiPanel grow paddingSize="l">
               <EuiFlexGroup direction="row">
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type="keyboard" size="l" />
+                  <EuiIcon aria-hidden type="keyboard" size="l" />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiTitle size="s">
@@ -162,7 +162,7 @@ export const SearchApplicationDocumentation = () => {
             <EuiPanel grow paddingSize="l">
               <EuiFlexGroup direction="row">
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type="securitySignal" size="l" />
+                  <EuiIcon type="securitySignal" size="l" aria-hidden={true} />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiTitle size="s">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/docs_explorer.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/docs_explorer.tsx
@@ -153,7 +153,7 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
             {hasSchemaConflicts && (
               <>
                 <EuiFlexItem>
-                  <EuiIcon type="alert" color="danger" />
+                  <EuiIcon type="alert" color="danger" aria-hidden={true} />
                 </EuiFlexItem>
                 {!isTourClosed && <EuiSpacer size="xs" />}
               </>
@@ -249,7 +249,13 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
           </EuiContextMenuItem>
           <EuiContextMenuItem
             key="Schema"
-            icon={hasSchemaConflicts ? <EuiIcon type="warning" color="danger" /> : 'kqlField'}
+            icon={
+              hasSchemaConflicts ? (
+                <EuiIcon type="warning" color="danger" aria-hidden={true} />
+              ) : (
+                'kqlField'
+              )
+            }
             onClick={() =>
               navigateToUrl(
                 generateEncodedPath(SEARCH_APPLICATION_CONTENT_PATH, {
@@ -323,7 +329,7 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
           <EuiHorizontalRule margin="none" />
           <EuiContextMenuItem
             key="delete"
-            icon={<EuiIcon type="trash" color="danger" />}
+            icon={<EuiIcon aria-hidden type="trash" color="danger" />}
             onClick={() => {
               if (searchApplicationData) {
                 openDeleteSearchApplicationModal();

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/docs_explorer.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/docs_explorer.tsx
@@ -153,7 +153,7 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
             {hasSchemaConflicts && (
               <>
                 <EuiFlexItem>
-                  <EuiIcon type="alert" color="danger" aria-hidden={true} />
+                  <EuiIcon type="alert" color="danger" aria-hidden />
                 </EuiFlexItem>
                 {!isTourClosed && <EuiSpacer size="xs" />}
               </>
@@ -251,7 +251,7 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
             key="Schema"
             icon={
               hasSchemaConflicts ? (
-                <EuiIcon type="warning" color="danger" aria-hidden={true} />
+                <EuiIcon type="warning" color="danger" aria-hidden />
               ) : (
                 'kqlField'
               )

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/search_ui_components.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/search_ui_components.tsx
@@ -139,7 +139,7 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
           />
           {hiddenFields > 0 && (
             <EuiFlexGroup gutterSize="s" alignItems="center">
-              <EuiIcon type="arrowRight" color="subdued" />
+              <EuiIcon type="arrowRight" color="subdued" aria-hidden={true} />
               <EuiTextColor color="subdued">
                 <code>
                   <FormattedMessage

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/search_ui_components.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/search_ui_components.tsx
@@ -139,7 +139,7 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
           />
           {hiddenFields > 0 && (
             <EuiFlexGroup gutterSize="s" alignItems="center">
-              <EuiIcon type="arrowRight" color="subdued" aria-hidden={true} />
+              <EuiIcon type="arrowRight" color="subdued" aria-hidden />
               <EuiTextColor color="subdued">
                 <code>
                   <FormattedMessage

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_content.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_content.tsx
@@ -99,7 +99,7 @@ export const SearchApplicationContent = () => {
               ),
             text: (
               <>
-                <EuiIcon size="s" type="arrowLeft" /> {searchApplicationName}
+                <EuiIcon size="s" type="arrowLeft" aria-hidden={true} /> {searchApplicationName}
               </>
             ),
           },
@@ -132,7 +132,7 @@ export const SearchApplicationContent = () => {
             isSelected: contentTabId === SearchApplicationContentTabs.SCHEMA,
             label: (
               <EuiFlexGroup gutterSize="s" alignItems="center">
-                {hasSchemaConflicts && <EuiIcon type="warning" color="danger" />}
+                {hasSchemaConflicts && <EuiIcon aria-hidden type="warning" color="danger" />}
                 {SCHEMA_TAB_TITLE}
               </EuiFlexGroup>
             ),

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_content.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_content.tsx
@@ -99,7 +99,7 @@ export const SearchApplicationContent = () => {
               ),
             text: (
               <>
-                <EuiIcon size="s" type="arrowLeft" aria-hidden={true} /> {searchApplicationName}
+                <EuiIcon size="s" type="arrowLeft" aria-hidden /> {searchApplicationName}
               </>
             ),
           },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_schema.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_schema.tsx
@@ -225,7 +225,16 @@ export const SearchApplicationSchema: React.FC = () => {
     {
       render: ({ type }: SchemaField) => {
         if (type !== 'conflict') return null;
-        return <EuiIcon type="error" color="danger" />;
+        return (
+          <EuiIcon
+            type="error"
+            color="danger"
+            aria-label={i18n.translate(
+              'xpack.enterpriseSearch.searchApplications.searchApplication.schema.conflictIndicator',
+              { defaultMessage: 'Field type conflict' }
+            )}
+          />
+        );
       },
       width: '24px',
     },
@@ -238,7 +247,7 @@ export const SearchApplicationSchema: React.FC = () => {
       ),
       render: ({ name, type }: SchemaField) => (
         <EuiFlexGroup gutterSize="s" alignItems="center">
-          {name.includes('.') && <EuiIcon type="sortRight" color="subdued" />}
+          {name.includes('.') && <EuiIcon aria-hidden type="sortRight" color="subdued" />}
           <EuiText size="s" color={type === 'conflict' ? 'danger' : 'primary'}>
             <p>{name}</p>
           </EuiText>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/search_application_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/search_application_indices_flyout.tsx
@@ -75,7 +75,7 @@ export const SearchApplicationIndicesFlyout: React.FC = () => {
       ),
       render: (health: 'red' | 'green' | 'yellow' | 'unavailable') => (
         <span>
-          <EuiIcon type="dot" color={healthColorsMap[health] ?? ''} />
+          <EuiIcon aria-hidden type="dot" color={healthColorsMap[health] ?? ''} />
           &nbsp;{health ?? '-'}
         </span>
       ),

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/search_applications_list.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/search_applications_list.tsx
@@ -59,7 +59,7 @@ export const CreateSearchApplicationButton: React.FC<CreateSearchApplicationButt
       title={
         <EuiFlexGroup justifyContent="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="beaker" aria-hidden={true} />
+            <EuiIcon type="beaker" aria-hidden />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <FormattedMessage

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/search_applications_list.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_applications/search_applications_list.tsx
@@ -59,7 +59,7 @@ export const CreateSearchApplicationButton: React.FC<CreateSearchApplicationButt
       title={
         <EuiFlexGroup justifyContent="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="beaker" />
+            <EuiIcon type="beaker" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <FormattedMessage

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx
@@ -142,7 +142,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
           <EuiFlexItem>
             <EuiFlexGroup responsive={false} gutterSize="xs">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="check" />
+                <EuiIcon type="check" aria-hidden />
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiText size="s">
@@ -206,7 +206,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
           <EuiFlexItem>
             <EuiFlexGroup responsive={false} gutterSize="xs">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="check" />
+                <EuiIcon type="check" aria-hidden />
               </EuiFlexItem>
               <EuiFlexItem>
                 {i18n.translate(
@@ -227,7 +227,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
               <EuiFlexItem>
                 <EuiFlexGroup responsive={false} gutterSize="xs">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="check" />
+                    <EuiIcon type="check" aria-hidden />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     {i18n.translate(

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx
@@ -106,7 +106,7 @@ export const RunFromSourceStep: React.FC<RunFromSourceStepProps> = ({
               })}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="popout" aria-hidden={true} />
+              <EuiIcon type="popout" aria-hidden />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiButton>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx
@@ -106,7 +106,7 @@ export const RunFromSourceStep: React.FC<RunFromSourceStepProps> = ({
               })}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="popout" />
+              <EuiIcon type="popout" aria-hidden={true} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiButton>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_options_buttons.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_options_buttons.tsx
@@ -50,7 +50,7 @@ export const RunOptionsButtons: React.FC<RunOptionsButtonsProps> = ({
               label={
                 <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="logoDocker" size="l" />
+                    <EuiIcon type="logoDocker" size="l" aria-hidden />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiText>
@@ -77,7 +77,7 @@ export const RunOptionsButtons: React.FC<RunOptionsButtonsProps> = ({
               label={
                 <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="logoGithub" size="l" />
+                    <EuiIcon type="logoGithub" size="l" aria-hidden />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiText>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -93,7 +93,7 @@ export const ConnectorConfiguration: React.FC = () => {
           <EuiFlexGroup gutterSize="m" direction="row" alignItems="center">
             {iconPath && (
               <EuiFlexItem grow={false}>
-                <EuiIcon size="xl" type={iconPath} />
+                <EuiIcon size="xl" type={iconPath} aria-hidden />
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false}>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
@@ -199,7 +199,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({
             >
               {connectorDefinition && connectorDefinition.iconPath && (
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type={connectorDefinition.iconPath} size="xl" />
+                  <EuiIcon type={connectorDefinition.iconPath} size="xl" aria-hidden />
                 </EuiFlexItem>
               )}
               <EuiFlexItem>
@@ -326,7 +326,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({
               <EuiFlexItem>
                 <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
                   <EuiFlexItem grow={false}>
-                    <EuiIcon type="documents" />
+                    <EuiIcon type="documents" aria-hidden />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiText size="s">

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -81,7 +81,7 @@ export const NativeConnectorConfiguration: React.FC = () => {
           <EuiFlexGroup gutterSize="m" direction="row" alignItems="center">
             {iconPath && (
               <EuiFlexItem grow={false}>
-                <EuiIcon size="xl" type={iconPath} />
+                <EuiIcon size="xl" type={iconPath} aria-hidden />
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false}>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_type.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_type.tsx
@@ -34,7 +34,7 @@ export const ConnectorType: React.FC<ConnectorTypeProps> = ({ serviceType }) => 
     <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
       {connector && connector.iconPath && (
         <EuiFlexItem grow={false}>
-          <EuiIcon type={connector.iconPath} size="m" />
+          <EuiIcon type={connector.iconPath} size="m" aria-hidden />
         </EuiFlexItem>
       )}
       <EuiFlexItem>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/choose_connector.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/choose_connector.tsx
@@ -129,7 +129,7 @@ export const ChooseConnector: React.FC<ChooseConnectorSelectableProps> = ({
       }
       return {
         _append,
-        _prepend: <EuiIcon size="l" type={connector.iconPath} />,
+        _prepend: <EuiIcon size="l" type={connector.iconPath} aria-hidden />,
         'aria-label': connector.name + _ariaLabelAppend,
         key: key.toString(),
         label: connector.name,

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/create_connector.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/create_connector.tsx
@@ -259,6 +259,7 @@ export const CreateConnector: React.FC = () => {
                               css={css`
                                 margin-right: ${euiTheme.size.m};
                               `}
+                              aria-hidden
                             />
                             {selectedConnector?.name}
                           </>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/finish_up_step.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/finish_up_step.tsx
@@ -118,7 +118,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
               <EuiFlexGroup gutterSize="m">
                 <EuiFlexItem>
                   <EuiCard
-                    icon={<EuiIcon size="xxl" type="machineLearningApp" />}
+                    icon={<EuiIcon size="xxl" type="machineLearningApp" aria-hidden={true} />}
                     titleSize="s"
                     title={i18n.translate(
                       'xpack.enterpriseSearch.createConnector.finishUpStep.euiCard.chatWithYourDataLabel',
@@ -170,7 +170,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiCard
-                    icon={<EuiIcon size="xxl" type="discoverApp" />}
+                    icon={<EuiIcon size="xxl" type="discoverApp" aria-hidden={true} />}
                     titleSize="s"
                     title={i18n.translate(
                       'xpack.enterpriseSearch.createConnector.finishUpStep.euiCard.exploreYourDataLabel',
@@ -230,7 +230,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiCard
-                    icon={<EuiIcon size="xxl" type={connectorLogo} />}
+                    icon={<EuiIcon size="xxl" type={connectorLogo} aria-hidden />}
                     titleSize="s"
                     title={i18n.translate(
                       'xpack.enterpriseSearch.createConnector.finishUpStep.euiCard.manageYourConnectorLabel',
@@ -296,6 +296,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                       `}
                       size="m"
                       type="visVega"
+                      aria-hidden={true}
                     />
                   }
                   title={i18n.translate(
@@ -324,6 +325,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                       `}
                       size="m"
                       type="console"
+                      aria-hidden
                     />
                   }
                   title={i18n.translate(

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/finish_up_step.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/finish_up_step.tsx
@@ -118,7 +118,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
               <EuiFlexGroup gutterSize="m">
                 <EuiFlexItem>
                   <EuiCard
-                    icon={<EuiIcon size="xxl" type="machineLearningApp" aria-hidden={true} />}
+                    icon={<EuiIcon size="xxl" type="machineLearningApp" aria-hidden />}
                     titleSize="s"
                     title={i18n.translate(
                       'xpack.enterpriseSearch.createConnector.finishUpStep.euiCard.chatWithYourDataLabel',
@@ -170,7 +170,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiCard
-                    icon={<EuiIcon size="xxl" type="discoverApp" aria-hidden={true} />}
+                    icon={<EuiIcon size="xxl" type="discoverApp" aria-hidden />}
                     titleSize="s"
                     title={i18n.translate(
                       'xpack.enterpriseSearch.createConnector.finishUpStep.euiCard.exploreYourDataLabel',
@@ -296,7 +296,7 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                       `}
                       size="m"
                       type="visVega"
-                      aria-hidden={true}
+                      aria-hidden
                     />
                   }
                   title={i18n.translate(

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx
@@ -58,7 +58,7 @@ export const ElasticManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         gutterSize="s"
                       >
                         <EuiFlexItem grow={false}>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
@@ -86,10 +86,10 @@ export const ElasticManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         justifyContent="center"
                       >
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="web" />
+                          <EuiIcon color="primary" size="l" type="web" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="logoElastic" />
+                          <EuiIcon color="primary" size="l" type="logoElastic" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx
@@ -55,13 +55,13 @@ export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
                       justifyContent="center"
                     >
                       <EuiFlexItem grow={false}>
-                        <EuiIcon color="primary" size="l" type="web" />
+                        <EuiIcon color="primary" size="l" type="web" aria-hidden />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon size="m" type="sortRight" />
+                        <EuiIcon size="m" type="sortRight" aria-hidden />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon color="primary" size="l" type="launch" />
+                        <EuiIcon color="primary" size="l" type="launch" aria-hidden={true} />
                       </EuiFlexItem>
                     </EuiFlexGroup>
                     <EuiFlexItem>
@@ -114,7 +114,7 @@ export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         gutterSize="s"
                       >
                         <EuiFlexItem grow={false}>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>
@@ -143,19 +143,19 @@ export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         justifyContent="center"
                       >
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="globe" />
+                          <EuiIcon color="primary" size="l" type="globe" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon size="m" type="sortRight" />
+                          <EuiIcon size="m" type="sortRight" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="web" />
+                          <EuiIcon color="primary" size="l" type="web" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon size="m" type="sortRight" />
+                          <EuiIcon size="m" type="sortRight" aria-hidden />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiIcon color="primary" size="l" type="logoElasticsearch" />
+                          <EuiIcon color="primary" size="l" type="logoElasticsearch" aria-hidden />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx
@@ -61,7 +61,7 @@ export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
                         <EuiIcon size="m" type="sortRight" aria-hidden />
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiIcon color="primary" size="l" type="launch" aria-hidden={true} />
+                        <EuiIcon color="primary" size="l" type="launch" aria-hidden />
                       </EuiFlexItem>
                     </EuiFlexGroup>
                     <EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/pipeline_item.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/pipeline_item.tsx
@@ -19,6 +19,8 @@ import {
 import React, { useCallback } from 'react';
 import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 
+import { i18n } from '@kbn/i18n';
+
 import { useKibana } from '../../../../../../hooks/use_kibana';
 import type { InferenceUsageInfo } from '../../../../types';
 import { PIPELINE_URL } from '../../../../constants';
@@ -54,8 +56,15 @@ export const PipelineItem: React.FC<UsageProps> = ({ usageItem }) => {
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiLink data-test-subj="navigateToPipelinePage" onClick={navigateToPipeline}>
-              <EuiIcon size="s" type="popout" />
+            <EuiLink
+              data-test-subj="navigateToPipelinePage"
+              onClick={navigateToPipeline}
+              aria-label={i18n.translate(
+                'xpack.searchInferenceEndpoints.pipelineItem.openPipelineLink',
+                { defaultMessage: 'Open pipeline' }
+              )}
+            >
+              <EuiIcon size="s" type="popout" aria-hidden={true} />
             </EuiLink>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/render_message_with_icon.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/render_message_with_icon.tsx
@@ -22,7 +22,7 @@ export const RenderMessageWithIcon: React.FC<RenderMessageWithIconProps> = ({
 }) => (
   <EuiFlexGroup alignItems={'center'} gutterSize={'s'}>
     <EuiFlexItem grow={false}>
-      <EuiIcon size="s" type={icon} color={color} />
+      <EuiIcon size="s" type={icon} color={color} aria-hidden={true} />
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <EuiText size={'xs'} textAlign={'left'} color={labelColor ?? 'default'}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix `@elastic/eui/icon-accessibility-rules` lint violations across @elastic/search-kibana files (#269038)](https://github.com/elastic/kibana/pull/269038)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-14T19:39:11Z","message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across @elastic/search-kibana files (#269038)\n\nResolves 102 `@elastic/eui/icon-accessibility-rules` violations across\n46 files owned by `@elastic/search-kibana`.\n\n## Approach\n\nEach `EuiIcon` classified as decorative or meaningful per\n`.agents/skills/accessibility/SKILL.md`:\n\n- **Decorative** (icon accompanies visible text conveying the same\nmeaning) → `aria-hidden={true}`\n- **Meaningful** (standalone icon conveying information) → `aria-label`\nwith `i18n.translate()`\n\n```tsx\n// Decorative: text already communicates meaning\n<EuiIcon type=\"warning\" aria-hidden={true} />\n<span>{errorMessage}</span>\n\n// Meaningful: icon is the sole indicator\n<EuiIcon type=\"error\" color=\"danger\" aria-label={i18n.translate(\n  'xpack.enterpriseSearch.schema.conflictIndicator',\n  { defaultMessage: 'Field type conflict' }\n)} />\n```\n\n## Scope\n\n- `src/platform/packages/shared/kbn-search-api-panels`\n- `src/platform/packages/shared/kbn-search-connectors`\n- `x-pack/platform/packages/shared/kbn-search-index-documents`\n- `x-pack/platform/plugins/shared/content_connectors`\n- `x-pack/platform/plugins/shared/search_inference_endpoints`\n- `x-pack/solutions/search/packages/shared-ui`\n- `x-pack/solutions/search/plugins/enterprise_search`\n\n~97 icons were decorative (`aria-hidden`), ~5 were meaningful\n(`aria-label` + i18n).\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node scripts/eslint\n--no-error-on-unmatched-pattern --rule\n{&#34;@elastic/eui/icon-accessibility-rules&#34;: &#34;error&#34;}\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_options_buttons.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_type.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/choose_connector.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/create_connector.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/finish_up_step.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"697906cb39ead5bcdd01b74cbf9966962d65453c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","💝community","backport:version","a11y:agent-pr","v9.5.0","v9.3.5","v9.4.2"],"title":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across @elastic/search-kibana files","number":269038,"url":"https://github.com/elastic/kibana/pull/269038","mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across @elastic/search-kibana files (#269038)\n\nResolves 102 `@elastic/eui/icon-accessibility-rules` violations across\n46 files owned by `@elastic/search-kibana`.\n\n## Approach\n\nEach `EuiIcon` classified as decorative or meaningful per\n`.agents/skills/accessibility/SKILL.md`:\n\n- **Decorative** (icon accompanies visible text conveying the same\nmeaning) → `aria-hidden={true}`\n- **Meaningful** (standalone icon conveying information) → `aria-label`\nwith `i18n.translate()`\n\n```tsx\n// Decorative: text already communicates meaning\n<EuiIcon type=\"warning\" aria-hidden={true} />\n<span>{errorMessage}</span>\n\n// Meaningful: icon is the sole indicator\n<EuiIcon type=\"error\" color=\"danger\" aria-label={i18n.translate(\n  'xpack.enterpriseSearch.schema.conflictIndicator',\n  { defaultMessage: 'Field type conflict' }\n)} />\n```\n\n## Scope\n\n- `src/platform/packages/shared/kbn-search-api-panels`\n- `src/platform/packages/shared/kbn-search-connectors`\n- `x-pack/platform/packages/shared/kbn-search-index-documents`\n- `x-pack/platform/plugins/shared/content_connectors`\n- `x-pack/platform/plugins/shared/search_inference_endpoints`\n- `x-pack/solutions/search/packages/shared-ui`\n- `x-pack/solutions/search/plugins/enterprise_search`\n\n~97 icons were decorative (`aria-hidden`), ~5 were meaningful\n(`aria-label` + i18n).\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node scripts/eslint\n--no-error-on-unmatched-pattern --rule\n{&#34;@elastic/eui/icon-accessibility-rules&#34;: &#34;error&#34;}\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_options_buttons.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_type.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/choose_connector.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/create_connector.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/finish_up_step.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"697906cb39ead5bcdd01b74cbf9966962d65453c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269038","number":269038,"mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across @elastic/search-kibana files (#269038)\n\nResolves 102 `@elastic/eui/icon-accessibility-rules` violations across\n46 files owned by `@elastic/search-kibana`.\n\n## Approach\n\nEach `EuiIcon` classified as decorative or meaningful per\n`.agents/skills/accessibility/SKILL.md`:\n\n- **Decorative** (icon accompanies visible text conveying the same\nmeaning) → `aria-hidden={true}`\n- **Meaningful** (standalone icon conveying information) → `aria-label`\nwith `i18n.translate()`\n\n```tsx\n// Decorative: text already communicates meaning\n<EuiIcon type=\"warning\" aria-hidden={true} />\n<span>{errorMessage}</span>\n\n// Meaningful: icon is the sole indicator\n<EuiIcon type=\"error\" color=\"danger\" aria-label={i18n.translate(\n  'xpack.enterpriseSearch.schema.conflictIndicator',\n  { defaultMessage: 'Field type conflict' }\n)} />\n```\n\n## Scope\n\n- `src/platform/packages/shared/kbn-search-api-panels`\n- `src/platform/packages/shared/kbn-search-connectors`\n- `x-pack/platform/packages/shared/kbn-search-index-documents`\n- `x-pack/platform/plugins/shared/content_connectors`\n- `x-pack/platform/plugins/shared/search_inference_endpoints`\n- `x-pack/solutions/search/packages/shared-ui`\n- `x-pack/solutions/search/plugins/enterprise_search`\n\n~97 icons were decorative (`aria-hidden`), ~5 were meaningful\n(`aria-label` + i18n).\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node scripts/eslint\n--no-error-on-unmatched-pattern --rule\n{&#34;@elastic/eui/icon-accessibility-rules&#34;: &#34;error&#34;}\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/generated_config_fields.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_options_buttons.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_type.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/choose_connector.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/create_connector.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/finish_up_step.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx\nx-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"697906cb39ead5bcdd01b74cbf9966962d65453c"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/269374","number":269374,"state":"MERGED","mergeCommit":{"sha":"197dd64948e0e6370c8a752ab362d6331c528fdc","message":"[9.4] Fix `@elastic/eui/icon-accessibility-rules` lint violations across @elastic/search-kibana files (#269038) (#269374)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Fix `@elastic/eui/icon-accessibility-rules` lint violations across\n@elastic/search-kibana files\n(#269038)](https://github.com/elastic/kibana/pull/269038)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>"}}]}] BACKPORT-->