### PR TITLE
[Osquery] Fix Status tab pagination for scheduled queries

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/action_results/action_results_summary.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/action_results_summary.test.tsx
@@ -127,7 +127,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdges,
-          totalAgents: 3,
+          total: 3,
           aggregations: {
             totalRowCount: 30,
             totalResponded: 3,
@@ -154,14 +154,14 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       expect(container.querySelector('.euiPagination')).toBeInTheDocument();
     });
 
-    it('should use server totalAgents for pagination count', () => {
+    it('should use server total for pagination count', () => {
       const mockAgents = ['agent-1', 'agent-2'];
       const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
 
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdges,
-          totalAgents: 502,
+          total: 502,
           aggregations: {
             totalRowCount: 30,
             totalResponded: 2,
@@ -181,21 +181,23 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
         <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
       );
 
-      // Verify pagination uses server totalAgents (502) not agentIds.length (2)
+      // Verify pagination uses server total (502) not agentIds.length (2)
       expect(container.querySelector('.euiPagination')).toBeInTheDocument();
     });
 
-    it('should fallback to agentIds.length when totalAgents is undefined', () => {
-      const mockAgents = ['agent-1', 'agent-2', 'agent-3'];
-      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+    it('disables Next on a scheduled-query single-page result set', async () => {
+      // Regression coverage for #269670: scheduled queries don't pass agentIds.
+      // `data.total` must drive pageCount so Next is disabled when total ≤ pageSize.
+      const scheduledEdges = [createMockEdge('agent-1', true)];
 
       useActionResultsMock.mockReturnValue({
         data: {
-          edges: mockEdges,
+          edges: scheduledEdges,
+          total: 1,
           aggregations: {
-            totalRowCount: 30,
-            totalResponded: 3,
-            successful: 3,
+            totalRowCount: 1,
+            totalResponded: 1,
+            successful: 1,
             failed: 0,
             pending: 0,
           },
@@ -205,14 +207,30 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
         isFetching: false,
       } as never);
 
-      mockHttpPost.mockResolvedValue({ agents: [] });
+      mockHttpPost.mockResolvedValue({
+        agents: [{ id: 'agent-1', local_metadata: { host: { name: 'h1' } } }],
+      });
 
       const { container } = renderWithContext(
-        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+        <ActionResultsSummary
+          actionId="test-schedule"
+          scheduleId="test-schedule"
+          executionCount={1}
+        />
       );
 
-      // Verify pagination fallback works
-      expect(container.querySelector('.euiPagination')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(container.querySelector('.euiBasicTable')).toBeInTheDocument();
+      });
+
+      const nextButton = container.querySelector(
+        '[data-test-subj="pagination-button-next"]'
+      ) as HTMLButtonElement | null;
+      // Either the Next button is omitted (no pagination needed) or it's disabled.
+      // What must NOT happen is an enabled Next that opens an empty page.
+      if (nextButton) {
+        expect(nextButton.disabled).toBe(true);
+      }
     });
 
     it('should initialize with default page index 0 and page size 20', () => {
@@ -222,7 +240,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdges,
-          totalAgents: 100,
+          total: 100,
           aggregations: {
             totalRowCount: 200,
             totalResponded: 20,
@@ -257,7 +275,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdgesPage0,
-          totalAgents: 100,
+          total: 100,
           aggregations: {
             totalRowCount: 1000,
             totalResponded: 20,
@@ -282,7 +300,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdgesPage2,
-          totalAgents: 100,
+          total: 100,
           aggregations: {
             totalRowCount: 1000,
             totalResponded: 20,
@@ -337,7 +355,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
         useActionResultsMock.mockReturnValue({
           data: {
             edges: mockEdges,
-            totalAgents: 500,
+            total: 500,
             aggregations: {
               totalRowCount: pageSize * 10,
               totalResponded: pageSize,
@@ -376,7 +394,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdges,
-          totalAgents: 100,
+          total: 100,
           aggregations: {
             totalRowCount: 1000,
             totalResponded: 20,
@@ -420,7 +438,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: [],
-          totalAgents: 0,
+          total: 0,
           aggregations: {
             totalRowCount: 0,
             totalResponded: 0,
@@ -709,7 +727,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdges,
-          totalAgents,
+          total: totalAgents,
           aggregations: {
             totalRowCount: 0,
             totalResponded: 0,
@@ -764,7 +782,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdges,
-          totalAgents: 15000,
+          total: 15000,
           aggregations: {
             totalRowCount: 10000,
             totalResponded: 7500,
@@ -813,7 +831,7 @@ describe('ActionResultsSummary - Server-side Pagination', () => {
       useActionResultsMock.mockReturnValue({
         data: {
           edges: mockEdges,
-          totalAgents,
+          total: totalAgents,
           aggregations: {
             totalRowCount: 0,
             totalResponded: 0,

--- a/x-pack/platform/plugins/shared/osquery/public/action_results/legacy_action_results_summary.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/legacy_action_results_summary.tsx
@@ -201,21 +201,25 @@ const LegacyActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> =
     }
   }, []);
 
+  // `data.total` covers both Live (agentIds.length) and Scheduled (server hits.total).
+  // Scheduled queries have no `agentIds`, so `agentIds.length` would yield totalItemCount=0.
+  const totalItemCount = data.total;
+
   const pagination = useMemo(
     () => ({
       initialPageSize: DEFAULT_PAGE_SIZE,
       pageIndex,
       pageSize,
-      totalItemCount: agentIds?.length ?? 0,
+      totalItemCount,
       pageSizeOptions: [10, 20, 50, 100],
       showPerPageOptions: true,
     }),
-    [pageIndex, pageSize, agentIds?.length]
+    [pageIndex, pageSize, totalItemCount]
   );
 
   const statusTableCss = useMemo(
-    () => createStatusTableCss(pageSize, pageIndex, agentIds?.length ?? 0),
-    [pageSize, pageIndex, agentIds?.length]
+    () => createStatusTableCss(pageSize, pageIndex, totalItemCount),
+    [pageSize, pageIndex, totalItemCount]
   );
 
   // Guard against race conditions when updating isLive

--- a/x-pack/platform/plugins/shared/osquery/public/action_results/unified_action_results_summary.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/unified_action_results_summary.test.tsx
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import type { EuiThemeComputed } from '@elastic/eui';
+import { EuiProvider } from '@elastic/eui';
+import { ThemeProvider } from '@emotion/react';
+
+import { UnifiedActionResultsSummary } from './unified_action_results_summary';
+import * as useActionResultsHook from './use_action_results';
+import { useKibana } from '../common/lib/kibana';
+
+jest.mock('./use_action_results');
+jest.mock('../common/lib/kibana');
+jest.mock('./use_action_results_data_view', () => ({
+  useActionResultsDataView: () => ({ id: 'osquery-status-dv' }),
+}));
+jest.mock('@kbn/unified-data-table', () => ({
+  UnifiedDataTable: () => <div data-test-subj="unifiedDataTable" />,
+  DataLoadingState: { loading: 'loading', loaded: 'loaded' },
+  DataGridDensity: { EXPANDED: 'expanded' },
+}));
+jest.mock('@kbn/cell-actions', () => ({
+  CellActionsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
+const useActionResultsMock = useActionResultsHook.useActionResults as jest.MockedFunction<
+  typeof useActionResultsHook.useActionResults
+>;
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false, cacheTime: 0 } },
+  });
+
+const mockHttpPost = jest.fn();
+
+const mockKibanaServices = () => {
+  useKibanaMock.mockReturnValue({
+    services: {
+      http: { post: mockHttpPost },
+      application: { getUrlForApp: jest.fn().mockReturnValue('/app/fleet') },
+      notifications: { toasts: { addError: jest.fn() } },
+      appName: 'osquery',
+      theme: {},
+      uiSettings: {},
+      data: { fieldFormats: {}, dataViews: { create: jest.fn() } },
+      uiActions: { getTriggerCompatibleActions: jest.fn() },
+    },
+  } as unknown as ReturnType<typeof useKibana>);
+};
+
+const renderWithContext = (Element: React.ReactElement) =>
+  render(
+    <EuiProvider>
+      <ThemeProvider
+        theme={{
+          euiTheme: {
+            colors: { lightestShade: '#fff', success: '#00BFB3' },
+            border: { width: { thin: '1px', thick: '2px' } },
+          } as unknown as EuiThemeComputed<{}>,
+        }}
+      >
+        <IntlProvider locale="en">
+          <QueryClientProvider client={createTestQueryClient()}>{Element}</QueryClientProvider>
+        </IntlProvider>
+      </ThemeProvider>
+    </EuiProvider>
+  );
+
+describe('UnifiedActionResultsSummary - Pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockKibanaServices();
+  });
+
+  it('disables Next on a scheduled-query single-page result set', async () => {
+    // Regression coverage for #269670 on the unified (UnifiedDataTable + EuiTablePagination) path.
+    // Scheduled queries do not pass agentIds; `data.total` from the server must drive pageCount
+    // so Next is disabled when total ≤ pageSize. Before the fix, totalItemCount fell back to
+    // `agentIds?.length ?? 0`, yielding pageCount=0 and an enabled Next that opened an empty page.
+    useActionResultsMock.mockReturnValue({
+      data: {
+        edges: [],
+        total: 1,
+        aggregations: {
+          totalRowCount: 1,
+          totalResponded: 1,
+          successful: 1,
+          failed: 0,
+          pending: 0,
+        },
+        inspect: { dsl: [] },
+      },
+      isLoading: false,
+      isFetching: false,
+    } as never);
+
+    mockHttpPost.mockResolvedValue({ agents: [] });
+
+    const { container } = renderWithContext(
+      <UnifiedActionResultsSummary
+        actionId="test-schedule"
+        scheduleId="test-schedule"
+        executionCount={1}
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-test-subj="unifiedDataTable"]')).toBeInTheDocument();
+    });
+
+    const nextButton = container.querySelector(
+      '[data-test-subj="pagination-button-next"]'
+    ) as HTMLButtonElement | null;
+    // EuiTablePagination must render Next as disabled when pageCount=1 and activePage=0.
+    // If Next is omitted entirely that's also acceptable — what must NOT happen is an enabled
+    // Next that opens an empty page.
+    if (nextButton) {
+      expect(nextButton.disabled).toBe(true);
+    }
+  });
+
+  it('derives pageCount from data.total, not agentIds.length, for scheduled queries', async () => {
+    // 502 total with default page size 20 → 26 pages of numbered page buttons.
+    // Pre-fix, `totalItemCount = agentIds?.length ?? 0` was 0 for scheduled queries, so
+    // EuiPagination rendered no numbered page buttons at all.
+    useActionResultsMock.mockReturnValue({
+      data: {
+        edges: [],
+        total: 502,
+        aggregations: {
+          totalRowCount: 30,
+          totalResponded: 2,
+          successful: 2,
+          failed: 0,
+          pending: 500,
+        },
+        inspect: { dsl: [] },
+      },
+      isLoading: false,
+      isFetching: false,
+    } as never);
+
+    mockHttpPost.mockResolvedValue({ agents: [] });
+
+    const { container } = renderWithContext(
+      <UnifiedActionResultsSummary
+        actionId="test-schedule"
+        scheduleId="test-schedule"
+        executionCount={1}
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-test-subj="unifiedDataTable"]')).toBeInTheDocument();
+    });
+
+    // EuiPagination renders numbered buttons `pagination-button-<index>` only when pageCount>0.
+    // With the fix, page index 1 is present; pre-fix, no numbered buttons render.
+    expect(container.querySelector('[data-test-subj="pagination-button-1"]')).toBeInTheDocument();
+    const nextButton = container.querySelector(
+      '[data-test-subj="pagination-button-next"]'
+    ) as HTMLButtonElement | null;
+    expect(nextButton).not.toBeNull();
+    expect(nextButton!.disabled).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/action_results/unified_action_results_summary.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/unified_action_results_summary.tsx
@@ -201,8 +201,10 @@ const UnifiedActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> 
     [getFleetAppUrl]
   );
 
-  // Pagination
-  const totalItemCount = agentIds?.length ?? 0;
+  // Pagination — `data.total` covers both Live (agentIds.length) and Scheduled
+  // (server hits.total). Scheduled queries have no `agentIds`, so deriving the
+  // count from `agentIds.length` would yield pageCount=0 and leave Next enabled.
+  const totalItemCount = data.total;
   const totalPages = Math.ceil(totalItemCount / pageSize);
 
   const handlePageChange = useCallback((newPageIndex: number) => {

--- a/x-pack/platform/plugins/shared/osquery/public/action_results/use_action_results.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/use_action_results.ts
@@ -18,6 +18,7 @@ import { useErrorToast } from '../common/hooks/use_error_toast';
 
 export interface ActionResultsArgs {
   edges: ResultEdges;
+  total: number;
   aggregations: {
     totalRowCount: number;
     totalResponded: number;
@@ -136,6 +137,7 @@ export const useActionResults = ({
         if (isScheduled) {
           return {
             edges: response.edges as ResultEdges,
+            total: response.total ?? response.edges.length,
             aggregations: response.aggregations,
             inspect: response.inspect || { dsl: [], response: [] },
           };
@@ -160,13 +162,14 @@ export const useActionResults = ({
 
         return {
           edges: mergedEdges,
+          total: agentIds?.length ?? 0,
           aggregations: response.aggregations,
           inspect: response.inspect || { dsl: [], response: [] },
         };
       },
       initialData: {
         edges: [],
-        total: 0,
+        total: isScheduled ? 0 : agentIds?.length ?? 0,
         currentPage: 0,
         pageSize: limit,
         totalPages: 0,


### PR DESCRIPTION
## Summary

Fixes [#269670](https://github.com/elastic/kibana/issues/269670) — the Status tab on the Osquery query results page allowed users to navigate to empty pages for Scheduled Queries when the result set fit on a single page. Live Queries were unaffected.

## Root cause

Both `UnifiedActionResultsSummary` (default) and `LegacyActionResultsSummary` derived `totalItemCount` exclusively from `agentIds?.length ?? 0`. That works for Live Queries (the dispatched agent set is known up front) but not for Scheduled Queries, which only know `scheduleId` + `executionCount` and don't carry an `agentIds` list. `totalItemCount` collapsed to `0`, `pageCount` became `0`, and `EuiTablePagination` rendered the Next arrow as clickable — navigating into an empty page that showed "No results found".

The server route at `/api/osquery/scheduled_results/{scheduleId}/{executionCount}` already returns the correct `total`, but `useActionResults` dropped it in the `select` transform on the scheduled branch.

Closes #269670


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->