### PR TITLE
[9.4] Add aria-label/aria-labelledby to EuiPopover components for accessibility (#269437)

### DIFF
--- a/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.test.tsx
+++ b/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.test.tsx
@@ -239,7 +239,7 @@ describe('ToolbarSelector', () => {
     await user.hover(button);
 
     await waitFor(() => {
-      expect(screen.getByText('Default Label')).toBeInTheDocument();
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Default Label');
     });
   });
 });

--- a/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.test.tsx
+++ b/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.test.tsx
@@ -195,7 +195,7 @@ describe('ToolbarSelector', () => {
     );
     await user.click(screen.getByTestId('toolbarSelectorOptionalPropsButton'));
     expect(screen.getByText('Maximum selection limit reached')).toBeInTheDocument();
-    expect(screen.getAllByLabelText('My Popover Title')).toHaveLength(3);
+    expect(screen.getAllByLabelText('My Popover Title')).toHaveLength(4);
   });
 
   it('uses buttonTooltipContent when provided instead of buttonLabel for tooltip', async () => {

--- a/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.tsx
+++ b/src/platform/packages/shared/shared-ux/toolbar_selector/src/toolbar_selector.tsx
@@ -19,6 +19,7 @@ import {
   EuiPanel,
   EuiToolTip,
   EuiOutsideClickDetector,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { ToolbarButton } from '@kbn/shared-ux-button-toolbar';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -75,6 +76,7 @@ export const ToolbarSelector = ({
   fullWidth = false,
 }: ToolbarSelectorProps) => {
   const { euiTheme } = useEuiTheme();
+  const popoverTitleId = useGeneratedHtmlId();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [labelPopoverDisabled, setLabelPopoverDisabled] = useState(false);
 
@@ -191,6 +193,14 @@ export const ToolbarSelector = ({
       <EuiPopover
         id={dataTestSubj}
         ownFocus
+        aria-labelledby={popoverTitle ? popoverTitleId : undefined}
+        aria-label={
+          !popoverTitle
+            ? i18n.translate('sharedUXPackages.toolbarSelectorPopover.ariaLabel', {
+                defaultMessage: 'Selector options',
+              })
+            : undefined
+        }
         anchorPosition="downLeft"
         repositionToCrossAxis={false}
         initialFocus={
@@ -235,7 +245,11 @@ export const ToolbarSelector = ({
         isOpen={isOpen}
         closePopover={closePopover}
       >
-        {popoverTitle && <EuiPopoverTitle paddingSize="s">{popoverTitle}</EuiPopoverTitle>}
+        {popoverTitle && (
+          <EuiPopoverTitle paddingSize="s" id={popoverTitleId}>
+            {popoverTitle}
+          </EuiPopoverTitle>
+        )}
         <EuiSelectable<SelectableEntry>
           id={`${dataTestSubj}Selectable`}
           singleSelection={singleSelection ?? true}

--- a/x-pack/platform/packages/shared/logs-overview/src/components/shared/grouping_license_cta_popover.tsx
+++ b/x-pack/platform/packages/shared/logs-overview/src/components/shared/grouping_license_cta_popover.tsx
@@ -13,6 +13,7 @@ import {
   EuiPopoverFooter,
   EuiPopoverTitle,
   EuiText,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useBoolean } from '@kbn/react-hooks';
@@ -38,6 +39,7 @@ export type GroupingLicenseCtaPopoverDependencies =
 export const GroupingLicenseCtaPopover = React.memo<GroupingLicenseCtaPopoverProps>(
   ({ dependencies, showDetails }) => {
     const [isPopoverOpen, { off: closePopover, toggle: togglePopover }] = useBoolean(false);
+    const popoverTitleId = useGeneratedHtmlId();
 
     const groupingCtaPopoverButton = React.useMemo(
       () => (
@@ -60,8 +62,9 @@ export const GroupingLicenseCtaPopover = React.memo<GroupingLicenseCtaPopoverPro
         isOpen={isPopoverOpen}
         closePopover={closePopover}
         anchorPosition="downRight"
+        aria-labelledby={popoverTitleId}
       >
-        <EuiPopoverTitle>{groupingLicenseCtaMessageTitle}</EuiPopoverTitle>
+        <EuiPopoverTitle id={popoverTitleId}>{groupingLicenseCtaMessageTitle}</EuiPopoverTitle>
         <div style={{ width: '300px' }}>
           <EuiText>
             <p>{groupingLicenseCtaMessageDescription}</p>

--- a/x-pack/platform/packages/shared/logs-overview/src/components/shared/grouping_selector.tsx
+++ b/x-pack/platform/packages/shared/logs-overview/src/components/shared/grouping_selector.tsx
@@ -65,6 +65,7 @@ export const GroupingSelector: React.FC<GroupingSelectorProps> = ({
       isOpen={isPopoverOpen}
       closePopover={() => setIsPopoverOpen(false)}
       anchorPosition="downRight"
+      aria-label={groupingSelectorPopoverAriaLabel}
     >
       <EuiContextMenuPanel items={groupingSelectorItems} />
     </EuiPopover>
@@ -82,5 +83,12 @@ const groupingItemCategoriesTitle = i18n.translate(
   'xpack.observabilityLogsOverview.groupingSelector.categories',
   {
     defaultMessage: 'Log Patterns',
+  }
+);
+
+const groupingSelectorPopoverAriaLabel = i18n.translate(
+  'xpack.observabilityLogsOverview.groupingSelector.popoverAriaLabel',
+  {
+    defaultMessage: 'Select grouping option',
   }
 );

--- a/x-pack/platform/plugins/shared/logs_shared/public/components/logging/log_entry_flyout/log_entry_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/logs_shared/public/components/logging/log_entry_flyout/log_entry_actions_menu.tsx
@@ -13,6 +13,7 @@ import {
   type UptimeOverviewLocatorInfraParams,
 } from '@kbn/deeplinks-observability';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { getRouterLinkProps } from '@kbn/router-utils';
 import type { BrowserUrlService } from '@kbn/share-plugin/public';
 import React, { useMemo } from 'react';
@@ -74,6 +75,9 @@ export const LogEntryActionsMenu = ({ logEntry }: LogEntryActionsMenuProps) => {
   return (
     <EuiPopover
       anchorPosition="downRight"
+      aria-label={i18n.translate('xpack.logsShared.logEntryActionsMenu.popoverAriaLabel', {
+        defaultMessage: 'Investigate actions',
+      })}
       button={
         <EuiButton
           data-test-subj="logEntryActionsMenuButton"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Add aria-label/aria-labelledby to EuiPopover components for accessibility (#269437)](https://github.com/elastic/kibana/pull/269437)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-15T10:14:21Z","message":"Add aria-label/aria-labelledby to EuiPopover components for accessibility (#269437)\n\nFixes 4 `@elastic/eui/require-aria-label-for-modals` lint violations\nacross `@elastic/obs-exploration-team` files.\n\n### Changes\n\n- **`toolbar_selector.tsx`** — `aria-labelledby` pointing at\n`EuiPopoverTitle` via `useGeneratedHtmlId()`; falls back to `aria-label`\nwhen no `popoverTitle` is provided\n- **`grouping_license_cta_popover.tsx`** — `aria-labelledby` pointing at\n`EuiPopoverTitle` via `useGeneratedHtmlId()`\n- **`grouping_selector.tsx`** — `aria-label` with `i18n.translate` (no\nvisible title in popover)\n- **`log_entry_actions_menu.tsx`** — `aria-label` with `i18n.translate`\n(no visible title in popover)\n\nPattern used per\n`.agents/skills/accessibility/references/components/overlays.md`:\n\n```tsx\n// With visible title (preferred)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId}>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n</EuiPopover>\n\n// Without visible title\n<EuiPopover aria-label={i18n.translate('...', { defaultMessage: '...' })}>\n```\n\nCloses https://github.com/elastic/kibana/issues/269436\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node scripts/kbn\nbootstrap $0; sep=RS }` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node install.js dd ldd\nb/li\u0004\u0018` (dns block)\n> - `iojs.org`\n> - Triggering command: `/usr/bin/curl curl -q --fail --compressed -L -s\nREDACTED -o -` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"f3c594d7f2a9b1401fe9c8d2f553eb4e2f673f10","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","💝community","backport:version","a11y:agent-pr","v9.5.0","v9.3.5","v9.4.2"],"title":"Add aria-label/aria-labelledby to EuiPopover components for accessibility","number":269437,"url":"https://github.com/elastic/kibana/pull/269437","mergeCommit":{"message":"Add aria-label/aria-labelledby to EuiPopover components for accessibility (#269437)\n\nFixes 4 `@elastic/eui/require-aria-label-for-modals` lint violations\nacross `@elastic/obs-exploration-team` files.\n\n### Changes\n\n- **`toolbar_selector.tsx`** — `aria-labelledby` pointing at\n`EuiPopoverTitle` via `useGeneratedHtmlId()`; falls back to `aria-label`\nwhen no `popoverTitle` is provided\n- **`grouping_license_cta_popover.tsx`** — `aria-labelledby` pointing at\n`EuiPopoverTitle` via `useGeneratedHtmlId()`\n- **`grouping_selector.tsx`** — `aria-label` with `i18n.translate` (no\nvisible title in popover)\n- **`log_entry_actions_menu.tsx`** — `aria-label` with `i18n.translate`\n(no visible title in popover)\n\nPattern used per\n`.agents/skills/accessibility/references/components/overlays.md`:\n\n```tsx\n// With visible title (preferred)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId}>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n</EuiPopover>\n\n// Without visible title\n<EuiPopover aria-label={i18n.translate('...', { defaultMessage: '...' })}>\n```\n\nCloses https://github.com/elastic/kibana/issues/269436\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node scripts/kbn\nbootstrap $0; sep=RS }` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node install.js dd ldd\nb/li\u0004\u0018` (dns block)\n> - `iojs.org`\n> - Triggering command: `/usr/bin/curl curl -q --fail --compressed -L -s\nREDACTED -o -` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"f3c594d7f2a9b1401fe9c8d2f553eb4e2f673f10"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269437","number":269437,"mergeCommit":{"message":"Add aria-label/aria-labelledby to EuiPopover components for accessibility (#269437)\n\nFixes 4 `@elastic/eui/require-aria-label-for-modals` lint violations\nacross `@elastic/obs-exploration-team` files.\n\n### Changes\n\n- **`toolbar_selector.tsx`** — `aria-labelledby` pointing at\n`EuiPopoverTitle` via `useGeneratedHtmlId()`; falls back to `aria-label`\nwhen no `popoverTitle` is provided\n- **`grouping_license_cta_popover.tsx`** — `aria-labelledby` pointing at\n`EuiPopoverTitle` via `useGeneratedHtmlId()`\n- **`grouping_selector.tsx`** — `aria-label` with `i18n.translate` (no\nvisible title in popover)\n- **`log_entry_actions_menu.tsx`** — `aria-label` with `i18n.translate`\n(no visible title in popover)\n\nPattern used per\n`.agents/skills/accessibility/references/components/overlays.md`:\n\n```tsx\n// With visible title (preferred)\nconst popoverTitleId = useGeneratedHtmlId();\n<EuiPopover aria-labelledby={popoverTitleId}>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n</EuiPopover>\n\n// Without visible title\n<EuiPopover aria-label={i18n.translate('...', { defaultMessage: '...' })}>\n```\n\nCloses https://github.com/elastic/kibana/issues/269436\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node scripts/kbn\nbootstrap $0; sep=RS }` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2 ias_name` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node install.js dd ldd\nb/li\u0004\u0018` (dns block)\n> - `iojs.org`\n> - Triggering command: `/usr/bin/curl curl -q --fail --compressed -L -s\nREDACTED -o -` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"f3c594d7f2a9b1401fe9c8d2f553eb4e2f673f10"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/269488","number":269488,"state":"OPEN"},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/269465","number":269465,"state":"OPEN"}]}] BACKPORT-->