### PR TITLE
[Alerting v2] Add preview query option to agent builder canvas

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_child.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_child.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import {
   EuiFlyout,
@@ -17,33 +17,22 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiLoadingSpinner,
   EuiText,
-  EuiCallOut,
-  EuiEmptyPrompt,
-  EuiToolTip,
-  EuiSuperDatePicker,
-  EuiSelect,
-  EuiPanel,
   EuiTabs,
   EuiTab,
-  EuiDataGrid,
-  type EuiDataGridColumn,
-  type EuiDataGridCellValueElementProps,
+  EuiPanel,
 } from '@elastic/eui';
-import { CodeEditor, ESQL_LANG_ID, type monaco } from '@kbn/code-editor';
+import type { monaco } from '@kbn/code-editor';
 import type { ComposeFormValues } from './compose_form_types';
 import { getBreachQuery } from './compose_form_types';
 import { useRuleFormServices } from '../../form/contexts/rule_form_context';
-import { useDataFields } from '../../form/hooks/use_data_fields';
 import type {
   ComposeDiscoverState,
   ComposeDiscoverAction,
   SandboxTabConfig,
   SandboxApplyData,
 } from './types';
-import { useQueryExecution } from './use_query_execution';
-import { ComposeDiscoverChart } from './compose_discover_chart';
+import { DiscoverSandboxPanel } from './discover_sandbox_panel';
 import { ComposeDiscoverTabs, TAB_DEFINITIONS, visibleTabIds } from './compose_discover_tabs';
 
 interface ComposeDiscoverChildProps {
@@ -55,18 +44,14 @@ interface ComposeDiscoverChildProps {
   onRecoveryEditorMount?: (editor: monaco.editor.IStandaloneCodeEditor) => void;
   onClose: () => void;
   /** Called when the user clicks "Apply changes". The parent writes the query
-   *  into RHF (the source of truth) and updates the reducer cache. */
+   *  into react-hook-form (the source of truth) and updates the reducer cache. */
   onApply: (data: SandboxApplyData) => void;
 }
 
 const CHILD_FLYOUT_TITLE_ID = 'composeDiscoverChildTitle';
-const VISIBLE_ROWS = 10;
 const INITIAL_EDITOR_HEIGHT = 200;
 const MIN_EDITOR_HEIGHT = 80;
 const MAX_EDITOR_HEIGHT = 600;
-
-const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
-const RUN_SHORTCUT_LABEL = isMac ? '⌘⏎' : 'Ctrl+Enter';
 
 export const ComposeDiscoverChild: React.FC<ComposeDiscoverChildProps> = ({
   state,
@@ -84,102 +69,25 @@ export const ComposeDiscoverChild: React.FC<ComposeDiscoverChildProps> = ({
   const [localAlertBlock, setLocalAlertBlock] = useState(state.alertBlock);
   const [localRecoveryBlock, setLocalRecoveryBlock] = useState(state.recoveryBlock);
 
-  // Read timeField and the base query from RHF
   const { setValue: setFormValue, watch: watchForm } = useFormContext<ComposeFormValues>();
   const timeField = watchForm('timeField') ?? '@timestamp';
   const formQuery = getBreachQuery(watchForm('query'));
 
-  // In single mode, sync localQuery when RHF's query changes externally
-  // (e.g. from YAML edits that debounce into RHF). When the change comes
-  // from this Sandbox's own "Apply changes", formQuery equals localQuery
-  // so the setState is a no-op.
+  // In single mode, sync localQuery when react-hook-form's query changes
+  // externally (e.g. from YAML edits that debounce into the form).
   useEffect(() => {
     if (!isSplit) {
       setLocalQuery(formQuery);
     }
   }, [formQuery, isSplit]);
 
-  // Date range persists in the reducer so it's remembered across Sandbox open/close.
-  // It is intentionally not connected to schedule.lookback in FormValues — it's a
-  // preview window for testing the query, not a rule configuration field.
   const dateStart = state.sandboxDateStart;
   const dateEnd = state.sandboxDateEnd;
 
-  const timeRange = useMemo(() => ({ from: dateStart, to: dateEnd }), [dateStart, dateEnd]);
-
-  // In split mode the "active" query for execution and field-detection is the full assembled
-  // query (base + alert block). In single mode it is the local editor content.
+  // In split mode the "active" query for execution is the full assembled query.
   const activeQuery = isSplit
     ? [localBaseQuery, localAlertBlock].filter(Boolean).join('\n')
     : localQuery;
-
-  // Only fetch fields when the query has a real index pattern after FROM.
-  const queryForFields = /^\s*FROM\s+[a-zA-Z0-9_.*-]/i.test(activeQuery) ? activeQuery : '';
-  const { data: fieldMap } = useDataFields({
-    query: queryForFields,
-    http: services.http,
-    dataViews: services.dataViews,
-  });
-
-  const timeFieldOptions = useMemo(() => {
-    const dateFields = Object.values(fieldMap)
-      .filter((f) => f.type === 'date')
-      .map((f) => f.name)
-      .sort();
-
-    // No index queried yet (or index has no date fields) — show @timestamp as the
-    // conventional default. Never inject it alongside real fields so the selector
-    // only shows fields that actually exist in the index.
-    if (dateFields.length === 0) {
-      return [{ value: '@timestamp', text: '@timestamp' }];
-    }
-
-    return dateFields.map((name) => ({ value: name, text: name }));
-  }, [fieldMap]);
-
-  // Keep the selected time field in sync with what the index actually has.
-  useEffect(() => {
-    const dateFieldNames = Object.values(fieldMap)
-      .filter((f) => f.type === 'date')
-      .map((f) => f.name);
-
-    if (dateFieldNames.length === 0) {
-      // Editor cleared or no date fields — reset to @timestamp convention.
-      if (timeField !== '@timestamp') setFormValue('timeField', '@timestamp');
-    } else if (!dateFieldNames.includes(timeField)) {
-      // Index changed and selected field isn't present — pick the first real one.
-      setFormValue('timeField', dateFieldNames[0]);
-    }
-  }, [fieldMap, timeField, setFormValue]);
-
-  const {
-    columns,
-    rows,
-    totalRowCount,
-    isLoading,
-    isError,
-    error,
-    run,
-    hasRun,
-    lastExecutedQuery,
-  } = useQueryExecution({
-    query: activeQuery,
-    timeField,
-    timeRange,
-    data: services.data,
-  });
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-        e.preventDefault();
-        e.stopPropagation();
-        run();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown, true);
-    return () => window.removeEventListener('keydown', handleKeyDown, true);
-  }, [run]);
 
   const handleDone = useCallback(() => {
     onApply({
@@ -191,45 +99,6 @@ export const ComposeDiscoverChild: React.FC<ComposeDiscoverChildProps> = ({
     });
   }, [isSplit, localQuery, localBaseQuery, localAlertBlock, localRecoveryBlock, onApply]);
 
-  const gridColumns: EuiDataGridColumn[] = useMemo(
-    () =>
-      columns.map((col) => ({
-        id: col.id,
-        displayAsText: col.displayAsText,
-        schema: col.esType,
-      })),
-    [columns]
-  );
-
-  const [visibleColumns, setVisibleColumns] = useState<string[]>([]);
-
-  const prevColumnIdsRef = useRef('');
-  useEffect(() => {
-    const ids = columns.map((c) => c.id).join(',');
-    if (ids !== prevColumnIdsRef.current) {
-      prevColumnIdsRef.current = ids;
-      setVisibleColumns(columns.map((c) => c.id));
-    }
-  }, [columns]);
-
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: VISIBLE_ROWS });
-  const onChangePage = useCallback((pageIndex: number) => {
-    setPagination((prev) => ({ ...prev, pageIndex }));
-  }, []);
-  const onChangeItemsPerPage = useCallback((pageSize: number) => {
-    setPagination({ pageIndex: 0, pageSize });
-  }, []);
-
-  const renderCellValue = useCallback(
-    ({ rowIndex, columnId }: EuiDataGridCellValueElementProps) => {
-      const row = rows[rowIndex];
-      if (!row) return null;
-      const value = row[columnId];
-      return <>{value ?? '—'}</>;
-    },
-    [rows]
-  );
-
   const splitTabs = useMemo(() => {
     if (!isSplit) return [];
     const tabIds = visibleTabIds(tabConfig);
@@ -238,7 +107,7 @@ export const ComposeDiscoverChild: React.FC<ComposeDiscoverChildProps> = ({
 
   const editorPanelStyles: React.CSSProperties = useMemo(
     () => ({
-      resize: 'vertical',
+      resize: 'vertical' as const,
       overflow: 'auto',
       height: INITIAL_EDITOR_HEIGHT,
       minHeight: MIN_EDITOR_HEIGHT,
@@ -246,6 +115,44 @@ export const ComposeDiscoverChild: React.FC<ComposeDiscoverChildProps> = ({
     }),
     []
   );
+
+  const splitEditorSlot = isSplit ? (
+    <>
+      {splitTabs.length > 0 && (
+        <>
+          <EuiTabs>
+            {splitTabs.map((tab) => (
+              <EuiTab
+                key={tab.id}
+                isSelected={state.activeTab === tab.id}
+                onClick={() => dispatch({ type: 'SET_TAB', tab: tab.id })}
+                data-test-subj={`composeDiscoverTab-${tab.id}`}
+              >
+                {tab.label}
+              </EuiTab>
+            ))}
+          </EuiTabs>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      <EuiPanel hasBorder paddingSize="s" style={editorPanelStyles}>
+        <ComposeDiscoverTabs
+          baseQuery={localBaseQuery}
+          alertBlock={localAlertBlock}
+          recoveryBlock={localRecoveryBlock}
+          onBaseQueryChange={setLocalBaseQuery}
+          onAlertBlockChange={setLocalAlertBlock}
+          onRecoveryBlockChange={setLocalRecoveryBlock}
+          activeTab={state.activeTab}
+          onTabChange={(tab) => dispatch({ type: 'SET_TAB', tab })}
+          tabConfig={tabConfig}
+          onAlertEditorMount={onAlertEditorMount}
+          onRecoveryEditorMount={onRecoveryEditorMount}
+          hideTabBar
+        />
+      </EuiPanel>
+    </>
+  ) : undefined;
 
   return (
     <EuiFlyout type="overlay" size="fill" onClose={onClose} aria-labelledby={CHILD_FLYOUT_TITLE_ID}>
@@ -262,178 +169,19 @@ export const ComposeDiscoverChild: React.FC<ComposeDiscoverChildProps> = ({
       </EuiFlyoutHeader>
 
       <EuiFlyoutBody>
-        {/* ── 0. Tab bar (split mode only) ─────────────────────────────── */}
-        {splitTabs.length > 0 && (
-          <>
-            <EuiTabs>
-              {splitTabs.map((tab) => (
-                <EuiTab
-                  key={tab.id}
-                  isSelected={state.activeTab === tab.id}
-                  onClick={() => dispatch({ type: 'SET_TAB', tab: tab.id })}
-                  data-test-subj={`composeDiscoverTab-${tab.id}`}
-                >
-                  {tab.label}
-                </EuiTab>
-              ))}
-            </EuiTabs>
-            <EuiSpacer size="s" />
-          </>
-        )}
-
-        {/* ── 1. Time field / date picker / Search row — one line ──────── */}
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
-          <EuiFlexItem grow={false} style={{ width: 200, minWidth: 0 }}>
-            <EuiSelect
-              options={timeFieldOptions}
-              value={timeField}
-              aria-label="Time field for rule execution"
-              onChange={(e) => setFormValue('timeField', e.target.value)}
-              compressed
-              prepend="Time field"
-              data-test-subj="composeDiscoverTimeField"
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow>
-            <EuiSuperDatePicker
-              start={dateStart}
-              end={dateEnd}
-              onTimeChange={({ start, end }) => {
-                dispatch({ type: 'SET_SANDBOX_DATE_RANGE', start, end });
-              }}
-              showUpdateButton={false}
-              compressed
-              width="full"
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiToolTip content={`Search (${RUN_SHORTCUT_LABEL})`}>
-              <EuiButton
-                size="s"
-                onClick={run}
-                isLoading={isLoading}
-                data-test-subj="composeDiscoverRunQuery"
-              >
-                Search
-              </EuiButton>
-            </EuiToolTip>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size="s" />
-
-        {/* ── 2. Editor — bordered panel ──────────────────────────────── */}
-        <EuiPanel hasBorder paddingSize="s" style={{ ...editorPanelStyles }}>
-          {isSplit ? (
-            <ComposeDiscoverTabs
-              baseQuery={localBaseQuery}
-              alertBlock={localAlertBlock}
-              recoveryBlock={localRecoveryBlock}
-              onBaseQueryChange={setLocalBaseQuery}
-              onAlertBlockChange={setLocalAlertBlock}
-              onRecoveryBlockChange={setLocalRecoveryBlock}
-              activeTab={state.activeTab}
-              onTabChange={(tab) => dispatch({ type: 'SET_TAB', tab })}
-              tabConfig={tabConfig}
-              onAlertEditorMount={onAlertEditorMount}
-              onRecoveryEditorMount={onRecoveryEditorMount}
-              hideTabBar
-            />
-          ) : (
-            <CodeEditor
-              languageId={ESQL_LANG_ID}
-              value={localQuery}
-              onChange={setLocalQuery}
-              height="100%"
-              options={{
-                minimap: { enabled: false },
-                automaticLayout: true,
-                scrollBeyondLastLine: false,
-                fontSize: 13,
-              }}
-            />
-          )}
-        </EuiPanel>
-        <EuiSpacer size="s" />
-
-        {/* ── 3. Footer stats ─────────────────────────────────────────── */}
-        {hasRun && !isLoading && !isError && (
-          <EuiText size="xs" color="subdued">
-            {totalRowCount.toLocaleString()} {totalRowCount === 1 ? 'result' : 'results'}
-          </EuiText>
-        )}
-
-        <EuiSpacer size="s" />
-
-        {/* ── 4. Results ──────────────────────────────────────────────── */}
-        <EuiSpacer size="m" />
-
-        {!hasRun && (
-          <EuiEmptyPrompt
-            iconType="playFilled"
-            title={<h4>Run your query to see results</h4>}
-            body={
-              <p>
-                Click <strong>Search</strong> or press <strong>{RUN_SHORTCUT_LABEL}</strong> to
-                execute the query.
-              </p>
-            }
-          />
-        )}
-
-        {hasRun && isLoading && (
-          <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: 200 }}>
-            <EuiFlexItem grow={false}>
-              <EuiLoadingSpinner size="l" />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        )}
-
-        {hasRun && isError && (
-          <EuiCallOut announceOnMount color="danger" iconType="error" title="Query error">
-            <p>{error}</p>
-          </EuiCallOut>
-        )}
-
-        {hasRun && !isLoading && !isError && rows.length === 0 && activeQuery.trim() && (
-          <EuiEmptyPrompt
-            iconType="search"
-            title={<h4>No results</h4>}
-            body={<p>The query returned no results for the current time range.</p>}
-          />
-        )}
-
-        {hasRun && !isLoading && !isError && rows.length > 0 && (
-          <>
-            <ComposeDiscoverChart
-              query={lastExecutedQuery ?? activeQuery}
-              timeField={timeField}
-              timeRange={timeRange}
-              columns={columns}
-            />
-
-            <EuiSpacer size="m" />
-
-            <EuiDataGrid
-              aria-label="Query results"
-              columns={gridColumns}
-              columnVisibility={{ visibleColumns, setVisibleColumns }}
-              rowCount={rows.length}
-              renderCellValue={renderCellValue}
-              pagination={{
-                ...pagination,
-                pageSizeOptions: [10, 25, 50],
-                onChangePage,
-                onChangeItemsPerPage,
-              }}
-              gridStyle={{ border: 'all', header: 'shade', fontSize: 's', cellPadding: 's' }}
-              toolbarVisibility={{
-                showColumnSelector: true,
-                showSortSelector: true,
-                showFullScreenSelector: false,
-              }}
-            />
-          </>
-        )}
+        <DiscoverSandboxPanel
+          query={activeQuery}
+          timeField={timeField}
+          dateStart={dateStart}
+          dateEnd={dateEnd}
+          onDateRangeChange={(start, end) =>
+            dispatch({ type: 'SET_SANDBOX_DATE_RANGE', start, end })
+          }
+          onTimeFieldChange={(field) => setFormValue('timeField', field)}
+          onQueryChange={isSplit ? undefined : setLocalQuery}
+          services={{ http: services.http, data: services.data, dataViews: services.dataViews }}
+          editorSlot={splitEditorSlot}
+        />
       </EuiFlyoutBody>
 
       <EuiFlyoutFooter>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -69,7 +69,7 @@ const EDIT_MODE_OPTIONS = [
 export interface ComposeDiscoverFlyoutProps {
   historyKey: symbol;
   mode?: ComposeDiscoverMode;
-  /** The existing rule — provided when mode === 'edit'. Used to seed the RHF form. */
+  /** The existing rule — provided when mode === 'edit'. Used to seed the form. */
   rule?: Parameters<typeof mapRuleToComposeFormValues>[0];
   /** The ID of the rule being edited. Required when mode === 'edit'. */
   ruleId?: string;
@@ -204,7 +204,7 @@ export const ComposeDiscoverFlyout: React.FC<ComposeDiscoverFlyoutProps> = ({
   const isLastStep = uiState.step === steps.length - 1;
 
   /*
-   * Sync recovery into RHF.query (composed blocks.recover or standalone recover).
+   * Sync recovery into the form query (composed blocks.recover or standalone recover).
    * When tracking + custom recovery, persist the Sandbox recovery block/shape.
    * Otherwise strip recover from the canonical query shape.
    */
@@ -262,8 +262,8 @@ export const ComposeDiscoverFlyout: React.FC<ComposeDiscoverFlyoutProps> = ({
   const debouncedParseRef = useRef<ReturnType<typeof setTimeout>>();
 
   // Wraps setYamlText with a debounced (~300 ms) lenient parse that pushes
-  // every YAML keystroke into RHF. The Sandbox watches RHF, so it sees
-  // YAML edits live. Passed to YamlRuleForm as the setYamlText prop.
+  // every YAML keystroke into react-hook-form. The Sandbox watches the form,
+  // so it sees YAML edits live. Passed to YamlRuleForm as the setYamlText prop.
   const handleSetYamlText = useCallback(
     (yaml: string) => {
       setYamlText(yaml);
@@ -310,9 +310,8 @@ export const ComposeDiscoverFlyout: React.FC<ComposeDiscoverFlyoutProps> = ({
   }, [methods, dispatch]);
 
   // Imperative handler for Sandbox "Apply changes". Writes the committed
-  // query into both RHF (the source of truth) and the reducer cache, then
-  // regenerates YAML if in YAML mode. No effects involved for the eval
-  // query — every Apply call executes this directly.
+  // query into both react-hook-form (the source of truth) and the reducer
+  // cache, then regenerates YAML if in YAML mode.
   const handleSandboxApply = useCallback(
     (data: SandboxApplyData) => {
       const updatedQuery: RuleQuery = data.isSplit
@@ -355,8 +354,8 @@ export const ComposeDiscoverFlyout: React.FC<ComposeDiscoverFlyoutProps> = ({
     }
   });
 
-  // YAML "Save" — flush any pending debounce into RHF, then run the shared
-  // handleSubmit path so validation + submission use a single pipeline.
+  // YAML "Save" — flush any pending debounce into react-hook-form, then run
+  // the shared handleSubmit path so validation + submission use a single pipeline.
   const handleYamlSave = useCallback(() => {
     clearTimeout(debouncedParseRef.current);
     const result = parseYamlToFormValues(yamlText);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form.tsx
@@ -376,7 +376,7 @@ function AlertConditionStep({
         data-test-subj="composeDiscoverTrackingToggle"
       />
 
-      {/* Schedule and lookback — connected to RHF via useFormContext() internally */}
+      {/* Schedule and lookback — connected to react-hook-form via useFormContext() internally */}
       <EuiSpacer size="m" />
       <ScheduleField />
       <EuiSpacer size="m" />
@@ -443,7 +443,7 @@ function RecoveryConditionStep({
 function DetailsAndArtifactsStep() {
   return (
     <>
-      {/* Name, description, tags — connected to RHF via useFormContext() internally */}
+      {/* Name, description, tags — connected to react-hook-form via useFormContext() internally */}
       <RuleDetailsFieldGroup />
 
       <EuiHorizontalRule margin="m" />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/discover_sandbox_panel.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/discover_sandbox_panel.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { DiscoverSandboxPanel, type DiscoverSandboxPanelProps } from './discover_sandbox_panel';
+
+const mockRun = jest.fn();
+jest.mock('./use_query_execution', () => ({
+  useQueryExecution: () => ({
+    columns: [],
+    rows: [],
+    totalRowCount: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    run: mockRun,
+    hasRun: false,
+    lastExecutedQuery: null,
+  }),
+}));
+
+jest.mock('./compose_discover_chart', () => ({
+  ComposeDiscoverChart: () => <div data-test-subj="mockChart" />,
+}));
+
+jest.mock('../../form/hooks/use_data_fields', () => ({
+  useDataFields: () => ({
+    data: { '@timestamp': { name: '@timestamp', type: 'date' } },
+  }),
+}));
+
+jest.mock('@kbn/code-editor', () => ({
+  ESQL_LANG_ID: 'esql',
+  CodeEditor: ({ value, options }: { value: string; options?: Record<string, unknown> }) => (
+    <pre
+      data-test-subj="codeEditorMock"
+      data-readonly={String(options?.readOnly ?? false)}
+      data-dom-readonly={String(options?.domReadOnly ?? false)}
+    >
+      {value}
+    </pre>
+  ),
+}));
+
+const createMockServices = (): DiscoverSandboxPanelProps['services'] => ({
+  http: {} as any,
+  data: { search: { search: jest.fn() } } as any,
+  dataViews: {} as any,
+});
+
+const defaultProps: DiscoverSandboxPanelProps = {
+  query: 'FROM logs-* | STATS count() BY host.name',
+  timeField: '@timestamp',
+  dateStart: 'now-15m',
+  dateEnd: 'now',
+  onDateRangeChange: jest.fn(),
+  onTimeFieldChange: jest.fn(),
+  onQueryChange: jest.fn(),
+  services: createMockServices(),
+};
+
+const renderPanel = (overrides: Partial<DiscoverSandboxPanelProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DiscoverSandboxPanel {...defaultProps} {...overrides} />
+    </QueryClientProvider>
+  );
+};
+
+describe('DiscoverSandboxPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the code editor with the query', () => {
+    renderPanel();
+    const editor = screen.getByTestId('codeEditorMock');
+    expect(editor).toBeDefined();
+    expect(editor.textContent).toContain('FROM logs-*');
+  });
+
+  it('renders the time field selector', () => {
+    renderPanel();
+    expect(screen.getByTestId('composeDiscoverTimeField')).toBeDefined();
+  });
+
+  it('renders the search button', () => {
+    renderPanel();
+    expect(screen.getByTestId('composeDiscoverRunQuery')).toBeDefined();
+  });
+
+  it('shows empty prompt before query is run', () => {
+    renderPanel();
+    expect(screen.getByText('Run your query to see results')).toBeDefined();
+  });
+
+  describe('readOnly mode', () => {
+    it('sets the editor to readOnly when readOnly is true', () => {
+      renderPanel({ readOnly: true });
+      const editor = screen.getByTestId('codeEditorMock');
+      expect(editor.dataset.readonly).toBe('true');
+      expect(editor.dataset.domReadonly).toBe('true');
+    });
+
+    it('sets the editor to editable when readOnly is false', () => {
+      renderPanel({ readOnly: false });
+      const editor = screen.getByTestId('codeEditorMock');
+      expect(editor.dataset.readonly).toBe('false');
+      expect(editor.dataset.domReadonly).toBe('false');
+    });
+
+    it('disables the time field selector when readOnly', () => {
+      renderPanel({ readOnly: true });
+      const select = screen.getByTestId('composeDiscoverTimeField');
+      expect(select).toBeDisabled();
+    });
+
+    it('enables the time field selector when not readOnly', () => {
+      renderPanel({ readOnly: false });
+      const select = screen.getByTestId('composeDiscoverTimeField');
+      expect(select).not.toBeDisabled();
+    });
+  });
+
+  describe('editorSlot', () => {
+    it('renders the editorSlot instead of the default editor when provided', () => {
+      renderPanel({
+        editorSlot: <div data-test-subj="customEditorSlot">Custom editor</div>,
+      });
+      expect(screen.getByTestId('customEditorSlot')).toBeDefined();
+      expect(screen.queryByTestId('codeEditorMock')).toBeNull();
+    });
+
+    it('renders the default editor when editorSlot is not provided', () => {
+      renderPanel();
+      expect(screen.getByTestId('codeEditorMock')).toBeDefined();
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/discover_sandbox_panel.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/discover_sandbox_panel.tsx
@@ -1,0 +1,316 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiDataGrid,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiSelect,
+  EuiSpacer,
+  EuiSuperDatePicker,
+  EuiText,
+  EuiToolTip,
+  type EuiDataGridColumn,
+  type EuiDataGridCellValueElementProps,
+} from '@elastic/eui';
+import { CodeEditor, ESQL_LANG_ID } from '@kbn/code-editor';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { HttpStart } from '@kbn/core/public';
+import { useQueryExecution } from './use_query_execution';
+import { ComposeDiscoverChart } from './compose_discover_chart';
+import { useDataFields } from '../../form/hooks/use_data_fields';
+
+export interface DiscoverSandboxServices {
+  http: HttpStart;
+  data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
+}
+
+export interface DiscoverSandboxPanelProps {
+  query: string;
+  timeField: string;
+  dateStart: string;
+  dateEnd: string;
+  onDateRangeChange: (start: string, end: string) => void;
+  onTimeFieldChange?: (field: string) => void;
+  onQueryChange?: (query: string) => void;
+  readOnly?: boolean;
+  services: DiscoverSandboxServices;
+  /**
+   * When provided, replaces the default CodeEditor panel entirely.
+   * Used by the form wrapper to render split-mode tab editors.
+   */
+  editorSlot?: React.ReactNode;
+}
+
+const VISIBLE_ROWS = 10;
+const INITIAL_EDITOR_HEIGHT = 200;
+const MIN_EDITOR_HEIGHT = 80;
+const MAX_EDITOR_HEIGHT = 600;
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
+const RUN_SHORTCUT_LABEL = isMac ? '⌘⏎' : 'Ctrl+Enter';
+
+export const DiscoverSandboxPanel: React.FC<DiscoverSandboxPanelProps> = ({
+  query,
+  timeField,
+  dateStart,
+  dateEnd,
+  onDateRangeChange,
+  onTimeFieldChange,
+  onQueryChange,
+  readOnly = false,
+  services,
+  editorSlot,
+}) => {
+  const timeRange = useMemo(() => ({ from: dateStart, to: dateEnd }), [dateStart, dateEnd]);
+
+  const queryForFields = /^\s*FROM\s+[a-zA-Z0-9_.*-]/i.test(query) ? query : '';
+  const { data: fieldMap } = useDataFields({
+    query: queryForFields,
+    http: services.http,
+    dataViews: services.dataViews,
+  });
+
+  const timeFieldOptions = useMemo(() => {
+    const dateFields = Object.values(fieldMap)
+      .filter((f) => f.type === 'date')
+      .map((f) => f.name)
+      .sort();
+
+    if (dateFields.length === 0) {
+      return [{ value: timeField, text: timeField }];
+    }
+
+    return dateFields.map((name) => ({ value: name, text: name }));
+  }, [fieldMap, timeField]);
+
+  const {
+    columns,
+    rows,
+    totalRowCount,
+    isLoading,
+    isError,
+    error,
+    run,
+    hasRun,
+    lastExecutedQuery,
+  } = useQueryExecution({
+    query,
+    timeField,
+    timeRange,
+    data: services.data,
+  });
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        run();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [run]);
+
+  const gridColumns: EuiDataGridColumn[] = useMemo(
+    () =>
+      columns.map((col) => ({
+        id: col.id,
+        displayAsText: col.displayAsText,
+        schema: col.esType,
+      })),
+    [columns]
+  );
+
+  const [visibleColumns, setVisibleColumns] = useState<string[]>([]);
+
+  const prevColumnIdsRef = useRef('');
+  useEffect(() => {
+    const ids = columns.map((c) => c.id).join(',');
+    if (ids !== prevColumnIdsRef.current) {
+      prevColumnIdsRef.current = ids;
+      setVisibleColumns(columns.map((c) => c.id));
+    }
+  }, [columns]);
+
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: VISIBLE_ROWS });
+  const onChangePage = useCallback((pageIndex: number) => {
+    setPagination((prev) => ({ ...prev, pageIndex }));
+  }, []);
+  const onChangeItemsPerPage = useCallback((pageSize: number) => {
+    setPagination({ pageIndex: 0, pageSize });
+  }, []);
+
+  const renderCellValue = useCallback(
+    ({ rowIndex, columnId }: EuiDataGridCellValueElementProps) => {
+      const row = rows[rowIndex];
+      if (!row) return null;
+      const value = row[columnId];
+      return <>{value ?? '—'}</>;
+    },
+    [rows]
+  );
+
+  const editorPanelStyles: React.CSSProperties = useMemo(
+    () => ({
+      resize: readOnly ? undefined : ('vertical' as const),
+      overflow: 'auto',
+      height: INITIAL_EDITOR_HEIGHT,
+      minHeight: MIN_EDITOR_HEIGHT,
+      maxHeight: MAX_EDITOR_HEIGHT,
+    }),
+    [readOnly]
+  );
+
+  return (
+    <>
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+        <EuiFlexItem grow={false} style={{ width: 200, minWidth: 0 }}>
+          <EuiSelect
+            options={timeFieldOptions}
+            value={timeField}
+            aria-label="Time field for rule execution"
+            onChange={(e) => onTimeFieldChange?.(e.target.value)}
+            compressed
+            prepend="Time field"
+            disabled={readOnly}
+            data-test-subj="composeDiscoverTimeField"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow>
+          <EuiSuperDatePicker
+            start={dateStart}
+            end={dateEnd}
+            onTimeChange={({ start, end }) => onDateRangeChange(start, end)}
+            showUpdateButton={false}
+            compressed
+            width="full"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiToolTip content={`Search (${RUN_SHORTCUT_LABEL})`}>
+            <EuiButton
+              size="s"
+              onClick={run}
+              isLoading={isLoading}
+              data-test-subj="composeDiscoverRunQuery"
+            >
+              Search
+            </EuiButton>
+          </EuiToolTip>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+
+      {editorSlot ?? (
+        <EuiPanel hasBorder paddingSize="s" style={editorPanelStyles}>
+          <CodeEditor
+            languageId={ESQL_LANG_ID}
+            value={query}
+            onChange={(val) => onQueryChange?.(val)}
+            height="100%"
+            options={{
+              minimap: { enabled: false },
+              automaticLayout: true,
+              scrollBeyondLastLine: false,
+              fontSize: 13,
+              readOnly,
+              domReadOnly: readOnly,
+            }}
+          />
+        </EuiPanel>
+      )}
+      <EuiSpacer size="s" />
+
+      {hasRun && !isLoading && !isError && (
+        <EuiText size="xs" color="subdued">
+          {totalRowCount.toLocaleString()} {totalRowCount === 1 ? 'result' : 'results'}
+        </EuiText>
+      )}
+
+      <EuiSpacer size="s" />
+      <EuiSpacer size="m" />
+
+      {!hasRun && (
+        <EuiEmptyPrompt
+          iconType="playFilled"
+          title={<h4>Run your query to see results</h4>}
+          body={
+            <p>
+              Click <strong>Search</strong> or press <strong>{RUN_SHORTCUT_LABEL}</strong> to
+              execute the query.
+            </p>
+          }
+        />
+      )}
+
+      {hasRun && isLoading && (
+        <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: 200 }}>
+          <EuiFlexItem grow={false}>
+            <EuiLoadingSpinner size="l" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      )}
+
+      {hasRun && isError && (
+        <EuiCallOut announceOnMount color="danger" iconType="error" title="Query error">
+          <p>{error}</p>
+        </EuiCallOut>
+      )}
+
+      {hasRun && !isLoading && !isError && rows.length === 0 && query.trim() && (
+        <EuiEmptyPrompt
+          iconType="search"
+          title={<h4>No results</h4>}
+          body={<p>The query returned no results for the current time range.</p>}
+        />
+      )}
+
+      {hasRun && !isLoading && !isError && rows.length > 0 && (
+        <>
+          <ComposeDiscoverChart
+            query={lastExecutedQuery ?? query}
+            timeField={timeField}
+            timeRange={timeRange}
+            columns={columns}
+          />
+
+          <EuiSpacer size="m" />
+
+          <EuiDataGrid
+            aria-label="Query results"
+            columns={gridColumns}
+            columnVisibility={{ visibleColumns, setVisibleColumns }}
+            rowCount={rows.length}
+            renderCellValue={renderCellValue}
+            pagination={{
+              ...pagination,
+              pageSizeOptions: [10, 25, 50],
+              onChangePage,
+              onChangeItemsPerPage,
+            }}
+            gridStyle={{ border: 'all', header: 'shade', fontSize: 's', cellPadding: 's' }}
+            toolbarVisibility={{
+              showColumnSelector: true,
+              showSortSelector: true,
+              showFullScreenSelector: false,
+            }}
+          />
+        </>
+      )}
+    </>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/index.ts
@@ -7,3 +7,9 @@
 
 export { ComposeDiscoverFlyout } from './compose_discover_flyout';
 export type { ComposeDiscoverFlyoutProps } from './compose_discover_flyout';
+
+export { DiscoverSandboxPanel } from './discover_sandbox_panel';
+export type {
+  DiscoverSandboxPanelProps,
+  DiscoverSandboxServices,
+} from './discover_sandbox_panel';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/types.ts
@@ -49,8 +49,8 @@ export type SandboxTabConfig =
 
 /**
  * Data passed from the Sandbox child to the flyout parent on "Apply changes".
- * The flyout writes these values into RHF (the source of truth) and updates
- * the reducer cache.
+ * The flyout writes these values into react-hook-form (the source of truth)
+ * and updates the reducer cache.
  */
 export interface SandboxApplyData {
   isSplit: boolean;
@@ -65,10 +65,10 @@ export interface SandboxApplyData {
  *
  * This reducer manages navigation, Sandbox state, and split-query cache.
  * All form values (name, schedule, delays, etc.) live in useForm<ComposeFormValues>()
- * via RHF and are never stored here. The query/split fields are a write-through
- * cache: written imperatively alongside RHF at Apply time. RHF is the source
- * of truth — these fields exist so the form view can display query summaries
- * without subscribing to RHF watchers.
+ * via react-hook-form and are never stored here. The query/split fields are a
+ * write-through cache: written imperatively alongside the form at Apply time.
+ * react-hook-form is the source of truth — these fields exist so the form view
+ * can display query summaries without subscribing to form watchers.
  */
 export interface ComposeDiscoverState {
   mode: ComposeDiscoverMode;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.ts
@@ -124,7 +124,7 @@ export const formValuesToYamlObject = (values: FormValues): YamlRuleObject => {
  * Parses the YAML structure and extracts all recognised fields, providing
  * safe defaults for any that are missing. YAML syntax errors are still
  * reported. Field-level validation (required name, valid ES|QL, etc.)
- * is handled by RHF at submit time, keeping a single validation pipeline.
+ * is handled by react-hook-form at submit time, keeping a single validation pipeline.
  */
 export const parseYamlToFormValues = (yamlString: string): YamlParseResult => {
   let parsed: unknown;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/yaml_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/yaml_rule_form.tsx
@@ -43,11 +43,11 @@ export interface YamlRuleFormProps {
  *
  * Provides a YAML editor for editing rule configuration with ES|QL autocomplete.
  * Parsing is always lenient — YAML syntax errors are surfaced, but missing
- * required fields get safe defaults. Field-level validation is handled by RHF
+ * required fields get safe defaults. Field-level validation is handled by react-hook-form
  * at submit time through `methods.handleSubmit()`.
  *
  * In the compose-discover flyout context, the parent owns submission and
- * passes a debounced `setYamlText` that also syncs into RHF on every
+ * passes a debounced `setYamlText` that also syncs into react-hook-form on every
  * keystroke. The blur handler here acts as a "flush now" fallback.
  *
  * In the standalone RuleForm context, the parent passes `onSubmit` and

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -12,6 +12,10 @@ export { DynamicRuleFormFlyout, StandaloneRuleFormFlyout } from './flyout';
 export { ComposeDiscoverFlyout } from './flyout/compose_discover';
 export type { ComposeDiscoverFlyoutProps } from './flyout/compose_discover';
 
+// Discover sandbox — reusable read-only ES|QL sandbox panel
+export { DiscoverSandboxPanel } from './flyout/compose_discover';
+export type { DiscoverSandboxPanelProps, DiscoverSandboxServices } from './flyout/compose_discover';
+
 // Lazy components (without Suspense wrapper) - for consumers who need full control
 export {
   LazyDynamicRuleFormFlyout,
@@ -30,6 +34,7 @@ export { RuleResultsPreview } from './form';
 
 // Context - for consumers who need custom integrations
 export { RuleFormProvider, useRuleFormServices, useRuleFormMeta } from './form';
+
 
 // Mappers
 export {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/query_preview_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/query_preview_flyout.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryPreviewFlyout } from './query_preview_flyout';
+
+const mockServices: Record<string, unknown> = {
+  'core:http': {},
+  'core:notifications': { toasts: { addSuccess: jest.fn() } },
+  'core:application': {},
+  'plugin:data': { search: { search: jest.fn() } },
+  'plugin:dataViews': {},
+  'plugin:lens': { EmbeddableComponent: () => null, stateHelperApi: jest.fn() },
+};
+
+jest.mock('@kbn/core-di-browser', () => ({
+  CoreStart: (key: string) => `core:${key}`,
+  useService: (key: string) => mockServices[key] ?? {},
+}));
+
+jest.mock('@kbn/core-di', () => ({
+  PluginStart: (key: string) => `plugin:${key}`,
+}));
+
+jest.mock('@kbn/alerting-v2-rule-form', () => ({
+  DiscoverSandboxPanel: ({ query, readOnly }: { query: string; readOnly?: boolean }) => (
+    <div data-test-subj="mockSandboxPanel" data-query={query} data-readonly={String(readOnly)} />
+  ),
+  RuleFormProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('QueryPreviewFlyout', () => {
+  const defaultProps = {
+    query: 'FROM logs-* | STATS count() BY host.name',
+    timeField: '@timestamp',
+    onClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the flyout with "Query preview" title', () => {
+    render(<QueryPreviewFlyout {...defaultProps} />);
+    expect(screen.getByText('Query preview')).toBeDefined();
+  });
+
+  it('renders a Close button in the footer', () => {
+    render(<QueryPreviewFlyout {...defaultProps} />);
+    expect(screen.getByTestId('queryPreviewClose')).toBeDefined();
+  });
+
+  it('does not render an "Apply changes" button', () => {
+    render(<QueryPreviewFlyout {...defaultProps} />);
+    expect(screen.queryByText('Apply changes')).toBeNull();
+  });
+
+  it('renders the sandbox panel in readOnly mode', () => {
+    render(<QueryPreviewFlyout {...defaultProps} />);
+    const panel = screen.getByTestId('mockSandboxPanel');
+    expect(panel.dataset.readonly).toBe('true');
+  });
+
+  it('renders the query in the sandbox panel', () => {
+    render(<QueryPreviewFlyout {...defaultProps} />);
+    const panel = screen.getByTestId('mockSandboxPanel');
+    expect(panel.dataset.query).toContain('FROM logs-*');
+  });
+
+  it('calls onClose when the Close button is clicked', () => {
+    render(<QueryPreviewFlyout {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('queryPreviewClose'));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/query_preview_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/query_preview_flyout.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import { PluginStart } from '@kbn/core-di';
+import type { HttpStart, NotificationsStart, ApplicationStart } from '@kbn/core/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import { DiscoverSandboxPanel, RuleFormProvider } from '@kbn/alerting-v2-rule-form';
+
+const QUERY_PREVIEW_FLYOUT_TITLE_ID = 'queryPreviewFlyoutTitle';
+
+export interface QueryPreviewFlyoutProps {
+  query: string;
+  timeField: string;
+  onClose: () => void;
+}
+
+const QueryPreviewFlyoutInner: React.FC<QueryPreviewFlyoutProps> = ({
+  query,
+  timeField,
+  onClose,
+}) => {
+  const http = useService<HttpStart>(CoreStart('http'));
+  const notifications = useService<NotificationsStart>(CoreStart('notifications'));
+  const application = useService<ApplicationStart>(CoreStart('application'));
+  const data = useService<DataPublicPluginStart>(PluginStart('data'));
+  const dataViews = useService<DataViewsPublicPluginStart>(PluginStart('dataViews'));
+  const lens = useService<LensPublicStart>(PluginStart('lens'));
+
+  const services = useMemo(
+    () => ({ http, notifications, application, data, dataViews, lens }),
+    [http, notifications, application, data, dataViews, lens]
+  );
+
+  const [dateStart, setDateStart] = useState('now-15m');
+  const [dateEnd, setDateEnd] = useState('now');
+
+  const handleDateRangeChange = useCallback((start: string, end: string) => {
+    setDateStart(start);
+    setDateEnd(end);
+  }, []);
+
+  return (
+    <RuleFormProvider services={services} meta={{ layout: 'flyout' }}>
+      <EuiFlyout type="overlay" size="fill" onClose={onClose} aria-labelledby={QUERY_PREVIEW_FLYOUT_TITLE_ID}>
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="s" id={QUERY_PREVIEW_FLYOUT_TITLE_ID}>
+            <h3>
+              {i18n.translate('xpack.alertingV2.queryPreview.title', {
+                defaultMessage: 'Query preview',
+              })}
+            </h3>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+
+        <EuiFlyoutBody>
+          <DiscoverSandboxPanel
+            query={query}
+            timeField={timeField}
+            dateStart={dateStart}
+            dateEnd={dateEnd}
+            onDateRangeChange={handleDateRangeChange}
+            readOnly
+            services={{ http, data, dataViews }}
+          />
+        </EuiFlyoutBody>
+
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty onClick={onClose} data-test-subj="queryPreviewClose">
+                {i18n.translate('xpack.alertingV2.queryPreview.closeButton', {
+                  defaultMessage: 'Close',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      </EuiFlyout>
+    </RuleFormProvider>
+  );
+};
+
+/**
+ * Read-only flyout that displays an ES|QL query with execution results,
+ * chart, and data grid. Must be rendered inside a DI Context.Provider.
+ * Used by the rule attachment canvas to preview agent-created queries
+ * without editing capabilities.
+ */
+export const QueryPreviewFlyout: React.FC<QueryPreviewFlyoutProps> = (props) => {
+  const queryClient = useMemo(() => new QueryClient(), []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <QueryPreviewFlyoutInner {...props} />
+    </QueryClientProvider>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.test.tsx
@@ -13,8 +13,10 @@ jest.mock('@kbn/core-di-browser', () => ({
   Context: {
     Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   },
-  useService: () => ({}),
-  CoreStart: (key: string) => key,
+}));
+
+jest.mock('./query_preview_flyout', () => ({
+  QueryPreviewFlyout: () => <div data-test-subj="mockQueryPreviewFlyout" />,
 }));
 
 jest.mock('../../components/rule_details/rule_context', () => ({
@@ -28,6 +30,16 @@ jest.mock('../../components/rule_details/rule_header_description', () => ({
 jest.mock('../../components/rule_details/sidebar/rule_sidebar', () => ({
   RuleSidebar: () => <div data-test-subj="mockRuleSidebar" />,
 }));
+
+const createMockContainer = () => {
+  const services: Record<string, unknown> = {
+    'core:http': { basePath: { prepend: (p: string) => p } },
+    'plugin:data': { search: { search: jest.fn() } },
+    'plugin:dataViews': {},
+    'plugin:lens': { EmbeddableComponent: () => null, stateHelperApi: jest.fn() },
+  };
+  return { get: (key: string) => services[key] ?? {} } as any;
+};
 
 const createMockServices = () => ({
   rulesApi: {
@@ -43,7 +55,7 @@ const createMockServices = () => ({
   notifications: {
     toasts: { addSuccess: jest.fn(), addError: jest.fn() },
   } as any,
-  container: {} as any,
+  container: createMockContainer(),
 });
 
 const createAttachment = (overrides: { origin?: string; enabled?: boolean } = {}) => ({
@@ -194,6 +206,20 @@ describe('RuleCanvasContent', () => {
       const { calls } = registerActionButtons.mock;
       expect(calls[0][0]).toEqual([]);
       expect(calls[calls.length - 1][0].length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('preview query button', () => {
+    it('registers Preview query button for proposed rules', () => {
+      const { registerActionButtons } = renderCanvas();
+      const buttons = getLastRegisteredButtons(registerActionButtons);
+      expect(buttons.find((b) => b.label === 'Preview query')).toBeDefined();
+    });
+
+    it('registers Preview query button for persisted rules', () => {
+      const { registerActionButtons } = renderCanvas({ origin: 'rule-123' });
+      const buttons = getLastRegisteredButtons(registerActionButtons);
+      expect(buttons.find((b) => b.label === 'Preview query')).toBeDefined();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/rule_canvas_content.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { EuiPanel, EuiSpacer } from '@elastic/eui';
 import {
   ActionButtonType,
@@ -16,6 +16,7 @@ import type { ApplicationStart, IBasePath, NotificationsStart } from '@kbn/core/
 import { Context } from '@kbn/core-di-browser';
 import { i18n } from '@kbn/i18n';
 import type { Container } from 'inversify';
+import { QueryPreviewFlyout } from './query_preview_flyout';
 import { RuleProvider } from '../../components/rule_details/rule_context';
 import { RuleHeaderDescription } from '../../components/rule_details/rule_header_description';
 import { RuleSidebar } from '../../components/rule_details/sidebar/rule_sidebar';
@@ -33,6 +34,10 @@ export interface RuleCanvasContentProps
   container: Container;
 }
 
+const PREVIEW_BUTTON_LABEL = i18n.translate('xpack.alertingV2.ruleAttachment.previewQuery', {
+  defaultMessage: 'Preview query',
+});
+
 export const RuleCanvasContent = ({
   attachment,
   registerActionButtons,
@@ -45,6 +50,7 @@ export const RuleCanvasContent = ({
 }: RuleCanvasContentProps) => {
   const { data, origin } = attachment;
   const isPersisted = hasOrigin(origin);
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   // Start false so the first effect registers [],
   // matching the canvas_flyout clear effect. The second cycle (mounted=true)
@@ -60,6 +66,13 @@ export const RuleCanvasContent = ({
       registerActionButtons([]);
       return;
     }
+
+    const previewButton = {
+      label: PREVIEW_BUTTON_LABEL,
+      icon: 'playFilled' as const,
+      type: ActionButtonType.SECONDARY,
+      handler: () => setPreviewOpen(true),
+    };
 
     if (!isPersisted) {
       registerActionButtons([
@@ -83,6 +96,7 @@ export const RuleCanvasContent = ({
             );
           },
         },
+        previewButton,
       ]);
       return;
     }
@@ -108,6 +122,7 @@ export const RuleCanvasContent = ({
           );
         },
       },
+      previewButton,
       {
         label: i18n.translate('xpack.alertingV2.ruleAttachment.viewInRules', {
           defaultMessage: 'View in Rules',
@@ -141,6 +156,13 @@ export const RuleCanvasContent = ({
           <RuleSidebar />
         </EuiPanel>
       </RuleProvider>
+      {previewOpen && (
+        <QueryPreviewFlyout
+          query={data.evaluation.query.base}
+          timeField={data.time_field ?? '@timestamp'}
+          onClose={() => setPreviewOpen(false)}
+        />
+      )}
     </Context.Provider>
   );
 };


### PR DESCRIPTION
## Summary

- Extracts a reusable `DiscoverSandboxPanel` presentation component from `ComposeDiscoverChild`, separating the data layer (form context) from the presentation layer (ES|QL editor, results grid, Lens chart)
- Adds a read-only `QueryPreviewFlyout` to the agent builder canvas that lets users preview agent-created ES|QL queries using the sandbox panel
- Registers a "Preview query" action button in the agent builder canvas header that opens the flyout


https://github.com/user-attachments/assets/39159096-5f15-43ca-b0ea-d5506cb7153b

## Changes

### Shared package (`@kbn/alerting-v2-rule-form`)
- **`discover_sandbox_panel.tsx`** (new) — Pure presentation component rendering a read-only ES|QL code editor, query execution results grid, and Lens chart visualization. Internally handles field fetching via `useDataFields`.
- **`compose_discover_child.tsx`** — Refactored to be a thin wrapper that pulls data from react-hook-form context and passes it to `DiscoverSandboxPanel`
- **`index.ts`** — Exports `DiscoverSandboxPanel` and its types for use by the agent builder attachment

### Agent builder attachment (`alerting_v2/public/agent_builder/attachments/`)
- **`query_preview_flyout.tsx`** (new) — Read-only flyout that resolves services from the DI container and renders `DiscoverSandboxPanel` inside a `RuleFormProvider`
- **`rule_canvas_content.tsx`** — Registers the "Preview query" header button via `registerActionButtons` and manages flyout open/close state

### Tests
- **`discover_sandbox_panel.test.tsx`** (new) — Unit tests for the sandbox panel covering render, read-only editor, query execution, and chart display
- **`query_preview_flyout.test.tsx`** (new) — Unit tests for the preview flyout covering render, close behavior, and service resolution
- **`rule_canvas_content.test.tsx`** — Updated to cover the preview button registration and flyout toggle

## Test plan

- [ ] Verify "Preview query" button appears in agent builder canvas header
- [ ] Verify clicking the button opens a read-only flyout with the ES|QL query
- [ ] Verify the flyout shows query results and Lens chart after running
- [ ] Verify the flyout closes via the close button
- [ ] Verify existing Compose Discover form flyout behavior is unchanged
- [ ] Run unit tests: `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/agent_builder/attachments/`
- [ ] Run unit tests: `node scripts/jest x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/discover_sandbox_panel`


Made with [Cursor](https://cursor.com)