### PR TITLE
[9.3] Fix content connector redirects to be basePath and space-aware (#269571)

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/moon.yml
+++ b/x-pack/platform/plugins/shared/content_connectors/moon.yml
@@ -60,6 +60,7 @@ dependsOn:
   - '@kbn/core-http-browser-mocks'
   - '@kbn/home-plugin'
   - '@kbn/logging'
+  - '@kbn/deeplinks-management'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/content_connectors/public/api/connector/add_connector_api_logic.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/api/connector/add_connector_api_logic.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { HttpSetup, NavigateToUrlOptions } from '@kbn/core/public';
+import type { HttpSetup } from '@kbn/core/public';
 import type { Actions } from '../api_logic/create_api_logic';
 import { createApiLogic } from '../api_logic/create_api_logic';
 
@@ -33,7 +33,6 @@ export interface AddConnectorApiLogicResponse {
   id: string;
   indexName: string;
   uiFlags?: Record<string, boolean>;
-  navigateToUrl?: (url: string, options?: NavigateToUrlOptions) => Promise<void>;
 }
 
 export const addConnector = async ({

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/generated_config_fields.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/components/generated_config_fields.tsx
@@ -26,6 +26,7 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { Connector } from '@kbn/search-connectors';
 
 import type { ApiKey } from '../../../api/connector/generate_connector_api_key_api_logic';
@@ -93,6 +94,9 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
   generateApiKey,
   isGenerateLoading,
 }) => {
+  const {
+    services: { http },
+  } = useKibana();
   const generateButtonRef = useRef<HTMLButtonElement>(null);
   const refreshButtonRef = useRef<HTMLButtonElement>(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -236,7 +240,7 @@ export const GeneratedConfigFields: React.FC<GeneratedConfigFieldsProps> = ({
               <EuiFlexItem grow={false}>
                 <EuiLink
                   data-test-subj="enterpriseSearchConnectorDeploymentLink"
-                  href={generateEncodedPath(MANAGE_API_KEYS_URL, {})}
+                  href={http?.basePath.prepend(MANAGE_API_KEYS_URL)}
                   external
                   target="_blank"
                 >

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_detail.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connector_detail/connector_detail.tsx
@@ -15,6 +15,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { EuiTabProps } from '@elastic/eui';
 import { EuiButton, EuiPageTemplate } from '@elastic/eui';
 import type { ChromeBreadcrumb } from '@kbn/core/public';
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import { CONNECTOR_DETAIL_TAB_PATH } from '../routes';
 import { ConnectorScheduling } from '../search_index/connector/connector_scheduling';
 import { ConnectorSyncRules } from '../search_index/connector/sync_rules/connector_rules';
@@ -88,15 +89,12 @@ export const ConnectorDetail: React.FC = () => {
         defaultMessage: 'Overview',
       }),
       onClick: () => {
-        application?.navigateToUrl(
-          `${generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.OVERVIEW,
-            }
-          )}`
-        );
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.OVERVIEW,
+          })}`,
+        });
       },
     },
     {
@@ -111,15 +109,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () => {
-        application?.navigateToUrl(
-          `${generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.DOCUMENTS,
-            }
-          )}`
-        );
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.DOCUMENTS,
+          })}`,
+        });
       },
     },
     {
@@ -134,15 +129,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () =>
-        application?.navigateToUrl(
-          generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.INDEX_MAPPINGS,
-            }
-          )
-        ),
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.INDEX_MAPPINGS,
+          })}`,
+        }),
     },
   ];
 
@@ -159,15 +151,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () =>
-        application?.navigateToUrl(
-          generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.SYNC_RULES,
-            }
-          )
-        ),
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.SYNC_RULES,
+          })}`,
+        }),
     },
 
     {
@@ -182,15 +171,12 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () =>
-        application?.navigateToUrl(
-          generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.SCHEDULING,
-            }
-          )
-        ),
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.SCHEDULING,
+          })}`,
+        }),
     },
   ];
 
@@ -206,37 +192,14 @@ export const ConnectorDetail: React.FC = () => {
         }
       ),
       onClick: () =>
-        application?.navigateToUrl(
-          generateEncodedPath(
-            `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId,
-              tabId: ConnectorDetailTabId.CONFIGURATION,
-            }
-          )
-        ),
+        application?.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId,
+            tabId: ConnectorDetailTabId.CONFIGURATION,
+          })}`,
+        }),
     },
   ];
-
-  /* const PIPELINES_TAB = {
-    content: <SearchIndexPipelines />,
-    disabled: !index,
-    id: ConnectorDetailTabId.PIPELINES,
-    isSelected: tabId === ConnectorDetailTabId.PIPELINES,
-    label: i18n.translate(
-      'xpack.contentConnectors.connectors.connectorDetail.pipelinesTabLabel',
-      {
-        defaultMessage: 'Pipelines',
-      }
-    ),
-    onClick: () =>
-      application?.navigateToUrl(
-        generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
-          connectorId,
-          tabId: ConnectorDetailTabId.PIPELINES,
-        })
-      ),
-  }; */
 
   interface TabMenuItem {
     content: JSX.Element;
@@ -249,12 +212,7 @@ export const ConnectorDetail: React.FC = () => {
     testSubj?: string;
   }
 
-  const tabs: TabMenuItem[] = [
-    ...ALL_INDICES_TABS,
-    ...CONNECTOR_TABS,
-    // ...[PIPELINES_TAB],
-    ...CONFIG_TAB,
-  ];
+  const tabs: TabMenuItem[] = [...ALL_INDICES_TABS, ...CONNECTOR_TABS, ...CONFIG_TAB];
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const selectedTab = useMemo(() => tabs.find((tab) => tab.id === tabId), [tabId]);

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connectors_table.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/connectors_table.tsx
@@ -14,6 +14,7 @@ import { i18n } from '@kbn/i18n';
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { Meta } from '@kbn/search-connectors';
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import { CONNECTOR_DETAIL_PATH, SEARCH_INDEX_PATH } from '../routes';
 import {
   connectorStatusToColor,
@@ -179,24 +180,18 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
             if (isCrawler) {
               // crawler always has an index this is to satisfy TS
               if (connector.index_name) {
-                application?.navigateToUrl(
-                  generateEncodedPath(
-                    `/app/management/data/content_connectors${SEARCH_INDEX_PATH}`,
-                    {
-                      indexName: connector.index_name,
-                    }
-                  )
-                );
+                application?.navigateToApp(MANAGEMENT_APP_ID, {
+                  path: `/data/content_connectors${generateEncodedPath(SEARCH_INDEX_PATH, {
+                    indexName: connector.index_name,
+                  })}`,
+                });
               }
             } else {
-              application?.navigateToUrl(
-                generateEncodedPath(
-                  `/app/management/data/content_connectors${CONNECTOR_DETAIL_PATH}`,
-                  {
-                    connectorId: connector.id,
-                  }
-                )
-              );
+              application?.navigateToApp(MANAGEMENT_APP_ID, {
+                path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_PATH, {
+                  connectorId: connector.id,
+                })}`,
+              });
             }
           },
           type: 'icon',

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/choose_connector.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/choose_connector.tsx
@@ -94,10 +94,10 @@ export const ChooseConnector: React.FC<ChooseConnectorSelectableProps> = ({
     [connectorTypes]
   );
   const { selectedConnector } = useValues(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { setSelectedConnector } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
 
   const getInitialOptions = () => {

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration.tsx
@@ -66,7 +66,7 @@ export const ManualConfiguration: React.FC<ManualConfigurationProps> = ({
     setPopover(false);
   };
   const { selectedConnector, rawName } = useValues(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [flyoutContent, setFlyoutContent] = useState<'manual_config' | 'client'>();

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/components/manual_configuration_flyout.tsx
@@ -72,10 +72,10 @@ export const ManualConfigurationFlyout: React.FC<ManualConfigurationFlyoutProps>
   } = useKibana();
 
   const { connectorName } = useValues(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { setRawName, createConnector } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { euiTheme } = useEuiTheme();
   return (

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/configuration_step.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/configuration_step.tsx
@@ -49,7 +49,7 @@ export const ConfigurationStep: React.FC<ConfigurationStepProps> = ({
   const { connector, isWaitingOnAgentlessDeployment } = useValues(ConnectorViewLogic({ http }));
   const { updateConnectorConfiguration } = useActions(ConnectorViewLogic({ http }));
   const { setFormDirty } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const [isFormEditing, setIsFormEditing] = useState<boolean>(false);
   const { status } = useValues(ConnectorConfigurationApiLogic);

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/create_connector.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/create_connector.tsx
@@ -86,10 +86,10 @@ const CreateConnector: React.FC = () => {
   useBreadcrumbs(createConnectorBreadcrumbs, appParams, chrome);
 
   const { selectedConnector, currentStep, isFormDirty, connectorId } = useValues(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { setCurrentStep } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const stepStates = generateStepState(currentStep);
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/finish_up_step.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/finish_up_step.tsx
@@ -30,6 +30,8 @@ import { i18n } from '@kbn/i18n';
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
+
 import { DEV_TOOLS_CONSOLE_PATH, CONNECTOR_DETAIL_TAB_PATH } from '../../routes';
 
 import { ConnectorDetailTabId } from '../../connector_detail/connector_detail';
@@ -188,15 +190,15 @@ export const FinishUpStep: React.FC<FinishUpStepProps> = ({ title }) => {
                             fill
                             onClick={() => {
                               if (connector) {
-                                application?.navigateToUrl(
-                                  generateEncodedPath(
-                                    `/app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
+                                application?.navigateToApp(MANAGEMENT_APP_ID, {
+                                  path: `/data/content_connectors${generateEncodedPath(
+                                    CONNECTOR_DETAIL_TAB_PATH,
                                     {
                                       connectorId: connector.id,
                                       tabId: ConnectorDetailTabId.CONFIGURATION,
                                     }
-                                  )
-                                );
+                                  )}`,
+                                });
                               }
                             }}
                           >

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/create_connector/start_step.tsx
@@ -73,9 +73,9 @@ const StartStep: React.FC<StartStepProps> = ({
     isGenerateLoading,
     isCreateLoading,
     isFormDirty,
-  } = useValues(NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl }));
+  } = useValues(NewConnectorLogic({ http, navigateToApp: application?.navigateToApp }));
   const { setRawName, createConnector, generateConnectorName, setFormDirty } = useActions(
-    NewConnectorLogic({ http, navigateToUrl: application?.navigateToUrl })
+    NewConnectorLogic({ http, navigateToApp: application?.navigateToApp })
   );
   const { connector } = useValues(ConnectorViewLogic({ http }));
 

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/connectors/elastic_managed_web_crawler_empty_prompt.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { DecorativeHorizontalStepper } from '@kbn/search-connectors';
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import { CRAWLERS_PATH } from '../routes';
 import { BACK_BUTTON_LABEL, COMING_SOON_LABEL } from './translations';
 import { SearchEmptyPrompt } from '../search_empty_prompt';
@@ -23,7 +24,10 @@ export const ElasticManagedWebCrawlerEmptyPrompt: React.FC = () => {
     <SearchEmptyPrompt
       backButton={{
         label: BACK_BUTTON_LABEL,
-        onClickBack: () => application?.navigateToUrl(CRAWLERS_PATH),
+        onClickBack: () =>
+          application?.navigateToApp(MANAGEMENT_APP_ID, {
+            path: `/data/content_connectors${CRAWLERS_PATH}`,
+          }),
       }}
       icon="web"
       title={i18n.translate('xpack.contentConnectors.elasticManagedWebCrawlerEmpty.title', {

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/new_index/method_connector/new_connector_logic.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/new_index/method_connector/new_connector_logic.ts
@@ -10,7 +10,8 @@ import { kea } from 'kea';
 
 import type { Connector, ConnectorDefinition } from '@kbn/search-connectors';
 
-import type { HttpSetup, NavigateToUrlOptions } from '@kbn/core/public';
+import type { ApplicationStart, HttpSetup } from '@kbn/core/public';
+import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 import type {
   AddConnectorApiLogicActions,
   AddConnectorApiLogicArgs,
@@ -91,7 +92,7 @@ type NewConnectorActions = {
 
 export interface NewConnectorLogicProps {
   http?: HttpSetup;
-  navigateToUrl?: (url: string, options?: NavigateToUrlOptions) => Promise<void>;
+  navigateToApp?: ApplicationStart['navigateToApp'];
 }
 
 export const NewConnectorLogic = kea<
@@ -99,7 +100,7 @@ export const NewConnectorLogic = kea<
 >({
   key: (props) => ({
     http: props.http,
-    navigateToUrl: props.navigateToUrl,
+    navigateToApp: props.navigateToApp,
   }),
   actions: {
     createConnector: ({
@@ -139,16 +140,13 @@ export const NewConnectorLogic = kea<
   },
   listeners: ({ actions, values, props }) => ({
     connectorCreated: ({ id, uiFlags }) => {
-      if (uiFlags?.shouldNavigateToConnectorAfterCreate && props.navigateToUrl) {
-        props.navigateToUrl(
-          generateEncodedPath(
-            `app/management/data/content_connectors${CONNECTOR_DETAIL_TAB_PATH}`,
-            {
-              connectorId: id,
-              tabId: SearchIndexTabId.CONFIGURATION,
-            }
-          )
-        );
+      if (uiFlags?.shouldNavigateToConnectorAfterCreate && props.navigateToApp) {
+        props.navigateToApp(MANAGEMENT_APP_ID, {
+          path: `/data/content_connectors${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+            connectorId: id,
+            tabId: SearchIndexTabId.CONFIGURATION,
+          })}`,
+        });
       } else {
         actions.fetchConnector({ connectorId: id, http: props.http });
         if (!uiFlags || uiFlags.shouldGenerateAfterCreate) {

--- a/x-pack/platform/plugins/shared/content_connectors/tsconfig.json
+++ b/x-pack/platform/plugins/shared/content_connectors/tsconfig.json
@@ -57,6 +57,7 @@
     "@kbn/spaces-plugin",
     "@kbn/core-http-browser-mocks",
     "@kbn/home-plugin",
-    "@kbn/logging"
+    "@kbn/logging",
+    "@kbn/deeplinks-management"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix content connector redirects to be basePath and space-aware (#269571)](https://github.com/elastic/kibana/pull/269571)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dennis Tismenko","email":"dennis.tismenko@elastic.co"},"sourceCommit":{"committedDate":"2026-05-15T20:41:44Z","message":"Fix content connector redirects to be basePath and space-aware (#269571)\n\n## Summary\n\nFixes client-side navigation within the content connectors UI to handle\n`server.basePath` and Kibana space prefixes, resolving 404s on the\nconnector detail tabs and the post-creation \"Manage connector\" button.\nCalls to `application.navigateToUrl` with hardcoded absolute paths (e.g.\n`/app/management/data/content_connectors/...`) bypassed both prefixes\nand triggered a redirect to a route Kibana could not resolve. Changes\ninclude:\n\n- Replaced `navigateToUrl(absolutePath)` in `connector_detail.tsx`,\n`finish_up_step.tsx`, and `new_connector_logic.ts` with\n`navigateToApp(MANAGEMENT_APP_ID, { path })`, which composes the\nbasePath and space prefix via `ScopedHistory`.\n- Renamed the `navigateToUrl` prop on `NewConnectorLogic` to\n`navigateToApp` and updated the callers.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nFixes client-side navigation within the content connectors UI to honor\n`server.basePath` and Kibana space prefixes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"78cbc91f54f4ba5b11204c4b6a05521f418c0fff","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.5.0","v9.3.5","v9.4.2"],"title":"Fix content connector redirects to be basePath and space-aware","number":269571,"url":"https://github.com/elastic/kibana/pull/269571","mergeCommit":{"message":"Fix content connector redirects to be basePath and space-aware (#269571)\n\n## Summary\n\nFixes client-side navigation within the content connectors UI to handle\n`server.basePath` and Kibana space prefixes, resolving 404s on the\nconnector detail tabs and the post-creation \"Manage connector\" button.\nCalls to `application.navigateToUrl` with hardcoded absolute paths (e.g.\n`/app/management/data/content_connectors/...`) bypassed both prefixes\nand triggered a redirect to a route Kibana could not resolve. Changes\ninclude:\n\n- Replaced `navigateToUrl(absolutePath)` in `connector_detail.tsx`,\n`finish_up_step.tsx`, and `new_connector_logic.ts` with\n`navigateToApp(MANAGEMENT_APP_ID, { path })`, which composes the\nbasePath and space prefix via `ScopedHistory`.\n- Renamed the `navigateToUrl` prop on `NewConnectorLogic` to\n`navigateToApp` and updated the callers.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nFixes client-side navigation within the content connectors UI to honor\n`server.basePath` and Kibana space prefixes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"78cbc91f54f4ba5b11204c4b6a05521f418c0fff"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269571","number":269571,"mergeCommit":{"message":"Fix content connector redirects to be basePath and space-aware (#269571)\n\n## Summary\n\nFixes client-side navigation within the content connectors UI to handle\n`server.basePath` and Kibana space prefixes, resolving 404s on the\nconnector detail tabs and the post-creation \"Manage connector\" button.\nCalls to `application.navigateToUrl` with hardcoded absolute paths (e.g.\n`/app/management/data/content_connectors/...`) bypassed both prefixes\nand triggered a redirect to a route Kibana could not resolve. Changes\ninclude:\n\n- Replaced `navigateToUrl(absolutePath)` in `connector_detail.tsx`,\n`finish_up_step.tsx`, and `new_connector_logic.ts` with\n`navigateToApp(MANAGEMENT_APP_ID, { path })`, which composes the\nbasePath and space prefix via `ScopedHistory`.\n- Renamed the `navigateToUrl` prop on `NewConnectorLogic` to\n`navigateToApp` and updated the callers.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\nFixes client-side navigation within the content connectors UI to honor\n`server.basePath` and Kibana space prefixes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"78cbc91f54f4ba5b11204c4b6a05521f418c0fff"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/269585","number":269585,"state":"MERGED","mergeCommit":{"sha":"6ddd55bad71baeab7e721915e24292fef3d615cb","message":"[9.4] Fix content connector redirects to be basePath and space-aware (#269571) (#269585)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Fix content connector redirects to be basePath and space-aware\n(#269571)](https://github.com/elastic/kibana/pull/269571)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dennis Tismenko <dennis.tismenko@elastic.co>"}}]}] BACKPORT-->