### PR TITLE
Fix content connector redirects to be basePath and space-aware

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/moon.yml
+++ b/x-pack/platform/plugins/shared/content_connectors/moon.yml
@@ -61,6 +61,7 @@ dependsOn:
   - '@kbn/home-plugin'
   - '@kbn/logging'
   - '@kbn/shared-ux-ai-components'
+  - '@kbn/deeplinks-management'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/content_connectors/public/api/connector/add_connector_api_logic.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/api/connector/add_connector_api_logic.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { HttpSetup, NavigateToUrlOptions } from '@kbn/core/public';
+import type { HttpSetup } from '@kbn/core/public';
 import type { Actions } from '../api_logic/create_api_logic';
 import { createApiLogic } from '../api_logic/create_api_logic';
 
@@ -33,7 +33,6 @@ export interface AddConnectorApiLogicResponse {
   id: string;
   indexName: string;
   uiFlags?: Record<string, boolean>;
-  navigateToUrl?: (url: string, options?: NavigateToUrlOptions) => Promise<void>;
 }
 
 export const addConnector = async ({

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/generated_config_fields.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/generated_config_fields.tsx
@@ -26,6 +26,7 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { Connector } from '@kbn/search-connectors';
 
 import type { ApiKey } from '../../../api/connector/generate_connector_api_key_api_logic';
@@ -93,6 +94,9 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
   generateApiKey,
   isGenerateLoading,
 }) => {
+  const {
+    services: { http },
+  } = useKibana();
   const generateButtonRef = useRef<HTMLButtonElement>(null);
   const refreshButtonRef = useRef<HTMLButtonElement>(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -238,7 +242,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
               <EuiFlexItem grow={false}>
                 <EuiLink
                   data-test-subj="enterpriseSearchConnectorDeploymentLink"
-                  href={generateEncodedPath(MANAGE_API_KEYS_URL, {})}
+                  href={http?.basePath.prepend(MANAGE_API_KEYS_URL)}
                   external
                   target="_blank"
                 >

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_detail.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_detail.tsx
@@ -15,6 +15,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { EuiTabProps } from '@elastic/eui';
 import { EuiButton, EuiPageTemplate } from '@elastic/eui';
 import type { ChromeBreadcrumb } from '@kbn/core/public';
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import { CONNECTOR_DETAIL_TAB_PATH } from '../routes';
 import { ConnectorScheduling } from '../search_index/connector/connector_scheduling';
 import { ConnectorSyncRules } from '../search_index/connector/sync_rules/connector_rules';
@@ -88,15 +89,12 @@ export const ConnectorDetail: React.FC = () => {
         defaultMessage: 'Overview',
       }),
       onClick: () => {
-        application?.navigateToUrl(
-          `${generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.OVERVIEW,
-            }
-          )}`
-        );
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.OVERVIEW,
+          })}`,
+        });
       },
     },
     {
@@ -111,15 +109,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () => {
-        application?.navigateToUrl(
-          `${generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.DOCUMENTS,
-            }
-          )}`
-        );
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.DOCUMENTS,
+          })}`,
+        });
       },
     },
     {
@@ -134,15 +129,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () =>
-        application?.navigateToUrl(
-          generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.INDEX_MAPPINGS,
-            }
-          )
-        ),
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.INDEX_MAPPINGS,
+          })}`,
+        }),
     },
   ];
 
@@ -159,15 +151,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () =>
-        application?.navigateToUrl(
-          generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.SYNC_RULES,
-            }
-          )
-        ),
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.SYNC_RULES,
+          })}`,
+        }),
     },
 
     {
@@ -182,15 +171,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () =>
-        application?.navigateToUrl(
-          generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.SCHEDULING,
-            }
-          )
-        ),
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.SCHEDULING,
+          })}`,
+        }),
     },
   ];
 
@@ -206,15 +192,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () =>
-        application?.navigateToUrl(
-          generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.CONFIGURATION,
-            }
-          )
-        ),
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.CONFIGURATION,
+          })}`,
+        }),
     },
   ];
 

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_detail.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_detail.tsx
@@ -201,26 +201,6 @@ export const ConnectorDetail: React.FC = () => {
     },
   ];
 
-  /* const PIPELINES_TAB = {
-    content: <SearchIndexPipelines />,
-    disabled: !index,
-    id: ConnectorDetailTabId.PIPELINES,
-    isSelected: tabId === ConnectorDetailTabId.PIPELINES,
-    label: i18n.translate(
-      'xpack.contentConnectors.connectors.connectorDetail.pipelinesTabLabel',
-      {
-        defaultMessage: 'Pipelines',
-      }
-    ),
-    onClick: () =>
-      application?.navigateToUrl(
-        generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
-          connectorId,
-          tabId: ConnectorDetailTabId.PIPELINES,
-        })
-      ),
-  }; */
-
   interface TabMenuItem {
     content: JSX.Element;
     disabled?: boolean;
@@ -232,12 +212,7 @@ export const ConnectorDetail: React.FC = () => {
     testSubj?: string;
   }
 
-  const tabs: TabMenuItem[] = [
-    ...ALL_INDICES_TABS,
-    ...CONNECTOR_TABS,
-    // ...[PIPELINES_TAB],
-    ...CONFIG_TAB,
-  ];
+  const tabs: TabMenuItem[] = [...ALL_INDICES_TABS, ...CONNECTOR_TABS, ...CONFIG_TAB];
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const selectedTab = useMemo(() => tabs.find((tab) => tab.id === tabId), [tabId]);

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connectors_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connectors_table.tsx
@@ -14,6 +14,7 @@ import { i18n } from '@kbn/i18n';
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { Meta } from '@kbn/search-connectors';
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import { CONNECTOR_DETAIL_PATH, SEARCH_INDEX_PATH } from '../routes';
 import {
   connectorStatusToColor,
@@ -180,24 +181,18 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
             if (isCrawler) {
               // crawler always has an index this is to satisfy TS
               if (connector.index_name) {
-                application?.navigateToUrl(
-                  generateEncodedPath(
-                    `/app/management/data/content_connectors${SEARCH_INDEX_PATH}`,
-                    {
-                      indexName: connector.index_name,
-                    }
-                  )
-                );
+                application?.navigateToApp(MANAGEMENT_APP_ID, {
+                  path: `/data/content_connectors${generateEncodedPath(SEARCH_INDEX_PATH, {
+                    indexName: connector.index_name,
+                  })}`,
+                });
               }
             } else {
-              application?.navigateToUrl(
-                generateEncodedPath(
-                  `/app/management/data/content_connectors${CONNECTOR_DETAIL_PATH}`,
-                  {
-                    connectorId: connector.id,
-                  }
-                )
-              );
+              application?.navigateToApp(MANAGEMENT_APP_ID, {
+                path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_PATH, {
+                  connectorId: connector.id,
+                })}`,
+              });
             }
           },
           type: 'icon',

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/choose_connector.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/choose_connector.tsx
@@ -96,10 +96,10 @@ export const ChooseConnector: React.FC<ChooseConnectorSelectableProps> = ({
     [connectorTypes]
   );
   const { selectedConnector } = useValues(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { setSelectedConnector } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
 
   const getInitialOptions = () => {

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration.tsx
@@ -66,7 +66,7 @@ export const ManualConfiguration: React.FC<ManualConfigurationProps> = ({
     setPopover(false);
   };
   const { selectedConnector, rawName } = useValues(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [flyoutContent, setFlyoutContent] = useState<'manual_config' | 'client'>();

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration_flyout.tsx
@@ -72,10 +72,10 @@ export const ManualConfigurationFlyout: React.FC<ManualConfigurationFlyoutProps>
   } = useKibana();
 
   const { connectorName } = useValues(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { setRawName, createConnector } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { euiTheme } = useEuiTheme();
   return (

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/configuration_step.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/configuration_step.tsx
@@ -49,7 +49,7 @@ export const ConfigurationStep: React.FC<ConfigurationStepProps> = ({
   const { connector, isWaitingOnAgentlessDeployment } = useValues(ConnectorViewLogic({ http }));
   const { updateConnectorConfiguration } = useActions(ConnectorViewLogic({ http }));
   const { setFormDirty } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const [isFormEditing, setIsFormEditing] = useState<boolean>(false);
   const { status } = useValues(ConnectorConfigurationApiLogic);

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/create_connector.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/create_connector.tsx
@@ -86,10 +86,10 @@ const CreateConnector: React.FC = () => {
   useBreadcrumbs(createConnectorBreadcrumbs, appParams, chrome);
 
   const { selectedConnector, currentStep, isFormDirty, connectorId } = useValues(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { setCurrentStep } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const stepStates = generateStepState(currentStep);
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/finish_up_step.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/finish_up_step.tsx
@@ -30,6 +30,8 @@ import { i18n } from '@kbn/i18n';
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
+
 import { DEV_TOOLS_CONSOLE_PATH, CONNECTOR_DETAIL_TAB_PATH } from '../../routes';
 
 import { ConnectorDetailTabId } from '../../connector_detail/connector_detail';
@@ -188,15 +190,15 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                             fill
                             onClick={() => {
                               if (connector) {
-                                application?.navigateToUrl(
-                                  generateEncodedPath(
-                                    `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
+                                application?.navigateToApp(MANAGEMENT_APP_ID, {
+                                  path: `/data/content_connectors${generateEncodedPath(
+                                    CONNECTOR_DETAIL_TAB_PATH,
                                     {
                                       connectorId: connector.id,
                                       tabId: ConnectorDetailTabId.CONFIGURATION,
                                     }
-                                  )
-                                );
+                                  )}`,
+                                });
                               }
                             }}
                           >

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/start_step.tsx
@@ -73,9 +73,9 @@ const StartStep: React.FC<StartStepProps> = ({
     isGenerateLoading,
     isCreateLoading,
     isFormDirty,
-  } = useValues(NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl }));
+  } = useValues(NewConnectorLogic({ http, navigateToApp: application?.navigateToApp }));
   const { setRawName, createConnector, generateConnectorName, setFormDirty } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { connector } = useValues(ConnectorViewLogic({ http }));
 

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { DecorativeHorizontalStepper } from '@kbn/search-connectors';
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import { CRAWLERS_PATH } from '../routes';
 import { BACK_BUTTON_LABEL, COMING_SOON_LABEL } from './translations';
 import { SearchEmptyPrompt } from '../search_empty_prompt';
@@ -23,7 +24,10 @@ export const ElasticManagedWebCrawlerEmptyPrompt: React.FC = () => {
     <SearchEmptyPrompt
       backButton={{
         label: BACK_BUTTON_LABEL,
-        onClickBack: () => application?.navigateToUrl(CRAWLERS_PATH),
+        onClickBack: () =>
+          application?.navigateToApp(MANAGEMENT_APP_ID, {
+            path: `/data/content_connectors${CRAWLERS_PATH}`,
+          }),
       }}
       icon="web"
       title={i18n.translate('xpack.contentConnectors.elasticManagedWebCrawlerEmpty.title', {

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/new_index/method_connector/new_connector_logic.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/new_index/method_connector/new_connector_logic.ts
@@ -10,7 +10,8 @@ import { kea } from 'kea';
 
 import type { Connector, ConnectorDefinition } from '@kbn/search-connectors';
 
-import type { HttpSetup, NavigateToUrlOptions } from '@kbn/core/public';
+import type { ApplicationStart, HttpSetup } from '@kbn/core/public';
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import type {
   AddConnectorApiLogicActions,
   AddConnectorApiLogicArgs,
@@ -91,7 +92,7 @@ type NewConnectorActions = {
 
 export interface NewConnectorLogicProps {
   http?: HttpSetup;
-  navigateToUrl?: (url: string, options?: NavigateToUrlOptions) => Promise<void>;
+  navigateToApp?: ApplicationStart['navigateToApp'];
 }
 
 export const NewConnectorLogic = kea<
@@ -99,7 +100,7 @@ export const NewConnectorLogic = kea<
 >({
   key: (props) => ({
     http: props.http,
-    navigateToUrl: props.navigateToUrl,
+    navigateToApp: props.navigateToApp,
   }),
   actions: {
     createConnector: ({
@@ -139,16 +140,13 @@ export const NewConnectorLogic = kea<
   },
   listeners: ({ actions, values, props }) => ({
     connectorCreated: ({ id, uiFlags }) => {
-      if (uiFlags?.shouldNavigateToConnectorAfterCreate && props.navigateToUrl) {
-        props.navigateToUrl(
-          generateEncodedPath(
-            `app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId: id,
-              tabId: SearchIndexTabId.CONFIGURATION,
-            }
-          )
-        );
+      if (uiFlags?.shouldNavigateToConnectorAfterCreate && props.navigateToApp) {
+        props.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId: id,
+            tabId: SearchIndexTabId.CONFIGURATION,
+          })}`,
+        });
       } else {
         actions.fetchConnector({ connectorId: id, http: props.http });
         if (!uiFlags || uiFlags.shouldGenerateAfterCreate) {

--- a/x-pack/platform/plugins/shared/content_connectors/tsconfig.json
+++ b/x-pack/platform/plugins/shared/content_connectors/tsconfig.json
@@ -58,6 +58,7 @@
     "@kbn/core-http-browser-mocks",
     "@kbn/home-plugin",
     "@kbn/logging",
-    "@kbn/shared-ux-ai-components"
+    "@kbn/shared-ux-ai-components",
+    "@kbn/deeplinks-management"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes client-side navigation within the content connectors UI to handle `server.basePath` and Kibana space prefixes, resolving 404s on the connector detail tabs and the post-creation "Manage connector" button. Calls to `application.navigateToUrl` with hardcoded absolute paths (e.g. `/app/management/data/content_connectors/...`) bypassed both prefixes and triggered a redirect to a route Kibana could not resolve. Changes include:

- Replaced `navigateToUrl(absolutePath)` in `connector_detail.tsx`, `finish_up_step.tsx`, and `new_connector_logic.ts` with `navigateToApp(MANAGEMENT_APP_ID, { path })`, which composes the basePath and space prefix via `ScopedHistory`.
- Renamed the `navigateToUrl` prop on `NewConnectorLogic` to `navigateToApp` and updated the callers.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note
Fixes client-side navigation within the content connectors UI to honor `server.basePath` and Kibana space prefixes.




<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->