### PR TITLE
[Streams] Add empty steps to suggestions not generated guard

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/suggest_pipeline_actor.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/suggest_pipeline_actor.ts
@@ -55,8 +55,7 @@ export async function suggestPipelineLogic(input: SuggestPipelineInput): Promise
       })
       .pipe(
         map((event) => {
-          // Handle case where LLM couldn't generate suggestions
-          if (event.pipeline === null) {
+          if (event.pipeline === null || event.pipeline.steps.length === 0) {
             throw new NoSuggestionsError(
               i18n.translate(
                 'xpack.streams.streamDetailView.managementTab.enrichment.noSuggestionsError',


### PR DESCRIPTION
Closes https://github.com/elastic/streams-program/issues/1318

## Summary

An empty `{ steps: [] }` response will now follow the same path as a `null` pipeline: the state machine transitions to `noSuggestionsFound`, showing the "Could not generate suggestions" callout with the option to retry

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->