### PR TITLE
fix(kbn-evals): retry on fetch failed / other side closed connection drops

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/retry_utils.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/retry_utils.test.ts
@@ -91,6 +91,18 @@ describe('withRetry', () => {
     expect(fn).toHaveBeenCalledTimes(3);
   });
 
+  it.each([
+    ['fetch failed', 'fetch failed'],
+    ['other side closed', 'other side closed'],
+    ['KbnClientRequesterError wrapping fetch failed', 'Status: N/A, Cause: fetch failed -- and ran out of retries'],
+  ])('retries on transient connection drop: %s', async (_label, message) => {
+    const err = new Error(message);
+    const fn = jest.fn().mockRejectedValueOnce(err).mockResolvedValueOnce('ok');
+    const result = await withRetry(fn, fastRetryOptions);
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
   it('invokes onRetry hook between attempts', async () => {
     const onRetry = jest.fn();
     const fn = jest.fn().mockRejectedValueOnce(makeStatusError(503)).mockResolvedValueOnce('ok');

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/retry_utils.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/retry_utils.ts
@@ -120,8 +120,9 @@ function isRetryable(error: any): { retry: boolean; retryAfterMs?: number } {
     return { retry: true, retryAfterMs };
   }
 
-  // Common transient network issues (best-effort)
-  if (/ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND/i.test(message)) {
+  // Common transient network issues (best-effort).
+  // "fetch failed" / "other side closed" are undici's signals for a dropped TCP connection.
+  if (/ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|fetch failed|other side closed/i.test(message)) {
     return { retry: true };
   }
 


### PR DESCRIPTION
## Summary

- Adds `fetch failed` and `other side closed` to the retryable network error patterns in `isRetryable()` (`retry_utils.ts`)
- These are undici's signals for a dropped TCP connection — the server closes the socket before the response is sent
- Previously `withRetry` treated these as terminal, skipping all retry attempts; now they retry like `ECONNRESET`/`ETIMEDOUT`

Root cause of weekly evals build #16 failure: `anomalous_behavior_active_jobs.spec.ts` hit a transient connection drop mid-request to `/internal/inference/prompt`, but `isRetryable()` returned `{ retry: false }` and the error propagated immediately.

## Test plan

- [x] `node scripts/jest x-pack/platform/packages/shared/kbn-evals/src/utils/retry_utils.test.ts` — 19 tests pass (3 new cases cover exact error shapes from CI)