### PR TITLE
[scripts/check] exclude integration tests from fast path

### DIFF
--- a/src/dev/run_check.test.ts
+++ b/src/dev/run_check.test.ts
@@ -277,9 +277,7 @@ describe('run_check', () => {
       if (p === '/repo/src/core/server/integration_tests/user_storage/jest.integration.config.js') {
         return true;
       }
-      return (
-        p === '/repo/packages/foo/jest.config.js' || p === '/repo/packages/bar/jest.config.js'
-      );
+      return p === '/repo/packages/foo/jest.config.js' || p === '/repo/packages/bar/jest.config.js';
     });
 
     await handler(createArgs());

--- a/src/dev/run_check.test.ts
+++ b/src/dev/run_check.test.ts
@@ -263,6 +263,33 @@ describe('run_check', () => {
     expect(output).toContain('lint  ✓ 10 files (fixed 2 files)');
   });
 
+  it('skips fast path when changed test files are integration tests', async () => {
+    mockResolveValidationBaseContext.mockResolvedValue({
+      ...baseContext,
+      runContext: {
+        ...baseContext.runContext,
+        changedFiles: ['src/core/server/integration_tests/user_storage/remove.test.ts'],
+      },
+    });
+
+    mockExistsSync.mockImplementation((p: string) => {
+      // Simulate a jest.integration.config.js in the test file's directory
+      if (p === '/repo/src/core/server/integration_tests/user_storage/jest.integration.config.js') {
+        return true;
+      }
+      return (
+        p === '/repo/packages/foo/jest.config.js' || p === '/repo/packages/bar/jest.config.js'
+      );
+    });
+
+    await handler(createArgs());
+
+    // Fast path (execa) must not have been called
+    expect(mockExeca).not.toHaveBeenCalled();
+    // Should fall through to the Moon path instead
+    expect(mockRunJestViaMoon).toHaveBeenCalled();
+  });
+
   it('uses test-only fast path when all changed files are test files', async () => {
     mockResolveValidationBaseContext.mockResolvedValue({
       ...baseContext,

--- a/src/dev/run_check.ts
+++ b/src/dev/run_check.ts
@@ -138,6 +138,18 @@ const TEST_FILE_RE = /\.(?:test|spec)\.(js|mjs|ts|tsx)$/;
 
 const isTestFile = (filePath: string) => TEST_FILE_RE.test(filePath);
 
+const isIntegrationTestFile = (filePath: string): boolean => {
+  let dir = Path.dirname(Path.resolve(REPO_ROOT, filePath));
+  while (true) {
+    if (existsSync(Path.join(dir, 'jest.integration.config.js'))) {
+      return true;
+    }
+    if (dir === REPO_ROOT || dir === Path.dirname(dir)) break;
+    dir = Path.dirname(dir);
+  }
+  return false;
+};
+
 const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
 
 const runJestTestsDirectly = async (
@@ -273,6 +285,7 @@ run(
         jestProgress.writeResult(line('jest', '—', 'no changed files', jestProgress.elapsed()));
       } else if (
         changedFiles.every(isTestFile) &&
+        !changedFiles.some(isIntegrationTestFile) &&
         (() => {
           // Fast path only safe when all test files share a single jest config.
           const configs = new Set(changedFiles.map(findJestConfig).filter(Boolean));


### PR DESCRIPTION
`run_check.ts` has a fast path that runs `scripts/jest` directly when all changed files are test files sharing one jest config. `findJestConfig` only searches for unit test config names (`jest.config.js`, etc.) and ignore `jest.integration.config.js`. So for a changed integration test file like `src/core/server/integration_tests/user_storage/remove.test.ts`, it walks up past the integration config and finds `src/core/server/jest.config.js`, triggering the fast path with `scripts/jest` (the unit test runner), which is wrong.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->