### PR TITLE
[9.4] fix: APM Traces table horizontal scroll on narrow viewports (#269936)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/index.tsx
@@ -50,7 +50,7 @@ export function TopTracesOverview() {
         </EuiFlexItem>
       )}
 
-      <EuiFlexItem grow>
+      <EuiFlexItem grow style={{ minWidth: 0 }}>
         <TraceList response={response} />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/trace_overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/trace_overview/index.tsx
@@ -29,7 +29,9 @@ export function TraceOverview({
           contentProps: {
             style: {
               display: 'flex',
+              flexDirection: 'column',
               flexGrow: 1,
+              minInlineSize: 0,
             },
           },
         }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix: APM Traces table horizontal scroll on narrow viewports (#269936)](https://github.com/elastic/kibana/pull/269936)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2026-05-19T13:58:49Z","message":"fix: APM Traces table horizontal scroll on narrow viewports (#269936)\n\n## Summary\n\nFollow-up to #264992 — that PR fixed horizontal-scroll clipping on\n**Service inventory** and **Service overview**, but **Traces** has an\nextra flex layer (`pageSectionProps.contentProps: { display: 'flex',\nflexGrow: 1 }` on its template) that no other APM page uses, so the same\nclipping bug still affected it.\n\n- **`TraceOverview` template** (`trace_overview/index.tsx`):\ncontentProps used `display: flex` with the default row direction. That\nmade the inner `EuiFlexGroup direction=\"column\"` a row-direction flex\nitem with the default `min-width: auto`, so the wide table pushed it\npast the viewport and got clipped without a scrollbar. Switch to\n`flex-direction: column` and add `min-inline-size: 0` so the content can\nshrink and the table's own scroll container (EUI `scrollableInline` +\nthe `ManagedTable` wrapper from #264992) takes over.\n- **`TopTracesOverview`** (`top_traces_overview/index.tsx`): add\n`style={{ minWidth: 0 }}` to the `EuiFlexItem` wrapping `TraceList`,\nmatching the pattern used for `ServiceInventory` / `ApmOverview` so wide\ntables don't expand the flex item beyond its parent.\n\n## Before \n\n\nhttps://github.com/user-attachments/assets/e40dba2a-fea2-45ce-8674-0e6a8b381c5f\n\n## After\n\n\nhttps://github.com/user-attachments/assets/dc68e1f2-d3d8-4146-a641-791112bf69d5\n\n\n## Testing\n\n1. Open Observability → APM → **Traces**.\n2. Ensure the table has data and all columns (Name, Originating service,\nLatency, Traces per minute, Impact, Actions) are present.\n3. Reduce the browser width or narrow the main content area (e.g. open\nthe sidebar).\n4. Confirm:\n   - The table shows a usable horizontal scrollbar.\n- All columns are reachable by scrolling horizontally inside the table\nregion.\n- The page itself does not gain a horizontal scrollbar / no content is\nclipped at the right edge.\n\n## References\n\nCloses elastic/kibana#269668\nRelated to #264992\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"05487c31635d05df354f1b634e32f0930a218b0b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","backport:version","v9.4.0","Team:obs-presentation","v9.5.0"],"title":"fix: APM Traces table horizontal scroll on narrow viewports","number":269936,"url":"https://github.com/elastic/kibana/pull/269936","mergeCommit":{"message":"fix: APM Traces table horizontal scroll on narrow viewports (#269936)\n\n## Summary\n\nFollow-up to #264992 — that PR fixed horizontal-scroll clipping on\n**Service inventory** and **Service overview**, but **Traces** has an\nextra flex layer (`pageSectionProps.contentProps: { display: 'flex',\nflexGrow: 1 }` on its template) that no other APM page uses, so the same\nclipping bug still affected it.\n\n- **`TraceOverview` template** (`trace_overview/index.tsx`):\ncontentProps used `display: flex` with the default row direction. That\nmade the inner `EuiFlexGroup direction=\"column\"` a row-direction flex\nitem with the default `min-width: auto`, so the wide table pushed it\npast the viewport and got clipped without a scrollbar. Switch to\n`flex-direction: column` and add `min-inline-size: 0` so the content can\nshrink and the table's own scroll container (EUI `scrollableInline` +\nthe `ManagedTable` wrapper from #264992) takes over.\n- **`TopTracesOverview`** (`top_traces_overview/index.tsx`): add\n`style={{ minWidth: 0 }}` to the `EuiFlexItem` wrapping `TraceList`,\nmatching the pattern used for `ServiceInventory` / `ApmOverview` so wide\ntables don't expand the flex item beyond its parent.\n\n## Before \n\n\nhttps://github.com/user-attachments/assets/e40dba2a-fea2-45ce-8674-0e6a8b381c5f\n\n## After\n\n\nhttps://github.com/user-attachments/assets/dc68e1f2-d3d8-4146-a641-791112bf69d5\n\n\n## Testing\n\n1. Open Observability → APM → **Traces**.\n2. Ensure the table has data and all columns (Name, Originating service,\nLatency, Traces per minute, Impact, Actions) are present.\n3. Reduce the browser width or narrow the main content area (e.g. open\nthe sidebar).\n4. Confirm:\n   - The table shows a usable horizontal scrollbar.\n- All columns are reachable by scrolling horizontally inside the table\nregion.\n- The page itself does not gain a horizontal scrollbar / no content is\nclipped at the right edge.\n\n## References\n\nCloses elastic/kibana#269668\nRelated to #264992\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"05487c31635d05df354f1b634e32f0930a218b0b"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269936","number":269936,"mergeCommit":{"message":"fix: APM Traces table horizontal scroll on narrow viewports (#269936)\n\n## Summary\n\nFollow-up to #264992 — that PR fixed horizontal-scroll clipping on\n**Service inventory** and **Service overview**, but **Traces** has an\nextra flex layer (`pageSectionProps.contentProps: { display: 'flex',\nflexGrow: 1 }` on its template) that no other APM page uses, so the same\nclipping bug still affected it.\n\n- **`TraceOverview` template** (`trace_overview/index.tsx`):\ncontentProps used `display: flex` with the default row direction. That\nmade the inner `EuiFlexGroup direction=\"column\"` a row-direction flex\nitem with the default `min-width: auto`, so the wide table pushed it\npast the viewport and got clipped without a scrollbar. Switch to\n`flex-direction: column` and add `min-inline-size: 0` so the content can\nshrink and the table's own scroll container (EUI `scrollableInline` +\nthe `ManagedTable` wrapper from #264992) takes over.\n- **`TopTracesOverview`** (`top_traces_overview/index.tsx`): add\n`style={{ minWidth: 0 }}` to the `EuiFlexItem` wrapping `TraceList`,\nmatching the pattern used for `ServiceInventory` / `ApmOverview` so wide\ntables don't expand the flex item beyond its parent.\n\n## Before \n\n\nhttps://github.com/user-attachments/assets/e40dba2a-fea2-45ce-8674-0e6a8b381c5f\n\n## After\n\n\nhttps://github.com/user-attachments/assets/dc68e1f2-d3d8-4146-a641-791112bf69d5\n\n\n## Testing\n\n1. Open Observability → APM → **Traces**.\n2. Ensure the table has data and all columns (Name, Originating service,\nLatency, Traces per minute, Impact, Actions) are present.\n3. Reduce the browser width or narrow the main content area (e.g. open\nthe sidebar).\n4. Confirm:\n   - The table shows a usable horizontal scrollbar.\n- All columns are reachable by scrolling horizontally inside the table\nregion.\n- The page itself does not gain a horizontal scrollbar / no content is\nclipped at the right edge.\n\n## References\n\nCloses elastic/kibana#269668\nRelated to #264992\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"05487c31635d05df354f1b634e32f0930a218b0b"}}]}] BACKPORT-->