### PR TITLE
[Streams] Create default snapshot repository modal

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/README.md
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/README.md
@@ -1,0 +1,15 @@
+# Data Phases Components
+
+This directory contains UI components used by the stream lifecycle data tiers flow.
+
+Run `yarn storybook streams_app` from the Kibana root to preview these components locally.
+
+## `DefaultSnapshotRepositoryRequiredModal`
+
+`default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.tsx` is shown when a user tries to add a frozen ILM phase but no snapshot repositories are available. Frozen phases require a snapshot repository, so the modal asks the user to create a default repository before refreshing the lifecycle panel.
+
+The create action is rendered as a filled `EuiSplitButton.ActionPrimary` link. The parent should provide `createDefaultRepositoryUrl` with `application.getUrlForApp('management', { path: '/data/snapshot_restore/add_repository' })`, and the modal opens it with `target="_blank"` so the user can create the repository in Snapshot and Restore without losing their current stream lifecycle context.
+
+The refresh action is the split button secondary icon action. It stays in the modal and calls `onRefresh`, which should re-fetch snapshot repositories and continue the frozen phase flow once a repository exists. Because this action is icon-only, it must keep an accessible `aria-label`.
+
+Use `EuiSplitButton` here instead of separate buttons so the create and refresh actions share the connected filled-button treatment from EUI. Avoid `EuiButtonGroup` for this case because it is intended for selection controls, not related actions.

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.stories.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.stories.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { DefaultSnapshotRepositoryRequiredModal } from './default_snapshot_repository_required_modal';
+
+const meta: Meta<typeof DefaultSnapshotRepositoryRequiredModal> = {
+  component: DefaultSnapshotRepositoryRequiredModal,
+  title: 'streams/DefaultSnapshotRepositoryRequiredModal',
+  argTypes: {
+    onCancel: { control: false },
+    onRefresh: { control: false },
+    'data-test-subj': { control: false },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DefaultSnapshotRepositoryRequiredModal>;
+
+export const Default: Story = {
+  args: {
+    createDefaultRepositoryUrl: '/app/management/data/snapshot_restore/add_repository',
+    isRefreshing: false,
+  },
+  render: (args) => (
+    <DefaultSnapshotRepositoryRequiredModal
+      {...args}
+      onCancel={() => action('onCancel')()}
+      onRefresh={() => action('onRefresh')()}
+    />
+  ),
+};
+
+export const Refreshing: Story = {
+  args: {
+    createDefaultRepositoryUrl: '/app/management/data/snapshot_restore/add_repository',
+    isRefreshing: true,
+  },
+  render: (args) => (
+    <DefaultSnapshotRepositoryRequiredModal
+      {...args}
+      onCancel={() => action('onCancel')()}
+      onRefresh={() => action('onRefresh')()}
+    />
+  ),
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { DefaultSnapshotRepositoryRequiredModal } from './default_snapshot_repository_required_modal';
+
+describe('DefaultSnapshotRepositoryRequiredModal', () => {
+  const createDefaultRepositoryUrl = '/app/management/data/snapshot_restore/add_repository';
+
+  it('links to create a default snapshot repository in a new tab', () => {
+    renderWithI18n(
+      <DefaultSnapshotRepositoryRequiredModal
+        createDefaultRepositoryUrl={createDefaultRepositoryUrl}
+        onCancel={() => {}}
+        onRefresh={() => {}}
+      />
+    );
+
+    expect(
+      screen.getByTestId('defaultSnapshotRepositoryRequiredModalCreateDefaultRepositoryButton')
+    ).toHaveAttribute('href', createDefaultRepositoryUrl);
+    expect(
+      screen.getByTestId('defaultSnapshotRepositoryRequiredModalCreateDefaultRepositoryButton')
+    ).toHaveAttribute('target', '_blank');
+  });
+
+  it('calls onCancel when cancel is clicked', () => {
+    const onCancel = jest.fn();
+
+    renderWithI18n(
+      <DefaultSnapshotRepositoryRequiredModal
+        createDefaultRepositoryUrl={createDefaultRepositoryUrl}
+        onCancel={onCancel}
+        onRefresh={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('defaultSnapshotRepositoryRequiredModalCancelButton'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('calls onRefresh when refresh is clicked', () => {
+    const onRefresh = jest.fn();
+
+    renderWithI18n(
+      <DefaultSnapshotRepositoryRequiredModal
+        createDefaultRepositoryUrl={createDefaultRepositoryUrl}
+        onCancel={() => {}}
+        onRefresh={onRefresh}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('defaultSnapshotRepositoryRequiredModalRefreshButton'));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('disables refresh while refreshing', () => {
+    const onRefresh = jest.fn();
+
+    renderWithI18n(
+      <DefaultSnapshotRepositoryRequiredModal
+        createDefaultRepositoryUrl={createDefaultRepositoryUrl}
+        onCancel={() => {}}
+        onRefresh={onRefresh}
+        isRefreshing={true}
+      />
+    );
+
+    const refreshButton = screen.getByTestId('defaultSnapshotRepositoryRequiredModalRefreshButton');
+
+    expect(refreshButton).toBeDisabled();
+
+    fireEvent.click(refreshButton);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSplitButton,
+  EuiText,
+  useEuiTheme,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+
+export interface DefaultSnapshotRepositoryRequiredModalProps {
+  onCancel: () => void;
+  createDefaultRepositoryUrl: string;
+  onRefresh: () => void;
+  isRefreshing?: boolean;
+  'data-test-subj'?: string;
+}
+
+export const DefaultSnapshotRepositoryRequiredModal = ({
+  onCancel,
+  createDefaultRepositoryUrl,
+  onRefresh,
+  isRefreshing,
+  'data-test-subj': dataTestSubj = 'defaultSnapshotRepositoryRequiredModal',
+}: DefaultSnapshotRepositoryRequiredModalProps) => {
+  const titleId = useGeneratedHtmlId({ prefix: 'defaultSnapshotRepositoryRequiredModalTitle' });
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiModal onClose={onCancel} aria-labelledby={titleId} maxWidth={euiTheme.breakpoint.s}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={titleId} data-test-subj={`${dataTestSubj}Title`}>
+          {i18n.translate('xpack.streams.defaultSnapshotRepositoryRequiredModal.title', {
+            defaultMessage: 'Default snapshot repository required',
+          })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiText>
+          {i18n.translate('xpack.streams.defaultSnapshotRepositoryRequiredModal.description', {
+            defaultMessage:
+              'To add a frozen phase to a stream using a data stream lifecycle, first create a default snapshot repository, then refresh this panel.',
+          })}
+        </EuiText>
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              data-test-subj={`${dataTestSubj}CancelButton`}
+              flush="left"
+              onClick={onCancel}
+            >
+              {i18n.translate('xpack.streams.defaultSnapshotRepositoryRequiredModal.cancel', {
+                defaultMessage: 'Cancel',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false}>
+            <EuiSplitButton fill size="m">
+              <EuiSplitButton.ActionPrimary
+                data-test-subj={`${dataTestSubj}CreateDefaultRepositoryButton`}
+                href={createDefaultRepositoryUrl}
+                target="_blank"
+              >
+                {i18n.translate(
+                  'xpack.streams.defaultSnapshotRepositoryRequiredModal.createDefaultRepository',
+                  {
+                    defaultMessage: 'Create default repository',
+                  }
+                )}
+              </EuiSplitButton.ActionPrimary>
+              <EuiSplitButton.ActionSecondary
+                iconType="refresh"
+                isLoading={Boolean(isRefreshing)}
+                disabled={Boolean(isRefreshing)}
+                aria-label={i18n.translate(
+                  'xpack.streams.defaultSnapshotRepositoryRequiredModal.refreshAriaLabel',
+                  {
+                    defaultMessage: 'Refresh snapshot repositories',
+                  }
+                )}
+                data-test-subj={`${dataTestSubj}RefreshButton`}
+                onClick={onRefresh}
+              />
+            </EuiSplitButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/266048

## Summary
- Adds the default snapshot repository required modal for the Streams lifecycle flow when adding a frozen ILM phase requires a snapshot repository.
- The modal gives users a primary action to create a default repository in Snapshot and Restore in a new tab, plus a refresh action to recheck repositories and continue the phase editing flow.
- Adds Storybook coverage for the default and refreshing states, plus a README for the data phases components folder documenting the modal contract, Storybook command, and expected create/refresh behavior.

### Test plan
Manual: preview the component with `yarn storybook streams_app` and verify:
  - The modal title is `Default snapshot repository required`
  - The body explains that a default snapshot repository is required before refreshing the panel
  - The primary action says `Create default repository`
  - The secondary refresh icon has an accessible label and shows the loading/disabled state in the refreshing story

### Evidence
<img width="632" height="259" alt="Screenshot 2026-05-18 at 14 57 07" src="https://github.com/user-attachments/assets/214d22d1-04e4-40a9-9506-0f3a8415a0ba" />
