### PR TITLE
[Obs Alerts] Expand alert consumer list to include ml and stackAlerts

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/constants.ts
@@ -21,6 +21,8 @@ export const observabilityAlertFeatureIds: ValidFeatureId[] = [
   AlertConsumers.SLO,
   AlertConsumers.OBSERVABILITY,
   AlertConsumers.ALERTS,
+  AlertConsumers.ML,
+  AlertConsumers.STACK_ALERTS,
 ];
 
 export const observabilityRuleCreationValidConsumers: RuleCreationValidConsumer[] = [


### PR DESCRIPTION
## Summary

Alerts produced by rules with `consumer: 'ml'` (created from the ML app) and `consumer: 'stackAlerts'` (created from Stack Management) were invisible on the Observability Alerts page (`/app/observability/alerts`). This was reported by field users on serverless O11y projects who create ML anomaly detection rules from the ML Managed Jobs UI.

**Root cause:** The `observabilityAlertFeatureIds` constant used to filter the alerts table excluded `ml` and `stackAlerts` from its consumer list.

**Fix:** Add `AlertConsumers.ML` and `AlertConsumers.STACK_ALERTS` to the list.

**Security:** The backend independently enforces RBAC authorization via `getAuthorizationFilter()` in `alerting_authorization_kuery.ts`, which restricts alert results to only the consumers the authenticated user has privilege for — regardless of what the client requests. Adding consumers to the client-side list is safe: users without the relevant feature privileges (e.g. no ML feature access) will not see those alerts.

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios — no test changes required; no tests assert on the specific consumer list membership
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release Notes

ML anomaly detection alerts and Stack alerts are now visible on the Observability Alerts page for users who have the corresponding feature privileges.