### PR TITLE
[One Workflow] fix ES search sort validation

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/elasticsearch/overrides/elasticsearch.search.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/elasticsearch/overrides/elasticsearch.search.ts
@@ -146,7 +146,7 @@ This situation can occur because the splitting criterion is based on Lucene docu
     ...search.shape,
     ...getShapeAt(search_request, 'query'),
     index: types_indices,
-    // Elasticsearch accepts several body sort syntaxes that are stricter in the OpenAPI schema.
+    // The OpenAPI-generated schema for sort is too restrictive; ES accepts complex body-sort objects that the schema rejects.
     sort: z.any().optional(),
   }),
   outputSchema: global_search_response_body,

--- a/src/platform/packages/shared/kbn-workflows/spec/elasticsearch/overrides/elasticsearch.search.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/elasticsearch/overrides/elasticsearch.search.ts
@@ -146,6 +146,8 @@ This situation can occur because the splitting criterion is based on Lucene docu
     ...search.shape,
     ...getShapeAt(search_request, 'query'),
     index: types_indices,
+    // Elasticsearch accepts several body sort syntaxes that are stricter in the OpenAPI schema.
+    sort: z.any().optional(),
   }),
   outputSchema: global_search_response_body,
 };

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema_from_connectors.es.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema_from_connectors.es.test.ts
@@ -32,6 +32,34 @@ describe('generateYamlSchemaFromConnectors / elasticsearch connectors', () => {
     expect(() => workflowSchema.parse({ steps: [] })).toThrow();
   });
 
+  it('should accept elasticsearch.search body-style sort objects', () => {
+    const result = workflowSchema.safeParse({
+      name: 'test-workflow',
+      enabled: true,
+      triggers: [{ type: 'manual' }],
+      steps: [
+        {
+          name: 'search-sorted-docs',
+          type: 'elasticsearch.search',
+          with: {
+            index: 'test-index',
+            query: { match_all: {} },
+            sort: [
+              {
+                '@timestamp': {
+                  order: 'desc',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
   ES_VALID_SAMPLE_STEPS.forEach((step) => {
     it(`${step.type} (${step.name})`, async () => {
       const result = workflowSchema.safeParse({

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/get_workflow_json_schema.es.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/get_workflow_json_schema.es.test.ts
@@ -59,6 +59,36 @@ describe('getWorkflowJsonSchema / elasticsearch connectors', () => {
     expect(JSON.stringify(jsonSchema).length).toBeGreaterThan(20);
   });
 
+  it('should allow elasticsearch.search body-style sort objects in Monaco / YAML LSP', async () => {
+    const diagnostics = await validateWithYamlLsp(
+      'test-elasticsearch-search-body-sort.yaml',
+      yaml.stringify({
+        name: 'test-workflow',
+        enabled: true,
+        triggers: [{ type: 'manual' }],
+        steps: [
+          {
+            name: 'search-sorted-docs',
+            type: 'elasticsearch.search',
+            with: {
+              index: 'test-index',
+              query: { match_all: {} },
+              sort: [
+                {
+                  '@timestamp': {
+                    order: 'desc',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
   ES_VALID_SAMPLE_STEPS.forEach((step) => {
     it(`${step.type}`, async () => {
       const diagnostics = await validateWithYamlLsp(

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/samples/es_steps.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/samples/es_steps.ts
@@ -60,7 +60,13 @@ export const ES_VALID_SAMPLE_STEPS = [
       timeout: '30s',
       track_total_hits: true,
       _source: ['message', 'timestamp'],
-      sort: 'timestamp:desc',
+      sort: [
+        {
+          '@timestamp': {
+            order: 'desc',
+          },
+        },
+      ],
       highlight: {
         fields: {
           message: {},


### PR DESCRIPTION
## Summary

- Allows `elasticsearch.search` workflow steps to validate Elasticsearch body-style `sort` syntax, including object entries with `order: desc`.
- Updates the ES connector validation sample to cover the real body syntax instead of the misleading `field:direction` string form.

## References

Closes elastic/security-team#17429

## Test plan

- [x] `node scripts/jest src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema_from_connectors.es.test.ts src/platform/packages/shared/kbn-workflows/spec/lib/get_workflow_json_schema.es.test.ts`
- [x] `node scripts/eslint src/platform/packages/shared/kbn-workflows/spec/lib/samples/es_steps.ts src/platform/packages/shared/kbn-workflows/spec/elasticsearch/overrides/elasticsearch.search.ts`


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->