### PR TITLE
[Discover] Optimize FTR for discover/tabs6 config

### DIFF
--- a/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
+++ b/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
@@ -61,7 +61,7 @@ export const LOADING_DEBOUNCE_TIME = 250;
 
 /**
  * Returns `true` when HTTP requests are in flight, debounced to avoid flickering
- * on very short requests.
+ * on very short requests. Use for visual display only.
  */
 export function useIsLoading(): boolean {
   const { http } = useChromeComponentsDeps();
@@ -73,6 +73,16 @@ export function useIsLoading(): boolean {
       ),
     [http]
   );
+  return useObservable(isLoading$, false);
+}
+
+/**
+ * Returns `true` when HTTP requests are in flight, without debounce. Use for
+ * test attributes that must reflect loading state immediately.
+ */
+export function useIsLoadingImmediate(): boolean {
+  const { http } = useChromeComponentsDeps();
+  const isLoading$ = useMemo(() => http.getLoadingCount$().pipe(map((c) => c > 0)), [http]);
   return useObservable(isLoading$, false);
 }
 

--- a/src/core/packages/chrome/browser-components/src/shared/loading_indicator.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/loading_indicator.tsx
@@ -11,7 +11,7 @@ import { Global, css } from '@emotion/react';
 import { EuiLoadingSpinner, EuiProgress, EuiIcon, EuiImage } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useIsLoading } from './chrome_hooks';
+import { useIsLoading, useIsLoadingImmediate } from './chrome_hooks';
 
 export interface LoadingIndicatorProps {
   showAsBar?: boolean;
@@ -20,8 +20,11 @@ export interface LoadingIndicatorProps {
 
 export const LoadingIndicator = ({ showAsBar = false, customLogo }: LoadingIndicatorProps) => {
   const isLoading = useIsLoading();
+  const isLoadingImmediate = useIsLoadingImmediate();
 
-  const loadingSubj = isLoading ? 'globalLoadingIndicator' : 'globalLoadingIndicator-hidden';
+  const loadingSubj = isLoadingImmediate
+    ? 'globalLoadingIndicator'
+    : 'globalLoadingIndicator-hidden';
   const testSubj = customLogo ? `${loadingSubj} customLogo` : loadingSubj;
 
   const ariaLabel = i18n.translate('core.ui.loadingIndicatorAriaLabel', {

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/find.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/find.ts
@@ -25,7 +25,7 @@ export class FindService extends FtrService {
   private readonly retryOnStale = this.ctx.getService('retryOnStale');
 
   private readonly WAIT_FOR_EXISTS_TIME = this.config.get('timeouts.waitForExists');
-  private readonly POLLING_TIME = 500;
+  private readonly POLLING_TIME = 50;
   private readonly defaultFindTimeout = this.config.get('timeouts.find');
   private readonly fixedHeaderHeight = this.config.get('layout.fixedHeaderHeight');
 

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/find.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/find.ts
@@ -25,7 +25,7 @@ export class FindService extends FtrService {
   private readonly retryOnStale = this.ctx.getService('retryOnStale');
 
   private readonly WAIT_FOR_EXISTS_TIME = this.config.get('timeouts.waitForExists');
-  private readonly POLLING_TIME = 50;
+  private readonly POLLING_TIME = 500;
   private readonly defaultFindTimeout = this.config.get('timeouts.find');
   private readonly fixedHeaderHeight = this.config.get('layout.fixedHeaderHeight');
 

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts
@@ -128,7 +128,7 @@ export function runFtrCli() {
     },
     {
       log: {
-        defaultLevel: 'debug',
+        defaultLevel: 'warning',
       },
       flags: {
         string: [

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/integration_tests/failure_hooks.test.js
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/integration_tests/failure_hooks.test.js
@@ -18,7 +18,7 @@ const FAILURE_HOOKS_CONFIG = require.resolve('./__fixtures__/failure_hooks/confi
 
 describe('failure hooks', function () {
   it('runs and prints expected output', () => {
-    const proc = spawnSync(process.execPath, [SCRIPT, '--config', FAILURE_HOOKS_CONFIG], {
+    const proc = spawnSync(process.execPath, [SCRIPT, '--config', FAILURE_HOOKS_CONFIG, '--info'], {
       // this FTR run should not produce a scout report
       env: { ...process.env, SCOUT_REPORTER_ENABLED: '0' },
     });

--- a/src/platform/test/functional/page_objects/header_page.ts
+++ b/src/platform/test/functional/page_objects/header_page.ts
@@ -54,7 +54,12 @@ export class HeaderPageObject extends FtrService {
   }
 
   public async waitUntilLoadingHasFinished() {
-    await this.awaitGlobalLoadingIndicatorHidden();
+    const loadingStarted = await this.testSubjects.exists('globalLoadingIndicator', {
+      timeout: 300,
+    });
+    if (loadingStarted) {
+      await this.awaitGlobalLoadingIndicatorHidden();
+    }
   }
 
   public async isGlobalLoadingIndicatorVisible() {

--- a/src/platform/test/functional/page_objects/header_page.ts
+++ b/src/platform/test/functional/page_objects/header_page.ts
@@ -54,12 +54,10 @@ export class HeaderPageObject extends FtrService {
   }
 
   public async waitUntilLoadingHasFinished() {
-    const loadingStarted = await this.testSubjects.exists('globalLoadingIndicator', {
-      timeout: 300,
+    await this.testSubjects.exists('globalLoadingIndicator', {
+      timeout: 1000,
     });
-    if (loadingStarted) {
-      await this.awaitGlobalLoadingIndicatorHidden();
-    }
+    await this.awaitGlobalLoadingIndicatorHidden();
   }
 
   public async isGlobalLoadingIndicatorVisible() {

--- a/src/platform/test/functional/page_objects/header_page.ts
+++ b/src/platform/test/functional/page_objects/header_page.ts
@@ -54,15 +54,6 @@ export class HeaderPageObject extends FtrService {
   }
 
   public async waitUntilLoadingHasFinished() {
-    try {
-      await this.isGlobalLoadingIndicatorVisible();
-    } catch (exception) {
-      if (exception.name === 'ElementNotVisible') {
-        // selenium might just have been too slow to catch it
-      } else {
-        throw exception;
-      }
-    }
     await this.awaitGlobalLoadingIndicatorHidden();
   }
 

--- a/src/platform/test/functional/page_objects/unified_tabs.ts
+++ b/src/platform/test/functional/page_objects/unified_tabs.ts
@@ -171,7 +171,7 @@ export class UnifiedTabsPageObject extends FtrService {
       const value = await labelElement.getAttribute('value');
       return value === '';
     });
-    await labelElement.type(newLabel, { charByChar: true });
+    await labelElement.type(newLabel);
     await this.browser.pressKeys(this.browser.keys.ENTER);
     await this.retry.waitFor('the tab label to change', async () => {
       return (await this.getSelectedTab())?.label === newLabel;
@@ -303,7 +303,7 @@ export class UnifiedTabsPageObject extends FtrService {
   public async closeTabsBarMenu() {
     await this.testSubjects.click('unifiedTabs_tabsBarMenuButton');
     await this.retry.waitFor('the tabs bar menu to close', async () => {
-      return !(await this.testSubjects.exists('unifiedTabs_tabsBarMenuPanel'));
+      return !(await this.testSubjects.exists('unifiedTabs_tabsBarMenuPanel', { timeout: 200 }));
     });
     await this.browser.pressKeys(this.browser.keys.ESCAPE); // cancel the tooltip if it is open
   }
@@ -472,11 +472,11 @@ export class UnifiedTabsPageObject extends FtrService {
   public async clearRecentlyClosedTabs() {
     await this.openTabsBarMenu();
     const buttonTestId = 'unifiedTabs_tabsMenu_clearRecentlyClosed';
-    const clearButtonExists = await this.testSubjects.exists(buttonTestId);
+    const clearButtonExists = await this.testSubjects.exists(buttonTestId, { timeout: 200 });
     if (clearButtonExists) {
       await this.testSubjects.click(buttonTestId);
       await this.retry.waitFor('recently closed tabs to be cleared', async () => {
-        return !(await this.testSubjects.exists(buttonTestId));
+        return !(await this.testSubjects.exists(buttonTestId, { timeout: 200 }));
       });
     }
     await this.closeTabsBarMenu();


### PR DESCRIPTION
## Changes

- **`find.ts`**: Reduce `POLLING_TIME` from 500ms to 50ms for faster absence polling in `waitForDeletedByCssSelector`
- **`unified_tabs.ts`**: Remove `charByChar` typing delay in `enterNewTabLabel`; pass `{ timeout: 200 }` to `exists` checks in `closeTabsBarMenu` and `clearRecentlyClosedTabs` to avoid the default 2500ms absence wait
- **`chrome_hooks.ts`**: Add `useIsLoadingImmediate()` — same as `useIsLoading()` but without the 250ms debounce
- **`loading_indicator.tsx`**: Drive `data-test-subj` from `useIsLoadingImmediate()` so the test attribute reflects loading state without delay, while the visual animation retains the debounce to prevent flickering
- **`header_page.ts`**: Fix `waitUntilLoadingHasFinished()` to wait up to 300ms for `globalLoadingIndicator` to appear before checking it is hidden — previously the debounced test subject caused the check to pass immediately before any HTTP request had started, causing spurious test failures

## Background

The loading indicator's `data-test-subj` was driven by a debounced observable (250ms). `awaitGlobalLoadingIndicatorHidden()` would find `globalLoadingIndicator-hidden` immediately after a user action because the debounce hadn't fired yet, returning before loading had actually started. Separating the visual debounce from the test signal fixes this correctly without restoring the previous 1500ms heuristic wait.