### PR TITLE
[9.4] fix(ui-settings, security): skip async UI setting defaults on anonymous pages (#269675)

### DIFF
--- a/src/core/packages/rendering/server-internal/src/rendering_service.test.ts
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.test.ts
@@ -226,6 +226,42 @@ function renderTestCases(
       expect(data.legacyMetadata.globalUiSettings.user).toEqual({}); // user settings are not injected
     });
 
+    it('does not call getUserProvided for anonymous pages', async () => {
+      const [render] = await getRender();
+      await render(createKibanaRequest(), uiSettings, {
+        isAnonymousPage: true,
+      });
+
+      expect(uiSettings.client.getUserProvided).not.toHaveBeenCalled();
+      expect(uiSettings.globalClient.getUserProvided).not.toHaveBeenCalled();
+    });
+
+    it('does not resolve async default `getValue` for anonymous pages', async () => {
+      const getValue = jest.fn().mockResolvedValue('async-default');
+      uiSettings.client.getRegistered.mockReturnValue({
+        registered: { name: 'title', getValue },
+      });
+
+      const [render] = await getRender();
+      await render(createKibanaRequest(), uiSettings, {
+        isAnonymousPage: true,
+      });
+
+      expect(getValue).not.toHaveBeenCalled();
+    });
+
+    it('resolves async default `getValue` for non-anonymous pages', async () => {
+      const getValue = jest.fn().mockResolvedValue('async-default');
+      uiSettings.client.getRegistered.mockReturnValue({
+        registered: { name: 'title', getValue },
+      });
+
+      const [render] = await getRender();
+      await render(createKibanaRequest(), uiSettings);
+
+      expect(getValue).toHaveBeenCalledTimes(1);
+    });
+
     it('calls `getCommonStylesheetPaths` with the correct parameters', async () => {
       getSettingValueMock.mockImplementation((settingName: string) => {
         if (settingName === 'theme:darkMode') {

--- a/src/core/packages/rendering/server-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.tsx
@@ -190,28 +190,29 @@ export class RenderingService {
     const { serverBasePath, publicBaseUrl } = http.basePath;
 
     // Grouping all async HTTP requests to run them concurrently for performance reasons.
+    // Anonymous pages skip user-scoped values and async default values (the latter typically
+    // call ES via `asCurrentUser`, which would 401 on an unauthenticated request).
     const [
       defaultSettings,
       settingsUserValues = {},
       globalSettingsUserValues = {},
       userSettingDarkMode,
-    ] = await Promise.all([
-      // All sites
-      withAsyncDefaultValues(request, uiSettings.client?.getRegistered()),
-      // Only non-anonymous pages
-      ...(!isAnonymousPage
-        ? ([
+    ] = await Promise.all(
+      isAnonymousPage
+        ? [uiSettings.client?.getRegistered() ?? {}]
+        : ([
+            withAsyncDefaultValues(request, uiSettings.client?.getRegistered()),
             uiSettings.client?.getUserProvided(),
             uiSettings.globalClient?.getUserProvided(),
             // dark mode
             userSettings?.getUserSettingDarkMode(request),
           ] as [
+            ReturnType<typeof withAsyncDefaultValues>,
             Promise<Record<string, UserProvidedValues>>,
             Promise<Record<string, UserProvidedValues>>,
             Promise<DarkModeValue> | undefined
           ])
-        : []),
-    ]);
+    );
 
     const settings = {
       defaults: defaultSettings,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix(ui-settings, security): skip async UI setting defaults on anonymous pages (#269675)](https://github.com/elastic/kibana/pull/269675)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-05-18T16:31:23Z","message":"fix(ui-settings, security): skip async UI setting defaults on anonymous pages (#269675)\n\n## Summary\n\n> [!IMPORTANT]\n> **For reviewers:** This fix assumes async `getValue` defaults are\ncomputed for the authenticated user only, so it skips them entirely on\nanonymous pages. If you think that contract is too strong (i.e. some\nasync defaults could legitimately run without a session/credentials),\nthe alternative is to drop this framework-level guard and instead have\n**every** `getValue` consumer check `request.auth.isAuthenticated`\nitself. Happy to switch to that approach if you prefer.\n\nOpening a fresh Kibana tab (no session) logged this error on every cold\nload:\n\n> [ERROR][plugins.security.authentication] Re-authentication is not\npossible for the following error: ... \"missing authentication\ncredentials for REST request [/_security/user/_has_privileges]\" ...\n\n## Root cause\n\nThe rendering service unconditionally resolved async UI setting defaults\nvia `withAsyncDefaultValues(request, ...)` when rendering anonymous\npages such as `/login`. The `gen_ai_settings` plugin registers an async\ndefault for `genAiSettings:defaultAIConnector` whose `getValue` callback\nfetches the user's connectors:\n\n1. `renderAnonymousCoreApp()` triggers `rendering.render()` on `/login`\n2. `withAsyncDefaultValues` invokes every registered `getValue`,\nincluding the gen_ai one\n3. `getValue` calls `actionsClient.getAll()`, which runs\n`ActionsAuthorization.ensureAuthorized` and ultimately\n`asCurrentUser.security.hasPrivileges(...)`\n4. The login-page request has no auth headers, ES returns 401\n5. The security plugin's `setUnauthorizedErrorHandler` logs the\n\"Re-authentication is not possible\" ERROR before the plugin's own\ntry/catch returns `NO_DEFAULT_CONNECTOR`\n\nThe page rendered correctly, but the error fired on every cold tab open.\n\n## Fix\n\nSkip `withAsyncDefaultValues` when `isAnonymousPage` is `true` and\nreturn the synchronously-registered defaults instead. Anonymous pages\nhave no authenticated user, so user-scoped async defaults have no\ncorrect value to compute and would only produce noise (or, in this case,\nan error) when they hit ES.\n\nConsolidated the two existing `isAnonymousPage` branches in\n`rendering_service.tsx` into a single ternary while I was here.\n\n## Notes\n\n`gen_ai_settings`' own try/catch already prevented user-visible\nbreakage, but every other plugin registering an async `getValue` would\nhit the same trap. Folding the guard into the rendering service\ndocuments the contract that async defaults are computed for the\nauthenticated user only.","sha":"3c0570bc16753596bec7bf6854e23a551ccf4816","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.5.0"],"title":"fix(ui-settings, security): skip async UI setting defaults on anonymous pages","number":269675,"url":"https://github.com/elastic/kibana/pull/269675","mergeCommit":{"message":"fix(ui-settings, security): skip async UI setting defaults on anonymous pages (#269675)\n\n## Summary\n\n> [!IMPORTANT]\n> **For reviewers:** This fix assumes async `getValue` defaults are\ncomputed for the authenticated user only, so it skips them entirely on\nanonymous pages. If you think that contract is too strong (i.e. some\nasync defaults could legitimately run without a session/credentials),\nthe alternative is to drop this framework-level guard and instead have\n**every** `getValue` consumer check `request.auth.isAuthenticated`\nitself. Happy to switch to that approach if you prefer.\n\nOpening a fresh Kibana tab (no session) logged this error on every cold\nload:\n\n> [ERROR][plugins.security.authentication] Re-authentication is not\npossible for the following error: ... \"missing authentication\ncredentials for REST request [/_security/user/_has_privileges]\" ...\n\n## Root cause\n\nThe rendering service unconditionally resolved async UI setting defaults\nvia `withAsyncDefaultValues(request, ...)` when rendering anonymous\npages such as `/login`. The `gen_ai_settings` plugin registers an async\ndefault for `genAiSettings:defaultAIConnector` whose `getValue` callback\nfetches the user's connectors:\n\n1. `renderAnonymousCoreApp()` triggers `rendering.render()` on `/login`\n2. `withAsyncDefaultValues` invokes every registered `getValue`,\nincluding the gen_ai one\n3. `getValue` calls `actionsClient.getAll()`, which runs\n`ActionsAuthorization.ensureAuthorized` and ultimately\n`asCurrentUser.security.hasPrivileges(...)`\n4. The login-page request has no auth headers, ES returns 401\n5. The security plugin's `setUnauthorizedErrorHandler` logs the\n\"Re-authentication is not possible\" ERROR before the plugin's own\ntry/catch returns `NO_DEFAULT_CONNECTOR`\n\nThe page rendered correctly, but the error fired on every cold tab open.\n\n## Fix\n\nSkip `withAsyncDefaultValues` when `isAnonymousPage` is `true` and\nreturn the synchronously-registered defaults instead. Anonymous pages\nhave no authenticated user, so user-scoped async defaults have no\ncorrect value to compute and would only produce noise (or, in this case,\nan error) when they hit ES.\n\nConsolidated the two existing `isAnonymousPage` branches in\n`rendering_service.tsx` into a single ternary while I was here.\n\n## Notes\n\n`gen_ai_settings`' own try/catch already prevented user-visible\nbreakage, but every other plugin registering an async `getValue` would\nhit the same trap. Folding the guard into the rendering service\ndocuments the contract that async defaults are computed for the\nauthenticated user only.","sha":"3c0570bc16753596bec7bf6854e23a551ccf4816"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269675","number":269675,"mergeCommit":{"message":"fix(ui-settings, security): skip async UI setting defaults on anonymous pages (#269675)\n\n## Summary\n\n> [!IMPORTANT]\n> **For reviewers:** This fix assumes async `getValue` defaults are\ncomputed for the authenticated user only, so it skips them entirely on\nanonymous pages. If you think that contract is too strong (i.e. some\nasync defaults could legitimately run without a session/credentials),\nthe alternative is to drop this framework-level guard and instead have\n**every** `getValue` consumer check `request.auth.isAuthenticated`\nitself. Happy to switch to that approach if you prefer.\n\nOpening a fresh Kibana tab (no session) logged this error on every cold\nload:\n\n> [ERROR][plugins.security.authentication] Re-authentication is not\npossible for the following error: ... \"missing authentication\ncredentials for REST request [/_security/user/_has_privileges]\" ...\n\n## Root cause\n\nThe rendering service unconditionally resolved async UI setting defaults\nvia `withAsyncDefaultValues(request, ...)` when rendering anonymous\npages such as `/login`. The `gen_ai_settings` plugin registers an async\ndefault for `genAiSettings:defaultAIConnector` whose `getValue` callback\nfetches the user's connectors:\n\n1. `renderAnonymousCoreApp()` triggers `rendering.render()` on `/login`\n2. `withAsyncDefaultValues` invokes every registered `getValue`,\nincluding the gen_ai one\n3. `getValue` calls `actionsClient.getAll()`, which runs\n`ActionsAuthorization.ensureAuthorized` and ultimately\n`asCurrentUser.security.hasPrivileges(...)`\n4. The login-page request has no auth headers, ES returns 401\n5. The security plugin's `setUnauthorizedErrorHandler` logs the\n\"Re-authentication is not possible\" ERROR before the plugin's own\ntry/catch returns `NO_DEFAULT_CONNECTOR`\n\nThe page rendered correctly, but the error fired on every cold tab open.\n\n## Fix\n\nSkip `withAsyncDefaultValues` when `isAnonymousPage` is `true` and\nreturn the synchronously-registered defaults instead. Anonymous pages\nhave no authenticated user, so user-scoped async defaults have no\ncorrect value to compute and would only produce noise (or, in this case,\nan error) when they hit ES.\n\nConsolidated the two existing `isAnonymousPage` branches in\n`rendering_service.tsx` into a single ternary while I was here.\n\n## Notes\n\n`gen_ai_settings`' own try/catch already prevented user-visible\nbreakage, but every other plugin registering an async `getValue` would\nhit the same trap. Folding the guard into the rendering service\ndocuments the contract that async defaults are computed for the\nauthenticated user only.","sha":"3c0570bc16753596bec7bf6854e23a551ccf4816"}}]}] BACKPORT-->