### PR TITLE
[ResponseOps][Rules] Extra top padding in Rules list page creates unintended gap below tab bar

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
@@ -7,7 +7,6 @@
 
 import React, { lazy, useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiSpacer } from '@elastic/eui';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Routes, Route } from '@kbn/shared-ux-router';
@@ -199,7 +198,6 @@ const RulesPage = () => {
           })),
         }}
       >
-        <EuiSpacer size="l" />
         <Routes>
           <Route exact path="/logs" component={renderLogsList} />
           <Route exact path="/" component={renderRulesList} />


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/269871

## Summary

- removed extra spacer

<img width="1602" height="848" alt="Screenshot 2026-05-19 at 13 39 13" src="https://github.com/user-attachments/assets/457e382e-ad1f-450d-b2e9-2fff02ea8128" />
