### PR TITLE
[kbn-check-saved-objects-cli] Validate ignore_above on keyword/flattened mapping fields

### DIFF
--- a/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/mappings_updated_no_bump.json
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/mappings_updated_no_bump.json
@@ -92,6 +92,7 @@
       "mappings": {
         "dynamic": false,
         "properties.someNewProperty.type": "keyword",
+        "properties.someNewProperty.ignore_above": 1024,
         "properties.taskType.type": "keyword",
         "properties.scheduledAt.type": "date",
         "properties.runAt.type": "date",

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/nested_mapping_fields.json
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/nested_mapping_fields.json
@@ -28,7 +28,9 @@
       "mappings": {
         "dynamic": false,
         "properties.topLevel.type": "keyword",
-        "properties.parent.properties.child.type": "keyword"
+        "properties.topLevel.ignore_above": 1024,
+        "properties.parent.properties.child.type": "keyword",
+        "properties.parent.properties.child.ignore_above": 1024
       }
     }
   }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/new_mappings_not_in_model_version.json
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/new_mappings_not_in_model_version.json
@@ -129,7 +129,8 @@
         "properties.partition.type": "integer",
         "properties.priority.type": "integer",
         "properties.userScope.properties.apiKeyId.type": "keyword",
-        "properties.newUndeclaredField.type": "keyword"
+        "properties.newUndeclaredField.type": "keyword",
+        "properties.newUndeclaredField.ignore_above": 1024
       }
     }
   }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/two_new_model_versions.json
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/two_new_model_versions.json
@@ -118,7 +118,9 @@
       "mappings": {
         "dynamic": false,
         "properties.someNewProperty.type": "keyword",
+        "properties.someNewProperty.ignore_above": 1024,
         "properties.anotherNewProperty.type": "keyword",
+        "properties.anotherNewProperty.ignore_above": 1024,
         "properties.taskType.type": "keyword",
         "properties.scheduledAt.type": "date",
         "properties.runAt.type": "date",

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
@@ -257,6 +257,33 @@ export function validateNoIndexOrEnabledFalseInAllMappings(
   throwIfIndexOrEnabledFalse(name, fieldsWithIndexFalse, fieldsWithEnabledFalse);
 }
 
+const TYPES_REQUIRING_IGNORE_ABOVE = new Set(['keyword', 'flattened']);
+
+/**
+ * Returns the paths of all `keyword` and `flattened` mapping fields that are missing an
+ * `ignore_above` constraint. Paths are expressed in schema format (dot-separated, with
+ * `.properties.` collapsed), e.g. `parent.child` or `name.fields.keyword`.
+ */
+export function getFieldsMissingIgnoreAbove(mappings: Record<string, unknown>): string[] {
+  return Object.entries(mappings)
+    .filter(([key, value]) => {
+      if (!key.endsWith('.type')) return false;
+      if (!TYPES_REQUIRING_IGNORE_ABOVE.has(value as string)) return false;
+      const fieldPrefix = key.slice(0, -'.type'.length);
+      // Non-indexed fields are never indexed, so ignore_above has no effect on them.
+      if (mappings[`${fieldPrefix}.index`] === false) return false;
+      return !(`${fieldPrefix}.ignore_above` in mappings);
+    })
+    .map(([key]) => {
+      const fieldPrefix = key.slice(0, -'.type'.length);
+      const withoutTopLevelPrefix = fieldPrefix.startsWith('properties.')
+        ? fieldPrefix.slice('properties.'.length)
+        : fieldPrefix;
+      return toSchemaPathFormat(withoutTopLevelPrefix);
+    })
+    .sort();
+}
+
 /**
  * Returns the invalid name/title fields for a given mapping snapshot, expressed as
  * `{ fieldName, description }` pairs. The caller decides whether to warn or throw.

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.test.ts
@@ -216,6 +216,141 @@ describe('validateChangesExistingType', () => {
     );
   });
 
+  describe('ignore_above validation', () => {
+    const sharedModelVersionIgnoreAbove = {
+      version: '1',
+      modelVersionHash: 'hash',
+      changeTypes: [],
+      hasTransformation: false,
+      newMappings: [],
+      schemas: { create: 'hash', forwardCompatibility: 'hash' },
+    };
+
+    const buildRecordIgnoreAbove = (
+      mappings: Record<string, unknown> = {}
+    ): MigrationInfoRecord => ({
+      name: 'my-type',
+      hash: 'hash',
+      migrationVersions: [],
+      schemaVersions: [],
+      modelVersions: [sharedModelVersionIgnoreAbove],
+      mappings,
+    });
+
+    const baseRegisteredType: SavedObjectsType = {
+      name: 'my-type',
+      namespaceType: 'agnostic',
+      hidden: false,
+      mappings: { dynamic: false, properties: {} },
+      modelVersions: {},
+    } as unknown as SavedObjectsType;
+
+    it('should warn (not throw) when a keyword field was already missing ignore_above in the baseline', () => {
+      const from = buildRecordIgnoreAbove({ 'properties.myField.type': 'keyword' });
+      const to = buildRecordIgnoreAbove({ 'properties.myField.type': 'keyword' });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: baseRegisteredType, log })
+      ).not.toThrow();
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "pre-existing 'keyword' or 'flattened' mapping fields without 'ignore_above'"
+        )
+      );
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('myField'));
+    });
+
+    it('should warn (not throw) when a flattened field was already missing ignore_above in the baseline', () => {
+      const from = buildRecordIgnoreAbove({ 'properties.dataField.type': 'flattened' });
+      const to = buildRecordIgnoreAbove({ 'properties.dataField.type': 'flattened' });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: baseRegisteredType, log })
+      ).not.toThrow();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('dataField'));
+    });
+
+    it('should throw when a new keyword field is introduced without ignore_above', () => {
+      const from = buildRecordIgnoreAbove({});
+      const to = buildRecordIgnoreAbove({ 'properties.newField.type': 'keyword' });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: baseRegisteredType, log })
+      ).toThrowError(
+        /The SO type 'my-type' has newly introduced 'keyword' or 'flattened' mapping fields without 'ignore_above': newField/
+      );
+    });
+
+    it('should throw when a new flattened field is introduced without ignore_above', () => {
+      const from = buildRecordIgnoreAbove({});
+      const to = buildRecordIgnoreAbove({ 'properties.dataField.type': 'flattened' });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: baseRegisteredType, log })
+      ).toThrowError(
+        /The SO type 'my-type' has newly introduced 'keyword' or 'flattened' mapping fields without 'ignore_above': dataField/
+      );
+    });
+
+    it('should not throw or warn when all keyword fields have ignore_above', () => {
+      // Use the same mappings in from and to to avoid triggering the "no model version bump" check.
+      const mappings = {
+        'properties.myField.type': 'keyword',
+        'properties.myField.ignore_above': 1024,
+      };
+      const from = buildRecordIgnoreAbove(mappings);
+      const to = buildRecordIgnoreAbove(mappings);
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: baseRegisteredType, log })
+      ).not.toThrow();
+      expect(log).not.toHaveBeenCalledWith(expect.stringContaining('ignore_above'));
+    });
+
+    it('should warn for pre-existing fields and throw for newly introduced ones in the same type', () => {
+      const from = buildRecordIgnoreAbove({ 'properties.oldField.type': 'keyword' });
+      const to = buildRecordIgnoreAbove({
+        'properties.oldField.type': 'keyword',
+        'properties.newField.type': 'keyword',
+      });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: baseRegisteredType, log })
+      ).toThrowError(/newField/);
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('pre-existing'));
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('oldField'));
+    });
+
+    it('should throw when a new keyword subfield (multi-field) is introduced without ignore_above', () => {
+      const from = buildRecordIgnoreAbove({ 'properties.name.type': 'text' });
+      const to = buildRecordIgnoreAbove({
+        'properties.name.type': 'text',
+        'properties.name.fields.keyword.type': 'keyword',
+      });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: baseRegisteredType, log })
+      ).toThrowError(/name\.fields\.keyword/);
+    });
+
+    it('should not throw when a keyword field lost ignore_above relative to baseline (treated as newly introduced problem)', () => {
+      // A field that had ignore_above in the baseline but lost it is a newly introduced problem,
+      // even though the field key existed before.
+      const from = buildRecordIgnoreAbove({
+        'properties.myField.type': 'keyword',
+        'properties.myField.ignore_above': 1024,
+      });
+      const to = buildRecordIgnoreAbove({ 'properties.myField.type': 'keyword' });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: baseRegisteredType, log })
+      ).toThrowError(
+        /The SO type 'my-type' has newly introduced 'keyword' or 'flattened' mapping fields without 'ignore_above': myField/
+      );
+      expect(log).not.toHaveBeenCalled();
+    });
+  });
+
   describe('name/title field type validation', () => {
     const sharedModelVersion = {
       version: '1',
@@ -295,7 +430,7 @@ describe('validateChangesExistingType', () => {
       expect(log).not.toHaveBeenCalled();
     });
 
-    it('should not validate types not searchable via the management page', () => {
+    it('should not validate name/title field types for types not searchable via the management page', () => {
       const internalType: SavedObjectsType = {
         name: 'my-type',
         namespaceType: 'agnostic',
@@ -306,13 +441,17 @@ describe('validateChangesExistingType', () => {
       } as unknown as SavedObjectsType;
       // Use the same keyword mapping in both from and to so that the model-version check does not
       // fire — we only want to verify that the name/title check is skipped for internal types.
+      // Both snapshots have the same keyword field, so it is treated as pre-existing by the
+      // ignore_above check, which emits a warning but does not throw.
       const from = buildRecord({ 'properties.name.type': 'keyword' });
       const to = buildRecord({ 'properties.name.type': 'keyword' });
 
       expect(() =>
         validateChangesExistingType({ from, to, registeredType: internalType, log })
       ).not.toThrow();
-      expect(log).not.toHaveBeenCalled();
+      expect(log).not.toHaveBeenCalledWith(
+        expect.stringContaining("'name' or 'title' fields with incorrect types")
+      );
     });
   });
 });

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
@@ -22,6 +22,7 @@ import {
   validateNoModelVersionChanges,
   validateModelVersionsChanges,
   validateNewMappingsInModelVersion,
+  validateIgnoreAboveExistingType,
   validateNameTitleFieldTypesExistingType,
 } from './existing_type_utils';
 
@@ -63,6 +64,9 @@ export function validateChangesExistingType({
 
   // validate that name and title fields are of type "text"
   validateNameTitleFieldTypesExistingType(name, to, from, registeredType, log);
+
+  // validate that keyword and flattened fields have ignore_above
+  validateIgnoreAboveExistingType(name, to, from, log);
 
   const newModelVersionCount = to.modelVersions.length - from.modelVersions.length;
 

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type_utils.ts
@@ -12,6 +12,7 @@ import { cloneDeep, difference } from 'lodash';
 import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
 import type { MigrationInfoRecord, ModelVersionSummary } from '../../types';
 import {
+  getFieldsMissingIgnoreAbove,
   getMappingFieldPaths,
   validateAllMappingsInModelVersion,
   getLatestModelVersion,
@@ -152,6 +153,44 @@ export function validateNewMappingsInModelVersion(
         newModelVersion.version
       }': ${undeclaredFields.join(', ')}. ` +
         `All new mapping fields must be declared via 'mappings_addition' changes in the corresponding model version.`
+    );
+  }
+}
+
+/**
+ * Validates that all `keyword` and `flattened` mapping fields on an **existing** SO type define
+ * `ignore_above`. Fields that were already missing the constraint in the baseline (`from`) emit a
+ * warning instead of throwing, because the fix (adding a model version with `ignore_above`) is
+ * low-risk but still requires deliberate action. Newly introduced fields always throw.
+ */
+export function validateIgnoreAboveExistingType(
+  name: string,
+  to: MigrationInfoRecord,
+  from: MigrationInfoRecord,
+  log: (message: string) => void
+): void {
+  const missingInTo = getFieldsMissingIgnoreAbove(to.mappings);
+  if (missingInTo.length === 0) return;
+
+  const missingInFromSet = new Set(getFieldsMissingIgnoreAbove(from.mappings));
+  const preExisting = missingInTo.filter((field) => missingInFromSet.has(field));
+  const newlyIntroduced = missingInTo.filter((field) => !missingInFromSet.has(field));
+
+  if (preExisting.length > 0) {
+    log(
+      `⚠️  The SO type '${name}' has pre-existing 'keyword' or 'flattened' mapping fields without 'ignore_above': ${preExisting.join(
+        ', '
+      )}. ` +
+        `Consider adding 'ignore_above' to prevent Elasticsearch from silently dropping strings that exceed the limit.`
+    );
+  }
+
+  if (newlyIntroduced.length > 0) {
+    throw new Error(
+      `❌ The SO type '${name}' has newly introduced 'keyword' or 'flattened' mapping fields without 'ignore_above': ${newlyIntroduced.join(
+        ', '
+      )}. ` +
+        `Add 'ignore_above' to prevent Elasticsearch from silently dropping strings that exceed the limit.`
     );
   }
 }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.test.ts
@@ -251,7 +251,7 @@ describe('validateChangesNewType', () => {
 
   it('should not throw for types not searchable via the management page, even if name field has non-text type', () => {
     const to = buildNewType('my-internal-type', {
-      mappings: { 'properties.name.type': 'keyword' },
+      mappings: { 'properties.name.type': 'keyword', 'properties.name.ignore_above': 1024 },
     });
     // importableAndExportable: false is the exemption criterion — the management find route
     // only searches types with importableAndExportable: true
@@ -278,6 +278,76 @@ describe('validateChangesNewType', () => {
     expect(() => callValidate(to, hiddenExportableType)).toThrow(
       /The SO type 'my-hidden-exportable-type' has 'name' or 'title' fields with incorrect types/
     );
+  });
+
+  describe('ignore_above validation', () => {
+    it('should throw when a keyword field is missing ignore_above', () => {
+      const to = buildNewType('my-type', {
+        mappings: { 'properties.myField.type': 'keyword' },
+      });
+
+      expect(() => callValidate(to, createMockType('my-type', ['myField']))).toThrowError(
+        /The SO type 'my-type' has 'keyword' or 'flattened' mapping fields without 'ignore_above': myField/
+      );
+    });
+
+    it('should throw when a flattened field is missing ignore_above', () => {
+      const to = buildNewType('my-type', {
+        mappings: { 'properties.dataField.type': 'flattened' },
+      });
+
+      expect(() => callValidate(to, createMockType('my-type', ['dataField']))).toThrowError(
+        /The SO type 'my-type' has 'keyword' or 'flattened' mapping fields without 'ignore_above': dataField/
+      );
+    });
+
+    it('should not throw when all keyword fields have ignore_above', () => {
+      const to = buildNewType('my-type', {
+        mappings: {
+          'properties.myField.type': 'keyword',
+          'properties.myField.ignore_above': 1024,
+        },
+      });
+
+      expect(() => callValidate(to, createMockType('my-type', ['myField']))).not.toThrow();
+    });
+
+    it('should throw when a keyword subfield (multi-field) is missing ignore_above', () => {
+      const to = buildNewType('my-type', {
+        mappings: {
+          'properties.name.type': 'text',
+          'properties.name.fields.keyword.type': 'keyword',
+        },
+      });
+
+      expect(() => callValidate(to, createMockType('my-type', ['name']))).toThrowError(
+        /name\.fields\.keyword/
+      );
+    });
+
+    it('should throw when a nested keyword field is missing ignore_above', () => {
+      const to = buildNewType('my-type', {
+        mappings: {
+          'properties.parent.properties.child.type': 'keyword',
+        },
+      });
+
+      expect(() =>
+        callValidate(to, createMockType('my-type', ['parent.child']))
+      ).toThrowError(/parent\.child/);
+    });
+
+    it('should not throw when a text field with a keyword subfield has ignore_above on the subfield', () => {
+      const to = buildNewType('my-type', {
+        mappings: {
+          'properties.name.type': 'text',
+          'properties.name.fields.keyword.type': 'keyword',
+          'properties.name.fields.keyword.ignore_above': 2048,
+        },
+      });
+
+      expect(() => callValidate(to, createMockType('my-type', ['name']))).not.toThrow();
+    });
   });
 
   it('should not throw when mapping has nested fields that match schema (path format normalization)', () => {
@@ -370,7 +440,9 @@ describe('validateChangesNewType', () => {
     const to = buildNewType('my-array-type', {
       mappings: {
         'properties.destinations.properties.id.type': 'keyword',
+        'properties.destinations.properties.id.ignore_above': 1024,
         'properties.destinations.properties.type.type': 'keyword',
+        'properties.destinations.properties.type.ignore_above': 1024,
       },
     });
 

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.test.ts
@@ -332,9 +332,9 @@ describe('validateChangesNewType', () => {
         },
       });
 
-      expect(() =>
-        callValidate(to, createMockType('my-type', ['parent.child']))
-      ).toThrowError(/parent\.child/);
+      expect(() => callValidate(to, createMockType('my-type', ['parent.child']))).toThrowError(
+        /parent\.child/
+      );
     });
 
     it('should not throw when a text field with a keyword subfield has ignore_above on the subfield', () => {

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.ts
@@ -18,7 +18,7 @@ import {
   validateInitialModelVersion,
   getFirstModelVersion,
 } from './common_utils';
-import { validateNameTitleFieldTypesNewType } from './new_type_utils';
+import { validateIgnoreAboveNewType, validateNameTitleFieldTypesNewType } from './new_type_utils';
 
 interface ValidateChangesNewTypeParams {
   to: MigrationInfoRecord;
@@ -53,4 +53,7 @@ export function validateChangesNewType({ to, registeredType }: ValidateChangesNe
 
   // validate that name and title fields are of type "text"
   validateNameTitleFieldTypesNewType(name, to, registeredType);
+
+  // validate that keyword and flattened fields have ignore_above
+  validateIgnoreAboveNewType(name, to);
 }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type_utils.ts
@@ -9,7 +9,30 @@
 
 import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
 import type { MigrationInfoRecord } from '../../types';
-import { getInvalidNameTitleFields, isSearchableViaManagement } from './common_utils';
+import {
+  getFieldsMissingIgnoreAbove,
+  getInvalidNameTitleFields,
+  isSearchableViaManagement,
+} from './common_utils';
+
+/**
+ * Validates that all `keyword` and `flattened` mapping fields on a **new** SO type define
+ * `ignore_above`. Without this constraint, Elasticsearch silently drops strings that exceed
+ * the default length limit during indexing, which can cause hard-to-diagnose data loss.
+ *
+ * Throws if any field is missing `ignore_above`.
+ */
+export function validateIgnoreAboveNewType(name: string, to: MigrationInfoRecord): void {
+  const fieldsMissing = getFieldsMissingIgnoreAbove(to.mappings);
+  if (fieldsMissing.length > 0) {
+    throw new Error(
+      `❌ The SO type '${name}' has 'keyword' or 'flattened' mapping fields without 'ignore_above': ${fieldsMissing.join(
+        ', '
+      )}. ` +
+        `Add 'ignore_above' to prevent Elasticsearch from silently dropping strings that exceed the limit.`
+    );
+  }
+}
 
 /**
  * Validates that `name` and `title` mapping fields use `type: text` on a **new** SO type being


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana-team/issues/3139

Adds a new validation to the **Check changes in Saved Objects** CI step that enforces `ignore_above` on `keyword` and `flattened` mapping fields.

Without `ignore_above`, Elasticsearch silently drops strings that exceed the default index limit during indexing, which can cause hard-to-diagnose data loss. This check surfaces the problem at definition time rather than at runtime.

### Behaviour

Mirrors the existing name/title field type check pattern:

- **New SO types** → **hard error**: new types must be correct from day 0.
- **Existing SO types**:
  - Fields already missing `ignore_above` in the baseline → **warning** (pre-existing debt, cannot require reindexing).
  - Fields newly introduced without `ignore_above` → **hard error**.

Fields with `index: false` are exempt (non-indexed fields are never indexed, so `ignore_above` has no effect). Multi-fields (e.g. `name.fields.keyword`) are included in the check.

### Implementation

| File | Change |
|------|--------|
| `common_utils.ts` | `getFieldsMissingIgnoreAbove(mappings)` — scans a flat mapping snapshot for keyword/flattened fields missing `ignore_above` |
| `new_type_utils.ts` | `validateIgnoreAboveNewType(name, to)` — throws on any missing `ignore_above` |
| `existing_type_utils.ts` | `validateIgnoreAboveExistingType(name, to, from, log)` — warns for pre-existing, throws for newly introduced |
| `new_type.ts` / `existing_type.ts` | Wired in at the end of each type's check sequence |
| Test fixtures | Updated with `ignore_above` where new keyword fields were added (so the fixtures represent valid mappings and the originally intended validation can be reached) |

## Test plan

- [x] All 54 existing and new unit tests pass (`node scripts/jest packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes`)
- [ ] CI green

Made with [Cursor](https://cursor.com)