### PR TITLE
[Security] Fix screen reader context announcement for help links in API Key flyout

### DIFF
--- a/x-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx
+++ b/x-pack/platform/packages/shared/security/api_key_management/src/components/api_key_flyout.tsx
@@ -842,22 +842,7 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                           </EuiFlexItem>
                         </EuiFlexGroup>
                       </EuiPanel>
-                      <FormRow
-                        helpText={
-                          <EuiLink
-                            href={docLinks!.links.apis.createApiKeyRoleDescriptors}
-                            target="_blank"
-                            external
-                          >
-                            <FormattedMessage
-                              id="xpack.security.accountManagement.apiKeyFlyout.roleDescriptorsHelpText"
-                              defaultMessage="Learn how to structure role descriptors."
-                            />
-                          </EuiLink>
-                        }
-                        fullWidth
-                        data-test-subj="apiKeysRoleDescriptorsCodeEditor"
-                      >
+                      <FormRow fullWidth data-test-subj="apiKeysRoleDescriptorsCodeEditor">
                         <FormField
                           as={CodeEditorField}
                           name="role_descriptors"
@@ -892,6 +877,18 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                           height={200}
                         />
                       </FormRow>
+                      <EuiText size="xs">
+                        <EuiLink
+                          href={docLinks!.links.apis.createApiKeyRoleDescriptors}
+                          target="_blank"
+                          external
+                        >
+                          <FormattedMessage
+                            id="xpack.security.accountManagement.apiKeyFlyout.roleDescriptorsHelpText"
+                            defaultMessage="Learn how to structure role descriptors."
+                          />
+                        </EuiLink>
+                      </EuiText>
                     </>
                   )}
                 </EuiPanel>
@@ -928,22 +925,7 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                 {formik.values.includeMetadata && (
                   <>
                     <EuiSpacer />
-                    <FormRow
-                      data-test-subj="apiKeysMetadataCodeEditor"
-                      helpText={
-                        <EuiLink
-                          href={docLinks!.links.apis.createApiKeyMetadata}
-                          target="_blank"
-                          external
-                        >
-                          <FormattedMessage
-                            id="xpack.security.accountManagement.apiKeyFlyout.metadataHelpText"
-                            defaultMessage="Learn how to structure metadata."
-                          />
-                        </EuiLink>
-                      }
-                      fullWidth
-                    >
+                    <FormRow data-test-subj="apiKeysMetadataCodeEditor" fullWidth>
                       <FormField
                         as={CodeEditorField}
                         name="metadata"
@@ -977,6 +959,18 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                         height={200}
                       />
                     </FormRow>
+                    <EuiText size="xs">
+                      <EuiLink
+                        href={docLinks!.links.apis.createApiKeyMetadata}
+                        target="_blank"
+                        external
+                      >
+                        <FormattedMessage
+                          id="xpack.security.accountManagement.apiKeyFlyout.metadataHelpText"
+                          defaultMessage="Learn how to structure metadata."
+                        />
+                      </EuiLink>
+                    </EuiText>
                   </>
                 )}
               </EuiPanel>


### PR DESCRIPTION
When using a screen reader on the API Key creation flyout, tabbing to the "Learn how to structure role descriptors" or "Learn how to structure metadata" links caused the reader to announce the entire surrounding panel content (the switch label and description text) before reading the link itself. This violated WCAG SC 4.1.2 because those links were nested inside the `helpText` prop of the code editor's form row, wiring them into the editor's `aria-describedby` chain and inheriting the panel's accessible context. Moving both links to standalone `EuiText` elements placed immediately after their respective form rows breaks that association, so screen readers announce only the link when it receives focus.

Closes https://github.com/elastic/kibana/issues/195285

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



## Release note

Fixes screen readers announcing the full Security Privileges panel context when focusing the help links in the API Key creation flyout.
