### PR TITLE
[AI / CI] fix concurrency and worktrees in artifacts

### DIFF
--- a/.github/workflows/failed-backport-resolver.lock.yml
+++ b/.github/workflows/failed-backport-resolver.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bc836587756b3ddf978e428135a048d6c69393022c48aebd58ba6d776dc3923b","compiler_version":"v0.71.5","agent_id":"claude","agent_model":"opus"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3aec543b47f5a6a725b012989a0b6d3e6d4122a2f2365f443347923821ffdf18","compiler_version":"v0.71.5","agent_id":"claude","agent_model":"opus"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LITELLM_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -72,8 +72,24 @@ name: "Failed Backport Resolver"
 permissions: {}
 
 concurrency:
-  cancel-in-progress: true
-  group: failed-backport-resolver-${{ github.event.issue.number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: false
+  group: |-
+    ${{
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.login == 'kibanamachine' &&
+          (
+            contains(github.event.comment.body, 'Some backports could not be created') ||
+            contains(github.event.comment.body, 'All backports failed')
+          )
+        )
+      ) &&
+      format('failed-backport-resolver-{0}', github.event.issue.number || github.event.inputs.pr_number) ||
+      format('failed-backport-resolver-{0}', github.run_id)
+    }}
 
 run-name: "Failed Backport Resolver"
 
@@ -228,23 +244,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_8c717e5c44e427a4_EOF'
+          cat << 'GH_AW_PROMPT_ce63383b1c5ddb46_EOF'
           <system>
-          GH_AW_PROMPT_8c717e5c44e427a4_EOF
+          GH_AW_PROMPT_ce63383b1c5ddb46_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8c717e5c44e427a4_EOF'
+          cat << 'GH_AW_PROMPT_ce63383b1c5ddb46_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_pull_request(max:8), assign_to_user(max:8), missing_tool, missing_data, noop
-          GH_AW_PROMPT_8c717e5c44e427a4_EOF
+          GH_AW_PROMPT_ce63383b1c5ddb46_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_8c717e5c44e427a4_EOF'
+          cat << 'GH_AW_PROMPT_ce63383b1c5ddb46_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_8c717e5c44e427a4_EOF
+          GH_AW_PROMPT_ce63383b1c5ddb46_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_8c717e5c44e427a4_EOF'
+          cat << 'GH_AW_PROMPT_ce63383b1c5ddb46_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -273,15 +289,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_8c717e5c44e427a4_EOF
+          GH_AW_PROMPT_ce63383b1c5ddb46_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_8c717e5c44e427a4_EOF'
+          cat << 'GH_AW_PROMPT_ce63383b1c5ddb46_EOF'
           </system>
           {{#runtime-import .github/workflows/failed-backport-resolver.md}}
-          GH_AW_PROMPT_8c717e5c44e427a4_EOF
+          GH_AW_PROMPT_ce63383b1c5ddb46_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -497,9 +513,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_73d3ee18db9d1b91_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5053e855fac3ce6d_EOF'
           {"add_comment":{"footer":true,"max":2,"target":"${{ github.event.issue.number || github.event.inputs.pr_number }}"},"assign_to_user":{"max":8,"target":"*"},"create_pull_request":{"allowed_base_branches":["[0-9]*.[0-9]*"],"auto_close_issue":false,"draft":false,"fallback_as_issue":false,"footer":true,"labels":["backport"],"max":8,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"],"protected_files_policy":"allowed"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_73d3ee18db9d1b91_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5053e855fac3ce6d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -749,7 +765,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_ef670136d356adc4_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_04a1c3a4b0da4794_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -792,7 +808,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ef670136d356adc4_EOF
+          GH_AW_MCP_CONFIG_04a1c3a4b0da4794_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/failed-backport-resolver.md
+++ b/.github/workflows/failed-backport-resolver.md
@@ -31,8 +31,24 @@ if: >-
   )
 
 concurrency:
-  group: failed-backport-resolver-${{ github.event.issue.number || github.event.inputs.pr_number || github.run_id }}
-  cancel-in-progress: true
+  group: >-
+    ${{
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.login == 'kibanamachine' &&
+          (
+            contains(github.event.comment.body, 'Some backports could not be created') ||
+            contains(github.event.comment.body, 'All backports failed')
+          )
+        )
+      ) &&
+      format('failed-backport-resolver-{0}', github.event.issue.number || github.event.inputs.pr_number) ||
+      format('failed-backport-resolver-{0}', github.run_id)
+    }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -141,16 +157,18 @@ Resolve failed automatic backports for the pull request identified by the inject
 
 ## Parent Workflow
 
-1. Read `/tmp/gh-aw/agent/pr-metadata.json` and `/tmp/gh-aw/agent/pr-issue-comments.json`. Use those prefetched files as the source of truth for PR metadata and comments, and capture `author.login` from `pr-metadata.json` as the source PR author login.
+1. Read `/tmp/gh-aw/agent/pr-metadata.json` and `/tmp/gh-aw/agent/pr-issue-comments.json`. Use those prefetched files as the source of truth for PR metadata and comments, and capture `author.login` from `pr-metadata.json` as the source PR author login. Also read `crossReferencedPulls` from `pr-metadata.json`; it contains compact metadata for pull requests that GitHub cross-referenced from the source PR timeline.
 2. From `pr-issue-comments.json`, use the latest `kibanamachine` comment whose body contains `Some backports could not be created` or `All backports failed`.
 3. Parse that comment for target branches that failed. A failed branch is any branch row whose result says `Backport failed because of merge conflicts`, or an equivalent failure row under the matching failure heading.
 4. Read `versions.json` and build the active branch allowlist from `versions[].branch`. Drop any parsed failed branch that is not in that allowlist, and mention the skipped branch in the final comment.
 5. Read `.backportrc.json` for non-branch PR conventions only. Ignore branch lists in `.backportrc.json`; active branches come from `versions.json`.
-6. Before starting a target branch, inspect only source PR-local data for an existing backport: `pr-metadata.json`, `pr-issue-comments.json`, and any PRs directly linked from those comments or the source PR body. Treat a linked open PR as existing only when it has the `backport` label and targets the same branch. Do not perform broad repository PR searches.
-7. For each remaining target branch, launch one parallel task with the `backport-branch-worker` sub-agent defined at the end of this workflow. Pass only the source PR number, source PR title, source PR URL, source PR author login, source branch, source merge commit SHA, target branch, repository from `GH_AW_GITHUB_REPOSITORY`, and the workflow run URL built from `GH_AW_GITHUB_REPOSITORY` and `GH_AW_GITHUB_RUN_ID`.
-8. Wait for every branch task to finish. Do not stop after the first failure.
-9. For each successful branch task, ensure it called `create_pull_request`. Do not call `create_pull_request` again for the same branch.
-10. Post exactly one final `add_comment` after all branch tasks finish. Include a compact table with `Branch`, `Status`, and `Result`. Use statuses: `created`, `existing`, `skipped`, `needs manual backport`, or `failed`. Do not fabricate PR URLs; gh-aw safe outputs will attach related created PRs to the comment after processing.
+6. Before starting a target branch, inspect only source PR-local data for an existing backport: `pr-metadata.json`, `crossReferencedPulls`, `pr-issue-comments.json`, and any PRs directly linked from those comments or the source PR body. Treat an open PR as existing only when it has the `backport` label and targets the same branch. Do not perform broad repository PR searches.
+7. If every remaining failed branch already has an existing open backport PR, call `add_comment` exactly once with the final comment table, use status `existing` for those branches, and do not launch branch workers.
+8. Create the shared parent directory for worker worktrees by running `mkdir -p /tmp/gh-aw-worktrees`.
+9. For each remaining target branch, launch one parallel task with the `backport-branch-worker` sub-agent defined at the end of this workflow. Pass only the source PR number, source PR title, source PR URL, source PR author login, source branch, source merge commit SHA, target branch, repository from `GH_AW_GITHUB_REPOSITORY`, and the workflow run URL built from `GH_AW_GITHUB_REPOSITORY` and `GH_AW_GITHUB_RUN_ID`.
+10. Wait for every branch task to finish. Do not stop after the first failure.
+11. For each successful branch task, ensure it called `create_pull_request`. Do not call `create_pull_request` again for the same branch.
+12. Post exactly one final `add_comment` after all branch tasks finish. Include a compact table with `Branch`, `Status`, and `Result`. Use statuses: `created`, `existing`, `skipped`, `needs manual backport`, or `failed`. Do not fabricate PR URLs; gh-aw safe outputs will attach related created PRs to the comment after processing.
 
 ## Final Comment Format
 
@@ -186,7 +204,9 @@ The parent task will provide:
 - workflow run URL
 - repository, always `elastic/kibana`
 
-Create exactly one isolated git worktree for the target branch from the already-fetched target branch ref. Use a branch/worktree name that starts with `backport/` and includes the source PR number and target branch.
+Create exactly one isolated git worktree for the target branch from the already-fetched target branch ref. Use a branch/worktree name that starts with `backport/` and includes the source PR number and target branch. Place the worktree under `/tmp/gh-aw-worktrees`, using a path like `/tmp/gh-aw-worktrees/wt-<source PR number>-<target branch>`.
+
+Never create a worktree, full repository copy, or package install output under `/tmp/gh-aw`. That directory is uploaded as workflow artifacts.
 
 Cherry-pick the source merge commit into the target branch worktree with `git cherry-pick -x <source merge commit SHA>`.
 

--- a/.github/workflows/prefetch-pr-context.yml
+++ b/.github/workflows/prefetch-pr-context.yml
@@ -54,11 +54,74 @@ jobs:
             ' "$files_json" > "$output_file"
           }
 
+          add_cross_referenced_pulls_to_metadata() {
+            local owner="${REPO%%/*}"
+            local repo_name="${REPO#*/}"
+            local cross_refs_file
+            cross_refs_file="$(mktemp)"
+
+            gh api graphql \
+              -f owner="$owner" \
+              -f repo="$repo_name" \
+              -F number="$PR_NUMBER" \
+              -f query='
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
+                        nodes {
+                          ... on CrossReferencedEvent {
+                            source {
+                              ... on PullRequest {
+                                number
+                                url
+                                state
+                                baseRefName
+                                title
+                                labels(first: 50) {
+                                  nodes {
+                                    name
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ' \
+              --jq '
+                [
+                  .data.repository.pullRequest.timelineItems.nodes[]?.source
+                  | select(. != null)
+                  | select(.number != null)
+                  | {
+                      number,
+                      url,
+                      state,
+                      baseRefName,
+                      title,
+                      labels: [.labels.nodes[]?.name]
+                    }
+                ]
+              ' > "$cross_refs_file"
+
+            jq --slurpfile crossReferencedPulls "$cross_refs_file" \
+              '. + { crossReferencedPulls: $crossReferencedPulls[0] }' \
+              /tmp/pr-context/pr-metadata.json > /tmp/pr-context/pr-metadata-with-cross-refs.json
+
+            mv /tmp/pr-context/pr-metadata-with-cross-refs.json /tmp/pr-context/pr-metadata.json
+          }
+
           mkdir -p /tmp/pr-context
 
           gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json number,title,body,url,isDraft,author,baseRefName,headRefName,labels,mergeCommit,mergedAt,state \
             > /tmp/pr-context/pr-metadata.json
+
+          add_cross_referenced_pulls_to_metadata
 
           fetch_paginated_array \
             "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" \


### PR DESCRIPTION
## Summary

`.github/workflows/failed-backport-resolver.md` is still in `staging` mode to prevent writes while testing.

- The subagents created worktrees in a path that gets uploaded automatically, this creates a giant artifact. Subagents are now directed to a different directory to create the worktrees.
    - https://github.com/elastic/kibana/actions/runs/25931726923/job/76227092281#step:40:122
- The concurrency settings were not resolving correctly for `kibanamachine` comments that were not about failed backports
- There was metadata missing for cross referenced PRs in the parent PR, this causes existing backports to be missed and the agents try to create another.

### Testing
- Validated prefetch workflow changes locally.