### PR TITLE
Test PR. Check kibana-elasticsearch-snapshot-verify pipeline with a working ES snapshot.

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/prebuilt_rules_package/air_gapped/install_large_bundled_package.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/prebuilt_rules_package/air_gapped/install_large_bundled_package.ts
@@ -42,6 +42,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       // Install the package with 15000 prebuilt historical version of rules rules and 750 unique rules
+      // HERE
       await installPrebuiltRulesAndTimelines(es, supertest);
 
       // Verify that status is updated after package installation


### PR DESCRIPTION

## Summary

The purpose of this PR is to branch out a copy of `main` and run a [kibana-elasticsearch-snapshot-verify](https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify) pipeline with an earlier snapshot of elasticsearch, to verify hypothesis that recent changes in ES are causing problems with the FTR test `install_large_bundled_package.ts`.

[Slack conversation](https://elastic.slack.com/archives/C02HA9E8221/p1779095550722079) (internal link).

If the pipeline passes with kibana at `main` as of today (branched out at `d7a01d156de`) and an earlier ES snapshot as of 11th of May (before the pipeline started failing), then the issue is far more likely to be recent changes made to elasticsearch (between the snapshot taken on the 11th and the one on the 12th) that reduced performance of calls made by that test.

👉  New pipeline: https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify/builds/8072


```
ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/9.5.0/archives/20260511-022512_32342fb5/manifest.json"
```

<img width="800" alt="image" src="https://github.com/user-attachments/assets/1d303e83-5732-4465-ad04-bb25680b3f5d" />


#### Some info about the calls made by the test `install_large_bundled_package.ts`

| # | Phase | Method | Endpoint | Helper / Constant | Notes |
|---|---|---|---|---|---|
| 1 | `beforeEach` | `POST` | `/api/detection_engine/rules/_bulk_action` | `deleteAllRules` → `DETECTION_ENGINE_RULES_BULK_ACTION` | Body: `{ action: 'delete', query: '' }`. Wrapped in `countDownTest` (up to 50 attempts, 1 s apart) |
| 2 | `beforeEach` | `GET` | `/api/detection_engine/rules/_find?page=1&per_page=1` | `deleteAllRules` → `DETECTION_ENGINE_RULES_URL_FIND` | Verifies `total === 0` after deletion |
| 3 | `beforeEach` | `DELETE` | `/api/fleet/epm/packages/security_detection_engine` | `deletePrebuiltRulesFleetPackage` → `epmRouteService.getRemovePath(PREBUILT_RULES_PACKAGE_NAME)` | Body: `{ force: true }`. Wrapped in `retryService.tryWithRetries` (up to 3 attempts, 3 min total) |
| 4 | `it` (pre) | `GET` | `/api/detection_engine/rules/prepackaged/_status` | `getPrebuiltRulesAndTimelinesStatus` → `PREBUILT_RULES_STATUS_URL` | First call; verifies status is empty |
| 5 | `it` (install) | `PUT` | `/api/detection_engine/rules/prepackaged` | `installPrebuiltRulesAndTimelines` → `PREBUILT_RULES_URL` | The heavy one — installs the 3,000-rule bundled package |
| 6 | `it` (post) | `GET` | `/api/detection_engine/rules/prepackaged/_status` | `getPrebuiltRulesAndTimelinesStatus` → `PREBUILT_RULES_STATUS_URL` | Second call; verifies post-install status |

Plus direct ES traffic (no Kibana HTTP endpoint involved):

- `deleteAllPrebuiltRuleAssets(es, log)` — ES `deleteByQuery` against `SECURITY_SOLUTION_SAVED_OBJECT_INDEX` filtered by `type:security-rule`, with `wait_for_completion: true` and `refresh: true`.
- `refreshSavedObjectIndices(es)` — called from `getPrebuiltRulesAndTimelinesStatus`, `installPrebuiltRulesAndTimelines`, and `deletePrebuiltRulesFleetPackage` to force a refresh on the security-solution and alerting SO indices.

For more info on [actual ES calls see generated report](https://github.com/sdesalas/kibana-knowledge/blob/main/reports/es-calls-install-large-bundled-package.md).

