### PR TITLE
feat(streams): index sigevents memory pages into the SML for agent discovery

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
@@ -18,6 +18,7 @@ export enum AttachmentType {
   esql = 'esql',
   visualization = 'visualization',
   connector = 'connector',
+  sigeventMemoryPage = 'sigevent_memory_page',
 }
 
 interface AttachmentDataMap {
@@ -26,6 +27,7 @@ interface AttachmentDataMap {
   [AttachmentType.screenContext]: ScreenContextAttachmentData;
   [AttachmentType.visualization]: VisualizationAttachmentData;
   [AttachmentType.connector]: ConnectorAttachmentData;
+  [AttachmentType.sigeventMemoryPage]: SigeventMemoryPageAttachmentData;
 }
 
 export const esqlAttachmentDataSchema = z.object({
@@ -156,3 +158,21 @@ export interface ConnectorAttachmentData {
 }
 
 export type AttachmentDataOf<Type extends AttachmentType> = AttachmentDataMap[Type];
+
+export const sigeventMemoryPageAttachmentDataSchema = z.object({
+  memory_page_id: z.string(),
+  memory_page_name: z.string(),
+  memory_page_title: z.string(),
+});
+
+/**
+ * Data for a sigevent memory page attachment.
+ */
+export interface SigeventMemoryPageAttachmentData {
+  /** The stable UUID of the memory page */
+  memory_page_id: string;
+  /** The unique name of the memory page */
+  memory_page_name: string;
+  /** The human-readable title of the memory page */
+  memory_page_title: string;
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
@@ -42,3 +42,4 @@ export type ScreenContextAttachment = Attachment<AttachmentType.screenContext>;
 export type EsqlAttachment = Attachment<AttachmentType.esql>;
 export type VisualizationAttachment = Attachment<AttachmentType.visualization>;
 export type ConnectorAttachment = Attachment<AttachmentType.connector>;
+export type SigeventMemoryPageAttachment = Attachment<AttachmentType.sigeventMemoryPage>;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
@@ -13,6 +13,7 @@ export type {
   EsqlAttachment,
   VisualizationAttachment,
   ConnectorAttachment,
+  SigeventMemoryPageAttachment,
 } from './attachments';
 
 export type {
@@ -29,6 +30,7 @@ export {
   screenContextAttachmentDataSchema,
   visualizationAttachmentDataSchema,
   connectorAttachmentDataSchema,
+  sigeventMemoryPageAttachmentDataSchema,
   CONNECTOR_TAG_PREFIX,
   type TextAttachmentData,
   type ScreenContextAttachmentData,
@@ -37,6 +39,7 @@ export {
   type EsqlAttachmentData,
   type VisualizationAttachmentData,
   type ConnectorAttachmentData,
+  type SigeventMemoryPageAttachmentData,
 } from './attachment_types';
 
 export type {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.test.ts
@@ -20,6 +20,7 @@ const mockAttachmentsAdd = jest.fn();
 const getAgentContextLayer = jest.fn(() => ({
   search: jest.fn(),
   indexAttachment: jest.fn(),
+  indexAttachmentSystem: jest.fn(),
   getDocuments: jest.fn(),
   getTypeDefinition: jest.fn(),
   resolveSmlAttachItems: mockResolveSmlAttachItems,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_search.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_search.test.ts
@@ -15,6 +15,7 @@ const mockSearch = jest.fn();
 const getAgentContextLayer = jest.fn(() => ({
   search: mockSearch,
   indexAttachment: jest.fn(),
+  indexAttachmentSystem: jest.fn(),
   getDocuments: jest.fn(),
   getTypeDefinition: jest.fn(),
   resolveSmlAttachItems: jest.fn(),

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/connector_lifecycle/connector_lifecycle_handler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/connector_lifecycle/connector_lifecycle_handler.test.ts
@@ -19,6 +19,7 @@ const createMockUiSettingsClient = (experimentalFeaturesEnabled = true) => ({
 
 const createMockAgentContextLayer = () => ({
   indexAttachment: jest.fn().mockResolvedValue(undefined),
+  indexAttachmentSystem: jest.fn().mockResolvedValue(undefined),
 });
 
 const createMockGetStartServices = (

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/plugin.ts
@@ -164,6 +164,17 @@ export class AgentContextLayerPlugin
           logger: this.logger.get('sml'),
         });
       },
+      indexAttachmentSystem: async (params) => {
+        return smlService.indexAttachment({
+          originId: params.originId,
+          attachmentType: params.attachmentType,
+          action: params.action,
+          spaces: params.spaces,
+          esClient: elasticsearch.client.asInternalUser,
+          savedObjectsClient: savedObjects.createInternalRepository(),
+          logger: this.logger.get('sml'),
+        });
+      },
     };
   }
 

--- a/x-pack/platform/plugins/shared/agent_context_layer/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_context_layer/server/types.ts
@@ -78,6 +78,12 @@ export interface AgentContextLayerPluginStart {
   }) => Promise<SmlResolvedItemResult[]>;
 
   indexAttachment: (params: SmlIndexAttachmentParams) => Promise<void>;
+
+  /**
+   * Index an attachment from a system/internal context where no HTTP request is available.
+   * Skips SO-client scoping; intended for background tasks (e.g. memory writes).
+   */
+  indexAttachmentSystem: (params: SmlIndexAttachmentSystemParams) => Promise<void>;
 }
 
 export interface SmlIndexAttachmentParams {
@@ -87,4 +93,12 @@ export interface SmlIndexAttachmentParams {
   action: SmlIndexAction;
   spaceId?: string;
   includedHiddenTypes?: string[];
+}
+
+export interface SmlIndexAttachmentSystemParams {
+  originId: string;
+  attachmentType: string;
+  action: SmlIndexAction;
+  /** Space IDs this item belongs to. Use ['*'] for space-agnostic content. */
+  spaces: string[];
 }

--- a/x-pack/platform/plugins/shared/streams/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/streams/kibana.jsonc
@@ -30,6 +30,7 @@
     ],
     "optionalPlugins": [
       "agentBuilder",
+      "agentContextLayer",
       "alertingVTwo",
       "cloud",
       "esql",

--- a/x-pack/platform/plugins/shared/streams/moon.yml
+++ b/x-pack/platform/plugins/shared/streams/moon.yml
@@ -95,6 +95,7 @@ dependsOn:
   - '@kbn/core-security-server'
   - '@kbn/workflows-management-plugin'
   - '@kbn/workflows'
+  - '@kbn/workflows-extensions'
   - '@kbn/agent-builder-plugin'
   - '@kbn/data-streams'
   - '@kbn/es-mappings'

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/register.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/register.ts
@@ -71,6 +71,7 @@ export const registerStreamsAgentBuilder = async ({
     new MemoryServiceImpl({
       logger: logger.get('memory'),
       esClient,
+      onAfterWrite: server.memoryIndexCallback,
     });
 
   const memoryToolsOptions = {

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/index.ts
@@ -18,6 +18,7 @@ export type {
 } from './types';
 
 export { MemoryServiceImpl } from './memory_service';
+export type { MemoryIndexCallback } from './memory_service';
 
 export {
   formatExistingPages,

--- a/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/memory/memory_service.ts
@@ -32,6 +32,12 @@ const isIndexNotFoundError = (err: unknown): boolean => {
 
 type MemoryCollapseField = 'name' | 'id';
 
+/** Called after a memory entry is created, updated, or deleted so external systems (e.g. SML) can re-index. */
+export type MemoryIndexCallback = (params: {
+  id: string;
+  action: 'create' | 'update' | 'delete';
+}) => Promise<void>;
+
 /**
  * MemoryServiceImpl backed by two append-only data streams:
  *   - .significant_events-memories  (pages, latest version resolved via field collapse)
@@ -45,11 +51,31 @@ export class MemoryServiceImpl implements MemoryService {
   private readonly esClient: ElasticsearchClient;
   private readonly historyStorage: ReturnType<typeof createMemoryHistoryStorage>;
   private readonly logger: Logger;
+  private readonly onAfterWrite?: MemoryIndexCallback;
 
-  constructor({ logger, esClient }: { logger: Logger; esClient: ElasticsearchClient }) {
+  constructor({
+    logger,
+    esClient,
+    onAfterWrite,
+  }: {
+    logger: Logger;
+    esClient: ElasticsearchClient;
+    /** Optional callback fired after create/update/delete. Used for SML event-driven indexing. */
+    onAfterWrite?: MemoryIndexCallback;
+  }) {
     this.logger = logger;
     this.esClient = esClient;
     this.historyStorage = createMemoryHistoryStorage({ esClient });
+    this.onAfterWrite = onAfterWrite;
+  }
+
+  private fireIndexCallback(id: string, action: 'create' | 'update' | 'delete'): void {
+    if (!this.onAfterWrite) return;
+    this.onAfterWrite({ id, action }).catch((error) => {
+      this.logger.warn(
+        `Memory index callback failed for entry '${id}' (${action}): ${(error as Error).message}`
+      );
+    });
   }
 
   // ── Write helpers ──
@@ -176,6 +202,7 @@ export class MemoryServiceImpl implements MemoryService {
 
     await this._indexPage(entry);
     await this._writeHistory(entry, 'create', `Created entry "${name}"`, user);
+    this.fireIndexCallback(entry.id, 'create');
     return entry;
   }
 
@@ -233,6 +260,7 @@ export class MemoryServiceImpl implements MemoryService {
       changeSummary ?? `Updated entry "${updated.name}"`,
       user
     );
+    this.fireIndexCallback(updated.id, 'update');
     return updated;
   }
 
@@ -257,6 +285,7 @@ export class MemoryServiceImpl implements MemoryService {
       },
     });
     await this._writeHistory(tombstone, 'delete', `Deleted entry "${current.name}"`, user);
+    this.fireIndexCallback(id, 'delete');
   }
 
   async rename({

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -83,6 +83,10 @@ import {
   type ContinuousKiExtractionWorkflowService,
 } from './lib/workflows/continuous_extraction_workflow';
 import { installMemoryWorkflows } from './lib/memory/install_managed_workflows';
+import {
+  createSigeventMemoryPageSmlType,
+  SIGEVENT_MEMORY_PAGE_SML_TYPE,
+} from './sml_types/sigevent_memory_page';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
@@ -447,6 +451,14 @@ export class StreamsPlugin
       );
     }
 
+    if (plugins.agentContextLayer) {
+      plugins.agentContextLayer.registerType(
+        createSigeventMemoryPageSmlType({
+          getStartServices: core.getStartServices,
+        })
+      );
+    }
+
     core
       .getStartServices()
       .then(async ([coreStart]) => {
@@ -614,6 +626,30 @@ export class StreamsPlugin
       const memoryTriggerRegistry = new MemoryTriggerRegistry({ logger: this.logger });
       memoryTriggerRegistry.register(discoveryCompletedTrigger);
       this.server.memoryTriggerRegistry = memoryTriggerRegistry;
+
+      // Wire SML event-driven indexing for memory entries when agentContextLayer is available.
+      // The callback checks isMemoryEnabled at call time so it's a no-op while memory is off.
+      if (plugins.agentContextLayer) {
+        const isMemoryEnabled = async () => {
+          try {
+            const soClient = core.savedObjects.createInternalRepository();
+            const uiSettings = core.uiSettings.asScopedToClient(soClient);
+            return await uiSettings.get<boolean>(OBSERVABILITY_STREAMS_ENABLE_MEMORY);
+          } catch {
+            return false;
+          }
+        };
+        const agentContextLayer = plugins.agentContextLayer;
+        this.server.memoryIndexCallback = async ({ id, action }) => {
+          if (!(await isMemoryEnabled())) return;
+          await agentContextLayer.indexAttachmentSystem({
+            originId: id,
+            attachmentType: SIGEVENT_MEMORY_PAGE_SML_TYPE,
+            action,
+            spaces: ['*'],
+          });
+        };
+      }
     }
 
     this.processorSuggestionsService.setConsoleStart(plugins.console);

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/memory/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/memory/route.ts
@@ -34,10 +34,13 @@ const assertMemoryEnabled = async (uiSettingsClient: IUiSettingsClient) => {
   }
 };
 
+import type { MemoryIndexCallback } from '../../../lib/memory';
+
 const createMemoryService = (
   esClient: import('@kbn/core-elasticsearch-server').ElasticsearchClient,
-  logger: Logger
-) => new MemoryServiceImpl({ logger, esClient });
+  logger: Logger,
+  onAfterWrite?: MemoryIndexCallback
+) => new MemoryServiceImpl({ logger, esClient, onAfterWrite });
 
 const createEntryRoute = createServerRoute({
   endpoint: 'POST /internal/streams/memory/entries',
@@ -63,7 +66,7 @@ const createEntryRoute = createServerRoute({
   handler: async ({ params, request, server, logger, getScopedClients }): Promise<MemoryEntry> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const authUser = server.core.security.authc.getCurrentUser(request);
     const user = authUser?.username ?? 'unknown';
@@ -95,7 +98,7 @@ const getEntryRoute = createServerRoute({
   handler: async ({ params, request, server, logger, getScopedClients }): Promise<MemoryEntry> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     return memory.get({ id: params.path.id });
   },
@@ -118,7 +121,7 @@ const getEntryByNameRoute = createServerRoute({
   handler: async ({ params, request, server, logger, getScopedClients }): Promise<MemoryEntry> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const entry = await memory.getByName({ name: params.query.name });
     if (!entry) {
@@ -154,7 +157,7 @@ const updateEntryRoute = createServerRoute({
   handler: async ({ params, request, server, logger, getScopedClients }): Promise<MemoryEntry> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const authUser = server.core.security.authc.getCurrentUser(request);
     const user = authUser?.username ?? 'unknown';
@@ -191,7 +194,7 @@ const deleteEntryRoute = createServerRoute({
   }): Promise<{ deleted: boolean }> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const authUser = server.core.security.authc.getCurrentUser(request);
     const user = authUser?.username ?? 'unknown';
@@ -219,7 +222,7 @@ const renameEntryRoute = createServerRoute({
   handler: async ({ params, request, server, logger, getScopedClients }): Promise<MemoryEntry> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const authUser = server.core.security.authc.getCurrentUser(request);
     const user = authUser?.username ?? 'unknown';
@@ -261,7 +264,7 @@ const searchRoute = createServerRoute({
   }): Promise<{ results: MemorySearchResult[] }> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const results = await memory.search({
       query: params.body.query,
@@ -294,7 +297,7 @@ const getCategoryTreeRoute = createServerRoute({
   }): Promise<{ tree: MemoryCategoryNode[] }> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const tree = await memory.getCategoryTree();
     return { tree };
@@ -330,7 +333,7 @@ const getHistoryRoute = createServerRoute({
   }): Promise<{ history: MemoryVersionRecord[] }> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const history = await memory.getHistory({
       entryId: params.path.id,
@@ -366,7 +369,7 @@ const getVersionRoute = createServerRoute({
   }): Promise<MemoryVersionRecord> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     return memory.getVersion({
       entryId: params.path.id,
@@ -403,7 +406,7 @@ const recentChangesRoute = createServerRoute({
   }): Promise<{ changes: MemoryVersionRecord[] }> => {
     const { uiSettingsClient, scopedClusterClient } = await getScopedClients({ request });
     await assertMemoryEnabled(uiSettingsClient);
-    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger);
+    const memory = createMemoryService(scopedClusterClient.asCurrentUser, logger, server.memoryIndexCallback);
 
     const changes = await memory.getRecentChanges({
       size: params.query?.size,

--- a/x-pack/platform/plugins/shared/streams/server/sml_types/sigevent_memory_page.ts
+++ b/x-pack/platform/plugins/shared/streams/server/sml_types/sigevent_memory_page.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup } from '@kbn/core/server';
+import type { SmlTypeDefinition } from '@kbn/agent-context-layer-plugin/server';
+import {
+  AttachmentType,
+  type SigeventMemoryPageAttachmentData,
+} from '@kbn/agent-builder-common/attachments';
+import { OBSERVABILITY_STREAMS_ENABLE_MEMORY } from '@kbn/management-settings-ids';
+import { MemoryServiceImpl } from '../lib/memory';
+import type { StreamsPluginStartDependencies } from '../types';
+
+export const SIGEVENT_MEMORY_PAGE_SML_TYPE = 'sigevent_memory_page';
+
+interface SigeventMemoryPageSmlTypeDeps {
+  getStartServices: CoreSetup<StreamsPluginStartDependencies>['getStartServices'];
+}
+
+const buildIsMemoryEnabled =
+  (getStartServices: CoreSetup<StreamsPluginStartDependencies>['getStartServices']) =>
+  async (): Promise<boolean> => {
+    try {
+      const [coreStart] = await getStartServices();
+      const soClient = coreStart.savedObjects.createInternalRepository();
+      const uiSettings = coreStart.uiSettings.asScopedToClient(soClient);
+      return await uiSettings.get<boolean>(OBSERVABILITY_STREAMS_ENABLE_MEMORY);
+    } catch {
+      return false;
+    }
+  };
+
+export const createSigeventMemoryPageSmlType = (
+  deps: SigeventMemoryPageSmlTypeDeps
+): SmlTypeDefinition => {
+  const { getStartServices } = deps;
+  const isMemoryEnabled = buildIsMemoryEnabled(getStartServices);
+
+  return {
+    id: SIGEVENT_MEMORY_PAGE_SML_TYPE,
+
+    fetchFrequency: () => '5m',
+
+    list: (context) => ({
+      async *[Symbol.asyncIterator]() {
+        if (!(await isMemoryEnabled())) {
+          return;
+        }
+
+        const memory = new MemoryServiceImpl({
+          logger: context.logger.get('sml-sigevent-memory'),
+          esClient: context.esClient,
+        });
+
+        const entries = await memory.listAll();
+        if (entries.length > 0) {
+          yield entries.map((entry) => ({
+            id: entry.id,
+            updatedAt: entry.updated_at,
+            spaces: ['*'],
+          }));
+        }
+      },
+    }),
+
+    getSmlData: async (originId, context) => {
+      if (!(await isMemoryEnabled())) {
+        return undefined;
+      }
+
+      try {
+        const memory = new MemoryServiceImpl({
+          logger: context.logger.get('sml-sigevent-memory'),
+          esClient: context.esClient,
+        });
+
+        const entry = await memory.get({ id: originId });
+
+        const descriptionParts: string[] = [];
+        if (entry.categories.length > 0) {
+          descriptionParts.push(`Categories: ${entry.categories.join(', ')}`);
+        }
+        if (entry.tags.length > 0) {
+          descriptionParts.push(`Tags: ${entry.tags.join(', ')}`);
+        }
+
+        return {
+          chunks: [
+            {
+              type: SIGEVENT_MEMORY_PAGE_SML_TYPE,
+              title: entry.title,
+              content: entry.content,
+              description: descriptionParts.length > 0 ? descriptionParts.join(' | ') : undefined,
+            },
+          ],
+        };
+      } catch (error) {
+        context.logger.warn(
+          `SML sigevent_memory_page: failed to get data for '${originId}': ${
+            (error as Error).message
+          }`
+        );
+        return undefined;
+      }
+    },
+
+    toAttachment: async (item) => {
+      const data: SigeventMemoryPageAttachmentData = {
+        memory_page_id: item.origin_id,
+        memory_page_name: item.title,
+        memory_page_title: item.title,
+      };
+
+      return {
+        type: AttachmentType.sigeventMemoryPage,
+        data,
+      };
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/streams/server/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/types.ts
@@ -10,6 +10,10 @@ import type { AlertingServerStart as AlertingV2ServerStart } from '@kbn/alerting
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
 import type { CoreStart, ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { AgentBuilderPluginSetup, AgentBuilderPluginStart } from '@kbn/agent-builder-server';
+import type {
+  AgentContextLayerPluginSetup,
+  AgentContextLayerPluginStart,
+} from '@kbn/agent-context-layer-plugin/server';
 import type { GlobalSearchPluginSetup } from '@kbn/global-search-plugin/server';
 import type {
   EncryptedSavedObjectsPluginSetup,
@@ -46,6 +50,7 @@ import type {
 } from '@kbn/search-inference-endpoints/server';
 import type { StreamsConfig } from '../common/config';
 import type { MemoryTriggerRegistry } from './lib/memory/triggers';
+import type { MemoryIndexCallback } from './lib/memory/memory_service';
 
 export interface StreamsServer {
   core: CoreStart;
@@ -63,6 +68,8 @@ export interface StreamsServer {
   ensureMemorySkillRegistered?: () => void;
   workflowsManagement?: WorkflowsServerPluginSetup;
   spaces?: SpacesPluginStart;
+  /** Fires after memory create/update/delete to push changes into the SML index. */
+  memoryIndexCallback?: MemoryIndexCallback;
 }
 
 export interface ElasticsearchAccessorOptions {
@@ -71,6 +78,7 @@ export interface ElasticsearchAccessorOptions {
 
 export interface StreamsPluginSetupDependencies {
   agentBuilder?: AgentBuilderPluginSetup;
+  agentContextLayer?: AgentContextLayerPluginSetup;
   encryptedSavedObjects: EncryptedSavedObjectsPluginSetup;
   taskManager: TaskManagerSetupContract;
   alerting: AlertingServerSetup;
@@ -98,6 +106,7 @@ export interface StreamsPluginStartDependencies {
   fieldsMetadata: FieldsMetadataServerStart;
   console: ConsoleServerStart;
   agentBuilder?: AgentBuilderPluginStart;
+  agentContextLayer?: AgentContextLayerPluginStart;
   spaces?: SpacesPluginStart;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginStart;
   workflowsExtensions?: WorkflowsExtensionsServerPluginStart;


### PR DESCRIPTION
## Summary

- Adds a new `sigevent_memory_page` SML type in the Streams plugin, registering the sigevents memory knowledge base (wiki-style markdown pages stored in `chatSystemIndex('memory')`) into the Semantic Metadata Layer so agents can discover and attach memory pages via `sml_search` alongside dashboards, connectors, and other indexed artifacts.
- Adds `AttachmentType.sigeventMemoryPage` / `SigeventMemoryPageAttachmentData` to `agent-builder-common`.
- Adds `indexAttachmentSystem` to `AgentContextLayerPluginStart` for internal/background callers that have no HTTP request available.
- The SML type and event-driven callback both gate on the `OBSERVABILITY_STREAMS_ENABLE_MEMORY` uiSetting at call time — no indexing occurs while the feature flag is off.

## How it works

**Crawler path:** The `agentContextLayer` crawler calls `list()` every 5 minutes. When memory is enabled, it enumerates all `MemoryEntry` pages and indexes each as an `SmlChunk` with the page's markdown content and category/tag metadata for semantic search.

**Event-driven path:** `MemoryServiceImpl` now accepts an optional `onAfterWrite` callback. The streams plugin wires this to `agentContextLayer.indexAttachmentSystem()` at start time (guarded by the feature flag), so create/update/delete operations push immediate updates to the SML index without waiting for the next crawl.

## Test plan

- [ ] Type check passes: `node scripts/type_check --project x-pack/platform/plugins/shared/streams/tsconfig.json`
- [ ] Lint passes: `node scripts/check_changes.ts`
- [ ] Enable `observability:streamsEnableMemory` uiSetting, run significant events discovery, verify memory pages appear in `sml_search` results
- [ ] Disable the setting, verify `list()` returns nothing and event-driven writes do not call `indexAttachmentSystem`

Made with [Cursor](https://cursor.com)