### PR TITLE
[9.3] Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/search-kibana files (#269037)

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/components/code_box.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/code_box.tsx
@@ -144,6 +144,7 @@ export const CodeBox: React.FC<CodeBoxProps> = ({
                 <EuiFlexItem>
                   <EuiThemeProvider colorMode="light">
                     <EuiPopover
+                      aria-label={selectLanguageDescription}
                       button={button}
                       isOpen={isPopoverOpen}
                       closePopover={() => setIsPopoverOpen(false)}

--- a/src/platform/packages/shared/kbn-search-connectors/components/configuration/platinum_license_popover.tsx
+++ b/src/platform/packages/shared/kbn-search-connectors/components/configuration/platinum_license_popover.tsx
@@ -21,6 +21,7 @@ import {
   EuiFlexItem,
   EuiButton,
   useEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -41,9 +42,15 @@ export const PlatinumLicensePopover: React.FC<PlatinumLicensePopoverProps> = ({
   subscriptionLink,
 }) => {
   const { euiTheme } = useEuiTheme();
+  const popoverTitleId = useGeneratedHtmlId();
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
-      <EuiPopoverTitle>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      aria-labelledby={popoverTitleId}
+    >
+      <EuiPopoverTitle id={popoverTitleId}>
         {i18n.translate('searchConnectors.connectors.upgradeTitle', {
           defaultMessage: 'Upgrade to Elastic Platinum',
         })}

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/adaptive_allocations_title.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/adaptive_allocations_title.tsx
@@ -16,12 +16,14 @@ import {
   EuiSpacer,
   EuiTitle,
   EuiText,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 
 export const AdaptiveAllocationsTitle: FC = () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   return (
     <>
@@ -39,6 +41,7 @@ export const AdaptiveAllocationsTitle: FC = () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             anchorPosition="upCenter"
+            aria-labelledby={popoverTitleId}
             button={
               <EuiButtonIcon
                 color="text"
@@ -56,7 +59,7 @@ export const AdaptiveAllocationsTitle: FC = () => {
             isOpen={isPopoverOpen}
             closePopover={() => setIsPopoverOpen(false)}
           >
-            <EuiPopoverTitle>
+            <EuiPopoverTitle id={popoverTitleId}>
               <FormattedMessage
                 id="xpack.inferenceEndpointUICommon.components.sectionPopoverTitle"
                 defaultMessage="Adaptive resources"

--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_field.tsx
@@ -84,6 +84,7 @@ export const ResultField: React.FC<ResultFieldProps> = ({
         <EuiFlexGroup direction="row" alignItems="center" gutterSize="xs" justifyContent="center">
           <EuiFlexItem grow={false}>
             <EuiPopover
+              aria-label={fieldTypeLabel}
               closePopover={() => setIsPopoverOpen(false)}
               button={
                 <EuiButtonIcon

--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_header.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_header.tsx
@@ -18,6 +18,7 @@ import {
   EuiTextColor,
   EuiTitle,
   useEuiTheme,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -49,6 +50,7 @@ const Definition: React.FC<TermDef> = ({ label }) => (
 const MetadataPopover: React.FC<MetaDataProps> = ({ id, onDocumentDelete }) => {
   const [popoverIsOpen, setPopoverIsOpen] = useState(false);
   const closePopover = () => setPopoverIsOpen(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const metaDataIcon = (
     <EuiButtonIcon
@@ -68,8 +70,13 @@ const MetadataPopover: React.FC<MetaDataProps> = ({ id, onDocumentDelete }) => {
   );
 
   return (
-    <EuiPopover button={metaDataIcon} isOpen={popoverIsOpen} closePopover={closePopover}>
-      <EuiPopoverTitle>
+    <EuiPopover
+      button={metaDataIcon}
+      isOpen={popoverIsOpen}
+      closePopover={closePopover}
+      aria-labelledby={popoverTitleId}
+    >
+      <EuiPopoverTitle id={popoverTitleId}>
         {i18n.translate('xpack.searchIndexDocuments.result.header.metadata.title', {
           defaultMessage: 'Document metadata',
         })}

--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/rich_result_header.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/rich_result_header.tsx
@@ -24,6 +24,7 @@ import {
   useEuiTheme,
   EuiToolTip,
   copyToClipboard,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -115,6 +116,7 @@ const MetadataPopover: React.FC<MetaDataProps> = ({
 }) => {
   const [popoverIsOpen, setPopoverIsOpen] = useState(false);
   const closePopover = () => setPopoverIsOpen(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const metaDataIcon = (
     <EuiButtonIcon
@@ -138,8 +140,13 @@ const MetadataPopover: React.FC<MetaDataProps> = ({
   );
 
   return (
-    <EuiPopover button={metaDataIcon} isOpen={popoverIsOpen} closePopover={closePopover}>
-      <EuiPopoverTitle>
+    <EuiPopover
+      button={metaDataIcon}
+      isOpen={popoverIsOpen}
+      closePopover={closePopover}
+      aria-labelledby={popoverTitleId}
+    >
+      <EuiPopoverTitle id={popoverTitleId}>
         <FormattedMessage
           id="xpack.searchIndexDocuments.result.compactCard.header.metadata.title"
           defaultMessage="Document metadata"

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connectors.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connectors.tsx
@@ -168,6 +168,10 @@ const Connectors: React.FC<ConnectorsProps> = ({ isCrawler, isCrawlerSelfManaged
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiPopover
+                    aria-label={i18n.translate(
+                      'xpack.contentConnectors.connectors.moreOptionsPopover.ariaLabel',
+                      { defaultMessage: 'More connector options' }
+                    )}
                     isOpen={showMoreOptionsPopover}
                     closePopover={() => setShowMoreOptionsPopover(false)}
                     button={

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/connector_description_popover.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/connector_description_popover.tsx
@@ -104,6 +104,9 @@ export const ConnectorDescriptionPopover: React.FC<ConnectorDescriptionPopoverPr
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.contentConnectors.createConnector.infoPopover.ariaLabel', {
+        defaultMessage: 'Connector description',
+      })}
       anchorPosition="upCenter"
       button={
         <EuiButtonIcon

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration.tsx
@@ -227,6 +227,10 @@ GET connector-${rawName}/_search
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate(
+          'xpack.contentConnectors.createConnector.finishUpStep.popover.ariaLabel',
+          { defaultMessage: 'More configuration options' }
+        )}
         id={splitButtonPopoverId}
         button={
           <EuiButtonIcon

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/shared/header_actions/syncs_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/shared/header_actions/syncs_context_menu.tsx
@@ -179,6 +179,10 @@ export const SyncsContextMenu: React.FC<SyncsContextMenuProps> = ({ disabled = f
 
   return (
     <EuiPopover
+      aria-label={i18n.translate(
+        'xpack.contentConnectors.content.index.syncButton.popover.ariaLabel',
+        { defaultMessage: 'Sync options' }
+      )}
       button={
         <EuiButton
           disabled={disabled || isWaitingForConnector}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_toolbar/analytics_collection_toolbar.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_toolbar/analytics_collection_toolbar.tsx
@@ -126,6 +126,10 @@ export const AnalyticsCollectionToolbar: React.FC = () => {
       <RedirectAppLinks coreStart={{ application }}>
         <EuiFlexItem grow={false}>
           <EuiPopover
+            aria-label={i18n.translate(
+              'xpack.enterpriseSearch.analytics.collectionsView.managePopover.ariaLabel',
+              { defaultMessage: 'Manage collection options' }
+            )}
             button={
               <EuiButton iconType="arrowDown" iconSide="right" onClick={togglePopover}>
                 <FormattedMessage

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/docs_explorer.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/docs_explorer.tsx
@@ -144,6 +144,10 @@ const ConfigurationPopover: React.FC<ConfigurationPopOverProps> = ({
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate(
+          'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.configuration.popover.ariaLabel',
+          { defaultMessage: 'Configuration options' }
+        )}
         anchorPosition="downCenter"
         isOpen={showConfiguration}
         panelPaddingSize="none"

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_schema.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/search_application_schema.tsx
@@ -415,6 +415,10 @@ export const SearchApplicationSchema: React.FC = () => {
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiPopover
+                aria-label={i18n.translate(
+                  'xpack.enterpriseSearch.searchApplications.searchApplication.schema.filters.popover.ariaLabel',
+                  { defaultMessage: 'Filter by field types' }
+                )}
                 button={filterButton}
                 isOpen={isFilterByPopoverOpen}
                 closePopover={() => setIsFilterByPopoverOpen(false)}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/manual_configuration.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/manual_configuration.tsx
@@ -220,6 +220,10 @@ GET connector-${rawName}/_search
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate(
+          'xpack.enterpriseSearch.createConnector.finishUpStep.popover.ariaLabel',
+          { defaultMessage: 'More configuration options' }
+        )}
         id={splitButtonPopoverId}
         button={
           <EuiButtonIcon

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
@@ -70,6 +70,10 @@ export const TrainedModelHealthPopover: React.FC<InferencePipeline> = (pipeline)
   return (
     <>
       <EuiPopover
+        aria-label={i18n.translate(
+          'xpack.enterpriseSearch.inferencePipelineCard.popover.ariaLabel',
+          { defaultMessage: 'Inference pipeline actions' }
+        )}
         button={actionButton}
         isOpen={isPopOverOpen}
         closePopover={() => setIsPopOverOpen(false)}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/manage_custom_pipeline_actions.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/manage_custom_pipeline_actions.tsx
@@ -36,6 +36,10 @@ export const ManageCustomPipelineActions: React.FC<ManageCustomPipelineProps> = 
   };
   return (
     <EuiPopover
+      aria-label={i18n.translate(
+        'xpack.enterpriseSearch.content.indices.pipelines.ingestionPipeline.managePopover.ariaLabel',
+        { defaultMessage: 'Manage pipeline options' }
+      )}
       button={
         <EuiButtonEmpty
           buttonRef={buttonRef}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/header_actions/syncs_context_menu.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/header_actions/syncs_context_menu.tsx
@@ -170,6 +170,10 @@ export const SyncsContextMenu: React.FC<SyncsContextMenuProps> = ({ disabled = f
 
   return (
     <EuiPopover
+      aria-label={i18n.translate(
+        'xpack.enterpriseSearch.content.index.syncButton.popover.ariaLabel',
+        { defaultMessage: 'Sync options' }
+      )}
       button={
         <EuiButton
           disabled={disabled || isWaitingForConnector}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/endpoints_header_action.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/endpoints_header_action.tsx
@@ -38,7 +38,14 @@ export const EndpointsHeaderAction: React.FC<React.PropsWithChildren<{}>> = ({ c
         </EuiFlexGroup>
       </EuiHeaderLinks>
       {open && (
-        <EuiFlyout onClose={() => setOpen(false)} size={'s'}>
+        <EuiFlyout
+          aria-label={i18n.translate(
+            'xpack.enterpriseSearch.pageTemplate.endpointsFlyout.ariaLabel',
+            { defaultMessage: 'Endpoints & API keys' }
+          )}
+          onClose={() => setOpen(false)}
+          size={'s'}
+        >
           <KibanaWiredConnectionDetailsProvider>
             <ConnectionDetailsFlyoutContent />
           </KibanaWiredConnectionDetailsProvider>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/add_data_button.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/add_data_button.tsx
@@ -84,6 +84,9 @@ export const AddDataButton: React.FC = () => {
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.search.gettingStarted.addDataButton.popover.ariaLabel', {
+        defaultMessage: 'Add data options',
+      })}
       button={button}
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/token_estimate_tooltip.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/token_estimate_tooltip.tsx
@@ -19,6 +19,7 @@ import {
   EuiCallOut,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { useFormContext } from 'react-hook-form';
 import { docLinks } from '../../../common/doc_links';
 import { useLLMsModels } from '../../hooks/use_llms_models';
@@ -55,6 +56,10 @@ export const TokenEstimateTooltip: React.FC<TokenEstimateTooltipProps> = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate(
+        'xpack.searchPlayground.chat.message.tokenEstimateTooltip.popover.ariaLabel',
+        { defaultMessage: 'Token estimate breakdown' }
+      )}
       id={normalContextMenuPopoverId}
       button={
         <EuiButtonEmpty

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/playground_more_options.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/playground_more_options.tsx
@@ -87,6 +87,10 @@ export const PlaygroundMoreOptionsMenu = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate(
+        'xpack.searchPlayground.savedPlayground.moreOptions.popover.ariaLabel',
+        { defaultMessage: 'More options' }
+      )}
       isOpen={showMoreOptions}
       closePopover={closePopover}
       panelPaddingSize="none"

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_draggable_list/query_rule_list_item_content.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_draggable_list/query_rule_list_item_content.tsx
@@ -201,6 +201,10 @@ export const QueryRuleListItemContent: React.FC<QueryRuleListItemContentProps> =
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiPopover
+                  aria-label={i18n.translate(
+                    'xpack.search.queryRulesetDetail.draggableList.actionsPopover.ariaLabel',
+                    { defaultMessage: 'Rule actions' }
+                  )}
                   id="queryRuleActionsPopover"
                   button={
                     <EuiButtonIcon

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.tsx
@@ -374,6 +374,10 @@ export const QueryRulesetDetail: React.FC<QueryRulesetDetailProps> = ({ createMo
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiPopover
+                    aria-label={i18n.translate(
+                      'xpack.queryRules.queryRulesetDetail.actionsPopover.ariaLabel',
+                      { defaultMessage: 'Ruleset actions' }
+                    )}
                     id={splitButtonPopoverActionsId}
                     button={
                       <EuiButtonIcon

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_rule_table.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_rule_table.tsx
@@ -18,6 +18,7 @@ import {
   EuiPopoverTitle,
   EuiText,
   EuiTextTruncate,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { SynonymsSynonymRule } from '@elastic/elasticsearch/lib/api/types';
 import { i18n } from '@kbn/i18n';
@@ -41,6 +42,7 @@ export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: st
     size: pageSize,
   });
   const [addNewRulePopoverOpen, setAddNewRulePopoverOpen] = useState(false);
+  const addRulePopoverTitleId = useGeneratedHtmlId();
 
   const [isRuleFlyoutOpen, setIsRuleFlyoutOpen] = useState(true);
   const [synonymsRuleToEdit, setSynonymsRuleToEdit] = useState<string | null>(null);
@@ -221,6 +223,7 @@ export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: st
       {data.data.length !== 0 && (
         <>
           <EuiPopover
+            aria-labelledby={addRulePopoverTitleId}
             button={
               <EuiButton
                 data-test-subj="searchSynonymsSynonymsSetRuleTableAddRuleButton"
@@ -237,7 +240,7 @@ export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: st
             isOpen={addNewRulePopoverOpen}
             closePopover={() => setAddNewRulePopoverOpen(false)}
           >
-            <EuiPopoverTitle>
+            <EuiPopoverTitle id={addRulePopoverTitleId}>
               {i18n.translate('xpack.searchSynonyms.synonymsSetTable.addRule.title', {
                 defaultMessage: 'Select a rule type',
               })}

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_connector.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_connector.tsx
@@ -114,6 +114,10 @@ export const EditConnector: React.FC = () => {
             )}
             <span>
               <EuiPopover
+                aria-label={i18n.translate(
+                  'xpack.serverlessSearch.connectors.menuPopover.ariaLabel',
+                  { defaultMessage: 'Connector actions' }
+                )}
                 id={'connectorMenu'}
                 button={
                   <EuiButtonIcon


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/search-kibana files (#269037)](https://github.com/elastic/kibana/pull/269037)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-15T07:46:23Z","message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/search-kibana files (#269037)\n\nAdds missing `aria-label` or `aria-labelledby` to 26\n`EuiPopover`/`EuiFlyout` components flagged by the\n`@elastic/eui/require-aria-label-for-modals` ESLint rule.\n\n## Approach\n\n- **Popovers with visible titles** (`EuiPopoverTitle`): wired\n`aria-labelledby` + `useGeneratedHtmlId` on the title element (5 files)\n- **Popovers without visible titles** (context menus, filter dropdowns):\nadded `aria-label` with `i18n.translate` (20 files)\n- **EuiFlyout without title**: added `aria-label` with `i18n.translate`\n(1 file)\n\nExample — popover with existing title:\n\n```tsx\nconst popoverTitleId = useGeneratedHtmlId();\n\n<EuiPopover aria-labelledby={popoverTitleId} ...>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n</EuiPopover>\n```\n\nExample — popover without title:\n\n```tsx\n<EuiPopover\n  aria-label={i18n.translate('...popover.ariaLabel', { defaultMessage: 'Sync options' })}\n  ...\n>\n```\n\nAll strings are localized via `i18n.translate`. No logic, layout, or\nbehavioral changes.\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js _TOKEN&#34;;\n}; f ldd b/li\u0004\u0018 nibrowser-gtk/sys/lib/libjxl.so.0.8` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"867c19e069b0a4345b3cce834c642819c6623601","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport:version","a11y:agent-pr","v9.5.0","v9.3.5","v9.4.2"],"title":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/search-kibana files","number":269037,"url":"https://github.com/elastic/kibana/pull/269037","mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/search-kibana files (#269037)\n\nAdds missing `aria-label` or `aria-labelledby` to 26\n`EuiPopover`/`EuiFlyout` components flagged by the\n`@elastic/eui/require-aria-label-for-modals` ESLint rule.\n\n## Approach\n\n- **Popovers with visible titles** (`EuiPopoverTitle`): wired\n`aria-labelledby` + `useGeneratedHtmlId` on the title element (5 files)\n- **Popovers without visible titles** (context menus, filter dropdowns):\nadded `aria-label` with `i18n.translate` (20 files)\n- **EuiFlyout without title**: added `aria-label` with `i18n.translate`\n(1 file)\n\nExample — popover with existing title:\n\n```tsx\nconst popoverTitleId = useGeneratedHtmlId();\n\n<EuiPopover aria-labelledby={popoverTitleId} ...>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n</EuiPopover>\n```\n\nExample — popover without title:\n\n```tsx\n<EuiPopover\n  aria-label={i18n.translate('...popover.ariaLabel', { defaultMessage: 'Sync options' })}\n  ...\n>\n```\n\nAll strings are localized via `i18n.translate`. No logic, layout, or\nbehavioral changes.\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js _TOKEN&#34;;\n}; f ldd b/li\u0004\u0018 nibrowser-gtk/sys/lib/libjxl.so.0.8` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"867c19e069b0a4345b3cce834c642819c6623601"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269037","number":269037,"mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/search-kibana files (#269037)\n\nAdds missing `aria-label` or `aria-labelledby` to 26\n`EuiPopover`/`EuiFlyout` components flagged by the\n`@elastic/eui/require-aria-label-for-modals` ESLint rule.\n\n## Approach\n\n- **Popovers with visible titles** (`EuiPopoverTitle`): wired\n`aria-labelledby` + `useGeneratedHtmlId` on the title element (5 files)\n- **Popovers without visible titles** (context menus, filter dropdowns):\nadded `aria-label` with `i18n.translate` (20 files)\n- **EuiFlyout without title**: added `aria-label` with `i18n.translate`\n(1 file)\n\nExample — popover with existing title:\n\n```tsx\nconst popoverTitleId = useGeneratedHtmlId();\n\n<EuiPopover aria-labelledby={popoverTitleId} ...>\n  <EuiPopoverTitle id={popoverTitleId}>...</EuiPopoverTitle>\n</EuiPopover>\n```\n\nExample — popover without title:\n\n```tsx\n<EuiPopover\n  aria-label={i18n.translate('...popover.ariaLabel', { defaultMessage: 'Sync options' })}\n  ...\n>\n```\n\nAll strings are localized via `i18n.translate`. No logic, layout, or\nbehavioral changes.\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2` (dns block)\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node scripts/kbn bootstrap`\n(dns block)\n> - Triggering command:\n`/home/REDACTED/work/_temp/ghcca-node/node/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack ldd 0.8.2` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node\n/opt/hostedtoolcache/node/24.14.1/x64/bin/node install.js _TOKEN&#34;;\n}; f ldd b/li\u0004\u0018 nibrowser-gtk/sys/lib/libjxl.so.0.8` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"867c19e069b0a4345b3cce834c642819c6623601"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/269601","number":269601,"state":"MERGED","mergeCommit":{"sha":"513f00c44630d9416ab4dd99cf84aac1e3ed8f3d","message":"[9.4] Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/search-kibana files (#269037) (#269601)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Fix `@elastic/eui/require-aria-label-for-modals` lint violations\nacross @elastic/search-kibana files\n(#269037)](https://github.com/elastic/kibana/pull/269037)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>"}}]}] BACKPORT-->