### PR TITLE
[kbn-code-owners] Add `elastic/security-genai-research-and-development` team under Security area

### DIFF
--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -83,6 +83,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/security-detection-rule-management',
     'elastic/security-engineering-productivity',
     'elastic/security-entity-analytics',
+    'elastic/security-genai-research-and-development',
     'elastic/security-generative-ai',
     'elastic/security-pds-deployment',
     'elastic/security-service-integrations',


### PR DESCRIPTION
This PR adds the [Security GenAI R&D Team](https://github.com/orgs/elastic/teams/security-genai-research-and-development) to the `security` code owner <> area mapping. Adding the team here ensures their tests are correctly attributed to the security area by our Scout Reporter.