### PR TITLE
Remove async imports from apm plugin setup and start methods

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -9,7 +9,7 @@ pageLoadAssetSize:
   aiops: 15227
   alerting: 22371
   alertingVTwo: 76778
-  apm: 28027
+  apm: 48558
   apmSourcesAccess: 2278
   automaticImport: 18629
   banners: 4006
@@ -173,7 +173,7 @@ pageLoadAssetSize:
   serverlessVectordb: 7618
   serverlessWorkplaceAI: 4855
   sessionView: 47912
-  share: 64066
+  share: 64059
   slo: 40437
   snapshotRestore: 22068
   spaces: 28871

--- a/x-pack/solutions/observability/plugins/apm/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/plugin.ts
@@ -109,6 +109,8 @@ import { createLazyFocusedTraceWaterfallRenderer } from './components/shared/foc
 import { createLazyFullTraceWaterfallRenderer } from './components/shared/trace_waterfall/lazy_create_full_trace_waterfall_renderer';
 import type { ApmCoreSetup } from './components/alerting/utils/create_lazy_component_with_context';
 import { registerEmbeddables } from './embeddable/register_embeddables';
+import { registerServiceMapAttachment } from './agent_builder/attachment_types';
+import { registerApmRuleTypes } from './components/alerting/rule_types/register_apm_rule_types';
 
 export type ApmPluginSetup = ReturnType<ApmPlugin['setup']>;
 export type ApmPluginStart = ReturnType<ApmPlugin['start']>;
@@ -511,18 +513,14 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       },
     });
 
-    import('./components/alerting/rule_types/register_apm_rule_types').then(
-      ({ registerApmRuleTypes }) => {
-        registerApmRuleTypes(observabilityRuleTypeRegistry, core as ApmCoreSetup, {
-          coreSetup: core,
-          pluginsSetup: plugins,
-          config,
-          kibanaEnvironment,
-          observabilityRuleTypeRegistry,
-          telemetry,
-        });
-      }
-    );
+    registerApmRuleTypes(observabilityRuleTypeRegistry, core as ApmCoreSetup, {
+      coreSetup: core,
+      pluginsSetup: plugins,
+      config,
+      kibanaEnvironment,
+      observabilityRuleTypeRegistry,
+      telemetry,
+    });
     registerEmbeddables({
       coreSetup: core,
       pluginsSetup: plugins,
@@ -556,9 +554,7 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       setApmInternalServices({});
     }
     if (plugins.agentBuilder) {
-      import('./agent_builder/attachment_types').then(({ registerServiceMapAttachment }) => {
-        registerServiceMapAttachment(plugins.agentBuilder!.attachments);
-      });
+      registerServiceMapAttachment(plugins.agentBuilder!.attachments);
     }
     plugins.observabilityAIAssistant?.service.register(async ({ registerRenderFunction }) => {
       const mod = await import('./assistant_functions');


### PR DESCRIPTION

Plugins should not async load chunks during plugin setup or start because:
* Hides true page load impact from page load bundle size - cheats limits.yml metrics
* Causes more work for browser to async load code in separate HTTP requests.

In the before image, notice how 4 apm chunks are loaded on initial home page load
<img height="500" alt="Screenshot 2026-05-18 at 10 40 46 AM" src="https://github.com/user-attachments/assets/6b2939a7-1d6b-4823-9530-d88127041220" />

In the after image, notice how 0 apm chunks are loaded on initial home page load
<img height="500" alt="Screenshot 2026-05-18 at 10 40 29 AM" src="https://github.com/user-attachments/assets/3172b4b9-c1d7-49d8-937c-d8611d2dbe45" />
