### PR TITLE
Revert "[Obs Alerts] Expand alert consumer list to include ml and stackAlerts"

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/constants.ts
@@ -21,8 +21,6 @@ export const observabilityAlertFeatureIds: ValidFeatureId[] = [
   AlertConsumers.SLO,
   AlertConsumers.OBSERVABILITY,
   AlertConsumers.ALERTS,
-  AlertConsumers.ML,
-  AlertConsumers.STACK_ALERTS,
 ];
 
 export const observabilityRuleCreationValidConsumers: RuleCreationValidConsumer[] = [


### PR DESCRIPTION
Reverts elastic/kibana#269718, didn't mean to merge this quite yet while we consider backwards-compatibility concerns in stateful especially. 