### PR TITLE
[AI-native design system] Add Figma-to-EUI mapping references for build-a-prototype-from-design skill

### DIFF
--- a/.agents/skills/build-a-prototype-from-design/references/eui-vs-kbnui.md
+++ b/.agents/skills/build-a-prototype-from-design/references/eui-vs-kbnui.md
@@ -1,0 +1,139 @@
+# EUI vs kbn-ui — routing decisions
+
+This reference is the decision layer between Step 1 (component identification)
+and Step 2 (Kibana chrome placement) of the "Build a prototype from this
+design" skill.
+
+Its job is to answer one question per resolved component:
+**Use the raw EUI component, or the Kibana-specific wrapper?**
+
+The default is always raw EUI. Use a kbn-ui wrapper only when this file
+explicitly says so.
+
+---
+
+## The rule in one sentence
+
+> If the component controls **page structure, navigation chrome, or
+> empty/error states at the page level**, use the kbn-ui wrapper.
+> For everything else, use raw EUI.
+
+---
+
+## Routing table
+
+| Design element | ❌ Never use in Kibana | ✅ Use instead | Package |
+|---|---|---|---|
+| Full page layout | `EuiPageTemplate` | `KibanaPageTemplate` | `@kbn/shared-ux-page-kibana-template` |
+| Page-level header | `EuiPageHeader` | See **Page header** section below | — |
+| No-data / onboarding page | Custom `EuiEmptyPrompt` layouts | `KibanaNoDataPage` | `@kbn/shared-ux-page-kibana-no-data` |
+| No-data with config options | Custom empty states | `NoDataConfigPage` | `@kbn/shared-ux-page-no-data-config` |
+| Solution-scoped left nav | `EuiSideNav` directly | `SolutionNav` | `@kbn/shared-ux-page-solution-nav` |
+| Error boundary | Raw `try/catch` in render | `KibanaErrorBoundary` | `@kbn/shared-ux-error-boundary` |
+| Section-level error boundary | — | `KibanaSectionErrorBoundary` | `@kbn/shared-ux-error-boundary` |
+
+Everything not in this table → **raw EUI**. Do not create Kibana-specific
+wrappers for buttons, panels, tables, forms, overlays, or display components.
+
+---
+
+## Page header
+
+The correct component depends on what Kibana solution or plugin you are
+prototyping for.
+
+> 🔍 **Needs verification** — confirm the correct import path and component
+> name with the owning team before the Day 4 test. The pattern varies across
+> Kibana solutions. Common options:
+
+- Some solutions use `EuiPageHeader` from `@elastic/eui` directly inside
+  a `KibanaPageTemplate` — this is acceptable when no Kibana-specific
+  header wrapper exists for that solution.
+- Others have a solution-specific header component. Check the existing
+  page files in the target plugin before deciding.
+- **Never invent a page header wrapper** — use what the solution already uses
+  for consistency.
+
+---
+
+## `KibanaPageTemplate` — what it replaces and why
+
+`EuiPageTemplate` works fine in isolation but does not wire up
+Kibana-specific concerns: solution navigation, no-data detection, and
+the global chrome offset. `KibanaPageTemplate` handles all of this.
+
+```tsx
+// ❌ Wrong in Kibana
+import { EuiPageTemplate } from '@elastic/eui';
+
+// ✅ Correct
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+```
+
+`KibanaPageTemplate` accepts the same props as `EuiPageTemplate` plus:
+- `solutionNav` — plug in a `SolutionNav` component for left-rail navigation
+- `noDataConfig` — declarative no-data state without a separate page
+
+---
+
+## `KibanaNoDataPage` — when to use it
+
+Use `KibanaNoDataPage` when the prototype shows an empty state that is
+**caused by the absence of data** (no indices, no data views, no saved
+objects) rather than by a search returning zero results.
+
+Zero-results empty states inside a populated page → `EuiEmptyPrompt` (raw EUI).
+First-time / no-data-source states → `KibanaNoDataPage`.
+
+---
+
+## `SolutionNav` — when to use it
+
+Use `SolutionNav` when the design shows a **persistent left-rail navigation**
+that is scoped to a solution (Observability, Security, Enterprise Search, etc.)
+rather than global Kibana navigation.
+
+The global Kibana navigation (top bar, left global nav) is **managed by the
+Kibana shell** — do not implement it in a prototype. Only implement the
+solution-level nav if the design shows one.
+
+---
+
+## Components that are always raw EUI in Kibana
+
+These are explicitly confirmed as raw EUI — do not wrap or replace them:
+
+| Component | Raw EUI import |
+|---|---|
+| All buttons | `EuiButton`, `EuiButtonEmpty`, `EuiButtonIcon`, `EuiButtonGroup` |
+| All overlays | `EuiFlyout`, `EuiModal`, `EuiConfirmModal`, `EuiPopover` |
+| All tables | `EuiBasicTable`, `EuiInMemoryTable`, `EuiDataGrid` |
+| All forms | `EuiForm`, `EuiFormRow`, `EuiFieldText`, `EuiComboBox`, etc. |
+| All display | `EuiCallOut`, `EuiBadge`, `EuiHealth`, `EuiStat`, `EuiPanel`, etc. |
+| All navigation sub-components | `EuiTabs`, `EuiBreadcrumbs`, `EuiPagination` |
+| Layout primitives | `EuiFlexGroup`, `EuiFlexItem`, `EuiSpacer` |
+| In-page empty states | `EuiEmptyPrompt` |
+| Typography | `EuiTitle`, `EuiText` |
+
+---
+
+## Decision flowchart
+
+```
+Is this component controlling the full page layout?
+  └─ Yes → KibanaPageTemplate
+
+Is this a page-level header with title + actions?
+  └─ Yes → Check existing solution pattern (see Page header section)
+
+Is this a full-page empty state caused by missing data?
+  └─ Yes → KibanaNoDataPage or NoDataConfigPage
+
+Is this a persistent solution-scoped left navigation?
+  └─ Yes → SolutionNav
+
+Is this a React error boundary at page or section level?
+  └─ Yes → KibanaErrorBoundary / KibanaSectionErrorBoundary
+
+Everything else → raw EUI from @elastic/eui
+```

--- a/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
+++ b/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
@@ -30,7 +30,7 @@ signal" column in this file is not enough to disambiguate.
 
 1. Scan the image systematically: chrome first → page structure → sections
    → micro-components. Follow the scan order in
-   [`mockup-reading.md`](./mockup-reading.md).
+   [`mockup-reading.md`](./mockup-reading.md). <!-- TODO -->
 2. For each visual element, match what you see against the
    **Visual signal** column in the table below.
 3. When two components look identical in a screenshot, use the

--- a/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
+++ b/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
@@ -14,11 +14,49 @@ For full prop APIs, usage examples, and detailed visual descriptions, read:
 
 ## Mode A — Figma file URL provided
 
-Code Connect handles the Figma component → code mapping automatically.
+Code Connect handles the Figma component → code mapping automatically via
+the **Figma MCP server**. The MCP must be installed and connected before
+any of the tool calls below will work.
 
-1. Call `get_design_context(url)` to extract the layer tree.
-2. Call `get_code_connect_map()` to get the Figma → EUI mappings.
-3. For any components not covered by Code Connect, call `get_code_connect_suggestions()`.
+### Pre-flight: verify the Figma MCP is available
+
+Before calling any Figma tool, confirm the MCP is running:
+
+- In **Claude Code**: run `/mcp` in the chat — the Figma server should
+  appear with a green ● status.
+- In **Claude.ai** (desktop app): open Settings → Integrations → MCP
+  and check that the Figma server is listed and enabled.
+
+**If the Figma MCP is not installed**, direct the user to set it up:
+
+1. Install the Figma MCP globally:
+   ```bash
+   npx figma-mcp install
+   ```
+   Or follow the official guide:
+   https://help.figma.com/hc/en-us/articles/32132100833559
+
+2. Provide a personal access token when prompted
+   (Figma → Settings → Security → Personal access tokens).
+
+3. Restart Claude Code / the Claude desktop app.
+
+4. Confirm with `/mcp` that the Figma server now shows a green ● status.
+
+> **If the MCP cannot be installed** (e.g. corporate environment, no
+> network access to Figma), fall back to **Mode B** — ask the user to
+> export the design as a PNG/JPG screenshot and continue from there.
+
+---
+
+### Mode A workflow (MCP confirmed available)
+
+1. Call `get_design_context(url)` to extract the layer tree and Code
+   Connect snippets for the provided Figma URL.
+2. Call `get_code_connect_map()` to get the full Figma → EUI mappings
+   for the file.
+3. For any components not covered by Code Connect, call
+   `get_code_connect_suggestions()` to get the closest matches.
 4. Check each resolved component against [`eui-vs-kbnui.md`](./eui-vs-kbnui.md)
    to confirm whether to use the raw EUI component or a Kibana wrapper.
 

--- a/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
+++ b/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
@@ -22,26 +22,56 @@ any of the tool calls below will work.
 
 Before calling any Figma tool, confirm the MCP is running:
 
-- In **Claude Code**: run `/mcp` in the chat — the Figma server should
-  appear with a green ● status.
-- In **Claude.ai** (desktop app): open Settings → Integrations → MCP
-  and check that the Figma server is listed and enabled.
+| Client | How to check |
+|---|---|
+| **Claude Code** | Run `/mcp` in the chat — the Figma server should appear with a green ● status |
+| **Claude.ai desktop** | Settings → Integrations → MCP — Figma server listed and enabled |
+| **Cursor** | Settings → Features → MCP (Cmd+Shift+J) — Figma server listed with a green ● |
 
-**If the Figma MCP is not installed**, direct the user to set it up:
+---
 
-1. Install the Figma MCP globally:
-   ```bash
-   npx figma-mcp install
+**If the Figma MCP is not installed**, direct the user to the right setup
+path for their client:
+
+#### Claude Code / Claude.ai desktop
+
+```bash
+npx figma-mcp install
+```
+
+When prompted, provide a Figma personal access token
+(Figma → Settings → Security → Personal access tokens).
+Restart Claude Code or the Claude desktop app, then verify with `/mcp`.
+
+#### Cursor
+
+1. Open `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project-level).
+   Create the file if it doesn't exist.
+
+2. Add the Figma server entry:
+   ```json
+   {
+     "mcpServers": {
+       "Figma": {
+         "command": "npx",
+         "args": ["-y", "@figma/mcp"],
+         "env": {
+           "FIGMA_API_KEY": "YOUR_PERSONAL_ACCESS_TOKEN"
+         }
+       }
+     }
+   }
    ```
-   Or follow the official guide:
-   https://help.figma.com/hc/en-us/articles/32132100833559
+   Replace `YOUR_PERSONAL_ACCESS_TOKEN` with a token from
+   Figma → Settings → Security → Personal access tokens.
 
-2. Provide a personal access token when prompted
-   (Figma → Settings → Security → Personal access tokens).
+3. Reload Cursor (Cmd+Shift+P → "Reload Window").
 
-3. Restart Claude Code / the Claude desktop app.
+4. Confirm in Settings → Features → MCP that the Figma server shows
+   a green ● status.
 
-4. Confirm with `/mcp` that the Figma server now shows a green ● status.
+Official guide for all clients:
+https://help.figma.com/hc/en-us/articles/32132100833559
 
 > **If the MCP cannot be installed** (e.g. corporate environment, no
 > network access to Figma), fall back to **Mode B** — ask the user to

--- a/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
+++ b/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
@@ -10,6 +10,10 @@ For routing decisions between raw EUI and Kibana-specific wrappers, see
 For full prop APIs and usage examples for any resolved component, read:
 `node_modules/@elastic/eui/metadata/components/[name].json`
 
+Each component JSON also contains a `visualDescription` field — a detailed
+visual recognition guide for the screenshot case. Read it when the "Visual
+signal" column in this file is not enough to disambiguate.
+
 ---
 
 ## How to use this reference

--- a/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
+++ b/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
@@ -1,170 +1,161 @@
 # Figma → EUI component mapping
 
 This reference is Step 1 of the "Build a prototype from this design" skill.
-Its job is to resolve every design element in a mockup to its correct EUI or
-kbn-ui code equivalent **before any code is written**.
+Its job is to resolve every design element to its correct EUI or kbn-ui
+equivalent **before any code is written**.
 
 For routing decisions between raw EUI and Kibana-specific wrappers, see
 [`eui-vs-kbnui.md`](./eui-vs-kbnui.md).
 
-For full prop APIs and usage examples for any resolved component, read:
+For full prop APIs, usage examples, and detailed visual descriptions, read:
 `node_modules/@elastic/eui/metadata/components/[name].json`
 
-Each component JSON also contains a `visualDescription` field — a detailed
-visual recognition guide for the screenshot case. Read it when the "Visual
-signal" column in this file is not enough to disambiguate.
+---
+
+## Mode A — Figma file URL provided
+
+Code Connect handles the Figma component → code mapping automatically.
+
+1. Call `get_design_context(url)` to extract the layer tree.
+2. Call `get_code_connect_map()` to get the Figma → EUI mappings.
+3. For any components not covered by Code Connect, call `get_code_connect_suggestions()`.
+4. Check each resolved component against [`eui-vs-kbnui.md`](./eui-vs-kbnui.md)
+   to confirm whether to use the raw EUI component or a Kibana wrapper.
 
 ---
 
-## How to use this reference
+## Mode B — Screenshot (PNG / JPG) provided
 
-### Mode A — Figma file URL provided
+Scan the image systematically: **chrome first → page structure → sections →
+micro-components**. Follow the scan order in
+[`mockup-reading.md`](./mockup-reading.md). <!-- TODO: Person C deliverable -->
 
-1. Call `get_design_context(url)` via the Figma MCP to extract the layer tree.
-2. Call `get_code_connect_map()` to check for any existing Code Connect mappings.
-3. For each component layer, match its name against the **Figma layer name**
-   column in the table below.
-4. Use the resolved EUI/kbn-ui name as the output for Step 2 of the skill.
+For each visual element, match what you see against the table below.
+When two components look similar, use the **Disambiguation** column.
+For more detail on any entry, read the `visualDescription` field in
+`node_modules/@elastic/eui/metadata/components/[name].json`.
 
-### Mode B — Screenshot (PNG / JPG) provided
-
-1. Scan the image systematically: chrome first → page structure → sections
-   → micro-components. Follow the scan order in
-   [`mockup-reading.md`](./mockup-reading.md). <!-- TODO -->
-2. For each visual element, match what you see against the
-   **Visual signal** column in the table below.
-3. When two components look identical in a screenshot, use the
-   **Disambiguation** column to decide.
-4. Flag anything that cannot be determined from visual evidence alone —
-   list both candidates and the deciding factor rather than guessing silently.
+Flag anything that cannot be determined from visual evidence alone — list
+both candidates and the deciding factor rather than guessing silently.
 
 ---
 
-## Mapping table
-
-> ⚠️ **Figma layer names** — marked with 🔍 where the exact Figma library
-> naming needs verification by the EUI design team. EUI code names and visual
-> signals are reliable; correct any 🔍 entries before the Day 4 test.
+## Visual recognition table
 
 ### Buttons
 
-| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
-|---|---|---|---|---|
-| `Button / Primary` | `EuiButton fill` | No | Solid colored background, rounded corners, text label | Filled = primary action |
-| `Button / Default` | `EuiButton` | No | Outlined border, transparent bg, text label | No fill = secondary action |
-| `Button / Empty` | `EuiButtonEmpty` | No | Text only, no border or background | Looks like a link but has button padding |
-| `Button / Icon` | `EuiButtonIcon` | No | Icon only, no text label visible | Always add `aria-label` |
-| `Button / Icon + Label` | `EuiButton iconType=…` | No | Icon left/right of text label inside a button box | Combined icon+label variant |
-| `Button Group` | `EuiButtonGroup` | No | Row of adjacent buttons sharing borders | Toggle group, not separate buttons |
+| What you see | EUI component | Disambiguation |
+|---|---|---|
+| Solid colored background, rounded corners, text label | `EuiButton fill` | Filled = primary action |
+| Outlined border, transparent background, text label | `EuiButton` | No fill = secondary |
+| Text only, no border or background, button padding | `EuiButtonEmpty` | Looks like a link — has padding |
+| Icon only, no text label | `EuiButtonIcon` | Always needs `aria-label` |
+| Icon + text label inside a button box | `EuiButton iconType=…` | |
+| Row of adjacent buttons sharing borders | `EuiButtonGroup` | Toggle group, not separate buttons |
 
 ### Display & status
 
-| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
-|---|---|---|---|---|
-| `Badge` | `EuiBadge` | No | Pill shape, rounded ends, colored fill, short text | Has a container. NOT EuiHealth (dot only) |
-| `Badge / Notification` | `EuiNotificationBadge` | No | Small circle with a number, typically on a button | Count indicator, not a status label |
-| `Callout / Info` | `EuiCallOut color="primary"` | No | Box with blue left border accent + icon | NOT a panel (no shadow) |
-| `Callout / Success` | `EuiCallOut color="success"` | No | Box with green left border | |
-| `Callout / Warning` | `EuiCallOut color="warning"` | No | Box with yellow left border | |
-| `Callout / Danger` | `EuiCallOut color="danger"` | No | Box with red left border | |
-| `Health` | `EuiHealth` | No | Small colored dot + inline text label | NOT EuiBadge (no pill, just a dot) |
-| `Stat` | `EuiStat` | No | Large metric value + small descriptor label | Always paired label+value. NOT EuiTitle |
-| `Avatar` | `EuiAvatar` | No | Circular element with initials or image | NOT EuiIcon (circular, not square) |
-| `Token` | `EuiToken` | No | Small colored icon in a rounded square container | Used in search results and field lists |
-| `Loading / Spinner` | `EuiLoadingSpinner` | No | Animated circle arc | |
-| `Loading / Elastic` | `EuiLoadingElastic` | No | Animated Elastic logo mark | |
-| `Empty Prompt` | `EuiEmptyPrompt` | No | Centered illustration + heading + body + CTA buttons | Large, page-filling. NOT EuiCallOut |
-| `Toast` | `EuiToast` | No | Small floating notification at screen edge | NOT EuiCallOut (positioned/floating) |
+| What you see | EUI component | Disambiguation |
+|---|---|---|
+| Pill shape, rounded ends, colored fill, short text | `EuiBadge` | Has a container. NOT EuiHealth (dot only) |
+| Small circle with a number, on or near a button | `EuiNotificationBadge` | Count indicator, not a status label |
+| Box with colored left border accent + icon + title | `EuiCallOut` | Color = info/success/warning/danger. NOT EuiPanel (no shadow) |
+| Small colored dot + short inline text label | `EuiHealth` | Just a dot. NOT EuiBadge (no pill shape) |
+| Large metric value + small descriptor label | `EuiStat` | Always a paired label+value. NOT EuiTitle alone |
+| Circular element with initials or image | `EuiAvatar` | Circular. NOT EuiIcon (square) |
+| Small colored icon in a rounded square container | `EuiToken` | Used in search results and field lists |
+| Animated circle arc | `EuiLoadingSpinner` | |
+| Centered illustration + heading + body + CTA buttons | `EuiEmptyPrompt` | Large, page-filling. NOT EuiCallOut (not an alert strip) |
+| Small floating notification at screen edge | `EuiToast` | Floating/positioned. NOT EuiCallOut |
 
 ### Layout & containers
 
-| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
-|---|---|---|---|---|
-| `Panel` | `EuiPanel` | No | White/light card with border or shadow, internal padding | No colored left border. NOT EuiCallOut |
-| `Panel / Split` | `EuiSplitPanel` | No | Two-pane panel with a shared border divider | |
-| `Flex Row` | `EuiFlexGroup` + `EuiFlexItem` | No | Horizontal arrangement of children with consistent gaps | Invisible in screenshots — infer from layout |
-| `Spacer` | `EuiSpacer` | No | Vertical whitespace block | Invisible — infer from gaps between elements |
-| `Horizontal Rule` | `EuiHorizontalRule` | No | Full-width divider line | Use instead of `<hr>` |
-| `Flyout` | `EuiFlyout` | No | Full-height panel sliding from viewport edge, dark overlay | NOT EuiModal (edge-anchored, not centered) |
-| `Modal` | `EuiModal` | No | Centered dialog over dark full-viewport overlay | NOT EuiFlyout (centered, not edge-anchored) |
-| `Popover` | `EuiPopover` | No | Small floating panel anchored to a trigger element | NOT EuiModal (small, trigger-anchored) |
+| What you see | EUI component | Disambiguation |
+|---|---|---|
+| White/light card, border or shadow, internal padding | `EuiPanel` | No colored left border. NOT EuiCallOut |
+| Two-pane container with a shared border divider | `EuiSplitPanel` | |
+| Children in a horizontal row with consistent gaps | `EuiFlexGroup` + `EuiFlexItem` | Invisible — infer from layout spacing |
+| Vertical whitespace gap between elements | `EuiSpacer` | Invisible — infer from the gap |
+| Full-width horizontal divider line | `EuiHorizontalRule` | |
+| Full-height panel sliding from viewport edge, dark overlay | `EuiFlyout` | Edge-anchored. NOT EuiModal (centered) |
+| Centered dialog over full-viewport dark overlay | `EuiModal` | Centered. NOT EuiFlyout (edge-anchored) |
+| Small floating panel anchored to a trigger | `EuiPopover` | Small, trigger-anchored. NOT EuiModal |
 
 ### Page structure
 
-| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
-|---|---|---|---|---|
-| `Page Template` | — | **Yes → `KibanaPageTemplate`** | Full-page scaffold: sidebar + header + content | Never use `EuiPageTemplate` in Kibana |
-| `Page Header` | — | **Yes → `KibanaPageHeader`** 🔍 | Page-level title bar with breadcrumbs + actions | Never use `EuiPageHeader` in Kibana. See `eui-vs-kbnui.md` |
-| `Page Section` | `EuiPageSection` | No | Content region within the page body | |
-| `No Data` | — | **Yes → `KibanaNoDataPage`** | Full-page empty state with data onboarding | From `@kbn/shared-ux-page-kibana-no-data` |
+| What you see | EUI component | Disambiguation |
+|---|---|---|
+| Full-page scaffold: sidebar + header + content area | `KibanaPageTemplate` | Never use `EuiPageTemplate` in Kibana |
+| Page-level title bar with breadcrumbs + action buttons | See [`eui-vs-kbnui.md`](./eui-vs-kbnui.md) | Pattern varies by solution |
+| Full-page empty state with data onboarding flow | `KibanaNoDataPage` | First-time / no data source. NOT EuiEmptyPrompt |
+| Content region inside the page body | `EuiPageSection` | |
 
 ### Navigation
 
-| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
-|---|---|---|---|---|
-| `Breadcrumbs` | `EuiBreadcrumbs` | No | Text items separated by › chevrons, last item plain | NOT EuiTabs, NOT EuiSteps |
-| `Tabs` | `EuiTabs` + `EuiTab` | No | Horizontal row of text tabs, active has underline | NOT EuiButtonGroup (tabs are non-exclusive nav) |
-| `Steps` | `EuiSteps` | No | Numbered vertical or horizontal progression | NOT EuiTabs (sequential, not navigational) |
-| `Side Nav` | `EuiSideNav` | No | Vertical tree menu with collapsible groups | App-level persistent nav |
-| `Solution Nav` | — | **Yes → `SolutionNav`** | Left-rail navigation in solution-scoped layouts | From `@kbn/shared-ux-page-solution-nav` |
-| `Pagination` | `EuiPagination` | No | Row of numbered page buttons with prev/next arrows | |
-| `Link` | `EuiLink` | No | Underlined or colored inline text link | NOT EuiButtonEmpty (not inline in text) |
+| What you see | EUI component | Disambiguation |
+|---|---|---|
+| Text items separated by › chevrons, last item plain | `EuiBreadcrumbs` | NOT EuiTabs, NOT EuiSteps |
+| Horizontal row of text tabs, active has underline | `EuiTabs` + `EuiTab` | NOT EuiButtonGroup |
+| Numbered vertical or horizontal progression | `EuiSteps` | Sequential. NOT EuiTabs |
+| Vertical tree menu with collapsible groups | `EuiSideNav` | Persistent app nav |
+| Persistent left-rail nav scoped to a solution | `SolutionNav` | NOT EuiSideNav directly — see `eui-vs-kbnui.md` |
+| Row of numbered page buttons with prev/next | `EuiPagination` | |
+| Underlined or colored inline text within a sentence | `EuiLink` | Inline in text. NOT EuiButtonEmpty |
 
 ### Forms
 
-| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
-|---|---|---|---|---|
-| `Form Row` | `EuiFormRow` | No | Label + input + help/error text stacked vertically | Always wraps an input |
-| `Field / Text` | `EuiFieldText` | No | Single-line bordered text input | NOT EuiTextArea (single line) |
-| `Field / Number` | `EuiFieldNumber` | No | Numeric text input | |
-| `Field / Password` | `EuiFieldPassword` | No | Password input with eye toggle icon | |
-| `Field / Search` | `EuiFieldSearch` | No | Narrow search input with magnifier icon | Narrower than EuiSearchBar |
-| `Select` | `EuiSelect` | No | Native dropdown with chevron | No in-field pills. NOT EuiComboBox |
-| `Combo Box` | `EuiComboBox` | No | Input with pill-shaped selected items inside, chevron | In-field pills = EuiComboBox |
-| `Search Bar` | `EuiSearchBar` | No | Full-width search with filter pills, prominent | Wider/more prominent than EuiFieldSearch |
-| `Switch` | `EuiSwitch` | No | Toggle pill with a sliding thumb, label alongside | NOT EuiCheckbox (pill shape vs square) |
-| `Checkbox` | `EuiCheckbox` | No | Square tick box | |
-| `Radio` | `EuiRadio` | No | Circular selection dot | |
-| `Text Area` | `EuiTextArea` | No | Multi-line bordered text input | NOT EuiFieldText (multi-line) |
+| What you see | EUI component | Disambiguation |
+|---|---|---|
+| Label + input + help/error text stacked vertically | `EuiFormRow` | Always wraps an input |
+| Single-line bordered text input | `EuiFieldText` | Single line. NOT EuiTextArea |
+| Password input with eye-toggle icon | `EuiFieldPassword` | |
+| Narrow input with magnifier icon | `EuiFieldSearch` | Narrower than EuiSearchBar |
+| Native dropdown with chevron, no pills | `EuiSelect` | No in-field pills. NOT EuiComboBox |
+| Input with pill-shaped selected items inside + chevron | `EuiComboBox` | In-field pills = EuiComboBox. NOT EuiSelect |
+| Full-width search with filter pills, prominent | `EuiSearchBar` | Wider and more prominent than EuiFieldSearch |
+| Toggle pill with sliding thumb + label | `EuiSwitch` | Pill shape. NOT EuiCheckbox (square) |
+| Square tick box | `EuiCheckbox` | |
+| Circular selection dot | `EuiRadio` | |
+| Multi-line bordered text input | `EuiTextArea` | Multi-line. NOT EuiFieldText |
 
 ### Data
 
-| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
-|---|---|---|---|---|
-| `Table / Basic` | `EuiBasicTable` | No | Header row + data rows, sort arrows, row actions | Visually identical to EuiInMemoryTable — differs by data source |
-| `Table / In Memory` | `EuiInMemoryTable` | No | Same visual as Basic Table + inline search/filter | Use when filtering/sorting is client-side |
-| `Data Grid` | `EuiDataGrid` | No | Cell-level editing, column resize handles, toolbar above | More complex than EuiBasicTable |
-| `Description List` | `EuiDescriptionList` | No | Key: value pairs stacked or inline | NOT a table (no columns/rows) |
+| What you see | EUI component | Disambiguation |
+|---|---|---|
+| Header row + data rows, sort arrows, row actions | `EuiBasicTable` or `EuiInMemoryTable` | Visually identical — use EuiInMemoryTable only if filtering is client-side |
+| Cell-level editing, column resize handles, toolbar above | `EuiDataGrid` | More complex than EuiBasicTable |
+| Key: value pairs, stacked or inline | `EuiDescriptionList` | NOT a table |
 
 ### Typography
 
-| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
-|---|---|---|---|---|
-| `Title / XL–XXS` | `EuiTitle size="…"` | No | Large/heavy heading text, no background | Use `as` prop to set h1–h6 semantic level |
-| `Text` | `EuiText` | No | Regular body copy, may contain paragraphs and lists | |
-| `Code` | `EuiCode` | No | Inline monospace code snippet | NOT EuiCodeBlock (inline vs block) |
-| `Code Block` | `EuiCodeBlock` | No | Multi-line syntax-highlighted code with copy button | |
+| What you see | EUI component | Disambiguation |
+|---|---|---|
+| Large or heavy heading text, no background | `EuiTitle` | Use `as` prop to set heading level |
+| Regular body copy, paragraphs or lists | `EuiText` | |
+| Inline monospace code snippet | `EuiCode` | Inline. NOT EuiCodeBlock |
+| Multi-line syntax-highlighted code with copy button | `EuiCodeBlock` | Block. NOT EuiCode |
 
 ---
 
 ## Output format
 
-After resolving all components from the design, produce a structured list
-before moving to Step 2. Example:
+After resolving all components, produce this structured list before moving
+to Step 2:
 
 ```
 Resolved components:
 - Page scaffold       → KibanaPageTemplate  (@kbn/shared-ux-page-kibana-template)
-- Page header         → KibanaPageHeader    (verify import — see eui-vs-kbnui.md)
+- Page header         → [see eui-vs-kbnui.md — verify with solution team]
 - Alert banner        → EuiCallOut color="warning"
-- Data table          → EuiBasicTable       (server-side data — 3 columns visible)
-- Row action buttons  → EuiButtonIcon       (2 per row, need aria-label)
-- Status column       → EuiHealth           (3 states: success / warning / danger)
+- Data table          → EuiBasicTable       (server-side data, 3 columns)
+- Row action buttons  → EuiButtonIcon       (2 per row — need aria-label)
+- Status column       → EuiHealth           (success / warning / danger)
 - Primary CTA         → EuiButton fill
 - Cancel action       → EuiButtonEmpty
+
 UNCERTAIN:
-- Top search area     → EuiSearchBar OR EuiFieldSearch — cannot determine width context from screenshot
+- Top search area     → EuiSearchBar OR EuiFieldSearch
+                        cannot determine width context from screenshot alone
 ```
 
-Anything marked UNCERTAIN must be resolved with the product designer or
-inferred from surrounding layout context before scaffolding begins.
+Anything marked UNCERTAIN must be resolved before scaffolding begins.

--- a/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
+++ b/.agents/skills/build-a-prototype-from-design/references/figma-to-eui.md
@@ -1,0 +1,166 @@
+# Figma → EUI component mapping
+
+This reference is Step 1 of the "Build a prototype from this design" skill.
+Its job is to resolve every design element in a mockup to its correct EUI or
+kbn-ui code equivalent **before any code is written**.
+
+For routing decisions between raw EUI and Kibana-specific wrappers, see
+[`eui-vs-kbnui.md`](./eui-vs-kbnui.md).
+
+For full prop APIs and usage examples for any resolved component, read:
+`node_modules/@elastic/eui/metadata/components/[name].json`
+
+---
+
+## How to use this reference
+
+### Mode A — Figma file URL provided
+
+1. Call `get_design_context(url)` via the Figma MCP to extract the layer tree.
+2. Call `get_code_connect_map()` to check for any existing Code Connect mappings.
+3. For each component layer, match its name against the **Figma layer name**
+   column in the table below.
+4. Use the resolved EUI/kbn-ui name as the output for Step 2 of the skill.
+
+### Mode B — Screenshot (PNG / JPG) provided
+
+1. Scan the image systematically: chrome first → page structure → sections
+   → micro-components. Follow the scan order in
+   [`mockup-reading.md`](./mockup-reading.md).
+2. For each visual element, match what you see against the
+   **Visual signal** column in the table below.
+3. When two components look identical in a screenshot, use the
+   **Disambiguation** column to decide.
+4. Flag anything that cannot be determined from visual evidence alone —
+   list both candidates and the deciding factor rather than guessing silently.
+
+---
+
+## Mapping table
+
+> ⚠️ **Figma layer names** — marked with 🔍 where the exact Figma library
+> naming needs verification by the EUI design team. EUI code names and visual
+> signals are reliable; correct any 🔍 entries before the Day 4 test.
+
+### Buttons
+
+| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
+|---|---|---|---|---|
+| `Button / Primary` | `EuiButton fill` | No | Solid colored background, rounded corners, text label | Filled = primary action |
+| `Button / Default` | `EuiButton` | No | Outlined border, transparent bg, text label | No fill = secondary action |
+| `Button / Empty` | `EuiButtonEmpty` | No | Text only, no border or background | Looks like a link but has button padding |
+| `Button / Icon` | `EuiButtonIcon` | No | Icon only, no text label visible | Always add `aria-label` |
+| `Button / Icon + Label` | `EuiButton iconType=…` | No | Icon left/right of text label inside a button box | Combined icon+label variant |
+| `Button Group` | `EuiButtonGroup` | No | Row of adjacent buttons sharing borders | Toggle group, not separate buttons |
+
+### Display & status
+
+| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
+|---|---|---|---|---|
+| `Badge` | `EuiBadge` | No | Pill shape, rounded ends, colored fill, short text | Has a container. NOT EuiHealth (dot only) |
+| `Badge / Notification` | `EuiNotificationBadge` | No | Small circle with a number, typically on a button | Count indicator, not a status label |
+| `Callout / Info` | `EuiCallOut color="primary"` | No | Box with blue left border accent + icon | NOT a panel (no shadow) |
+| `Callout / Success` | `EuiCallOut color="success"` | No | Box with green left border | |
+| `Callout / Warning` | `EuiCallOut color="warning"` | No | Box with yellow left border | |
+| `Callout / Danger` | `EuiCallOut color="danger"` | No | Box with red left border | |
+| `Health` | `EuiHealth` | No | Small colored dot + inline text label | NOT EuiBadge (no pill, just a dot) |
+| `Stat` | `EuiStat` | No | Large metric value + small descriptor label | Always paired label+value. NOT EuiTitle |
+| `Avatar` | `EuiAvatar` | No | Circular element with initials or image | NOT EuiIcon (circular, not square) |
+| `Token` | `EuiToken` | No | Small colored icon in a rounded square container | Used in search results and field lists |
+| `Loading / Spinner` | `EuiLoadingSpinner` | No | Animated circle arc | |
+| `Loading / Elastic` | `EuiLoadingElastic` | No | Animated Elastic logo mark | |
+| `Empty Prompt` | `EuiEmptyPrompt` | No | Centered illustration + heading + body + CTA buttons | Large, page-filling. NOT EuiCallOut |
+| `Toast` | `EuiToast` | No | Small floating notification at screen edge | NOT EuiCallOut (positioned/floating) |
+
+### Layout & containers
+
+| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
+|---|---|---|---|---|
+| `Panel` | `EuiPanel` | No | White/light card with border or shadow, internal padding | No colored left border. NOT EuiCallOut |
+| `Panel / Split` | `EuiSplitPanel` | No | Two-pane panel with a shared border divider | |
+| `Flex Row` | `EuiFlexGroup` + `EuiFlexItem` | No | Horizontal arrangement of children with consistent gaps | Invisible in screenshots — infer from layout |
+| `Spacer` | `EuiSpacer` | No | Vertical whitespace block | Invisible — infer from gaps between elements |
+| `Horizontal Rule` | `EuiHorizontalRule` | No | Full-width divider line | Use instead of `<hr>` |
+| `Flyout` | `EuiFlyout` | No | Full-height panel sliding from viewport edge, dark overlay | NOT EuiModal (edge-anchored, not centered) |
+| `Modal` | `EuiModal` | No | Centered dialog over dark full-viewport overlay | NOT EuiFlyout (centered, not edge-anchored) |
+| `Popover` | `EuiPopover` | No | Small floating panel anchored to a trigger element | NOT EuiModal (small, trigger-anchored) |
+
+### Page structure
+
+| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
+|---|---|---|---|---|
+| `Page Template` | — | **Yes → `KibanaPageTemplate`** | Full-page scaffold: sidebar + header + content | Never use `EuiPageTemplate` in Kibana |
+| `Page Header` | — | **Yes → `KibanaPageHeader`** 🔍 | Page-level title bar with breadcrumbs + actions | Never use `EuiPageHeader` in Kibana. See `eui-vs-kbnui.md` |
+| `Page Section` | `EuiPageSection` | No | Content region within the page body | |
+| `No Data` | — | **Yes → `KibanaNoDataPage`** | Full-page empty state with data onboarding | From `@kbn/shared-ux-page-kibana-no-data` |
+
+### Navigation
+
+| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
+|---|---|---|---|---|
+| `Breadcrumbs` | `EuiBreadcrumbs` | No | Text items separated by › chevrons, last item plain | NOT EuiTabs, NOT EuiSteps |
+| `Tabs` | `EuiTabs` + `EuiTab` | No | Horizontal row of text tabs, active has underline | NOT EuiButtonGroup (tabs are non-exclusive nav) |
+| `Steps` | `EuiSteps` | No | Numbered vertical or horizontal progression | NOT EuiTabs (sequential, not navigational) |
+| `Side Nav` | `EuiSideNav` | No | Vertical tree menu with collapsible groups | App-level persistent nav |
+| `Solution Nav` | — | **Yes → `SolutionNav`** | Left-rail navigation in solution-scoped layouts | From `@kbn/shared-ux-page-solution-nav` |
+| `Pagination` | `EuiPagination` | No | Row of numbered page buttons with prev/next arrows | |
+| `Link` | `EuiLink` | No | Underlined or colored inline text link | NOT EuiButtonEmpty (not inline in text) |
+
+### Forms
+
+| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
+|---|---|---|---|---|
+| `Form Row` | `EuiFormRow` | No | Label + input + help/error text stacked vertically | Always wraps an input |
+| `Field / Text` | `EuiFieldText` | No | Single-line bordered text input | NOT EuiTextArea (single line) |
+| `Field / Number` | `EuiFieldNumber` | No | Numeric text input | |
+| `Field / Password` | `EuiFieldPassword` | No | Password input with eye toggle icon | |
+| `Field / Search` | `EuiFieldSearch` | No | Narrow search input with magnifier icon | Narrower than EuiSearchBar |
+| `Select` | `EuiSelect` | No | Native dropdown with chevron | No in-field pills. NOT EuiComboBox |
+| `Combo Box` | `EuiComboBox` | No | Input with pill-shaped selected items inside, chevron | In-field pills = EuiComboBox |
+| `Search Bar` | `EuiSearchBar` | No | Full-width search with filter pills, prominent | Wider/more prominent than EuiFieldSearch |
+| `Switch` | `EuiSwitch` | No | Toggle pill with a sliding thumb, label alongside | NOT EuiCheckbox (pill shape vs square) |
+| `Checkbox` | `EuiCheckbox` | No | Square tick box | |
+| `Radio` | `EuiRadio` | No | Circular selection dot | |
+| `Text Area` | `EuiTextArea` | No | Multi-line bordered text input | NOT EuiFieldText (multi-line) |
+
+### Data
+
+| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
+|---|---|---|---|---|
+| `Table / Basic` | `EuiBasicTable` | No | Header row + data rows, sort arrows, row actions | Visually identical to EuiInMemoryTable — differs by data source |
+| `Table / In Memory` | `EuiInMemoryTable` | No | Same visual as Basic Table + inline search/filter | Use when filtering/sorting is client-side |
+| `Data Grid` | `EuiDataGrid` | No | Cell-level editing, column resize handles, toolbar above | More complex than EuiBasicTable |
+| `Description List` | `EuiDescriptionList` | No | Key: value pairs stacked or inline | NOT a table (no columns/rows) |
+
+### Typography
+
+| Figma layer name 🔍 | EUI component | kbn-ui instead? | Visual signal | Disambiguation |
+|---|---|---|---|---|
+| `Title / XL–XXS` | `EuiTitle size="…"` | No | Large/heavy heading text, no background | Use `as` prop to set h1–h6 semantic level |
+| `Text` | `EuiText` | No | Regular body copy, may contain paragraphs and lists | |
+| `Code` | `EuiCode` | No | Inline monospace code snippet | NOT EuiCodeBlock (inline vs block) |
+| `Code Block` | `EuiCodeBlock` | No | Multi-line syntax-highlighted code with copy button | |
+
+---
+
+## Output format
+
+After resolving all components from the design, produce a structured list
+before moving to Step 2. Example:
+
+```
+Resolved components:
+- Page scaffold       → KibanaPageTemplate  (@kbn/shared-ux-page-kibana-template)
+- Page header         → KibanaPageHeader    (verify import — see eui-vs-kbnui.md)
+- Alert banner        → EuiCallOut color="warning"
+- Data table          → EuiBasicTable       (server-side data — 3 columns visible)
+- Row action buttons  → EuiButtonIcon       (2 per row, need aria-label)
+- Status column       → EuiHealth           (3 states: success / warning / danger)
+- Primary CTA         → EuiButton fill
+- Cancel action       → EuiButtonEmpty
+UNCERTAIN:
+- Top search area     → EuiSearchBar OR EuiFieldSearch — cannot determine width context from screenshot
+```
+
+Anything marked UNCERTAIN must be resolved with the product designer or
+inferred from surrounding layout context before scaffolding begins.


### PR DESCRIPTION
## Summary

Part of the OnWeek (May 2025) contribution to the AI-native design system initiative tracked in [elastic/kibana-team#3100](https://github.com/elastic/kibana-team/issues/3100).

This PR adds `build-a-prototype-from-design` agent skill: the Figma-to-code translation layer that runs before any prototype code is written.

### Related PR

**EUI repo: [elastic/eui#9664](https://github.com/elastic/eui/pull/9664)** — ships machine-readable component metadata (`SKILL.md` + `index.json` + `components/*.json`) inside the `@elastic/eui` npm package. The files in this PR reference that metadata at runtime via `node_modules/@elastic/eui/metadata/`. The two PRs are designed as complementary layers:

```
figma-to-eui.md (this PR)           @elastic/eui/metadata/ (EUI PR #9664)
────────────────────────────         ──────────────────────────────────────
Figma layer name → EUI name          EUI name → props, types, example
Visual signal → component identity   visualDescription → detailed visual recognition
EUI vs kbn-ui routing decision       Correct usage rules and anti-patterns
```

---

## Files added

```
.agents/skills/build-a-prototype-from-design/references/
├── figma-to-eui.md      ← Figma component name → EUI/kbn-ui code mapping
└── eui-vs-kbnui.md      ← When to use a Kibana wrapper instead of raw EUI
```

### `figma-to-eui.md`

The translation layer for Step 1 of the skill. Covers:
- **Mode A** (Figma URL): how to use the Figma MCP (`get_design_context`, `get_code_connect_map`) and map extracted layer names to EUI components
- **Mode B** (screenshot / PNG / JPG): visual signal column + pointer to `visualDescription` fields in `@elastic/eui/metadata/` for disambiguation
- Mapping tables across 8 categories: buttons, display & status, layout, page structure, navigation, forms, data, typography
- Explicit `kbn-ui instead?` column flagging the 5 cases where a Kibana-specific wrapper replaces raw EUI
- Output format spec — the structured resolved-component list passed to Step 2

### `eui-vs-kbnui.md`

The routing decision guide. Covers:
- Routing table: `EuiPageTemplate` → `KibanaPageTemplate`, `KibanaNoDataPage`, `SolutionNav`, `KibanaErrorBoundary`
- Full list of components confirmed as always raw EUI in Kibana
- Decision flowchart for quick resolution
- Explicit rationale for each kbn-ui wrapper

---

## What's NOT in this PR (by design)

| Deliverable | Owner | Status |
|---|---|---|
| `SKILL.md` (top-level skill orchestrator) | Person C | Separate PR |
| `mockup-reading.md` | Person C | Separate PR — referenced as TODO |
| Chrome layout files (`chrome-layout-map.md`, region files) | Person B | Separate PR |
| `app-workspace.md`, `app-menu.md`, `sidebar.md` | Person C | Separate PR |

---

## Known gaps to review before Day 4

- **Figma layer names** — marked with 🔍 throughout `figma-to-eui.md`. These are approximations; the EUI design team needs to verify the exact naming from the Figma EUI library.
- **`KibanaPageHeader`** — flagged 🔍 in both files. Confirmed `KibanaPageTemplate` exists but could not find a canonical `KibanaPageHeader` wrapper. Needs verification with the owning team.
- **`visualDescription` fields** — the 25 core components are filled in [elastic/eui#9664](https://github.com/elastic/eui/pull/9664). Remaining 206 components have empty placeholders; contributions welcome.

---

## Validation

Day 4 test: agent correctly resolves all components from the test mockup before scaffolding begins — no wrong component choices, no raw HTML, no missed kbn-ui routing decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)