### PR TITLE
[Synthetics] [CCS] Add remoteName URL param to monitor detail page

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/locators/monitor_detail.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/locators/monitor_detail.ts
@@ -14,12 +14,14 @@ async function navigate({
   spaceId,
   timeRange,
   tabId,
+  remoteName,
 }: {
   configId: string;
   locationId?: string;
   spaceId?: string;
   timeRange?: TimeRange;
   tabId?: string;
+  remoteName?: string;
 }) {
   let queryParam = locationId ? `?locationId=${locationId}` : '';
   const tab = `${tabId ? `/${tabId}` : ''}`;
@@ -32,6 +34,10 @@ async function navigate({
     queryParam += queryParam
       ? `&dateRangeStart=${timeRange.from}&dateRangeEnd=${timeRange.to}`
       : `?dateRangeStart=${timeRange.from}&dateRangeEnd=${timeRange.to}`;
+  }
+
+  if (remoteName) {
+    queryParam += queryParam ? `&remoteName=${remoteName}` : `?remoteName=${remoteName}`;
   }
 
   return {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_page_title.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_page_title.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MonitorDetailsPageTitle } from './monitor_details_page_title';
+import { useSelectedMonitor } from './hooks/use_selected_monitor';
+import { useGetUrlParams } from '../../hooks';
+
+jest.mock('./hooks/use_selected_monitor', () => ({
+  useSelectedMonitor: jest.fn(),
+}));
+
+jest.mock('../../hooks', () => ({
+  useGetUrlParams: jest.fn(),
+}));
+
+jest.mock('./monitor_selector/monitor_selector', () => ({
+  MonitorSelector: () => <div data-test-subj="monitorSelectorStub" />,
+}));
+
+const mockUseSelectedMonitor = useSelectedMonitor as jest.MockedFunction<typeof useSelectedMonitor>;
+const mockUseGetUrlParams = useGetUrlParams as jest.MockedFunction<typeof useGetUrlParams>;
+
+describe('MonitorDetailsPageTitle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelectedMonitor.mockReturnValue({
+      monitor: { name: 'My monitor' },
+    } as ReturnType<typeof useSelectedMonitor>);
+  });
+
+  it('does not render the Remote badge for a local monitor', () => {
+    mockUseGetUrlParams.mockReturnValue({ remoteName: undefined } as ReturnType<
+      typeof useGetUrlParams
+    >);
+
+    render(<MonitorDetailsPageTitle />);
+
+    expect(screen.getByText('My monitor')).toBeInTheDocument();
+    expect(screen.queryByTestId('syntheticsRemoteBadge')).not.toBeInTheDocument();
+  });
+
+  it('renders the Remote badge when the URL has a `remoteName` param', () => {
+    mockUseGetUrlParams.mockReturnValue({ remoteName: 'cluster-a' } as ReturnType<
+      typeof useGetUrlParams
+    >);
+
+    render(<MonitorDetailsPageTitle />);
+
+    expect(screen.getByText('My monitor')).toBeInTheDocument();
+    expect(screen.getByTestId('syntheticsRemoteBadge')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_page_title.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_page_title.tsx
@@ -9,15 +9,23 @@ import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { MonitorSelector } from './monitor_selector/monitor_selector';
 import { useSelectedMonitor } from './hooks/use_selected_monitor';
+import { useGetUrlParams } from '../../hooks';
+import { SyntheticsRemoteBadge } from '../common/components/synthetics_remote_badge';
 
 export const MonitorDetailsPageTitle = () => {
   const { monitor } = useSelectedMonitor();
+  const { remoteName } = useGetUrlParams();
 
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
       <EuiFlexItem grow={false} data-test-subj="monitorNameTitle">
         {monitor?.name}
       </EuiFlexItem>
+      {remoteName && (
+        <EuiFlexItem grow={false}>
+          <SyntheticsRemoteBadge remote={{ remoteName }} />
+        </EuiFlexItem>
+      )}
       <EuiFlexItem>
         <MonitorSelector />
       </EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_detail_locator.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_detail_locator.test.ts
@@ -64,6 +64,31 @@ describe('useMonitorDetailLocator', () => {
     expect(result.current).toBe(mockUrl);
   });
 
+  it('should pass `remoteName` through to the locator when provided', async () => {
+    const mockUrl = 'http://example.com/monitor?remoteName=remote-1';
+    mockLocator.getRedirectUrl.mockReturnValue(mockUrl);
+
+    const { result } = renderHook(() =>
+      useMonitorDetailLocator({
+        configId: 'test-config',
+        locationId: 'test-location',
+        remoteName: 'remote-1',
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockLocator.getRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configId: 'test-config',
+          locationId: 'test-location',
+          remoteName: 'remote-1',
+        })
+      );
+    });
+
+    expect(result.current).toBe(mockUrl);
+  });
+
   it('should return undefined if locator is not available', async () => {
     (useKibana as jest.Mock).mockReturnValue({
       services: {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_detail_locator.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_detail_locator.ts
@@ -21,6 +21,7 @@ export interface MonitorDetailLocatorParams {
   spaces?: string[];
   tabId?: string;
   useAbsoluteDate?: boolean;
+  remoteName?: string;
 }
 
 export function useMonitorDetailLocator({
@@ -30,6 +31,7 @@ export function useMonitorDetailLocator({
   timeRange,
   tabId,
   useAbsoluteDate = false,
+  remoteName,
 }: MonitorDetailLocatorParams) {
   const { space } = useKibanaSpace();
   const [monitorUrl, setMonitorUrl] = useState<string | undefined>(undefined);
@@ -44,10 +46,11 @@ export function useMonitorDetailLocator({
       locationId,
       timeRange: useAbsoluteDate ? convertToAbsoluteTimeRange(timeRange) : timeRange,
       tabId,
+      remoteName,
       ...getMonitorSpaceToAppend(space, spaces),
     });
     setMonitorUrl(url);
-  }, [locator, configId, locationId, spaces, space, timeRange, tabId, useAbsoluteDate]);
+  }, [locator, configId, locationId, spaces, space, timeRange, tabId, useAbsoluteDate, remoteName]);
 
   return monitorUrl;
 }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/url_params/get_supported_url_params.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/url_params/get_supported_url_params.ts
@@ -40,6 +40,7 @@ export interface SyntheticsUrlParams {
   spaceId?: string;
   useLogicalAndFor?: UseLogicalAndField[];
   view?: Exclude<OverviewView, typeof DEFAULT_OVERVIEW_VIEW>;
+  remoteName?: string;
 }
 
 const { ABSOLUTE_DATE_RANGE_START, ABSOLUTE_DATE_RANGE_END, SEARCH, FILTERS, STATUS_FILTER } =
@@ -99,6 +100,7 @@ export const getSupportedUrlParams = (params: {
     spaceId,
     useLogicalAndFor,
     view,
+    remoteName,
   } = filteredParams;
 
   return {
@@ -134,6 +136,7 @@ export const getSupportedUrlParams = (params: {
     spaceId: spaceId || undefined,
     useLogicalAndFor: parseFilters(useLogicalAndFor),
     view: view && isOverviewView(view) && view !== DEFAULT_OVERVIEW_VIEW ? view : undefined,
+    remoteName: remoteName || undefined,
   };
 };
 


### PR DESCRIPTION
## Summary

Fixes part of https://github.com/elastic/kibana/issues/259272
- Add `remoteName?: string` to `SyntheticsUrlParams` and the monitor detail locator. Preserved across tabs via the existing `${search}` pattern.
- Render a "Remote" badge in `MonitorDetailsPageTitle` when the URL has `?remoteName=...`.



