### PR TITLE
[Ingest pipelines] Fix flaky scout tests

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/api/tests/structure_tree.spec.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/api/tests/structure_tree.spec.ts
@@ -61,8 +61,12 @@ apiTest.describe('Ingest pipelines structure tree API', { tag: tags.stateful.cla
       const processors: IngestProcessorContainer[] = [{ set: { field: 'foo', value: 'bar' } }];
 
       if (currentLevel < levels) {
-        for (let index = 0; index < childrenPerNode; index++) {
-          const childId = await createNode(currentLevel + 1, [...path, index]);
+        const childIds = await Promise.all(
+          Array.from({ length: childrenPerNode }, (_, index) =>
+            createNode(currentLevel + 1, [...path, index])
+          )
+        );
+        for (const childId of childIds) {
           processors.push({ pipeline: { name: childId } });
         }
       }

--- a/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/fixtures/page_objects/ingest_pipelines_page.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/fixtures/page_objects/ingest_pipelines_page.ts
@@ -163,6 +163,7 @@ export class IngestPipelinesPage {
 
   async closePipelineDetailsFlyout() {
     await this.flyoutCloseButton.click();
+    await this.detailsFlyout.waitFor({ state: 'hidden' });
   }
 
   async getDetailsFlyoutTitle() {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/fixtures/page_objects/ingest_pipelines_page.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/fixtures/page_objects/ingest_pipelines_page.ts
@@ -238,6 +238,7 @@ export class IngestPipelinesPage {
     await row.locator('[data-test-subj="deleteGeoipDatabaseButton"]').click();
     await this.geoipDatabaseConfirmation.fill('delete');
     await this.deleteGeoipDatabaseSubmitButton.click();
+    await this.deleteGeoipDatabaseSubmitButton.waitFor({ state: 'detached' });
   }
 
   private async fillDescription(description: string) {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/tests/manage_processors.spec.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/tests/manage_processors.spec.ts
@@ -21,7 +21,9 @@ test.describe('Ingest pipelines Manage Processors', { tag: tags.stateful.classic
       try {
         await esClient.ingest.deleteGeoipDatabase({ id: databaseId });
       } catch (error) {
-        log.debug(`GeoIP database pre-cleanup skipped for ${databaseId}: ${(error as Error).message}`);
+        log.debug(
+          `GeoIP database pre-cleanup skipped for ${databaseId}: ${(error as Error).message}`
+        );
       }
     }
   });

--- a/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/tests/manage_processors.spec.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/tests/manage_processors.spec.ts
@@ -10,12 +10,6 @@ import { expect } from '@kbn/scout/ui';
 import { test, testData } from '../fixtures';
 
 test.describe('Ingest pipelines Manage Processors', { tag: tags.stateful.classic }, () => {
-  test.beforeEach(async ({ browserAuth, pageObjects }) => {
-    await browserAuth.loginAsManageProcessorsUser();
-    await pageObjects.ingestPipelines.goto();
-    await pageObjects.ingestPipelines.navigateToManageProcessorsPage();
-  });
-
   test.beforeAll(async ({ esClient, log }) => {
     for (const databaseId of [testData.MAXMIND_DATABASE_ID, testData.IPINFO_DATABASE_ID]) {
       try {
@@ -26,6 +20,12 @@ test.describe('Ingest pipelines Manage Processors', { tag: tags.stateful.classic
         );
       }
     }
+  });
+
+  test.beforeEach(async ({ browserAuth, pageObjects }) => {
+    await browserAuth.loginAsManageProcessorsUser();
+    await pageObjects.ingestPipelines.goto();
+    await pageObjects.ingestPipelines.navigateToManageProcessorsPage();
   });
 
   test.afterAll(async ({ esClient, log }) => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/tests/manage_processors.spec.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/test/scout/ui/tests/manage_processors.spec.ts
@@ -16,6 +16,16 @@ test.describe('Ingest pipelines Manage Processors', { tag: tags.stateful.classic
     await pageObjects.ingestPipelines.navigateToManageProcessorsPage();
   });
 
+  test.beforeAll(async ({ esClient, log }) => {
+    for (const databaseId of [testData.MAXMIND_DATABASE_ID, testData.IPINFO_DATABASE_ID]) {
+      try {
+        await esClient.ingest.deleteGeoipDatabase({ id: databaseId });
+      } catch (error) {
+        log.debug(`GeoIP database pre-cleanup skipped for ${databaseId}: ${(error as Error).message}`);
+      }
+    }
+  });
+
   test.afterAll(async ({ esClient, log }) => {
     for (const databaseId of [testData.MAXMIND_DATABASE_ID, testData.IPINFO_DATABASE_ID]) {
       try {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/269616
Closes https://github.com/elastic/kibana/issues/269615
Closes https://github.com/elastic/kibana/issues/269313
Closes https://github.com/elastic/kibana/issues/269782

## Summary

This PR fixes few flaky tests that emerged after the ftr -> scout migration. There was one flaky test error, but seems unrelated.