### PR TITLE
[Chrome Next] Add app menu switch

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/app_menu.stories.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/app_menu.stories.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
@@ -387,5 +387,68 @@ export const DashboardEditModeWithStaticItems: Story = {
   args: {
     config: dashboardEditModeConfig,
     staticItems: staticItem,
+  },
+};
+
+const InteractiveSwitchWrapper = (props: AppMenuWrapperProps) => {
+  const [checked, setChecked] = useState(false);
+  const configWithSwitch: AppMenuConfig = {
+    ...props.config,
+    switch: {
+      id: 'switch',
+      label: 'Enabled',
+      labelProps: {},
+      checked,
+      onChange: (value) => {
+        setChecked(value);
+        action('switch-toggled')(value);
+      },
+      'data-test-subj': 'switch',
+    },
+  };
+
+  return <AppMenuWrapper {...props} config={configWithSwitch} />;
+};
+
+export const StandaloneSwitch: Story = {
+  name: 'Switch - standalone',
+  render: (args) => <InteractiveSwitchWrapper {...args} />,
+  args: {
+    config: {},
+  },
+};
+
+export const SwitchWithItems: Story = {
+  name: 'Switch with items and primary action',
+  render: (args) => <InteractiveSwitchWrapper {...args} />,
+  args: {
+    config: {
+      items: [
+        {
+          id: 'manualRun',
+          order: 1,
+          label: 'Manual run',
+          run: action('manual-run-clicked'),
+          iconType: 'play',
+          testId: 'manualRunButton',
+        },
+        {
+          id: 'settings',
+          order: 2,
+          label: 'Settings',
+          run: action('settings-clicked'),
+          iconType: 'gear',
+          testId: 'settingsButton',
+          overflow: true,
+        },
+      ],
+      primaryActionItem: {
+        run: action('edit-clicked'),
+        id: 'edit',
+        label: 'Edit',
+        testId: 'editButton',
+        iconType: 'controls',
+      },
+    },
   },
 };

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.test.tsx
@@ -148,4 +148,50 @@ describe('AppMenu', () => {
       expect(screen.queryByText('Single overflow item')).not.toBeInTheDocument();
     });
   });
+
+  describe('switch', () => {
+    const switchConfig: AppMenuConfig['switch'] = {
+      id: 'test-switch',
+      label: 'Test switch',
+      labelProps: {},
+      checked: false,
+      onChange: jest.fn(),
+      'data-test-subj': 'test-switch',
+    };
+
+    it('should render the app menu with only a switch (standalone)', () => {
+      render(<AppMenuComponent config={{ switch: switchConfig }} />);
+
+      expect(screen.getByTestId('app-menu')).toBeInTheDocument();
+      expect(screen.getByTestId('test-switch')).toBeInTheDocument();
+    });
+
+    it('should render the switch alongside menu items at xl breakpoint', () => {
+      render(<AppMenuComponent config={{ ...defaultConfig, switch: switchConfig }} />);
+
+      expect(screen.getByTestId('test-switch')).toBeInTheDocument();
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+      expect(screen.getByText('Item 2')).toBeInTheDocument();
+    });
+
+    it('should render the switch at m-l breakpoint', () => {
+      mockUseIsWithinBreakpoints.mockImplementation((breakpoints: string[]) => {
+        if (breakpoints.includes('m') && breakpoints.includes('l')) return true;
+        return false;
+      });
+
+      render(<AppMenuComponent config={{ ...defaultConfig, switch: switchConfig }} />);
+
+      expect(screen.getByTestId('test-switch')).toBeInTheDocument();
+    });
+
+    it('should not render standalone switch at collapsed breakpoint (only overflow)', () => {
+      mockUseIsWithinBreakpoints.mockReturnValue(false);
+
+      render(<AppMenuComponent config={{ switch: switchConfig }} />);
+
+      expect(screen.getByTestId('app-menu-overflow-button')).toBeInTheDocument();
+      expect(screen.queryByTestId('test-switch')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
@@ -13,6 +13,7 @@ import { getAppMenuItems, processStaticItems } from '../utils';
 import { AppMenuActionButton } from './app_menu_action_button';
 import { AppMenuItem } from './app_menu_item';
 import { AppMenuOverflowButton } from './app_menu_overflow_button';
+import { AppMenuSwitchComponent } from './app_menu_switch';
 import type { AppMenuConfig, AppMenuStaticItem } from '../types';
 
 export interface AppMenuItemsProps {
@@ -30,7 +31,8 @@ export interface AppMenuItemsProps {
   staticItems?: AppMenuStaticItem[];
 }
 
-const hasNoItems = (config: AppMenuConfig) => !config.items?.length && !config?.primaryActionItem;
+const hasNoItems = (config: AppMenuConfig) =>
+  !config.items?.length && !config?.primaryActionItem && !config?.switch;
 
 export const AppMenuComponent = ({
   config,
@@ -60,6 +62,7 @@ export const AppMenuComponent = ({
   }
 
   const primaryActionItem = config?.primaryActionItem;
+  const switchConfig = config?.switch;
   const showMoreButtonId = 'show-more';
 
   const headerLinksProps = {
@@ -108,6 +111,7 @@ export const AppMenuComponent = ({
       staticItems={processedStaticItems}
       isPopoverOpen={openPopoverId === showMoreButtonId}
       primaryActionItem={primaryActionItem}
+      switchConfig={switchConfig}
       onPopoverToggle={() => handlePopoverToggle(showMoreButtonId)}
       onPopoverClose={handleOnPopoverClose}
     />
@@ -120,6 +124,7 @@ export const AppMenuComponent = ({
   if (isBetweenMandXlBreakpoint) {
     return (
       <EuiHeaderLinks {...headerLinksProps}>
+        {switchConfig && <AppMenuSwitchComponent switchConfig={switchConfig} />}
         <AppMenuOverflowButton
           items={[...displayedItems, ...allOverflowItems]}
           staticItems={processedStaticItems}
@@ -135,6 +140,7 @@ export const AppMenuComponent = ({
   if (isAboveXlBreakpoint) {
     return (
       <EuiHeaderLinks {...headerLinksProps}>
+        {switchConfig && <AppMenuSwitchComponent switchConfig={switchConfig} />}
         {displayedItems?.length > 0 &&
           displayedItems.map((menuItem) => (
             <AppMenuItem

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_overflow_button.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_overflow_button.tsx
@@ -13,13 +13,14 @@ import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { getIsSelectedColor } from '../utils';
 import { AppMenuPopover } from './app_menu_popover';
-import type { AppMenuItemType, AppMenuPrimaryActionItem } from '../types';
+import type { AppMenuItemType, AppMenuPrimaryActionItem, AppMenuSwitch } from '../types';
 
 interface AppMenuShowMoreButtonProps {
   items: AppMenuItemType[];
   staticItems?: AppMenuItemType[];
   isPopoverOpen: boolean;
   primaryActionItem?: AppMenuPrimaryActionItem;
+  switchConfig?: AppMenuSwitch;
   onPopoverToggle: () => void;
   onPopoverClose: () => void;
 }
@@ -29,12 +30,13 @@ export const AppMenuOverflowButton = ({
   staticItems,
   isPopoverOpen,
   primaryActionItem,
+  switchConfig,
   onPopoverToggle,
   onPopoverClose,
 }: AppMenuShowMoreButtonProps) => {
   const { euiTheme } = useEuiTheme();
 
-  if (items.length === 0 && (!staticItems || staticItems.length === 0)) {
+  if (items.length === 0 && (!staticItems || staticItems.length === 0) && !switchConfig) {
     return null;
   }
 
@@ -78,6 +80,7 @@ export const AppMenuOverflowButton = ({
       })}
       isOpen={isPopoverOpen}
       primaryActionItem={primaryActionItem}
+      switchConfig={switchConfig}
       onClose={onPopoverClose}
       onCloseOverflowButton={onPopoverClose}
     />

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover.tsx
@@ -10,7 +10,12 @@
 import React, { useMemo, type ReactElement } from 'react';
 import { EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { getPopoverPanels, getTooltip } from '../utils';
-import type { AppMenuItemType, AppMenuPopoverItem, AppMenuPrimaryActionItem } from '../types';
+import type {
+  AppMenuItemType,
+  AppMenuPopoverItem,
+  AppMenuPrimaryActionItem,
+  AppMenuSwitch,
+} from '../types';
 
 interface AppMenuContextMenuProps {
   tooltipContent?: string | (() => string | undefined);
@@ -22,6 +27,7 @@ interface AppMenuContextMenuProps {
   isOpen: boolean;
   popoverWidth?: number;
   primaryActionItem?: AppMenuPrimaryActionItem;
+  switchConfig?: AppMenuSwitch;
   popoverTestId?: string;
   onClose: () => void;
   onCloseOverflowButton?: () => void;
@@ -37,6 +43,7 @@ export const AppMenuPopover = ({
   isOpen,
   popoverWidth,
   primaryActionItem,
+  switchConfig,
   popoverTestId = 'app-menu-popover',
   onClose,
   onCloseOverflowButton,
@@ -47,6 +54,7 @@ export const AppMenuPopover = ({
         items,
         staticItems,
         primaryActionItem,
+        switchConfig,
         rootPanelWidth: popoverWidth,
         rootPopoverTestId: popoverTestId,
         onClose,
@@ -57,6 +65,7 @@ export const AppMenuPopover = ({
       items,
       staticItems,
       primaryActionItem,
+      switchConfig,
       popoverWidth,
       popoverTestId,
       onClose,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_switch.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_switch.test.tsx
@@ -31,41 +31,11 @@ describe('AppMenuSwitchComponent', () => {
     expect(screen.getByText('Test switch')).toBeInTheDocument();
   });
 
-  it('should render as unchecked when checked is false', () => {
-    render(<AppMenuSwitchComponent switchConfig={defaultSwitchConfig} />);
-
-    const switchInput = screen.getByRole('switch');
-    expect(switchInput).not.toBeChecked();
-  });
-
-  it('should render as checked when checked is true', () => {
-    render(<AppMenuSwitchComponent switchConfig={{ ...defaultSwitchConfig, checked: true }} />);
-
-    const switchInput = screen.getByRole('switch');
-    expect(switchInput).toBeChecked();
-  });
-
   it('should call onChange with the new checked value when toggled', () => {
     const onChange = jest.fn();
     render(<AppMenuSwitchComponent switchConfig={{ ...defaultSwitchConfig, onChange }} />);
 
     fireEvent.click(screen.getByRole('switch'));
     expect(onChange).toHaveBeenCalledWith(true);
-  });
-
-  it('should use the default data-test-subj when not provided', () => {
-    render(<AppMenuSwitchComponent switchConfig={defaultSwitchConfig} />);
-
-    expect(screen.getByTestId('app-menu-switch')).toBeInTheDocument();
-  });
-
-  it('should use the custom data-test-subj when provided', () => {
-    render(
-      <AppMenuSwitchComponent
-        switchConfig={{ ...defaultSwitchConfig, 'data-test-subj': 'custom-switch' }}
-      />
-    );
-
-    expect(screen.getByTestId('custom-switch')).toBeInTheDocument();
   });
 });

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_switch.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_switch.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AppMenuSwitchComponent } from './app_menu_switch';
+import type { AppMenuSwitch } from '../types';
+
+describe('AppMenuSwitchComponent', () => {
+  const defaultSwitchConfig: AppMenuSwitch = {
+    id: 'test-switch',
+    label: 'Test switch',
+    labelProps: { className: 'test-label' },
+    checked: false,
+    onChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with the correct label', () => {
+    render(<AppMenuSwitchComponent switchConfig={defaultSwitchConfig} />);
+
+    expect(screen.getByText('Test switch')).toBeInTheDocument();
+  });
+
+  it('should render as unchecked when checked is false', () => {
+    render(<AppMenuSwitchComponent switchConfig={defaultSwitchConfig} />);
+
+    const switchInput = screen.getByRole('switch');
+    expect(switchInput).not.toBeChecked();
+  });
+
+  it('should render as checked when checked is true', () => {
+    render(<AppMenuSwitchComponent switchConfig={{ ...defaultSwitchConfig, checked: true }} />);
+
+    const switchInput = screen.getByRole('switch');
+    expect(switchInput).toBeChecked();
+  });
+
+  it('should call onChange with the new checked value when toggled', () => {
+    const onChange = jest.fn();
+    render(<AppMenuSwitchComponent switchConfig={{ ...defaultSwitchConfig, onChange }} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('should use the default data-test-subj when not provided', () => {
+    render(<AppMenuSwitchComponent switchConfig={defaultSwitchConfig} />);
+
+    expect(screen.getByTestId('app-menu-switch')).toBeInTheDocument();
+  });
+
+  it('should use the custom data-test-subj when provided', () => {
+    render(
+      <AppMenuSwitchComponent
+        switchConfig={{ ...defaultSwitchConfig, 'data-test-subj': 'custom-switch' }}
+      />
+    );
+
+    expect(screen.getByTestId('custom-switch')).toBeInTheDocument();
+  });
+});

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_switch.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_switch.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { EuiSwitchEvent } from '@elastic/eui';
+import { EuiSwitch, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { AppMenuSwitch } from '../types';
+
+interface AppMenuSwitchComponentProps {
+  switchConfig: AppMenuSwitch;
+}
+
+export const AppMenuSwitchComponent = ({ switchConfig }: AppMenuSwitchComponentProps) => {
+  const { euiTheme } = useEuiTheme();
+  const { id, label, labelProps, checked, onChange, 'data-test-subj': dataTestSubj } = switchConfig;
+
+  const switchCss = css`
+    margin-right: ${euiTheme.size.s};
+  `;
+
+  const handleChange = (e: EuiSwitchEvent) => {
+    onChange(e.target.checked);
+  };
+
+  return (
+    <EuiSwitch
+      id={id}
+      label={label}
+      labelProps={labelProps}
+      checked={checked}
+      onChange={handleChange}
+      compressed
+      css={switchCss}
+      data-test-subj={dataTestSubj ?? 'app-menu-switch'}
+    />
+  );
+};

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/index.ts
@@ -13,3 +13,4 @@ export { AppMenuActionButton } from './app_menu_action_button';
 export { AppMenuOverflowButton } from './app_menu_overflow_button';
 export { AppMenuPopover } from './app_menu_popover';
 export { AppMenuPopoverActionButtons } from './app_menu_popover_action_buttons';
+export { AppMenuSwitchComponent } from './app_menu_switch';

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
@@ -13,6 +13,7 @@ export { AppMenuActionButton } from './components';
 export { AppMenuOverflowButton } from './components';
 export { AppMenuPopover } from './components';
 export { AppMenuPopoverActionButtons } from './components';
+export { AppMenuSwitchComponent } from './components';
 
 export type {
   AppMenuRunAction,
@@ -23,6 +24,7 @@ export type {
   AppMenuPopoverItem,
   AppMenuSplitButtonProps,
   AppMenuStaticItem,
+  AppMenuSwitch,
 } from './types';
 
 export { APP_MENU_ITEM_LIMIT, DEFAULT_POPOVER_WIDTH } from './constants';
@@ -36,5 +38,6 @@ export {
   getAppMenuItems,
   getPopoverPanels,
   getPopoverActionItems,
+  getPopoverSwitchItems,
   getIsSelectedColor,
 } from './utils';

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { EuiHideForProps, IconType } from '@elastic/eui';
+import type { EuiHideForProps, EuiSwitchProps, IconType } from '@elastic/eui';
 import type { SplitButtonWithNotificationProps } from './components/split_button_with_notification';
 
 /**
@@ -255,6 +255,15 @@ export type AppMenuPopoverItem = Omit<
   labelBadgeText?: string;
 };
 
+export interface AppMenuSwitch {
+  id: string;
+  label: string;
+  labelProps: EuiSwitchProps['labelProps'];
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  'data-test-subj'?: string;
+}
+
 /**
  * Primary action button type. Can be either a simple button or a split button.
  */
@@ -285,4 +294,9 @@ export interface AppMenuConfig {
    * Primary action button to display in the app menu.
    */
   primaryActionItem?: AppMenuPrimaryActionItem;
+  /**
+   * App menu switch. Only one switch is available per app menu
+   * and it is rendered to the left of the menu items.
+   */
+  switch?: AppMenuSwitch;
 }

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
@@ -15,12 +15,13 @@ import {
   getAppMenuItems,
   mapAppMenuItemToPanelItem,
   getPopoverActionItems,
+  getPopoverSwitchItems,
   getPopoverPanels,
   getIsSelectedColor,
   processStaticItems,
 } from './utils';
 import { APP_MENU_ITEM_LIMIT } from './constants';
-import type { AppMenuItemType, AppMenuPopoverItem } from './types';
+import type { AppMenuItemType, AppMenuPopoverItem, AppMenuSwitch } from './types';
 
 describe('utils', () => {
   describe('createReturnFocus', () => {
@@ -486,7 +487,40 @@ describe('utils', () => {
     });
   });
 
+  describe('getPopoverSwitchItems', () => {
+    const defaultSwitch: AppMenuSwitch = {
+      id: 'test-switch',
+      label: 'Test switch',
+      labelProps: {},
+      checked: false,
+      onChange: jest.fn(),
+    };
+
+    it('should return a separator and a switch item', () => {
+      const result = getPopoverSwitchItems({ switchConfig: defaultSwitch });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].isSeparator).toBe(true);
+      expect(result[0].key).toBe('switch-separator');
+      expect(result[1].key).toBe('switch-test-switch');
+    });
+
+    it('should have a renderItem function for the switch item', () => {
+      const result = getPopoverSwitchItems({ switchConfig: defaultSwitch });
+
+      expect(result[1].renderItem).toBeDefined();
+    });
+  });
+
   describe('getPopoverPanels', () => {
+    const defaultSwitch: AppMenuSwitch = {
+      id: 'test-switch',
+      label: 'Test switch',
+      labelProps: {},
+      checked: false,
+      onChange: jest.fn(),
+    };
+
     it('should create single panel for flat items', () => {
       const items: AppMenuPopoverItem[] = [
         { id: '1', label: 'Item 1', run: jest.fn(), order: 1 },
@@ -704,6 +738,37 @@ describe('utils', () => {
       const staticIndex = panelItems.findIndex((i) => i.key === 'static1');
       const actionIndex = panelItems.findIndex((i) => i.key === 'action-items');
       expect(staticIndex).toBeLessThan(actionIndex);
+    });
+
+    it('should append switch items as the very last items in the panel', () => {
+      const items: AppMenuPopoverItem[] = [{ id: '1', label: 'Item 1', run: jest.fn(), order: 1 }];
+
+      const panels = getPopoverPanels({
+        items,
+        switchConfig: defaultSwitch,
+      });
+
+      const panelItems = panels[0].items as Array<{ key?: string; isSeparator?: boolean }>;
+      const switchIndex = panelItems.findIndex((i) => i.key === 'switch-test-switch');
+      expect(switchIndex).toBe(panelItems.length - 1);
+      // Separator should be right before the switch
+      expect(panelItems[switchIndex - 1].isSeparator).toBe(true);
+    });
+
+    it('should place switch after action items when both are present', () => {
+      const items: AppMenuPopoverItem[] = [{ id: '1', label: 'Item 1', run: jest.fn(), order: 1 }];
+
+      const panels = getPopoverPanels({
+        items,
+        primaryActionItem: { id: 'save', label: 'Save', run: jest.fn(), iconType: 'save' },
+        switchConfig: defaultSwitch,
+      });
+
+      const panelItems = panels[0].items as Array<{ key?: string }>;
+      const actionIndex = panelItems.findIndex((i) => i.key === 'action-items');
+      const switchIndex = panelItems.findIndex((i) => i.key === 'switch-test-switch');
+      expect(actionIndex).toBeLessThan(switchIndex);
+      expect(switchIndex).toBe(panelItems.length - 1);
     });
   });
 

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -16,6 +16,7 @@ import {
   type EuiContextMenuPanelItemDescriptor,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiSwitch,
 } from '@elastic/eui';
 import { getRouterLinkProps } from '@kbn/router-utils';
 import { AppMenuBadge } from './components/app_menu_badge';
@@ -26,6 +27,7 @@ import type {
   AppMenuItemType,
   AppMenuPopoverItem,
   AppMenuPrimaryActionItem,
+  AppMenuSwitch,
 } from './types';
 import { APP_MENU_ITEM_LIMIT, DEFAULT_POPOVER_WIDTH } from './constants';
 
@@ -278,12 +280,43 @@ export const getPopoverActionItems = ({
 };
 
 /**
+ * Generate switch items for the popover menu. The switch is rendered as the very last item
+ * with a separator above it.
+ */
+export const getPopoverSwitchItems = ({
+  switchConfig,
+}: {
+  switchConfig: AppMenuSwitch;
+}): EuiContextMenuPanelItemDescriptor[] => {
+  const separator = createSeparatorItem('switch-separator');
+
+  return [
+    separator,
+    {
+      key: `switch-${switchConfig.id}`,
+      renderItem: () => (
+        <EuiSwitch
+          id={switchConfig.id}
+          label={switchConfig.label}
+          labelProps={switchConfig.labelProps}
+          checked={switchConfig.checked}
+          onChange={(e) => switchConfig.onChange(e.target.checked)}
+          compressed
+          data-test-subj={switchConfig['data-test-subj'] ?? 'app-menu-switch'}
+        />
+      ),
+    },
+  ];
+};
+
+/**
  * Recursively generate EUI context menu panels from the provided menu items.
  */
 export const getPopoverPanels = ({
   items,
   staticItems,
   primaryActionItem,
+  switchConfig,
   startPanelId = 0,
   rootPanelWidth = DEFAULT_POPOVER_WIDTH,
   rootPopoverTestId,
@@ -294,6 +327,7 @@ export const getPopoverPanels = ({
   items: AppMenuPopoverItem[];
   staticItems?: AppMenuPopoverItem[];
   primaryActionItem?: AppMenuPrimaryActionItem;
+  switchConfig?: AppMenuSwitch;
   startPanelId?: number;
   rootPanelWidth?: number;
   rootPopoverTestId?: string;
@@ -303,6 +337,7 @@ export const getPopoverPanels = ({
 }): EuiContextMenuPanelDescriptor[] => {
   const panels: EuiContextMenuPanelDescriptor[] = [];
   const hasActionItems = Boolean(primaryActionItem);
+  const hasSwitchItem = Boolean(switchConfig);
   let currentPanelId = startPanelId;
 
   const processItems = ({
@@ -410,19 +445,23 @@ export const getPopoverPanels = ({
    * Action items are only added to the main panel and only in lower breakpoints (below "m").
    * They should not be available to be added via config.
    */
+  const mainPanel = panels.find((panel) => panel.id === startPanelId);
+
+  if (!mainPanel) return panels;
+
   if (hasActionItems) {
-    const mainPanel = panels.find((panel) => panel.id === startPanelId);
-
-    if (!mainPanel) return panels;
-
     const actionItems: EuiContextMenuPanelItemDescriptor[] = getPopoverActionItems({
       primaryActionItem,
       onCloseOverflowButton: onClose,
     });
 
     mainPanel.items = [...(mainPanel.items as EuiContextMenuPanelItemDescriptor[]), ...actionItems];
+  }
 
-    return panels;
+  if (hasSwitchItem && switchConfig) {
+    const switchItems = getPopoverSwitchItems({ switchConfig });
+
+    mainPanel.items = [...(mainPanel.items as EuiContextMenuPanelItemDescriptor[]), ...switchItems];
   }
 
   return panels;


### PR DESCRIPTION
## Summary

This PR adds `AppMenuSwitch` component. 

<img width="524" height="57" alt="Screenshot 2026-05-19 at 22 09 15" src="https://github.com/user-attachments/assets/bbda080d-fce2-444e-ae34-498adfe575d5" />

Closes: https://github.com/elastic/kibana/issues/268721
