### PR TITLE
[Actions] Fix HTTP connector TLS options through proxies

### DIFF
--- a/src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.test.ts
+++ b/src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.test.ts
@@ -52,6 +52,50 @@ describe('getCustomAgents', () => {
     expect(httpsAgent instanceof HttpsProxyAgent).toBeTruthy();
   });
 
+  test('passes target SSL overrides to the CONNECT-upgraded TLS request', async () => {
+    const callbackSpy = jest
+      .spyOn(HttpsProxyAgent.prototype, 'callback')
+      .mockResolvedValue({} as Awaited<ReturnType<HttpsProxyAgent['callback']>>);
+    const proxySettings = {
+      proxyUrl: 'http://someproxyhost',
+      proxySSLSettings: {
+        verificationMode: 'full',
+      },
+      proxyBypassHosts: undefined,
+      proxyOnlyHosts: undefined,
+    } as ProxySettings;
+
+    const { httpsAgent } = getCustomAgents({
+      logger,
+      proxySettings,
+      sslOverrides: {
+        verificationMode: 'none',
+      },
+      sslSettings: defaultSSLSettings,
+      url: targetUrl,
+    });
+
+    try {
+      await (httpsAgent as unknown as HttpsProxyAgent).callback(
+        {} as Parameters<HttpsProxyAgent['callback']>[0],
+        {
+          host: targetHost,
+          port: 443,
+          secureEndpoint: true,
+        } as Parameters<HttpsProxyAgent['callback']>[1]
+      );
+
+      expect(callbackSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          rejectUnauthorized: false,
+        })
+      );
+    } finally {
+      callbackSpy.mockRestore();
+    }
+  });
+
   test('return default agents for invalid proxy URL', () => {
     const proxySettings = {
       proxyUrl: ':nope: not a valid URL',

--- a/src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.ts
+++ b/src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.ts
@@ -33,6 +33,24 @@ interface GetCustomAgentsOpts {
   url: string;
 }
 
+class TargetSslHttpsProxyAgent extends HttpsProxyAgent {
+  constructor(
+    proxyOptions: ConstructorParameters<typeof HttpsProxyAgent>[0],
+    private readonly targetSSLOptions: AgentOptions
+  ) {
+    super(proxyOptions);
+  }
+
+  callback(
+    req: Parameters<HttpsProxyAgent['callback']>[0],
+    opts: Parameters<HttpsProxyAgent['callback']>[1]
+  ) {
+    // HttpsProxyAgent constructor options configure the proxy connection. Target TLS
+    // options must be merged into the CONNECT-upgraded request options instead.
+    return super.callback(req, { ...opts, ...this.targetSSLOptions });
+  }
+}
+
 export function getCustomAgents(opts: GetCustomAgentsOpts): GetCustomAgentsResponse {
   const {
     customHostSettings,
@@ -137,22 +155,26 @@ export function getCustomAgents(opts: GetCustomAgentsOpts): GetCustomAgentsRespo
   // We will though, copy over the calculated ssl options from above, into
   // the https agent.
   const httpAgent = new HttpProxyAgent(proxySettings.proxyUrl) as unknown as HttpAgent;
-  const httpsAgent = new HttpsProxyAgent({
-    host: proxyUrl.hostname,
-    port: Number(proxyUrl.port),
-    protocol: proxyUrl.protocol,
-    headers: proxySettings.proxyHeaders,
-    ...(proxyUrl.username &&
-      proxyUrl.password && { auth: `${proxyUrl.username}:${proxyUrl.password}` }),
-    // do not fail on invalid certs if value is false
-    ...proxyNodeSSLOptions,
-  }) as unknown as HttpsAgent;
+  const targetSSLOptions = agentOptions ?? agentSSLOptions;
+  const httpsAgent = new TargetSslHttpsProxyAgent(
+    {
+      host: proxyUrl.hostname,
+      port: Number(proxyUrl.port),
+      protocol: proxyUrl.protocol,
+      headers: proxySettings.proxyHeaders,
+      ...(proxyUrl.username &&
+        proxyUrl.password && { auth: `${proxyUrl.username}:${proxyUrl.password}` }),
+      // do not fail on invalid certs if value is false
+      ...proxyNodeSSLOptions,
+    },
+    targetSSLOptions
+  ) as unknown as HttpsAgent;
   // vsCode wasn't convinced HttpsProxyAgent is an https.Agent, so we convinced it
 
-  if (agentOptions) {
+  if (targetSSLOptions) {
     httpsAgent.options = {
       ...httpsAgent.options,
-      ...agentOptions,
+      ...targetSSLOptions,
     };
   }
 


### PR DESCRIPTION
## Summary
- For HTTPS requests through an HTTP proxy, forward target TLS options to the CONNECT-upgraded request created by `HttpsProxyAgent`.
- Ensures connector `verificationMode: none` and per-request SSL overrides like `fetcher.skip_ssl_verification` are honored when the proxy performs TLS inspection.
- Adds a regression test covering target SSL overrides through the proxy agent callback.

## Test plan
- `node scripts/jest src/platform/packages/shared/kbn-actions-utils/utils/get_custom_agents.test.ts`
- `node scripts/check_changes.ts`
- Manually reproduced with local mitmproxy before the fix and verified `_execute` succeeds after the fix.

## References
Closes elastic/security-team#17454
Closes https://github.com/elastic/kibana/issues/196602

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->