### PR TITLE
[Osquery] Fix export modal missing row count when pack query table is collapsed

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/row_kebab_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/row_kebab_menu.test.tsx
@@ -244,5 +244,41 @@ describe('RowKebabMenu — export branch', () => {
 
       expect(screen.getByTestId('osqueryExportConfirmButton')).toHaveTextContent('Export 100');
     });
+
+    it('uses row.docs as total fallback when the store has no entry (collapsed row)', () => {
+      useExportFiltersMock.mockReturnValue(undefined);
+
+      render(
+        <I18nProvider>
+          <RowKebabMenu
+            row={{ action_id: 'row-action-id', id: 'row-1', docs: 42 }}
+            actionId="parent-action-id"
+          />
+        </I18nProvider>
+      );
+
+      fireEvent.click(screen.getByTestId('packQueriesTableKebab-row-1'));
+      fireEvent.click(screen.getByTestId('osqueryExportResultsMenuItem'));
+
+      expect(screen.getByTestId('osqueryExportConfirmButton')).toHaveTextContent('Export 42');
+    });
+
+    it('prefers store total over row.docs when both are present', () => {
+      useExportFiltersMock.mockReturnValue({ total: 100 });
+
+      render(
+        <I18nProvider>
+          <RowKebabMenu
+            row={{ action_id: 'row-action-id', id: 'row-1', docs: 42 }}
+            actionId="parent-action-id"
+          />
+        </I18nProvider>
+      );
+
+      fireEvent.click(screen.getByTestId('packQueriesTableKebab-row-1'));
+      fireEvent.click(screen.getByTestId('osqueryExportResultsMenuItem'));
+
+      expect(screen.getByTestId('osqueryExportConfirmButton')).toHaveTextContent('Export 100');
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/row_kebab_menu.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/row_kebab_menu.tsx
@@ -21,7 +21,7 @@ import type { ExportFormat } from '../../results/use_export_results';
 import type { AddToTimelineHandler } from '../../types';
 
 interface RowKebabMenuProps {
-  row: { action_id?: string; id?: string };
+  row: { action_id?: string; id?: string; docs?: number };
   actionId: string | undefined;
   agentIds?: string[];
   addToTimeline?: AddToTimelineHandler;
@@ -179,7 +179,7 @@ const RowKebabMenuContent: React.FC<RowKebabMenuProps> = React.memo(
             isExporting={isExporting}
             hasActiveFilters={hasActiveFilters}
             filteredTotal={exportFilters?.filteredTotal}
-            total={exportFilters?.total}
+            total={exportFilters?.total ?? row.docs}
           />
         )}
       </>


### PR DESCRIPTION

## Summary

Fixes https://github.com/elastic/kibana/issues/269480.

When a user opens the **Export results** modal from the row kebab menu on a **collapsed** pack query row, the modal showed "Export" with no row count. Expanding the same row first caused the count to appear correctly.

**Root cause.** The modal's `total` prop is sourced from `ExportFiltersStore`, which is only written by `UnifiedResultsTable`. That component mounts only when the user expands the row to view results — so the store entry is
`undefined` for any collapsed row.

**Fix.** Every `PackQueryStatusItem` row already carries a `docs` field (sourced from `aggregations.responses_by_action_id.rows_count.value` — the same aggregation that populates `allResultsData.total` after expansion). Fall back to `row.docs` when the store has no entry:

```ts
total={exportFilters?.total ?? row.docs}
```

The filter-aware path is unaffected: `filteredTotal` and `hasActiveFilters` remain `undefined`/`false` for collapsed rows (no search bar → no active filters), so the "Only export filtered results" checkbox stays disabled and
the unfiltered count is shown.
