### PR TITLE
fix(ui-settings, security): skip async UI setting defaults on anonymous pages

### DIFF
--- a/src/core/packages/rendering/server-internal/src/rendering_service.test.ts
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.test.ts
@@ -240,6 +240,32 @@ function renderTestCases(
       expect(uiSettings.globalClient.getUserProvided).not.toHaveBeenCalled();
     });
 
+    it('does not resolve async default `getValue` for anonymous pages', async () => {
+      const getValue = jest.fn().mockResolvedValue('async-default');
+      uiSettings.client.getRegistered.mockReturnValue({
+        registered: { name: 'title', getValue },
+      });
+
+      const [render] = await getRender();
+      await render(createKibanaRequest(), uiSettings, {
+        isAnonymousPage: true,
+      });
+
+      expect(getValue).not.toHaveBeenCalled();
+    });
+
+    it('resolves async default `getValue` for non-anonymous pages', async () => {
+      const getValue = jest.fn().mockResolvedValue('async-default');
+      uiSettings.client.getRegistered.mockReturnValue({
+        registered: { name: 'title', getValue },
+      });
+
+      const [render] = await getRender();
+      await render(createKibanaRequest(), uiSettings);
+
+      expect(getValue).toHaveBeenCalledTimes(1);
+    });
+
     it('calls `getCommonStylesheetPaths` with the correct parameters', async () => {
       getSettingValueMock.mockImplementation((settingName: string) => {
         if (settingName === 'theme:darkMode') {

--- a/src/core/packages/rendering/server-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.tsx
@@ -189,18 +189,19 @@ export class RenderingService {
     const { serverBasePath, publicBaseUrl } = http.basePath;
 
     // Grouping all async HTTP requests to run them concurrently for performance reasons.
+    // Anonymous pages skip user-scoped values and async default values (the latter typically
+    // call ES via `asCurrentUser`, which would 401 on an unauthenticated request).
     const [
       defaultSettings,
       settingsUserValues = {},
       globalSettingsUserValues = {},
       userSettingDarkMode,
       userSettingLocale,
-    ] = await Promise.all([
-      // All sites
-      withAsyncDefaultValues(request, uiSettings.client?.getRegistered()),
-      // Only non-anonymous pages
-      ...(!isAnonymousPage
-        ? ([
+    ] = await Promise.all(
+      isAnonymousPage
+        ? [uiSettings.client?.getRegistered() ?? {}]
+        : ([
+            withAsyncDefaultValues(request, uiSettings.client?.getRegistered()),
             uiSettings.client?.getUserProvided(true),
             uiSettings.globalClient?.getUserProvided(true),
             // dark mode
@@ -208,13 +209,13 @@ export class RenderingService {
             // locale
             userSettings?.getUserSettingLocale(request),
           ] as [
+            ReturnType<typeof withAsyncDefaultValues>,
             Promise<Record<string, UserProvidedValues>>,
             Promise<Record<string, UserProvidedValues>>,
             Promise<DarkModeValue> | undefined,
             Promise<string> | undefined
           ])
-        : []),
-    ]);
+    );
 
     const settings = {
       defaults: defaultSettings,


### PR DESCRIPTION
## Summary

> [!IMPORTANT]
> **For reviewers:** This fix assumes async `getValue` defaults are computed for the authenticated user only, so it skips them entirely on anonymous pages. If you think that contract is too strong (i.e. some async defaults could legitimately run without a session/credentials), the alternative is to drop this framework-level guard and instead have **every** `getValue` consumer check `request.auth.isAuthenticated` itself. Happy to switch to that approach if you prefer.

Opening a fresh Kibana tab (no session) logged this error on every cold load:

> [ERROR][plugins.security.authentication] Re-authentication is not possible for the following error: ... "missing authentication credentials for REST request [/_security/user/_has_privileges]" ...

## Root cause

The rendering service unconditionally resolved async UI setting defaults via `withAsyncDefaultValues(request, ...)` when rendering anonymous pages such as `/login`. The `gen_ai_settings` plugin registers an async default for `genAiSettings:defaultAIConnector` whose `getValue` callback fetches the user's connectors:

1. `renderAnonymousCoreApp()` triggers `rendering.render()` on `/login`
2. `withAsyncDefaultValues` invokes every registered `getValue`, including the gen_ai one
3. `getValue` calls `actionsClient.getAll()`, which runs `ActionsAuthorization.ensureAuthorized` and ultimately `asCurrentUser.security.hasPrivileges(...)`
4. The login-page request has no auth headers, ES returns 401
5. The security plugin's `setUnauthorizedErrorHandler` logs the "Re-authentication is not possible" ERROR before the plugin's own try/catch returns `NO_DEFAULT_CONNECTOR`

The page rendered correctly, but the error fired on every cold tab open.

## Fix

Skip `withAsyncDefaultValues` when `isAnonymousPage` is `true` and return the synchronously-registered defaults instead. Anonymous pages have no authenticated user, so user-scoped async defaults have no correct value to compute and would only produce noise (or, in this case, an error) when they hit ES.

Consolidated the two existing `isAnonymousPage` branches in `rendering_service.tsx` into a single ternary while I was here.

## Notes

`gen_ai_settings`' own try/catch already prevented user-visible breakage, but every other plugin registering an async `getValue` would hit the same trap. Folding the guard into the rendering service documents the contract that async defaults are computed for the authenticated user only.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->