### PR TITLE
docs(agents): document type-check worktree rule and tsc --noEmit alternative

### DIFF
--- a/.agents/skills/branch-readiness-checks/SKILL.md
+++ b/.agents/skills/branch-readiness-checks/SKILL.md
@@ -18,7 +18,7 @@ If `max_wait_ms` is exceeded, report a timeout and continue to the next workflow
 |---|---:|---:|
 | `git diff`, `git merge-base` | 15000 | 1000 |
 | `node scripts/check_changes.ts --ref "$BASE"` | 180000 | 2000 |
-| `node scripts/lint_ts_projects.js`, `yarn test:type_check --project` | 120000 | 2000 |
+| `node scripts/lint_ts_projects.js`, `tsc --noEmit -p tsconfig.json`, `yarn test:type_check --project` | 120000 | 2000 |
 | `node scripts/generate codeowners`, `node scripts/regenerate_moon_projects.js` | 60000 | 2000 |
 | `yarn test:jest` (per package) | 300000 | 5000 |
 
@@ -67,11 +67,24 @@ This runs repo-wide but is fast. Note files modified by `--fix` and report any r
 
 ### Step 3: Type check
 
+> **Worktree rule**: run this step from the **root of the worktree that owns the branch**, not from any other worktree (e.g. `main`). Running `node scripts/type_check` / `yarn test:type_check` from the wrong root anchors `REPO_ROOT` incorrectly and writes `.d.ts` artefacts into that root's tree.
+
 Run type checking scoped to each affected package's `tsconfig.json`.
 Only one `--project` flag per invocation — run separate commands for each package.
 
+**Preferred — `tsc --noEmit` (no build artefacts):**
 ```bash
-yarn test:type_check --project path/to/tsconfig.json
+./node_modules/typescript/bin/tsc --noEmit -p path/to/tsconfig.json 2>&1 | grep 'path/to/my/file'
+```
+Use `grep` to show only errors in your changed files and ignore pre-existing failures in unrelated files.
+
+**Alternative — `node scripts/type_check` (project-build mode):**
+```bash
+node scripts/type_check --project path/to/tsconfig.json
+```
+This runs `tsc -b` internally and **emits `.d.ts` files** across the dependency tree. After the run, clean stray files with:
+```bash
+git ls-files --others --exclude-standard | grep '\.d\.ts$' | xargs rm -f
 ```
 
 **Also check downstream dependents** — find packages whose `kbn_references` include any affected

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,28 @@ Always run `node scripts/check_changes.ts` to validate your changes
 Follow existing patterns in the target area first; below are common defaults.
 
 ### Type check
+
+> **Worktree rule**: always run type checks from the **root of the worktree that owns the branch**. Running `node scripts/type_check` from a different worktree (e.g. `main`) while pointing `--project` at another worktree's `tsconfig.json` anchors `REPO_ROOT` to the wrong directory and scatters `.d.ts` artifacts into that tree.
+
+#### Option A — `node scripts/type_check` (project-build mode)
 `node scripts/type_check [--project path/to/tsconfig.json]`
 - Without `--project` it checks **all** projects (very slow). Always scope to a single project:
-  `node scripts/type_check --project src/core/packages/http/server-internal/tsconfig.json`
+ `node scripts/type_check --project src/core/packages/http/server-internal/tsconfig.json`
 - Only one `--project` per run. To check multiple packages, run separate commands.
-- `.buildkite/` is **not** a valid target for `scripts/type_check`. Buildkite scripts live in a separate workspace; typecheck them with `npm run typecheck` (or `yarn typecheck`) from inside `.buildkite/`.
+- `.buildkite/` is **not** a valid target. Typecheck Buildkite scripts with `npm run typecheck` from inside `.buildkite/`.
+- ⚠️ Uses `tsc -b` internally: compiles all referenced composite projects and **emits `.d.ts` files** across the tree. Afterwards, clean stray files with:
+  ```bash
+  git ls-files --others --exclude-standard | grep '\.d\.ts$' | xargs rm -f
+  ```
+
+#### Option B — `tsc --noEmit` (lighter, no build artefacts)
+Preferred when you only need to verify your changed files without polluting the working tree:
+```bash
+./node_modules/typescript/bin/tsc --noEmit -p path/to/tsconfig.json 2>&1 | grep 'path/to/my/changed/file'
+```
+- Find the narrowest applicable `tsconfig.json` by walking up from the changed file until you hit one.
+- No `.d.ts` files are emitted for the root project. Referenced composite packages may still emit (TypeScript project-references limitation); use the cleanup command above if needed.
+- Pipe through `grep` to surface only errors in your changed files and ignore pre-existing failures in unrelated files.
 
 ### TypeScript & Types
 - Use TypeScript for all new code; avoid `any` and `unknown`.


### PR DESCRIPTION
## Summary

Adds agent guidance for two pitfalls discovered while working on the `esArchiver` decommission effort (where PRs are developed in separate git worktrees):

1. **Wrong worktree**: `node scripts/type_check` anchors `REPO_ROOT` to wherever it is invoked. Running it from `main` while pointing `--project` at another worktree's `tsconfig.json` scatters `.d.ts` artefacts into the main worktree and produces incorrect paths.

2. **`.d.ts` pollution**: `node scripts/type_check` uses `tsc -b` (project-build mode) internally, which compiles all referenced composite projects and emits declaration files across the dependency tree — even when you only want to check one file.

### Changes

- **`AGENTS.md`** — "Type check" section:
  - Added a **Worktree rule** callout.
  - Split into **Option A** (`node scripts/type_check`, with `.d.ts` warning and cleanup command) and **Option B** (`tsc --noEmit`, preferred for targeted checks without artefacts).

- **`.agents/skills/branch-readiness-checks/SKILL.md`** — Step 3:
  - Added worktree warning.
  - Made `tsc --noEmit` the primary recommendation and kept `node scripts/type_check` as a documented alternative with the cleanup step.
  - Updated the command-timing table to include `tsc --noEmit`.

## Test plan

- [ ] Read both updated files and verify the guidance is accurate and clear.

Made with [Cursor](https://cursor.com)