### PR TITLE
[Scout Failing test] Saved objects tagging usage collector - reports correct tag usage counts via the telemetry endpoint

### DIFF
--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/usage/fetch_tag_usage_data.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/usage/fetch_tag_usage_data.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { fetchTagUsageData } from './fetch_tag_usage_data';
+
+const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+const makeBucket = (type: string, docCount: number, tagIds: string[]) => ({
+  key: type,
+  doc_count: docCount,
+  nested_ref: {
+    tag_references: {
+      doc_count: tagIds.length,
+      tag_id: { buckets: tagIds.map((id) => ({ key: id, doc_count: 1 })) },
+    },
+  },
+});
+
+const mockSearch = (buckets: ReturnType<typeof makeBucket>[]) => {
+  esClient.search.mockResolvedValue({
+    aggregations: { by_type: { buckets } },
+  } as unknown as Awaited<ReturnType<typeof esClient.search>>);
+};
+
+describe('fetchTagUsageData', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('passes kibanaIndices to the ES search query', async () => {
+    mockSearch([]);
+    await fetchTagUsageData({ esClient, kibanaIndices: ['.kibana_1', '.kibana_2'] });
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({ index: ['.kibana_1', '.kibana_2'] })
+    );
+  });
+
+  it('builds ES query with nested tag filters and aggregations', async () => {
+    mockSearch([]);
+    await fetchTagUsageData({ esClient, kibanaIndices: ['.kibana'] });
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ignore_unavailable: true,
+        filter_path: 'aggregations',
+        size: 0,
+        query: {
+          bool: {
+            must: [
+              {
+                nested: {
+                  path: 'references',
+                  query: {
+                    bool: {
+                      must: [{ term: { 'references.type': 'tag' } }],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+        aggs: expect.objectContaining({
+          by_type: expect.objectContaining({
+            terms: { field: 'type' },
+          }),
+        }),
+      })
+    );
+  });
+
+  it('returns zeroes when no tagged objects exist', async () => {
+    mockSearch([]);
+    const result = await fetchTagUsageData({ esClient, kibanaIndices: ['.kibana'] });
+    expect(result).toEqual({ usedTags: 0, taggedObjects: 0, types: {} });
+  });
+
+  it('counts tagged objects and distinct tags for a single type', async () => {
+    mockSearch([makeBucket('dashboard', 2, ['tag-1', 'tag-2', 'tag-4'])]);
+    const result = await fetchTagUsageData({ esClient, kibanaIndices: ['.kibana'] });
+    expect(result).toEqual({
+      usedTags: 3,
+      taggedObjects: 2,
+      types: {
+        dashboard: { taggedObjects: 2, usedTags: 3 },
+      },
+    });
+  });
+
+  it('deduplicates shared tags across types in the global usedTags count', async () => {
+    // tag-1 is used by both types — must be counted once globally, not twice
+    mockSearch([
+      makeBucket('dashboard', 2, ['tag-1', 'tag-2', 'tag-4']),
+      makeBucket('visualization', 3, ['tag-1', 'tag-3']),
+    ]);
+    const result = await fetchTagUsageData({ esClient, kibanaIndices: ['.kibana'] });
+
+    expect(result.usedTags).toBe(4); // tag-1, tag-2, tag-3, tag-4
+    expect(result.taggedObjects).toBe(5);
+    expect(result.types.dashboard).toEqual({ taggedObjects: 2, usedTags: 3 });
+    expect(result.types.visualization).toEqual({ taggedObjects: 3, usedTags: 2 });
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/usage/fetch_tag_usage_data.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/usage/fetch_tag_usage_data.test.ts
@@ -92,6 +92,32 @@ describe('fetchTagUsageData', () => {
     });
   });
 
+  it('counts distinct tag IDs, not doc_count sums, when the same tag appears on multiple objects of the same type', async () => {
+    mockSearch([
+      {
+        key: 'dashboard',
+        doc_count: 3,
+        nested_ref: {
+          tag_references: {
+            doc_count: 5,
+            tag_id: {
+              buckets: [
+                { key: 'tag-1', doc_count: 3 }, // tag-1 on all 3 dashboards
+                { key: 'tag-2', doc_count: 2 }, // tag-2 on 2 dashboards
+              ],
+            },
+          },
+        },
+      },
+    ]);
+    const result = await fetchTagUsageData({ esClient, kibanaIndices: ['.kibana'] });
+    expect(result).toEqual({
+      usedTags: 2, // 2 distinct tag IDs, not sum(3+2)=5
+      taggedObjects: 3,
+      types: { dashboard: { taggedObjects: 3, usedTags: 2 } },
+    });
+  });
+
   it('deduplicates shared tags across types in the global usedTags count', async () => {
     // tag-1 is used by both types — must be counted once globally, not twice
     mockSearch([

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/usage/tag_usage_collector.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/usage/tag_usage_collector.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  createCollectorFetchContextMock,
+  createUsageCollectionSetupMock,
+} from '@kbn/usage-collection-plugin/server/mocks';
+import { createTagUsageCollector } from './tag_usage_collector';
+import { tagUsageCollectorSchema } from './schema';
+import * as fetchTagUsageDataModule from './fetch_tag_usage_data';
+
+describe('createTagUsageCollector', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates usage collector with expected type and schema', () => {
+    const usageCollection = createUsageCollectionSetupMock();
+    const getKibanaIndices = jest.fn().mockResolvedValue(['.kibana']);
+
+    createTagUsageCollector({ usageCollection, getKibanaIndices });
+
+    expect(usageCollection.makeUsageCollector).toHaveBeenCalledTimes(1);
+    expect(usageCollection.makeUsageCollector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'saved_objects_tagging',
+        isReady: expect.any(Function),
+        schema: tagUsageCollectorSchema,
+        fetch: expect.any(Function),
+      })
+    );
+  });
+
+  it('fetches usage data with indices returned by getKibanaIndices', async () => {
+    const usageCollection = createUsageCollectionSetupMock();
+    const getKibanaIndices = jest.fn().mockResolvedValue(['.kibana_1', '.kibana_2']);
+    const fetchContext = createCollectorFetchContextMock();
+    const usageData = { usedTags: 4, taggedObjects: 5, types: {} };
+    const fetchTagUsageDataMock = jest
+      .spyOn(fetchTagUsageDataModule, 'fetchTagUsageData')
+      .mockResolvedValue(usageData);
+
+    createTagUsageCollector({ usageCollection, getKibanaIndices });
+    const collector = usageCollection.makeUsageCollector.mock.results[0].value;
+
+    await expect(collector.fetch(fetchContext)).resolves.toEqual(usageData);
+    expect(getKibanaIndices).toHaveBeenCalledTimes(1);
+    expect(fetchTagUsageDataMock).toHaveBeenCalledWith({
+      esClient: fetchContext.esClient,
+      kibanaIndices: ['.kibana_1', '.kibana_2'],
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/api/tests/tags_usage_collector.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/api/tests/tags_usage_collector.spec.ts
@@ -13,7 +13,6 @@ import { apiTest, TELEMETRY_HEADERS, KBN_ARCHIVES } from '../fixtures';
  * Dataset: 5 tags (tag-1..4 + unused-tag), 2 tagged dashboards, 3 tagged visualizations.
  * - dashboard refs: tag-1+tag-2, tag-2+tag-4 → 2 tagged objects, 3 distinct tags
  * - visualization refs: tag-1, tag-1+tag-3, tag-3 → 3 tagged objects, 2 distinct tags
- * - usedTags across all types: tag-1,2,3,4 → 4 (unused-tag never referenced)
  */
 apiTest.describe(
   'Saved Objects Tagging - usage collector',
@@ -44,14 +43,8 @@ apiTest.describe(
         const taggingStats =
           response.body[0].stats.stack_stats.kibana.plugins.saved_objects_tagging;
 
-        expect(taggingStats).toStrictEqual({
-          usedTags: 4,
-          taggedObjects: 5,
-          types: {
-            dashboard: { taggedObjects: 2, usedTags: 3 },
-            visualization: { taggedObjects: 3, usedTags: 2 },
-          },
-        });
+        expect(taggingStats.types.dashboard).toStrictEqual({ taggedObjects: 2, usedTags: 3 });
+        expect(taggingStats.types.visualization).toStrictEqual({ taggedObjects: 3, usedTags: 2 });
       }
     );
   }


### PR DESCRIPTION

## Summary

This PR resolves [Failing test: Saved Objects Tagging - usage collector - reports correct tag usage counts via the telemetry endpoint](https://github.com/elastic/kibana/issues/269542) issue.

You can read more details about this failure in the issue, but tl;dr - because of shared server in CI in main, Fleet is also installing tags, so our checks for "visualizations" and "dashboards" tags get polluted and test fail.

My solution is to instead add unit tests to cover most scenarios (request shape, response, deduplication of tags) and keep in Scout general contract that can coexist with Fleets' tags. 

### Copilot description:
This PR addresses CI flakiness in Scout telemetry tests caused by a shared server where Fleet also installs tags, by relaxing the Scout contract assertions and adding unit tests that validate tagging usage aggregation/deduplication behavior.

Changes:

- Loosen Scout telemetry assertions to only validate per-type tag usage counts (dashboard/visualization).
- Add unit tests for the usage collector wiring (type/schema + index propagation to fetcher).
- Add unit tests for ES query shape and tag usage aggregation/deduplication logic.