### PR TITLE
[9.4] Fix `@elastic/eui/icon-accessibility-rules` lint violations across data-discovery files (#269040)

### DIFF
--- a/src/platform/packages/shared/kbn-search-response-warnings/src/components/search_response_warnings/badge.tsx
+++ b/src/platform/packages/shared/kbn-search-response-warnings/src/components/search_response_warnings/badge.tsx
@@ -57,6 +57,7 @@ export const SearchResponseWarningsBadge = (props: Props) => {
         >
           <EuiIcon
             type="warning"
+            aria-hidden={true}
             css={css`
               margin-left: ${euiTheme.size.xxs};
             `}

--- a/src/platform/packages/shared/kbn-search-response-warnings/src/components/search_response_warnings/view_details_popover.tsx
+++ b/src/platform/packages/shared/kbn-search-response-warnings/src/components/search_response_warnings/view_details_popover.tsx
@@ -82,7 +82,7 @@ export const ViewDetailsPopover = (props: Props) => {
             data-test-subj="searchResponseWarningsViewDetails"
           >
             <>
-              {viewDetailsLabel} <EuiIcon type="chevronSingleRight" size="s" />
+              {viewDetailsLabel} <EuiIcon type="chevronSingleRight" size="s" aria-hidden={true} />
             </>
           </EuiLink>
         ) : (

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_item_button/field_item_button.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_item_button/field_item_button.tsx
@@ -27,7 +27,7 @@ import { FieldIcon, getFieldIconProps, getFieldSearchMatchingHighlight } from '@
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { type FieldListItem, type GetCustomFieldType } from '../../types';
 
-const DRAG_ICON = <EuiIcon type="drag" size="m" />;
+const DRAG_ICON = <EuiIcon type="drag" size="m" aria-hidden={true} />;
 
 /**
  * Props of FieldItemButton component

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/bytes/__snapshots__/bytes.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/bytes/__snapshots__/bytes.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`BytesFormatEditor should render normally 1`] = `
           />
            
           <EuiIcon
+            aria-hidden={true}
             type="link"
           />
         </EuiLink>

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/date/__snapshots__/date.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/date/__snapshots__/date.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`DateFormatEditor should render normally 1`] = `
           />
            
           <EuiIcon
+            aria-hidden={true}
             type="link"
           />
         </EuiLink>

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/date/date.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/date/date.tsx
@@ -60,7 +60,7 @@ export class DateFormatEditor extends DefaultFormatEditor<DateFormatEditorFormat
                   defaultMessage="Documentation"
                 />
                 &nbsp;
-                <EuiIcon type="link" />
+                <EuiIcon type="link" aria-hidden={true} />
               </EuiLink>
             </span>
           }

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/date_nanos/__snapshots__/date_nanos.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/date_nanos/__snapshots__/date_nanos.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`DateFormatEditor should render normally 1`] = `
           />
            
           <EuiIcon
+            aria-hidden={true}
             type="link"
           />
         </EuiLink>

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/date_nanos/date_nanos.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/date_nanos/date_nanos.tsx
@@ -59,7 +59,7 @@ export class DateNanosFormatEditor extends DefaultFormatEditor<DateNanosFormatEd
                   defaultMessage="Documentation"
                 />
                 &nbsp;
-                <EuiIcon type="link" />
+                <EuiIcon type="link" aria-hidden={true} />
               </EuiLink>
             </span>
           }

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/histogram/__snapshots__/histogram.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/histogram/__snapshots__/histogram.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`HistogramFormatEditor should render normally 1`] = `
           />
            
           <EuiIcon
+            aria-hidden={true}
             type="link"
           />
         </EuiLink>

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/histogram/histogram.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/histogram/histogram.tsx
@@ -84,7 +84,7 @@ export class HistogramFormatEditor extends DefaultFormatEditor<HistogramFormatEd
                   defaultMessage="Documentation"
                 />
                 &nbsp;
-                <EuiIcon type="link" />
+                <EuiIcon type="link" aria-hidden={true} />
               </EuiLink>
             </span>
           }

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/number/__snapshots__/number.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/number/__snapshots__/number.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`NumberFormatEditor should render normally 1`] = `
           />
            
           <EuiIcon
+            aria-hidden={true}
             type="link"
           />
         </EuiLink>

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/number/number.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/number/number.tsx
@@ -58,7 +58,7 @@ export class NumberFormatEditor extends DefaultFormatEditor<NumberFormatEditorPa
                   defaultMessage="Documentation"
                 />
                 &nbsp;
-                <EuiIcon type="link" />
+                <EuiIcon type="link" aria-hidden={true} />
               </EuiLink>
             </span>
           }

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/percent/__snapshots__/percent.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/percent/__snapshots__/percent.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`PercentFormatEditor should render normally 1`] = `
           />
            
           <EuiIcon
+            aria-hidden={true}
             type="link"
           />
         </EuiLink>

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
@@ -205,6 +205,7 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
                     type={
                       itemIdToExpandedRowMapValues[id] ? 'chevronSingleDown' : 'chevronSingleRight'
                     }
+                    aria-hidden={true}
                   />
                 </EuiFlexGroup>
               </EuiButtonEmpty>

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/index_header/index_header.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/index_header/index_header.tsx
@@ -77,7 +77,7 @@ export const IndexHeader: FC<PropsWithChildren<IndexHeaderProps>> = ({
           setIsOpen(false);
           deleteIndexPatternClick();
         }}
-        icon={<EuiIcon color="danger" type="trash" />}
+        icon={<EuiIcon color="danger" type="trash" aria-hidden={true} />}
         aria-label={removeAriaLabel}
         data-test-subj="deleteIndexPatternButton"
       >

--- a/src/platform/plugins/shared/data_view_management/public/components/empty_index_list_prompt/empty_index_list_prompt.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/empty_index_list_prompt/empty_index_list_prompt.tsx
@@ -89,7 +89,7 @@ export const EmptyIndexListPrompt = ({
               onClick={() => {
                 navigateToApp('integrations', { path: '/browse' });
               }}
-              icon={<EuiIcon size="xl" type="database" color="subdued" />}
+              icon={<EuiIcon size="xl" type="database" color="subdued" aria-hidden={true} />}
               title={
                 <FormattedMessage
                   id="indexPatternManagement.createDataView.emptyState.integrationCardTitle"
@@ -108,7 +108,7 @@ export const EmptyIndexListPrompt = ({
             <EuiCard
               onClick={() => navigateToApp('home', { path: '#/tutorial_directory/fileDataViz' })}
               css={styles.card}
-              icon={<EuiIcon size="xl" type="document" color="subdued" />}
+              icon={<EuiIcon size="xl" type="document" color="subdued" aria-hidden={true} />}
               title={
                 <FormattedMessage
                   id="indexPatternManagement.createDataView.emptyState.uploadCardTitle"
@@ -129,7 +129,7 @@ export const EmptyIndexListPrompt = ({
               onClick={() => {
                 navigateToApp('home', { path: '#/tutorial_directory/sampleData' });
               }}
-              icon={<EuiIcon size="xl" type="chartHeatmap" color="subdued" />}
+              icon={<EuiIcon size="xl" type="chartHeatmap" color="subdued" aria-hidden={true} />}
               title={
                 <FormattedMessage
                   id="indexPatternManagement.createDataView.emptyState.sampleDataCardTitle"
@@ -186,7 +186,7 @@ export const EmptyIndexListPrompt = ({
                           id="indexPatternManagement.createDataView.emptyState.checkDataButton"
                           defaultMessage="Check for new data"
                         />{' '}
-                        <EuiIcon type="refresh" size="s" />
+                        <EuiIcon type="refresh" size="s" aria-hidden={true} />
                       </EuiLink>
                     ),
                   },

--- a/src/platform/plugins/shared/data_view_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
@@ -540,6 +540,7 @@ exports[`FieldEditor should show conflict field warning 1`] = `
       helpText={
         <span>
           <eui-icon
+            aria-hidden={true}
             color="warning"
             size="s"
             type="warning"
@@ -833,6 +834,7 @@ exports[`FieldEditor should show deprecated lang warning 1`] = `
       helpText={
         <span>
           <eui-icon
+            aria-hidden={true}
             color="warning"
             size="s"
             type="warning"
@@ -1167,6 +1169,7 @@ exports[`FieldEditor should show multiple type field warning with a table contai
       helpText={
         <span>
           <eui-icon
+            aria-hidden={true}
             color="warning"
             size="s"
             type="warning"

--- a/src/platform/plugins/shared/data_view_management/public/components/field_editor/components/scripting_help/scripting_syntax.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/field_editor/components/scripting_help/scripting_syntax.tsx
@@ -36,7 +36,7 @@ export const ScriptingSyntax = () => {
                     id="indexPatternManagement.syntax.defaultLabel.painlessLink"
                     defaultMessage="Painless"
                   />{' '}
-                  <EuiIcon type="link" />
+                  <EuiIcon type="link" aria-hidden={true} />
                 </EuiLink>
               ),
             }}
@@ -63,7 +63,7 @@ export const ScriptingSyntax = () => {
                     defaultMessage="native Java APIs"
                   />
                   &nbsp;
-                  <EuiIcon type="link" />
+                  <EuiIcon type="link" aria-hidden={true} />
                 </EuiLink>
               ),
               syntax: (
@@ -73,7 +73,7 @@ export const ScriptingSyntax = () => {
                     defaultMessage="syntax"
                   />
                   &nbsp;
-                  <EuiIcon type="link" />
+                  <EuiIcon type="link" aria-hidden={true} />
                 </EuiLink>
               ),
             }}
@@ -99,7 +99,7 @@ export const ScriptingSyntax = () => {
                     defaultMessage="Lucene Expressions"
                   />
                   &nbsp;
-                  <EuiIcon type="link" />
+                  <EuiIcon type="link" aria-hidden={true} />
                 </EuiLink>
               ),
             }}

--- a/src/platform/plugins/shared/data_view_management/public/components/field_editor/field_editor.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/field_editor/field_editor.tsx
@@ -284,7 +284,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
         helpText={
           this.isDuplicateName() ? (
             <span>
-              <EuiIcon type="warning" color="warning" size="s" />
+              <EuiIcon type="warning" color="warning" size="s" aria-hidden={true} />
               &nbsp;
               <FormattedMessage
                 id="indexPatternManagement.mappingConflictLabel.mappingConflictDetail"
@@ -346,7 +346,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
         helpText={
           isDeprecatedLang ? (
             <span>
-              <EuiIcon type="warning" color="warning" size="s" />
+              <EuiIcon type="warning" color="warning" size="s" aria-hidden={true} />
               &nbsp;
               <strong>
                 <FormattedMessage

--- a/src/platform/plugins/shared/discover/public/components/common/error_callout.tsx
+++ b/src/platform/plugins/shared/discover/public/components/common/error_callout.tsx
@@ -35,7 +35,7 @@ export const ErrorCallout = ({ title, error, isEsqlMode }: Props) => {
 
   return (
     <EuiEmptyPrompt
-      icon={<EuiIcon size="l" type="error" color="danger" />}
+      icon={<EuiIcon size="l" type="error" color="danger" aria-hidden={true} />}
       color="plain"
       paddingSize="m"
       css={css`

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_value.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_value.tsx
@@ -77,7 +77,7 @@ const IgnoreWarning: React.FC<IgnoreWarningProps> = React.memo(({ rawValue, reas
         `}
       >
         <EuiFlexItem grow={false}>
-          <EuiIcon type="warning" color="warning" />
+          <EuiIcon type="warning" color="warning" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiTextColor color="warning">


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix `@elastic/eui/icon-accessibility-rules` lint violations across data-discovery files (#269040)](https://github.com/elastic/kibana/pull/269040)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-13T10:58:41Z","message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across data-discovery files (#269040)\n\nAdds `aria-hidden={true}` to 21 decorative `EuiIcon` instances across 14\nfiles owned by `@elastic/kibana-data-discovery`. All icons are purely\ndecorative—adjacent text already conveys the same information to\nassistive technology.\n\n### Changes\n\n- **External link indicators** (`type=\"link\"`) inside `<EuiLink>` with\nvisible text — `date.tsx`, `date_nanos.tsx`, `histogram.tsx`,\n`number.tsx`, `scripting_syntax.tsx`\n- **Chevron/arrow icons** inside buttons/links with text labels —\n`view_details_popover.tsx`, `delete_data_view_flyout_content.tsx`\n- **Status icons** (warning, error) next to descriptive text —\n`badge.tsx`, `field_editor.tsx`, `error_callout.tsx`,\n`table_cell_value.tsx`\n- **Card/decorative icons** where card title provides meaning —\n`empty_index_list_prompt.tsx`, `index_header.tsx`\n- **Drag handle** (visual-only affordance) — `field_item_button.tsx`\n\n```tsx\n// Before\n<EuiIcon type=\"link\" />\n\n// After\n<EuiIcon type=\"link\" aria-hidden={true} />\n```\n\nCloses https://github.com/elastic/kibana/issues/269033\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"156f3047862bec5cd8855e035707397f691b1d6b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","a11y:agent-pr","v9.5.0","v9.3.5","v9.4.2"],"title":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across data-discovery files","number":269040,"url":"https://github.com/elastic/kibana/pull/269040","mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across data-discovery files (#269040)\n\nAdds `aria-hidden={true}` to 21 decorative `EuiIcon` instances across 14\nfiles owned by `@elastic/kibana-data-discovery`. All icons are purely\ndecorative—adjacent text already conveys the same information to\nassistive technology.\n\n### Changes\n\n- **External link indicators** (`type=\"link\"`) inside `<EuiLink>` with\nvisible text — `date.tsx`, `date_nanos.tsx`, `histogram.tsx`,\n`number.tsx`, `scripting_syntax.tsx`\n- **Chevron/arrow icons** inside buttons/links with text labels —\n`view_details_popover.tsx`, `delete_data_view_flyout_content.tsx`\n- **Status icons** (warning, error) next to descriptive text —\n`badge.tsx`, `field_editor.tsx`, `error_callout.tsx`,\n`table_cell_value.tsx`\n- **Card/decorative icons** where card title provides meaning —\n`empty_index_list_prompt.tsx`, `index_header.tsx`\n- **Drag handle** (visual-only affordance) — `field_item_button.tsx`\n\n```tsx\n// Before\n<EuiIcon type=\"link\" />\n\n// After\n<EuiIcon type=\"link\" aria-hidden={true} />\n```\n\nCloses https://github.com/elastic/kibana/issues/269033\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"156f3047862bec5cd8855e035707397f691b1d6b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269040","number":269040,"mergeCommit":{"message":"Fix `@elastic/eui/icon-accessibility-rules` lint violations across data-discovery files (#269040)\n\nAdds `aria-hidden={true}` to 21 decorative `EuiIcon` instances across 14\nfiles owned by `@elastic/kibana-data-discovery`. All icons are purely\ndecorative—adjacent text already conveys the same information to\nassistive technology.\n\n### Changes\n\n- **External link indicators** (`type=\"link\"`) inside `<EuiLink>` with\nvisible text — `date.tsx`, `date_nanos.tsx`, `histogram.tsx`,\n`number.tsx`, `scripting_syntax.tsx`\n- **Chevron/arrow icons** inside buttons/links with text labels —\n`view_details_popover.tsx`, `delete_data_view_flyout_content.tsx`\n- **Status icons** (warning, error) next to descriptive text —\n`badge.tsx`, `field_editor.tsx`, `error_callout.tsx`,\n`table_cell_value.tsx`\n- **Card/decorative icons** where card title provides meaning —\n`empty_index_list_prompt.tsx`, `index_header.tsx`\n- **Drag handle** (visual-only affordance) — `field_item_button.tsx`\n\n```tsx\n// Before\n<EuiIcon type=\"link\" />\n\n// After\n<EuiIcon type=\"link\" aria-hidden={true} />\n```\n\nCloses https://github.com/elastic/kibana/issues/269033\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"156f3047862bec5cd8855e035707397f691b1d6b"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/269098","number":269098,"state":"OPEN"},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/269091","number":269091,"state":"OPEN"}]}] BACKPORT-->