### PR TITLE
Preserve ES|QL grouping when appending limit

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_limit.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_limit.test.ts
@@ -13,13 +13,22 @@ describe('appendLimitToQuery', () => {
   it('should append the limit clause to the query', () => {
     const queryString = 'FROM my_index';
     const updatedQueryString = appendLimitToQuery(queryString, 10);
-    expect(updatedQueryString).toBe('FROM my_index | LIMIT 10');
+    expect(updatedQueryString).toBe(`FROM my_index
+| LIMIT 10`);
   });
 
   it('should append the limit clause to the query with comments', () => {
     const queryString = 'FROM my_index | LIMIT 50 | STATS BY meow // new comment';
     const updatedQueryString = appendLimitToQuery(queryString, 10);
-    expect(updatedQueryString).toBe('FROM my_index | LIMIT 50 | STATS BY meow | LIMIT 10');
+    expect(updatedQueryString).toBe(`FROM my_index | LIMIT 50 | STATS BY meow // new comment
+| LIMIT 10`);
+  });
+
+  it('should keep arithmetic grouping intact when appending the limit clause', () => {
+    const queryString = 'FROM my_index | WHERE a > b / (c * 10)';
+    const updatedQueryString = appendLimitToQuery(queryString, 10);
+    expect(updatedQueryString).toBe(`FROM my_index | WHERE a > b / (c * 10)
+| LIMIT 10`);
   });
 
   it('shouldappend the limit clause to the query with no commands', () => {

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_limit.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_limit.ts
@@ -6,10 +6,12 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { BasicPrettyPrinter, Parser } from '@elastic/esql';
+import { appendToESQLQuery } from './utils';
 
 export const appendLimitToQuery = (queryString: string, limit: number) => {
-  const { root } = Parser.parse(queryString);
-  const prettyQueryString = BasicPrettyPrinter.print(root);
-  return `${prettyQueryString} | LIMIT ${limit}`;
+  const trimmedQueryString = queryString.trimEnd();
+  if (!trimmedQueryString) {
+    return ` | LIMIT ${limit}`;
+  }
+  return appendToESQLQuery(trimmedQueryString, `| LIMIT ${limit}`);
 };


### PR DESCRIPTION
## Summary

- Preserve the original ES|QL text when appending an alert limit clause
- Append the generated limit through the shared query appender so trailing comments stay intact
- Add regression coverage for arithmetic grouping such as `b / (c * 10)`

Fixes #269602

## Validation

- `node scripts/jest src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_limit.test.ts`
- `node scripts/type_check --project src/platform/packages/shared/kbn-esql-utils/tsconfig.json`
- `node scripts/eslint --fix src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_limit.ts src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_limit.test.ts`
- `node scripts/check_changes.ts`
- `git diff --check`
