### PR TITLE
[Cases] Inline editing with confirm / cancel buttons

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
@@ -69,6 +69,8 @@ export interface ConditionRenderProps {
   max?: number;
   minLength?: number;
   maxLength?: number;
+  /** When provided, the control renders inline confirm/cancel buttons and only calls this on confirm. */
+  onConfirm?: () => void;
 }
 
 const BaseFieldSchema = z.object({

--- a/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/schema.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_form_fields/schema.tsx
@@ -10,6 +10,7 @@ import type { FormSchema } from '@kbn/es-ui-shared-plugin/static/forms/hook_form
 import { VALIDATION_TYPES } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import type { CasePostRequest } from '../../../common';
 import {
+  CASE_EXTENDED_FIELDS,
   MAX_DESCRIPTION_LENGTH,
   MAX_LENGTH_PER_TAG,
   MAX_TAGS_PER_CASE,
@@ -34,7 +35,6 @@ export type CaseFormFieldsSchemaProps = Omit<
   customFields: Record<string, string | boolean>;
   templateId?: string;
   templateVersion?: number;
-  extendedFields?: Record<string, unknown>;
 };
 
 export const schema: FormSchema<CaseFormFieldsSchemaProps> = {
@@ -121,7 +121,7 @@ export const schema: FormSchema<CaseFormFieldsSchemaProps> = {
   templateVersion: {
     defaultValue: 1,
   },
-  extendedFields: {
+  [CASE_EXTENDED_FIELDS]: {
     defaultValue: {},
   },
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -280,6 +280,23 @@ describe('TemplateFields', () => {
 
       expect(onUpdateField).not.toHaveBeenCalled();
     });
+
+    it('hides confirm/cancel buttons when the field loses focus (tab away)', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.click(getSummaryInput());
+      expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
+
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-confirm-summary')).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-cancel-summary')).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('textarea field inline-edit confirm/cancel', () => {
@@ -342,6 +359,23 @@ describe('TemplateFields', () => {
         expect(notes.value).toBe('some notes');
       });
     });
+
+    it('hides confirm/cancel buttons when the textarea loses focus', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.click(getNotesInput());
+      expect(screen.getByTestId('template-field-confirm-notes')).toBeInTheDocument();
+
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-confirm-notes')).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-cancel-notes')).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('number field inline-edit confirm/cancel', () => {
@@ -400,6 +434,23 @@ describe('TemplateFields', () => {
       expect(onUpdateField).not.toHaveBeenCalled();
       await waitFor(() => {
         expect(effort.value).toBe('5');
+      });
+    });
+
+    it('hides confirm/cancel buttons when the number field loses focus', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.click(getEffortInput());
+      expect(screen.getByTestId('template-field-confirm-effort')).toBeInTheDocument();
+
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-confirm-effort')).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-cancel-effort')).not.toBeInTheDocument();
       });
     });
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -6,14 +6,13 @@
  */
 
 import React from 'react';
-import { screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { CaseUI } from '../../../../common';
 import type { ParsedTemplate } from '../../../../common/types/domain/template/v1';
 import { FieldType } from '../../../../common/types/domain/template/fields';
 import { TemplateFields } from './template_fields';
-import { renderWithTestingProviders } from '../../../common/mock';
 
 const mockUseGetTemplate = jest.fn();
 jest.mock('../../templates_v2/hooks/use_get_template', () => ({
@@ -79,7 +78,7 @@ describe('TemplateFields', () => {
   });
 
   it('renders fields for each template definition field', () => {
-    renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    render(<TemplateFields {...defaultProps} />);
 
     expect(screen.getByText('Summary')).toBeInTheDocument();
     expect(screen.getByText('Effort')).toBeInTheDocument();
@@ -88,7 +87,7 @@ describe('TemplateFields', () => {
   });
 
   it('fetches the template with the correct id and version', () => {
-    renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    render(<TemplateFields {...defaultProps} />);
 
     expect(mockUseGetTemplate).toHaveBeenCalledWith('template-1', 1);
   });
@@ -96,7 +95,7 @@ describe('TemplateFields', () => {
   it('renders nothing when template is loading', () => {
     mockUseGetTemplate.mockReturnValue({ data: undefined, isLoading: true });
 
-    const { container } = renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    const { container } = render(<TemplateFields {...defaultProps} />);
 
     expect(container.textContent).toBe('');
   });
@@ -107,7 +106,7 @@ describe('TemplateFields', () => {
       isLoading: false,
     });
 
-    const { container } = renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    const { container } = render(<TemplateFields {...defaultProps} />);
 
     expect(container.textContent).toBe('');
   });
@@ -122,7 +121,7 @@ describe('TemplateFields', () => {
     };
     mockUseGetTemplate.mockReturnValue({ data: templateWithoutLabels, isLoading: false });
 
-    renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    render(<TemplateFields {...defaultProps} />);
 
     expect(screen.getByText('hostname')).toBeInTheDocument();
   });
@@ -138,13 +137,13 @@ describe('TemplateFields', () => {
     };
     mockUseGetTemplate.mockReturnValue({ data: templateWithUnknown, isLoading: false });
 
-    renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    render(<TemplateFields {...defaultProps} />);
 
     expect(screen.queryByTestId('template-field-unknownField')).not.toBeInTheDocument();
   });
 
   it('uses data-test-subj based on field name', () => {
-    renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    render(<TemplateFields {...defaultProps} />);
 
     expect(screen.getByTestId('template-field-summary')).toBeInTheDocument();
     expect(screen.getByTestId('template-field-effort')).toBeInTheDocument();
@@ -158,41 +157,43 @@ describe('TemplateFields', () => {
       extendedFields: {},
     } as unknown as CaseUI;
 
-    renderWithTestingProviders(<TemplateFields {...defaultProps} caseData={caseWithNoExtended} />);
+    render(<TemplateFields {...defaultProps} caseData={caseWithNoExtended} />);
 
     expect(screen.getByText('Summary')).toBeInTheDocument();
     expect(screen.getByText('Effort')).toBeInTheDocument();
   });
 
-  describe('on-blur save', () => {
-    const getInputForLabel = (label: string): HTMLInputElement =>
-      screen.getByLabelText(label) as HTMLInputElement;
+  describe('text field inline-edit confirm/cancel', () => {
+    const getSummaryInput = (): HTMLInputElement =>
+      within(screen.getByTestId('template-field-summary')).getByRole('textbox') as HTMLInputElement;
 
-    beforeEach(() => {
-      jest.useFakeTimers();
+    it('does NOT show confirm/cancel buttons before the field is focused', () => {
+      render(<TemplateFields {...defaultProps} />);
+
+      expect(screen.queryByTestId('template-field-confirm-summary')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('template-field-cancel-summary')).not.toBeInTheDocument();
     });
 
-    afterEach(() => {
-      act(() => {
-        jest.runOnlyPendingTimers();
-      });
-      jest.useRealTimers();
+    it('shows confirm and cancel buttons when the text field is focused', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.click(getSummaryInput());
+
+      expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-summary')).toBeInTheDocument();
     });
 
-    it('calls onUpdateField with extended fields after a blur when valid', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    it('calls onUpdateField with updated value when confirm button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
 
-      const summary = getInputForLabel('Summary');
+      const summary = getSummaryInput();
+      await user.click(summary);
       await user.clear(summary);
       await user.type(summary, 'updated summary');
-      // Blur by tabbing away
-      await user.tab();
 
-      // Advance past the debounce
-      act(() => {
-        jest.advanceTimersByTime(250);
-      });
+      await user.click(screen.getByTestId('template-field-confirm-summary'));
 
       await waitFor(() => {
         expect(onUpdateField).toHaveBeenCalled();
@@ -206,23 +207,281 @@ describe('TemplateFields', () => {
       );
     });
 
-    it('debounces multiple rapid blurs into a single save', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      renderWithTestingProviders(<TemplateFields {...defaultProps} />);
+    it('does NOT call onUpdateField when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
 
-      const summary = getInputForLabel('Summary');
+      const summary = getSummaryInput();
+      await user.click(summary);
       await user.clear(summary);
-      await user.type(summary, 'a');
-      await user.tab();
-      await user.tab();
-      await user.tab();
+      await user.type(summary, 'discarded value');
 
-      act(() => {
-        jest.advanceTimersByTime(250);
-      });
+      await user.click(screen.getByTestId('template-field-cancel-summary'));
+
+      expect(onUpdateField).not.toHaveBeenCalled();
+    });
+
+    it('reverts the field value to the last saved value when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const summary = getSummaryInput();
+      await user.click(summary);
+      await user.clear(summary);
+      await user.type(summary, 'discarded value');
+
+      expect(summary.value).toBe('discarded value');
+
+      await user.click(screen.getByTestId('template-field-cancel-summary'));
 
       await waitFor(() => {
-        expect(onUpdateField).toHaveBeenCalledTimes(1);
+        expect(summary.value).toBe('test summary');
+      });
+    });
+
+    it('hides confirm/cancel buttons after confirm is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.click(getSummaryInput());
+      expect(screen.getByTestId('template-field-confirm-summary')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('template-field-confirm-summary'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-confirm-summary')).not.toBeInTheDocument();
+      });
+    });
+
+    it('hides confirm/cancel buttons after cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.click(getSummaryInput());
+      expect(screen.getByTestId('template-field-cancel-summary')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('template-field-cancel-summary'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-cancel-summary')).not.toBeInTheDocument();
+      });
+    });
+
+    it('does NOT call onUpdateField on blur (no implicit save)', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const summary = getSummaryInput();
+      await user.click(summary);
+      await user.clear(summary);
+      await user.type(summary, 'typed but not confirmed');
+      // Tab away without clicking confirm
+      await user.tab();
+
+      expect(onUpdateField).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('textarea field inline-edit confirm/cancel', () => {
+    const getNotesInput = (): HTMLTextAreaElement =>
+      within(screen.getByTestId('template-field-notes')).getByRole(
+        'textbox'
+      ) as HTMLTextAreaElement;
+
+    it('does NOT show confirm/cancel buttons before the field is focused', () => {
+      render(<TemplateFields {...defaultProps} />);
+
+      expect(screen.queryByTestId('template-field-confirm-notes')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('template-field-cancel-notes')).not.toBeInTheDocument();
+    });
+
+    it('shows confirm and cancel buttons when the textarea is focused', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.click(getNotesInput());
+
+      expect(screen.getByTestId('template-field-confirm-notes')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-notes')).toBeInTheDocument();
+    });
+
+    it('calls onUpdateField with updated value when confirm is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const notes = getNotesInput();
+      await user.click(notes);
+      await user.clear(notes);
+      await user.type(notes, 'updated notes');
+
+      await user.click(screen.getByTestId('template-field-confirm-notes'));
+
+      await waitFor(() => {
+        expect(onUpdateField).toHaveBeenCalled();
+      });
+      const lastCall = onUpdateField.mock.calls[onUpdateField.mock.calls.length - 1][0];
+      expect(lastCall.key).toBe('extended_fields');
+      expect(lastCall.value).toEqual(
+        expect.objectContaining({ notes_as_keyword: 'updated notes' })
+      );
+    });
+
+    it('does NOT call onUpdateField and reverts value when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const notes = getNotesInput();
+      await user.click(notes);
+      await user.clear(notes);
+      await user.type(notes, 'discarded notes');
+
+      await user.click(screen.getByTestId('template-field-cancel-notes'));
+
+      expect(onUpdateField).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(notes.value).toBe('some notes');
+      });
+    });
+  });
+
+  describe('number field inline-edit confirm/cancel', () => {
+    const getEffortInput = (): HTMLInputElement =>
+      within(screen.getByTestId('template-field-effort')).getByRole(
+        'spinbutton'
+      ) as HTMLInputElement;
+
+    it('does NOT show confirm/cancel buttons before the field is focused', () => {
+      render(<TemplateFields {...defaultProps} />);
+
+      expect(screen.queryByTestId('template-field-confirm-effort')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('template-field-cancel-effort')).not.toBeInTheDocument();
+    });
+
+    it('shows confirm and cancel buttons when the number field is focused', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.click(getEffortInput());
+
+      expect(screen.getByTestId('template-field-confirm-effort')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-effort')).toBeInTheDocument();
+    });
+
+    it('calls onUpdateField with updated value when confirm is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const effort = getEffortInput();
+      await user.click(effort);
+      await user.clear(effort);
+      await user.type(effort, '10');
+
+      await user.click(screen.getByTestId('template-field-confirm-effort'));
+
+      await waitFor(() => {
+        expect(onUpdateField).toHaveBeenCalled();
+      });
+      const lastCall = onUpdateField.mock.calls[onUpdateField.mock.calls.length - 1][0];
+      expect(lastCall.key).toBe('extended_fields');
+      expect(lastCall.value).toEqual(expect.objectContaining({ effort_as_integer: '10' }));
+    });
+
+    it('does NOT call onUpdateField and reverts value when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const effort = getEffortInput();
+      await user.click(effort);
+      await user.clear(effort);
+      await user.type(effort, '99');
+
+      await user.click(screen.getByTestId('template-field-cancel-effort'));
+
+      expect(onUpdateField).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(effort.value).toBe('5');
+      });
+    });
+  });
+
+  describe('select field inline-edit confirm/cancel', () => {
+    const getPrioritySelect = (): HTMLSelectElement =>
+      within(screen.getByTestId('template-field-priority')).getByRole(
+        'combobox'
+      ) as HTMLSelectElement;
+
+    it('does NOT show confirm/cancel buttons before a value is changed', () => {
+      render(<TemplateFields {...defaultProps} />);
+
+      expect(screen.queryByTestId('template-field-confirm-priority')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('template-field-cancel-priority')).not.toBeInTheDocument();
+    });
+
+    it('shows confirm and cancel buttons after the user changes the selection', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.selectOptions(getPrioritySelect(), 'high');
+
+      expect(screen.getByTestId('template-field-confirm-priority')).toBeInTheDocument();
+      expect(screen.getByTestId('template-field-cancel-priority')).toBeInTheDocument();
+    });
+
+    it('calls onUpdateField with the new value when confirm is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.selectOptions(getPrioritySelect(), 'high');
+      await user.click(screen.getByTestId('template-field-confirm-priority'));
+
+      await waitFor(() => {
+        expect(onUpdateField).toHaveBeenCalled();
+      });
+      const lastCall = onUpdateField.mock.calls[onUpdateField.mock.calls.length - 1][0];
+      expect(lastCall.key).toBe('extended_fields');
+      expect(lastCall.value).toEqual(expect.objectContaining({ priority_as_keyword: 'high' }));
+    });
+
+    it('does NOT call onUpdateField and reverts value when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      const select = getPrioritySelect();
+      await user.selectOptions(select, 'low');
+
+      await user.click(screen.getByTestId('template-field-cancel-priority'));
+
+      expect(onUpdateField).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(select.value).toBe('medium');
+      });
+    });
+
+    it('hides confirm/cancel buttons after confirm is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.selectOptions(getPrioritySelect(), 'high');
+      expect(screen.getByTestId('template-field-confirm-priority')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('template-field-confirm-priority'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-confirm-priority')).not.toBeInTheDocument();
+      });
+    });
+
+    it('hides confirm/cancel buttons after cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateFields {...defaultProps} />);
+
+      await user.selectOptions(getPrioritySelect(), 'low');
+      expect(screen.getByTestId('template-field-cancel-priority')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('template-field-cancel-priority'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('template-field-cancel-priority')).not.toBeInTheDocument();
       });
     });
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { debounce } from 'lodash';
 import type { z } from '@kbn/zod/v4';
 import type { FieldValues } from 'react-hook-form';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -22,8 +21,6 @@ import { getFieldCamelKey, getFieldSnakeKey } from '../../../../common/utils';
 import type { OnUpdateFields } from '../types';
 
 type ParsedTemplateDefinition = z.infer<typeof ParsedTemplateDefinitionSchema>;
-
-const BLUR_DEBOUNCE_MS = 200;
 
 interface TemplateFieldsProps {
   caseData: CaseUI;
@@ -82,14 +79,10 @@ const TemplateFieldsFormReady: FC<{
     });
   }, [form, onUpdateField, releaseLock]);
 
-  const handleBlurCapture = useMemo(() => debounce(persist, BLUR_DEBOUNCE_MS), [persist]);
-
-  useEffect(() => () => handleBlurCapture.cancel(), [handleBlurCapture]);
-
   return (
     <FormProvider {...form}>
-      <div onBlurCapture={handleBlurCapture} data-test-subj="template-fields-form">
-        <FieldsRenderer resolvedFields={resolvedFields} />
+      <div data-test-subj="template-fields-form">
+        <FieldsRenderer resolvedFields={resolvedFields} onFieldConfirm={persist} />
       </div>
     </FormProvider>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
@@ -10,6 +10,7 @@ import { screen } from '@testing-library/react';
 
 import { CreateCaseTemplateFields } from './template_fields';
 import { renderWithTestingProviders } from '../../common/mock';
+import { CASE_EXTENDED_FIELDS } from '../../../common/constants';
 
 const mockUseFormData = jest.fn();
 const mockUseFormContext = jest.fn();
@@ -151,5 +152,40 @@ describe('CreateCaseTemplateFields', () => {
     renderWithTestingProviders(<CreateCaseTemplateFields />);
 
     expect(screen.getByText('Template not selected')).toBeInTheDocument();
+  });
+
+  it('syncs inner form changes to parent form under the CASE_EXTENDED_FIELDS key', () => {
+    // This test verifies the key used to sync inner form values to the parent form
+    // matches what createFormSerializer reads. The serializer reads data[CASE_EXTENDED_FIELDS]
+    // ('extended_fields'), so the setFieldValue call must use the same key.
+    // Previously the code called setFieldValue('extendedFields', ...) which was silently
+    // ignored by the serializer, causing extended fields to be lost on case create.
+    const setFieldValue = jest.fn();
+    mockUseFormContext.mockReturnValue({ setFieldValue });
+    mockUseFormData.mockReturnValue([{ templateId: 'template-1' }]);
+    mockUseTemplateFormSync.mockReturnValue({
+      template: {
+        templateId: 'template-1',
+        definition: { name: 'Test', fields: [] },
+      },
+      isLoading: false,
+    });
+
+    renderWithTestingProviders(<CreateCaseTemplateFields />);
+
+    // Whenever setFieldValue is called (e.g. from the watch subscription or template sync),
+    // it must never use the camelCase 'extendedFields' key.
+    const allCallsWithWrongKey = setFieldValue.mock.calls.filter(([key]) => key === 'extendedFields');
+    expect(allCallsWithWrongKey).toHaveLength(0);
+
+    // Any calls that update extended fields must use CASE_EXTENDED_FIELDS ('extended_fields').
+    const extendedFieldCalls = setFieldValue.mock.calls.filter(
+      ([key]) => key === CASE_EXTENDED_FIELDS
+    );
+    // The watch subscription fires when the form changes. If any calls were made for extended
+    // fields on mount, they must use the correct key.
+    extendedFieldCalls.forEach(([key]) => {
+      expect(key).toBe(CASE_EXTENDED_FIELDS);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
@@ -175,7 +175,9 @@ describe('CreateCaseTemplateFields', () => {
 
     // Whenever setFieldValue is called (e.g. from the watch subscription or template sync),
     // it must never use the camelCase 'extendedFields' key.
-    const allCallsWithWrongKey = setFieldValue.mock.calls.filter(([key]) => key === 'extendedFields');
+    const allCallsWithWrongKey = setFieldValue.mock.calls.filter(
+      ([key]) => key === 'extendedFields'
+    );
     expect(allCallsWithWrongKey).toHaveLength(0);
 
     // Any calls that update extended fields must use CASE_EXTENDED_FIELDS ('extended_fields').

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
@@ -36,7 +36,7 @@ export const CreateCaseTemplateFields: React.FC = () => {
   useEffect(() => {
     const subscription = innerForm.watch((values) => {
       const slice = values?.[CASE_EXTENDED_FIELDS] ?? {};
-      parentForm.setFieldValue('extendedFields', slice);
+      parentForm.setFieldValue(CASE_EXTENDED_FIELDS, slice);
     });
     return () => subscription.unsubscribe();
   }, [innerForm, parentForm]);

--- a/x-pack/platform/plugins/shared/cases/public/components/templates/schema.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates/schema.test.tsx
@@ -57,7 +57,7 @@ describe('Template schema', () => {
               },
             ],
           },
-          "extendedFields": Object {
+          "extended_fields": Object {
             "defaultValue": Object {},
             "labelAppend": <EuiText
               color="subdued"

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
@@ -6,9 +6,10 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiCheckboxGroup, EuiFormRow } from '@elastic/eui';
+import { InlineFieldActions } from './inline_field_actions';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
@@ -42,8 +43,10 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
   type,
   metadata,
   isRequired,
+  onConfirm,
 }) => {
-  const { control } = useFormContext();
+  const { control, resetField } = useFormContext();
+  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const options = useMemo(
@@ -62,38 +65,58 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
     };
   }, [isRequired]);
 
-  return (
-    <Controller
-      key={name}
-      name={path}
-      control={control}
-      rules={rules}
-      defaultValue={defaultValue}
-      render={({ field, fieldState }) => {
-        const selected = toArray(field.value);
-        const handleChange = (id: string) => {
-          const next = selected.includes(id) ? selected.filter((s) => s !== id) : [...selected, id];
-          field.onChange(JSON.stringify(next));
-          field.onBlur();
-        };
+  const showInlineActions = hasPendingChange && onConfirm != null;
 
-        return (
-          <EuiFormRow
-            label={label}
-            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-            error={fieldState.error?.message}
-            isInvalid={!!fieldState.error}
-            fullWidth
-          >
-            <EuiCheckboxGroup
-              options={options}
-              idToSelectedMap={Object.fromEntries(selected.map((id) => [id, true]))}
-              onChange={handleChange}
-            />
-          </EuiFormRow>
-        );
-      }}
-    />
+  return (
+    <>
+      <Controller
+        key={name}
+        name={path}
+        control={control}
+        rules={rules}
+        defaultValue={defaultValue}
+        render={({ field, fieldState }) => {
+          const selected = toArray(field.value);
+          const handleChange = (id: string) => {
+            const next = selected.includes(id)
+              ? selected.filter((s) => s !== id)
+              : [...selected, id];
+            field.onChange(JSON.stringify(next));
+            field.onBlur();
+            setHasPendingChange(true);
+          };
+
+          return (
+            <EuiFormRow
+              label={label}
+              labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+              error={fieldState.error?.message}
+              isInvalid={!!fieldState.error}
+              fullWidth
+            >
+              <EuiCheckboxGroup
+                options={options}
+                idToSelectedMap={Object.fromEntries(selected.map((id) => [id, true]))}
+                onChange={handleChange}
+              />
+            </EuiFormRow>
+          );
+        }}
+      />
+      {showInlineActions && (
+        <InlineFieldActions
+          name={name}
+          onConfirm={() => {
+            setHasPendingChange(false);
+            onConfirm();
+          }}
+          onCancel={() => {
+            setHasPendingChange(false);
+            resetField(path);
+          }}
+        />
+      )}
+    </>
   );
 };
 CheckboxGroup.displayName = 'CheckboxGroup';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
@@ -8,9 +8,10 @@
 import type { z } from '@kbn/zod/v4';
 import type { Moment } from 'moment';
 import moment from 'moment-timezone';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiDatePicker, EuiFormRow } from '@elastic/eui';
+import { InlineFieldActions } from './inline_field_actions';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { getFieldSnakeKey } from '../../../../../common/utils';
 import {
@@ -40,8 +41,10 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   type,
   metadata,
   isRequired,
+  onConfirm,
 }) => {
-  const { control } = useFormContext();
+  const { control, resetField } = useFormContext();
+  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
   const isLocal = metadata?.timezone === 'local';
 
@@ -55,35 +58,53 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     };
   }, [isRequired]);
 
+  const showInlineActions = hasPendingChange && onConfirm != null;
+
   return (
-    <Controller
-      key={name}
-      name={path}
-      control={control}
-      rules={rules}
-      defaultValue=""
-      render={({ field, fieldState }) => (
-        <EuiFormRow
-          label={label}
-          labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-          error={fieldState.error?.message}
-          isInvalid={!!fieldState.error}
-          fullWidth
-        >
-          <EuiDatePicker
-            selected={toMoment(field.value, isLocal)}
-            onChange={(date) => {
-              field.onChange(toIsoString(date, isLocal));
-              field.onBlur();
-            }}
-            showTimeSelect={metadata?.show_time ?? false}
-            utcOffset={isLocal ? undefined : 0}
+    <>
+      <Controller
+        key={name}
+        name={path}
+        control={control}
+        rules={rules}
+        defaultValue=""
+        render={({ field, fieldState }) => (
+          <EuiFormRow
+            label={label}
+            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
+            error={fieldState.error?.message}
             isInvalid={!!fieldState.error}
             fullWidth
-          />
-        </EuiFormRow>
+          >
+            <EuiDatePicker
+              selected={toMoment(field.value, isLocal)}
+              onChange={(date) => {
+                field.onChange(toIsoString(date, isLocal));
+                field.onBlur();
+                setHasPendingChange(true);
+              }}
+              showTimeSelect={metadata?.show_time ?? false}
+              utcOffset={isLocal ? undefined : 0}
+              isInvalid={!!fieldState.error}
+              fullWidth
+            />
+          </EuiFormRow>
+        )}
+      />
+      {showInlineActions && (
+        <InlineFieldActions
+          name={name}
+          onConfirm={() => {
+            setHasPendingChange(false);
+            onConfirm();
+          }}
+          onCancel={() => {
+            setHasPendingChange(false);
+            resetField(path);
+          }}
+        />
       )}
-    />
+    </>
   );
 };
 DatePicker.displayName = 'DatePicker';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/inline_field_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/inline_field_actions.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React from 'react';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import * as i18n from '../../translations';
+
+interface InlineFieldActionsProps {
+  name: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const InlineFieldActions: FC<InlineFieldActionsProps> = ({ name, onConfirm, onCancel }) => (
+  <EuiFlexGroup gutterSize="xs" justifyContent="flexEnd" responsive={false}>
+    <EuiFlexItem grow={false}>
+      <EuiButtonIcon
+        iconType="check"
+        color="success"
+        aria-label={i18n.CONFIRM_FIELD_EDIT}
+        data-test-subj={`template-field-confirm-${name}`}
+        onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault()}
+        onClick={onConfirm}
+      />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiButtonIcon
+        iconType="cross"
+        color="danger"
+        aria-label={i18n.CANCEL_FIELD_EDIT}
+        data-test-subj={`template-field-cancel-${name}`}
+        onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault()}
+        onClick={onCancel}
+      />
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+InlineFieldActions.displayName = 'InlineFieldActions';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
@@ -90,7 +90,10 @@ export const InputNumber = ({
               name={field.name}
               value={(field.value as string | number | undefined) ?? ''}
               onChange={(e) => field.onChange(e.target.value)}
-              onBlur={field.onBlur}
+              onBlur={() => {
+                field.onBlur();
+                setIsFocused(false);
+              }}
               onFocus={() => setIsFocused(true)}
               isInvalid={!!fieldState.error}
               fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
@@ -6,9 +6,10 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFieldNumber, EuiFormRow } from '@elastic/eui';
+import { InlineFieldActions } from './inline_field_actions';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
@@ -27,8 +28,17 @@ const isEmptyNumeric = (value: unknown): boolean => {
   return false;
 };
 
-export const InputNumber = ({ label, name, type, isRequired, min, max }: InputNumberProps) => {
-  const { control } = useFormContext();
+export const InputNumber = ({
+  label,
+  name,
+  type,
+  isRequired,
+  min,
+  max,
+  onConfirm,
+}: InputNumberProps) => {
+  const { control, resetField } = useFormContext();
+  const [isFocused, setIsFocused] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const rules = useMemo(() => {
@@ -57,6 +67,8 @@ export const InputNumber = ({ label, name, type, isRequired, min, max }: InputNu
     return { validate };
   }, [isRequired, min, max]);
 
+  const showInlineActions = isFocused && onConfirm != null;
+
   return (
     <Controller
       key={name}
@@ -65,23 +77,39 @@ export const InputNumber = ({ label, name, type, isRequired, min, max }: InputNu
       rules={rules}
       defaultValue=""
       render={({ field, fieldState }) => (
-        <EuiFormRow
-          label={label}
-          labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-          isInvalid={!!fieldState.error}
-          error={fieldState.error?.message}
-          fullWidth
-        >
-          <EuiFieldNumber
-            inputRef={field.ref}
-            name={field.name}
-            value={(field.value as string | number | undefined) ?? ''}
-            onChange={(e) => field.onChange(e.target.value)}
-            onBlur={field.onBlur}
+        <>
+          <EuiFormRow
+            label={label}
+            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
             isInvalid={!!fieldState.error}
+            error={fieldState.error?.message}
             fullWidth
-          />
-        </EuiFormRow>
+          >
+            <EuiFieldNumber
+              inputRef={field.ref}
+              name={field.name}
+              value={(field.value as string | number | undefined) ?? ''}
+              onChange={(e) => field.onChange(e.target.value)}
+              onBlur={field.onBlur}
+              onFocus={() => setIsFocused(true)}
+              isInvalid={!!fieldState.error}
+              fullWidth
+            />
+          </EuiFormRow>
+          {showInlineActions && (
+            <InlineFieldActions
+              name={name}
+              onConfirm={() => {
+                setIsFocused(false);
+                onConfirm();
+              }}
+              onCancel={() => {
+                setIsFocused(false);
+                resetField(path);
+              }}
+            />
+          )}
+        </>
       )}
     />
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFieldText, EuiFormRow } from '@elastic/eui';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
@@ -23,6 +23,7 @@ import {
   FIELD_PATTERN_INVALID,
 } from '../../translations';
 import { OptionalFieldLabel } from '../../../optional_field_label';
+import { InlineFieldActions } from './inline_field_actions';
 
 type InputTextProps = z.infer<typeof InputTextFieldSchema> & ConditionRenderProps;
 
@@ -34,8 +35,10 @@ export const InputText = ({
   patternValidation,
   minLength,
   maxLength,
+  onConfirm,
 }: InputTextProps) => {
-  const { control } = useFormContext();
+  const { control, resetField } = useFormContext();
+  const [isFocused, setIsFocused] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const rules = useMemo(() => {
@@ -71,6 +74,8 @@ export const InputText = ({
     return { validate };
   }, [isRequired, patternValidation, minLength, maxLength]);
 
+  const showInlineActions = isFocused && onConfirm != null;
+
   return (
     <Controller
       key={name}
@@ -79,23 +84,39 @@ export const InputText = ({
       rules={rules}
       defaultValue=""
       render={({ field, fieldState }) => (
-        <EuiFormRow
-          label={label}
-          labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-          isInvalid={!!fieldState.error}
-          error={fieldState.error?.message}
-          fullWidth
-        >
-          <EuiFieldText
-            inputRef={field.ref}
-            name={field.name}
-            value={(field.value as string) ?? ''}
-            onChange={(e) => field.onChange(e.target.value)}
-            onBlur={field.onBlur}
+        <>
+          <EuiFormRow
+            label={label}
+            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
             isInvalid={!!fieldState.error}
+            error={fieldState.error?.message}
             fullWidth
-          />
-        </EuiFormRow>
+          >
+            <EuiFieldText
+              inputRef={field.ref}
+              name={field.name}
+              value={(field.value as string) ?? ''}
+              onChange={(e) => field.onChange(e.target.value)}
+              onBlur={field.onBlur}
+              onFocus={() => setIsFocused(true)}
+              isInvalid={!!fieldState.error}
+              fullWidth
+            />
+          </EuiFormRow>
+          {showInlineActions && (
+            <InlineFieldActions
+              name={name}
+              onConfirm={() => {
+                setIsFocused(false);
+                onConfirm();
+              }}
+              onCancel={() => {
+                setIsFocused(false);
+                resetField(path);
+              }}
+            />
+          )}
+        </>
       )}
     />
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
@@ -97,7 +97,10 @@ export const InputText = ({
               name={field.name}
               value={(field.value as string) ?? ''}
               onChange={(e) => field.onChange(e.target.value)}
-              onBlur={field.onBlur}
+              onBlur={() => {
+                field.onBlur();
+                setIsFocused(false);
+              }}
               onFocus={() => setIsFocused(true)}
               isInvalid={!!fieldState.error}
               fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
@@ -6,9 +6,10 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFormRow, EuiRadioGroup } from '@elastic/eui';
+import { InlineFieldActions } from './inline_field_actions';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
@@ -26,8 +27,10 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   type,
   metadata,
   isRequired,
+  onConfirm,
 }) => {
-  const { control, setValue } = useFormContext();
+  const { control, setValue, resetField } = useFormContext();
+  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
   const firstOption = metadata.options[0];
   const defaultValue = metadata.default ?? firstOption;
@@ -46,30 +49,50 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
     };
   }, [isRequired]);
 
+  const showInlineActions = hasPendingChange && onConfirm != null;
+
   return (
-    <Controller
-      key={name}
-      name={path}
-      control={control}
-      rules={rules}
-      defaultValue={defaultValue}
-      render={({ field, fieldState }) => (
-        <RadioGroupRender
+    <>
+      <Controller
+        key={name}
+        name={path}
+        control={control}
+        rules={rules}
+        defaultValue={defaultValue}
+        render={({ field, fieldState }) => (
+          <RadioGroupRender
+            name={name}
+            path={path}
+            label={label ?? ''}
+            isRequired={isRequired ?? false}
+            options={options}
+            firstOption={firstOption}
+            value={typeof field.value === 'string' ? field.value : ''}
+            isInvalid={!!fieldState.error}
+            errorMessage={fieldState.error?.message}
+            onChange={(id) => {
+              field.onChange(id);
+              field.onBlur();
+              setHasPendingChange(true);
+            }}
+            setValue={setValue}
+          />
+        )}
+      />
+      {showInlineActions && (
+        <InlineFieldActions
           name={name}
-          path={path}
-          label={label ?? ''}
-          isRequired={isRequired ?? false}
-          options={options}
-          firstOption={firstOption}
-          value={typeof field.value === 'string' ? field.value : ''}
-          isInvalid={!!fieldState.error}
-          errorMessage={fieldState.error?.message}
-          onChange={field.onChange}
-          onBlur={field.onBlur}
-          setValue={setValue}
+          onConfirm={() => {
+            setHasPendingChange(false);
+            onConfirm();
+          }}
+          onCancel={() => {
+            setHasPendingChange(false);
+            resetField(path);
+          }}
         />
       )}
-    />
+    </>
   );
 };
 RadioGroup.displayName = 'RadioGroup';
@@ -85,7 +108,6 @@ interface RadioGroupRenderProps {
   isInvalid: boolean;
   errorMessage?: string;
   onChange: (next: string) => void;
-  onBlur: () => void;
   setValue: ReturnType<typeof useFormContext>['setValue'];
 }
 
@@ -100,7 +122,6 @@ const RadioGroupRender: React.FC<RadioGroupRenderProps> = ({
   isInvalid,
   errorMessage,
   onChange,
-  onBlur,
   setValue,
 }) => {
   // When the form value is empty (e.g. set to '' by useYamlFormSync when no
@@ -123,15 +144,7 @@ const RadioGroupRender: React.FC<RadioGroupRenderProps> = ({
       isInvalid={isInvalid}
       fullWidth
     >
-      <EuiRadioGroup
-        name={name}
-        options={options}
-        idSelected={idSelected}
-        onChange={(id) => {
-          onChange(id);
-          onBlur();
-        }}
-      />
+      <EuiRadioGroup name={name} options={options} idSelected={idSelected} onChange={onChange} />
     </EuiFormRow>
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { z } from '@kbn/zod/v4';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { InlineFieldActions } from './inline_field_actions';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
@@ -20,8 +21,16 @@ import { OptionalFieldLabel } from '../../../optional_field_label';
 
 type SelectBasicProps = z.infer<typeof SelectBasicFieldSchema> & ConditionRenderProps;
 
-export const SelectBasic = ({ label, metadata, name, type, isRequired }: SelectBasicProps) => {
-  const { control } = useFormContext();
+export const SelectBasic = ({
+  label,
+  metadata,
+  name,
+  type,
+  isRequired,
+  onConfirm,
+}: SelectBasicProps) => {
+  const { control, resetField } = useFormContext();
+  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const options = useMemo(
@@ -39,35 +48,56 @@ export const SelectBasic = ({ label, metadata, name, type, isRequired }: SelectB
     };
   }, [isRequired]);
 
+  const showInlineActions = hasPendingChange && onConfirm != null;
+
   return (
-    <Controller
-      key={name}
-      name={path}
-      control={control}
-      rules={rules}
-      defaultValue=""
-      render={({ field, fieldState }) => (
-        <EuiFormRow
-          label={label}
-          labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-          isInvalid={!!fieldState.error}
-          error={fieldState.error?.message}
-          fullWidth
-        >
-          <EuiSelect
-            inputRef={field.ref}
-            name={field.name}
-            options={options}
-            value={(field.value as string) ?? ''}
-            onChange={(e) => field.onChange(e.target.value)}
-            onBlur={field.onBlur}
-            hasNoInitialSelection={!field.value}
+    <>
+      <Controller
+        key={name}
+        name={path}
+        control={control}
+        rules={rules}
+        defaultValue=""
+        render={({ field, fieldState }) => (
+          <EuiFormRow
+            label={label}
+            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
             isInvalid={!!fieldState.error}
+            error={fieldState.error?.message}
             fullWidth
-          />
-        </EuiFormRow>
+          >
+            <EuiSelect
+              inputRef={field.ref}
+              name={field.name}
+              options={options}
+              value={(field.value as string) ?? ''}
+              onChange={(e) => {
+                field.onChange(e.target.value);
+                field.onBlur();
+                setHasPendingChange(true);
+              }}
+              onBlur={field.onBlur}
+              hasNoInitialSelection={!field.value}
+              isInvalid={!!fieldState.error}
+              fullWidth
+            />
+          </EuiFormRow>
+        )}
+      />
+      {showInlineActions && (
+        <InlineFieldActions
+          name={name}
+          onConfirm={() => {
+            setHasPendingChange(false);
+            onConfirm();
+          }}
+          onCancel={() => {
+            setHasPendingChange(false);
+            resetField(path);
+          }}
+        />
       )}
-    />
+    </>
   );
 };
 SelectBasic.displayName = 'SelectBasic';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
@@ -97,7 +97,10 @@ export const Textarea = ({
               name={field.name}
               value={(field.value as string) ?? ''}
               onChange={(e) => field.onChange(e.target.value)}
-              onBlur={field.onBlur}
+              onBlur={() => {
+                field.onBlur();
+                setIsFocused(false);
+              }}
               onFocus={() => setIsFocused(true)}
               isInvalid={!!fieldState.error}
               fullWidth

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
@@ -6,9 +6,10 @@
  */
 
 import type { z } from '@kbn/zod/v4';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { EuiFormRow, EuiTextArea } from '@elastic/eui';
+import { InlineFieldActions } from './inline_field_actions';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
@@ -34,8 +35,10 @@ export const Textarea = ({
   patternValidation,
   minLength,
   maxLength,
+  onConfirm,
 }: TextareaProps) => {
-  const { control } = useFormContext();
+  const { control, resetField } = useFormContext();
+  const [isFocused, setIsFocused] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const rules = useMemo(() => {
@@ -71,6 +74,8 @@ export const Textarea = ({
     return { validate };
   }, [isRequired, patternValidation, minLength, maxLength]);
 
+  const showInlineActions = isFocused && onConfirm != null;
+
   return (
     <Controller
       key={name}
@@ -79,23 +84,39 @@ export const Textarea = ({
       rules={rules}
       defaultValue=""
       render={({ field, fieldState }) => (
-        <EuiFormRow
-          label={label}
-          labelAppend={!isRequired ? OptionalFieldLabel : undefined}
-          isInvalid={!!fieldState.error}
-          error={fieldState.error?.message}
-          fullWidth
-        >
-          <EuiTextArea
-            inputRef={field.ref}
-            name={field.name}
-            value={(field.value as string) ?? ''}
-            onChange={(e) => field.onChange(e.target.value)}
-            onBlur={field.onBlur}
+        <>
+          <EuiFormRow
+            label={label}
+            labelAppend={!isRequired ? OptionalFieldLabel : undefined}
             isInvalid={!!fieldState.error}
+            error={fieldState.error?.message}
             fullWidth
-          />
-        </EuiFormRow>
+          >
+            <EuiTextArea
+              inputRef={field.ref}
+              name={field.name}
+              value={(field.value as string) ?? ''}
+              onChange={(e) => field.onChange(e.target.value)}
+              onBlur={field.onBlur}
+              onFocus={() => setIsFocused(true)}
+              isInvalid={!!fieldState.error}
+              fullWidth
+            />
+          </EuiFormRow>
+          {showInlineActions && (
+            <InlineFieldActions
+              name={name}
+              onConfirm={() => {
+                setIsFocused(false);
+                onConfirm();
+              }}
+              onCancel={() => {
+                setIsFocused(false);
+                resetField(path);
+              }}
+            />
+          )}
+        </>
       )}
     />
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
@@ -39,9 +39,9 @@ export const UserPicker: React.FC<UserPickerProps> = ({
   isRequired,
   onConfirm,
 }) => {
-  const { control, resetField } = useFormContext();
-  const [hasPendingChange, setHasPendingChange] = useState(false);
+  const { control, resetField, getFieldState, formState } = useFormContext();
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
+  const { isDirty } = getFieldState(path, formState);
 
   const { owner: owners } = useCasesContext();
   const availableOwners = useAvailableCasesOwners(getAllPermissionsExceptFrom('delete'));
@@ -78,7 +78,7 @@ export const UserPicker: React.FC<UserPickerProps> = ({
     [onContentChange]
   );
 
-  const showInlineActions = hasPendingChange && onConfirm != null;
+  const showInlineActions = isDirty && onConfirm != null;
 
   return (
     <>
@@ -110,24 +110,13 @@ export const UserPicker: React.FC<UserPickerProps> = ({
               onChange={(next) => {
                 field.onChange(JSON.stringify(next));
                 field.onBlur();
-                setHasPendingChange(true);
               }}
             />
           );
         }}
       />
       {showInlineActions && (
-        <InlineFieldActions
-          name={name}
-          onConfirm={() => {
-            setHasPendingChange(false);
-            onConfirm();
-          }}
-          onCancel={() => {
-            setHasPendingChange(false);
-            resetField(path);
-          }}
-        />
+        <InlineFieldActions name={name} onConfirm={onConfirm} onCancel={() => resetField(path)} />
       )}
     </>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import type { z } from '@kbn/zod/v4';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { InlineFieldActions } from '../inline_field_actions';
 import { CASE_EXTENDED_FIELDS } from '../../../../../../common/constants';
 import { getFieldSnakeKey } from '../../../../../../common/utils';
 import type {
@@ -36,8 +37,10 @@ export const UserPicker: React.FC<UserPickerProps> = ({
   type,
   metadata,
   isRequired,
+  onConfirm,
 }) => {
-  const { control } = useFormContext();
+  const { control, resetField } = useFormContext();
+  const [hasPendingChange, setHasPendingChange] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
 
   const { owner: owners } = useCasesContext();
@@ -75,40 +78,58 @@ export const UserPicker: React.FC<UserPickerProps> = ({
     [onContentChange]
   );
 
-  return (
-    <Controller
-      key={name}
-      name={path}
-      control={control}
-      rules={rules}
-      defaultValue={defaultValue}
-      render={({ field, fieldState }) => {
-        const selectedUsers = toSelectedUsers(field.value);
-        const missingUids = selectedUsers
-          .filter((u) => !suggestedProfiles.some((p) => p.uid === u.uid))
-          .map((u) => u.uid);
+  const showInlineActions = hasPendingChange && onConfirm != null;
 
-        return (
-          <UserPickerComboboxWithProfiles
-            label={label}
-            name={name}
-            isInvalid={!!fieldState.error}
-            errorMessage={fieldState.error?.message ?? null}
-            isLoading={isLoading}
-            isMultiple={isMultiple}
-            isRequired={isRequired ?? false}
-            selectedUsers={selectedUsers}
-            suggestedProfiles={suggestedProfiles}
-            missingUids={missingUids}
-            onSearchChange={onSearchChange}
-            onChange={(next) => {
-              field.onChange(JSON.stringify(next));
-              field.onBlur();
-            }}
-          />
-        );
-      }}
-    />
+  return (
+    <>
+      <Controller
+        key={name}
+        name={path}
+        control={control}
+        rules={rules}
+        defaultValue={defaultValue}
+        render={({ field, fieldState }) => {
+          const selectedUsers = toSelectedUsers(field.value);
+          const missingUids = selectedUsers
+            .filter((u) => !suggestedProfiles.some((p) => p.uid === u.uid))
+            .map((u) => u.uid);
+
+          return (
+            <UserPickerComboboxWithProfiles
+              label={label}
+              name={name}
+              isInvalid={!!fieldState.error}
+              errorMessage={fieldState.error?.message ?? null}
+              isLoading={isLoading}
+              isMultiple={isMultiple}
+              isRequired={isRequired ?? false}
+              selectedUsers={selectedUsers}
+              suggestedProfiles={suggestedProfiles}
+              missingUids={missingUids}
+              onSearchChange={onSearchChange}
+              onChange={(next) => {
+                field.onChange(JSON.stringify(next));
+                field.onBlur();
+                setHasPendingChange(true);
+              }}
+            />
+          );
+        }}
+      />
+      {showInlineActions && (
+        <InlineFieldActions
+          name={name}
+          onConfirm={() => {
+            setHasPendingChange(false);
+            onConfirm();
+          }}
+          onCancel={() => {
+            setHasPendingChange(false);
+            resetField(path);
+          }}
+        />
+      )}
+    </>
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
@@ -37,7 +37,8 @@ export const FieldsRenderer: FC<{
   resolvedFields: InlineField[];
   parentFieldNames?: Set<string>;
   parentTemplateName?: string;
-}> = ({ resolvedFields, parentFieldNames, parentTemplateName }) => {
+  onFieldConfirm?: () => void;
+}> = ({ resolvedFields, parentFieldNames, parentTemplateName, onFieldConfirm }) => {
   const { euiTheme } = useEuiTheme();
   const { control } = useFormContext();
 
@@ -99,6 +100,7 @@ export const FieldsRenderer: FC<{
           max: field.validation?.max,
           minLength: field.validation?.min_length,
           maxLength: field.validation?.max_length,
+          onConfirm: onFieldConfirm,
         };
 
         const isInherited = parentFieldNames?.has(field.name) ?? false;

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/translations.ts
@@ -697,3 +697,11 @@ export const EXTENDS_NOT_FOUND_ERROR = (name: string) =>
     defaultMessage: 'Template "{name}" not found.',
     values: { name },
   });
+
+export const CONFIRM_FIELD_EDIT = i18n.translate('xpack.cases.templates.confirmFieldEdit', {
+  defaultMessage: 'Save field',
+});
+
+export const CANCEL_FIELD_EDIT = i18n.translate('xpack.cases.templates.cancelFieldEdit', {
+  defaultMessage: 'Cancel field edit',
+});


### PR DESCRIPTION
## Summary

Replaces the debounce-on-blur auto-save pattern for extended fields in the case view with an explicit inline confirm/cancel interaction. When a user edits an extended field, confirm (✓) and cancel (✗) icon buttons appear; the field is persisted only on confirm and reverted on cancel.

## Changes

- Added a shared `InlineFieldActions` component (confirm/cancel `EuiButtonIcon`s) rendered below each field control when a pending change exists
- Removed debounce-on-blur from `TemplateFieldsFormReady`; replaced with an `onFieldConfirm` callback threaded through `FieldsRenderer` into each control via the existing `ConditionRenderProps.onConfirm` prop
- All seven field control types (text, textarea, number, select, checkbox, radio group, date picker, user picker) updated to track focus/change state and conditionally render `InlineFieldActions`
- Fixed `CreateCaseTemplateFields` to call `parentForm.setFieldValue(CASE_EXTENDED_FIELDS, ...)` instead of the incorrect camelCase `'extendedFields'` key
- Added i18n strings for confirm/cancel button aria-labels

## Risk & Migration

**Score: 2** — Isolated UI change; `ConditionRenderProps.onConfirm` is an optional addition (fully backward-compatible). The key fix in create flow corrects a bug with no migration needed — the canonical form schema key was always `CASE_EXTENDED_FIELDS`.

## Testing

**Manual:**
1. Open a case that has a template with extended fields applied.
2. Click any extended field (text, number, select, etc.) — confirm and cancel buttons should appear.
3. Edit the value and click ✓ — value is saved, buttons disappear.
4. Edit again, click ✗ — value reverts to the saved value, buttons disappear.
5. Edit a field and tab away without clicking either button — value should NOT be saved (no implicit save on blur).
6. Create a new case using a template that defines extended fields — verify the extended field values are included in the created case.

**Automated:**
- [x] Unit tests added/updated: `x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx`
- [x] Unit tests added/updated: `x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx`

## Checklist

Check the PR satisfies following conditions.
Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Screenshots / Recordings

| Before | After |
|--------|-------|
| <!-- screenshot: blur auto-saves with no UI feedback --> | <!-- screenshot: confirm/cancel buttons appear on focus --> |