### PR TITLE
[Discover][ES|QL] Removes the automatic run of the 'Analyze my data' prompt

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/discover_agent_builder_config.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/discover_agent_builder_config.test.ts
@@ -14,7 +14,6 @@ import {
   toDiscoverQuery,
   buildScreenContext,
   buildEsqlResultsAttachment,
-  shouldPrefillEsqlPrompt,
 } from './discover_agent_builder_config';
 
 interface EsqlResultsData {
@@ -85,36 +84,6 @@ describe('buildScreenContext', () => {
         }),
       })
     );
-  });
-});
-
-describe('shouldPrefillEsqlPrompt', () => {
-  it('returns false when not in ES|QL mode', () => {
-    expect(shouldPrefillEsqlPrompt(false, null, false)).toBe(false);
-    expect(shouldPrefillEsqlPrompt(false, { id: undefined }, false)).toBe(false);
-    expect(shouldPrefillEsqlPrompt(false, { id: 'abc' }, false)).toBe(false);
-  });
-
-  it('returns false when already prefilled', () => {
-    expect(shouldPrefillEsqlPrompt(true, null, true)).toBe(false);
-    expect(shouldPrefillEsqlPrompt(true, { id: undefined }, true)).toBe(false);
-  });
-
-  it('returns false when activeConversation is undefined (pre-first-emission gap)', () => {
-    // Don't prefill before we know whether the sidebar is already open with an existing conversation.
-    expect(shouldPrefillEsqlPrompt(true, undefined, false)).toBe(false);
-  });
-
-  it('returns true when in ES|QL mode and sidebar is closed', () => {
-    expect(shouldPrefillEsqlPrompt(true, null, false)).toBe(true);
-  });
-
-  it('returns true when sidebar is open without a conversation id', () => {
-    expect(shouldPrefillEsqlPrompt(true, { id: undefined }, false)).toBe(true);
-  });
-
-  it('returns false once the conversation has an id', () => {
-    expect(shouldPrefillEsqlPrompt(true, { id: 'abc' }, false)).toBe(false);
   });
 });
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/discover_agent_builder_config.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/discover_agent_builder_config.tsx
@@ -7,11 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { z } from '@kbn/zod/v4';
 import { i18n } from '@kbn/i18n';
 import { isOfAggregateQueryType, type AggregateQuery, type Query } from '@kbn/es-query';
-import type { ActiveConversation } from '@kbn/agent-builder-browser';
 import type { BrowserApiToolDefinition } from '@kbn/agent-builder-browser/tools/browser_api_tool';
 import { AttachmentType, type AttachmentInput } from '@kbn/agent-builder-common/attachments';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
@@ -32,10 +31,6 @@ const SESSION_TAG = 'discover';
 const MAX_SAMPLE_ROWS = 10;
 const MAX_COLUMNS = 100;
 const MAX_VALUE_LENGTH = 100;
-
-const ESQL_INITIAL_MESSAGE = i18n.translate('discover.agentBuilder.esqlInitialMessage', {
-  defaultMessage: 'Analyze my data',
-});
 
 const updateQuerySchema = z.object({
   query: z.string().min(1).describe('The query string to apply to the current Discover tab.'),
@@ -98,21 +93,6 @@ export const buildScreenContext = (
     },
   },
 });
-
-export const shouldPrefillEsqlPrompt = (
-  isEsqlMode: boolean,
-  activeConversation: ActiveConversation | null | undefined,
-  hasPrefilled: boolean
-): boolean => {
-  if (!isEsqlMode || hasPrefilled) return false;
-  // Pre-first-emission: don't prefill — the sidebar might already be open with an
-  // existing conversation we shouldn't disrupt.
-  if (activeConversation === undefined) return false;
-  // Keep the prefill in config while sidebar is closed (null) or open without a
-  // conversation id yet. Dropping it during that window would wipe `initialMessage`
-  // before `use_initial_message` auto-sends.
-  return !activeConversation?.id;
-};
 
 export const buildEsqlResultsAttachment = (
   esqlQuery: string,
@@ -193,21 +173,6 @@ export const DiscoverAgentBuilderConfig = () => {
   const queryRef = useRef(query);
   queryRef.current = query;
 
-  // Tracks the agent-builder sidebar state. `undefined` means we haven't received
-  // the BehaviorSubject's first emission yet — we must not prefill because
-  // we don't know whether the sidebar is already open.
-  const [activeConversation, setActiveConversation] = useState<
-    ActiveConversation | null | undefined
-  >(undefined);
-
-  const hasPrefilledEsqlPromptRef = useRef(false);
-
-  useEffect(() => {
-    if (!agentBuilder) return;
-    const sub = agentBuilder.events.ui.activeConversation$.subscribe(setActiveConversation);
-    return () => sub.unsubscribe();
-  }, [agentBuilder]);
-
   const runQueryTool: BrowserApiToolDefinition<z.infer<typeof updateQuerySchema>> = useMemo(
     () => ({
       id: 'discover_run_query',
@@ -226,12 +191,6 @@ export const DiscoverAgentBuilderConfig = () => {
   const browserApiTools = useMemo(
     () => (isEsqlMode ? [runQueryTool] : []),
     [isEsqlMode, runQueryTool]
-  );
-
-  const prefillEsqlPrompt = shouldPrefillEsqlPrompt(
-    isEsqlMode,
-    activeConversation,
-    hasPrefilledEsqlPromptRef.current
   );
 
   useEffect(() => {
@@ -268,13 +227,6 @@ export const DiscoverAgentBuilderConfig = () => {
       sessionTag: SESSION_TAG,
       attachments,
       browserApiTools,
-      ...(prefillEsqlPrompt
-        ? {
-            newConversation: true,
-            initialMessage: ESQL_INITIAL_MESSAGE,
-            autoSendInitialMessage: true,
-          }
-        : {}),
     });
 
     return () => {
@@ -291,17 +243,9 @@ export const DiscoverAgentBuilderConfig = () => {
     hasEsqlResults,
     isEsqlMode,
     query,
-    prefillEsqlPrompt,
     timeRange,
     totalHits,
   ]);
-
-  // Mark the prompt as prefilled once a real conversation id exists.
-  useEffect(() => {
-    if (isEsqlMode && activeConversation?.id) {
-      hasPrefilledEsqlPromptRef.current = true;
-    }
-  }, [isEsqlMode, activeConversation]);
 
   return null;
 };


### PR DESCRIPTION
## Summary

This idea https://github.com/elastic/kibana/pull/268615 is cool but it can be annoying for someone who knows exactly what they want (i.e. create an ES|QL query). We decided to revert the automatic way of rendering the prompt. Graham and I want to make more discoverable but this is not possible yet through the agent builder. But we will follow up!
