### PR TITLE
[FTR] Reduce PageObjects.common.sleep calls in navigateToApp

### DIFF
--- a/src/platform/test/functional/page_objects/common_page.ts
+++ b/src/platform/test/functional/page_objects/common_page.ts
@@ -309,7 +309,8 @@ export class CommonPageObject extends FtrService {
         // accept alert if it pops up
         const alert = await this.browser.getAlert();
         await alert?.accept();
-        await this.sleep(700);
+        // browser.get() waits for document.readyState==='complete' before returning,
+        // so no sleep is needed here; the refresh below starts from a fully loaded page.
         this.log.debug('returned from get, calling refresh');
         await this.browser.refresh();
         let currentUrl = shouldLoginIfPrompted
@@ -365,8 +366,10 @@ export class CommonPageObject extends FtrService {
       });
 
       if (!skipUrlValidation) {
+        // Poll until the URL stops changing. No upfront sleep: if the URL has
+        // already settled we return immediately; the retry service's built-in
+        // 502ms delay provides spacing between checks when it is still moving.
         await this.retry.tryForTime(this.defaultFindTimeout, async () => {
-          await this.sleep(501);
           const currentUrl = await this.browser.getCurrentUrl();
           this.log.debug('in navigateTo url = ' + currentUrl);
           if (lastUrl !== currentUrl) {


### PR DESCRIPTION
Remove two unconditional sleeps from navigateToApp that fire on every navigation (4,281+ calls in CI):

- sleep(700) before browser.refresh(): browser.get() already blocks until document.readyState==='complete', so no sleep is needed before forcing a reload.

- sleep(501) inside the URL-stability retry loop: the retry service already waits 502ms between failed attempts. The upfront sleep wasted 501ms on every iteration including the first, meaning the happy path (URL already settled) paid 501ms for nothing.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->