### PR TITLE
Hide system and hidden dataStreams from streams list

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -44,6 +44,7 @@ import { State } from './state_management/state';
 import type { StreamsStorageClient } from './storage/streams_storage_client';
 import { checkAccess, checkAccessBulk } from './stream_crud';
 import { upsertDataStream } from './data_streams/manage_data_streams';
+import { shouldExcludeFromStreamsList } from './data_streams/should_exclude_from_streams_list';
 import type { FeatureClient } from './feature';
 
 interface AcknowledgeResponse<TResult extends Result> {
@@ -946,19 +947,21 @@ export class StreamsClient {
 
     const now = new Date().toISOString();
 
-    return response.data_streams.map((dataStream) => ({
-      type: 'classic' as const,
-      name: dataStream.name,
-      description: '',
-      updated_at: now,
-      ingest: {
-        lifecycle: { inherit: {} },
-        processing: { steps: [], updated_at: now },
-        settings: {},
-        classic: {},
-        failure_store: { inherit: {} },
-      },
-    }));
+    return response.data_streams
+      .filter((dataStream) => !shouldExcludeFromStreamsList(dataStream))
+      .map((dataStream) => ({
+        type: 'classic' as const,
+        name: dataStream.name,
+        description: '',
+        updated_at: now,
+        ingest: {
+          lifecycle: { inherit: {} },
+          processing: { steps: [], updated_at: now },
+          settings: {},
+          classic: {},
+          failure_store: { inherit: {} },
+        },
+      }));
   }
 
   /**

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/data_streams/should_exclude_from_streams_list.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/data_streams/should_exclude_from_streams_list.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IndicesDataStream } from '@elastic/elasticsearch/lib/api/types';
+import { shouldExcludeFromStreamsList } from './should_exclude_from_streams_list';
+
+const createDataStream = (
+  overrides: Partial<Pick<IndicesDataStream, 'name' | 'hidden' | '_meta'>>
+): Pick<IndicesDataStream, 'name' | 'hidden' | '_meta'> => ({
+  name: 'logs-nginx-default',
+  hidden: false,
+  ...overrides,
+});
+
+describe('shouldExcludeFromStreamsList', () => {
+  it('includes normal user-facing data streams', () => {
+    expect(shouldExcludeFromStreamsList(createDataStream({ name: 'logs-nginx-default' }))).toBe(
+      false
+    );
+  });
+
+  it('excludes hidden data streams with a dot prefix', () => {
+    expect(
+      shouldExcludeFromStreamsList(createDataStream({ name: '.some-stream', hidden: true }))
+    ).toBe(true);
+    expect(
+      shouldExcludeFromStreamsList(
+        createDataStream({
+          name: '.workflows-execution-data-stream-logs',
+          hidden: true,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('excludes hidden data streams without a dot prefix', () => {
+    expect(
+      shouldExcludeFromStreamsList(createDataStream({ name: 'some-stream', hidden: true }))
+    ).toBe(true);
+  });
+
+  it('excludes managed data streams with a dot prefix', () => {
+    expect(
+      shouldExcludeFromStreamsList(
+        createDataStream({ name: '.some-stream', _meta: { managed: true } })
+      )
+    ).toBe(true);
+    expect(
+      shouldExcludeFromStreamsList(
+        createDataStream({
+          name: '.workflows-execution-data-stream-logs',
+          hidden: true,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('excludes managed data streams without a dot prefix', () => {
+    expect(
+      shouldExcludeFromStreamsList(
+        createDataStream({ name: 'some-stream', _meta: { managed: true } })
+      )
+    ).toBe(true);
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/data_streams/should_exclude_from_streams_list.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/data_streams/should_exclude_from_streams_list.test.ts
@@ -9,8 +9,8 @@ import type { IndicesDataStream } from '@elastic/elasticsearch/lib/api/types';
 import { shouldExcludeFromStreamsList } from './should_exclude_from_streams_list';
 
 const createDataStream = (
-  overrides: Partial<Pick<IndicesDataStream, 'name' | 'hidden' | '_meta'>>
-): Pick<IndicesDataStream, 'name' | 'hidden' | '_meta'> => ({
+  overrides: Partial<Pick<IndicesDataStream, 'name' | 'hidden'>>
+): Pick<IndicesDataStream, 'hidden'> => ({
   name: 'logs-nginx-default',
   hidden: false,
   ...overrides,
@@ -23,7 +23,15 @@ describe('shouldExcludeFromStreamsList', () => {
     );
   });
 
-  it('excludes hidden data streams with a dot prefix', () => {
+  it('includes managed logs data streams that are not hidden', () => {
+    expect(
+      shouldExcludeFromStreamsList(
+        createDataStream({ name: 'logs-nginx.access-default', hidden: false })
+      )
+    ).toBe(false);
+  });
+
+  it('excludes hidden data streams', () => {
     expect(
       shouldExcludeFromStreamsList(createDataStream({ name: '.some-stream', hidden: true }))
     ).toBe(true);
@@ -40,30 +48,6 @@ describe('shouldExcludeFromStreamsList', () => {
   it('excludes hidden data streams without a dot prefix', () => {
     expect(
       shouldExcludeFromStreamsList(createDataStream({ name: 'some-stream', hidden: true }))
-    ).toBe(true);
-  });
-
-  it('excludes managed data streams with a dot prefix', () => {
-    expect(
-      shouldExcludeFromStreamsList(
-        createDataStream({ name: '.some-stream', _meta: { managed: true } })
-      )
-    ).toBe(true);
-    expect(
-      shouldExcludeFromStreamsList(
-        createDataStream({
-          name: '.workflows-execution-data-stream-logs',
-          hidden: true,
-        })
-      )
-    ).toBe(true);
-  });
-
-  it('excludes managed data streams without a dot prefix', () => {
-    expect(
-      shouldExcludeFromStreamsList(
-        createDataStream({ name: 'some-stream', _meta: { managed: true } })
-      )
     ).toBe(true);
   });
 });

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/data_streams/should_exclude_from_streams_list.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/data_streams/should_exclude_from_streams_list.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IndicesDataStream } from '@elastic/elasticsearch/lib/api/types';
+
+/**
+ * Streams list builds unmanaged entries from `indices.getDataStream()` without
+ * `expand_wildcards: hidden`. For superusers, elasticsearch still returns data
+ * streams that are both `system: true` and `hidden: true` (e.g. Workflows'
+ * `.workflows-events`, created on Kibana startup via `@kbn/data-streams`).
+ * elasticsearch treats system indices as visible when
+ * `SystemIndexAccessLevel.ALL` applies, bypassing the hidden flag.
+ *
+ * Without this filter those internal streams surface as unmanaged "classic"
+ * rows on `/app/streams/`. Fleet applies a similar exclusion for its data
+ * streams list (`handlers.ts`: dot-prefixed names such as `.workflows-events`).
+ */
+export const shouldExcludeFromStreamsList = (
+  dataStream: Pick<IndicesDataStream, 'hidden' | '_meta'>
+): boolean => {
+  if (dataStream.hidden === true) {
+    return true;
+  }
+
+  if (dataStream._meta?.managed === true) {
+    return true;
+  }
+
+  return false;
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/data_streams/should_exclude_from_streams_list.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/data_streams/should_exclude_from_streams_list.ts
@@ -20,13 +20,9 @@ import type { IndicesDataStream } from '@elastic/elasticsearch/lib/api/types';
  * streams list (`handlers.ts`: dot-prefixed names such as `.workflows-events`).
  */
 export const shouldExcludeFromStreamsList = (
-  dataStream: Pick<IndicesDataStream, 'hidden' | '_meta'>
+  dataStream: Pick<IndicesDataStream, 'hidden'>
 ): boolean => {
   if (dataStream.hidden === true) {
-    return true;
-  }
-
-  if (dataStream._meta?.managed === true) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Filters out internal elasticsearch data streams (e.g. Workflows `.workflows-events`) from the Streams list page. These streams are registered as hidden system data streams but still appear for superusers when kibana calls `indices.getDataStream()`.

### Problem

The Streams app (`/app/streams/`) builds its list from `GET /internal/streams`, which merges managed stream definitions with **all** data streams returned by `indices.getDataStream()`.

Workflows register hidden system data streams such as:

- `.workflows-events`
- `.workflows-execution-data-stream-logs`

Although these are `hidden: true` and system indices, **superusers** still receive them from `GET _data_stream` without requesting hidden wildcards. elasticsearch treats system indices as visible when `SystemIndexAccessLevel.ALL` applies, bypassing the hidden flag ([`IndexAbstractionResolver`](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java)).

As a result, these streams surfaced as unmanaged "classic" rows on the Streams list, which could be confusing for users and inconsistent with Fleet, which already excludes dot-prefixed system streams (e.g. `.workflows-events`).

### 🎥 Demo

#### Before the changes

<img width="1915" height="809" alt="Screenshot 2026-05-18 at 12 57 12" src="https://github.com/user-attachments/assets/2c29433b-2fa1-4963-8be5-2305c553ddd3" />

#### After the changes

<img width="1905" height="906" alt="Screenshot 2026-05-18 at 12 47 24" src="https://github.com/user-attachments/assets/20a451b5-b8e9-4e7a-9735-efea02e62d73" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->