### PR TITLE
docs: mark data.autocomplete.* settings as deprecated since 8.3.0

### DIFF
--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -907,6 +907,11 @@ groups:
       - setting: data.autocomplete.valueSuggestions.timeout
         description: |
           Specifies the time in milliseconds to wait for autocomplete suggestions from Elasticsearch. Allowed values are between 1 and 1200000.
+          
+          :::{note}
+          :applies_to: stack: ga 9.4.0!-9.4.1!
+          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Migrate to `unifiedSearch.autocomplete.valueSuggestions.timeout` or upgrade to a later version.
+          :::
         datatype: int
         default: 1000
         applies_to:

--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -891,11 +891,6 @@ groups:
       - setting: data.autocomplete.valueSuggestions.terminateAfter
         description: |
           Specifies the max number of documents loaded by each shard to generate autocomplete suggestions. Allowed values are between 1 and 10000000.
-          
-          :::{note}
-          :applies_to: stack: ga 9.4.0!-9.4.1!
-          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Migrate to `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` or upgrade to a later version.
-          :::
         datatype: int
         default: 100000
         applies_to:
@@ -903,15 +898,13 @@ groups:
           - "ech: unavailable"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` instead."
+        note: |
+          :applies_to: stack: ga 9.4.0!-9.4.1!
+          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Migrate to `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` or upgrade to a later version.
 
       - setting: data.autocomplete.valueSuggestions.timeout
         description: |
           Specifies the time in milliseconds to wait for autocomplete suggestions from Elasticsearch. Allowed values are between 1 and 1200000.
-          
-          :::{note}
-          :applies_to: stack: ga 9.4.0!-9.4.1!
-          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Migrate to `unifiedSearch.autocomplete.valueSuggestions.timeout` or upgrade to a later version.
-          :::
         datatype: int
         default: 1000
         applies_to:
@@ -919,6 +912,9 @@ groups:
           - "ech: unavailable"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.timeout` instead."
+        note: |
+          :applies_to: stack: ga 9.4.0!-9.4.1!
+          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Migrate to `unifiedSearch.autocomplete.valueSuggestions.timeout` or upgrade to a later version.
 
       - setting: unifiedSearch.autocomplete.valueSuggestions.timeout
         description: |

--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -903,11 +903,6 @@ groups:
           - "ech: unavailable"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` instead."
-        note: |
-          :::{note}
-          :applies_to: stack: ga 9.4.0!-9.4.1!
-          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Upgrade to 9.4.2 or later, or migrate to `unifiedSearch.autocomplete.valueSuggestions.terminateAfter`.
-          :::
 
       - setting: data.autocomplete.valueSuggestions.timeout
         description: |

--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -898,6 +898,11 @@ groups:
           - "ech: unavailable"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` instead."
+        note: |
+          :::{note}
+          :applies_to: stack: ga 9.4.0!-9.4.1!
+          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Upgrade to 9.4.2 or later, or migrate to `unifiedSearch.autocomplete.valueSuggestions.terminateAfter`.
+          :::
 
       - setting: data.autocomplete.valueSuggestions.timeout
         description: |
@@ -909,6 +914,11 @@ groups:
           - "ech: unavailable"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.timeout` instead."
+        note: |
+          :::{note}
+          :applies_to: stack: ga 9.4.0!-9.4.1!
+          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Upgrade to 9.4.2 or later, or migrate to `unifiedSearch.autocomplete.valueSuggestions.timeout`.
+          :::
 
       - setting: unifiedSearch.autocomplete.valueSuggestions.timeout
         description: |

--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -891,6 +891,11 @@ groups:
       - setting: data.autocomplete.valueSuggestions.terminateAfter
         description: |
           Specifies the max number of documents loaded by each shard to generate autocomplete suggestions. Allowed values are between 1 and 10000000.
+          
+          :::{note}
+          :applies_to: stack: ga 9.4.0!-9.4.1!
+          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Migrate to `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` or upgrade to a later version.
+          :::
         datatype: int
         default: 100000
         applies_to:

--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -914,11 +914,6 @@ groups:
           - "ech: unavailable"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.timeout` instead."
-        note: |
-          :::{note}
-          :applies_to: stack: ga 9.4.0!-9.4.1!
-          Using this setting in Kibana 9.4.0 and 9.4.1 causes a startup failure due to a known regression. Upgrade to 9.4.2 or later, or migrate to `unifiedSearch.autocomplete.valueSuggestions.timeout`.
-          :::
 
       - setting: unifiedSearch.autocomplete.valueSuggestions.timeout
         description: |

--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -895,7 +895,7 @@ groups:
         default: 100000
         applies_to:
           - "stack: deprecated 8.3"
-          - "ech: unavailable"
+          - "ech: ga"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` instead."
         note: |
@@ -909,7 +909,7 @@ groups:
         default: 1000
         applies_to:
           - "stack: deprecated 8.3"
-          - "ech: unavailable"
+          - "ech: ga"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.timeout` instead."
         note: |
@@ -922,7 +922,7 @@ groups:
         datatype: int
         default: 1000
         applies_to:
-          stack: ga
+          stack: ga 8.3
           ech: ga
           self: ga
 
@@ -932,7 +932,7 @@ groups:
         datatype: int
         default: 100000
         applies_to:
-          stack: ga
+          stack: ga 8.3
           ech: ga
           self: ga
         note: "To reload the logging settings, send a SIGHUP signal to {{kib}}. For more logging configuration options, see the [Configure Logging in {{kib}}](docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md) guide."

--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -895,7 +895,7 @@ groups:
         default: 100000
         applies_to:
           - "stack: deprecated 8.3"
-          - "ech: ga"
+          - "ech: unavailable"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` instead."
 
@@ -906,7 +906,7 @@ groups:
         default: 1000
         applies_to:
           - "stack: deprecated 8.3"
-          - "ech: ga"
+          - "ech: unavailable"
           - "self: ga"
         deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.timeout` instead."
 

--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -894,9 +894,10 @@ groups:
         datatype: int
         default: 100000
         applies_to:
-          stack: ga
-          ech: ga
-          self: ga
+          - "stack: deprecated 8.3"
+          - "ech: ga"
+          - "self: ga"
+        deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.terminateAfter` instead."
 
       - setting: data.autocomplete.valueSuggestions.timeout
         description: |
@@ -904,9 +905,10 @@ groups:
         datatype: int
         default: 1000
         applies_to:
-          stack: ga
-          ech: ga
-          self: ga
+          - "stack: deprecated 8.3"
+          - "ech: ga"
+          - "self: ga"
+        deprecation_details: "Deprecated in 8.3.0. Use `unifiedSearch.autocomplete.valueSuggestions.timeout` instead."
 
       - setting: unifiedSearch.autocomplete.valueSuggestions.timeout
         description: |


### PR DESCRIPTION
## Summary

This PR addresses elastic/docs-content#6511.

The page [General settings in Kibana](https://www.elastic.co/docs/reference/kibana/configuration-reference/general-settings) lists \`data.autocomplete.valueSuggestions.terminateAfter\` and \`data.autocomplete.valueSuggestions.timeout\` without any deprecation indicator, making them appear as valid current settings.

These settings were deprecated in Kibana 8.3.0 when the autocomplete logic was moved from the \`data\` plugin to the \`unified_search\` plugin (now \`kql\`) via [#129977](https://github.com/elastic/kibana/pull/129977). The canonical settings since 8.3.0 are \`unifiedSearch.autocomplete.valueSuggestions.terminateAfter\` and \`unifiedSearch.autocomplete.valueSuggestions.timeout\`.

The backward-compatible deprecation handler (which remaps the old keys to the new ones with a warning) was accidentally removed in [#246674](https://github.com/elastic/kibana/pull/246674) and restored in [#268872](https://github.com/elastic/kibana/pull/268872) (backported to v9.4.2 and v9.5.0). During the window between 9.4.0 and 9.4.1, customers using \`data.autocomplete.*\` in \`kibana.yml\` experienced startup failures.

All three generations of the settings (\`kibana.*\`, \`data.*\`, \`unifiedSearch.*\`) are explicitly allowlisted in ECH and work for users on ECH deployments.

## Changes

- **\`docs/reference/configuration-reference/general-settings.yml\`**:
  - Marks \`data.autocomplete.valueSuggestions.terminateAfter\` and \`data.autocomplete.valueSuggestions.timeout\` as \`deprecated 8.3\` on stack, with \`deprecation_details\` pointing to the \`unifiedSearch.*\` replacements.
  - Adds an inline note on both deprecated settings warning that using them in Kibana 9.4.0–9.4.1 causes a startup failure, and advising users to migrate or upgrade.
  - Adds \`unifiedSearch.autocomplete.valueSuggestions.timeout\` and \`unifiedSearch.autocomplete.valueSuggestions.terminateAfter\` as \`stack: ga 8.3\` entries so the canonical settings are properly documented.

## Resolves

Closes elastic/docs-content#6511

---

> **AI-assisted draft** — created with Claude Sonnet 4.6 in Cursor.
> Review all generated content for factual accuracy before merging.