### PR TITLE
[ES|QL] Adds telemetry to the AI features

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -56,7 +56,7 @@ pageLoadAssetSize:
   embeddableAlertsTable: 6524
   enterpriseSearch: 37565
   entityStore: 9718
-  esql: 25000
+  esql: 29547
   esqlDataGrid: 10209
   esUiShared: 101220
   evals: 6375

--- a/src/platform/packages/private/kbn-esql-editor/src/comment_to_esql/use_comment_to_esql.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/comment_to_esql/use_comment_to_esql.ts
@@ -14,6 +14,7 @@ import type { MutableRefObject } from 'react';
 import { i18n } from '@kbn/i18n';
 import { NL_TO_ESQL_ROUTE } from '@kbn/esql-types';
 import type { HttpStart, NotificationsStart } from '@kbn/core/public';
+import { AiReviewAction, type ESQLEditorTelemetryService } from '../telemetry/telemetry_service';
 import { ReviewActionsWidget } from './review_actions_widget';
 import { CODE_ADDED_CLASS, GENERATING_HINT_CLASS, LINE_REPLACED_CLASS } from '../editor_ai.styles';
 
@@ -45,6 +46,7 @@ interface UseCommentToEsqlParams {
   // Hides any already-visible ghost-line hint so it doesn't overlap with the
   // "Generating..." decoration during the LLM call. Populated by useGhostLineHint.
   clearGhostHintRef?: MutableRefObject<() => void>;
+  telemetryService?: ESQLEditorTelemetryService;
 }
 
 export const useCommentToEsql = ({
@@ -54,6 +56,7 @@ export const useCommentToEsql = ({
   notifications,
   isEnabled,
   clearGhostHintRef,
+  telemetryService,
 }: UseCommentToEsqlParams) => {
   const { euiTheme } = useEuiTheme();
   const reviewStateRef = useRef<CommentReviewState | null>(null);
@@ -134,13 +137,17 @@ export const useCommentToEsql = ({
     const editor = editorRef.current;
     const model = editorModel.current;
     const state = reviewStateRef.current;
+    cleanup();
     if (!editor || !model || !state) {
-      cleanup();
       return;
     }
 
-    const { replacedLineNumber } = state;
-    cleanup();
+    const { replacedLineNumber, generatedLineStart, generatedLineEnd } = state;
+
+    telemetryService?.trackCommentToEsqlReviewed({
+      action: AiReviewAction.ACCEPT,
+      linesGenerated: generatedLineEnd - generatedLineStart + 1,
+    });
 
     if (replacedLineNumber) {
       const lineContent = model.getLineContent(replacedLineNumber);
@@ -157,7 +164,7 @@ export const useCommentToEsql = ({
         },
       ]);
     }
-  }, [editorRef, editorModel, cleanup]);
+  }, [editorRef, editorModel, cleanup, telemetryService]);
 
   const rejectChange = useCallback(() => {
     const editor = editorRef.current;
@@ -165,15 +172,21 @@ export const useCommentToEsql = ({
     const state = reviewStateRef.current;
     if (!editor || !model || !state) return;
 
+    const { generatedLineStart, generatedLineEnd } = state;
     cleanup();
+
+    telemetryService?.trackCommentToEsqlReviewed({
+      action: AiReviewAction.REJECT,
+      linesGenerated: generatedLineEnd - generatedLineStart + 1,
+    });
 
     editor.executeEdits('nl-to-esql-reject', [
       {
-        range: new monaco.Range(state.generatedLineStart, 1, state.generatedLineEnd + 1, 1),
+        range: new monaco.Range(generatedLineStart, 1, generatedLineEnd + 1, 1),
         text: null,
       },
     ]);
-  }, [editorRef, editorModel, cleanup]);
+  }, [editorRef, editorModel, cleanup, telemetryService]);
 
   const showReview = useCallback(
     (state: CommentReviewState) => {
@@ -278,6 +291,26 @@ export const useCommentToEsql = ({
     [http, notifications.toasts]
   );
 
+  const trackCommentResult = useCallback(
+    (
+      nlLength: number,
+      isCompletion: boolean,
+      contextQueryLength: number,
+      startTime: number,
+      success: boolean,
+      generatedLineCount?: number
+    ) =>
+      telemetryService?.trackCommentToEsqlSubmitted({
+        nlLength,
+        isCompletion,
+        contextQueryLength,
+        success,
+        durationMs: Date.now() - startTime,
+        ...(generatedLineCount !== undefined ? { generatedLineCount } : {}),
+      }),
+    [telemetryService]
+  );
+
   const generateFromComment = useCallback(async () => {
     if (!isEnabled) return;
     const editor = editorRef.current;
@@ -328,6 +361,7 @@ export const useCommentToEsql = ({
 
     const controller = new AbortController();
     abortControllerRef.current = controller;
+    const startTime = Date.now();
 
     // Ensures the generating flag and decoration are reset on every exit path,
     // even if a downstream step throws (e.g. executeEdits on a disposed model).
@@ -339,14 +373,34 @@ export const useCommentToEsql = ({
         controller.signal
       );
 
-      // Was aborted (retrigger / cleanup) or had no content.
-      if (controller.signal.aborted || !result) {
+      // Was aborted (retrigger / cleanup) — swallow and let the new run own the UX.
+      if (controller.signal.aborted) {
         if (abortControllerRef.current === controller) {
           abortControllerRef.current = undefined;
         }
         return;
       }
       abortControllerRef.current = undefined;
+
+      if (!result) {
+        trackCommentResult(
+          nlInstruction.length,
+          isCompletion,
+          nonCommentContent.length,
+          startTime,
+          false
+        );
+        return;
+      }
+
+      trackCommentResult(
+        nlInstruction.length,
+        isCompletion,
+        nonCommentContent.length,
+        startTime,
+        true,
+        result.content.trimEnd().split('\n').length
+      );
 
       const liveModel = editorModel.current;
       const anchorRanges = commentAnchorRef.current?.getRanges() ?? [];
@@ -387,6 +441,7 @@ export const useCommentToEsql = ({
     generateESQL,
     showReview,
     isEnabled,
+    trackCommentResult,
   ]);
 
   return {

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -30,6 +30,7 @@ import { visorStyles, visorWidthPercentage, dropdownWidthPercentage } from './vi
 import type { ESQLEditorDeps } from '../types';
 import { useNlToEsqlCheck } from '../hooks/use_nl_to_esql_check';
 import { reportEsqlError } from '../report_error';
+import type { ESQLEditorTelemetryService } from '../telemetry/telemetry_service';
 
 export { VisorMode } from './mode_selector';
 
@@ -44,6 +45,7 @@ export interface QuickSearchVisorProps {
   onUpdateAndSubmitQuery: (query: string) => void;
   // Callback to toggle the visor visibility
   onToggleVisor: () => void;
+  telemetryService?: ESQLEditorTelemetryService;
 }
 
 export const searchPlaceholder = i18n.translate('esqlEditor.visor.searchPlaceholder', {
@@ -68,6 +70,7 @@ export function QuickSearchVisor({
   isVisible,
   onUpdateAndSubmitQuery,
   onToggleVisor,
+  telemetryService,
 }: QuickSearchVisorProps) {
   const kibana = useKibana<ESQLEditorDeps>();
   const { kql, core, data } = kibana.services;
@@ -109,11 +112,32 @@ export function QuickSearchVisor({
     [selectedSources, query, onUpdateAndSubmitQuery]
   );
 
+  const trackNlResult = useCallback(
+    (
+      nlLength: number,
+      contextQueryLength: number,
+      startTime: number,
+      success: boolean,
+      errorCode?: string,
+      generatedQueryLength?: number
+    ) =>
+      telemetryService?.trackVisorNlSubmitted({
+        nlLength,
+        contextQueryLength,
+        success,
+        durationMs: Date.now() - startTime,
+        ...(errorCode ? { errorCode } : {}),
+        ...(generatedQueryLength !== undefined ? { generatedQueryLength } : {}),
+      }),
+    [telemetryService]
+  );
+
   const onNlSubmit = useCallback(async () => {
     const trimmed = nlValue.trim();
     if (!trimmed || isNlLoading) return;
 
     setIsNlLoading(true);
+    const startTime = Date.now();
     try {
       const result = await core.http.post<{ content: string }>(NL_TO_ESQL_ROUTE, {
         body: JSON.stringify({
@@ -122,11 +146,23 @@ export function QuickSearchVisor({
         }),
       });
       if (result.content) {
+        trackNlResult(
+          trimmed.length,
+          query.length,
+          startTime,
+          true,
+          undefined,
+          result.content.length
+        );
         onUpdateAndSubmitQuery(result.content);
         setNlValue('');
       }
     } catch (error) {
       reportEsqlError(error, { errorType: 'NlToEsql' });
+      const errorCode = String(
+        (error as { body?: { statusCode?: number } })?.body?.statusCode ?? ''
+      );
+      trackNlResult(trimmed.length, query.length, startTime, false, errorCode || undefined);
       const message =
         (error as { body?: { message?: string } })?.body?.message ??
         i18n.translate('esqlEditor.visor.nlError', {
@@ -136,7 +172,15 @@ export function QuickSearchVisor({
     } finally {
       setIsNlLoading(false);
     }
-  }, [nlValue, isNlLoading, core.http, core.notifications.toasts, onUpdateAndSubmitQuery, query]);
+  }, [
+    nlValue,
+    isNlLoading,
+    core.http,
+    core.notifications.toasts,
+    onUpdateAndSubmitQuery,
+    query,
+    trackNlResult,
+  ]);
 
   const checkConnectorAvailability = useCallback(async () => {
     if (connectorCheckRef.current) return;

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -567,6 +567,7 @@ const ESQLEditorInternal = function ESQLEditor({
     notifications: core.notifications,
     isEnabled: isNlToEsqlEnabled,
     clearGhostHintRef,
+    telemetryService,
   });
 
   const onGenerateFromCommentRef = useRef(onGenerateFromComment);
@@ -627,6 +628,7 @@ const ESQLEditorInternal = function ESQLEditor({
     http: core.http,
     notifications: core.notifications,
     isEnabled: isNlToEsqlEnabled,
+    telemetryService,
   });
 
   const { lookupIndexBadgeStyle, addLookupIndicesDecorator } = useLookupIndexCommand(
@@ -893,6 +895,7 @@ const ESQLEditorInternal = function ESQLEditor({
             onUpdateAndSubmitQuery(newQuery, QuerySource.QUICK_SEARCH)
           }
           onToggleVisor={onToggleVisor}
+          telemetryService={telemetryService}
         />
       )}
       {(isHistoryOpen || (isLanguageComponentOpen && editorIsInline)) && (

--- a/src/platform/packages/private/kbn-esql-editor/src/suggest_fix/use_suggest_fix.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/suggest_fix/use_suggest_fix.ts
@@ -14,6 +14,7 @@ import type { MutableRefObject } from 'react';
 import { i18n } from '@kbn/i18n';
 import { SUGGEST_FIX_ROUTE, FIX_WITH_AI_COMMAND_ID } from '@kbn/esql-types';
 import type { HttpStart, NotificationsStart } from '@kbn/core/public';
+import { AiReviewAction, type ESQLEditorTelemetryService } from '../telemetry/telemetry_service';
 import { ReviewActionsWidget } from '../comment_to_esql/review_actions_widget';
 import { CODE_ADDED_CLASS, GENERATING_HINT_CLASS, LINE_REPLACED_CLASS } from '../editor_ai.styles';
 import { findChangedRegion } from './utils';
@@ -73,6 +74,7 @@ interface UseSuggestFixParams {
   http: HttpStart;
   notifications: NotificationsStart;
   isEnabled: boolean;
+  telemetryService?: ESQLEditorTelemetryService;
 }
 
 export const useSuggestFix = ({
@@ -81,6 +83,7 @@ export const useSuggestFix = ({
   http,
   notifications,
   isEnabled,
+  telemetryService,
 }: UseSuggestFixParams) => {
   const { euiTheme } = useEuiTheme();
 
@@ -124,6 +127,30 @@ export const useSuggestFix = ({
     abortInFlight();
   }, [clearGeneratingDecoration, abortInFlight]);
 
+  const trackFixResult = useCallback(
+    (
+      queryLength: number,
+      startTime: number,
+      success: boolean,
+      errorCode?: string | null,
+      changedLineCount?: number
+    ) =>
+      telemetryService?.trackFixWithAiSubmitted({
+        queryLength,
+        success,
+        durationMs: Date.now() - startTime,
+        errorCode: errorCode ?? undefined,
+        ...(changedLineCount !== undefined ? { changedLineCount } : {}),
+      }),
+    [telemetryService]
+  );
+
+  const trackFixReview = useCallback(
+    (action: AiReviewAction, linesChanged: number) =>
+      telemetryService?.trackFixWithAiReviewed({ action, linesChanged }),
+    [telemetryService]
+  );
+
   const acceptFix = useCallback(() => {
     const editor = editorRef.current;
     const model = editorModel.current;
@@ -134,6 +161,8 @@ export const useSuggestFix = ({
     if (!editor || !model || !state) {
       return;
     }
+
+    trackFixReview(AiReviewAction.ACCEPT, state.generatedLineEnd - state.generatedLineStart + 1);
 
     // Remove only the original changed lines — the fix lines shift up to replace them
     editor.executeEdits('esql-suggest-fix-accept', [
@@ -147,7 +176,7 @@ export const useSuggestFix = ({
         text: null,
       },
     ]);
-  }, [editorRef, editorModel, cleanup]);
+  }, [editorRef, editorModel, cleanup, trackFixReview]);
 
   const rejectFix = useCallback(() => {
     const editor = editorRef.current;
@@ -159,6 +188,8 @@ export const useSuggestFix = ({
     if (!editor || !model || !state) {
       return;
     }
+
+    trackFixReview(AiReviewAction.REJECT, state.generatedLineEnd - state.generatedLineStart + 1);
 
     // Remove the "\n" connector + fix lines by selecting from the end of the last
     // original changed line through the end of the last fix line.
@@ -173,7 +204,7 @@ export const useSuggestFix = ({
         text: null,
       },
     ]);
-  }, [editorRef, editorModel, cleanup]);
+  }, [editorRef, editorModel, cleanup, trackFixReview]);
 
   const showReview = useCallback(
     (state: ReviewState) => {
@@ -269,6 +300,7 @@ export const useSuggestFix = ({
 
       const controller = new AbortController();
       abortControllerRef.current = controller;
+      const startTime = Date.now();
 
       try {
         const result = await http.post<{ content: string }>(SUGGEST_FIX_ROUTE, {
@@ -276,13 +308,19 @@ export const useSuggestFix = ({
           signal: controller.signal,
         });
 
-        if (controller.signal.aborted || !result?.content) {
+        // Was aborted (retrigger / cleanup) — swallow and let the new run own the UX.
+        if (controller.signal.aborted) {
           if (abortControllerRef.current === controller) {
             abortControllerRef.current = undefined;
           }
           return;
         }
         abortControllerRef.current = undefined;
+
+        if (!result?.content) {
+          trackFixResult(queryString.length, startTime, false, errorCode);
+          return;
+        }
 
         const fixedQuery = result.content.replace(/\n+$/, '');
         const originalLines = model.getValue().split('\n');
@@ -317,6 +355,14 @@ export const useSuggestFix = ({
         const generatedLineStart = lastChangedOriginalLine + 1;
         const generatedLineEnd = lastChangedOriginalLine + changedFixedLines.length;
 
+        trackFixResult(
+          queryString.length,
+          startTime,
+          true,
+          errorCode,
+          generatedLineEnd - generatedLineStart + 1
+        );
+
         showReview({
           firstChangedOriginalLine,
           lastChangedOriginalLine,
@@ -325,6 +371,7 @@ export const useSuggestFix = ({
         });
       } catch (error) {
         if (controller.signal.aborted) return;
+        trackFixResult(queryString.length, startTime, false, errorCode);
         const message =
           (error as { body?: { message?: string } })?.body?.message ??
           i18n.translate('esqlEditor.suggestFix.error', {
@@ -344,6 +391,7 @@ export const useSuggestFix = ({
       rejectFix,
       showReview,
       clearGeneratingDecoration,
+      trackFixResult,
     ]
   );
 

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/events_registration.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/events_registration.ts
@@ -26,6 +26,11 @@ export const ESQL_CONTROL_CANCELLED = 'esql.control_cancelled';
 export const ESQL_CONTROL_SAVED = 'esql.control_saved';
 export const ESQL_RESOURCE_BROWSER_OPENED = 'esql.resource_browser_opened';
 export const ESQL_RESOURCE_BROWSER_ITEM_TOGGLED = 'esql.resource_browser_item_toggled';
+export const ESQL_VISOR_NL_SUBMITTED = 'esql.visor_nl_submitted';
+export const ESQL_COMMENT_TO_ESQL_SUBMITTED = 'esql.comment_to_esql_submitted';
+export const ESQL_COMMENT_TO_ESQL_REVIEWED = 'esql.comment_to_esql_reviewed';
+export const ESQL_FIX_WITH_AI_SUBMITTED = 'esql.fix_with_ai_submitted';
+export const ESQL_FIX_WITH_AI_REVIEWED = 'esql.fix_with_ai_reviewed';
 
 /**
  * Registers the esql editor analytics events.
@@ -243,6 +248,129 @@ export const registerESQLEditorAnalyticsEvents = once((analytics: AnalyticsServi
       action: {
         type: 'keyword',
         _meta: { description: 'Whether the item was added or removed. add|remove' },
+      },
+    },
+  });
+
+  analytics.registerEventType({
+    eventType: ESQL_VISOR_NL_SUBMITTED,
+    schema: {
+      nl_length: {
+        type: 'long',
+        _meta: { description: 'Character count of the natural language instruction.' },
+      },
+      context_query_length: {
+        type: 'long',
+        _meta: { description: 'Character count of the current ES|QL query sent as context.' },
+      },
+      success: {
+        type: 'boolean',
+        _meta: { description: 'Whether the LLM returned a query successfully.' },
+      },
+      error_code: {
+        type: 'keyword',
+        _meta: { optional: true, description: 'HTTP status code as string on failure.' },
+      },
+      duration_ms: {
+        type: 'long',
+        _meta: { description: 'Milliseconds from submit to result.' },
+      },
+      generated_query_length: {
+        type: 'long',
+        _meta: {
+          optional: true,
+          description: 'Character count of the generated query on success.',
+        },
+      },
+    },
+  });
+
+  analytics.registerEventType({
+    eventType: ESQL_COMMENT_TO_ESQL_SUBMITTED,
+    schema: {
+      nl_length: {
+        type: 'long',
+        _meta: { description: 'Character count of the comment instruction.' },
+      },
+      is_completion: {
+        type: 'boolean',
+        _meta: {
+          description: 'True when the editor already has non-comment ES|QL code (append mode).',
+        },
+      },
+      context_query_length: {
+        type: 'long',
+        _meta: { description: 'Character count of non-comment code sent as context.' },
+      },
+      success: {
+        type: 'boolean',
+        _meta: { description: 'Whether the LLM returned code successfully.' },
+      },
+      error_code: {
+        type: 'keyword',
+        _meta: { optional: true, description: 'HTTP status code as string on failure.' },
+      },
+      duration_ms: {
+        type: 'long',
+        _meta: { description: 'Milliseconds from trigger to result.' },
+      },
+      generated_line_count: {
+        type: 'long',
+        _meta: { optional: true, description: 'Number of lines generated on success.' },
+      },
+    },
+  });
+
+  analytics.registerEventType({
+    eventType: ESQL_COMMENT_TO_ESQL_REVIEWED,
+    schema: {
+      action: {
+        type: 'keyword',
+        _meta: { description: 'User decision on the generated code. accept|reject' },
+      },
+      lines_generated: {
+        type: 'long',
+        _meta: { description: 'Number of lines in the generated suggestion.' },
+      },
+    },
+  });
+
+  analytics.registerEventType({
+    eventType: ESQL_FIX_WITH_AI_SUBMITTED,
+    schema: {
+      error_code: {
+        type: 'keyword',
+        _meta: { optional: true, description: 'ES|QL error code that triggered the fix.' },
+      },
+      query_length: {
+        type: 'long',
+        _meta: { description: 'Character count of the full query sent as context.' },
+      },
+      success: {
+        type: 'boolean',
+        _meta: { description: 'Whether the LLM returned a fix successfully.' },
+      },
+      duration_ms: {
+        type: 'long',
+        _meta: { description: 'Milliseconds from trigger to result.' },
+      },
+      changed_line_count: {
+        type: 'long',
+        _meta: { optional: true, description: 'Number of lines in the generated fix on success.' },
+      },
+    },
+  });
+
+  analytics.registerEventType({
+    eventType: ESQL_FIX_WITH_AI_REVIEWED,
+    schema: {
+      action: {
+        type: 'keyword',
+        _meta: { description: 'User decision on the AI fix. accept|reject' },
+      },
+      lines_changed: {
+        type: 'long',
+        _meta: { description: 'Number of lines in the generated fix.' },
       },
     },
   });

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.test.ts
@@ -10,6 +10,7 @@
 import type { AnalyticsServiceStart } from '@kbn/core/server';
 import {
   ESQLEditorTelemetryService,
+  AiReviewAction,
   ResourceBrowserType,
   ResourceBrowserOpenedFrom,
 } from './telemetry_service';
@@ -18,6 +19,11 @@ import {
   ESQL_LOOKUP_JOIN_ACTION_SHOWN,
   ESQL_RESOURCE_BROWSER_ITEM_TOGGLED,
   ESQL_RESOURCE_BROWSER_OPENED,
+  ESQL_VISOR_NL_SUBMITTED,
+  ESQL_COMMENT_TO_ESQL_SUBMITTED,
+  ESQL_COMMENT_TO_ESQL_REVIEWED,
+  ESQL_FIX_WITH_AI_SUBMITTED,
+  ESQL_FIX_WITH_AI_REVIEWED,
 } from './events_registration';
 import { reportEsqlError } from '../report_error';
 
@@ -159,6 +165,216 @@ describe('ESQLEditorTelemetryService', () => {
         expect(reportEsqlError).toHaveBeenCalledWith(expect.any(Error), {
           errorType: 'HoverMessageParse',
         });
+      });
+    });
+  });
+
+  describe('trackVisorNlSubmitted', () => {
+    it('tracks a successful NL submission with all fields, omitting error_code', () => {
+      telemetryService.trackVisorNlSubmitted({
+        nlLength: 42,
+        contextQueryLength: 100,
+        success: true,
+        durationMs: 1500,
+        generatedQueryLength: 80,
+      });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_VISOR_NL_SUBMITTED, {
+        nl_length: 42,
+        context_query_length: 100,
+        success: true,
+        duration_ms: 1500,
+        generated_query_length: 80,
+      });
+      const payload = (mockAnalytics.reportEvent as jest.Mock).mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(payload).not.toHaveProperty('error_code');
+    });
+
+    it('tracks a failed NL submission with error code, omitting generated_query_length', () => {
+      telemetryService.trackVisorNlSubmitted({
+        nlLength: 42,
+        contextQueryLength: 100,
+        success: false,
+        durationMs: 300,
+        errorCode: '500',
+      });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_VISOR_NL_SUBMITTED, {
+        nl_length: 42,
+        context_query_length: 100,
+        success: false,
+        duration_ms: 300,
+        error_code: '500',
+      });
+      const payload = (mockAnalytics.reportEvent as jest.Mock).mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(payload).not.toHaveProperty('generated_query_length');
+    });
+
+    it('omits error_code when not provided', () => {
+      telemetryService.trackVisorNlSubmitted({
+        nlLength: 10,
+        contextQueryLength: 50,
+        success: false,
+        durationMs: 200,
+      });
+
+      const payload = (mockAnalytics.reportEvent as jest.Mock).mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(payload).not.toHaveProperty('error_code');
+    });
+  });
+
+  describe('trackCommentToEsqlSubmitted', () => {
+    it('tracks a successful comment-to-esql generation with all fields', () => {
+      telemetryService.trackCommentToEsqlSubmitted({
+        nlLength: 30,
+        isCompletion: true,
+        contextQueryLength: 60,
+        success: true,
+        durationMs: 2000,
+        generatedLineCount: 3,
+      });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_COMMENT_TO_ESQL_SUBMITTED, {
+        nl_length: 30,
+        is_completion: true,
+        context_query_length: 60,
+        success: true,
+        duration_ms: 2000,
+        generated_line_count: 3,
+      });
+    });
+
+    it('tracks a failed generation with error code, omitting generated_line_count', () => {
+      telemetryService.trackCommentToEsqlSubmitted({
+        nlLength: 30,
+        isCompletion: false,
+        contextQueryLength: 0,
+        success: false,
+        durationMs: 400,
+        errorCode: '503',
+      });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_COMMENT_TO_ESQL_SUBMITTED, {
+        nl_length: 30,
+        is_completion: false,
+        context_query_length: 0,
+        success: false,
+        duration_ms: 400,
+        error_code: '503',
+      });
+      const payload = (mockAnalytics.reportEvent as jest.Mock).mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(payload).not.toHaveProperty('generated_line_count');
+    });
+  });
+
+  describe('trackCommentToEsqlReviewed', () => {
+    it('tracks an accept action', () => {
+      telemetryService.trackCommentToEsqlReviewed({
+        action: AiReviewAction.ACCEPT,
+        linesGenerated: 4,
+      });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_COMMENT_TO_ESQL_REVIEWED, {
+        action: AiReviewAction.ACCEPT,
+        lines_generated: 4,
+      });
+    });
+
+    it('tracks a reject action', () => {
+      telemetryService.trackCommentToEsqlReviewed({
+        action: AiReviewAction.REJECT,
+        linesGenerated: 2,
+      });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_COMMENT_TO_ESQL_REVIEWED, {
+        action: AiReviewAction.REJECT,
+        lines_generated: 2,
+      });
+    });
+  });
+
+  describe('trackFixWithAiSubmitted', () => {
+    it('tracks a successful fix with all fields', () => {
+      telemetryService.trackFixWithAiSubmitted({
+        errorCode: 'SYNTAX_ERROR',
+        queryLength: 120,
+        success: true,
+        durationMs: 1800,
+        changedLineCount: 2,
+      });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_FIX_WITH_AI_SUBMITTED, {
+        error_code: 'SYNTAX_ERROR',
+        query_length: 120,
+        success: true,
+        duration_ms: 1800,
+        changed_line_count: 2,
+      });
+    });
+
+    it('tracks a failed fix, omitting changed_line_count', () => {
+      telemetryService.trackFixWithAiSubmitted({
+        queryLength: 120,
+        success: false,
+        durationMs: 500,
+      });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_FIX_WITH_AI_SUBMITTED, {
+        query_length: 120,
+        success: false,
+        duration_ms: 500,
+      });
+      const payload = (mockAnalytics.reportEvent as jest.Mock).mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(payload).not.toHaveProperty('changed_line_count');
+    });
+
+    it('omits error_code when not provided', () => {
+      telemetryService.trackFixWithAiSubmitted({
+        queryLength: 50,
+        success: true,
+        durationMs: 1000,
+        changedLineCount: 1,
+      });
+
+      const payload = (mockAnalytics.reportEvent as jest.Mock).mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(payload).not.toHaveProperty('error_code');
+    });
+  });
+
+  describe('trackFixWithAiReviewed', () => {
+    it('tracks an accept action', () => {
+      telemetryService.trackFixWithAiReviewed({ action: AiReviewAction.ACCEPT, linesChanged: 3 });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_FIX_WITH_AI_REVIEWED, {
+        action: AiReviewAction.ACCEPT,
+        lines_changed: 3,
+      });
+    });
+
+    it('tracks a reject action', () => {
+      telemetryService.trackFixWithAiReviewed({ action: AiReviewAction.REJECT, linesChanged: 1 });
+
+      expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(ESQL_FIX_WITH_AI_REVIEWED, {
+        action: AiReviewAction.REJECT,
+        lines_changed: 1,
       });
     });
   });

--- a/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/telemetry/telemetry_service.ts
@@ -34,10 +34,20 @@ import {
   ESQL_RECOMMENDED_QUERY_CLICKED,
   ESQL_STARRED_QUERY_CLICKED,
   ESQL_SUGGESTIONS_WITH_CUSTOM_COMMAND_SHOWN,
+  ESQL_VISOR_NL_SUBMITTED,
+  ESQL_COMMENT_TO_ESQL_SUBMITTED,
+  ESQL_COMMENT_TO_ESQL_REVIEWED,
+  ESQL_FIX_WITH_AI_SUBMITTED,
+  ESQL_FIX_WITH_AI_REVIEWED,
 } from './events_registration';
 import type { IndexEditorCommandArgs } from '../lookup_join/use_lookup_index_editor';
 import { COMMAND_ID as LOOKUP_INDEX_EDITOR_COMMAND } from '../lookup_join/use_lookup_index_editor';
 import { reportEsqlError } from '../report_error';
+
+export enum AiReviewAction {
+  ACCEPT = 'accept',
+  REJECT = 'reject',
+}
 
 export enum ResourceBrowserType {
   DATA_SOURCES = 'data_sources',
@@ -275,5 +285,79 @@ export class ESQLEditorTelemetryService {
     this._reportPerformanceEvent(
       this._buildBaseLatencyEvent('esql_editor_validation_latency', payload)
     );
+  }
+
+  public trackVisorNlSubmitted(params: {
+    nlLength: number;
+    contextQueryLength: number;
+    success: boolean;
+    errorCode?: string;
+    durationMs: number;
+    generatedQueryLength?: number;
+  }) {
+    this._reportEvent(ESQL_VISOR_NL_SUBMITTED, {
+      nl_length: params.nlLength,
+      context_query_length: params.contextQueryLength,
+      success: params.success,
+      duration_ms: params.durationMs,
+      ...(params.errorCode !== undefined ? { error_code: params.errorCode } : {}),
+      ...(params.generatedQueryLength !== undefined
+        ? { generated_query_length: params.generatedQueryLength }
+        : {}),
+    });
+  }
+
+  public trackCommentToEsqlSubmitted(params: {
+    nlLength: number;
+    isCompletion: boolean;
+    contextQueryLength: number;
+    success: boolean;
+    errorCode?: string;
+    durationMs: number;
+    generatedLineCount?: number;
+  }) {
+    this._reportEvent(ESQL_COMMENT_TO_ESQL_SUBMITTED, {
+      nl_length: params.nlLength,
+      is_completion: params.isCompletion,
+      context_query_length: params.contextQueryLength,
+      success: params.success,
+      duration_ms: params.durationMs,
+      ...(params.errorCode !== undefined ? { error_code: params.errorCode } : {}),
+      ...(params.generatedLineCount !== undefined
+        ? { generated_line_count: params.generatedLineCount }
+        : {}),
+    });
+  }
+
+  public trackCommentToEsqlReviewed(params: { action: AiReviewAction; linesGenerated: number }) {
+    this._reportEvent(ESQL_COMMENT_TO_ESQL_REVIEWED, {
+      action: params.action,
+      lines_generated: params.linesGenerated,
+    });
+  }
+
+  public trackFixWithAiSubmitted(params: {
+    errorCode?: string;
+    queryLength: number;
+    success: boolean;
+    durationMs: number;
+    changedLineCount?: number;
+  }) {
+    this._reportEvent(ESQL_FIX_WITH_AI_SUBMITTED, {
+      query_length: params.queryLength,
+      success: params.success,
+      duration_ms: params.durationMs,
+      ...(params.errorCode !== undefined ? { error_code: params.errorCode } : {}),
+      ...(params.changedLineCount !== undefined
+        ? { changed_line_count: params.changedLineCount }
+        : {}),
+    });
+  }
+
+  public trackFixWithAiReviewed(params: { action: AiReviewAction; linesChanged: number }) {
+    this._reportEvent(ESQL_FIX_WITH_AI_REVIEWED, {
+      action: params.action,
+      lines_changed: params.linesChanged,
+    });
   }
 }


### PR DESCRIPTION
## New AI telemetry events


  ### `esql.visor_nl_submitted`
  Fired when the user submits a natural language query in the Quick Search Visor.

  | Field | Type | Optional | Description |
  |---|---|---|---|
  | `nl_length` | long | | Character count of the NL instruction |
  | `context_query_length` | long | | Character count of the current ES\|QL query sent as context |
  | `success` | boolean | | Whether the LLM returned a query successfully |
  | `duration_ms` | long | | Milliseconds from submit to result |
  | `error_code` | keyword | ✓ | HTTP status code as string on failure |
  | `generated_query_length` | long | ✓ | Character count of the generated query on success |

  ### `esql.comment_to_esql_submitted`
  Fired when the user presses Cmd+J to generate ES\|QL from a `//` comment.

  | Field | Type | Optional | Description |
  |---|---|---|---|
  | `nl_length` | long | | Character count of the comment instruction |
  | `is_completion` | boolean | | `true` when the editor already has non-comment ES\|QL (append mode) |
  | `context_query_length` | long | | Character count of non-comment code sent as context |
  | `success` | boolean | | Whether the LLM returned code successfully |
  | `duration_ms` | long | | Milliseconds from trigger to result |
  | `error_code` | keyword | ✓ | HTTP status code as string on failure |
  | `generated_line_count` | long | ✓ | Number of lines generated on success |

  ### `esql.comment_to_esql_reviewed`
  Fired when the user accepts or rejects a comment-to-ES\|QL suggestion.

  | Field | Type | Optional | Description |
  |---|---|---|---|
  | `action` | keyword | | User decision: `accept` \| `reject` |
  | `lines_generated` | long | | Number of lines in the suggestion |

  ### `esql.fix_with_ai_submitted`
  Fired when the user triggers Fix with AI on a query error.

  | Field | Type | Optional | Description |
  |---|---|---|---|
  | `query_length` | long | | Character count of the full query sent as context |
  | `success` | boolean | | Whether the LLM returned a fix successfully |
  | `duration_ms` | long | | Milliseconds from trigger to result |
  | `error_code` | keyword | ✓ | ES\|QL error code that triggered the fix |
  | `changed_line_count` | long | ✓ | Number of lines in the generated fix on success |

  ### `esql.fix_with_ai_reviewed`
  Fired when the user accepts or rejects an AI fix suggestion.

  | Field | Type | Optional | Description |
  |---|---|---|---|
  | `action` | keyword | | User decision: `accept` \| `reject` |
  | `lines_changed` | long | | Number of lines in the generated fix |

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




