### PR TITLE
[ES|QL] Removes unused types from the monitoring function

### DIFF
--- a/src/platform/plugins/shared/esql/server/metrics.ts
+++ b/src/platform/plugins/shared/esql/server/metrics.ts
@@ -17,9 +17,6 @@ export const esqlRouteRequestCounter = meter.createCounter('kibana.esql.route.re
   valueType: ValueType.INT,
 });
 
-export type EsqlRouteName = 'datasets' | 'views' | 'timefield';
-export type EsqlRouteOutcome = 'success' | 'failure';
-
 export const getErrorStatusCode = (error: unknown): number => {
   const err = error as { statusCode?: number; meta?: { statusCode?: number } } | null;
   return err?.statusCode ?? err?.meta?.statusCode ?? 500;


### PR DESCRIPTION
## Summary

Follow up of https://github.com/elastic/kibana/pull/269027. I forgot to clean up the unused types



