### PR TITLE
[Fleet] Use Failed label for failed integration status

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getStatusDisplay } from './manage_integrations_table';
+
+describe('getStatusDisplay', () => {
+  it('uses distinct labels for failed and cancelled integrations', () => {
+    expect(getStatusDisplay('failed')).toEqual(
+      expect.objectContaining({
+        color: 'danger',
+        iconType: 'cross',
+        label: 'Failed',
+      })
+    );
+    expect(getStatusDisplay('cancelled')).toEqual(
+      expect.objectContaining({
+        color: 'danger',
+        iconType: 'cross',
+        label: 'Cancelled',
+      })
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
@@ -74,7 +74,7 @@ const isIntegrationPackageReady = (item: CreatedIntegrationRow): boolean =>
   item.successfulDataStreamCount === item.totalDataStreamCount &&
   (item.status === 'completed' || item.status === 'approved');
 
-function getStatusDisplay(status: TaskStatus): {
+export function getStatusDisplay(status: TaskStatus): {
   color: 'success' | 'danger' | 'default' | 'hollow';
   iconType?: string;
   label: string;
@@ -85,8 +85,9 @@ function getStatusDisplay(status: TaskStatus): {
     case 'completed':
       return { color: 'success', iconType: 'check', label: 'Success' };
     case 'failed':
+      return { color: 'danger', iconType: 'cross', label: 'Failed' };
     case 'cancelled':
-      return { color: 'danger', iconType: 'cross', label: 'Fail' };
+      return { color: 'danger', iconType: 'cross', label: 'Cancelled' };
     case 'processing':
     case 'pending':
     default:


### PR DESCRIPTION
Closes #268852

## Summary
- Shows Failed for failed managed integrations, matching the Status filter label.
- Keeps cancelled integrations labelled Cancelled instead of sharing the failed label.
- Adds a focused regression test for failed and cancelled status display labels.

## Tests
- git diff --check

Not run locally because this fresh clone is not bootstrapped: targeted Jest, check_changes, and eslint all require node_modules/@kbn/setup-node-env.