### PR TITLE
fix(type-check): add --skip-emit flag to scripts/type_check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,12 @@ Always run `node scripts/check_changes.ts` to validate your changes
 Follow existing patterns in the target area first; below are common defaults.
 
 ### Type check
-`node scripts/type_check [--project path/to/tsconfig.json]`
+`node scripts/type_check [--project path/to/tsconfig.json] [--skip-emit]`
 - Without `--project` it checks **all** projects (very slow). Always scope to a single project:
   `node scripts/type_check --project src/core/packages/http/server-internal/tsconfig.json`
 - Only one `--project` per run. To check multiple packages, run separate commands.
+- Pass `--skip-emit` to avoid writing `.d.ts` files to `target/types/` (recommended for targeted checks to keep the working tree clean):
+  `node scripts/type_check --project src/core/packages/http/server-internal/tsconfig.json --skip-emit`
 - `.buildkite/` is **not** a valid target for `scripts/type_check`. Buildkite scripts live in a separate workspace; typecheck them with `npm run typecheck` (or `yarn typecheck`) from inside `.buildkite/`.
 
 ### TypeScript & Types

--- a/packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts
@@ -32,14 +32,17 @@ export const runLegacyTypeCheckCli = () => {
     async ({ log, flagsReader, procRunner }) => {
       const { TS_PROJECTS } = await import('@kbn/ts-projects');
       const shouldCleanCache = flagsReader.boolean('clean-cache');
+      const noEmit = flagsReader.boolean('skip-emit');
       const withArchive = flagsReader.boolean('with-archive');
-      const shouldRestoreArchive = withArchive || flagsReader.boolean('restore-archive');
-      const shouldUploadArchive = withArchive || flagsReader.boolean('upload-archive');
+      const shouldRestoreArchive = !noEmit && (withArchive || flagsReader.boolean('restore-archive'));
+      const shouldUploadArchive = !noEmit && (withArchive || flagsReader.boolean('upload-archive'));
 
       if (shouldCleanCache) {
         await cleanTypeCheckCaches(log, TS_PROJECTS);
         return;
       }
+
+      const projectFilter = normalizeProjectPath(flagsReader.path('project'), log);
 
       const { updateRootRefsConfig, cleanupRootRefsConfig, ROOT_REFS_CONFIG_PATH } = await import(
         './root_refs_config'
@@ -57,7 +60,6 @@ export const runLegacyTypeCheckCli = () => {
         );
       }
 
-      const projectFilter = normalizeProjectPath(flagsReader.path('project'), log);
       const projects = TS_PROJECTS.filter(
         (project) =>
           !project.isTypeCheckDisabled() && (!projectFilter || project.path === projectFilter)
@@ -81,6 +83,7 @@ export const runLegacyTypeCheckCli = () => {
             '-b',
             buildTarget,
             '--pretty',
+            ...(noEmit ? ['--noEmit'] : []),
             ...(flagsReader.boolean('verbose') ? ['--verbose'] : []),
             ...(flagsReader.boolean('extended-diagnostics') ? ['--extendedDiagnostics'] : []),
           ],
@@ -148,6 +151,7 @@ export const runLegacyTypeCheckCli = () => {
           'clean-cache',
           'cleanup',
           'extended-diagnostics',
+          'skip-emit',
           'with-archive',
           'restore-archive',
           'upload-archive',
@@ -161,6 +165,10 @@ export const runLegacyTypeCheckCli = () => {
                                   identify that none of the imports have changed (it uses creation/update
                                   times) but cleaning them prevents leaving garbage around the repo.
         --extended-diagnostics  Turn on extended diagnostics in the TypeScript compiler
+        --skip-emit             Run tsc in --noEmit mode: type-checks without writing any .d.ts or
+                                  .tsbuildinfo files. Recommended for targeted single-project checks
+                                  (avoids polluting target/types/ across the dependency tree).
+                                  Implies skipping --restore-archive and --upload-archive.
         --restore-archive       Restore cached artifacts from GCS before running tsc
         --upload-archive        Upload resulting artifacts to GCS after a successful tsc run
         --with-archive          Shorthand for \`--restore-archive --upload-archive\`


### PR DESCRIPTION
## Summary

Addresses feedback from [@tylersmalley](https://github.com/tylersmalley) on [#269739](https://github.com/elastic/kibana/pull/269739): fix \`scripts/type_check\` rather than documenting workarounds.

\`tsc -b\` always emits \`.d.ts\` files to \`target/types/\` throughout the dependency tree, even for targeted single-project checks via \`--project\`. This pollutes the working tree with untracked files.

### Changes

**\`packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts\`**: add \`--skip-emit\` boolean flag that passes \`--noEmit\` to the underlying \`tsc -b\` call. TypeScript has supported \`tsc --build --noEmit\` since 4.x: it resolves all project references and type-checks the full composite graph without writing \`.d.ts\` or \`.tsbuildinfo\` files. Archive restore/upload is skipped automatically when the flag is set.

The flag is named \`--skip-emit\` rather than \`--no-emit\` because \`getopts\` (used by \`@kbn/dev-cli-runner\`) treats \`--no-<flag>\` as a negation operator — \`--no-emit\` would be parsed as negating a flag named \`emit\` rather than as a standalone flag.

**\`AGENTS.md\`**: add a single concise bullet documenting the flag and recommending it for targeted checks.

### Usage

```bash
# type-check a single package without emitting any files
node scripts/type_check --project packages/kbn-pm/tsconfig.json --skip-emit
```

## Test plan

- Run \`node scripts/type_check --help\` and verify \`--skip-emit\` appears in the output.
- Run \`node scripts/type_check --project <some-package>/tsconfig.json --skip-emit\` and verify:
  - Type errors are reported correctly.
  - No \`.d.ts\` files are written to \`target/types/\`.
  - \`git status\` shows no new untracked files after the run.