### PR TITLE
[ResponseOps][Alerting] Encrypt api_key_pending_invalidation SOs written by UIAM provisioning task

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/integration_tests/api_key_pending_invalidation_encryption.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/integration_tests/api_key_pending_invalidation_encryption.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TestElasticsearchUtils, TestKibanaUtils } from '@kbn/core-test-helpers-kbn-server';
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { setupTestServers } from './lib';
+import { bulkMarkApiKeysForInvalidation } from '../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
+import { API_KEY_PENDING_INVALIDATION_TYPE } from '../saved_objects';
+
+// Locks in the encryption-on-write contract for `api_key_pending_invalidation`
+// SOs. The bug fixed in PR #254211's follow-up was that the UIAM provisioning
+// task built its writer via `createInternalRepository`, which has no
+// extensions; the resulting SOs persisted `apiKeyId` / `uiamApiKey` as
+// plaintext, and the alerting invalidation task then failed to decrypt them
+// with "Invalid initialization vector". This suite proves:
+//   1. Writes via `getUnsafeInternalClient` are encrypted at rest in ES.
+//   2. Writes via `createInternalRepository` are *not* — so any future
+//      regression that routes pending-invalidation writes through that factory
+//      will fail this test.
+describe('api_key_pending_invalidation encryption-on-write', () => {
+  let esServer: TestElasticsearchUtils;
+  let kibanaServer: TestKibanaUtils;
+  let esClient: ElasticsearchClient;
+  let unsafeInternalClient: SavedObjectsClientContract;
+  let plainInternalClient: SavedObjectsClientContract;
+  const logger = loggingSystemMock.createLogger();
+
+  // Encrypts a base64(id:value) string and persists an
+  // `api_key_pending_invalidation` SO via the supplied client; returns the
+  // raw `_source` from ES so the test can inspect what actually landed in
+  // the index (post-encryption-extension).
+  const persistAndReadRaw = async (
+    client: SavedObjectsClientContract,
+    encodedKey: string
+  ): Promise<{
+    apiKeyId: string;
+    uiamApiKey?: string;
+    _docId: string;
+  }> => {
+    await bulkMarkApiKeysForInvalidation({ apiKeys: [encodedKey] }, logger, client);
+
+    const search = await esClient.search<{
+      type: string;
+      api_key_pending_invalidation: { apiKeyId: string; uiamApiKey?: string };
+    }>({
+      index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+      query: { term: { type: API_KEY_PENDING_INVALIDATION_TYPE } },
+      sort: [{ updated_at: { order: 'desc' } }],
+      size: 1,
+    });
+    const hit = search.hits.hits[0];
+    expect(hit).toBeDefined();
+    const source = hit._source!;
+    return {
+      apiKeyId: source.api_key_pending_invalidation.apiKeyId,
+      uiamApiKey: source.api_key_pending_invalidation.uiamApiKey,
+      _docId: hit._id!,
+    };
+  };
+
+  const cleanPendingInvalidations = async () => {
+    await esClient.deleteByQuery({
+      index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+      query: { term: { type: API_KEY_PENDING_INVALIDATION_TYPE } },
+      refresh: true,
+      conflicts: 'proceed',
+    });
+  };
+
+  beforeAll(async () => {
+    const setupResult = await setupTestServers({
+      xpack: {
+        encryptedSavedObjects: {
+          // Any 32+ char value works; this key only exists for the duration
+          // of the test process.
+          encryptionKey: 'a'.repeat(32),
+        },
+      },
+    });
+    esServer = setupResult.esServer;
+    kibanaServer = setupResult.kibanaServer;
+
+    esClient = kibanaServer.coreStart.elasticsearch.client.asInternalUser;
+
+    // ESO encryption extension ships with `getUnsafeInternalClient` (and the
+    // request-scoped client), but not with `createInternalRepository`.
+    unsafeInternalClient = kibanaServer.coreStart.savedObjects.getUnsafeInternalClient({
+      includedHiddenTypes: [API_KEY_PENDING_INVALIDATION_TYPE],
+    });
+    plainInternalClient = kibanaServer.coreStart.savedObjects.createInternalRepository([
+      API_KEY_PENDING_INVALIDATION_TYPE,
+    ]);
+  });
+
+  afterAll(async () => {
+    if (kibanaServer) {
+      await kibanaServer.stop();
+    }
+    if (esServer) {
+      await esServer.stop();
+    }
+  });
+
+  beforeEach(async () => {
+    await cleanPendingInvalidations();
+  });
+
+  it('encrypts apiKeyId and uiamApiKey when written via getUnsafeInternalClient (UIAM key)', async () => {
+    const apiKeyId = 'uiam-key-id-123';
+    const uiamSecret = 'essu_uiam-secret-value';
+    const encodedKey = Buffer.from(`${apiKeyId}:${uiamSecret}`).toString('base64');
+
+    const raw = await persistAndReadRaw(unsafeInternalClient, encodedKey);
+
+    // ESO replaces the field with a base64 encrypted blob; never the literal
+    // input. The exact format is opaque, but it must not be the plaintext id
+    // and must be substantially longer than the input.
+    expect(raw.apiKeyId).not.toBe(apiKeyId);
+    expect(raw.apiKeyId.length).toBeGreaterThan(apiKeyId.length);
+    expect(raw.uiamApiKey).toBeDefined();
+    expect(raw.uiamApiKey).not.toBe(uiamSecret);
+    expect(raw.uiamApiKey!.length).toBeGreaterThan(uiamSecret.length);
+  });
+
+  it('encrypts apiKeyId when written via getUnsafeInternalClient (ES-only key)', async () => {
+    const apiKeyId = 'es-key-id-abc';
+    const esSecret = 'plain-es-secret';
+    const encodedKey = Buffer.from(`${apiKeyId}:${esSecret}`).toString('base64');
+
+    const raw = await persistAndReadRaw(unsafeInternalClient, encodedKey);
+
+    expect(raw.apiKeyId).not.toBe(apiKeyId);
+    expect(raw.apiKeyId.length).toBeGreaterThan(apiKeyId.length);
+    // No uiamApiKey is written for non-UIAM credentials, so it must be absent.
+    expect(raw.uiamApiKey).toBeUndefined();
+  });
+
+  it('persists apiKeyId / uiamApiKey AS PLAINTEXT when written via createInternalRepository (regression contract)', async () => {
+    // This is the path that caused the production bug. The assertion is
+    // intentionally inverted: it documents that `createInternalRepository`
+    // is unsafe for encrypted SO types, so the producer of these SOs must
+    // never be wired to it. If a future change makes
+    // `createInternalRepository` apply the encryption extension, this test
+    // will fail and the bug fix's wiring rationale should be revisited.
+    const apiKeyId = 'plaintext-leak-id';
+    const uiamSecret = 'essu_plaintext-leak-secret';
+    const encodedKey = Buffer.from(`${apiKeyId}:${uiamSecret}`).toString('base64');
+
+    const raw = await persistAndReadRaw(plainInternalClient, encodedKey);
+
+    expect(raw.apiKeyId).toBe(apiKeyId);
+    expect(raw.uiamApiKey).toBe(uiamSecret);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/provisioning/lib/create_provisioning_run_context.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/provisioning/lib/create_provisioning_run_context.ts
@@ -26,11 +26,12 @@ export const createProvisioningRunContext = async (
     includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE],
   });
   const unsafeSavedObjectsClient = coreStart.savedObjects.getUnsafeInternalClient({
-    includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE],
+    includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE, API_KEY_PENDING_INVALIDATION_TYPE],
   });
+  // The provisioning status SO has no encrypted attributes, so a plain internal
+  // repository is sufficient here.
   const savedObjectsClient = coreStart.savedObjects.createInternalRepository([
     UIAM_API_KEYS_PROVISIONING_STATUS_SAVED_OBJECT_TYPE,
-    API_KEY_PENDING_INVALIDATION_TYPE,
   ]);
   return {
     coreStart,

--- a/x-pack/platform/plugins/shared/alerting/server/provisioning/uiam_api_key_provisioning_task.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/provisioning/uiam_api_key_provisioning_task.test.ts
@@ -6,7 +6,12 @@
  */
 
 import { of, Subject } from 'rxjs';
-import { loggingSystemMock, coreMock, savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
+import {
+  loggingSystemMock,
+  coreMock,
+  savedObjectsClientMock,
+  savedObjectsRepositoryMock,
+} from '@kbn/core/server/mocks';
 import type { CoreSetup, CoreStart } from '@kbn/core/server';
 import type { ConvertUiamAPIKeysResponse } from '@kbn/core-security-server';
 import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
@@ -21,7 +26,11 @@ import {
   RESCHEDULE_DELAY_MS,
 } from './constants';
 import { emptyState } from './uiam_api_key_provisioning_task_state';
-import { RULE_SAVED_OBJECT_TYPE } from '../saved_objects';
+import {
+  API_KEY_PENDING_INVALIDATION_TYPE,
+  RULE_SAVED_OBJECT_TYPE,
+  UIAM_API_KEYS_PROVISIONING_STATUS_SAVED_OBJECT_TYPE,
+} from '../saved_objects';
 import {
   UiamApiKeyProvisioningEntityType,
   UiamApiKeyProvisioningStatus,
@@ -44,11 +53,26 @@ import { bulkMarkApiKeysForInvalidation } from '../invalidate_pending_api_keys/b
 function createMockCore(uiamConvert: jest.Mock): {
   coreSetup: CoreSetup;
   coreStart: CoreStart;
+  unsafeSavedObjectsClient: ReturnType<typeof savedObjectsClientMock.create>;
   savedObjectsClient: ReturnType<typeof savedObjectsRepositoryMock.create>;
   encryptedSavedObjectsClient: ReturnType<typeof encryptedSavedObjectsMock.createClient>;
 } {
   const coreSetup = coreMock.createSetup();
   const coreStart = coreMock.createStart();
+  // Two distinct mocks so test assertions reflect the production wiring:
+  //   - `unsafeSavedObjectsClient` is what `getUnsafeInternalClient` returns
+  //     in production (a `SavedObjectsClient` with the ESO encryption
+  //     extension applied). The provisioning task uses it for rule writes
+  //     (`bulkUpdate`) and for `api_key_pending_invalidation` writes
+  //     dispatched through `bulkMarkApiKeysForInvalidation`.
+  //   - `savedObjectsClient` is what `createInternalRepository` returns (a
+  //     plain `ISavedObjectsRepository` with no extensions). The task uses
+  //     it only for `uiam_api_keys_provisioning_status` writes (`bulkCreate`),
+  //     which has no encrypted attributes.
+  // Conflating the two would hide the bug fixed by routing pending-
+  // invalidation writes through the encryption-aware client (see
+  // `create_provisioning_run_context.ts`).
+  const unsafeSavedObjectsClient = savedObjectsClientMock.create();
   const savedObjectsClient = savedObjectsRepositoryMock.create();
   const encryptedSavedObjectsClient = encryptedSavedObjectsMock.createClient();
 
@@ -59,7 +83,9 @@ function createMockCore(uiamConvert: jest.Mock): {
   };
   coreSetup.getStartServices = jest.fn().mockResolvedValue([coreStart, plugins]);
 
-  coreStart.savedObjects.getUnsafeInternalClient = jest.fn().mockReturnValue(savedObjectsClient);
+  coreStart.savedObjects.getUnsafeInternalClient = jest
+    .fn()
+    .mockReturnValue(unsafeSavedObjectsClient);
   coreStart.savedObjects.createInternalRepository = jest.fn().mockReturnValue(savedObjectsClient);
 
   const uiam = coreStart.security?.authc?.apiKeys?.uiam as
@@ -70,7 +96,13 @@ function createMockCore(uiamConvert: jest.Mock): {
     uiam.convert = uiamConvert;
   }
 
-  return { coreSetup, coreStart, savedObjectsClient, encryptedSavedObjectsClient };
+  return {
+    coreSetup,
+    coreStart,
+    unsafeSavedObjectsClient,
+    savedObjectsClient,
+    encryptedSavedObjectsClient,
+  };
 }
 
 /** Set up the ESO PIT finder to yield the given saved_objects (rules) when find() is iterated */
@@ -392,8 +424,12 @@ describe('UiamApiKeyProvisioningTask', () => {
   describe('runTask', () => {
     it('increments state.runs and returns no runAt when no rules to process', async () => {
       const uiamConvert = jest.fn().mockResolvedValueOnce({ results: [] });
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, []);
 
@@ -413,8 +449,52 @@ describe('UiamApiKeyProvisioningTask', () => {
 
       expect(result).toEqual({ state: { runs: 6 } });
       expect(uiamConvert).not.toHaveBeenCalled();
-      expect(savedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
+      expect(unsafeSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
       expect(savedObjectsClient.bulkCreate).not.toHaveBeenCalled();
+    });
+
+    // Regression: the orphan-invalidation path used to receive a repository
+    // built via `createInternalRepository`, which has no extensions and stores
+    // `apiKeyId` / `uiamApiKey` as plaintext. The alerting invalidation task
+    // then failed to decrypt them with "Invalid initialization vector".
+    // The client used to write `api_key_pending_invalidation` SOs must come
+    // from `getUnsafeInternalClient` so the ESO encryption extension is wired
+    // up. The provisioning-status SO has no encrypted attributes and is fine
+    // on a plain internal repository.
+    it('builds the encryption-aware SO client with rule and api_key_pending_invalidation as hidden types', async () => {
+      const uiamConvert = jest.fn().mockResolvedValueOnce({ results: [] });
+      const { coreSetup, coreStart, encryptedSavedObjectsClient } = createMockCore(uiamConvert);
+
+      mockPitFinderRules(encryptedSavedObjectsClient, []);
+
+      const task = new UiamApiKeyProvisioningTask({ logger, isServerless: true, analytics });
+      const taskManager = { registerTaskDefinitions: jest.fn() };
+      task.register({
+        core: coreSetup as CoreSetup<AlertingPluginsStart>,
+        taskManager: taskManager as never,
+      });
+
+      const def =
+        taskManager.registerTaskDefinitions.mock.calls[0][0][API_KEY_PROVISIONING_TASK_TYPE];
+      const runner = def.createTaskRunner({ taskInstance: createTaskInstance() });
+      await runner.run();
+
+      expect(coreStart.savedObjects.getUnsafeInternalClient).toHaveBeenCalledWith({
+        includedHiddenTypes: expect.arrayContaining([
+          RULE_SAVED_OBJECT_TYPE,
+          API_KEY_PENDING_INVALIDATION_TYPE,
+        ]),
+      });
+      expect(coreStart.savedObjects.createInternalRepository).toHaveBeenCalledWith([
+        UIAM_API_KEYS_PROVISIONING_STATUS_SAVED_OBJECT_TYPE,
+      ]);
+      // The plain internal repository must never be used for the encrypted
+      // `api_key_pending_invalidation` type.
+      const createInternalRepository = coreStart.savedObjects.createInternalRepository as jest.Mock;
+      const allInternalHiddenTypes = createInternalRepository.mock.calls.flatMap(
+        ([includedHiddenTypes]) => includedHiddenTypes ?? []
+      );
+      expect(allInternalHiddenTypes).not.toContain(API_KEY_PENDING_INVALIDATION_TYPE);
     });
 
     it('returns runAt RESCHEDULE_DELAY_MS from now when response.total indicates more batches to process', async () => {
@@ -432,11 +512,11 @@ describe('UiamApiKeyProvisioningTask', () => {
         ),
       } as ConvertUiamAPIKeysResponse);
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
+      const { coreSetup, unsafeSavedObjectsClient, encryptedSavedObjectsClient } =
         createMockCore(uiamConvert);
       mockPitFinderRules(encryptedSavedObjectsClient, rules, batchSize + 1);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: rules.map((r) => ({
           id: r.id,
           type: RULE_SAVED_OBJECT_TYPE,
@@ -469,7 +549,7 @@ describe('UiamApiKeyProvisioningTask', () => {
       expect(runAt.getTime()).toBeGreaterThanOrEqual(beforeRun + RESCHEDULE_DELAY_MS - 1000);
       expect(runAt.getTime()).toBeLessThanOrEqual(afterRun + RESCHEDULE_DELAY_MS + 1000);
       expect(uiamConvert).toHaveBeenCalledTimes(1);
-      expect(savedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(unsafeSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
       expect(logger.info).toHaveBeenCalledWith(
         `Wrote provisioning status: ${batchSize} total (0 skipped, 0 failed conversions, ${batchSize} completed, 0 failed updates).`,
         { tags: TAGS }
@@ -485,8 +565,12 @@ describe('UiamApiKeyProvisioningTask', () => {
         ],
       } as ConvertUiamAPIKeysResponse);
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       const rules = [
         createRuleSavedObject({
@@ -507,7 +591,7 @@ describe('UiamApiKeyProvisioningTask', () => {
       ];
       mockPitFinderRules(encryptedSavedObjectsClient, rules);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
           {
             id: 'rule-1',
@@ -554,7 +638,7 @@ describe('UiamApiKeyProvisioningTask', () => {
       expect(uiamConvert).toHaveBeenCalledTimes(1);
       expect(uiamConvert).toHaveBeenCalledWith(['es-api-key-1', 'es-api-key-2', 'es-api-key-3']);
       // uiamApiKey is stored as base64(id:key) per task implementation
-      expect(savedObjectsClient.bulkUpdate).toHaveBeenCalledWith(
+      expect(unsafeSavedObjectsClient.bulkUpdate).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
             type: RULE_SAVED_OBJECT_TYPE,
@@ -632,8 +716,12 @@ describe('UiamApiKeyProvisioningTask', () => {
         ],
       } as ConvertUiamAPIKeysResponse);
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
         createRuleSavedObject({
@@ -653,7 +741,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         }),
       ]);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
           {
             id: 'rule-2',
@@ -683,7 +771,7 @@ describe('UiamApiKeyProvisioningTask', () => {
       expect(result).toEqual({ state: { runs: 1 } });
       expect(uiamConvert).toHaveBeenCalledWith(['es-api-key-2', 'es-api-key-3', 'es-api-key-4']);
       // uiamApiKey is stored as base64(id:key) per task implementation
-      expect(savedObjectsClient.bulkUpdate).toHaveBeenCalledWith(
+      expect(unsafeSavedObjectsClient.bulkUpdate).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
             type: RULE_SAVED_OBJECT_TYPE,
@@ -745,7 +833,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         ],
       } as ConvertUiamAPIKeysResponse);
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
+      const { coreSetup, unsafeSavedObjectsClient, encryptedSavedObjectsClient } =
         createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
@@ -770,7 +858,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         }),
       ]);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
           {
             id: 'rule-default',
@@ -813,7 +901,7 @@ describe('UiamApiKeyProvisioningTask', () => {
       });
       await runner.run();
 
-      const bulkUpdateCall = savedObjectsClient.bulkUpdate.mock.calls[0][0];
+      const bulkUpdateCall = unsafeSavedObjectsClient.bulkUpdate.mock.calls[0][0];
       expect(bulkUpdateCall).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ id: 'rule-default', namespace: 'default' }),
@@ -829,8 +917,12 @@ describe('UiamApiKeyProvisioningTask', () => {
 
     it('skips rules with no apiKey and writes SKIPPED status', async () => {
       const uiamConvert = jest.fn();
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
         createRuleSavedObject({
@@ -855,7 +947,7 @@ describe('UiamApiKeyProvisioningTask', () => {
 
       expect(result).toEqual({ state: { runs: 1 } });
       expect(uiamConvert).not.toHaveBeenCalled();
-      expect(savedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
+      expect(unsafeSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
       expect(savedObjectsClient.bulkCreate).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
@@ -922,8 +1014,12 @@ describe('UiamApiKeyProvisioningTask', () => {
 
     it('skips rules that already have uiamApiKey and writes SKIPPED status', async () => {
       const uiamConvert = jest.fn();
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
         createRuleSavedObject({
@@ -952,7 +1048,7 @@ describe('UiamApiKeyProvisioningTask', () => {
 
       expect(result).toEqual({ state: { runs: 1 } });
       expect(uiamConvert).not.toHaveBeenCalled();
-      expect(savedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
+      expect(unsafeSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
       expect(savedObjectsClient.bulkCreate).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
@@ -976,7 +1072,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         results: [createConvertSuccessResult({ key: 'uiam-1' })],
       });
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
+      const { coreSetup, unsafeSavedObjectsClient, encryptedSavedObjectsClient } =
         createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
@@ -987,7 +1083,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         }),
       ]);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
           {
             id: 'rule-1',
@@ -1015,7 +1111,7 @@ describe('UiamApiKeyProvisioningTask', () => {
       const result = await runner.run();
 
       expect(result).toEqual({ state: { runs: 1 } });
-      expect(savedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(unsafeSavedObjectsClient.bulkUpdate).toHaveBeenCalledTimes(1);
       expect(logger.info).toHaveBeenCalledWith(
         'Wrote provisioning status: 1 total (0 skipped, 0 failed conversions, 1 completed, 0 failed updates).',
         { tags: TAGS }
@@ -1126,7 +1222,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         ],
       } as ConvertUiamAPIKeysResponse);
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
+      const { coreSetup, unsafeSavedObjectsClient, encryptedSavedObjectsClient } =
         createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
@@ -1164,13 +1260,17 @@ describe('UiamApiKeyProvisioningTask', () => {
         'Error converting API keys: Number of converted API keys does not match the number of API keys to convert',
         expect.any(Object)
       );
-      expect(savedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
+      expect(unsafeSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
     });
 
     it('throws when createPointInTimeFinderDecryptedAsInternalUser throws', async () => {
       const uiamConvert = jest.fn();
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       (
         encryptedSavedObjectsClient.createPointInTimeFinderDecryptedAsInternalUser as jest.Mock
@@ -1195,18 +1295,22 @@ describe('UiamApiKeyProvisioningTask', () => {
         expect.any(Object)
       );
       expect(uiamConvert).not.toHaveBeenCalled();
-      expect(savedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
+      expect(unsafeSavedObjectsClient.bulkUpdate).not.toHaveBeenCalled();
       expect(savedObjectsClient.bulkCreate).not.toHaveBeenCalled();
     });
 
-    it('rethrows without invalidating minted UIAM keys when savedObjectsClient.bulkUpdate throws', async () => {
+    it('rethrows without invalidating minted UIAM keys when unsafeSavedObjectsClient.bulkUpdate throws', async () => {
       (bulkMarkApiKeysForInvalidation as jest.Mock).mockClear();
       const uiamConvert = jest.fn().mockResolvedValue({
         results: [createConvertSuccessResult({ key: 'uiam-key-1' })],
       });
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
         createRuleSavedObject({
@@ -1216,7 +1320,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         }),
       ]);
 
-      savedObjectsClient.bulkUpdate.mockRejectedValue(new Error('bulkUpdate failed'));
+      unsafeSavedObjectsClient.bulkUpdate.mockRejectedValue(new Error('bulkUpdate failed'));
 
       const task = new UiamApiKeyProvisioningTask({ logger, isServerless: true, analytics });
       const taskManager = { registerTaskDefinitions: jest.fn() };
@@ -1253,7 +1357,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         ],
       } as ConvertUiamAPIKeysResponse);
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
+      const { coreSetup, unsafeSavedObjectsClient, encryptedSavedObjectsClient } =
         createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
@@ -1269,7 +1373,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         }),
       ]);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
           {
             id: 'r1',
@@ -1309,7 +1413,7 @@ describe('UiamApiKeyProvisioningTask', () => {
       expect(bulkMarkApiKeysForInvalidation).toHaveBeenCalledWith(
         { apiKeys: [orphanedKeyForR2] },
         logger,
-        savedObjectsClient
+        unsafeSavedObjectsClient
       );
     });
 
@@ -1321,8 +1425,12 @@ describe('UiamApiKeyProvisioningTask', () => {
         ],
       });
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
         createRuleSavedObject({
@@ -1337,7 +1445,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         }),
       ]);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
           {
             id: 'r1',
@@ -1367,7 +1475,7 @@ describe('UiamApiKeyProvisioningTask', () => {
       expect(result).toEqual({ state: { runs: 1 } });
       expect(uiamConvert).toHaveBeenCalledWith(['es-a', 'es-b']);
       // uiamApiKey is stored as base64(id:key) per task implementation
-      expect(savedObjectsClient.bulkUpdate).toHaveBeenCalledWith(
+      expect(unsafeSavedObjectsClient.bulkUpdate).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
             id: 'r1',
@@ -1401,8 +1509,12 @@ describe('UiamApiKeyProvisioningTask', () => {
         ],
       } as ConvertUiamAPIKeysResponse);
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
         createRuleSavedObject({
@@ -1417,7 +1529,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         }),
       ]);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
           {
             id: 'r1',
@@ -1490,8 +1602,12 @@ describe('UiamApiKeyProvisioningTask', () => {
         results: [createConvertSuccessResult({ key: 'uiam-1' })],
       } as ConvertUiamAPIKeysResponse);
 
-      const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
-        createMockCore(uiamConvert);
+      const {
+        coreSetup,
+        savedObjectsClient,
+        unsafeSavedObjectsClient,
+        encryptedSavedObjectsClient,
+      } = createMockCore(uiamConvert);
 
       mockPitFinderRules(encryptedSavedObjectsClient, [
         createRuleSavedObject({
@@ -1501,7 +1617,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         }),
       ]);
 
-      savedObjectsClient.bulkUpdate.mockResolvedValue({
+      unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
         saved_objects: [
           {
             id: 'r1',
@@ -1550,7 +1666,7 @@ describe('UiamApiKeyProvisioningTask', () => {
           ],
         } as ConvertUiamAPIKeysResponse);
 
-        const { coreSetup, savedObjectsClient, encryptedSavedObjectsClient } =
+        const { coreSetup, unsafeSavedObjectsClient, encryptedSavedObjectsClient } =
           createMockCore(uiamConvert);
 
         const rules = [
@@ -1571,7 +1687,7 @@ describe('UiamApiKeyProvisioningTask', () => {
         ];
         mockPitFinderRules(encryptedSavedObjectsClient, rules);
 
-        savedObjectsClient.bulkUpdate.mockResolvedValue({
+        unsafeSavedObjectsClient.bulkUpdate.mockResolvedValue({
           saved_objects: [
             {
               id: 'rule-1',

--- a/x-pack/platform/plugins/shared/alerting/server/provisioning/uiam_api_key_provisioning_task.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/provisioning/uiam_api_key_provisioning_task.ts
@@ -369,7 +369,7 @@ export class UiamApiKeyProvisioningTask {
         await bulkMarkApiKeysForInvalidation(
           { apiKeys: orphanedUiamApiKeys },
           this.logger,
-          context.savedObjectsClient
+          context.unsafeSavedObjectsClient
         );
       }
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced when the UIAM API key provisioning task was enabled: nodes started logging high volumes of

> Failed to decrypt attribute "apiKeyId" of saved object "api_key_pending_invalidation,...": Invalid initialization vector

The orphan-invalidation path inside `UiamApiKeyProvisioningTask` was creating `api_key_pending_invalidation` SOs through `coreStart.savedObjects.createInternalRepository(...)`. That factory returns a plain `ISavedObjectsRepository` with **no Saved Objects extensions**, so the ESO encryption extension never ran on write — `apiKeyId` and `uiamApiKey` were persisted as plaintext. The alerting invalidation task subsequently tried to decrypt them via the ESO client and failed with `Invalid initialization vector`, leaving orphaned UIAM keys un-invalidated and producing the noisy logs.

### Fix

In `create_provisioning_run_context.ts`:

- Build the encryption-aware client via `coreStart.savedObjects.getUnsafeInternalClient(...)` and add `API_KEY_PENDING_INVALIDATION_TYPE` to its `includedHiddenTypes` (alongside `RULE_SAVED_OBJECT_TYPE`). This is the client that carries the ESO encryption extension.
- Keep `coreStart.savedObjects.createInternalRepository([UIAM_API_KEYS_PROVISIONING_STATUS_SAVED_OBJECT_TYPE])` for the provisioning-status SO, which has no encrypted attributes.

In `uiam_api_key_provisioning_task.ts`:

- Route the orphan-invalidation `bulkMarkApiKeysForInvalidation(...)` call through `context.unsafeSavedObjectsClient` instead of `context.savedObjectsClient`.

### Tests

**Unit (`uiam_api_key_provisioning_task.test.ts`)** — refactored `createMockCore` so each factory returns its own properly-typed mock (`getUnsafeInternalClient` → `savedObjectsClientMock.create()`, `createInternalRepository` → `savedObjectsRepositoryMock.create()`), mirroring production wiring. Existing assertions split accordingly:

- All rule `bulkUpdate` mocking/assertions moved to `unsafeSavedObjectsClient.bulkUpdate` (encryption-aware path).
- `bulkCreate` of provisioning-status SOs stays on `savedObjectsClient.bulkCreate` (plain repo).
- Added a regression test asserting `getUnsafeInternalClient` is called with both `RULE_SAVED_OBJECT_TYPE` and `API_KEY_PENDING_INVALIDATION_TYPE`, and that `createInternalRepository` is *never* called with `API_KEY_PENDING_INVALIDATION_TYPE`.
- The `bulkMarkApiKeysForInvalidation` 3rd-arg assertion now expects the encryption-aware client. A future regression that swaps the factories will fail these tests.

**Jest integration (`api_key_pending_invalidation_encryption.test.ts`, new)** — boots Kibana + ES with an explicit `xpack.encryptedSavedObjects.encryptionKey`, then exercises `bulkMarkApiKeysForInvalidation` through both factories and reads raw `_source` from `.kibana_alerting_cases`:

- ✅ `getUnsafeInternalClient` writes encrypt `apiKeyId` and `uiamApiKey` at rest (UIAM key path).
- ✅ `getUnsafeInternalClient` writes encrypt `apiKeyId` for ES-only keys (no `uiamApiKey`).
- ✅ `createInternalRepository` writes persist `apiKeyId` / `uiamApiKey` as plaintext — locks in the contract that documented why pending-invalidation writes must never be wired to that factory. If a future change makes `createInternalRepository` apply the encryption extension, this test will fail and force a deliberate revisit.

## Verification

- `node scripts/jest x-pack/platform/plugins/shared/alerting/server/provisioning/uiam_api_key_provisioning_task.test.ts` — 35/35 passing.
- `node scripts/jest_integration --config x-pack/platform/plugins/shared/alerting/jest.integration.config.js x-pack/platform/plugins/shared/alerting/server/integration_tests/api_key_pending_invalidation_encryption.test.ts` — 3/3 passing.
- `node scripts/eslint --fix \$(git diff --name-only origin/main)` — clean.
- `node scripts/type_check --project x-pack/platform/plugins/shared/alerting/tsconfig.json` — clean.
- `node scripts/check_changes.ts` — all pre-commit checks passed.

## Release notes

Fixes UIAM API key provisioning so that pending-invalidation saved objects are encrypted at rest, eliminating noisy `Invalid initialization vector` decryption failures and ensuring orphaned UIAM keys are properly invalidated.

## Risk

Scoped to the UIAM API key provisioning task. The new wiring uses the same encryption-aware Saved Objects client that the rest of the alerting plugin already uses for encrypted SOs, and Saved Objects already correctly written in plaintext (pre-fix) will continue to fail to decrypt — they should be cleaned up out of band as before.

Made with [Cursor](https://cursor.com)