### PR TITLE
[Dashboards in chat]Fix open dashboard panel flyouts inside canvas

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_util/src/get_lazy_flyout_container.test.ts
+++ b/src/platform/packages/shared/presentation/presentation_util/src/get_lazy_flyout_container.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getLazyFlyoutContainerFromParent } from './get_lazy_flyout_container';
+
+describe('getLazyFlyoutContainerFromParent', () => {
+  it('returns null when parentApi is undefined', () => {
+    expect(getLazyFlyoutContainerFromParent(undefined)).toBeNull();
+  });
+
+  it('returns the element from getLazyFlyoutContainer', () => {
+    const element = document.createElement('div');
+    expect(
+      getLazyFlyoutContainerFromParent({
+        getLazyFlyoutContainer: () => element,
+      })
+    ).toBe(element);
+  });
+
+  it('returns null when getLazyFlyoutContainer is missing', () => {
+    expect(getLazyFlyoutContainerFromParent({})).toBeNull();
+  });
+});

--- a/src/platform/packages/shared/presentation/presentation_util/src/get_lazy_flyout_container.ts
+++ b/src/platform/packages/shared/presentation/presentation_util/src/get_lazy_flyout_container.ts
@@ -7,9 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { openLazyFlyout } from './src/open_lazy_flyout';
-export {
-  getLazyFlyoutContainerFromParent,
-  type ProvidesLazyFlyoutContainer,
-} from './src/get_lazy_flyout_container';
-export { tracksOverlays, type TracksOverlays } from './src/tracks_overlays';
+export interface ProvidesLazyFlyoutContainer {
+  getLazyFlyoutContainer?: () => HTMLElement | null;
+}
+
+export const getLazyFlyoutContainerFromParent = (parentApi: unknown): HTMLElement | null => {
+  if (typeof parentApi !== 'object' || parentApi === null) {
+    return null;
+  }
+
+  return (parentApi as ProvidesLazyFlyoutContainer).getLazyFlyoutContainer?.() ?? null;
+};

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.test.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.test.tsx
@@ -59,6 +59,7 @@ describe('openLazyFlyout', () => {
         type: 'push',
       })
     );
+    expect(openFlyout.mock.calls[0][1]).not.toHaveProperty('container');
   });
 
   it('opens overlay flyout scoped to parent container when provided', () => {

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.test.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.test.tsx
@@ -23,8 +23,9 @@ const core = {
   application: {
     currentAppId$: { pipe: () => ({ subscribe: () => {} }) },
   },
+  notifications: { toasts: { addWarning: jest.fn() } },
 } as unknown as CoreStart;
-const loadContent = jest.fn(async () => <div>Test Content</div>);
+const loadContent = jest.fn(async () => <>Test Content</>);
 const props = {
   core,
   loadContent,
@@ -56,6 +57,25 @@ describe('openLazyFlyout', () => {
         ownFocus: true,
         paddingSize: 'm',
         type: 'push',
+      })
+    );
+  });
+
+  it('opens overlay flyout scoped to parent container when provided', () => {
+    const container = document.createElement('div');
+    const parentApi = {
+      getLazyFlyoutContainer: () => container,
+    };
+
+    openLazyFlyout({ core, parentApi, loadContent });
+
+    expect(openFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        container,
+        type: 'overlay',
+        ownFocus: false,
+        isResizable: false,
       })
     );
   });

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
@@ -14,6 +14,7 @@ import useAsync from 'react-use/lib/useAsync';
 import { i18n } from '@kbn/i18n';
 import { focusFirstFocusable } from './focus_helpers';
 import { LoadingFlyout } from './loading_flyout';
+import { getLazyFlyoutContainerFromParent } from './get_lazy_flyout_container';
 import { tracksOverlays } from './tracks_overlays';
 
 const htmlId = htmlIdGenerator('modalTitleId');
@@ -55,6 +56,7 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
 
   const ariaLabelledBy = flyoutProps?.['aria-labelledby'] ?? htmlId();
   const overlayTracker = tracksOverlays(parentApi) ? parentApi : undefined;
+  const lazyFlyoutContainer = getLazyFlyoutContainerFromParent(parentApi);
 
   const onClose = () => {
     overlayTracker?.clearOverlays();
@@ -64,30 +66,30 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
     }
   };
 
-  const flyoutRef = core.overlays.openFlyout(
-    toMountPoint(
-      <LazyFlyout
-        closeFlyout={onClose}
-        loadContent={loadContent}
-        core={core}
-        ariaLabelledBy={ariaLabelledBy}
-      />,
-      core
-    ),
-    {
-      size: 500,
-      type: 'push',
-      paddingSize: 'm',
-      maxWidth: 800,
-      ownFocus: true,
-      isResizable: true,
-      outsideClickCloses: true,
-      className: 'kbnPresentationLazyFlyout',
-      'aria-labelledby': ariaLabelledBy,
-      onClose,
-      ...flyoutProps,
-    }
+  const lazyFlyout = (
+    <LazyFlyout
+      closeFlyout={onClose}
+      loadContent={loadContent}
+      core={core}
+      ariaLabelledBy={ariaLabelledBy}
+    />
   );
+
+  const flyoutRef = core.overlays.openFlyout(toMountPoint(lazyFlyout, core), {
+    size: 500,
+    type: lazyFlyoutContainer ? 'overlay' : 'push',
+    paddingSize: lazyFlyoutContainer ? undefined : 'm',
+    maxWidth: 800,
+    ownFocus: !lazyFlyoutContainer,
+    isResizable: !lazyFlyoutContainer,
+    outsideClickCloses: true,
+    className: 'kbnPresentationLazyFlyout',
+    'aria-labelledby': ariaLabelledBy,
+    container: lazyFlyoutContainer ?? undefined,
+    onClose,
+    ...flyoutProps,
+  });
+
   overlayTracker?.openOverlay(flyoutRef, { focusedPanelId });
   return flyoutRef;
 };

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
@@ -85,8 +85,9 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
     outsideClickCloses: true,
     className: 'kbnPresentationLazyFlyout',
     'aria-labelledby': ariaLabelledBy,
-    container: lazyFlyoutContainer ?? undefined,
     onClose,
+    // Omit `container` when unset so Eui keeps its `#app-main-scroll` default for push flyouts.
+    ...(lazyFlyoutContainer ? { container: lazyFlyoutContainer } : {}),
     ...flyoutProps,
   });
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -203,6 +203,7 @@ export function getDashboardApi({
       };
     },
     isEmbeddedExternally: Boolean(creationOptions?.isEmbeddedExternally),
+    getLazyFlyoutContainer: creationOptions?.getLazyFlyoutContainer,
     isManaged,
     getSerializedState: () => ({
       attributes: getState(),

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
@@ -133,6 +133,12 @@ export interface DashboardCreationOptions {
   isEmbeddedExternally?: boolean;
 
   /**
+   * Returns the DOM element that nested lazy flyouts (e.g. panel settings) should use as
+   * their `container`, such as the Agent Builder canvas flyout body.
+   */
+  getLazyFlyoutContainer?: () => HTMLElement | null;
+
+  /**
    * Returns the embeddable app context for the dashboard.
    *
    * @param dashboardId - The optional dashboard ID.
@@ -192,6 +198,7 @@ export type DashboardApi = CanExpandPanels &
     highlightPanel: (panelRef: HTMLDivElement) => void;
     highlightPanelId$: PublishingSubject<string | undefined>;
     isEmbeddedExternally: boolean;
+    getLazyFlyoutContainer?: () => HTMLElement | null;
     isEditableByUser: boolean;
     isManaged: boolean;
     locator?: Pick<LocatorPublic<DashboardLocatorParams>, 'navigate' | 'getRedirectUrl'>;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -46,6 +46,11 @@ export interface CanvasRenderCallbacks {
   /** Close the canvas (expanded flyout view) */
   closeCanvas: () => void;
   /**
+   * Returns the DOM element that should contain nested flyouts (e.g. panel settings)
+   * opened while the canvas is visible.
+   */
+  getLazyFlyoutContainer?: () => HTMLElement | null;
+  /**
    * Optional callback for externally-controlled inline preview state.
    * Use to mark an attachment as currently previewed outside canvas.
    */

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -94,6 +94,9 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
     setDynamicButtons(buttons);
   }, []);
 
+  const lazyFlyoutContainerRef = useRef<HTMLDivElement>(null);
+  const getLazyFlyoutContainer = useCallback(() => lazyFlyoutContainerRef.current, []);
+
   const canvasHeaderActionButtons = useMemo(() => {
     if (!canvasState) {
       return dynamicButtons;
@@ -132,6 +135,13 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
     }
   `;
 
+  const lazyFlyoutContainerStyles = css`
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  `;
+
   return (
     <EuiFlyout
       onClose={closeCanvas}
@@ -153,20 +163,23 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
         previewBadgeState="preview_available"
       />
       <EuiFlyoutBody css={flyoutBodyStyles}>
-        <React.Fragment key={`${attachment.id}:${canvasState.version ?? 'latest'}`}>
-          {uiDefinition.renderCanvasContent(
-            {
-              attachment,
-              isSidebar,
-              openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
-            },
-            {
-              registerActionButtons,
-              updateOrigin,
-              closeCanvas,
-            }
-          )}
-        </React.Fragment>
+        <div ref={lazyFlyoutContainerRef} css={lazyFlyoutContainerStyles}>
+          <React.Fragment key={`${attachment.id}:${canvasState.version ?? 'latest'}`}>
+            {uiDefinition.renderCanvasContent(
+              {
+                attachment,
+                isSidebar,
+                openSidebarConversation: isSidebar ? undefined : openSidebarConversation,
+              },
+              {
+                registerActionButtons,
+                updateOrigin,
+                closeCanvas,
+                getLazyFlyoutContainer,
+              }
+            )}
+          </React.Fragment>
+        </div>
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_attachment.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_attachment.tsx
@@ -29,6 +29,7 @@ export type DashboardCanvasAttachmentProps = AttachmentRenderProps<DashboardAtta
   data: DataPublicPluginStart;
   checkSavedDashboardExist: (dashboardId: string) => Promise<boolean>;
   canWriteDashboards: boolean;
+  getLazyFlyoutContainer?: () => HTMLElement | null;
 };
 
 export const DashboardCanvasAttachment = (props: DashboardCanvasAttachmentProps) => {

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
@@ -58,11 +58,13 @@ export const DashboardCanvasContent = ({
   data,
   checkSavedDashboardExist,
   canWriteDashboards,
+  getLazyFlyoutContainer,
 }: AttachmentRenderProps<DashboardAttachment> & {
   dashboardState: DashboardState;
   registerActionButtons: (buttons: ActionButton[]) => void;
   updateOrigin: (origin: string) => Promise<unknown>;
   closeCanvas: () => void;
+  getLazyFlyoutContainer?: () => HTMLElement | null;
   dashboardLocator?: DashboardRendererProps['locator'];
   openSidebarConversation?: () => void;
   searchBarComponent: UnifiedSearchPublicPluginStart['ui']['SearchBar'];
@@ -115,8 +117,9 @@ export const DashboardCanvasContent = ({
     () =>
       Promise.resolve({
         getInitialInput: () => ({ ...dashboardState, viewMode: 'view' as const }),
+        getLazyFlyoutContainer,
       }),
-    [dashboardState]
+    [dashboardState, getLazyFlyoutContainer]
   );
 
   const dashboardLocatorParams = useMemo<DashboardLocatorParams>(


### PR DESCRIPTION
Resolves #266336

## Summary
- Pass a lazy flyout container from Agent Builder canvas into embedded dashboards.
- When `getLazyFlyoutContainer` is set, `openLazyFlyout` uses `type: overlay` and scopes the flyout to that element instead of pushing `#app-main-scroll`.
- Fixes chat width jumping when opening panel settings (e.g. customize panel) while canvas is open.

## Test plan
- [ ] Open Agent Builder conversation with dashboard attachment in canvas
- [ ] Open canvas flyout - chat should narrow once
- [ ] Click panel gear - customize panel flyout appears inside canvas
- [ ] Chat width stays unchanged when panel settings opens
- [ ] Regular dashboard (non-canvas) panel settings still work as before

The video below demonstrates the fix:


https://github.com/user-attachments/assets/05c0b2b8-2fc5-4885-a6c6-42d3552de67e



