### PR TITLE
fix stray .d.ts files from type_check in git worktrees

### DIFF
--- a/packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts
@@ -63,6 +63,10 @@ export const runLegacyTypeCheckCli = () => {
           !project.isTypeCheckDisabled() && (!projectFilter || project.path === projectFilter)
       );
 
+      if (projectFilter && projects.length === 0) {
+        throw createFailError(`Could not find a TypeScript project at '${projectFilter}'.`);
+      }
+
       const createdConfigs = await createTypeCheckConfigs(log, projects, TS_PROJECTS);
       let tscFailed = false;
       try {

--- a/src/platform/packages/shared/kbn-repo-info/index.js
+++ b/src/platform/packages/shared/kbn-repo-info/index.js
@@ -31,11 +31,11 @@ const readKibanaPkgJson = (path) => {
   }
 };
 
-const findKibanaPackageJson = () => {
-  // search for the kibana directory, since this file is moved around it might
-  // not be where we think but should always be a relatively close parent
-  // of this directory
-  const startDir = __dirname;
+/**
+ * @param {string} startDir
+ * @returns {{ kibanaDir: string, kibanaPkgJson: KibanaPackageJson } | undefined}
+ */
+const searchForKibanaPackageJson = (startDir) => {
   const { root: rootDir } = Path.parse(startDir);
   let cursor = startDir;
   while (true) {
@@ -53,10 +53,29 @@ const findKibanaPackageJson = () => {
 
     const parent = Path.dirname(cursor);
     if (parent === rootDir) {
-      throw new Error(`unable to find kibana directory from ${startDir}`);
+      return undefined;
     }
     cursor = parent;
   }
+};
+
+const findKibanaPackageJson = () => {
+  // In a git worktree, node_modules are shared with the primary worktree, so __dirname
+  // always resolves into the primary worktree's tree. Check process.cwd() first: if it
+  // is inside a *different* kibana root, prefer that root so REPO_ROOT matches the active
+  // working tree rather than the primary checkout.
+  const cwdResult = searchForKibanaPackageJson(process.cwd());
+  const dirnameResult = searchForKibanaPackageJson(__dirname);
+
+  if (!dirnameResult) {
+    throw new Error(`unable to find kibana directory from ${__dirname}`);
+  }
+
+  if (cwdResult && cwdResult.kibanaDir !== dirnameResult.kibanaDir) {
+    return cwdResult;
+  }
+
+  return dirnameResult;
 };
 
 const { kibanaDir, kibanaPkgJson } = findKibanaPackageJson();


### PR DESCRIPTION
Worktrees share `node_modules `with the primary checkout, so `@kbn/repo-info` always resolved `REPO_ROOT` to the primary tree. This caused tsc to emit target/types artifacts there instead of the active worktree.

Fix: prefer `process.cwd()` when it resolves to a different kibana root than `__dirname`. Also throw a clear error when `--project` matches no known project rather than silently falling back to checking every project.

Closes #269739

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->