### PR TITLE
[Search] Add error text to Sort By field in Docs Explorer

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/search_ui_components.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/search_ui_components.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { useValues } from 'kea';
 
@@ -18,6 +18,7 @@ import {
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiFormRow,
   EuiIcon,
   EuiPanel,
   EuiSelect,
@@ -204,6 +205,10 @@ export const ResultsPerPageView: React.FC<ResultsPerPageViewProps> = ({
       </EuiTitle>
       <EuiSelect
         id="results-per-page"
+        aria-label={i18n.translate(
+          'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.resultsPerPage.ariaLabel',
+          { defaultMessage: 'Results per page' }
+        )}
         options={
           options?.map((option) => ({
             text: i18n.translate(
@@ -228,36 +233,59 @@ export const Sorting = withSearch<
   Pick<SearchContextState, 'setSort' | 'sortList'>
 >(({ setSort, sortList }) => ({ setSort, sortList }))(({ sortableFields, sortList, setSort }) => {
   const [{ direction, field }] = !sortList?.length ? [{ direction: '', field: '' }] : sortList;
+  const [searchValue, setSearchValue] = useState('');
   const relevance = i18n.translate(
     'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.sortingView.relevanceLabel',
     { defaultMessage: 'Relevance' }
   );
 
+  const options = useMemo(
+    () => [
+      { label: relevance, value: '' },
+      ...sortableFields.map((f: string) => ({ label: f, value: f })),
+    ],
+    [relevance, sortableFields]
+  );
+
+  const isInvalid = useMemo(() => {
+    if (!searchValue) return false;
+    return !options.some((opt) => opt.label.includes(searchValue));
+  }, [searchValue, options]);
+
+  const invalidFieldError = i18n.translate(
+    'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.sortingView.invalidFieldError',
+    { defaultMessage: 'No matching field found' }
+  );
+
   return (
     <EuiFlexItem grow={false}>
-      <EuiFlexGroup direction="column" gutterSize="s">
-        <EuiTitle size="xxxs">
-          <label htmlFor="sorting-field">
-            <FormattedMessage
-              id="xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.sortingView.fieldLabel"
-              defaultMessage="Sort By"
-            />
-          </label>
-        </EuiTitle>
+      <EuiFormRow
+        label={
+          <FormattedMessage
+            id="xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.sortingView.fieldLabel"
+            defaultMessage="Sort By"
+          />
+        }
+        isInvalid={isInvalid}
+        error={invalidFieldError}
+      >
         <EuiComboBox
-          id="sorting-field"
+          aria-label={i18n.translate(
+            'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.sortingView.fieldAriaLabel',
+            { defaultMessage: 'Sort by field' }
+          )}
           isClearable={false}
           singleSelection={{ asPlainText: true }}
-          options={[
-            { label: relevance, value: '' },
-            ...sortableFields.map((f: string) => ({ label: f, value: f })),
-          ]}
+          options={options}
           selectedOptions={[{ label: !!field ? field : relevance, value: field }]}
-          onChange={([{ value }]) =>
-            setSort(value === '' ? [] : [{ direction: 'asc', field: value }], 'asc')
-          }
+          onChange={([{ value }]) => {
+            setSearchValue('');
+            setSort(value === '' ? [] : [{ direction: 'asc', field: value }], 'asc');
+          }}
+          onSearchChange={setSearchValue}
+          isInvalid={isInvalid}
         />
-      </EuiFlexGroup>
+      </EuiFormRow>
       {field !== '' && (
         <>
           <EuiSpacer size="m" />
@@ -272,6 +300,10 @@ export const Sorting = withSearch<
             </EuiTitle>
             <EuiSelect
               id="sorting-direction"
+              aria-label={i18n.translate(
+                'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.sortingView.directionAriaLabel',
+                { defaultMessage: 'Sort direction' }
+              )}
               onChange={(evt) => {
                 switch (evt.target.value) {
                   case 'asc':

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/search_ui_components.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/search_ui_components.tsx
@@ -159,8 +159,17 @@ export const ResultView: React.FC<ResultViewProps> = ({ result }) => {
 };
 export const SearchBar: React.FC<InputProps> = ({ additionalInputProps }) => (
   <EuiFlexGroup gutterSize="s">
-    <EuiFieldSearch fullWidth {...additionalInputProps} />
-    <EuiButton type="submit" color="primary" fill>
+    <EuiFieldSearch
+      data-test-subj="enterpriseSearchSearchBarFieldSearch"
+      fullWidth
+      {...additionalInputProps}
+    />
+    <EuiButton
+      data-test-subj="enterpriseSearchSearchBarSearchButton"
+      type="submit"
+      color="primary"
+      fill
+    >
       {i18n.translate(
         'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.inputView.searchLabel',
         {
@@ -204,6 +213,7 @@ export const ResultsPerPageView: React.FC<ResultsPerPageViewProps> = ({
         </label>
       </EuiTitle>
       <EuiSelect
+        data-test-subj="enterpriseSearchResultsPerPageViewSelect"
         id="results-per-page"
         aria-label={i18n.translate(
           'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.resultsPerPage.ariaLabel',
@@ -299,6 +309,7 @@ export const Sorting = withSearch<
               </label>
             </EuiTitle>
             <EuiSelect
+              data-test-subj="enterpriseSearchSortingSelect"
               id="sorting-direction"
               aria-label={i18n.translate(
                 'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.sortingView.directionAriaLabel',


### PR DESCRIPTION
## Summary

Adds error text to the Sort By field in the Search Applications Docs Explorer when users type a value that doesn't match any available sorting options.

## Changes

- Wrapped the Sort By combobox in `EuiFormRow` to display validation errors following EUI best practices
- Added validation logic that tracks user input via `onSearchChange` and shows an error when no matching field is found
- Added `aria-label` attributes to form controls (`EuiSelect`, `EuiComboBox`) to fix accessibility warnings

### Before
Field gets red color but no error text present below the field.

### After
Error text "No matching field found" is displayed below the field when the user types a value that doesn't match any sorting option.

<img width="1507" height="855" alt="Screenshot 2026-05-15 at 11 18 12" src="https://github.com/user-attachments/assets/3768d834-8393-444c-aa9a-833eabfb9f6a" />

## Test Plan

1. Navigate to Search > Build > Search Applications > [select an app] > Docs Explorer
2. Click on the "Sort By" dropdown
3. Type any text that doesn't match an available field (e.g., "xyz")
4. Verify the field shows a red border AND error text "No matching field found" appears below the field
5. Clear the text or select a valid option and verify the error disappears


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->