### PR TITLE
[Logs Essential] disabled genAiSettings & agentBuilder for logs essentials

### DIFF
--- a/config/serverless.oblt.complete.yml
+++ b/config/serverless.oblt.complete.yml
@@ -22,7 +22,11 @@ xpack.features.overrides:
   uptime.name: 'Synthetics'
   ### Workflows Management should be moved from Analytics category to the Observability one.
   workflowsManagement.category: 'observability'
-
+  ### Agent Builder should be moved from Analytics category to the Observability one.
+  agentBuilder.category: 'observability'
+  ### Agent Context Layer should match Agent Builder for role management (avoid orphan Kibana category).
+  agentContextLayer.category: 'observability'
+  
 # Elastic Managed LLMs
 xpack.actions.preconfigured:
   Anthropic-Claude-Sonnet-3-7:

--- a/config/serverless.oblt.logs_essentials.yml
+++ b/config/serverless.oblt.logs_essentials.yml
@@ -30,6 +30,8 @@ xpack.features.overrides:
   searchInferenceEndpoints.hidden: true
   ### Workflows Management feature should be hidden in this tier
   workflowsManagement.hidden: true
+  ### Agent Context Layer is hidden when Agent Builder is disabled for this tier
+  agentContextLayer.hidden: true
 
 
 xpack.fleet.internal.registry.excludePackages: [

--- a/config/serverless.oblt.logs_essentials.yml
+++ b/config/serverless.oblt.logs_essentials.yml
@@ -7,6 +7,11 @@ xpack.cloud.serverless.product_tier: logs_essentials
 xpack.infra.enabled: false
 xpack.slo.enabled: false
 xpack.observabilityAIAssistant.enabled: false
+xpack.agentBuilder.enabled: false
+xpack.genAiSettings.showAiBreadcrumb: false
+xpack.genAiSettings.showSpacesIntegration: false
+xpack.genAiSettings.showAiAssistantsVisibilitySetting: false
+xpack.genAiSettings.showChatExperienceSetting: false
 xpack.aiops.ui.enabled: false
 xpack.apm.enabled: false
 xpack.cases.enabled: false

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -25,10 +25,6 @@ xpack.features.overrides:
   ### Discover feature should be moved from Analytics category to the Observability one and its privileges are
   ### fine-tuned to grant access to Observability app.
   discover_v2.category: 'observability'
-  ### Agent Builder should be moved from Analytics category to the Observability one.
-  agentBuilder.category: 'observability'
-  ### Agent Context Layer should match Agent Builder for role management (avoid orphan Kibana category).
-  agentContextLayer.category: 'observability'
 
 # Customize empty page state for analytics apps
 no_data_page.analyticsNoDataPageFlavor: 'serverless_observability'

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -168,7 +168,7 @@ pageLoadAssetSize:
   securitySolutionEss: 38689
   securitySolutionServerless: 52082
   serverless: 7412
-  serverlessObservability: 19104
+  serverlessObservability: 19200
   serverlessSearch: 26287
   serverlessVectordb: 7618
   serverlessWorkplaceAI: 4855

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.test.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.test.ts
@@ -67,6 +67,18 @@ describe('Navigation Tree', () => {
     expect(agentsNode).toBeDefined();
   });
 
+  it('hides GenAI Settings in admin settings when unavailable', () => {
+    const { body } = createNavigationTree({ genAiSettingsAvailable: false });
+    const adminSettingsNode = body.find((item) => item.id === 'admin_and_settings');
+    const aiSection = adminSettingsNode?.children?.find(
+      (item) => item.title === 'AI' && 'children' in item
+    );
+
+    expect(aiSection?.children).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ link: 'management:genAiSettings' })])
+    );
+  });
+
   it('uses a single Alerts link to classic Observability alerts', () => {
     const { body } = createNavigationTree({ showAlertingV2: true });
     const alertsPanel = body.find(

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -22,12 +22,14 @@ export function filterForFeatureAvailability(
 export const createNavigationTree = ({
   streamsAvailable,
   overviewAvailable = true,
+  genAiSettingsAvailable = true,
   isCasesAvailable = true,
   showAiAssistant = true,
   showAlertingV2 = false,
 }: {
   streamsAvailable?: boolean;
   overviewAvailable?: boolean;
+  genAiSettingsAvailable?: boolean;
   isCasesAvailable?: boolean;
   showAiAssistant?: boolean;
   showAlertingV2?: boolean;

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/plugin.ts
@@ -57,6 +57,7 @@ export class ServerlessObservabilityPlugin
         return createNavigationTree({
           streamsAvailable: status === 'enabled',
           overviewAvailable: core.pricing.isFeatureAvailable('observability:complete_overview'),
+          genAiSettingsAvailable: core.pricing.isFeatureAvailable('observability:gen_ai_settings'),
           isCasesAvailable: Boolean(setupDeps.cases),
           showAiAssistant: chatExperience !== AIChatExperience.Agent,
           showAlertingV2: Boolean(core.application.capabilities.alertingVTwo),

--- a/x-pack/solutions/observability/plugins/serverless_observability/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/server/plugin.ts
@@ -65,6 +65,12 @@ export class ServerlessObservabilityPlugin
         products: [{ name: 'observability', tier: 'complete' }],
         description: 'Workflows - Enables the Workflows application in the Observability solution.',
       },
+      {
+        id: 'observability:gen_ai_settings',
+        products: [{ name: 'observability', tier: 'complete' }],
+        description:
+          'GenAI Settings management page - Enables Stack Management GenAI Settings for Observability.',
+      },
     ]);
     return {};
   }

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/privileges.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/privileges.ts
@@ -51,13 +51,11 @@ export default function ({ getPageObject, getPageObjects, getService }: FtrProvi
           return await privilege.getVisibleText();
         })
       );
-      expect(privileges.length).to.be(5);
+      expect(privileges.length).to.be(3);
       expect(text).to.eql([
         'Discover\nAll\nRead\nNone',
         'Dashboard\nAll\nRead\nNone',
         'Logs\nAll\nRead\nNone',
-        'Agent Builder\nAll\nRead\nNone',
-        'Agent Context Layer\nAll\nRead\nNone',
       ]);
     });
 


### PR DESCRIPTION
## Summary
resolves https://github.com/elastic/kibana/issues/269532

Disables AgentBuilder & genAiSettings for logs essentials. 

One thing I'm not sure of: is whether `agentContextLayer.category: 'observability'` should be moved to `serverless.obtl.complete.yml` with the `agentBuilder.category`, or not. Based off the serverless security settings, it should only be in complete. 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

