### PR TITLE
[9.4] [Security Solution][Detection Engine] enforce enableESQL setting in AI rule creation flow (#267247)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.ts
@@ -9,6 +9,7 @@ import type { AttachmentServiceStartContract } from '@kbn/agent-builder-browser'
 import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { ISessionService } from '@kbn/data-plugin/public';
 import { SecurityAgentBuilderAttachments } from '../../../common/constants';
 import type { ExperimentalFeatures } from '../../../common/experimental_features';
@@ -126,16 +127,18 @@ export const registerRuleAttachment = ({
   attachments,
   application,
   aiRuleCreation,
+  uiSettings,
 }: {
   attachments: AttachmentServiceStartContract;
   application: ApplicationStart;
   aiRuleCreation: AiRuleCreationService;
+  uiSettings: IUiSettingsClient;
 }): void => {
   void import(
     /* webpackChunkName: "security_rule_attachment" */
     './rule_attachment'
   ).then(({ registerRuleAttachment: register }) => {
-    register({ attachments, application, aiRuleCreation });
+    register({ attachments, application, aiRuleCreation, uiSettings });
   });
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule_attachment.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule_attachment.test.ts
@@ -6,8 +6,10 @@
  */
 
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { AttachmentServiceStartContract } from '@kbn/agent-builder-browser/attachments';
 import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { RULES_FEATURE_LATEST } from '@kbn/security-solution-features/constants';
 import { AiRuleCreationService } from '../../detection_engine/common/ai_rule_creation_store';
 import {
@@ -23,6 +25,14 @@ const validRule = {
   description: 'A test rule',
   severity: 'high',
   risk_score: 73,
+};
+
+const validEsqlRule = {
+  name: 'ES|QL Test Rule',
+  type: 'esql',
+  description: 'An ES|QL test rule',
+  severity: 'medium',
+  risk_score: 50,
 };
 
 const makeAttachment = (ruleJson: string, label?: string) => ({
@@ -42,6 +52,14 @@ const makeApplication = (canEdit: boolean) =>
     },
     navigateToApp: jest.fn(),
   } as unknown as ApplicationStart);
+
+const makeUiSettings = (esqlEnabled = true) =>
+  ({
+    get: jest.fn((key: string) => {
+      if (key === ENABLE_ESQL) return esqlEnabled;
+      return undefined;
+    }),
+  } as unknown as IUiSettingsClient);
 
 const makeActionButtonsParams = (ruleJson: string) => ({
   attachment: makeAttachment(ruleJson),
@@ -95,6 +113,7 @@ describe('createRuleAttachmentDefinition', () => {
         attachments: mockAttachments,
         application,
         aiRuleCreation,
+        uiSettings: makeUiSettings(),
       });
 
       expect(mockAddAttachmentType).toHaveBeenCalledTimes(1);
@@ -110,6 +129,7 @@ describe('createRuleAttachmentDefinition', () => {
         attachments: mockAttachments,
         application,
         aiRuleCreation,
+        uiSettings: makeUiSettings(),
       });
 
       const ruleCall = mockAddAttachmentType.mock.calls.find(
@@ -128,6 +148,7 @@ describe('createRuleAttachmentDefinition', () => {
         attachments: mockAttachments,
         application,
         aiRuleCreation,
+        uiSettings: makeUiSettings(),
       });
 
       const ruleCall = mockAddAttachmentType.mock.calls.find(
@@ -147,14 +168,22 @@ describe('createRuleAttachmentDefinition', () => {
   describe('getActionButtons', () => {
     it('returns empty array when attachment data is not parseable JSON', () => {
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const buttons = definition.getActionButtons!(makeActionButtonsParams('not-json') as never);
       expect(buttons).toEqual([]);
     });
 
     it('returns empty array when parsed rule has no name', () => {
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const buttons = definition.getActionButtons!(
         makeActionButtonsParams(JSON.stringify({ type: 'query' })) as never
       );
@@ -163,17 +192,64 @@ describe('createRuleAttachmentDefinition', () => {
 
     it('returns empty array when user lacks edit capabilities', () => {
       const application = makeApplication(false);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const buttons = definition.getActionButtons!(
         makeActionButtonsParams(JSON.stringify(validRule)) as never
       );
       expect(buttons).toEqual([]);
     });
 
+    it('returns empty array for esql rule when enableESQL setting is disabled', () => {
+      const application = makeApplication(true);
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(false),
+      });
+      const buttons = definition.getActionButtons!(
+        makeActionButtonsParams(JSON.stringify(validEsqlRule)) as never
+      );
+      expect(buttons).toEqual([]);
+    });
+
+    it('returns buttons for esql rule when enableESQL setting is enabled', () => {
+      const application = makeApplication(true);
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(true),
+      });
+      const buttons = definition.getActionButtons!(
+        makeActionButtonsParams(JSON.stringify(validEsqlRule)) as never
+      );
+      expect(buttons).toHaveLength(1);
+    });
+
+    it('returns buttons for non-esql rule even when enableESQL setting is disabled', () => {
+      const application = makeApplication(true);
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(false),
+      });
+      const buttons = definition.getActionButtons!(
+        makeActionButtonsParams(JSON.stringify(validRule)) as never
+      );
+      expect(buttons).toHaveLength(1);
+    });
+
     it('returns "Apply to creation" button when not on a rule form page', () => {
       (window as { location: unknown }).location = { pathname: '/app/security/overview' };
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const buttons = definition.getActionButtons!(
         makeActionButtonsParams(JSON.stringify(validRule)) as never
       );
@@ -187,7 +263,11 @@ describe('createRuleAttachmentDefinition', () => {
         pathname: '/app/security/rules/create',
       };
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const buttons = definition.getActionButtons!(
         makeActionButtonsParams(JSON.stringify(validRule)) as never
       );
@@ -200,7 +280,11 @@ describe('createRuleAttachmentDefinition', () => {
         pathname: '/app/security/rules/abc123/edit',
       };
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const buttons = definition.getActionButtons!(
         makeActionButtonsParams(JSON.stringify(validRule)) as never
       );
@@ -210,7 +294,11 @@ describe('createRuleAttachmentDefinition', () => {
 
     it('handler calls setAiCreatedRule with the parsed rule', () => {
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const buttons = definition.getActionButtons!(
         makeActionButtonsParams(JSON.stringify(validRule)) as never
       );
@@ -223,7 +311,11 @@ describe('createRuleAttachmentDefinition', () => {
     it('handler navigates to rule creation when not on a rule form page', () => {
       (window as { location: unknown }).location = { pathname: '/app/security/overview' };
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const params = makeActionButtonsParams(JSON.stringify(validRule));
       const buttons = definition.getActionButtons!(params as never);
 
@@ -237,7 +329,11 @@ describe('createRuleAttachmentDefinition', () => {
     it('handler opens sidebar conversation when navigating to rule creation', () => {
       (window as { location: unknown }).location = { pathname: '/app/security/overview' };
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const params = makeActionButtonsParams(JSON.stringify(validRule));
       const buttons = definition.getActionButtons!(params as never);
 
@@ -251,7 +347,11 @@ describe('createRuleAttachmentDefinition', () => {
         pathname: '/app/security/rules/create',
       };
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const params = makeActionButtonsParams(JSON.stringify(validRule));
       const buttons = definition.getActionButtons!(params as never);
 
@@ -265,7 +365,11 @@ describe('createRuleAttachmentDefinition', () => {
         pathname: '/app/security/rules/create',
       };
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const params = makeActionButtonsParams(JSON.stringify(validRule));
       const buttons = definition.getActionButtons!(params as never);
 
@@ -278,7 +382,11 @@ describe('createRuleAttachmentDefinition', () => {
   describe('getLabel', () => {
     it('returns attachmentLabel when provided', () => {
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const label = definition.getLabel(
         makeAttachment(JSON.stringify(validRule), 'My Rule') as never
       );
@@ -287,14 +395,22 @@ describe('createRuleAttachmentDefinition', () => {
 
     it('falls back to parsed rule name when no attachmentLabel', () => {
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const label = definition.getLabel(makeAttachment(JSON.stringify(validRule)) as never);
       expect(label).toBe('Test Rule');
     });
 
     it('returns default label when rule is not parseable', () => {
       const application = makeApplication(true);
-      const definition = createRuleAttachmentDefinition({ application, aiRuleCreation });
+      const definition = createRuleAttachmentDefinition({
+        application,
+        aiRuleCreation,
+        uiSettings: makeUiSettings(),
+      });
       const label = definition.getLabel(makeAttachment('invalid') as never);
       expect(label).toBe('Security Rule');
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule_attachment.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/rule_attachment.tsx
@@ -25,6 +25,8 @@ import type {
 import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { RULES_UI_EDIT_PRIVILEGE } from '@kbn/security-solution-features/constants';
 import { toSimpleRuleSchedule } from '../../../common/api/detection_engine/model/rule_schema/to_simple_rule_schedule';
 import type { RuleResponse } from '../../../common/api/detection_engine/model/rule_schema';
@@ -269,23 +271,27 @@ export const registerRuleAttachment = ({
   attachments,
   application,
   aiRuleCreation,
+  uiSettings,
 }: {
   attachments: AttachmentServiceStartContract;
   application: ApplicationStart;
   aiRuleCreation: AiRuleCreationService;
+  uiSettings: IUiSettingsClient;
 }): void => {
   attachments.addAttachmentType(
     SecurityAgentBuilderAttachments.rule,
-    createRuleAttachmentDefinition({ application, aiRuleCreation })
+    createRuleAttachmentDefinition({ application, aiRuleCreation, uiSettings })
   );
 };
 
 export const createRuleAttachmentDefinition = ({
   application,
   aiRuleCreation,
+  uiSettings,
 }: {
   application: ApplicationStart;
   aiRuleCreation: AiRuleCreationService;
+  uiSettings: IUiSettingsClient;
 }): AttachmentUIDefinition<RuleAttachment> => ({
   getLabel: (attachment) =>
     getRuleName(attachment) ??
@@ -298,6 +304,10 @@ export const createRuleAttachmentDefinition = ({
     const rule = parseRuleFromAttachment(attachment);
     const canEditRules = hasCapabilities(application.capabilities, RULES_UI_EDIT_PRIVILEGE);
     if (!rule || !canEditRules) {
+      return [];
+    }
+
+    if (rule.type === 'esql' && !uiSettings.get(ENABLE_ESQL)) {
       return [];
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../../rule_gaps/context/gap_auto_fill_scheduler_context';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useAgentBuilderAvailability } from '../../../../agent_builder/hooks/use_agent_builder_availability';
+import { useEsqlAvailability } from '../../../../common/hooks/esql/use_esql_availability';
 import { CpsMlRuleCallout } from '../../components/cps_ml_rule_callout/callout';
 
 const RulesPageContent = () => {
@@ -72,7 +73,9 @@ const RulesPageContent = () => {
 
   const aiRuleCreationEnabled = useIsExperimentalFeatureEnabled('aiRuleCreationEnabled');
   const { isAgentBuilderEnabled } = useAgentBuilderAvailability();
-  const isAiRuleCreationAvailable = aiRuleCreationEnabled && isAgentBuilderEnabled;
+  const { isEsqlRuleTypeEnabled } = useEsqlAvailability();
+  const isAiRuleCreationAvailable =
+    aiRuleCreationEnabled && isAgentBuilderEnabled && isEsqlRuleTypeEnabled;
   const deprecatedRulesCallout = useDeprecatedRulesTableCallout();
 
   if (

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -303,6 +303,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         attachments: plugins.agentBuilder.attachments,
         application: core.application,
         aiRuleCreation: this.services.aiRuleCreation,
+        uiSettings: core.uiSettings,
       });
       registerEntityAnalyticsDashboardAttachment({
         attachments: plugins.agentBuilder.attachments,

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/create_detection_rule_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/create_detection_rule_tool.test.ts
@@ -16,6 +16,7 @@ import {
   createToolTestMocks,
   setupMockCoreStartServices,
 } from '../__mocks__/test_helpers';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import {
   createDetectionRuleTool,
   SECURITY_CREATE_DETECTION_RULE_TOOL_ID,
@@ -57,9 +58,18 @@ describe('createDetectionRuleTool', () => {
     mockExperimentalFeatures
   ) as BuiltinToolDefinition<z.ZodObject<{ user_query: z.ZodString }>>;
 
+  let mockCoreStart: ReturnType<typeof setupMockCoreStartServices>;
+  let mockUiSettingsClient: ReturnType<
+    ReturnType<typeof setupMockCoreStartServices>['uiSettings']['asScopedToClient']
+  >;
+
   beforeEach(() => {
     jest.clearAllMocks();
-    setupMockCoreStartServices(mockCore, mockEsClient);
+    mockCoreStart = setupMockCoreStartServices(mockCore, mockEsClient);
+    mockUiSettingsClient = mockCoreStart.uiSettings.asScopedToClient(
+      mockCoreStart.savedObjects.getScopedClient(mockRequest)
+    );
+    jest.mocked(mockUiSettingsClient.get).mockResolvedValue(true);
     mockGetAgentBuilderResourceAvailability.mockResolvedValue({
       status: 'available',
     });
@@ -122,11 +132,37 @@ describe('createDetectionRuleTool', () => {
       });
     });
 
-    it('returns available status when experimental feature is enabled', async () => {
+    it('returns unavailable when space availability check fails', async () => {
       mockGetAgentBuilderResourceAvailability.mockResolvedValue({
-        status: 'available',
+        status: 'unavailable',
+        reason: 'Space is not available',
       });
 
+      const availability = await tool.availability?.handler(
+        createToolAvailabilityContext(mockRequest, 'default')
+      );
+
+      expect(availability).toEqual({
+        status: 'unavailable',
+        reason: 'Space is not available',
+      });
+    });
+
+    it('returns unavailable when ES|QL is disabled', async () => {
+      jest.mocked(mockUiSettingsClient.get).mockResolvedValue(false);
+
+      const availability = await tool.availability?.handler(
+        createToolAvailabilityContext(mockRequest, 'default')
+      );
+
+      expect(availability).toEqual({
+        status: 'unavailable',
+        reason: 'ES|QL is disabled in this space via the enableESQL advanced setting.',
+      });
+      expect(mockUiSettingsClient.get).toHaveBeenCalledWith(ENABLE_ESQL);
+    });
+
+    it('returns available when all checks pass', async () => {
       const availability = await tool.availability?.handler(
         createToolAvailabilityContext(mockRequest, 'default')
       );

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/create_detection_rule_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/create_detection_rule_tool.ts
@@ -10,6 +10,7 @@ import { ToolType } from '@kbn/agent-builder-common';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import type { BuiltinToolDefinition, StaticToolRegistration } from '@kbn/agent-builder-server';
 import type { CoreSetup, Logger } from '@kbn/core/server';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import type {
   SecuritySolutionPluginStart,
   SecuritySolutionPluginStartDependencies,
@@ -57,11 +58,29 @@ The tool stores the result as an attachment (creating new or updating existing).
           };
         }
 
-        return getAgentBuilderResourceAvailability({
+        const spaceAvailability = await getAgentBuilderResourceAvailability({
           core,
           request,
           logger,
         });
+
+        if (spaceAvailability.status === 'unavailable') {
+          return spaceAvailability;
+        }
+
+        const [coreStart] = await core.getStartServices();
+        const savedObjectsClient = coreStart.savedObjects.getScopedClient(request);
+        const uiSettingsClient = coreStart.uiSettings.asScopedToClient(savedObjectsClient);
+        const isEsqlEnabled = await uiSettingsClient.get<boolean>(ENABLE_ESQL);
+
+        if (!isEsqlEnabled) {
+          return {
+            status: 'unavailable',
+            reason: 'ES|QL is disabled in this space via the enableESQL advanced setting.',
+          };
+        }
+
+        return { status: 'available' };
       },
     },
     handler: async (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution][Detection Engine] enforce enableESQL setting in AI rule creation flow (#267247)](https://github.com/elastic/kibana/pull/267247)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Vitalii Dmyterko","email":"92328789+vitaliidm@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-18T10:37:31Z","message":"[Security Solution][Detection Engine] enforce enableESQL setting in AI rule creation flow (#267247)\n\n## Summary\n\nWhen the `enableESQL` advanced setting is disabled in a space, the AI\nrule creation flow should be blocked since the detection-rule-edit skill\nonly supports ES|QL rules. Currently the setting is only checked in the\nmanual rule type selector, but the AI path bypasses it entirely.\n\nThis PR enforces the setting at three layers:\n\n- **Client – context menu**: Adds `isEsqlRuleTypeEnabled` to the\n`isAiRuleCreationAvailable` check in the rules management page. When\nES|QL is disabled, the page falls back to the plain \"Create new rule\"\nbutton (no AI dropdown menu).\n- **Server – tool availability**: Adds an `enableESQL` uiSettings check\nto the `create_detection_rule` tool availability handler. When the\nsetting is false in the current space, the tool returns `unavailable`,\npreventing the LLM agent from invoking it.\n- **Client – attachment button**: Threads `uiSettings` through\n`registerRuleAttachment` and hides the \"Apply to creation\" / \"Update\nrule\" action button when the parsed rule is ES|QL type and the setting\nis off.\n\n### Screenshots\n\n| ES\\|QL disabled (plain button, no AI menu) | ES\\|QL enabled (dropdown\nwith AI rule creation) |\n|---|---|\n|\n![disabled](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/esql_disabled_no_ai_menu.png)\n|\n![enabled](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/esql_enabled_with_ai_menu.png)\n|\n\nAgent creates ES|QL rule even with enableESQL=false, but without calling\nES|QL tool.\n**Apply to creation** button is not available in this case\n\n![agent\nbug](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/agent_step4_response.png)\n\n### How to verify\n\n1. Go to **Management > Advanced Settings**, search for `enableESQL`,\ntoggle it **off**\n2. Navigate to **Security > Rules** — the \"Create a rule\" dropdown\nshould be replaced by a plain \"Create new rule\" button (no AI option)\n3. In Agent Builder, the `create_detection_rule` tool should be\nunavailable (agent cannot create ES|QL rules)\n4. Any existing ES|QL rule attachment should not show \"Apply to\ncreation\" / \"Update rule\" buttons\n\n## References\n\nCloses elastic/kibana#266378\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"f4b28c67da5978e52410389ab20f2a039cc801b0","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Detection Engine","backport:version","v9.4.0","v9.5.0"],"title":"[Security Solution][Detection Engine] enforce enableESQL setting in AI rule creation flow","number":267247,"url":"https://github.com/elastic/kibana/pull/267247","mergeCommit":{"message":"[Security Solution][Detection Engine] enforce enableESQL setting in AI rule creation flow (#267247)\n\n## Summary\n\nWhen the `enableESQL` advanced setting is disabled in a space, the AI\nrule creation flow should be blocked since the detection-rule-edit skill\nonly supports ES|QL rules. Currently the setting is only checked in the\nmanual rule type selector, but the AI path bypasses it entirely.\n\nThis PR enforces the setting at three layers:\n\n- **Client – context menu**: Adds `isEsqlRuleTypeEnabled` to the\n`isAiRuleCreationAvailable` check in the rules management page. When\nES|QL is disabled, the page falls back to the plain \"Create new rule\"\nbutton (no AI dropdown menu).\n- **Server – tool availability**: Adds an `enableESQL` uiSettings check\nto the `create_detection_rule` tool availability handler. When the\nsetting is false in the current space, the tool returns `unavailable`,\npreventing the LLM agent from invoking it.\n- **Client – attachment button**: Threads `uiSettings` through\n`registerRuleAttachment` and hides the \"Apply to creation\" / \"Update\nrule\" action button when the parsed rule is ES|QL type and the setting\nis off.\n\n### Screenshots\n\n| ES\\|QL disabled (plain button, no AI menu) | ES\\|QL enabled (dropdown\nwith AI rule creation) |\n|---|---|\n|\n![disabled](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/esql_disabled_no_ai_menu.png)\n|\n![enabled](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/esql_enabled_with_ai_menu.png)\n|\n\nAgent creates ES|QL rule even with enableESQL=false, but without calling\nES|QL tool.\n**Apply to creation** button is not available in this case\n\n![agent\nbug](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/agent_step4_response.png)\n\n### How to verify\n\n1. Go to **Management > Advanced Settings**, search for `enableESQL`,\ntoggle it **off**\n2. Navigate to **Security > Rules** — the \"Create a rule\" dropdown\nshould be replaced by a plain \"Create new rule\" button (no AI option)\n3. In Agent Builder, the `create_detection_rule` tool should be\nunavailable (agent cannot create ES|QL rules)\n4. Any existing ES|QL rule attachment should not show \"Apply to\ncreation\" / \"Update rule\" buttons\n\n## References\n\nCloses elastic/kibana#266378\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"f4b28c67da5978e52410389ab20f2a039cc801b0"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267247","number":267247,"mergeCommit":{"message":"[Security Solution][Detection Engine] enforce enableESQL setting in AI rule creation flow (#267247)\n\n## Summary\n\nWhen the `enableESQL` advanced setting is disabled in a space, the AI\nrule creation flow should be blocked since the detection-rule-edit skill\nonly supports ES|QL rules. Currently the setting is only checked in the\nmanual rule type selector, but the AI path bypasses it entirely.\n\nThis PR enforces the setting at three layers:\n\n- **Client – context menu**: Adds `isEsqlRuleTypeEnabled` to the\n`isAiRuleCreationAvailable` check in the rules management page. When\nES|QL is disabled, the page falls back to the plain \"Create new rule\"\nbutton (no AI dropdown menu).\n- **Server – tool availability**: Adds an `enableESQL` uiSettings check\nto the `create_detection_rule` tool availability handler. When the\nsetting is false in the current space, the tool returns `unavailable`,\npreventing the LLM agent from invoking it.\n- **Client – attachment button**: Threads `uiSettings` through\n`registerRuleAttachment` and hides the \"Apply to creation\" / \"Update\nrule\" action button when the parsed rule is ES|QL type and the setting\nis off.\n\n### Screenshots\n\n| ES\\|QL disabled (plain button, no AI menu) | ES\\|QL enabled (dropdown\nwith AI rule creation) |\n|---|---|\n|\n![disabled](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/esql_disabled_no_ai_menu.png)\n|\n![enabled](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/esql_enabled_with_ai_menu.png)\n|\n\nAgent creates ES|QL rule even with enableESQL=false, but without calling\nES|QL tool.\n**Apply to creation** button is not available in this case\n\n![agent\nbug](https://github.com/vitaliidm/kibana/releases/download/pr-267246-screenshots/agent_step4_response.png)\n\n### How to verify\n\n1. Go to **Management > Advanced Settings**, search for `enableESQL`,\ntoggle it **off**\n2. Navigate to **Security > Rules** — the \"Create a rule\" dropdown\nshould be replaced by a plain \"Create new rule\" button (no AI option)\n3. In Agent Builder, the `create_detection_rule` tool should be\nunavailable (agent cannot create ES|QL rules)\n4. Any existing ES|QL rule attachment should not show \"Apply to\ncreation\" / \"Update rule\" buttons\n\n## References\n\nCloses elastic/kibana#266378\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"f4b28c67da5978e52410389ab20f2a039cc801b0"}}]}] BACKPORT-->