### PR TITLE
fix: APM Traces table horizontal scroll on narrow viewports

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/index.tsx
@@ -50,7 +50,7 @@ export function TopTracesOverview() {
         </EuiFlexItem>
       )}
 
-      <EuiFlexItem grow>
+      <EuiFlexItem grow style={{ minWidth: 0 }}>
         <TraceList response={response} />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/trace_overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/trace_overview/index.tsx
@@ -65,7 +65,9 @@ export function TraceOverview({
             contentProps: {
               style: {
                 display: 'flex',
+                flexDirection: 'column',
                 flexGrow: 1,
+                minInlineSize: 0,
               },
             },
           }}


### PR DESCRIPTION
## Summary

Follow-up to #264992 — that PR fixed horizontal-scroll clipping on **Service inventory** and **Service overview**, but **Traces** has an extra flex layer (`pageSectionProps.contentProps: { display: 'flex', flexGrow: 1 }` on its template) that no other APM page uses, so the same clipping bug still affected it.

- **`TraceOverview` template** (`trace_overview/index.tsx`): contentProps used `display: flex` with the default row direction. That made the inner `EuiFlexGroup direction="column"` a row-direction flex item with the default `min-width: auto`, so the wide table pushed it past the viewport and got clipped without a scrollbar. Switch to `flex-direction: column` and add `min-inline-size: 0` so the content can shrink and the table's own scroll container (EUI `scrollableInline` + the `ManagedTable` wrapper from #264992) takes over.
- **`TopTracesOverview`** (`top_traces_overview/index.tsx`): add `style={{ minWidth: 0 }}` to the `EuiFlexItem` wrapping `TraceList`, matching the pattern used for `ServiceInventory` / `ApmOverview` so wide tables don't expand the flex item beyond its parent.

## Before 

  https://github.com/user-attachments/assets/e40dba2a-fea2-45ce-8674-0e6a8b381c5f  

## After

 https://github.com/user-attachments/assets/dc68e1f2-d3d8-4146-a641-791112bf69d5  


## Testing

1. Open Observability → APM → **Traces**.
2. Ensure the table has data and all columns (Name, Originating service, Latency, Traces per minute, Impact, Actions) are present.
3. Reduce the browser width or narrow the main content area (e.g. open the sidebar).
4. Confirm:
   - The table shows a usable horizontal scrollbar.
   - All columns are reachable by scrolling horizontally inside the table region.
   - The page itself does not gain a horizontal scrollbar / no content is clipped at the right edge.

## References

Closes elastic/kibana#269668
Related to #264992

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->