### PR TITLE
[ci] Unset SA after moon cache download

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -31,6 +31,7 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
       echo "Extracting moon-cache.tar.zst to ./.moon/cache"
       tar -xf ~/moon-cache.tar.zst -I zstd -C ./
     fi
+    .buildkite/scripts/common/activate_service_account.sh --unset-impersonation
   fi
 fi
 


### PR DESCRIPTION
Follow up to https://github.com/elastic/kibana/pull/269224

There's a conflict if later steps use a different service account, causing 403 errors.