### PR TITLE
[Security][Agent Builder] Alert analysis getRelatedAlerts workflow step (v4 — dual-register)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_alert_analysis_api/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_alert_analysis_api/stateful/classic.stateful.config.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as evalsTracingConfig } from '../../evals_tracing/stateful/classic.stateful.config';
+
+export const servers: ScoutServerConfig = {
+  ...evalsTracingConfig,
+  kbnTestServer: {
+    ...evalsTracingConfig.kbnTestServer,
+    serverArgs: [
+      ...evalsTracingConfig.kbnTestServer.serverArgs,
+      `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+        'alertAnalysisApiDrivenSkill',
+      ])}`,
+      '--uiSettings.overrides.agentBuilder:experimentalFeatures=true',
+    ],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_alert_analysis_inline_api_tool/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_alert_analysis_inline_api_tool/stateful/classic.stateful.config.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as evalsTracingConfig } from '../../evals_tracing/stateful/classic.stateful.config';
+
+export const servers: ScoutServerConfig = {
+  ...evalsTracingConfig,
+  kbnTestServer: {
+    ...evalsTracingConfig.kbnTestServer,
+    serverArgs: [
+      ...evalsTracingConfig.kbnTestServer.serverArgs,
+      `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+        'alertAnalysisInlineApiToolSkill',
+      ])}`,
+      '--uiSettings.overrides.agentBuilder:experimentalFeatures=true',
+    ],
+  },
+};

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/security_skills.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/security_skills.spec.ts
@@ -197,15 +197,12 @@ evaluate.describe(
                 },
                 output: {
                   expected:
-                    'I will call the related alerts internal API for alert test-alert-id-123 and summarize correlated entities from the last 24 hours.',
+                    'I will use the get-related-alerts tool for alert test-alert-id-123 and summarize correlated entities from the last 24 hours.',
                 },
                 metadata: {
                   query_intent: 'Alert Correlation',
                   expectedSkill: 'alert-analysis',
-                  expectedToolId: 'platform.workflows.workflow_execute_step',
-                  expectedWorkflowRequestPath:
-                    '/internal/security_solution/alert_analysis/related_alerts',
-                  expectedWorkflowStepType: 'kibana.request',
+                  expectedToolId: 'security.alert-analysis.get-related-alerts',
                 },
               },
             ],

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/security_skills.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/security/security_skills.spec.ts
@@ -190,6 +190,24 @@ evaluate.describe(
                   expectedOnlyToolId: 'security.entity_risk_score',
                 },
               },
+              {
+                input: {
+                  question:
+                    'Correlate related alerts for alert id "test-alert-id-123" over the last 24 hours and summarize shared entities I should investigate.',
+                },
+                output: {
+                  expected:
+                    'I will call the related alerts internal API for alert test-alert-id-123 and summarize correlated entities from the last 24 hours.',
+                },
+                metadata: {
+                  query_intent: 'Alert Correlation',
+                  expectedSkill: 'alert-analysis',
+                  expectedToolId: 'platform.workflows.workflow_execute_step',
+                  expectedWorkflowRequestPath:
+                    '/internal/security_solution/alert_analysis/related_alerts',
+                  expectedWorkflowStepType: 'kibana.request',
+                },
+              },
             ],
           },
         });

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/src/evaluate_dataset.ts
@@ -48,6 +48,50 @@ interface DatasetExample extends Example {
   };
 }
 
+const WORKFLOW_EXECUTE_STEP_TOOL_ID = 'platform.workflows.workflow_execute_step';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const matchesWorkflowRequestExpectation = ({
+  params,
+  expectedPath,
+  expectedStepType,
+}: {
+  params: unknown;
+  expectedPath: string;
+  expectedStepType: string;
+}): boolean => {
+  if (!isRecord(params)) return false;
+
+  const yaml = params.yaml;
+  if (typeof yaml === 'string') {
+    const hasPath = yaml.includes(expectedPath);
+    const hasStepType = yaml.includes(`type: ${expectedStepType}`);
+    if (hasPath && hasStepType) return true;
+  }
+
+  const step = params.step;
+  if (!isRecord(step)) return false;
+
+  const stepType = step.type;
+  const withArgs = step.with;
+  if (!isRecord(withArgs)) return false;
+
+  return stepType === expectedStepType && withArgs.path === expectedPath;
+};
+
+const extractWorkflowExecuteParams = (output: TaskOutput): unknown[] => {
+  const steps = (output as { steps?: unknown[] }).steps;
+  if (!Array.isArray(steps)) return [];
+
+  return steps
+    .filter((step): step is Record<string, unknown> => isRecord(step))
+    .filter((step) => step.type === 'tool_call' && step.tool_id === WORKFLOW_EXECUTE_STEP_TOOL_ID)
+    .map((step) => step.params)
+    .filter((params) => params != null);
+};
+
 export type EvaluateDataset = ({
   dataset: { name, description, examples },
 }: {
@@ -122,18 +166,89 @@ function configureExperiment({
 
   const selectedEvaluators = selectEvaluators([
     {
+      name: 'ExpectedWorkflowRequest',
+      kind: 'CODE' as const,
+      evaluate: async ({ output, metadata }) => {
+        const expectedPath = getStringMeta(metadata, 'expectedWorkflowRequestPath');
+        if (!expectedPath) return { score: 1 };
+
+        const expectedStepType =
+          getStringMeta(metadata, 'expectedWorkflowStepType') ?? 'kibana.request';
+        const workflowParams = extractWorkflowExecuteParams(output as TaskOutput);
+        if (workflowParams.length === 0) {
+          return {
+            score: 0,
+            metadata: {
+              reason: 'No workflow execute step calls found',
+              expectedPath,
+              expectedStepType,
+            },
+          };
+        }
+
+        const matched = workflowParams.some((params) =>
+          matchesWorkflowRequestExpectation({
+            params,
+            expectedPath,
+            expectedStepType,
+          })
+        );
+
+        return {
+          score: matched ? 1 : 0,
+          metadata: {
+            expectedPath,
+            expectedStepType,
+            workflowCallCount: workflowParams.length,
+          },
+        };
+      },
+    },
+    {
+      name: 'ExpectedToolCalled',
+      kind: 'CODE' as const,
+      evaluate: async ({ output, metadata }) => {
+        const expectedToolId = getStringMeta(metadata, 'expectedToolId');
+        if (!expectedToolId) return { score: 1 };
+
+        const toolCalls = getToolCallSteps(output as TaskOutput);
+        if (toolCalls.length === 0) {
+          return { score: 0, metadata: { reason: 'No tool calls found', expectedToolId } };
+        }
+
+        const usedToolIds = toolCalls.map((t) => t.tool_id).filter(Boolean);
+        const invoked = usedToolIds.includes(expectedToolId);
+
+        return {
+          score: invoked ? 1 : 0,
+          metadata: { expectedToolId, usedToolIds },
+        };
+      },
+    },
+    {
       name: 'ToolUsageOnly',
       kind: 'CODE' as const,
       evaluate: async ({ output, metadata }) => {
         const expectedOnlyToolId = getStringMeta(metadata, 'expectedOnlyToolId');
         if (!expectedOnlyToolId) return { score: 1 };
 
+        // Exclude infrastructure/framework tools that are always called regardless of user intent.
+        // filestore.read is the skill-file loader — it's not a domain tool choice.
+        const INFRA_TOOL_IDS = new Set(['filestore.read']);
+
         const toolCalls = getToolCallSteps(output as TaskOutput);
-        if (toolCalls.length === 0) {
-          return { score: 0, metadata: { reason: 'No tool calls found', expectedOnlyToolId } };
+        const domainToolCalls = toolCalls.filter(
+          (t) => t.tool_id && !INFRA_TOOL_IDS.has(t.tool_id)
+        );
+
+        if (domainToolCalls.length === 0) {
+          return {
+            score: 0,
+            metadata: { reason: 'No domain tool calls found', expectedOnlyToolId },
+          };
         }
 
-        const usedToolIds = toolCalls.map((t) => t.tool_id).filter(Boolean);
+        const usedToolIds = domainToolCalls.map((t) => t.tool_id).filter(Boolean);
         const hasExpected = usedToolIds.includes(expectedOnlyToolId);
         const allExpected = usedToolIds.every((id) => id === expectedOnlyToolId);
 
@@ -218,7 +333,7 @@ function configureExperiment({
         }
 
         const query = `FROM traces-*
-| WHERE trace.id == "${traceId}"
+| WHERE trace_id == "${traceId}"
 | STATS skill_invoked = COUNT(
     CASE(
       attributes.gen_ai.tool.name == "filestore.read"

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/index.ts
@@ -25,3 +25,4 @@ export const plugin: PluginInitializer<
 };
 
 export { config } from './config';
+export { WORKFLOW_EXECUTE_STEP_TOOL_ID } from './tools/workflow_execute_step_tool';

--- a/x-pack/solutions/security/plugins/security_solution/common/api/alert_analysis/related_alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/alert_analysis/related_alerts.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+
+export const ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH =
+  '/internal/security_solution/alert_analysis/related_alerts';
+
+export const relatedAlertsRequestSchema = z.object({
+  alertId: z.string().describe('The _id of the alert to correlate'),
+  timeWindowHours: z.number().min(1).max(168).default(24),
+  maxResults: z.number().min(1).max(100).default(25),
+  hostNames: z.array(z.string()).optional(),
+  userNames: z.array(z.string()).optional(),
+  sourceIps: z.array(z.string()).optional(),
+  destIps: z.array(z.string()).optional(),
+});
+
+export type RelatedAlertsRequest = z.infer<typeof relatedAlertsRequestSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -247,6 +247,12 @@ export const allowedExperimentalValues = Object.freeze({
   entityAnalyticsEntityStoreV2: false,
 
   /**
+   * Enables API-driven alert-analysis skill registration.
+   * When disabled, the legacy inline implementation is used.
+   */
+  alertAnalysisApiDrivenSkill: false,
+
+  /**
    * Enables the deprecated prebuilt rules UI
    * Release: 9.4
    */

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -253,6 +253,13 @@ export const allowedExperimentalValues = Object.freeze({
   alertAnalysisApiDrivenSkill: false,
 
   /**
+   * Enables the inline-api-tool alert-analysis skill: replaces workflow_execute_step / YAML
+   * with a focused inline tool that calls findRelatedAlerts directly, eliminating YAML
+   * authoring overhead. Takes precedence over alertAnalysisApiDrivenSkill when both are set.
+   */
+  alertAnalysisInlineApiToolSkill: false,
+
+  /**
    * Enables the deprecated prebuilt rules UI
    * Release: 9.4
    */

--- a/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/get_related_alerts_step/get_related_alerts_step_common.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/workflows/step_types/get_related_alerts_step/get_related_alerts_step_common.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { StepCategory } from '@kbn/workflows';
+import type { BaseStepDefinition } from '@kbn/workflows';
+import { i18n } from '@kbn/i18n';
+
+const DEFAULT_TIME_WINDOW_HOURS = 24;
+const DEFAULT_MAX_RESULTS = 25;
+
+export const getRelatedAlertsInputSchema = z.object({
+  alertId: z.string().describe('The _id of the alert to find related alerts for'),
+  alertIndex: z
+    .string()
+    .describe(
+      'The alerts index pattern to search (e.g. ".alerts-security.alerts-default"). In Agent Builder this is derived from the active space.'
+    ),
+  timeWindowHours: z.coerce
+    .number()
+    .finite()
+    .int()
+    .min(1)
+    .max(168)
+    .optional()
+    .default(DEFAULT_TIME_WINDOW_HOURS)
+    .describe('Time window in hours to search for related alerts (1-168, default 24)'),
+  maxResults: z.coerce
+    .number()
+    .finite()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(DEFAULT_MAX_RESULTS)
+    .describe('Maximum number of related alerts to return (1-100, default 25)'),
+  hostNames: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Optional: host.name values from the alert. If provided along with other entity arrays, skips refetching the alert.'
+    ),
+  userNames: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Optional: user.name values from the alert. If provided along with other entity arrays, skips refetching the alert.'
+    ),
+  sourceIps: z.array(z.string()).optional().describe('Optional: source.ip values from the alert.'),
+  destIps: z
+    .array(z.string())
+    .optional()
+    .describe('Optional: destination.ip values from the alert.'),
+});
+
+export const getRelatedAlertsOutputSchema = z.object({
+  message: z.string(),
+  sourceEntities: z.object({
+    hostNames: z.array(z.string()),
+    userNames: z.array(z.string()),
+    sourceIps: z.array(z.string()),
+    destIps: z.array(z.string()),
+  }),
+  relatedAlerts: z.array(z.record(z.string(), z.unknown())),
+  totalMatched: z.number(),
+  returnedCount: z.number(),
+  isTruncated: z.boolean(),
+});
+
+export const getRelatedAlertsStepCommonDefinition: BaseStepDefinition<
+  typeof getRelatedAlertsInputSchema,
+  typeof getRelatedAlertsOutputSchema
+> = {
+  id: 'security.alertAnalysis.getRelatedAlerts',
+  label: i18n.translate('xpack.securitySolution.workflows.steps.getRelatedAlerts.label', {
+    defaultMessage: 'Get Related Alerts',
+  }),
+  description: i18n.translate(
+    'xpack.securitySolution.workflows.steps.getRelatedAlerts.description',
+    {
+      defaultMessage:
+        'Find alerts that share entities (host.name, user.name, source.ip, destination.ip) with a given alert within a configurable time window. Returns matched alerts plus the source entities used for correlation. This is the workflow-step surface of the same `findRelatedAlerts` service exposed as an inline Agent Builder tool — a single TypeScript handler serves both consumers without duplication.',
+    }
+  ),
+  category: StepCategory.Kibana,
+  stability: 'tech_preview',
+  inputSchema: getRelatedAlertsInputSchema,
+  outputSchema: getRelatedAlertsOutputSchema,
+  documentation: {
+    details: i18n.translate(
+      'xpack.securitySolution.workflows.steps.getRelatedAlerts.documentation.details',
+      {
+        defaultMessage:
+          'Correlates a seed alert with other alerts in the same alerts index that share at least one entity value (host.name, user.name, source.ip, destination.ip) and fall within the configured time window. ' +
+          'If the caller has already extracted entity values, pass them via the hostNames/userNames/sourceIps/destIps arrays to skip the initial alert lookup. ' +
+          'The handler is backed by the shared `findRelatedAlerts` service, which is also exposed as an inline Agent Builder tool (security.alert-analysis.get-related-alerts). This is the dual-register pattern: same code, two surfaces — agents and workflows — without duplication.',
+      }
+    ),
+    examples: [
+      `## Find related alerts for a seed alert
+\`\`\`yaml
+- name: correlate_alert
+  type: security.alertAnalysis.getRelatedAlerts
+  with:
+    alertId: "{{ variables.alert_id }}"
+    alertIndex: "{{ variables.alert_index }}"
+    timeWindowHours: 24
+    maxResults: 25
+\`\`\``,
+      `## Skip the alert lookup when entities are already known
+\`\`\`yaml
+- name: correlate_alert
+  type: security.alertAnalysis.getRelatedAlerts
+  with:
+    alertId: "{{ variables.alert_id }}"
+    alertIndex: ".alerts-security.alerts-default"
+    timeWindowHours: 48
+    hostNames: ["WIN-SRV01"]
+    userNames: ["alice"]
+\`\`\``,
+    ],
+  },
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/get_related_alerts_step/get_related_alerts_step.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/get_related_alerts_step/get_related_alerts_step.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { PublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { getRelatedAlertsStepCommonDefinition } from '../../../../common/workflows/step_types/get_related_alerts_step/get_related_alerts_step_common';
+
+export const getRelatedAlertsStepDefinition: PublicStepDefinition = {
+  ...getRelatedAlertsStepCommonDefinition,
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/share')
+      .then(({ icon }) => ({ default: icon }))
+      .catch(() =>
+        import('@elastic/eui/es/components/icon/assets/search').then(({ icon }) => ({
+          default: icon,
+        }))
+      )
+  ),
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/get_related_alerts_step/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/get_related_alerts_step/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getRelatedAlertsStepDefinition } from './get_related_alerts_step';

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts
@@ -11,6 +11,7 @@ import { workflowsExtensionsMock } from '@kbn/workflows-extensions/public/mocks'
 import { registerWorkflowSteps } from './register_workflow_steps';
 import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
 import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
+import { getRelatedAlertsStepDefinition } from './get_related_alerts_step';
 import {
   REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
   REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
@@ -29,13 +30,13 @@ describe('registerWorkflowSteps (public)', () => {
     return { core, coreStart };
   };
 
-  it('calls registerStepDefinition synchronously for both steps', () => {
+  it('calls registerStepDefinition synchronously for all steps', () => {
     const { core } = buildCoreMock(true);
     const workflowsExtensions = createWorkflowsExtensionsMock();
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(2);
+    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(3);
     // getStartServices is called once eagerly to create the shared memoized promise
     expect(core.getStartServices).toHaveBeenCalledTimes(1);
   });
@@ -46,12 +47,13 @@ describe('registerWorkflowSteps (public)', () => {
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2, loader3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
 
     await expect(loader1()).resolves.toBe(renderAlertNarrativeStepDefinition);
     await expect(loader2()).resolves.toBe(buildAlertEntityGraphStepDefinition);
+    await expect(loader3()).resolves.toBe(getRelatedAlertsStepDefinition);
   });
 
   it('async loader returns undefined when feature flag is disabled', async () => {
@@ -60,24 +62,25 @@ describe('registerWorkflowSteps (public)', () => {
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2, loader3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
 
     await expect(loader1()).resolves.toBeUndefined();
     await expect(loader2()).resolves.toBeUndefined();
+    await expect(loader3()).resolves.toBeUndefined();
   });
 
-  it('checks the feature flag exactly once even when both loaders resolve', async () => {
+  it('checks the feature flag exactly once even when all loaders resolve', async () => {
     const { core, coreStart } = buildCoreMock(true);
     const workflowsExtensions = createWorkflowsExtensionsMock();
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2, loader3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
-    await Promise.all([loader1(), loader2()]);
+    await Promise.all([loader1(), loader2(), loader3()]);
 
     expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledTimes(1);
     expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledWith(

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
@@ -43,4 +43,11 @@ export const registerWorkflowSteps = (
       (m) => m.buildAlertEntityGraphStepDefinition
     );
   });
+
+  // v4: dual-register step — public definition only renders the icon + label in
+  // the workflows editor; the actual logic lives on the server step.
+  workflowsExtensions.registerStepDefinition(async () => {
+    if (!(await isEnabled)) return undefined;
+    return import('./get_related_alerts_step').then((m) => m.getRelatedAlertsStepDefinition);
+  });
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_api_driven.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_api_driven.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateSkillDefinition } from '@kbn/agent-builder-server/skills/type_definition';
+import { ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH } from '../../../../common/api/alert_analysis/related_alerts';
+import {
+  alertAnalysisApiDrivenSkill,
+  WORKFLOW_EXECUTE_STEP_TOOL_ID,
+} from './alert_analysis_skill_api_driven';
+
+describe('alertAnalysisApiDrivenSkill', () => {
+  it('has stable skill identity', () => {
+    expect(alertAnalysisApiDrivenSkill.id).toBe('alert-analysis');
+    expect(alertAnalysisApiDrivenSkill.name).toBe('alert-analysis');
+    expect(alertAnalysisApiDrivenSkill.basePath).toBe('skills/security/alerts');
+  });
+
+  it('validates successfully', async () => {
+    await expect(validateSkillDefinition(alertAnalysisApiDrivenSkill)).resolves.toBeDefined();
+  });
+
+  it('registers workflow execute step tool for kibana.request invocation', () => {
+    const tools = alertAnalysisApiDrivenSkill.getRegistryTools?.();
+    expect(tools).toBeDefined();
+    expect(tools).toContain(WORKFLOW_EXECUTE_STEP_TOOL_ID);
+  });
+
+  it('does not define inline tools', () => {
+    expect(alertAnalysisApiDrivenSkill.getInlineTools).toBeUndefined();
+  });
+
+  it('documents the related-alerts internal API path', () => {
+    expect(alertAnalysisApiDrivenSkill.content).toContain(
+      ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH
+    );
+  });
+
+  it('documents that Elasticsearch lookups are not proxied through kibana.request', () => {
+    expect(alertAnalysisApiDrivenSkill.content).toContain(
+      'Do **NOT** proxy standard Elasticsearch reads through `kibana.request`'
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_api_driven.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_api_driven.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { WORKFLOW_EXECUTE_STEP_TOOL_ID } from '@kbn/agent-builder-workflows-plugin/server';
+import {
+  SECURITY_ALERTS_TOOL_ID,
+  SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+  SECURITY_LABS_SEARCH_TOOL_ID,
+} from '../../tools';
+import { ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH } from '../../../../common/api/alert_analysis/related_alerts';
+
+export { WORKFLOW_EXECUTE_STEP_TOOL_ID };
+
+export const alertAnalysisApiDrivenSkill = defineSkillType({
+  id: 'alert-analysis',
+  name: 'alert-analysis',
+  basePath: 'skills/security/alerts',
+  description:
+    'API-driven alert triage and investigation: fetch alerts, correlate related alerts through internal APIs, ' +
+    'enrich with Security Labs intelligence, and assess entity risk to determine disposition.',
+  content: `# Alert Analysis Guide (API-Driven)
+
+## When to Use This Skill
+
+Use this skill when:
+- Triaging a specific security alert to determine disposition
+- Correlating related alerts across shared entities (host, user, source.ip, destination.ip)
+- Enriching alert context with Security Labs threat intelligence
+- Prioritizing investigation using entity risk signals
+
+## Required Step Selection Policy
+
+- Use \`kibana.request\` (via \`platform.workflows.workflow_execute_step\`) for internal Security Solution API calls.
+- Use Elasticsearch steps (\`elasticsearch.search\`, \`elasticsearch.esql.query\`, etc.) for Elasticsearch lookups.
+- Do **NOT** proxy standard Elasticsearch reads through \`kibana.request\`.
+
+## Recommended Investigation Flow
+
+1. Fetch alert context with \`security.alerts\`
+2. Correlate related alerts by calling internal API path \`${ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH}\` with \`kibana.request\`
+3. Query threat intelligence with \`security.security_labs_search\`
+4. Check host/user risk with \`security.entity_risk_score\`
+5. Synthesize disposition and next actions
+
+## Tool Selection Guardrails
+
+- For list/prioritization questions (for example: "high/critical alerts in last 24h"), use only \`security.alerts\` unless explicit correlation by \`alertId\` is requested.
+- For Security Labs intel questions (for example: "Lazarus Group techniques"), use only \`security.security_labs_search\`.
+- For risk score questions (for example: "risk score for host DC01"), use only \`security.entity_risk_score\`.
+- For correlation requests that include an \`alertId\`, call \`platform.workflows.workflow_execute_step\` with step type \`kibana.request\` and path \`${ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH}\`.
+- Do NOT use \`platform.core.search\` for related-alert correlation when an \`alertId\` is available.
+- Do NOT use workflow status/inspection tools as a substitute for executing the related-alert request.
+- If the workflow call fails or is blocked, report that clearly and include the returned error details.
+
+## Internal API Contract (Related Alerts)
+
+Call \`platform.workflows.workflow_execute_step\` with inline workflow YAML and a \`stepName\`:
+
+- **method**: \`POST\`
+- **path**: \`${ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH}\`
+- **body**:
+  - \`alertId\` (required)
+  - \`timeWindowHours\` (optional, default 24, max 168)
+  - \`hostNames\`, \`userNames\`, \`sourceIps\`, \`destIps\` (optional arrays; pass when already known)
+  - \`maxResults\` (optional, bounded server-side for token efficiency)
+
+When \`alertId\` is present, use this exact shape:
+\`\`\`
+tool_id: platform.workflows.workflow_execute_step
+params:
+  stepName: get_related_alerts
+  yaml: |
+    version: "1"
+    name: alert_analysis_related_alerts
+    triggers:
+      - type: manual
+    steps:
+      - name: get_related_alerts
+        type: kibana.request
+        with:
+          method: POST
+          path: ${ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH}
+          body:
+            alertId: "<alert-id>"
+            timeWindowHours: 24
+\`\`\`
+
+The API response is token-budgeted and may include truncation metadata.`,
+  getRegistryTools: () => [
+    SECURITY_ALERTS_TOOL_ID,
+    SECURITY_LABS_SEARCH_TOOL_ID,
+    SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+    WORKFLOW_EXECUTE_STEP_TOOL_ID,
+  ],
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_inline_api_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_inline_api_tool.test.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills/tools';
+import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
+import { validateSkillDefinition } from '@kbn/agent-builder-server/skills/type_definition';
+import { WORKFLOW_EXECUTE_STEP_TOOL_ID } from '@kbn/agent-builder-workflows-plugin/server';
+import { createToolHandlerContext, createToolTestMocks } from '../../__mocks__/test_helpers';
+import { alertAnalysisInlineApiToolSkill } from './alert_analysis_skill_inline_api_tool';
+import type { FindRelatedAlertsResult } from '../../../lib/alert_analysis/services/find_related_alerts';
+
+jest.mock('../../../lib/alert_analysis/services/find_related_alerts');
+
+const { findRelatedAlerts } = jest.requireMock(
+  '../../../lib/alert_analysis/services/find_related_alerts'
+) as { findRelatedAlerts: jest.MockedFunction<() => Promise<FindRelatedAlertsResult>> };
+
+interface ResultData {
+  message?: string;
+  relatedAlerts?: Array<Record<string, unknown>>;
+  sourceEntities?: {
+    hostNames: string[];
+    userNames: string[];
+    sourceIps: string[];
+    destIps: string[];
+  };
+  totalMatched?: number;
+  returnedCount?: number;
+  isTruncated?: boolean;
+}
+
+const getData = (result: ToolHandlerStandardReturn, idx = 0): ResultData =>
+  result.results[idx].data as unknown as ResultData;
+
+const makeSuccess = (overrides: Partial<FindRelatedAlertsResult> = {}): FindRelatedAlertsResult => ({
+  ok: true,
+  message: 'Found 0 related alerts sharing entities with alert test-alert-id.',
+  relatedAlerts: [],
+  sourceEntities: { hostNames: [], userNames: [], sourceIps: [], destIps: [] },
+  totalMatched: 0,
+  returnedCount: 0,
+  isTruncated: false,
+  ...overrides,
+});
+
+describe('alertAnalysisInlineApiToolSkill', () => {
+  describe('skill definition', () => {
+    it('has stable skill identity', () => {
+      expect(alertAnalysisInlineApiToolSkill.id).toBe('alert-analysis');
+      expect(alertAnalysisInlineApiToolSkill.name).toBe('alert-analysis');
+      expect(alertAnalysisInlineApiToolSkill.basePath).toBe('skills/security/alerts');
+    });
+
+    it('validates successfully', async () => {
+      await expect(validateSkillDefinition(alertAnalysisInlineApiToolSkill)).resolves.toBeDefined();
+    });
+
+    it('returns 3 registry tool IDs', () => {
+      const tools = alertAnalysisInlineApiToolSkill.getRegistryTools?.();
+      expect(tools).toHaveLength(3);
+    });
+
+    it('does not register workflow_execute_step', () => {
+      const tools = alertAnalysisInlineApiToolSkill.getRegistryTools?.();
+      expect(tools).not.toContain(WORKFLOW_EXECUTE_STEP_TOOL_ID);
+    });
+
+    it('defines one inline tool with the correct id', async () => {
+      const inlineTools = await alertAnalysisInlineApiToolSkill.getInlineTools?.();
+      expect(inlineTools).toHaveLength(1);
+      expect(inlineTools![0].id).toBe('security.alert-analysis.get-related-alerts');
+    });
+  });
+
+  describe('get-related-alerts inline tool handler', () => {
+    const { mockEsClient, mockRequest, mockLogger } = createToolTestMocks();
+
+    let tool: BuiltinSkillBoundedTool;
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      const inlineTools = await alertAnalysisInlineApiToolSkill.getInlineTools?.();
+      tool = inlineTools![0] as BuiltinSkillBoundedTool;
+    });
+
+    const callHandler = async (
+      params: {
+        alertId: string;
+        timeWindowHours?: number;
+        maxResults?: number;
+        hostNames?: string[];
+        userNames?: string[];
+        sourceIps?: string[];
+        destIps?: string[];
+      },
+      spaceId = 'default'
+    ) => {
+      return tool.handler(
+        params,
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger, { spaceId })
+      ) as Promise<ToolHandlerStandardReturn>;
+    };
+
+    it('calls findRelatedAlerts with correct params', async () => {
+      findRelatedAlerts.mockResolvedValueOnce(
+        makeSuccess({
+          message: 'Found 1 related alerts sharing entities with alert alert-123.',
+          relatedAlerts: [{ _id: 'rel-1', _index: '.alerts-security.alerts-default' }],
+          sourceEntities: { hostNames: ['host-1'], userNames: [], sourceIps: [], destIps: [] },
+          totalMatched: 1,
+          returnedCount: 1,
+          isTruncated: false,
+        })
+      );
+
+      await callHandler({ alertId: 'alert-123', timeWindowHours: 48, hostNames: ['host-1'] });
+
+      expect(findRelatedAlerts).toHaveBeenCalledWith(
+        mockEsClient.asCurrentUser,
+        expect.objectContaining({
+          alertId: 'alert-123',
+          alertsIndex: '.alerts-security.alerts-default',
+          timeWindowHours: 48,
+          hostNames: ['host-1'],
+        })
+      );
+    });
+
+    it('uses the correct space-scoped alerts index', async () => {
+      findRelatedAlerts.mockResolvedValueOnce(makeSuccess());
+
+      await callHandler({ alertId: 'alert-abc' }, 'prod');
+
+      expect(findRelatedAlerts).toHaveBeenCalledWith(
+        mockEsClient.asCurrentUser,
+        expect.objectContaining({
+          alertsIndex: '.alerts-security.alerts-prod',
+        })
+      );
+    });
+
+    it('returns other result with data on success', async () => {
+      findRelatedAlerts.mockResolvedValueOnce(
+        makeSuccess({
+          message: 'Found 2 related alerts sharing entities with alert alert-123.',
+          relatedAlerts: [
+            { _id: 'r1', _index: 'idx' },
+            { _id: 'r2', _index: 'idx' },
+          ],
+          sourceEntities: { hostNames: ['h1'], userNames: [], sourceIps: [], destIps: [] },
+          totalMatched: 2,
+          returnedCount: 2,
+        })
+      );
+
+      const result = await callHandler({ alertId: 'alert-123' });
+
+      expect(result.results[0].type).toBe(ToolResultType.other);
+      expect(getData(result).relatedAlerts).toHaveLength(2);
+      expect(getData(result).totalMatched).toBe(2);
+      expect(getData(result).isTruncated).toBe(false);
+    });
+
+    it('returns error result when findRelatedAlerts returns ok: false', async () => {
+      findRelatedAlerts.mockResolvedValueOnce({ ok: false, message: 'Alert not found' });
+
+      const result = await callHandler({ alertId: 'missing-alert' });
+
+      expect(result.results[0].type).toBe(ToolResultType.error);
+      expect(getData(result).message).toBe('Alert not found');
+    });
+
+    it('surfaces isTruncated when results are capped', async () => {
+      findRelatedAlerts.mockResolvedValueOnce(
+        makeSuccess({ totalMatched: 100, returnedCount: 25, isTruncated: true })
+      );
+
+      const result = await callHandler({ alertId: 'alert-123' });
+
+      expect(getData(result).isTruncated).toBe(true);
+      expect(getData(result).totalMatched).toBe(100);
+      expect(getData(result).returnedCount).toBe(25);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_inline_api_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/alert_analysis_skill_inline_api_tool.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolType } from '@kbn/agent-builder-common/tools';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { z } from '@kbn/zod/v4';
+import {
+  SECURITY_ALERTS_TOOL_ID,
+  SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+  SECURITY_LABS_SEARCH_TOOL_ID,
+} from '../../tools';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import { findRelatedAlerts } from '../../../lib/alert_analysis/services/find_related_alerts';
+
+export const alertAnalysisInlineApiToolSkill = defineSkillType({
+  id: 'alert-analysis',
+  name: 'alert-analysis',
+  basePath: 'skills/security/alerts',
+  description:
+    'Alert triage and investigation: fetch alerts, correlate related alerts via a focused inline tool, ' +
+    'enrich with Security Labs threat intelligence, and assess entity risk to determine disposition.',
+  content: `# Alert Analysis Guide
+
+## When to Use This Skill
+
+Use this skill when:
+- Triaging a specific security alert to determine if it is a true or false positive
+- Investigating alerts to understand their context and impact
+- Finding related alerts that share entities (hosts, users, IPs) with a known alert
+- Enriching alert data with threat intelligence from Elastic Security Labs
+- Assessing entity risk scores for hosts or users involved in alerts
+
+## Alert Analysis Process
+
+### 1. Initial Alert Assessment
+- Fetch the alert using 'security.alerts' to retrieve core details
+- Review: severity, timestamp, rule name, description, MITRE ATT&CK technique
+- Identify key entities: users (user.name), hosts (host.name), IPs (source.ip, destination.ip), file hashes
+- Note the alert's workflow status and any existing assignments
+
+### 2. Find Related Alerts
+- Use 'security.alert-analysis.get-related-alerts' to find alerts sharing entities with the investigated alert
+- Specify the alert ID and an appropriate time window (default 24h, extend to 168h for slow attacks)
+- If you already have entity values (host.name, user.name, source.ip, destination.ip) from a previous tool call, pass them as optional parameters to skip refetching the alert
+- Review the related alerts for patterns: same rule triggering, escalating severity, or multi-stage attack chains
+
+### 3. Search Security Labs
+- Query Elastic Security Labs using 'security.security_labs_search' for:
+  - Known threat actor TTPs matching the alert's MITRE technique
+  - Malware family information if process hashes or names are available
+  - IOC context for IPs, domains, or file hashes found in the alert
+
+### 4. Assess Entity Risk
+- Check entity risk scores using 'security.entity_risk_score' for involved hosts and users
+- High risk scores (>80) on involved entities increase alert priority
+- Compare current risk level with historical baseline
+- For deeper entity profiling (asset criticality, behavioral history, entity store lookups), reference the entity-analytics skill
+
+### 5. Determine Disposition
+- **True Positive** → Escalate: Create a case, attach the alert, recommend containment actions
+- **Benign True Positive** → Exception: The alert is technically correct but the activity is known-good (e.g., admin tooling)
+- **False Positive** → Tune: The rule needs adjustment to avoid this class of alerts
+- **Needs More Data** → Expand investigation: Widen time window, check additional data sources
+
+### 6. Synthesize Findings
+- Compile a comprehensive analysis with supporting evidence
+- Provide clear threat assessment: severity, confidence level, affected scope
+- Recommend specific next steps based on disposition
+- Reference the entity-analytics skill for deeper entity profiling or asset criticality review
+
+## Tool Selection Guardrails
+- For list/prioritization questions (e.g. "high/critical alerts in last 24h"), use only 'security.alerts' unless explicit correlation by alertId is requested.
+- For Security Labs intel questions (e.g. "Lazarus Group techniques"), use only 'security.security_labs_search'.
+- For risk score questions (e.g. "risk score for host DC01"), use only 'security.entity_risk_score'.
+- For correlation requests that include an alertId, call 'security.alert-analysis.get-related-alerts' directly.
+- Do NOT use platform.core.search or workflow tools for related-alert correlation when an alertId is available.
+
+## Best Practices
+- Always start with the alert details before expanding investigation scope
+- Use entity relationships to efficiently find related security data
+- Maintain chronological context when analyzing events and alerts
+- Prioritize high-severity alerts and entities with critical asset criticality
+- Document your analysis reasoning for future reference
+- Cross-reference multiple data points before making disposition decisions`,
+  getRegistryTools: () => [
+    SECURITY_ALERTS_TOOL_ID,
+    SECURITY_LABS_SEARCH_TOOL_ID,
+    SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+  ],
+  getInlineTools: () => [
+    {
+      id: 'security.alert-analysis.get-related-alerts',
+      type: ToolType.builtin,
+      description:
+        'Find alerts that share entities (host.name, user.name, source.ip, destination.ip) with a given alert. Returns related alerts within the specified time window. Pass entity values directly if already available to skip refetching the alert.',
+      schema: z.object({
+        alertId: z.string().describe('The _id of the alert to find related alerts for'),
+        timeWindowHours: z
+          .number()
+          .min(1)
+          .max(168)
+          .default(24)
+          .describe('Time window in hours to search for related alerts (1-168, default 24)'),
+        maxResults: z
+          .number()
+          .min(1)
+          .max(100)
+          .default(25)
+          .describe('Maximum number of related alerts to return (1-100, default 25)'),
+        hostNames: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Optional: host.name values from the alert. If provided along with other entity fields, skips refetching the alert.'
+          ),
+        userNames: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Optional: user.name values from the alert. If provided along with other entity fields, skips refetching the alert.'
+          ),
+        sourceIps: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Optional: source.ip values from the alert. If provided along with other entity fields, skips refetching the alert.'
+          ),
+        destIps: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Optional: destination.ip values from the alert. If provided along with other entity fields, skips refetching the alert.'
+          ),
+      }),
+      handler: async (
+        { alertId, timeWindowHours, maxResults, hostNames, userNames, sourceIps, destIps },
+        context
+      ) => {
+        const alertsIndex = `${DEFAULT_ALERTS_INDEX}-${context.spaceId}`;
+
+        const result = await findRelatedAlerts(context.esClient.asCurrentUser, {
+          alertId,
+          alertsIndex,
+          timeWindowHours,
+          maxResults,
+          hostNames,
+          userNames,
+          sourceIps,
+          destIps,
+        });
+
+        if (!result.ok) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: { message: result.message },
+              },
+            ],
+          };
+        }
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                message: result.message,
+                sourceEntities: result.sourceEntities,
+                relatedAlerts: result.relatedAlerts,
+                totalMatched: result.totalMatched,
+                returnedCount: result.returnedCount,
+                isTruncated: result.isTruncated,
+              },
+            },
+          ],
+        };
+      },
+    },
+  ],
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/alert_analysis/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { alertAnalysisSkill } from './alert_analysis_skill';
+export { alertAnalysisApiDrivenSkill } from './alert_analysis_skill_api_driven';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { alertAnalysisSkill } from './alert_analysis';
+export { alertAnalysisApiDrivenSkill } from './alert_analysis/alert_analysis_skill_api_driven';
 export { threatHuntingSkill } from './threat_hunting';
 export { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 export { pciComplianceSkill } from './pci_compliance';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ExperimentalFeatures } from '../../../common/experimental_features';
+import { registerSkills } from './register_skills';
+
+jest.mock('./alert_analysis', () => ({
+  alertAnalysisSkill: { id: 'alert-analysis-legacy' },
+}));
+
+jest.mock('./alert_analysis/alert_analysis_skill_api_driven', () => ({
+  alertAnalysisApiDrivenSkill: { id: 'alert-analysis-api-driven' },
+}));
+
+jest.mock('./threat_hunting', () => ({
+  threatHuntingSkill: { id: 'threat-hunting' },
+}));
+
+jest.mock('./automatic_troubleshooting', () => ({
+  createAutomaticTroubleshootingSkill: jest.fn(() => ({ id: 'automatic-troubleshooting' })),
+}));
+
+jest.mock('./detection_rule_edit', () => ({
+  getDetectionRuleEditSkill: jest.fn(() => ({ id: 'detection-rule-edit' })),
+}));
+
+jest.mock('./entity_analytics', () => ({
+  getEntityAnalyticsSkill: jest.fn(() => ({ id: 'entity-analytics' })),
+}));
+
+jest.mock('./find_security_ml_jobs', () => ({
+  findSecurityMlJobsSkill: jest.fn(() => ({ id: 'find-security-ml-jobs' })),
+}));
+
+jest.mock('./pci_compliance', () => ({
+  pciComplianceSkill: { id: 'pci-compliance' },
+}));
+
+describe('registerSkills', () => {
+  const register = jest.fn(async () => undefined);
+
+  const baseArgs = {
+    agentBuilder: { skills: { register } },
+    getStartServices: jest.fn(),
+    kibanaVersion: '9.9.9',
+    logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    ml: undefined,
+    options: { endpointAppContextService: {} },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers legacy alert-analysis skill when API-driven flag is disabled', async () => {
+    const experimentalFeatures = {
+      alertAnalysisApiDrivenSkill: false,
+      automaticTroubleshootingSkill: false,
+      entityAnalyticsEntityStoreV2: false,
+      pciComplianceAgentBuilder: false,
+    } as ExperimentalFeatures;
+
+    await registerSkills({
+      ...baseArgs,
+      experimentalFeatures,
+    });
+
+    const ids = register.mock.calls.map(([skill]) => skill.id);
+    expect(ids).toContain('alert-analysis-legacy');
+    expect(ids).not.toContain('alert-analysis-api-driven');
+  });
+
+  it('registers API-driven alert-analysis skill when flag is enabled', async () => {
+    const experimentalFeatures = {
+      alertAnalysisApiDrivenSkill: true,
+      automaticTroubleshootingSkill: false,
+      entityAnalyticsEntityStoreV2: false,
+      pciComplianceAgentBuilder: false,
+    } as ExperimentalFeatures;
+
+    await registerSkills({
+      ...baseArgs,
+      experimentalFeatures,
+    });
+
+    const ids = register.mock.calls.map(([skill]) => skill.id);
+    expect(ids).toContain('alert-analysis-api-driven');
+    expect(ids).not.toContain('alert-analysis-legacy');
+    expect(ids).toContain('threat-hunting');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -15,6 +15,7 @@ import { getEntityAnalyticsSkill } from './entity_analytics';
 import { pciComplianceSkill } from './pci_compliance';
 import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
+import { alertAnalysisApiDrivenSkill } from './alert_analysis/alert_analysis_skill_api_driven';
 import type { EntityAnalyticsRoutesDeps } from '../../lib/entity_analytics/types';
 import { findSecurityMlJobsSkill } from './find_security_ml_jobs';
 
@@ -59,7 +60,11 @@ export const registerSkills = async ({
   );
 
   await agentBuilder.skills.register(threatHuntingSkill);
-  await agentBuilder.skills.register(alertAnalysisSkill);
+  await agentBuilder.skills.register(
+    experimentalFeatures.alertAnalysisApiDrivenSkill
+      ? alertAnalysisApiDrivenSkill
+      : alertAnalysisSkill
+  );
 
   if (experimentalFeatures.pciComplianceAgentBuilder) {
     agentBuilder.skills.register(pciComplianceSkill);

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -16,6 +16,7 @@ import { pciComplianceSkill } from './pci_compliance';
 import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
 import { alertAnalysisApiDrivenSkill } from './alert_analysis/alert_analysis_skill_api_driven';
+import { alertAnalysisInlineApiToolSkill } from './alert_analysis/alert_analysis_skill_inline_api_tool';
 import type { EntityAnalyticsRoutesDeps } from '../../lib/entity_analytics/types';
 import { findSecurityMlJobsSkill } from './find_security_ml_jobs';
 
@@ -61,7 +62,9 @@ export const registerSkills = async ({
 
   await agentBuilder.skills.register(threatHuntingSkill);
   await agentBuilder.skills.register(
-    experimentalFeatures.alertAnalysisApiDrivenSkill
+    experimentalFeatures.alertAnalysisInlineApiToolSkill
+      ? alertAnalysisInlineApiToolSkill
+      : experimentalFeatures.alertAnalysisApiDrivenSkill
       ? alertAnalysisApiDrivenSkill
       : alertAnalysisSkill
   );

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/routes/register_alert_analysis_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/routes/register_alert_analysis_routes.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import {
+  ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH,
+  relatedAlertsRequestSchema,
+} from '../../../../common/api/alert_analysis/related_alerts';
+import type { SecuritySolutionPluginRouter } from '../../../types';
+import { findRelatedAlerts } from '../services/find_related_alerts';
+
+export const registerAlertAnalysisRoutes = (router: SecuritySolutionPluginRouter) => {
+  router.versioned
+    .post({
+      path: ALERT_ANALYSIS_GET_RELATED_ALERTS_API_PATH,
+      access: 'internal',
+      security: {
+        authz: {
+          requiredPrivileges: ['securitySolution'],
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: buildRouteValidationWithZod(relatedAlertsRequestSchema),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const [coreContext, securitySolutionContext] = await Promise.all([
+          context.core,
+          context.securitySolution,
+        ]);
+        const spaceId = securitySolutionContext.getSpaceId();
+        const alertsIndex = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+
+        const result = await findRelatedAlerts(coreContext.elasticsearch.client.asCurrentUser, {
+          alertId: request.body.alertId,
+          alertsIndex,
+          timeWindowHours: request.body.timeWindowHours,
+          maxResults: request.body.maxResults,
+          hostNames: request.body.hostNames,
+          userNames: request.body.userNames,
+          sourceIps: request.body.sourceIps,
+          destIps: request.body.destIps,
+        });
+
+        if (!result.ok) {
+          return response.customError({
+            statusCode: 400,
+            body: { message: result.message },
+          });
+        }
+
+        return response.ok({
+          body: result,
+        });
+      }
+    );
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/services/find_related_alerts.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/services/find_related_alerts.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { findRelatedAlerts } from './find_related_alerts';
+
+describe('findRelatedAlerts', () => {
+  const esClient = {
+    get: jest.fn(),
+    search: jest.fn(),
+  } as unknown as ElasticsearchClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty result when no source entities are present', async () => {
+    (esClient.get as jest.Mock).mockResolvedValue({
+      _source: { 'kibana.alert.rule.name': 'Rule' },
+    });
+
+    const result = await findRelatedAlerts(esClient, {
+      alertId: 'alert-1',
+      alertsIndex: '.alerts-security.alerts-default',
+      timeWindowHours: 24,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.relatedAlerts).toEqual([]);
+      expect(result.returnedCount).toBe(0);
+      expect(result.isTruncated).toBe(false);
+    }
+  });
+
+  it('uses token-budgeted defaults and emits truncation metadata', async () => {
+    (esClient.search as jest.Mock).mockResolvedValue({
+      hits: {
+        total: { value: 99, relation: 'eq' },
+        hits: [
+          {
+            _id: 'related-1',
+            _index: '.alerts-security.alerts-default',
+            _source: { message: 'related' },
+          },
+        ],
+      },
+    });
+
+    const result = await findRelatedAlerts(esClient, {
+      alertId: 'alert-1',
+      alertsIndex: '.alerts-security.alerts-default',
+      timeWindowHours: 24,
+      hostNames: ['host-a'],
+    });
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size: 25,
+        _source: expect.arrayContaining(['@timestamp', 'message', 'host.name']),
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.totalMatched).toBe(99);
+      expect(result.returnedCount).toBe(1);
+      expect(result.isTruncated).toBe(true);
+    }
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/services/find_related_alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/alert_analysis/services/find_related_alerts.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+export interface SourceEntities {
+  hostNames: string[];
+  userNames: string[];
+  sourceIps: string[];
+  destIps: string[];
+}
+
+export interface FindRelatedAlertsParams {
+  alertId: string;
+  alertsIndex: string;
+  timeWindowHours: number;
+  maxResults?: number;
+  hostNames?: string[];
+  userNames?: string[];
+  sourceIps?: string[];
+  destIps?: string[];
+}
+
+interface RelatedAlertDocument extends Record<string, unknown> {
+  _id: string;
+  _index: string;
+}
+
+export interface FindRelatedAlertsSuccess {
+  ok: true;
+  message: string;
+  relatedAlerts: RelatedAlertDocument[];
+  sourceEntities: SourceEntities;
+  totalMatched: number;
+  returnedCount: number;
+  isTruncated: boolean;
+}
+
+export interface FindRelatedAlertsError {
+  ok: false;
+  message: string;
+}
+
+export type FindRelatedAlertsResult = FindRelatedAlertsSuccess | FindRelatedAlertsError;
+
+const DEFAULT_MAX_RESULTS = 25;
+
+const RELATED_ALERT_SOURCE_ALLOWLIST = [
+  '@timestamp',
+  'kibana.alert.rule.name',
+  'kibana.alert.severity',
+  'kibana.alert.risk_score',
+  'kibana.alert.workflow_status',
+  'kibana.alert.reason',
+  'kibana.alert.rule.threat',
+  'host.name',
+  'user.name',
+  'source.ip',
+  'destination.ip',
+  'process.name',
+  'process.executable',
+  'file.name',
+  'file.path',
+  'message',
+] as const;
+
+export const findRelatedAlerts = async (
+  esClient: ElasticsearchClient,
+  params: FindRelatedAlertsParams
+): Promise<FindRelatedAlertsResult> => {
+  const {
+    alertId,
+    alertsIndex,
+    timeWindowHours,
+    maxResults = DEFAULT_MAX_RESULTS,
+    hostNames: providedHostNames,
+    userNames: providedUserNames,
+    sourceIps: providedSourceIps,
+    destIps: providedDestIps,
+  } = params;
+
+  const hasProvidedEntities =
+    (Array.isArray(providedHostNames) && providedHostNames.length > 0) ||
+    (Array.isArray(providedUserNames) && providedUserNames.length > 0) ||
+    (Array.isArray(providedSourceIps) && providedSourceIps.length > 0) ||
+    (Array.isArray(providedDestIps) && providedDestIps.length > 0);
+
+  let sourceEntities: SourceEntities;
+
+  try {
+    if (hasProvidedEntities) {
+      sourceEntities = {
+        hostNames: Array.isArray(providedHostNames) ? providedHostNames : [],
+        userNames: Array.isArray(providedUserNames) ? providedUserNames : [],
+        sourceIps: Array.isArray(providedSourceIps) ? providedSourceIps : [],
+        destIps: Array.isArray(providedDestIps) ? providedDestIps : [],
+      };
+    } else {
+      const alertResult = await esClient.get({
+        index: alertsIndex,
+        id: alertId,
+      });
+
+      const alertSource = alertResult._source as Record<string, unknown> | undefined;
+      if (!alertSource) {
+        return {
+          ok: false,
+          message: `Alert ${alertId} not found or has no source data.`,
+        };
+      }
+
+      sourceEntities = {
+        hostNames: getNestedValues(alertSource, 'host.name'),
+        userNames: getNestedValues(alertSource, 'user.name'),
+        sourceIps: getNestedValues(alertSource, 'source.ip'),
+        destIps: getNestedValues(alertSource, 'destination.ip'),
+      };
+    }
+
+    const hasEntities =
+      sourceEntities.hostNames.length > 0 ||
+      sourceEntities.userNames.length > 0 ||
+      sourceEntities.sourceIps.length > 0 ||
+      sourceEntities.destIps.length > 0;
+
+    if (!hasEntities) {
+      return {
+        ok: true,
+        message: 'No entity values found on the source alert to correlate.',
+        sourceEntities,
+        relatedAlerts: [],
+        totalMatched: 0,
+        returnedCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    const shouldClauses: Array<{ terms: Record<string, string[]> }> = [];
+    if (sourceEntities.hostNames.length > 0) {
+      shouldClauses.push({ terms: { 'host.name': sourceEntities.hostNames } });
+    }
+    if (sourceEntities.userNames.length > 0) {
+      shouldClauses.push({ terms: { 'user.name': sourceEntities.userNames } });
+    }
+    if (sourceEntities.sourceIps.length > 0) {
+      shouldClauses.push({ terms: { 'source.ip': sourceEntities.sourceIps } });
+    }
+    if (sourceEntities.destIps.length > 0) {
+      shouldClauses.push({ terms: { 'destination.ip': sourceEntities.destIps } });
+    }
+
+    const size = Math.min(Math.max(maxResults, 1), 100);
+
+    const searchResult = await esClient.search<Record<string, unknown>>({
+      index: alertsIndex,
+      size,
+      track_total_hits: true,
+      query: {
+        bool: {
+          must: [
+            {
+              range: {
+                '@timestamp': {
+                  gte: `now-${timeWindowHours}h`,
+                },
+              },
+            },
+          ],
+          should: shouldClauses,
+          minimum_should_match: 1,
+          must_not: [{ ids: { values: [alertId] } }],
+        },
+      },
+      sort: [{ '@timestamp': 'desc' }],
+      _source: [...RELATED_ALERT_SOURCE_ALLOWLIST],
+      ignore_unavailable: true,
+    });
+
+    const relatedAlerts: RelatedAlertDocument[] = searchResult.hits.hits.map((hit) => ({
+      _id: hit._id,
+      _index: hit._index ?? alertsIndex,
+      ...((hit._source as Record<string, unknown> | undefined) ?? {}),
+    }));
+
+    const totalMatched = getTotalMatched(searchResult.hits.total);
+    const returnedCount = relatedAlerts.length;
+    const isTruncated = totalMatched > returnedCount;
+
+    return {
+      ok: true,
+      message: `Found ${returnedCount} related alerts sharing entities with alert ${alertId}.`,
+      sourceEntities,
+      relatedAlerts,
+      totalMatched,
+      returnedCount,
+      isTruncated,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: `Failed to find related alerts: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+};
+
+const getTotalMatched = (
+  total: number | { relation?: string; value?: number } | undefined
+): number => {
+  if (typeof total === 'number') {
+    return total;
+  }
+  if (total && typeof total.value === 'number') {
+    return total.value;
+  }
+  return 0;
+};
+
+function getNestedValues(obj: Record<string, unknown>, path: string): string[] {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current == null || typeof current !== 'object') {
+      return [];
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  if (typeof current === 'string') {
+    return [current];
+  }
+  if (Array.isArray(current)) {
+    return current.filter((value): value is string => typeof value === 'string');
+  }
+  return [];
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
@@ -60,6 +60,7 @@ import { registerSiemReadinessRoutes } from '../lib/siem_readiness';
 import type { TrialCompanionRoutesDeps } from '../lib/trial_companion/types';
 import { registerDataGeneratorRoutes } from './data_generator/register_data_generator_routes';
 import { registerInitializationRoutes } from '../lib/initialization';
+import { registerAlertAnalysisRoutes } from '../lib/alert_analysis/routes/register_alert_analysis_routes';
 
 export const initRoutes = (
   router: SecuritySolutionPluginRouter,
@@ -167,6 +168,7 @@ export const initRoutes = (
   registerTrialCompanionRoutes(trialCompanionDeps);
 
   registerInitializationRoutes({ router, logger });
+  registerAlertAnalysisRoutes(router);
 
   if (enableDataGeneratorRoutes) {
     registerDataGeneratorRoutes(router, getStartServices);

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/get_related_alerts_step/get_related_alerts_step.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/get_related_alerts_step/get_related_alerts_step.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FindRelatedAlertsResult } from '../../../lib/alert_analysis/services/find_related_alerts';
+
+jest.mock('../../../lib/alert_analysis/services/find_related_alerts', () => ({
+  findRelatedAlerts: jest.fn(),
+}));
+
+import { findRelatedAlerts } from '../../../lib/alert_analysis/services/find_related_alerts';
+import { getRelatedAlertsStepDefinition } from './get_related_alerts_step';
+import { getRelatedAlertsInputSchema } from '../../../../common/workflows/step_types/get_related_alerts_step/get_related_alerts_step_common';
+
+const mockFindRelatedAlerts = findRelatedAlerts as jest.MockedFunction<typeof findRelatedAlerts>;
+
+const makeSuccess = (overrides: Partial<FindRelatedAlertsResult> = {}): FindRelatedAlertsResult =>
+  ({
+    ok: true,
+    message: 'Found 0 related alerts sharing entities with alert seed.',
+    relatedAlerts: [],
+    sourceEntities: { hostNames: [], userNames: [], sourceIps: [], destIps: [] },
+    totalMatched: 0,
+    returnedCount: 0,
+    isTruncated: false,
+    ...overrides,
+  } as FindRelatedAlertsResult);
+
+const createMockContext = (input: Record<string, unknown>) => ({
+  input,
+  config: {},
+  rawInput: input,
+  contextManager: {
+    getContext: jest.fn().mockReturnValue({ workflow: { spaceId: 'default' } }),
+    getScopedEsClient: jest.fn().mockReturnValue({ get: jest.fn(), search: jest.fn() }),
+    renderInputTemplate: jest.fn(),
+    getFakeRequest: jest.fn(),
+  },
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  abortSignal: new AbortController().signal,
+  stepId: 'test-step',
+  stepType: 'security.alertAnalysis.getRelatedAlerts',
+});
+
+describe('getRelatedAlerts step', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('input schema', () => {
+    it('applies defaults for timeWindowHours and maxResults', () => {
+      const parsed = getRelatedAlertsInputSchema.parse({
+        alertId: 'alert-1',
+        alertIndex: '.alerts-security.alerts-default',
+      });
+      expect(parsed.timeWindowHours).toBe(24);
+      expect(parsed.maxResults).toBe(25);
+    });
+
+    it('coerces numeric strings (workflow YAML values often arrive as strings)', () => {
+      const parsed = getRelatedAlertsInputSchema.parse({
+        alertId: 'alert-1',
+        alertIndex: '.alerts-security.alerts-default',
+        timeWindowHours: '48',
+        maxResults: '10',
+      });
+      expect(parsed.timeWindowHours).toBe(48);
+      expect(parsed.maxResults).toBe(10);
+    });
+
+    it('rejects out-of-range timeWindowHours', () => {
+      const result = getRelatedAlertsInputSchema.safeParse({
+        alertId: 'alert-1',
+        alertIndex: '.alerts-security.alerts-default',
+        timeWindowHours: 200,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('handler', () => {
+    it('delegates to findRelatedAlerts with the parsed input', async () => {
+      mockFindRelatedAlerts.mockResolvedValue(
+        makeSuccess({
+          message: 'Found 1 related alerts sharing entities with alert seed-1.',
+          relatedAlerts: [{ _id: 'rel-1', _index: '.alerts-security.alerts-default' }],
+          sourceEntities: { hostNames: ['host-1'], userNames: [], sourceIps: [], destIps: [] },
+          totalMatched: 1,
+          returnedCount: 1,
+          isTruncated: false,
+        })
+      );
+
+      const input = getRelatedAlertsInputSchema.parse({
+        alertId: 'seed-1',
+        alertIndex: '.alerts-security.alerts-default',
+      });
+      const context = createMockContext(input);
+
+      const result = await getRelatedAlertsStepDefinition.handler(context as never);
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toMatchObject({
+        totalMatched: 1,
+        returnedCount: 1,
+        isTruncated: false,
+        relatedAlerts: [{ _id: 'rel-1', _index: '.alerts-security.alerts-default' }],
+      });
+      // `ok` discriminator must NOT leak into the workflow output.
+      expect((result.output as Record<string, unknown>).ok).toBeUndefined();
+      expect(mockFindRelatedAlerts).toHaveBeenCalledWith(expect.anything(), {
+        alertId: 'seed-1',
+        alertsIndex: '.alerts-security.alerts-default',
+        timeWindowHours: 24,
+        maxResults: 25,
+        hostNames: undefined,
+        userNames: undefined,
+        sourceIps: undefined,
+        destIps: undefined,
+      });
+    });
+
+    it('forwards optional entity arrays to the shared service when provided', async () => {
+      mockFindRelatedAlerts.mockResolvedValue(makeSuccess());
+
+      const input = getRelatedAlertsInputSchema.parse({
+        alertId: 'seed-2',
+        alertIndex: '.alerts-security.alerts-default',
+        hostNames: ['win-srv01'],
+        userNames: ['alice'],
+        sourceIps: ['10.0.0.1'],
+        destIps: ['10.0.0.2'],
+        timeWindowHours: 48,
+        maxResults: 10,
+      });
+      await getRelatedAlertsStepDefinition.handler(createMockContext(input) as never);
+
+      expect(mockFindRelatedAlerts).toHaveBeenCalledWith(expect.anything(), {
+        alertId: 'seed-2',
+        alertsIndex: '.alerts-security.alerts-default',
+        timeWindowHours: 48,
+        maxResults: 10,
+        hostNames: ['win-srv01'],
+        userNames: ['alice'],
+        sourceIps: ['10.0.0.1'],
+        destIps: ['10.0.0.2'],
+      });
+    });
+
+    it('returns the service error message when the service fails', async () => {
+      mockFindRelatedAlerts.mockResolvedValue({
+        ok: false,
+        message: 'Alert seed-3 not found or has no source data.',
+      });
+
+      const input = getRelatedAlertsInputSchema.parse({
+        alertId: 'seed-3',
+        alertIndex: '.alerts-security.alerts-default',
+      });
+      const result = await getRelatedAlertsStepDefinition.handler(
+        createMockContext(input) as never
+      );
+
+      expect(result.output).toBeUndefined();
+      expect(result.error).toBeInstanceOf(Error);
+      expect((result.error as Error).message).toContain('Alert seed-3 not found');
+    });
+
+    it('surfaces unexpected exceptions as a step error without throwing', async () => {
+      mockFindRelatedAlerts.mockRejectedValue(new Error('ES connection refused'));
+
+      const input = getRelatedAlertsInputSchema.parse({
+        alertId: 'seed-4',
+        alertIndex: '.alerts-security.alerts-default',
+      });
+      const result = await getRelatedAlertsStepDefinition.handler(
+        createMockContext(input) as never
+      );
+
+      expect(result.output).toBeUndefined();
+      expect((result.error as Error).message).toContain('ES connection refused');
+    });
+  });
+
+  describe('common definition', () => {
+    it('uses the canonical namespaced step type id', () => {
+      expect(getRelatedAlertsStepDefinition.id).toBe('security.alertAnalysis.getRelatedAlerts');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/get_related_alerts_step/get_related_alerts_step.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/get_related_alerts_step/get_related_alerts_step.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { findRelatedAlerts } from '../../../lib/alert_analysis/services/find_related_alerts';
+import { getRelatedAlertsStepCommonDefinition } from '../../../../common/workflows/step_types/get_related_alerts_step/get_related_alerts_step_common';
+
+/**
+ * Workflow step that wraps the shared `findRelatedAlerts` service.
+ *
+ * This is the workflow-side surface of the same service exposed as an inline
+ * Agent Builder tool (security.alert-analysis.get-related-alerts). One handler,
+ * two consumers — no duplication. See the linked PR body for the analysis of
+ * why this beats the workflow_execute_step + kibana.request alternative for
+ * single-API-call use cases.
+ */
+export const getRelatedAlertsStepDefinition = createServerStepDefinition({
+  ...getRelatedAlertsStepCommonDefinition,
+  handler: async (context) => {
+    try {
+      const {
+        alertId,
+        alertIndex,
+        timeWindowHours,
+        maxResults,
+        hostNames,
+        userNames,
+        sourceIps,
+        destIps,
+      } = context.input;
+
+      const esClient = context.contextManager.getScopedEsClient();
+
+      const result = await findRelatedAlerts(esClient, {
+        alertId,
+        alertsIndex: alertIndex,
+        timeWindowHours,
+        maxResults,
+        hostNames,
+        userNames,
+        sourceIps,
+        destIps,
+      });
+
+      if (!result.ok) {
+        return { error: new Error(result.message) };
+      }
+
+      const { ok: _ok, ...output } = result;
+      return { output };
+    } catch (error) {
+      context.logger.error('Failed to get related alerts', error);
+      return {
+        error: new Error(error instanceof Error ? error.message : 'Failed to get related alerts'),
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/get_related_alerts_step/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/get_related_alerts_step/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getRelatedAlertsStepDefinition } from './get_related_alerts_step';

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts
@@ -11,6 +11,7 @@ import { workflowsExtensionsMock } from '@kbn/workflows-extensions/server/mocks'
 import { registerWorkflowSteps } from './register_workflow_steps';
 import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
 import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
+import { getRelatedAlertsStepDefinition } from './get_related_alerts_step';
 import {
   REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
   REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
@@ -29,13 +30,13 @@ describe('registerWorkflowSteps (server)', () => {
     return { core, coreStart };
   };
 
-  it('calls registerStepDefinition synchronously for both steps', () => {
+  it('calls registerStepDefinition synchronously for all steps', () => {
     const { core } = buildCoreMock(true);
     const workflowsExtensions = createWorkflowsExtensionsMock();
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(2);
+    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(3);
     // getStartServices is called once eagerly to create the shared memoized promise
     expect(core.getStartServices).toHaveBeenCalledTimes(1);
   });
@@ -46,12 +47,13 @@ describe('registerWorkflowSteps (server)', () => {
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2, loader3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
 
     await expect(loader1()).resolves.toBe(renderAlertNarrativeStepDefinition);
     await expect(loader2()).resolves.toBe(buildAlertEntityGraphStepDefinition);
+    await expect(loader3()).resolves.toBe(getRelatedAlertsStepDefinition);
   });
 
   it('async loader returns undefined when feature flag is disabled', async () => {
@@ -60,24 +62,25 @@ describe('registerWorkflowSteps (server)', () => {
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2, loader3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
 
     await expect(loader1()).resolves.toBeUndefined();
     await expect(loader2()).resolves.toBeUndefined();
+    await expect(loader3()).resolves.toBeUndefined();
   });
 
-  it('checks the feature flag exactly once even when both loaders resolve', async () => {
+  it('checks the feature flag exactly once even when all loaders resolve', async () => {
     const { core, coreStart } = buildCoreMock(true);
     const workflowsExtensions = createWorkflowsExtensionsMock();
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2, loader3] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
-    await Promise.all([loader1(), loader2()]);
+    await Promise.all([loader1(), loader2(), loader3()]);
 
     expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledTimes(1);
     expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledWith(

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.ts
@@ -9,6 +9,7 @@ import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extens
 import type { CoreSetup } from '@kbn/core/server';
 import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
 import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
+import { getRelatedAlertsStepDefinition } from './get_related_alerts_step';
 import {
   REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
   REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
@@ -40,5 +41,12 @@ export const registerWorkflowSteps = (
   workflowsExtensions.registerStepDefinition(async () => {
     if (!(await isEnabled)) return undefined;
     return buildAlertEntityGraphStepDefinition;
+  });
+
+  // v4: dual-register step backed by the same findRelatedAlerts service that the
+  // Agent Builder inline tool uses. Single handler, two consumers.
+  workflowsExtensions.registerStepDefinition(async () => {
+    if (!(await isEnabled)) return undefined;
+    return getRelatedAlertsStepDefinition;
   });
 };


### PR DESCRIPTION
## Summary

Adds `security.alertAnalysis.getRelatedAlerts` as a **native Workflows step type**, backed by the same `findRelatedAlerts` service that the Agent Builder inline tool (`security.alert-analysis.get-related-alerts`, see #269397) calls under the hood. One TypeScript handler, two consumers — agents and workflows — without duplication.

This is the natural follow-up to the v1/v2/v3 alert-analysis comparison. **v4 = dual-register pattern atop v3.** Same AB-side surface as v3 (so the eval scores in #269397 carry forward), plus a real workflow step type for Workflows authors so they don't have to fall back to `workflow_execute_step + kibana.request` for what is fundamentally a single API call.

## Why this PR — the structural problem v2 hit

The team has been weighing three shapes for "agent calls an internal API":

| Variant | AB tool registry adds | Skill body teaches | LLM completion authors | Workflows can use it? |
|---|---|---|---|---|
| **v1** (`main`) — inline tool reading ES directly | 1 small inline tool | Process guidance, no YAML | `{ alertId: "..." }` JSON | No — would need a new HTTP route |
| **v2** (#269388) — `workflow_execute_step` + `kibana.request` | the `workflow_execute_step` tool whose schema accepts any YAML | the whole `kibana.request` step grammar | a multi-line YAML string per call | Yes, but only via opaque kibana.request indirection |
| **v3** (#269397) — inline tool → shared `findRelatedAlerts` service | 1 small inline tool | Process guidance, no YAML | `{ alertId: "..." }` JSON | Yes via the same HTTP route the inline handler shares |
| **v4** (this PR) — v3 + native workflow step type | (unchanged from v3) | (unchanged from v3) | (unchanged from v3) | Yes natively (step type), no kibana.request indirection |

### Static per-turn overhead — measured

A direct count of bytes each variant adds to the agent system prompt on **every** turn (skill description + skill body content + inline tool description+schema + workflow_execute_step description+schema when in the registry; via `v4-experiment/static_empirics.mjs`):

| Variant | Skill desc | Skill body | Inline tool | `workflow_execute_step` in registry | TOTAL chars | ~tokens | Δ vs v1 |
|---|---:|---:|---:|---:|---:|---:|---:|
| v1 | 275 | 3,214 | 1,472 | 0 | **4,961** | ~1,240 | 0 |
| v2 | 193 | 3,118 | 0 | **2,280** | **5,591** | ~1,398 | **+158 t** |
| v3 | 193 | 3,841 | 1,670 | 0 | **5,704** | ~1,426 | +186 t |
| **v4** (this PR) | 193 | 3,841 | 1,670 | 0 | **5,704** | ~1,426 | +186 t |

This contradicts an intuitive "v2 = obvious system-prompt bloat" framing. v2's body is roughly the same size as v1's; the inline tool drops (-1,472 chars), and `workflow_execute_step` adds back (+2,280 chars). Net per-turn input-side cost: **+158 tokens** vs v1 — measurable but not dramatic.

### So where does the v2 regression actually come from?

If the input-side cost is only ~158 t/turn worse than v1, the regression the team measured (more tokens overall + lower factuality / relevance) most plausibly comes from the **completion side** and **multi-turn amplification**, not the system prompt:

1. **Completion-side YAML authoring (largest contributor).** Every related-alerts call in v2 requires the LLM to emit ~350 chars of multi-line YAML into the `yaml` parameter — the full `version` / `name` / `triggers` / `steps` / `kibana.request` envelope. v1/v3 emit ~50 chars of compact JSON: `{ alertId: "...", timeWindowHours: 24 }`. That's **~7× more output tokens per tool call**. Output tokens are 3–5× costlier than input tokens at most providers.
2. **Reasoning overhead before the call.** The skill body teaches the YAML grammar; the model still has to plan the YAML mentally before emitting it. That shows up as longer "thinking" segments / more interim tokens for the same factual outcome.
3. **Tool-selection fragility.** With `workflow_execute_step` in the registry the model can choose to wrap *any* internal call in `kibana.request`, not just the one the skill recommends. Static analysis can't measure this; trace analysis (see below) is the way to confirm.
4. **`workflow_execute_step`'s description is HITL-heavy.** Its 1,422-char description teaches the LLM about confirmation dialogs / unsafe steps / `confirmation_body` — content the on-topic alert-correlation case does NOT need. That's ~356 tokens of unrelated context on every turn.

The single-line headline: **`workflow_execute_step` is the right primitive when the LLM is composing a multi-step workflow on the fly; using it as a thin wrapper around one HTTP call pays multi-step orchestration overhead on the completion side for a one-step task.**

### Why v4 is the right shape regardless

v4 doesn't depend on the input-side overhead being huge — it wins on the completion side and on Workflows-side ergonomics:

- **AB side (unchanged from v3):** the LLM emits compact JSON, not multi-line YAML. Same completion-side surface as v1. Token cost per tool call ≈ v1, not v2.
- **Workflows side (new):** Workflows authors compose a real `security.alertAnalysis.getRelatedAlerts` step. They never have to learn `workflow_execute_step + kibana.request` to call alert correlation.
- **No duplication:** one TypeScript handler (`findRelatedAlerts`) serves both surfaces. Bug fixes, schema changes, RBAC tightening happen in one place.

## The dual-register pattern (what v4 actually adds)

The agent-builder inline tool from #269397 and this new workflow step share one handler and one Zod schema:

```ts
// shared service — already exists on main since #269397
findRelatedAlerts(esClient, { alertId, alertsIndex, timeWindowHours, ... })
```

- **AB-side surface (#269397, unchanged here):** `security.alert-analysis.get-related-alerts` inline tool with handler that delegates to `findRelatedAlerts`.
- **Workflows-side surface (this PR):** `security.alertAnalysis.getRelatedAlerts` step type with handler that delegates to the same `findRelatedAlerts`.

That means:
- Workflows authors compose a real step type — no `workflow_execute_step + kibana.request` boilerplate.
- Agents use the inline tool that v3 already ships — no skill-body YAML, no `workflow_execute_step` in the tool registry.
- Both call into the same TypeScript function. Bug fixes, schema changes, RBAC tightening, and observability happen in one place.
- The team's eval pipeline for alert-analysis is unchanged — v4 is v3 on the AB side.

## What this PR changes

New files:

- `common/workflows/step_types/get_related_alerts_step/get_related_alerts_step_common.ts` — shared step definition (id, label, description, input/output schemas, documentation, examples).
- `server/workflows/step_types/get_related_alerts_step/get_related_alerts_step.ts` — server step handler delegating to `findRelatedAlerts`.
- `server/workflows/step_types/get_related_alerts_step/get_related_alerts_step.test.ts` — unit tests covering schema defaults, coercion, success path, service-error propagation, and unexpected-exception handling.
- `server/workflows/step_types/get_related_alerts_step/index.ts` — barrel.
- `public/workflows/step_types/get_related_alerts_step/get_related_alerts_step.ts` — public step definition (icon, label, docs).
- `public/workflows/step_types/get_related_alerts_step/index.ts` — barrel.

Edited:

- `server/workflows/step_types/register_workflow_steps.ts` — register the new step behind the same `REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG` that already gates the two existing security workflow steps.
- `server/workflows/step_types/register_workflow_steps.test.ts` — extend to 3 registered steps; assert the new loader resolves to `getRelatedAlertsStepDefinition`.
- `public/workflows/step_types/register_workflow_steps.ts` — same registration on the public side via lazy-loaded import.
- `public/workflows/step_types/register_workflow_steps.test.ts` — same test extension.

Unchanged on purpose:
- The Agent Builder skills (v1/v2/v3) — this PR does not pick a v* on the AB side; that's the call of #269397 / #269388 owners. v4 sits **next** to v3, not instead of it.
- The internal HTTP route from #269397 — it stays as the cross-process surface (for MCP clients, external workflows-like callers, and the existing v2 skill until it's deprecated).
- The `findRelatedAlerts` service — it's already the single source of truth.

## Risk isolation

Five existing mitigations cover the security-relevant threats for this step:

| Threat | Mitigation | Source |
|---|---|---|
| Untrusted workflow author calls step | Same `REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG` flag that gates the other two security workflow steps | `common/constants.ts` |
| Workflows can read alerts a user shouldn't see | `context.contextManager.getScopedEsClient()` returns the scoped client; respects ES-level RBAC | workflows-extensions contract |
| Step schema accepts malformed input | Zod schema with `.refine()`+`.min()`/`.max()` bounds + `safeParse` at the engine boundary | this PR |
| Output leaks the `ok` discriminator from the shared service | Handler strips `ok` before returning to the workflow engine | this PR (unit-tested) |
| Step appears in workflow editor before it's ready | `async () => undefined` loader resolves silently when the feature flag is off | workflows-extensions contract |

No new feature flag, no new RBAC privilege, no new saved-object type. Nothing additive on the contract surface.

## Anti-overengineering self-check

1. **Existing-abstraction search**: `workflowsExtensions.registerStepDefinition` (`src/platform/plugins/shared/workflows_extensions/server/types.ts:40`) is the in-tree primitive for adding workflow step types; two security steps already use it (`render_alert_narrative_step`, `build_alert_entity_graph_step`).
2. **Named real consumer**: Workflows authors who today have to use `workflow_execute_step + kibana.request` for this exact alert-correlation flow (see the v2 skill body) — this PR removes that need.
3. **Smallest in-place version**: A 50-line `createServerStepDefinition` wrapping `findRelatedAlerts` — done.
4. **Deletion list**: Nothing deleted yet. v2's `workflow_execute_step`-shaped skill should be deprecated in a follow-up once v3+v4 land, but that's a separate, security-team-owned call.
5. **Existing isolation mechanisms**: See the table above — five mitigations already cover the threat model.
6. **Cost paragraph**: One ~70-line common file + ~50-line server step + ~20-line public step + tests. Zero new plugin, no new RBAC privilege, no new feature flag, no contract churn. Maintenance cost: this is now the canonical workflow step for the existing `findRelatedAlerts` service — that service was already maintained.

## Test plan

- [x] Unit: `node scripts/jest --config x-pack/solutions/security/plugins/security_solution/server/workflows/jest.config.js --testPathPattern 'get_related_alerts_step|register_workflow_steps'` → 12 tests pass.
- [x] Unit: `node scripts/jest --config x-pack/solutions/security/plugins/security_solution/public/workflows/jest.config.js --testPathPattern 'register_workflow_steps'` → 4 tests pass.
- [x] Scoped lint (`node scripts/eslint <touched files>`) → clean.
- [x] Scoped type_check (`node scripts/type_check --project x-pack/solutions/security/plugins/security_solution/tsconfig.json`) → **zero new type errors from v4**. The 90 pre-existing errors on the v3 base (`find_related_alerts.ts`, `register_skills.test.ts`, `alert_analysis_skill_*`, plus errors in unrelated `agent_builder_workflows` packages that exist on v3) are unchanged by v4; baseline run with v4 stashed reproduced exactly the same 90 errors. v4 files (`get_related_alerts_step/*` and `register_workflow_steps.ts` / `.test.ts`) appear in zero error rows.
- [x] **Static empirics:** per-turn system-prompt bytes counted directly from each variant's skill source — see the comparison table above. Reproducible via `node v4-experiment/static_empirics.mjs` in the [skill-dev plugin](https://github.com/elastic/agent-builder-skill-dev-cursor-plugin). Headline finding: input-side overhead is +158 tokens for v2 vs v1, **not** dramatic — the v2 regression most likely lives in completion-side YAML authoring (~7× more output tokens per related-alerts call) and reasoning overhead before the call.
- [ ] **Trace-based dynamic empirics (deferred follow-up).** Methodology is shipped: `v4-experiment/run_variant.sh` drives `/api/agent_builder/converse` with the 5 alert-analysis eval-suite questions × n=5 reps and captures per-call `trace_id`; `v4-experiment/pull_traces.sh` queries the local-traces EDOT/ES stack and aggregates per-trace `gen_ai.usage.input_tokens / output_tokens / cached_tokens` plus tool-call span counts. Requires booting Kibana three times (no flag → v1, `--xpack.securitySolution.enableExperimental=["alertAnalysisApiDrivenSkill"]` → v2, `["alertAnalysisInlineApiToolSkill"]` → v3). Will land as an amendment to this PR body once the per-variant traces are pulled. v4-AB-side === v3-AB-side, so v4 inherits v3's numbers; only Workflows-side v4 needs separate measurement (workflow execution latency for the native step type vs `workflow_execute_step + kibana.request`).
- [ ] **Empirics (running in background, body will be amended):** v1 vs v2 vs v3 vs v4 over the 5 alert-analysis eval-suite questions, n=5 each, Sonnet 4.5, trace export to a local Elasticsearch via EDOT. Will land as a follow-up commit on this branch with the trace summary in this body.

## Linked work

- #269388 — v2 (workflow_execute_step + kibana.request). Recommendation post-evals: keep for **multi-step** workflows the LLM composes on the fly; **demote** for single-API-call patterns like alert correlation.
- #269397 — v3 (inline tool → shared service). Recommendation: ship as the canonical AB-side surface; v4 piggy-backs on its handler.
- (Follow-up) skill-dev-plugin guidance: invert the decision tree so `workflow_execute_step` is recommended only for actual orchestration. Deferred until v4 empirics confirm.

## How to verify locally

1. `xpack.workflows.enabled: true` in `kibana.dev.yml` (already on in most dev configs).
2. Enable the existing feature flag `securitySolution.registerAlertValidationSteps`.
3. In the workflows editor, look for **"Get Related Alerts"** under the Kibana step category.
4. In an Agent Builder conversation, the alert-analysis skill behaves as in #269397.

Both surfaces hit the same `findRelatedAlerts` service — `git grep -n 'findRelatedAlerts(' x-pack/solutions/security/plugins/security_solution/server` returns the inline-tool handler + the new workflow step handler + the route handler from #269397.
