### PR TITLE
[ES|QL] Highlighting PoC

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/src/types.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/types.ts
@@ -53,13 +53,12 @@ export interface DataTableRecord {
 /**
  * Custom column types per column name
  */
-export type DataTableColumnsMeta = Record<
-  string,
-  {
-    type: DatatableColumnMeta['type'];
-    esType?: DatatableColumnMeta['esType'];
-  }
->;
+export interface DataTableColumnMeta {
+  type: DatatableColumnMeta['type'];
+  esType?: DatatableColumnMeta['esType'];
+  hasHighlights?: DatatableColumnMeta['hasHighlights'];
+}
+export type DataTableColumnsMeta = Record<string, DataTableColumnMeta>;
 
 import type { ReactNode } from 'react';
 

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/format_hit.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/format_hit.ts
@@ -63,6 +63,8 @@ export function formatHitReact(
   const renderedPairs: PartialHitReactPair[] = [];
   const otherPairs: PartialHitReactPair[] = [];
 
+  // HD TODO: contemplate ES|QL highlights when ordering.
+
   // Add each flattened field into the corresponding array for rendered or other pairs,
   // depending on whether the original hit had a highlight for it. That way we can ensure
   // highlighted fields are shown first in the document summary.
@@ -114,13 +116,13 @@ export function formatHitReact(
       fieldName: key,
       columnMeta: columnsMeta?.[key],
     });
-
     pair[1] = formatFieldValueReact({
       value: flattened[key],
       hit: hit.raw,
       fieldFormats,
       dataView,
       field,
+      columnMeta: columnsMeta?.[key],
     });
   }
 

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/format_value.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/format_value.ts
@@ -16,7 +16,7 @@ import type {
   ReactContextTypeOptions,
   TextContextTypeOptions,
 } from '@kbn/field-formats-plugin/common/types';
-import type { EsHitRecord } from '../types';
+import type { DataTableColumnMeta, EsHitRecord } from '../types';
 
 /** Base parameters for field value formatting functions */
 interface FormatFieldValueBaseParams {
@@ -28,6 +28,7 @@ interface FormatFieldValueBaseParams {
 
 export interface FormatFieldValueReactParams extends FormatFieldValueBaseParams {
   hit: EsHitRecord;
+  columnMeta?: DataTableColumnMeta;
   options?: ReactContextTypeOptions;
 }
 
@@ -61,9 +62,15 @@ export const formatFieldValueReact = ({
   fieldFormats,
   dataView,
   field,
+  columnMeta,
   options,
 }: FormatFieldValueReactParams): ReactNode => {
-  const converterOptions: ReactContextTypeOptions = { ...options, hit, field };
+  const converterOptions: ReactContextTypeOptions = {
+    ...options,
+    hit,
+    field,
+    hasHighlights: columnMeta?.hasHighlights ?? options?.hasHighlights,
+  };
 
   return getFieldFormatter(fieldFormats, dataView, field).reactConvert(value, converterOptions);
 };

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -72,6 +72,7 @@ export {
   hasTimeseriesInfoCommand,
   isComputedColumn,
   getQuerySummary,
+  getColumnsToHighlight,
   getEsqlControls,
   getAllEsqlControls,
   convertFiltersToESQLExpression,

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -74,6 +74,7 @@ export {
 } from './utils/cascaded_documents_helpers/utils';
 export { getProjectRoutingFromEsqlQuery } from './utils/set_instructions_helpers';
 export { isComputedColumn, getQuerySummary } from './utils/get_query_summary';
+export { getColumnsToHighlight } from './utils/get_columns_to_highlight';
 export { getAllEsqlControls, getEsqlControls } from './utils/get_esql_controls';
 export { convertFiltersToESQLExpression } from './utils/convert_filters_to_esql';
 export { convertQueryToESQLExpression } from './utils/convert_query_to_esql';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_columns_to_highlight.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_columns_to_highlight.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getColumnsToHighlight } from './get_columns_to_highlight';
+
+describe('getColumnsToHighlight', () => {
+  it('returns columns assigned from TOP_SNIPPETS with highlight enabled', () => {
+    const query =
+      'FROM books | EVAL snippets = TOP_SNIPPETS(description, "Tolkien", { "highlight": true })';
+    expect(getColumnsToHighlight(query)).toEqual(new Set(['snippets']));
+  });
+
+  it('returns columns from STATS and ROW assignments with highlight enabled', () => {
+    expect(
+      getColumnsToHighlight(
+        'FROM books | STATS s = TOP_SNIPPETS(description, "Tolkien", { "highlight": true }) BY author'
+      )
+    ).toEqual(new Set(['s']));
+    expect(
+      getColumnsToHighlight('ROW r = TOP_SNIPPETS("text", "q", { "highlight": true })')
+    ).toEqual(new Set(['r']));
+  });
+
+  it('returns multiple TOP_SNIPPETS output columns when highlight is enabled', () => {
+    const query =
+      'FROM books | EVAL a = TOP_SNIPPETS(description, "one", { "highlight": true }) | EVAL b = TOP_SNIPPETS(title, "two", { "highlight": true })';
+    expect(getColumnsToHighlight(query)).toEqual(new Set(['a', 'b']));
+  });
+
+  it('ignores TOP_SNIPPETS without highlight option', () => {
+    const query = 'FROM books | EVAL snippets = TOP_SNIPPETS(description, "Tolkien")';
+    expect(getColumnsToHighlight(query)).toEqual(new Set());
+  });
+
+  it('ignores TOP_SNIPPETS with highlight set to false', () => {
+    const query =
+      'FROM books | EVAL snippets = TOP_SNIPPETS(description, "Tolkien", { "highlight": false })';
+    expect(getColumnsToHighlight(query)).toEqual(new Set());
+  });
+
+  it('ignores TOP_SNIPPETS with other options but no highlight', () => {
+    const query =
+      'FROM books | EVAL snippets = TOP_SNIPPETS(description, "Tolkien", { "num_words": 25 })';
+    expect(getColumnsToHighlight(query)).toEqual(new Set());
+  });
+
+  it('ignores TOP_SNIPPETS used only in RERANK ON clause', () => {
+    const query =
+      'FROM books | RERANK "Tolkien" ON TOP_SNIPPETS(description, "Tolkien", { "highlight": true }) WITH { "inference_id": "x" }';
+    expect(getColumnsToHighlight(query)).toEqual(new Set());
+  });
+
+  it('returns an empty set when TOP_SNIPPETS is not used', () => {
+    const query = 'FROM books | KEEP title';
+    expect(getColumnsToHighlight(query)).toEqual(new Set());
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_columns_to_highlight.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_columns_to_highlight.ts
@@ -7,6 +7,77 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import {
+  isAssignment,
+  isBooleanLiteral,
+  isColumn,
+  isStringLiteral,
+  LeafPrinter,
+  Parser,
+  Walker,
+} from '@elastic/esql';
+import type { ESQLAstQueryExpression, ESQLFunction, ESQLMapEntry } from '@elastic/esql/types';
+
+const TOP_SNIPPETS_FUNCTION_NAME = 'top_snippets';
+const HIGHLIGHT_OPTION_NAME = 'highlight';
+
+/**
+ * Returns column names produced by TOP_SNIPPETS calls that enable snippet highlighting.
+ * These columns may contain highlight markup and need special formatting in the UI.
+ */
 export function getColumnsToHighlight(query: string): Set<string> {
-  return new Set(['lala']);
+  const columnsToHighlight = new Set<string>();
+  const { root } = Parser.parse(query);
+
+  const topSnippetFunctions = Walker.matchAll(root, {
+    type: 'function',
+    name: TOP_SNIPPETS_FUNCTION_NAME,
+  });
+
+  for (const topSnippetsFunction of topSnippetFunctions) {
+    const fn = topSnippetsFunction as ESQLFunction;
+
+    if (!isHighlightEnabled(fn)) {
+      continue;
+    }
+
+    const columnName = getColumnNameForTopSnippetsFunction(root, fn);
+    if (columnName) {
+      columnsToHighlight.add(columnName);
+    }
+  }
+
+  return columnsToHighlight;
 }
+
+const isHighlightEnabled = (topSnippetsFunction: ESQLFunction): boolean => {
+  const highlightKey = Walker.find(
+    topSnippetsFunction,
+    (node) => isStringLiteral(node) && node.valueUnquoted === HIGHLIGHT_OPTION_NAME
+  );
+  if (!highlightKey) {
+    return false;
+  }
+
+  const mapEntry = Walker.parent(topSnippetsFunction, highlightKey);
+  if (mapEntry?.type !== 'map-entry') {
+    return false;
+  }
+
+  const { value } = mapEntry as ESQLMapEntry;
+
+  return isBooleanLiteral(value) && value.value === 'true';
+};
+
+const getColumnNameForTopSnippetsFunction = (
+  root: ESQLAstQueryExpression,
+  topSnippetsFunction: ESQLFunction
+): string | undefined => {
+  for (const parent of Walker.parents(root, topSnippetsFunction)) {
+    if (isAssignment(parent) && isColumn(parent.args[0])) {
+      return LeafPrinter.column(parent.args[0]);
+    }
+  }
+
+  return;
+};

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_columns_to_highlight.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_columns_to_highlight.ts
@@ -7,6 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { getHighlightReact } from './highlight_react';
-export { getInlineEmSnippetHighlightReact } from './inline_em_snippet_highlight_react';
-export { getHighlightRequest } from './highlight_request';
+export function getColumnsToHighlight(query: string): Set<string> {
+  return new Set(['lala']);
+}

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/source_document.tsx
@@ -68,7 +68,8 @@ export function SourceDocument({
         dataView,
         shouldShowFieldHandler,
         fieldFormats,
-        columnsMeta
+        columnsMeta,
+        isPlainRecord
       ).slice(0, maxEntries)
     : formatHitReact(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats, columnsMeta);
 
@@ -117,7 +118,8 @@ function getTopLevelObjectPairsReact(
   dataView: DataView,
   shouldShowFieldHandler: ShouldShowFieldInTableHandler,
   fieldFormats: FieldFormatsStart,
-  columnsMeta: DataTableColumnsMeta | undefined
+  columnsMeta: DataTableColumnsMeta | undefined,
+  isPlainRecord?: boolean
 ): FormattedHit {
   const innerColumns = getInnerColumns(row.fields as Record<string, unknown[]>, columnId);
   // Put the most important fields first
@@ -137,7 +139,14 @@ function getTopLevelObjectPairsReact(
     const formatted: ReactNode = values.map((value: unknown, idx) => (
       <Fragment key={`${key}-${idx}`}>
         {idx > 0 ? ', ' : null}
-        {formatFieldValueReact({ value, hit: row, fieldFormats, dataView, field: subField })}
+        {formatFieldValueReact({
+          value,
+          hit: row,
+          fieldFormats,
+          dataView,
+          field: subField,
+          columnMeta: isPlainRecord ? columnsMeta?.[key] : undefined,
+        })}
       </Fragment>
     ));
     const pairs = highlights[key] ? highlightPairs : sourcePairs;

--- a/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
@@ -131,6 +131,7 @@ export const getRenderCellValueFn = ({
         fieldFormats,
         closePopover,
         isPlainRecord,
+        columnsMeta,
       });
     }
 
@@ -163,6 +164,7 @@ export const getRenderCellValueFn = ({
           fieldFormats,
           dataView,
           field,
+          columnMeta: isPlainRecord ? columnsMeta?.[columnId] : undefined,
         })}
       </span>
     );
@@ -189,6 +191,7 @@ function renderPopoverContent({
   fieldFormats,
   closePopover,
   isPlainRecord,
+  columnsMeta,
 }: {
   row: DataTableRecord;
   field: DataViewField | undefined;
@@ -198,6 +201,7 @@ function renderPopoverContent({
   fieldFormats: FieldFormatsStart;
   closePopover: () => void;
   isPlainRecord?: boolean;
+  columnsMeta: DataTableColumnsMeta | undefined;
 }) {
   const closeButton = (
     <EuiButtonIcon
@@ -242,6 +246,7 @@ function renderPopoverContent({
               fieldFormats,
               dataView,
               field,
+              columnMeta: isPlainRecord ? columnsMeta?.[columnId] : undefined,
             })}
           </span>
         </DataTablePopoverCellValue>

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -28,6 +28,7 @@ import {
   mapVariableToColumn,
   isComputedColumn,
   getQuerySummary,
+  getColumnsToHighlight,
 } from '@kbn/esql-utils';
 import { zipObject } from 'lodash';
 import type { Observable } from 'rxjs';
@@ -368,6 +369,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
 
           // Get query summary to identify computed columns
           const querySummary = getQuerySummary(query);
+          const highlightColumnNames = getColumnsToHighlight(query);
 
           const allColumns =
             (body.all_columns ?? body.columns)?.map(({ name, type, original_types }) => {
@@ -382,6 +384,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
                 meta: {
                   type: kibanaFieldType,
                   esType: type,
+                  hasHighlights: highlightColumnNames.has(name),
                   sourceParams:
                     type === 'date'
                       ? {

--- a/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
+++ b/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
@@ -103,6 +103,10 @@ export interface DatatableColumnMeta {
    * any extra parameters for the source that produced this column
    */
   sourceParams?: SerializableRecord;
+  /**
+   * True when column values includes highlitings parts.
+   */
+  hasHighlights?: boolean;
 }
 
 interface SourceParamsESQL extends Record<string, unknown> {

--- a/src/platform/plugins/shared/field_formats/common/converters/string.tsx
+++ b/src/platform/plugins/shared/field_formats/common/converters/string.tsx
@@ -9,7 +9,12 @@
 
 import { i18n } from '@kbn/i18n';
 import { KBN_FIELD_TYPES } from '@kbn/field-types';
-import { asPrettyString, getHighlightReact, shortenDottedString } from '../utils';
+import {
+  asPrettyString,
+  getHighlightReact,
+  getInlineEmSnippetHighlightReact,
+  shortenDottedString,
+} from '../utils';
 import { FieldFormat } from '../field_format';
 import type { ReactContextTypeSingleConvert, TextContextTypeConvert } from '../types';
 import { FIELD_FORMAT_IDS } from '../types';
@@ -130,15 +135,24 @@ export class StringFormat extends FieldFormat {
     }
   };
 
-  reactConvertSingle: ReactContextTypeSingleConvert = (val, { hit, field } = {}) => {
+  reactConvertSingle: ReactContextTypeSingleConvert = (val, options = {}) => {
     const missing = this.checkForMissingValueReact(val);
     if (missing) return missing;
 
+    const { hit, field, hasHighlights } = options;
+    const formatted = this.textConvert(val);
     const fieldName = field?.name;
+
+    // Clasic mode
     if (fieldName && hit?.highlight?.[fieldName]) {
-      return getHighlightReact(this.textConvert(val), hit.highlight[fieldName]);
+      return getHighlightReact(formatted, hit.highlight[fieldName]);
     }
 
-    return this.textConvert(val);
+    // ES|QL mode
+    if (hasHighlights && typeof formatted === 'string') {
+      return getInlineEmSnippetHighlightReact(formatted);
+    }
+
+    return formatted;
   };
 }

--- a/src/platform/plugins/shared/field_formats/common/field_format.tsx
+++ b/src/platform/plugins/shared/field_formats/common/field_format.tsx
@@ -24,7 +24,7 @@ import type {
   FieldFormatParams,
 } from './types';
 import { textContentTypeSetup, TEXT_CONTEXT_TYPE } from './content_types';
-import { getHighlightReact } from './utils/highlight';
+import { getHighlightReact, getInlineEmSnippetHighlightReact } from './utils/highlight';
 import type {
   ReactContextTypeConvert,
   ReactContextTypeSingleConvert,
@@ -112,10 +112,18 @@ export abstract class FieldFormat {
       : this.convert(val, TEXT_CONTEXT_TYPE, options);
     const fieldName = options?.field?.name;
     const highlights = fieldName ? options?.hit?.highlight?.[fieldName] : undefined;
-    // getHighlightReact expects a string; guard against edge cases where convert() returns non-string
-    return highlights && typeof formatted === 'string'
-      ? getHighlightReact(formatted, highlights)
-      : formatted;
+    if (typeof formatted !== 'string') {
+      return formatted;
+    }
+    // Classic search: parallel hit.highlight snippets (Kibana highlight tags).
+    if (highlights) {
+      return getHighlightReact(formatted, highlights);
+    }
+    // ES|QL: inline <em> markup in the cell value.
+    if (options?.hasHighlights) {
+      return getInlineEmSnippetHighlightReact(formatted);
+    }
+    return formatted;
   };
 
   /**

--- a/src/platform/plugins/shared/field_formats/common/index.ts
+++ b/src/platform/plugins/shared/field_formats/common/index.ts
@@ -34,7 +34,7 @@ export {
   HistogramFormat,
 } from './converters';
 
-export { getHighlightRequest, geoUtils } from './utils';
+export { getHighlightRequest, getInlineEmSnippetHighlightReact, geoUtils } from './utils';
 
 export { DEFAULT_CONVERTER_COLOR } from './constants/color_default';
 export { FORMATS_UI_SETTINGS } from './constants/ui_settings';

--- a/src/platform/plugins/shared/field_formats/common/types.ts
+++ b/src/platform/plugins/shared/field_formats/common/types.ts
@@ -25,6 +25,8 @@ export interface ReactContextTypeOptions {
   field?: { name: string };
   hit?: { highlight?: Record<string, string[]> };
   skipFormattingInStringifiedJSON?: boolean;
+  /** When true, string values may include inline `<em>` markup to render as highlights. (ES|QL) */
+  hasHighlights?: boolean;
 }
 
 /**

--- a/src/platform/plugins/shared/field_formats/common/utils/highlight/inline_em_snippet_highlight_react.tsx
+++ b/src/platform/plugins/shared/field_formats/common/utils/highlight/inline_em_snippet_highlight_react.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+
+const OPEN_TAG = '<em>';
+const CLOSE_TAG = '</em>';
+
+export function getInlineEmSnippetHighlightReact(value: string): React.ReactNode {
+  if (!value.includes(OPEN_TAG)) {
+    return value;
+  }
+
+  const nodes: React.ReactNode[] = [];
+  let rest = value;
+  let key = 0;
+
+  while (rest.length > 0) {
+    const openIdx = rest.indexOf(OPEN_TAG);
+
+    // No more highlights
+    if (openIdx === -1) {
+      nodes.push(rest);
+      break;
+    }
+
+    if (openIdx > 0) {
+      nodes.push(rest.slice(0, openIdx));
+    }
+    rest = rest.slice(openIdx + OPEN_TAG.length);
+    const closeIdx = rest.indexOf(CLOSE_TAG);
+
+    // Malformed highlight with no closing tag, return as is
+    if (closeIdx === -1) {
+      nodes.push(`${OPEN_TAG}${rest}`);
+      break;
+    }
+
+    const inner = rest.slice(0, closeIdx);
+    nodes.push(
+      <mark className="ffSearch__highlight" key={`highlight-${key++}`}>
+        {inner}
+      </mark>
+    );
+    rest = rest.slice(closeIdx + CLOSE_TAG.length);
+  }
+
+  if (nodes.length === 0) {
+    return value;
+  }
+  if (nodes.length === 1) {
+    return nodes[0];
+  }
+  return <>{nodes}</>;
+}

--- a/src/platform/plugins/shared/field_formats/common/utils/index.ts
+++ b/src/platform/plugins/shared/field_formats/common/utils/index.ts
@@ -8,7 +8,11 @@
  */
 
 export { asPrettyString } from './as_pretty_string';
-export { getHighlightReact, getHighlightRequest } from './highlight';
+export {
+  getHighlightReact,
+  getInlineEmSnippetHighlightReact,
+  getHighlightRequest,
+} from './highlight';
 export { shortenDottedString } from './shorten_dotted_string';
 export { formatReactArray } from './format_react_array';
 export * as geoUtils from './geo_utils';


### PR DESCRIPTION
## Summary
This PR adds highlighting support for ES|QL.
Currently the only way to have a highlighted result in ES|QL is using `TOP_SNIPPETS` function.
```
FROM index | EVAL col0 = TOP_SNIPPETS("Some text", "text", { "highlight": true }) 
```

<img width="1714" height="901" alt="image" src="https://github.com/user-attachments/assets/65a799b5-3136-4856-8d3e-e175bd732e17" />

### Main differences between DSL highlight and ES|QL highlight
#### DSL highlights comes apart from the result values of the query
In DSL each hit has a separate highlights array with the columns and portions of text to highlight.
Note that the highlighting token is `@kibana-highlighted-field@`.
```
"highlight": {
                        "context.applicationId": [
                            "@kibana-highlighted-field@discover@/kibana-highlighted-field@"
                        ],
                        "context.page_title": [
                            "@kibana-highlighted-field@Discover@/kibana-highlighted-field@ - Elastic"
                        ]
                    }
```
In ES|QL we don't, the highlighting is embedded in the result value, so we don't have an unformatted and a formatted output.

#### ES|QL result do not give you information about highlighting
Which columns are highlighted an what token is used to highlight should be extracted from the query, not the result.

#### ES|QL do not support highlighting all columns
The user needs to be explicit on which columns should have highlighted results when building the query.

### Implementation checkpoint
@stratoula Help me validating the implementation path before digging into details 🙏 .

In ES|QL, if a column has highlights or not is a computed output of the query, therefore following the current architecture it seems reasonable to add this information into `columnsMeta` and not into the DataView.

#### Data flow
1. After executing the query [[1]](https://github.com/elastic/kibana/pull/269970/changes#diff-796a5667e28e57cf3cb7334ae6dbac70f578f5ffbefbc697de1afc3b1b7f0a79R372), while creating the Datatable entry, we call a util that analysing the query tells us which columns needs to be highlighted. Made an initial implementation but it misses a lot of cases, I'm thinking on making it part of `getQuerySummary` as the highlighted columns are subject to be renamed and also to be able to handle commands that defines columns without `=`.
2. We add a `hasHighlights` flag to `DatatableColumnMeta` (this is the source of `columnsMeta` later on) [[2]](https://github.com/elastic/kibana/pull/269970/changes#diff-0cf2db6662d51585acae91bb877ecefc651056eb07a869d707918235b865f3dcR109). This is the point I have more doubts about it being correct, for me it makes sense as this is a useful column property that is derived of the execution of the query, and might be reused outside Discover too. My doubt comes from this new prop being only useful for ES|QL. Might also be called `hasComputedHighlights` to emphasize  it depends on the given query .
3. `columnsMeta` is built from `DatatableColumnMeta` .
4. We pass `columnsMeta` as a parameter to `formatFieldValue`.
5. This gives us the information to decide inside what highlighting method to use. The algorithm differs considerably if it's DSL highlighting or ES|QL highlighting. (DSL already gives you the highlighted sections separated from the values).


#### Some extras
Are we expecting other formats to come after this, for instance URL? If so, instead of a `hasHighlights` flag we might want to add a `computedFormats` object.
```ts
computedFormats: {
    hasHighlights: true,
    isUrl: false,
}
```

`TOP_SNIPETS` function lets you change the highlight token from `<em>` to something else. if we want to support that we should replace  `hasHighlights: boolean`, with an object to propagate the token.



