### PR TITLE
[kbn-evals] Add on-demand evals - Buildkite

### DIFF
--- a/.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml
+++ b/.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: bk-kibana-evals-on-demand
+  description: 'Runs a single @kbn/evals suite and model on demand (manual New build or API trigger)'
+  links:
+    - url: 'https://buildkite.com/elastic/kibana-evals-on-demand'
+      title: Pipeline link
+spec:
+  type: buildkite-pipeline
+  owner: 'group:obs-ai-team'
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: 'Kibana / Evals / On-demand LLM Evals'
+      description: 'Runs one @kbn/evals suite against one model on a chosen branch (manual Buildkite trigger)'
+    spec:
+      env:
+        KBN_EVALS: '1'
+      allow_rebuilds: true
+      branch_configuration: ''
+      cancel_intermediate_builds: true
+      default_branch: main
+      repository: elastic/kibana
+      pipeline_file: .buildkite/pipelines/evals/on_demand_evals.yml
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        publish_commit_status: false
+        trigger_mode: none
+        prefix_pull_request_fork_branch_names: false
+        skip_pull_request_builds_for_existing_commits: false
+        build_tags: false
+      teams:
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+        obs-ai-team:
+          access_level: MANAGE_BUILD_AND_READ
+        security-generative_ai:
+          access_level: MANAGE_BUILD_AND_READ
+        workchat-eng:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+      tags:
+        - kibana
+        - kbn-evals

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -8,8 +8,8 @@ spec:
   type: url
   targets:
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/cloud-security-posture/cspm-agentless-scout.yml
-    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-agent-builder-smoke-tests-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-apis-capacity-testing-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -9,6 +9,7 @@ spec:
   targets:
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/cloud-security-posture/cspm-agentless-scout.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/evals/kibana-evals.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-agent-builder-smoke-tests-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-apis-capacity-testing-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml

--- a/.buildkite/pipelines/evals/on_demand_evals.yml
+++ b/.buildkite/pipelines/evals/on_demand_evals.yml
@@ -1,0 +1,59 @@
+env:
+  KBN_EVALS: '1'
+steps:
+  - label: '👨‍🔧 Pre-Build'
+    command: .buildkite/scripts/lifecycle/pre_build.sh
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-2
+
+  - wait
+
+  - label: '🧑‍🏭 Build Kibana Distribution'
+    command: .buildkite/scripts/steps/build_kibana.sh
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-8
+    key: build
+    if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
+
+  - wait
+
+  - label: ':pipeline: Validate on-demand eval inputs'
+    key: validate-on-demand-inputs
+    command: bash .buildkite/scripts/steps/evals/validate_on_demand_inputs.sh
+    depends_on:
+      - build
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-2
+
+  - label: 'LLM Evals: On-demand'
+    key: kbn-evals-on-demand
+    command: bash .buildkite/scripts/steps/evals/run_suite.sh
+    depends_on:
+      - build
+      - validate-on-demand-inputs
+    env:
+      KBN_EVALS: '1'
+      FTR_EIS_CCM: '1'
+      EVAL_FANOUT: '1'
+    timeout_in_minutes: 120
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-8
+      preemptible: true
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1

--- a/.buildkite/scripts/steps/evals/validate_on_demand_inputs.sh
+++ b/.buildkite/scripts/steps/evals/validate_on_demand_inputs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GOLDEN_CLUSTER_EVALS_URL='https://kbn-evals-serverless-ed035a.kb.us-central1.gcp.elastic.cloud/app/evals'
+PIPELINE_URL='https://buildkite.com/elastic/kibana-evals-on-demand'
+
+missing=()
+if [[ -z "${EVAL_SUITE_ID:-}" ]]; then
+  missing+=('EVAL_SUITE_ID')
+fi
+if [[ -z "${EVAL_MODEL_GROUPS:-}" ]]; then
+  missing+=('EVAL_MODEL_GROUPS')
+fi
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  echo "On-demand eval build is missing required environment variable(s): ${missing[*]}"
+  echo ""
+  echo "When starting a New build, set environment variables on the build. Example:"
+  echo ""
+  node x-pack/platform/packages/shared/kbn-evals/scripts/ci/resolve_on_demand_eval_env.js \
+    --suite agent-builder \
+    --model eis/openai-gpt-5.4 \
+    --format env
+  echo ""
+  echo "Suite ids are listed in .buildkite/pipelines/evals/evals.suites.json"
+  echo "Model values match PR labels without the models: prefix (e.g. eis/openai-gpt-5.4)."
+  echo ""
+  echo "Pipeline: ${PIPELINE_URL}"
+  exit 1
+fi
+
+# Validate suite id exists (fail fast with a helpful list).
+node x-pack/platform/packages/shared/kbn-evals/scripts/ci/resolve_on_demand_eval_env.js \
+  --suite "${EVAL_SUITE_ID}" \
+  --model "${EVAL_MODEL_GROUPS}" \
+  --format env >/dev/null
+
+echo "On-demand eval inputs:"
+echo "  EVAL_SUITE_ID=${EVAL_SUITE_ID}"
+echo "  EVAL_MODEL_GROUPS=${EVAL_MODEL_GROUPS}"
+if [[ -n "${EVALUATION_CONNECTOR_ID:-}" ]]; then
+  echo "  EVALUATION_CONNECTOR_ID=${EVALUATION_CONNECTOR_ID}"
+fi
+if [[ -n "${EVAL_SERVER_CONFIG_SET:-}" ]]; then
+  echo "  EVAL_SERVER_CONFIG_SET=${EVAL_SERVER_CONFIG_SET}"
+fi
+echo ""
+echo "Results will be exported to the golden cluster evals UI:"
+echo "  ${GOLDEN_CLUSTER_EVALS_URL}"
+if [[ -n "${BUILDKITE_BUILD_ID:-}" ]]; then
+  echo "  Run id prefix after the eval step: bk-${BUILDKITE_BUILD_ID}"
+fi
+
+if command -v buildkite-agent >/dev/null 2>&1; then
+  annotate_body="$(cat <<EOF
+**On-demand LLM eval**
+
+- Suite: \`${EVAL_SUITE_ID}\`
+- Model: \`${EVAL_MODEL_GROUPS}\`
+- [Evals UI (golden cluster)](${GOLDEN_CLUSTER_EVALS_URL})
+$(
+  if [[ -n "${BUILDKITE_BUILD_ID:-}" ]]; then
+    echo "- Run id prefix: \`bk-${BUILDKITE_BUILD_ID}\`"
+  fi
+)
+EOF
+)"
+  buildkite-agent annotate "$annotate_body" --style info --context kbn-evals-on-demand || true
+fi

--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -122,6 +122,7 @@ node scripts/evals start --suite agent-builder
 `evals init` walks you through EIS (Cloud Connected Mode) connector discovery or validates existing connectors in `kibana.dev.yml`. It outputs an `export KIBANA_TESTING_AI_CONNECTORS="..."` command to paste into your shell.
 
 `evals start` orchestrates the full stack in one terminal:
+
 1. Starts the EDOT collector (Docker) for trace capture -- exports traces to the configured tracing Elasticsearch cluster (via `TRACING_ES_URL`)
 2. Starts Scout (ES + Kibana with `evals_tracing` config)
 3. Enables EIS CCM on the Scout ES cluster (if using EIS connectors)
@@ -161,6 +162,7 @@ node scripts/evals start --suite attack-discovery --export-profile local
 ```
 
 Notes:
+
 - `--datasets-profile <name>` loads `EVALUATIONS_KBN_URL` / `EVALUATIONS_KBN_API_KEY` from `config.<name>.json`
 - `--export-profile <name>` loads `EVALUATIONS_ES_URL`, `TRACING_ES_URL`, and `TRACING_EXPORTERS` from `config.<name>.json`
 
@@ -210,6 +212,48 @@ The CLI uses suite metadata from:
 .buildkite/pipelines/evals/evals.suites.json
 ```
 
+### On-demand evals (Buildkite)
+
+Run a single suite and model on any branch without opening a PR or waiting for the full Kibana PR pipeline:
+
+1. Open [kibana-evals-on-demand](https://buildkite.com/elastic/kibana-evals-on-demand) on Buildkite
+2. Click **New build** and select the branch (or commit) to evaluate
+3. Add **environment variables** for the build (see table below). Generate them with the resolver CLI or set them manually.
+
+Pipeline registration: [`.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml`](../../../../../.buildkite/pipeline-resource-definitions/evals/kibana-evals-on-demand.yml).
+
+| Variable                  | Required | Description                                                                                    |
+| ------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `EVAL_SUITE_ID`           | yes      | Suite id from `evals.suites.json` (same as `evals:<id>` PR labels without the prefix)          |
+| `EVAL_MODEL_GROUPS`       | yes      | Model group (same as `models:<group>` PR labels without the prefix), e.g. `eis/openai-gpt-5.4` |
+| `EVALUATION_CONNECTOR_ID` | no       | LLM-as-judge connector override (same as `models:judge:<value>` without the prefix)            |
+| `EVAL_SERVER_CONFIG_SET`  | no       | Set automatically by the resolver when the suite defines one in `evals.suites.json`            |
+
+The pipeline step sets `FTR_EIS_CCM=1` and `EVAL_FANOUT=1`. For EIS models, also set `EVAL_INCLUDE_EIS_MODELS=1` (included when using the resolver).
+
+**Generate environment variables locally:**
+
+```bash
+node x-pack/platform/packages/shared/kbn-evals/scripts/ci/resolve_on_demand_eval_env.js \
+  --suite agent-builder \
+  --model eis/openai-gpt-5.4 \
+  --format env
+```
+
+Optional judge:
+
+```bash
+node x-pack/platform/packages/shared/kbn-evals/scripts/ci/resolve_on_demand_eval_env.js \
+  --suite agent-builder \
+  --model eis/openai-gpt-5.4 \
+  --judge eis/anthropic-claude-4.6-sonnet \
+  --format env
+```
+
+Copy the output into the **Environment variables** field when starting a New build.
+
+**Results:** Scores and traces are exported to the [golden cluster evals UI](https://kbn-evals-serverless-ed035a.kb.us-central1.gcp.elastic.cloud/app/evals). Filter by git branch on the runs list, or by run id prefix `bk-<buildkite_build_id>` (see the Buildkite build annotation after the validate step).
+
 ### CI labels
 
 Eval suites can be triggered in PR CI by adding GitHub labels:
@@ -240,6 +284,7 @@ The `models:*` and `models:judge:*` labels are automatically synced from LiteLLM
 - **On demand**: Add the `ci:sync-model-labels` label to any PR to trigger label sync in PR CI.
 
 The sync step:
+
 1. Discovers available models from both **LiteLLM** (`GET /v1/models`) and **EIS** (via `discover_eis_models.js`)
 2. Creates/updates labels for all discovered models
 3. Marks stale labels as deprecated (renamed from `models:*` to `deprecated:models:*`)
@@ -384,7 +429,7 @@ node scripts/evals dataplex sync --dry-run
 node scripts/evals dataplex sync --print-commands
 ```
 
-Note: The **Dataplex "Aspect types"** console page lists *schemas*. Snapshot datasets themselves show up under Dataplex **Entries**.
+Note: The **Dataplex "Aspect types"** console page lists _schemas_. Snapshot datasets themselves show up under Dataplex **Entries**.
 
 <details>
 <summary>Manual flow (if you prefer full control)</summary>
@@ -667,11 +712,11 @@ This creates a dedicated `evaluationsEsClient` that connects to your evaluations
 
 Use these settings when traces, evaluation results, or managed datasets live outside the default Scout Kibana/Elasticsearch pair.
 
-| Variable | CLI flag | Purpose |
-| --- | --- | --- |
-| `TRACING_ES_URL` | `--trace-es-url` | Sends trace-based evaluator queries to a separate monitoring Elasticsearch cluster. |
-| `EVALUATIONS_ES_URL` | `--evaluations-es-url` | Exports evaluation scores to a separate Elasticsearch cluster. |
-| `EVALUATIONS_KBN_URL` | `--evaluations-kbn-url` | Routes dataset upsert and dataset lookup operations to a separate Kibana instance. |
+| Variable                  | CLI flag                    | Purpose                                                                                |
+| ------------------------- | --------------------------- | -------------------------------------------------------------------------------------- |
+| `TRACING_ES_URL`          | `--trace-es-url`            | Sends trace-based evaluator queries to a separate monitoring Elasticsearch cluster.    |
+| `EVALUATIONS_ES_URL`      | `--evaluations-es-url`      | Exports evaluation scores to a separate Elasticsearch cluster.                         |
+| `EVALUATIONS_KBN_URL`     | `--evaluations-kbn-url`     | Routes dataset upsert and dataset lookup operations to a separate Kibana instance.     |
 | `EVALUATIONS_KBN_API_KEY` | `--evaluations-kbn-api-key` | Optional API key used for dataset Kibana operations when `EVALUATIONS_KBN_URL` is set. |
 
 #### Using a Separate Kibana for Dataset Operations
@@ -765,12 +810,12 @@ This grants:
 
 Copy the returned `encoded` value and use it for all four secret fields in your vault config:
 
-| Config field | Env variable | Value |
-| --- | --- | --- |
-| `evaluationsEs.apiKey` | `EVALUATIONS_ES_API_KEY` | `<encoded>` |
-| `tracingEs.apiKey` | `TRACING_ES_API_KEY` | `<encoded>` |
-| `evaluationsKbn.apiKey` | `EVALUATIONS_KBN_API_KEY` | `<encoded>` |
-| `tracingExporters[0].http.headers.Authorization` | via `TRACING_EXPORTERS` | `ApiKey <encoded>` |
+| Config field                                     | Env variable              | Value              |
+| ------------------------------------------------ | ------------------------- | ------------------ |
+| `evaluationsEs.apiKey`                           | `EVALUATIONS_ES_API_KEY`  | `<encoded>`        |
+| `tracingEs.apiKey`                               | `TRACING_ES_API_KEY`      | `<encoded>`        |
+| `evaluationsKbn.apiKey`                          | `EVALUATIONS_KBN_API_KEY` | `<encoded>`        |
+| `tracingExporters[0].http.headers.Authorization` | via `TRACING_EXPORTERS`   | `ApiKey <encoded>` |
 
 ### Exporting to a separate Elasticsearch cluster
 

--- a/x-pack/platform/packages/shared/kbn-evals/scripts/ci/get_suite_info.js
+++ b/x-pack/platform/packages/shared/kbn-evals/scripts/ci/get_suite_info.js
@@ -31,5 +31,6 @@ process.stdout.write(
     id: suite.id,
     name: suite.name,
     slackChannel: suite.slackChannel,
+    serverConfigSet: suite.serverConfigSet,
   })
 );

--- a/x-pack/platform/packages/shared/kbn-evals/scripts/ci/resolve_on_demand_eval_env.js
+++ b/x-pack/platform/packages/shared/kbn-evals/scripts/ci/resolve_on_demand_eval_env.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const { readFileSync } = require('fs');
+const { fromRoot } = require('@kbn/repo-info');
+
+const SUITES_PATH = fromRoot('.buildkite/pipelines/evals/evals.suites.json');
+
+function normalizeBuildkiteKey(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Mirrors normalizeEvaluationConnectorId in eval_pipeline.ts.
+ */
+function normalizeEvaluationConnectorId(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (trimmed.startsWith('eis/')) {
+    return `eis-${normalizeBuildkiteKey(trimmed.slice('eis/'.length))}`;
+  }
+
+  if (trimmed.includes('/')) {
+    return `litellm-${normalizeBuildkiteKey(trimmed)}`;
+  }
+
+  return trimmed;
+}
+
+function parseArgs(argv) {
+  const args = { suite: '', model: '', judge: '', format: 'json' };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--suite' && argv[i + 1]) {
+      args.suite = argv[++i].trim();
+    } else if (arg === '--model' && argv[i + 1]) {
+      args.model = argv[++i].trim();
+    } else if (arg === '--judge' && argv[i + 1]) {
+      args.judge = argv[++i].trim();
+    } else if (arg === '--format' && argv[i + 1]) {
+      args.format = argv[++i].trim();
+    } else if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function loadSuites() {
+  const raw = readFileSync(SUITES_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed?.suites) ? parsed.suites : [];
+}
+
+function resolveOnDemandEvalEnv({ suiteId, model, judge }) {
+  if (!suiteId) {
+    throw new Error('Suite id is required (--suite)');
+  }
+  if (!model) {
+    throw new Error('Model is required (--model)');
+  }
+
+  const suites = loadSuites();
+  const suite = suites.find((s) => s?.id === suiteId);
+  if (!suite) {
+    const known = suites
+      .map((s) => s.id)
+      .filter(Boolean)
+      .sort()
+      .join(', ');
+    throw new Error(`Unknown eval suite "${suiteId}". Known suites: ${known || '(none)'}`);
+  }
+
+  const env = {
+    EVAL_SUITE_ID: suiteId,
+    EVAL_MODEL_GROUPS: model,
+    FTR_EIS_CCM: '1',
+    EVAL_FANOUT: '1',
+  };
+
+  if (model.startsWith('eis/')) {
+    env.EVAL_INCLUDE_EIS_MODELS = '1';
+  }
+
+  if (suite.serverConfigSet) {
+    env.EVAL_SERVER_CONFIG_SET = suite.serverConfigSet;
+  }
+
+  const evaluationConnectorId = judge ? normalizeEvaluationConnectorId(judge) : undefined;
+  if (evaluationConnectorId) {
+    env.EVALUATION_CONNECTOR_ID = evaluationConnectorId;
+    if (judge.startsWith('eis/') || evaluationConnectorId.startsWith('eis-')) {
+      env.EVAL_INCLUDE_EIS_MODELS = '1';
+    }
+  }
+
+  return env;
+}
+
+function printUsage() {
+  console.error(`Usage:
+  node resolve_on_demand_eval_env.js --suite <id> --model <model-group> [--judge <connector-or-model>]
+    [--format json|env]
+
+Examples:
+  --suite agent-builder --model eis/openai-gpt-5.4
+  --suite agent-builder --model llm-gateway/gpt-5.1 --judge eis/anthropic-claude-4.6-sonnet
+`);
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  let env;
+  try {
+    env = resolveOnDemandEvalEnv({
+      suiteId: args.suite,
+      model: args.model,
+      judge: args.judge,
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  if (args.format === 'env') {
+    for (const [key, value] of Object.entries(env)) {
+      process.stdout.write(`${key}=${value}\n`);
+    }
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(env)}\n`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  normalizeBuildkiteKey,
+  normalizeEvaluationConnectorId,
+  resolveOnDemandEvalEnv,
+};


### PR DESCRIPTION
## Summary

On-demand evals (Buildkite)

Run a single suite and model on any branch without opening a PR or waiting for the full Kibana PR pipeline


