### PR TITLE
[FTR] Remove 500ms implicit wait floor from waitForDeletedByCssSelector

### DIFF
--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/find.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/find.ts
@@ -25,7 +25,6 @@ export class FindService extends FtrService {
   private readonly retryOnStale = this.ctx.getService('retryOnStale');
 
   private readonly WAIT_FOR_EXISTS_TIME = this.config.get('timeouts.waitForExists');
-  private readonly POLLING_TIME = 500;
   private readonly defaultFindTimeout = this.config.get('timeouts.find');
   private readonly fixedHeaderHeight = this.config.get('layout.fixedHeaderHeight');
 
@@ -468,7 +467,8 @@ export class FindService extends FtrService {
     timeout: number = this.defaultFindTimeout
   ) {
     this.log.debug(`Find.waitForDeletedByCssSelector('${selector}') with timeout=${timeout}`);
-    await this._withTimeout(this.POLLING_TIME);
+    // Implicit timeout 0: findElements returns immediately when absent, no per-iteration 500ms floor.
+    await this._withTimeout(0);
     try {
       await this.driver.wait(
         async () => {

--- a/src/platform/test/functional/apps/dashboard_elements/controls/common/range_slider.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/controls/common/range_slider.ts
@@ -185,8 +185,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('applies filter from the first control on the second control', async () => {
         const secondId = (await dashboardControls.getAllControlIds())[1];
-        await dashboardControls.rangeSliderWaitForLoading(secondId);
-        await dashboardControls.validateRange('placeholder', secondId, '100', '1000');
+        await retry.try(async () => {
+          await dashboardControls.rangeSliderWaitForLoading(secondId);
+          await dashboardControls.validateRange('placeholder', secondId, '100', '1000');
+        });
         await dashboard.clearUnsavedChanges();
       });
 

--- a/src/platform/test/functional/page_objects/dashboard_page_controls.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page_controls.ts
@@ -794,12 +794,14 @@ export class DashboardPageControls extends FtrService {
     expectedLowerBound: string,
     expectedUpperBound: string
   ) {
-    expect(await this.rangeSliderGetLowerBoundAttribute(controlId, compare)).to.be(
-      expectedLowerBound
-    );
-    expect(await this.rangeSliderGetUpperBoundAttribute(controlId, compare)).to.be(
-      expectedUpperBound
-    );
+    await this.retry.try(async () => {
+      expect(await this.rangeSliderGetLowerBoundAttribute(controlId, compare)).to.be(
+        expectedLowerBound
+      );
+      expect(await this.rangeSliderGetUpperBoundAttribute(controlId, compare)).to.be(
+        expectedUpperBound
+      );
+    });
   }
 
   // Time slider functions

--- a/src/platform/test/functional/page_objects/dashboard_page_controls.ts
+++ b/src/platform/test/functional/page_objects/dashboard_page_controls.ts
@@ -794,14 +794,12 @@ export class DashboardPageControls extends FtrService {
     expectedLowerBound: string,
     expectedUpperBound: string
   ) {
-    await this.retry.try(async () => {
-      expect(await this.rangeSliderGetLowerBoundAttribute(controlId, compare)).to.be(
-        expectedLowerBound
-      );
-      expect(await this.rangeSliderGetUpperBoundAttribute(controlId, compare)).to.be(
-        expectedUpperBound
-      );
-    });
+    expect(await this.rangeSliderGetLowerBoundAttribute(controlId, compare)).to.be(
+      expectedLowerBound
+    );
+    expect(await this.rangeSliderGetUpperBoundAttribute(controlId, compare)).to.be(
+      expectedUpperBound
+    );
   }
 
   // Time slider functions

--- a/x-pack/platform/test/functional/page_objects/index_management_page.ts
+++ b/x-pack/platform/test/functional/page_objects/index_management_page.ts
@@ -271,33 +271,33 @@ export function IndexManagementPageProvider({ getService, getPageObjects }: FtrP
     },
 
     async expectIndexIsDeleted(indexName: string) {
-      try {
-        const table = await find.byCssSelector('table');
-        const rows = await table.findAllByTestSubject('indexTableRow');
+      await retry.waitFor(`index ${indexName} to be removed from the table`, async () => {
+        try {
+          const table = await find.byCssSelector('table');
+          const rows = await table.findAllByTestSubject('indexTableRow');
 
-        const indexNames = await Promise.all(
-          rows.map(async (row) => {
-            try {
-              return await (
-                await row.findByTestSubject('indexTableIndexNameLink')
-              ).getVisibleText();
-            } catch (error) {
-              // If the current row is stale, it has already been removed
-              if (error.name === 'StaleElementReferenceError') return undefined;
-              throw error; // Rethrow unexpected errors
-            }
-          })
-        ).then((names) => names.filter((name) => name !== undefined));
+          const indexNames = await Promise.all(
+            rows.map(async (row) => {
+              try {
+                return await (
+                  await row.findByTestSubject('indexTableIndexNameLink')
+                ).getVisibleText();
+              } catch (error) {
+                // If the current row is stale, it has already been removed
+                if (error.name === 'StaleElementReferenceError') return undefined;
+                throw error;
+              }
+            })
+          ).then((names) => names.filter((name) => name !== undefined));
 
-        expect(indexNames.includes(indexName)).to.be(false);
-      } catch (error) {
-        if (error.name === 'StaleElementReferenceError') {
-          // If the table itself is stale, it means all rows have been removed
-          return; // Pass the test since the table is gone
-        } else {
-          throw error; // Rethrow unexpected errors
+          return !indexNames.includes(indexName);
+        } catch (error) {
+          if (error.name === 'StaleElementReferenceError') {
+            return true; // Table is gone, so index is deleted
+          }
+          throw error;
         }
-      }
+      });
     },
     async manageIndex(indexName: string) {
       const id = `checkboxSelectIndex-${indexName}`;


### PR DESCRIPTION
Setting the implicit timeout to 0 lets findElements return immediately when the element is absent, eliminating a ~500ms minimum per polling iteration across 16,314 calls (~10,000 seconds total).