### PR TITLE
[One workflow] fix: validate empty workflow execute ids

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/workflow_execute_step_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/workflow_execute_step_impl.test.ts
@@ -167,6 +167,42 @@ describe('WorkflowExecuteStepImpl', () => {
       });
     });
 
+    it.each([
+      { name: 'empty string', renderedWorkflowId: '' },
+      { name: 'undefined', renderedWorkflowId: undefined },
+    ])(
+      'should fail before lookup when rendered workflow-id is $name',
+      async ({ renderedWorkflowId }) => {
+        const init = createMockInit();
+        const ctx = (init.stepExecutionRuntime as any).contextManager;
+        ctx.renderValueAccordingToContext.mockReturnValue({
+          'workflow-id': renderedWorkflowId,
+          inputs: { rendered: true },
+        });
+
+        const step = new WorkflowExecuteStepImpl(init);
+        await step.run();
+
+        const repo = init.workflowRepository as jest.Mocked<WorkflowRepository>;
+        const stepRuntime = init.stepExecutionRuntime as jest.Mocked<StepExecutionRuntime>;
+        expect(stepRuntime.setInput).toHaveBeenCalledWith({
+          'workflow-id': '',
+          inputs: { rendered: true },
+        });
+        expect(repo.getWorkflow).not.toHaveBeenCalled();
+        expect(stepRuntime.failStep).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message:
+              'workflow.execute step "execute-step-1" in workflow "parent-workflow-id" rendered an empty workflow-id.',
+          })
+        );
+        expect(
+          (init.workflowExecutionRuntime as jest.Mocked<WorkflowExecutionRuntimeManager>)
+            .navigateToNextNode
+        ).toHaveBeenCalled();
+      }
+    );
+
     it('should fail when depth limit is exceeded', async () => {
       const init = createMockInit();
       (init.stepExecutionRuntime as any).workflowExecution.context = {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/workflow_execute_step_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/workflow_execute_step_impl.ts
@@ -78,7 +78,18 @@ export class WorkflowExecuteStepImpl implements NodeImplementation, CancellableN
     const { 'workflow-id': workflowId, inputs = {} } = renderedWith;
     const mappedInputs =
       typeof inputs === 'object' && inputs !== null ? (inputs as Record<string, unknown>) : {};
-    return { workflowId: String(workflowId), inputs: mappedInputs };
+    return { workflowId: String(workflowId ?? ''), inputs: mappedInputs };
+  }
+
+  private assertValidWorkflowId(workflowId: string): void {
+    if (workflowId.trim().length > 0) {
+      return;
+    }
+
+    const { node, stepExecutionRuntime } = this.init;
+    throw new Error(
+      `${node.type} step "${node.stepId}" in workflow "${stepExecutionRuntime.workflowExecution.workflowId}" rendered an empty workflow-id.`
+    );
   }
 
   /**
@@ -125,6 +136,8 @@ export class WorkflowExecuteStepImpl implements NodeImplementation, CancellableN
     const executor = node.type === 'workflow.execute' ? this.syncExecutor : this.asyncExecutor;
 
     try {
+      this.assertValidWorkflowId(workflowId);
+
       const rawDepth = stepExecutionRuntime.workflowExecution.context?.parentDepth;
       const currentDepth = (typeof rawDepth === 'number' ? rawDepth : -1) + 1;
       const maxWorkflowDepth = this.init.config.maxWorkflowDepth;


### PR DESCRIPTION
## Summary
- Validates the rendered `workflow-id` for `workflow.execute` / `workflow.executeAsync` before calling `WorkflowRepository.getWorkflow()`.
- Converts empty or missing rendered IDs into a clear workflow-step failure instead of surfacing Elasticsearch's low-level `Ids can't be empty` error.
- Adds unit coverage for empty string and `undefined` rendered workflow IDs to verify lookup is skipped and the step fails cleanly.

## Issue
Closes elastic/security-team#17474

## Context
Overview reported a `plugins.workflowsExecutionEngine` error for project `a295dc487bc4417891ec28df36b018c9` where the log message was:

```text
Failed to get workflow : ResponseError: search_phase_execution_exception
  Root causes:
    query_shard_exception: failed to create query: Ids can't be empty
```

The blank workflow ID indicates a composed workflow step rendered its `workflow-id` to an empty value. This PR keeps the failure at the workflow execution layer and makes the error actionable with the step ID and parent workflow ID.

## Screenshots
**Before**
<img width="1270" height="851" alt="Image" src="https://github.com/user-attachments/assets/73851dc1-0ed0-493b-aef0-b57f193ab322" />

**After**
<img width="1270" height="851" alt="Screenshot 2026-05-19 at 16 44 21" src="https://github.com/user-attachments/assets/7e294268-8da9-4256-a4d5-7363e81be5df" />

## Customer impact
No impact beyond the non-informative error message for the failed execution. The engine catches the exception, records the step/workflow execution failure, and continues worker processing for other executions.

## Test plan
- `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/workflow_execute_step_impl.test.ts`
- `node scripts/check_changes.ts`