### PR TITLE
[Alerting V2] Add step header to rule flyout

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
+import { applicationServiceMock } from '@kbn/core/public/mocks';
+import type { RuleFormServices } from '../../form/contexts/rule_form_context';
+import { ComposeDiscoverFlyout } from './compose_discover_flyout';
+import type { ComposeDiscoverFlyoutProps } from './compose_discover_flyout';
+
+jest.mock('@kbn/code-editor', () => ({
+  CodeEditor: () => <div data-test-subj="codeEditorMock" />,
+}));
+
+jest.mock('@kbn/esql-editor', () => ({
+  ESQLEditor: () => <div data-test-subj="esqlEditorMock" />,
+}));
+
+jest.mock('./compose_discover_form', () => {
+  const actual = jest.requireActual('./use_compose_discover_state');
+  return {
+    getSteps: (tracking: boolean) =>
+      actual.getStepIds(tracking).map((id: string) => {
+        const titles: Record<string, string> = {
+          alertCondition: 'Alert Condition',
+          recoveryCondition: 'Recovery Condition',
+          details: 'Details & Artifacts',
+          notifications: 'Notifications',
+        };
+        return { id, title: titles[id], render: () => <div /> };
+      }),
+    ComposeDiscoverForm: () => <div data-test-subj="composeDiscoverFormMock" />,
+  };
+});
+
+jest.mock('./compose_discover_child', () => ({
+  ComposeDiscoverChild: () => <div data-test-subj="composeDiscoverChildMock" />,
+}));
+
+jest.mock('./use_esql_providers', () => ({
+  useEsqlAutocomplete: jest.fn(),
+}));
+
+jest.mock('./use_split_query_completion', () => ({
+  useSplitQueryCompletion: () => ({ onEditorMount: jest.fn() }),
+}));
+
+jest.mock('../../form/utils/yaml_form_utils', () => ({
+  serializeFormToYaml: () => '',
+  parseYamlToFormValues: () => ({ values: null }),
+}));
+
+jest.mock('../../form/yaml_rule_form', () => ({
+  YamlRuleForm: () => <div data-test-subj="yamlRuleFormMock" />,
+}));
+
+const createMockServices = (): RuleFormServices => ({
+  http: httpServiceMock.createStartContract(),
+  data: dataPluginMock.createStartContract(),
+  dataViews: dataViewPluginMocks.createStartContract(),
+  notifications: notificationServiceMock.createStartContract(),
+  application: applicationServiceMock.createStartContract(),
+  lens: { createStartContract: jest.fn() } as unknown as RuleFormServices['lens'],
+});
+
+const defaultProps: ComposeDiscoverFlyoutProps = {
+  historyKey: Symbol('test'),
+  mode: 'create',
+  onClose: jest.fn(),
+  services: createMockServices(),
+  onCreateRule: jest.fn(),
+};
+
+const renderFlyout = (overrides: Partial<ComposeDiscoverFlyoutProps> = {}) =>
+  render(
+    <IntlProvider locale="en">
+      <ComposeDiscoverFlyout {...defaultProps} {...overrides} />
+    </IntlProvider>
+  );
+
+describe('ComposeDiscoverFlyout', () => {
+  describe('HorizontalMinimalStepper', () => {
+    it('renders the stepper with the correct aria-label for step 1 of 3', () => {
+      renderFlyout();
+
+      const stepper = screen.getByRole('group', { name: /Step 1 of 3: Alert Condition/ });
+      expect(stepper).toBeInTheDocument();
+    });
+
+    it('renders 3 steps when tracking is disabled (default)', () => {
+      renderFlyout();
+
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+      expect(screen.getByText('Alert Condition')).toBeInTheDocument();
+    });
+
+    it('does not render the stepper in YAML mode', () => {
+      renderFlyout();
+
+      const toggleGroup = screen.getByTestId('composeDiscoverEditModeToggle');
+      const yamlButton =
+        toggleGroup.querySelector('button[data-test-subj="yaml"]') ??
+        toggleGroup.querySelectorAll('button')[1];
+      fireEvent.click(yamlButton!);
+
+      expect(screen.queryByRole('group', { name: /Step \d+ of \d+/ })).not.toBeInTheDocument();
+      expect(screen.getByTestId('composeDiscoverYamlBadge')).toBeInTheDocument();
+    });
+  });
+
+  describe('flyout title', () => {
+    it('shows "Create alert rule" in create mode', () => {
+      renderFlyout({ mode: 'create' });
+      expect(screen.getByText('Create alert rule')).toBeInTheDocument();
+    });
+
+    it('shows "Edit alert rule" in edit mode', () => {
+      renderFlyout({ mode: 'edit' });
+      expect(screen.getByText('Edit alert rule')).toBeInTheDocument();
+    });
+  });
+
+  describe('footer navigation', () => {
+    it('shows Next button on non-final step', () => {
+      renderFlyout();
+      expect(screen.getByTestId('composeDiscoverNext')).toBeInTheDocument();
+      expect(screen.queryByTestId('composeDiscoverSubmit')).not.toBeInTheDocument();
+    });
+
+    it('does not show Back button on the first step', () => {
+      renderFlyout();
+      expect(screen.queryByTestId('composeDiscoverBack')).not.toBeInTheDocument();
+    });
+
+    it('disables Next when query is not committed on alertCondition step', () => {
+      renderFlyout();
+      expect(screen.getByTestId('composeDiscoverNext')).toBeDisabled();
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
@@ -13,6 +13,7 @@ import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { applicationServiceMock } from '@kbn/core/public/mocks';
+import { lensPluginMock } from '@kbn/lens-plugin/public/mocks';
 import type { RuleFormServices } from '../../form/contexts/rule_form_context';
 import { ComposeDiscoverFlyout } from './compose_discover_flyout';
 import type { ComposeDiscoverFlyoutProps } from './compose_discover_flyout';
@@ -69,7 +70,7 @@ const createMockServices = (): RuleFormServices => ({
   dataViews: dataViewPluginMocks.createStartContract(),
   notifications: notificationServiceMock.createStartContract(),
   application: applicationServiceMock.createStartContract(),
-  lens: { createStartContract: jest.fn() } as unknown as RuleFormServices['lens'],
+  lens: lensPluginMock.createStartContract(),
 });
 
 const defaultProps: ComposeDiscoverFlyoutProps = {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -38,6 +38,7 @@ import {
 import type { ComposeDiscoverMode, SandboxApplyData } from './types';
 import { useComposeDiscoverState, getSandboxTabConfig } from './use_compose_discover_state';
 import { ComposeDiscoverForm, getSteps } from './compose_discover_form';
+import { HorizontalMinimalStepper, type MinimalStep } from './horizontal_minimal_stepper';
 import { ComposeDiscoverChild } from './compose_discover_child';
 import { useEsqlAutocomplete } from './use_esql_providers';
 import { useSplitQueryCompletion } from './use_split_query_completion';
@@ -396,7 +397,7 @@ export const ComposeDiscoverFlyout: React.FC<ComposeDiscoverFlyoutProps> = ({
               responsive={false}
               style={{ marginTop: 8 }}
             >
-              <EuiFlexItem grow={false}>
+              <EuiFlexItem grow>
                 {uiState.yamlMode ? (
                   <EuiBadge color="hollow" data-test-subj="composeDiscoverYamlBadge">
                     {i18n.translate('xpack.alertingV2.composeDiscover.yamlMode.badge', {
@@ -404,7 +405,19 @@ export const ComposeDiscoverFlyout: React.FC<ComposeDiscoverFlyoutProps> = ({
                     })}
                   </EuiBadge>
                 ) : (
-                  <>{/* Step indicator coming in PR A — HorizontalMinimalStepper */}</>
+                  <HorizontalMinimalStepper
+                    steps={steps.map(
+                      (s, i): MinimalStep => ({
+                        title: s.title,
+                        status:
+                          i < uiState.step
+                            ? 'complete'
+                            : i === uiState.step
+                            ? 'current'
+                            : 'incomplete',
+                      })
+                    )}
+                  />
                 )}
               </EuiFlexItem>
               <EuiFlexItem grow={false}>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -86,6 +86,12 @@ export interface ComposeDiscoverFlyoutProps {
 
 const FLYOUT_TITLE_ID = 'composeDiscoverFlyoutTitle';
 
+const getStepStatus = (currentStep: number, stepIndex: number): MinimalStep['status'] => {
+  if (stepIndex < currentStep) return 'complete';
+  if (stepIndex === currentStep) return 'current';
+  return 'incomplete';
+};
+
 /** Bridge YAML parse (FormValues) into compose form shape until yaml_form_utils adopts ComposeFormValues. */
 const formValuesFromYamlToCompose = (parsed: FormValues): ComposeFormValues => ({
   kind: parsed.kind,
@@ -409,12 +415,7 @@ export const ComposeDiscoverFlyout: React.FC<ComposeDiscoverFlyoutProps> = ({
                     steps={steps.map(
                       (s, i): MinimalStep => ({
                         title: s.title,
-                        status:
-                          i < uiState.step
-                            ? 'complete'
-                            : i === uiState.step
-                            ? 'current'
-                            : 'incomplete',
+                        status: getStepStatus(uiState.step, i),
                       })
                     )}
                   />


### PR DESCRIPTION
## Summary

Closes  https://github.com/elastic/kibana/issues/269758

Adds step header to new rule flyout

<img width="483" height="719" alt="Screenshot 2026-05-18 at 10 08 35 AM" src="https://github.com/user-attachments/assets/9310422a-c4b2-43f1-a78a-d0d8db5350e6" />

<img width="481" height="779" alt="Screenshot 2026-05-18 at 10 08 54 AM" src="https://github.com/user-attachments/assets/2a266106-1d54-424c-ad97-7c158e109b49" />

<img width="481" height="780" alt="Screenshot 2026-05-18 at 10 09 05 AM" src="https://github.com/user-attachments/assets/49811a94-3548-48a6-91bf-ff18e0408d23" />
