### PR TITLE
[Streams/Index Management] Move default snapshot repository modal

### DIFF
--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/README.md
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/README.md
@@ -45,6 +45,21 @@ const tabs = [
 | `size` | `number` | no | Flyout width in pixels (default: `400`) |
 | `children` | `(selectedTabId: TId) => ReactNode` | yes | Render prop receiving the active tab ID |
 
+### `DefaultSnapshotRepositoryRequiredModal`
+
+Modal shown when a user tries to add a frozen phase but no snapshot repositories are available. The primary action is a link to create a default repository in Snapshot and Restore (`target="_blank"`). Pass `createDefaultRepositoryUrl` from `application.getUrlForApp('management', { path: '/data/snapshot_restore/add_repository' })` (or equivalent). The split-button secondary action calls `onRefresh` to re-fetch repositories; keep `aria-label` on the icon action via the built-in i18n string.
+
+```typescript
+import { DefaultSnapshotRepositoryRequiredModal } from '@kbn/data-lifecycle-phases';
+
+<DefaultSnapshotRepositoryRequiredModal
+  createDefaultRepositoryUrl={url}
+  onCancel={close}
+  onRefresh={refetchRepositories}
+  isRefreshing={isLoading}
+/>
+```
+
 ### `InspectIlmPolicyFlyout`
 
 A stateless flyout for inspecting an ILM policy. Displays a **Summary** tab (per-phase accordions with action details) and a **JSON** tab (copyable `PUT _ilm/policy/…` request).

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/moon.yml
@@ -20,6 +20,7 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/storybook'
   - '@kbn/index-lifecycle-management-common-shared'
+  - '@kbn/test-jest-helpers'
 tags:
   - shared-common
   - package

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.stories.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.stories.tsx
@@ -12,7 +12,7 @@ import { DefaultSnapshotRepositoryRequiredModal } from './default_snapshot_repos
 
 const meta: Meta<typeof DefaultSnapshotRepositoryRequiredModal> = {
   component: DefaultSnapshotRepositoryRequiredModal,
-  title: 'streams/DefaultSnapshotRepositoryRequiredModal',
+  title: 'Data Lifecycle Phases / Default Snapshot Repository Required Modal',
   argTypes: {
     onCancel: { control: false },
     onRefresh: { control: false },

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import '@testing-library/jest-dom';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithI18n } from '@kbn/test-jest-helpers';
 import { DefaultSnapshotRepositoryRequiredModal } from './default_snapshot_repository_required_modal';

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.tsx
@@ -22,6 +22,8 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 
+const I18N_PREFIX = 'xpack.dataLifecyclePhases.defaultSnapshotRepositoryRequiredModal';
+
 export interface DefaultSnapshotRepositoryRequiredModalProps {
   onCancel: () => void;
   createDefaultRepositoryUrl: string;
@@ -44,7 +46,7 @@ export const DefaultSnapshotRepositoryRequiredModal = ({
     <EuiModal onClose={onCancel} aria-labelledby={titleId} maxWidth={euiTheme.breakpoint.s}>
       <EuiModalHeader>
         <EuiModalHeaderTitle id={titleId} data-test-subj={`${dataTestSubj}Title`}>
-          {i18n.translate('xpack.streams.defaultSnapshotRepositoryRequiredModal.title', {
+          {i18n.translate(`${I18N_PREFIX}.title`, {
             defaultMessage: 'Default snapshot repository required',
           })}
         </EuiModalHeaderTitle>
@@ -52,9 +54,9 @@ export const DefaultSnapshotRepositoryRequiredModal = ({
 
       <EuiModalBody>
         <EuiText>
-          {i18n.translate('xpack.streams.defaultSnapshotRepositoryRequiredModal.description', {
+          {i18n.translate(`${I18N_PREFIX}.description`, {
             defaultMessage:
-              'To add a frozen phase to a stream using a data stream lifecycle, first create a default snapshot repository, then refresh this panel.',
+              'To add a frozen phase, you need a default snapshot repository first. Create one in Snapshot and Restore, then refresh this panel.',
           })}
         </EuiText>
       </EuiModalBody>
@@ -67,7 +69,7 @@ export const DefaultSnapshotRepositoryRequiredModal = ({
               flush="left"
               onClick={onCancel}
             >
-              {i18n.translate('xpack.streams.defaultSnapshotRepositoryRequiredModal.cancel', {
+              {i18n.translate(`${I18N_PREFIX}.cancel`, {
                 defaultMessage: 'Cancel',
               })}
             </EuiButtonEmpty>
@@ -80,23 +82,17 @@ export const DefaultSnapshotRepositoryRequiredModal = ({
                 href={createDefaultRepositoryUrl}
                 target="_blank"
               >
-                {i18n.translate(
-                  'xpack.streams.defaultSnapshotRepositoryRequiredModal.createDefaultRepository',
-                  {
-                    defaultMessage: 'Create default repository',
-                  }
-                )}
+                {i18n.translate(`${I18N_PREFIX}.createDefaultRepository`, {
+                  defaultMessage: 'Create default repository',
+                })}
               </EuiSplitButton.ActionPrimary>
               <EuiSplitButton.ActionSecondary
                 iconType="refresh"
                 isLoading={Boolean(isRefreshing)}
                 disabled={Boolean(isRefreshing)}
-                aria-label={i18n.translate(
-                  'xpack.streams.defaultSnapshotRepositoryRequiredModal.refreshAriaLabel',
-                  {
-                    defaultMessage: 'Refresh snapshot repositories',
-                  }
-                )}
+                aria-label={i18n.translate(`${I18N_PREFIX}.refreshAriaLabel`, {
+                  defaultMessage: 'Refresh snapshot repositories',
+                })}
                 data-test-subj={`${dataTestSubj}RefreshButton`}
                 onClick={onRefresh}
               />

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/index.ts
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/src/default_snapshot_repository_required_modal/index.ts
@@ -5,7 +5,5 @@
  * 2.0.
  */
 
-export * from './src/phases';
-export * from './src/inspect_ilm_policy_flyout';
-export * from './src/flyout_with_tabs';
-export * from './src/default_snapshot_repository_required_modal';
+export { DefaultSnapshotRepositoryRequiredModal } from './default_snapshot_repository_required_modal';
+export type { DefaultSnapshotRepositoryRequiredModalProps } from './default_snapshot_repository_required_modal';

--- a/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-data-lifecycle-phases/tsconfig.json
@@ -20,6 +20,7 @@
   "kbn_references": [
     "@kbn/i18n",
     "@kbn/storybook",
-    "@kbn/index-lifecycle-management-common-shared"
+    "@kbn/index-lifecycle-management-common-shared",
+    "@kbn/test-jest-helpers"
   ]
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/README.md
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle/data_phases/README.md
@@ -4,12 +4,4 @@ This directory contains UI components used by the stream lifecycle data tiers fl
 
 Run `yarn storybook streams_app` from the Kibana root to preview these components locally.
 
-## `DefaultSnapshotRepositoryRequiredModal`
-
-`default_snapshot_repository_required_modal/default_snapshot_repository_required_modal.tsx` is shown when a user tries to add a frozen ILM phase but no snapshot repositories are available. Frozen phases require a snapshot repository, so the modal asks the user to create a default repository before refreshing the lifecycle panel.
-
-The create action is rendered as a filled `EuiSplitButton.ActionPrimary` link. The parent should provide `createDefaultRepositoryUrl` with `application.getUrlForApp('management', { path: '/data/snapshot_restore/add_repository' })`, and the modal opens it with `target="_blank"` so the user can create the repository in Snapshot and Restore without losing their current stream lifecycle context.
-
-The refresh action is the split button secondary icon action. It stays in the modal and calls `onRefresh`, which should re-fetch snapshot repositories and continue the frozen phase flow once a repository exists. Because this action is icon-only, it must keep an accessible `aria-label`.
-
-Use `EuiSplitButton` here instead of separate buttons so the create and refresh actions share the connected filled-button treatment from EUI. Avoid `EuiButtonGroup` for this case because it is intended for selection controls, not related actions.
+Shared lifecycle UI such as `DefaultSnapshotRepositoryRequiredModal` lives in `@kbn/data-lifecycle-phases` (see that package’s README and `yarn storybook data_lifecycle_phases`).


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/266048
## Summary
In https://github.com/elastic/kibana/pull/269701 I created the default snapshot repository modal component but I did it on Streams package. I realized that this will be also used on Index Management, so this PR moves it to `kbn-data-lifecycle-phases` package that is the right place for this shared components.

If you wanna test it in the new location, you can run `yarn storybook data_lifecycle_phases`