### PR TITLE
[UIAM OAuth] Gate UIAM OAuth features with agentBuilder:uiamOAuthClientManagement

### DIFF
--- a/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
+++ b/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
@@ -64,6 +64,8 @@ export const ACCESSIBILITY_DISABLE_ANIMATIONS_ID = 'accessibility:disableAnimati
 export const AGENT_BUILDER_NAV_ENABLED_SETTING_ID = 'agentBuilder:navEnabled';
 export const AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID = 'agentBuilder:experimentalFeatures';
 export const AGENT_BUILDER_PRE_PROMPT_WORKFLOW_IDS = 'agentBuilder:prePromptWorkflowIds';
+export const AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID =
+  'agentBuilder:uiamOAuthClientManagement';
 
 // Autocomplete settings
 export const AUTOCOMPLETE_USE_TIME_RANGE_ID = 'autocomplete:useTimeRange';

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/uiam_oauth_local/serverless/security_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/uiam_oauth_local/serverless/security_complete.serverless.config.ts
@@ -25,7 +25,6 @@ export const servers: ScoutServerConfig = {
         MOCK_IDP_UIAM_OAUTH_BASE_URL,
       ])}`,
       `--xpack.security.mcp.oauth2.metadata.resource=http://localhost:5620`,
-      '--uiSettings.overrides.agentBuilder:uiamOAuthClientManagement=true',
     ],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/uiam_oauth_local/serverless/security_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/uiam_oauth_local/serverless/security_complete.serverless.config.ts
@@ -25,6 +25,7 @@ export const servers: ScoutServerConfig = {
         MOCK_IDP_UIAM_OAUTH_BASE_URL,
       ])}`,
       `--xpack.security.mcp.oauth2.metadata.resource=http://localhost:5620`,
+      '--uiSettings.overrides.agentBuilder:uiamOAuthClientManagement=true',
     ],
   },
 };

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -539,6 +539,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'agentBuilder:uiamOAuthClientManagement': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'workflows:ui:enabled': {
     type: 'boolean',
     _meta: { description: 'Whether Elastic Workflows and related experiences are enabled.' },

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -541,7 +541,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
   },
   'agentBuilder:uiamOAuthClientManagement': {
     type: 'boolean',
-    _meta: { description: 'Non-default value of setting.' },
+    _meta: {
+      description:
+        'Whether UIAM OAuth client management endpoints and the Agent Builder MCP Clients UI are enabled.',
+    },
   },
   'workflows:ui:enabled': {
     type: 'boolean',

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -55,6 +55,7 @@ export interface UsageStats {
   'agentBuilder:navEnabled': boolean;
   'agentBuilder:externalMcp': boolean;
   'agentBuilder:experimentalFeatures': boolean;
+  'agentBuilder:uiamOAuthClientManagement': boolean;
   'workflows:ui:enabled': boolean;
   'visualization:heatmap:maxBuckets': number;
   'visualization:regionmap:showWarnings': boolean;

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11604,6 +11604,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "agentBuilder:uiamOAuthClientManagement": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "workflows:ui:enabled": {
           "type": "boolean",
           "_meta": {

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11607,7 +11607,7 @@
         "agentBuilder:uiamOAuthClientManagement": {
           "type": "boolean",
           "_meta": {
-            "description": "Non-default value of setting."
+            "description": "Whether UIAM OAuth client management endpoints and the Agent Builder MCP Clients UI are enabled."
           }
         },
         "workflows:ui:enabled": {

--- a/src/platform/plugins/shared/telemetry/schema/schema_checks.test.ts
+++ b/src/platform/plugins/shared/telemetry/schema/schema_checks.test.ts
@@ -57,7 +57,7 @@ describe('Telemetry Schema Checks', () => {
      * setting description instead. When you remove an entry from the list below, decrement
      * `EXPECTED_COUNT`. The goal is for both this count and the list to reach zero.
      */
-    const EXPECTED_COUNT = 150;
+    const EXPECTED_COUNT = 149;
 
     expect(keysWithNonDefaultDescriptions).toHaveLength(EXPECTED_COUNT);
     expect(keysWithNonDefaultDescriptions).toEqual([
@@ -65,7 +65,6 @@ describe('Telemetry Schema Checks', () => {
       'agentBuilder:experimentalFeatures',
       'agentBuilder:externalMcp',
       'agentBuilder:navEnabled',
-      'agentBuilder:uiamOAuthClientManagement',
       'ai:anonymizationSettings',
       'aiAssistant:preferredAIAssistantType',
       'aiAssistant:preferredChatExperience',

--- a/src/platform/plugins/shared/telemetry/schema/schema_checks.test.ts
+++ b/src/platform/plugins/shared/telemetry/schema/schema_checks.test.ts
@@ -57,7 +57,7 @@ describe('Telemetry Schema Checks', () => {
      * setting description instead. When you remove an entry from the list below, decrement
      * `EXPECTED_COUNT`. The goal is for both this count and the list to reach zero.
      */
-    const EXPECTED_COUNT = 149;
+    const EXPECTED_COUNT = 150;
 
     expect(keysWithNonDefaultDescriptions).toHaveLength(EXPECTED_COUNT);
     expect(keysWithNonDefaultDescriptions).toEqual([
@@ -65,6 +65,7 @@ describe('Telemetry Schema Checks', () => {
       'agentBuilder:experimentalFeatures',
       'agentBuilder:externalMcp',
       'agentBuilder:navEnabled',
+      'agentBuilder:uiamOAuthClientManagement',
       'ai:anonymizationSettings',
       'aiAssistant:preferredAIAssistantType',
       'aiAssistant:preferredChatExperience',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.test.tsx
@@ -41,7 +41,7 @@ jest.mock('../../../hooks/use_conversation_list', () => ({
 
 jest.mock('../../../hooks/use_route_access_config', () => ({
   useRouteAccessConfig: () => ({
-    featureFlags: { experimental: false },
+    featureFlags: { experimental: false, uiamOAuthClientManagement: false },
     capabilities: { isUIAMEnabled: false },
   }),
 }));

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/mcp_server/mcp_connection_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/mcp_server/mcp_connection_button.tsx
@@ -17,9 +17,9 @@ import {
 import { i18n } from '@kbn/i18n';
 import useToggle from 'react-use/lib/useToggle';
 import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
-import { useExperimentalFeatures } from '../../../hooks/use_experimental_features';
 import { useIsUIAMEnabled } from '../../../hooks/use_is_uiam_enabled';
 import { useKibanaUrl } from '../../../hooks/use_kibana_url';
+import { useUiamOAuthClientManagement } from '../../../hooks/use_uiam_oauth_client_management';
 import { MCP_SERVER_PATH } from '../../../../../common/mcp';
 import { useNavigation } from '../../../hooks/use_navigation';
 import { appPaths } from '../../../utils/app_paths';
@@ -28,9 +28,9 @@ export const McpConnectionButton = () => {
   const { createAgentBuilderUrl } = useNavigation();
   const { kibanaUrl } = useKibanaUrl();
   const { docLinksService } = useAgentBuilderServices();
-  const experimental = useExperimentalFeatures();
   const isUIAMEnabled = useIsUIAMEnabled();
-  const showMcpClientManagement = experimental && isUIAMEnabled;
+  const isUiamOAuthClientManagementEnabled = useUiamOAuthClientManagement();
+  const showMcpClientManagement = isUIAMEnabled && isUiamOAuthClientManagementEnabled;
 
   const [isContextOpen, toggleContextOpen] = useToggle(false);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_feature_flags.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_feature_flags.ts
@@ -8,8 +8,13 @@
 import { useMemo } from 'react';
 import type { FeatureFlags } from '../route_config';
 import { useExperimentalFeatures } from './use_experimental_features';
+import { useUiamOAuthClientManagement } from './use_uiam_oauth_client_management';
 
 export const useFeatureFlags = (): FeatureFlags => {
   const experimental = useExperimentalFeatures();
-  return useMemo(() => ({ experimental }), [experimental]);
+  const uiamOAuthClientManagement = useUiamOAuthClientManagement();
+  return useMemo(
+    () => ({ experimental, uiamOAuthClientManagement }),
+    [experimental, uiamOAuthClientManagement]
+  );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_uiam_oauth_client_management.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_uiam_oauth_client_management.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID } from '@kbn/management-settings-ids';
+
+export const useUiamOAuthClientManagement = (): boolean => {
+  return useUiSetting<boolean>(AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID);
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.test.ts
@@ -17,7 +17,7 @@ import {
 } from './route_config';
 
 const allEnabled: RouteAccessConfig = {
-  featureFlags: { experimental: true },
+  featureFlags: { experimental: true, uiamOAuthClientManagement: true },
   capabilities: { isUIAMEnabled: true },
 };
 const enabledRoutesWithExperimental = getEnabledRoutes(allEnabled);
@@ -188,12 +188,15 @@ describe('route_config', () => {
     const findMcpRoute = (routes: ReturnType<typeof getEnabledRoutes>) =>
       routes.find((r) => r.path === mcpClientsPath);
 
-    const config = (experimental: boolean, isUIAMEnabled: boolean): RouteAccessConfig => ({
-      featureFlags: { experimental },
+    const config = (
+      uiamOAuthClientManagement: boolean,
+      isUIAMEnabled: boolean
+    ): RouteAccessConfig => ({
+      featureFlags: { experimental: true, uiamOAuthClientManagement },
       capabilities: { isUIAMEnabled },
     });
 
-    it('includes MCP clients route when both experimental and UIAM are enabled', () => {
+    it('includes MCP clients route when both uiamOAuthClientManagement and UIAM are enabled', () => {
       expect(findMcpRoute(getEnabledRoutes(config(true, true)))).toBeDefined();
     });
 
@@ -201,12 +204,23 @@ describe('route_config', () => {
       expect(findMcpRoute(getEnabledRoutes(config(true, false)))).toBeUndefined();
     });
 
-    it('excludes MCP clients route when experimental is disabled', () => {
+    it('excludes MCP clients route when uiamOAuthClientManagement is disabled', () => {
       expect(findMcpRoute(getEnabledRoutes(config(false, true)))).toBeUndefined();
     });
 
     it('excludes MCP clients route when both are disabled', () => {
       expect(findMcpRoute(getEnabledRoutes(config(false, false)))).toBeUndefined();
+    });
+
+    it('includes MCP clients route even when experimental is disabled (no longer experimental-gated)', () => {
+      expect(
+        findMcpRoute(
+          getEnabledRoutes({
+            featureFlags: { experimental: false, uiamOAuthClientManagement: true },
+            capabilities: { isUIAMEnabled: true },
+          })
+        )
+      ).toBeDefined();
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -35,6 +35,7 @@ export type SidebarView = 'conversation' | 'manage';
 
 export interface FeatureFlags {
   experimental: boolean;
+  uiamOAuthClientManagement: boolean;
 }
 
 export interface Capabilities {
@@ -53,6 +54,7 @@ export interface RouteDefinition {
   sidebarView: SidebarView;
   isExperimental?: boolean;
   requiresUIAM?: boolean;
+  requiresUiamOAuthClientManagement?: boolean;
   navLabel?: string;
   navIcon?: string;
 }
@@ -209,8 +211,8 @@ export const manageRoutes: RouteDefinition[] = [
     path: '/manage/tools/mcp_clients',
     viewId: agentBuilderViewIds.manageMcpClients,
     sidebarView: 'manage',
-    isExperimental: true,
     requiresUIAM: true,
+    requiresUiamOAuthClientManagement: true,
     element: <AgentBuilderMcpClientsPage />,
   },
   {
@@ -277,10 +279,11 @@ export interface SidebarNavItem {
 }
 
 const isRouteEnabled = (route: RouteDefinition, config: RouteAccessConfig): boolean => {
-  const { isExperimental, requiresUIAM } = route;
+  const { isExperimental, requiresUIAM, requiresUiamOAuthClientManagement } = route;
   const { featureFlags, capabilities } = config;
   if (isExperimental && !featureFlags.experimental) return false;
   if (requiresUIAM && !capabilities.isUIAMEnabled) return false;
+  if (requiresUiamOAuthClientManagement && !featureFlags.uiamOAuthClientManagement) return false;
   return true;
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/ui_settings.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/ui_settings.ts
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import {
   AGENT_BUILDER_NAV_ENABLED_SETTING_ID,
   AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID,
+  AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID,
 } from '@kbn/management-settings-ids';
 
 export const registerUISettings = ({ uiSettings }: { uiSettings: UiSettingsServiceSetup }) => {
@@ -44,6 +45,24 @@ export const registerUISettings = ({ uiSettings }: { uiSettings: UiSettingsServi
       technicalPreview: true,
       requiresPageReload: false,
       readonly: false,
+    },
+    [AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID]: {
+      description: i18n.translate(
+        'xpack.agentBuilder.uiSettings.uiamOAuthClientManagement.description',
+        {
+          defaultMessage:
+            'Internal gate for UIAM OAuth client management endpoints and the Agent Builder MCP Clients UI. Not intended for end-user use.',
+        }
+      ),
+      name: i18n.translate('xpack.agentBuilder.uiSettings.uiamOAuthClientManagement.name', {
+        defaultMessage: 'UIAM OAuth client management',
+      }),
+      schema: schema.boolean(),
+      value: false,
+      technicalPreview: true,
+      requiresPageReload: true,
+      readonly: true,
+      readonlyMode: 'strict',
     },
   });
 };

--- a/x-pack/platform/plugins/shared/security/moon.yml
+++ b/x-pack/platform/plugins/shared/security/moon.yml
@@ -104,6 +104,7 @@ dependsOn:
   - '@kbn/mock-idp-utils'
   - '@kbn/core-user-activity-server'
   - '@kbn/core-user-activity-server-mocks'
+  - '@kbn/management-settings-ids'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('Create OAuth Client route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -91,6 +95,19 @@ describe('Create OAuth Client route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({
+        body: { resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.createClient).not.toHaveBeenCalled();
   });
 
   it('returns error from service', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -6,6 +6,7 @@
  */
 
 import { createClientBodySchema } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -31,26 +32,30 @@ export function defineCreateOAuthClientRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.createClient(request, request.body);
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
-          });
-        }
+          const result = await oauth.createClient(request, request.body);
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        return response.ok({ body: result });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: result });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('Get OAuth Client route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -97,6 +101,17 @@ describe('Get OAuth Client route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({ params: { client_id: 'client-1' } }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.listClients).not.toHaveBeenCalled();
   });
 
   it('returns error from service', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -35,33 +36,37 @@ export function defineGetOAuthClientRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.listClients(request, request.params.client_id);
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
-          });
-        }
+          const result = await oauth.listClients(request, request.params.client_id);
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        const client = result.clients[0];
-        if (!client) {
-          return response.notFound({
-            body: { message: `OAuth client [${request.params.client_id}] not found` },
-          });
-        }
+          const client = result.clients[0];
+          if (!client) {
+            return response.notFound({
+              body: { message: `OAuth client [${request.params.client_id}] not found` },
+            });
+          }
 
-        return response.ok({ body: client });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: client });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('Get OAuth Connection route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -104,6 +108,19 @@ describe('Get OAuth Connection route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'client-1', connection_id: 'conn-1' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.listConnections).not.toHaveBeenCalled();
   });
 
   it('returns error from service', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -36,39 +37,43 @@ export function defineGetOAuthConnectionRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.listConnections(
-          request,
-          request.params.client_id,
-          request.params.connection_id
-        );
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
-          });
-        }
+          const result = await oauth.listConnections(
+            request,
+            request.params.client_id,
+            request.params.connection_id
+          );
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        const connection = result.connections[0];
-        if (!connection) {
-          return response.notFound({
-            body: {
-              message: `OAuth connection [${request.params.connection_id}] not found for client [${request.params.client_id}]`,
-            },
-          });
-        }
+          const connection = result.connections[0];
+          if (!connection) {
+            return response.notFound({
+              body: {
+                message: `OAuth connection [${request.params.connection_id}] not found for client [${request.params.client_id}]`,
+              },
+            });
+          }
 
-        return response.ok({ body: connection });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: connection });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('List OAuth Clients route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -81,6 +85,17 @@ describe('List OAuth Clients route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.listClients).not.toHaveBeenCalled();
   });
 
   it('returns error from service', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -37,26 +38,30 @@ export function defineListOAuthClientsRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.listClients(request, request.query.client_id);
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
-          });
-        }
+          const result = await oauth.listClients(request, request.query.client_id);
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        return response.ok({ body: result });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: result });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('List OAuth Connections route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -76,6 +80,17 @@ describe('List OAuth Connections route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.listConnections).not.toHaveBeenCalled();
   });
 
   it('returns error from service', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -40,30 +41,34 @@ export function defineListOAuthConnectionsRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.listConnections(
-          request,
-          request.query.client_id,
-          request.query.connection_id
-        );
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
-          });
-        }
+          const result = await oauth.listConnections(
+            request,
+            request.query.client_id,
+            request.query.connection_id
+          );
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        return response.ok({ body: result });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: result });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('Revoke OAuth Client route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -78,6 +82,20 @@ describe('Revoke OAuth Client route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1' },
+        body: {},
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.revokeClient).not.toHaveBeenCalled();
   });
 
   it('returns error from service', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -38,30 +39,34 @@ export function defineRevokeOAuthClientRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.revokeClient(
-          request,
-          request.params.client_id,
-          request.body.reason
-        );
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
-          });
-        }
+          const result = await oauth.revokeClient(
+            request,
+            request.params.client_id,
+            request.body.reason
+          );
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        return response.ok({ body: result });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: result });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('Revoke OAuth Connection route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -80,6 +84,20 @@ describe('Revoke OAuth Connection route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1', connection_id: 'conn1' },
+        body: {},
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.revokeConnection).not.toHaveBeenCalled();
   });
 
   it('returns error from service', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -39,31 +40,35 @@ export function defineRevokeOAuthConnectionRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.revokeConnection(
-          request,
-          request.params.client_id,
-          request.params.connection_id,
-          request.body.reason
-        );
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
-          });
-        }
+          const result = await oauth.revokeConnection(
+            request,
+            request.params.client_id,
+            request.params.connection_id,
+            request.body.reason
+          );
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        return response.ok({ body: result });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: result });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('Update OAuth Client route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -120,6 +124,20 @@ describe('Update OAuth Client route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1' },
+        body: { client_metadata: {} },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.updateClient).not.toHaveBeenCalled();
   });
 
   it('returns error from service', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { OAUTH_MAX_STRING_FIELD_LENGTH, updateClientBodySchema } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -36,29 +37,33 @@ export function defineUpdateOAuthClientRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.updateClient(request, request.params.client_id, {
-          ...request.body,
-          client_metadata: request.body.client_metadata ?? {},
-        });
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
+          const result = await oauth.updateClient(request, request.params.client_id, {
+            ...request.body,
+            client_metadata: request.body.client_metadata ?? {},
           });
-        }
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        return response.ok({ body: result });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: result });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.test.ts
@@ -20,9 +20,13 @@ import { routeDefinitionParamsMock } from '../index.mock';
 
 describe('Update OAuth Connection route', () => {
   function getMockContext(
-    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' },
+    { oauthManagementEnabled = true }: { oauthManagementEnabled?: boolean } = {}
   ) {
+    const coreContext = coreMock.createRequestHandlerContext();
+    (coreContext.uiSettings.client.get as jest.Mock).mockResolvedValue(oauthManagementEnabled);
     return coreMock.createCustomRequestHandlerContext({
+      core: coreContext,
       licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
     });
   }
@@ -83,6 +87,20 @@ describe('Update OAuth Connection route', () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when uiamOAuthClientManagement setting is disabled', async () => {
+    const response = await routeHandler(
+      getMockContext({ state: 'valid' }, { oauthManagementEnabled: false }),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1', connection_id: 'conn1' },
+        body: { name: 'Updated' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+    expect(oauthMock.updateConnection).not.toHaveBeenCalled();
   });
 
   it('returns 404 when license-disabled service returns null', async () => {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { OAUTH_MAX_STRING_FIELD_LENGTH, updateConnectionBodySchema } from './schemas';
+import { withOAuthManagementGate } from './with_oauth_management_gate';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -37,31 +38,35 @@ export function defineUpdateOAuthConnectionRoute({
         access: 'internal',
       },
     },
-    createLicensedRouteHandler(async (context, request, response) => {
-      try {
-        const { oauth } = getAuthenticationService();
-        if (!oauth) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: UIAM is not configured' },
-          });
-        }
+    withOAuthManagementGate(
+      createLicensedRouteHandler(async (context, request, response) => {
+        try {
+          const { oauth } = getAuthenticationService();
+          if (!oauth) {
+            return response.notFound({
+              body: { message: 'OAuth management is not available: UIAM is not configured' },
+            });
+          }
 
-        const result = await oauth.updateConnection(
-          request,
-          request.params.client_id,
-          request.params.connection_id,
-          request.body
-        );
-        if (!result) {
-          return response.notFound({
-            body: { message: 'OAuth management is not available: security features are disabled' },
-          });
-        }
+          const result = await oauth.updateConnection(
+            request,
+            request.params.client_id,
+            request.params.connection_id,
+            request.body
+          );
+          if (!result) {
+            return response.notFound({
+              body: {
+                message: 'OAuth management is not available: security features are disabled',
+              },
+            });
+          }
 
-        return response.ok({ body: result });
-      } catch (error) {
-        return response.customError(wrapIntoCustomErrorResponse(error));
-      }
-    })
+          return response.ok({ body: result });
+        } catch (error) {
+          return response.customError(wrapIntoCustomErrorResponse(error));
+        }
+      })
+    )
   );
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/with_oauth_management_gate.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/with_oauth_management_gate.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaResponseFactory, RequestHandler, RouteMethod } from '@kbn/core/server';
+import { AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID } from '@kbn/management-settings-ids';
+
+import type { SecurityRequestHandlerContext } from '../../types';
+
+/**
+ * Wraps an OAuth route handler so that requests return a `404 Not Found` when the
+ * `agentBuilder:uiamOAuthClientManagement` uiSetting resolves to `false`.
+ */
+export const withOAuthManagementGate = <
+  Params,
+  Query,
+  Body,
+  Context extends SecurityRequestHandlerContext,
+  Method extends RouteMethod,
+  ResponseFactory extends KibanaResponseFactory
+>(
+  handler: RequestHandler<Params, Query, Body, Context, Method, ResponseFactory>
+): RequestHandler<Params, Query, Body, Context, Method, ResponseFactory> => {
+  return async (context, request, response) => {
+    const { uiSettings } = await context.core;
+    const enabled = await uiSettings.client.get<boolean>(
+      AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID
+    );
+    if (!enabled) {
+      return response.notFound();
+    }
+
+    return handler(context, request, response);
+  };
+};

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
@@ -7,6 +7,7 @@
 
 import { parse as parseCookie } from 'tough-cookie';
 
+import { AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID } from '@kbn/management-settings-ids';
 import { createSAMLResponse } from '@kbn/mock-idp-utils';
 import { apiTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
@@ -21,7 +22,11 @@ apiTest.describe(
   () => {
     let authHeaders: Record<string, string>;
 
-    apiTest.beforeAll(async ({ apiClient, config: { organizationId, projectType } }) => {
+    apiTest.beforeAll(async ({ apiClient, kbnClient, config: { organizationId, projectType } }) => {
+      await kbnClient.uiSettings.update({
+        [AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID]: true,
+      });
+
       const samlResponse = await createSAMLResponse({
         username: '1234567890',
         email: 'elastic_admin@elastic.co',
@@ -39,6 +44,10 @@ apiTest.describe(
       const cookie = parseCookie(samlCallback.headers['set-cookie'][0])!.cookieString();
 
       authHeaders = { ...COMMON_UNSAFE_HEADERS, Cookie: cookie };
+    });
+
+    apiTest.afterAll(async ({ kbnClient }) => {
+      await kbnClient.uiSettings.unset(AGENT_BUILDER_UIAM_OAUTH_CLIENT_MANAGEMENT_SETTING_ID);
     });
 
     apiTest(

--- a/x-pack/platform/plugins/shared/security/tsconfig.json
+++ b/x-pack/platform/plugins/shared/security/tsconfig.json
@@ -97,7 +97,8 @@
     "@kbn/scout",
     "@kbn/mock-idp-utils",
     "@kbn/core-user-activity-server",
-    "@kbn/core-user-activity-server-mocks"
+    "@kbn/core-user-activity-server-mocks",
+    "@kbn/management-settings-ids"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Gates UIAM OAuth features in Kibana with a separate UI setting, `agentBuilder:uiamOAuthClientManagement`, separate from the `agentBuilder:experimentalFeatures` flag used currently. This PR also adds gating to the Kibana Security endpoints related to OAuth.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

