### PR TITLE
fix(tests, security): disable SAML Mock IdP plugin for stateful tests

### DIFF
--- a/src/platform/test/functional/config.base.js
+++ b/src/platform/test/functional/config.base.js
@@ -11,6 +11,9 @@ import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import { pageObjects } from './page_objects';
 import { services } from './services';
 
+// if config is executed on CI or locally
+const isRunOnCI = process.env.CI;
+
 export default async function ({ readConfigFile }) {
   const commonConfig = await readConfigFile(require.resolve('../common/config'));
 
@@ -44,6 +47,10 @@ export default async function ({ readConfigFile }) {
         `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify(['Fleet-Metrics-Task'])}`,
         // disable tours globally for all tests
         '--uiSettings.globalOverrides.hideAnnouncements=true',
+
+        // if the config is run locally, disable mock SAML IdP Kibana plugin, since Elasticsearch in stateful tests
+        // isn't configured with SAML.
+        ...(isRunOnCI ? [] : ['--mockIdpPlugin.enabled=false']),
       ],
     },
 

--- a/x-pack/platform/test/functional/config.base.ts
+++ b/x-pack/platform/test/functional/config.base.ts
@@ -11,6 +11,9 @@ import type { FtrConfigProviderContext } from '@kbn/test';
 import { services } from './services';
 import { pageObjects } from './page_objects';
 
+// if config is executed on CI or locally
+const isRunOnCI = process.env.CI;
+
 // the default export of config files must be a config provider
 // that returns an object with the projects config values
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
@@ -52,6 +55,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--server.restrictInternalApis=false',
         // disable fleet task that writes to metrics.fleet_server.* data streams, impacting functional tests
         `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify(['Fleet-Metrics-Task'])}`,
+        // if the config is run locally, disable mock SAML IdP Kibana plugin, since Elasticsearch in stateful tests
+        // isn't configured with SAML.
+        ...(isRunOnCI ? [] : ['--mockIdpPlugin.enabled=false']),
       ],
     },
     uiSettings: {


### PR DESCRIPTION
## Summary

Disable SAML Mock IdP plugin for stateful tests because, unlike deployment-agnostic tests, these don't configure SAML in the test Elasticsearch cluster.

This only affects stateful tests when run locally, where Kibana is run in development mode and automatically configures the SAML Mock IdP plugin. On CI, we run Kibana from a distribution without this test-only plugin.

