### PR TITLE
[9.3] [Fleet] Fix flaky policy_secrets integration tests (#269330)

### DIFF
--- a/x-pack/platform/test/fleet_api_integration/apis/policy_secrets.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/policy_secrets.ts
@@ -747,10 +747,16 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       it('should have correctly deleted unused secrets after update', async () => {
-        const searchRes = await getSecrets();
-        expect(searchRes.hits.hits.length).to.eql(5); // should have created 2 and deleted 2 docs
+        // Secret deletion is async — retry until the expected count is reached
+        let searchRes: Awaited<ReturnType<typeof getSecrets>> | undefined;
+        for (let i = 0; i < 5; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          searchRes = await getSecrets();
+          if (searchRes.hits.hits.length === 5) break;
+        }
+        expect(searchRes!.hits.hits.length).to.eql(5); // should have created 2 and deleted 2 docs
 
-        const secretValuesById = searchRes.hits.hits.reduce((acc: any, secret: any) => {
+        const secretValuesById = searchRes!.hits.hits.reduce((acc: any, secret: any) => {
           acc[secret._id] = secret._source.value;
           return acc;
         }, {});
@@ -911,13 +917,15 @@ export default function (providerContext: FtrProviderContext) {
           .set('kbn-xsrf', 'xxxx')
           .expect(200);
 
-        // sleep to allow for secrets to be deleted
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        // Secret deletion is async — retry until the expected count is reached
+        for (let i = 0; i < 5; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          const searchRes = await getSecrets();
+          // should have deleted new_package_secret_val_2 and new_package_multi_secret_val_3/4
+          if (searchRes.hits.hits.length === 5) return;
+        }
 
-        const searchRes = await getSecrets();
-
-        // should have deleted new_package_secret_val_2 and new_package_multi_secret_val_3/4
-        expect(searchRes.hits.hits.length).to.eql(5);
+        throw new Error('Secrets not deleted to expected count of 5');
       });
     });
 
@@ -964,9 +972,14 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('fleet server version requirements', () => {
       afterEach(async () => {
-        await cleanupAgents();
-        await cleanupPolicies();
-        await cleanupSecrets();
+        await pRetry(
+          async () => {
+            await cleanupAgents();
+            await cleanupPolicies();
+            await cleanupSecrets();
+          },
+          { retries: 3 }
+        );
       });
       it('should not store secrets if fleet server does not meet minimum version', async () => {
         const { fleetServerAgentPolicy } = await createFleetServerAgentPolicy();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Fleet] Fix flaky policy_secrets integration tests (#269330)](https://github.com/elastic/kibana/pull/269330)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-15T07:46:53Z","message":"[Fleet] Fix flaky policy_secrets integration tests (#269330)\n\n## Summary\nFixes flaky failures in `policy_secrets.ts` FTR integration tests across\ntwo root causes:\n\n**1. `afterEach` hook failures** — the `fleet server version\nrequirements` describe block's cleanup (`cleanupAgents` →\n`cleanupPolicies` → `cleanupSecrets`) was failing intermittently due to\ntransient 409 conflicts. Wrapped in `pRetry({ retries: 3 })`.\n\n**2. Async secret deletion races** — two tests asserted secret counts\nimmediately after a delete/update operation, before the async deletion\ncompleted. Applied the same retry loop (5 × 1s) already used in the\n`delete package policy` test.\n\nCloses #266407, #257724, #247484, #239701, #236967, #230676\n\n## Issues\n- fixes #266407 — update: deleted unused secrets after update\n- fixes #257724 — afterEach hook: \"should store secrets if there are no\nfleet servers\"\n- fixes #247484 — copy: should not delete used secrets on delete of\nduplicated package policy\n- fixes #239701 — afterEach hook: \"should not revert to plaintext values\nif the user adds an out of date fleet server\"\n- fixes #236967 — delete: should delete all secrets on package policy\ndelete\n- fixes #230676 — afterEach hook: \"should store secrets if additional\nfleet server does not meet minimum version, but is unenrolled\"","sha":"a20fb174497bd9fac28f122004205590368c8c3a","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.5.0","v8.19.16","v9.3.5","v9.4.2"],"title":"[Fleet] Fix flaky policy_secrets integration tests","number":269330,"url":"https://github.com/elastic/kibana/pull/269330","mergeCommit":{"message":"[Fleet] Fix flaky policy_secrets integration tests (#269330)\n\n## Summary\nFixes flaky failures in `policy_secrets.ts` FTR integration tests across\ntwo root causes:\n\n**1. `afterEach` hook failures** — the `fleet server version\nrequirements` describe block's cleanup (`cleanupAgents` →\n`cleanupPolicies` → `cleanupSecrets`) was failing intermittently due to\ntransient 409 conflicts. Wrapped in `pRetry({ retries: 3 })`.\n\n**2. Async secret deletion races** — two tests asserted secret counts\nimmediately after a delete/update operation, before the async deletion\ncompleted. Applied the same retry loop (5 × 1s) already used in the\n`delete package policy` test.\n\nCloses #266407, #257724, #247484, #239701, #236967, #230676\n\n## Issues\n- fixes #266407 — update: deleted unused secrets after update\n- fixes #257724 — afterEach hook: \"should store secrets if there are no\nfleet servers\"\n- fixes #247484 — copy: should not delete used secrets on delete of\nduplicated package policy\n- fixes #239701 — afterEach hook: \"should not revert to plaintext values\nif the user adds an out of date fleet server\"\n- fixes #236967 — delete: should delete all secrets on package policy\ndelete\n- fixes #230676 — afterEach hook: \"should store secrets if additional\nfleet server does not meet minimum version, but is unenrolled\"","sha":"a20fb174497bd9fac28f122004205590368c8c3a"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.3","9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269330","number":269330,"mergeCommit":{"message":"[Fleet] Fix flaky policy_secrets integration tests (#269330)\n\n## Summary\nFixes flaky failures in `policy_secrets.ts` FTR integration tests across\ntwo root causes:\n\n**1. `afterEach` hook failures** — the `fleet server version\nrequirements` describe block's cleanup (`cleanupAgents` →\n`cleanupPolicies` → `cleanupSecrets`) was failing intermittently due to\ntransient 409 conflicts. Wrapped in `pRetry({ retries: 3 })`.\n\n**2. Async secret deletion races** — two tests asserted secret counts\nimmediately after a delete/update operation, before the async deletion\ncompleted. Applied the same retry loop (5 × 1s) already used in the\n`delete package policy` test.\n\nCloses #266407, #257724, #247484, #239701, #236967, #230676\n\n## Issues\n- fixes #266407 — update: deleted unused secrets after update\n- fixes #257724 — afterEach hook: \"should store secrets if there are no\nfleet servers\"\n- fixes #247484 — copy: should not delete used secrets on delete of\nduplicated package policy\n- fixes #239701 — afterEach hook: \"should not revert to plaintext values\nif the user adds an out of date fleet server\"\n- fixes #236967 — delete: should delete all secrets on package policy\ndelete\n- fixes #230676 — afterEach hook: \"should store secrets if additional\nfleet server does not meet minimum version, but is unenrolled\"","sha":"a20fb174497bd9fac28f122004205590368c8c3a"}},{"branch":"8.19","label":"v8.19.16","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->