### PR TITLE
[Security Solution] Enable @kbn/change-history feature flag

### DIFF
--- a/x-pack/platform/packages/shared/kbn-change-history/src/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-change-history/src/constants.ts
@@ -34,5 +34,5 @@ export const DEFAULT_RESULT_SIZE = 100;
  * Remove this after General Availability
  * */
 export const FLAGS = {
-  FEATURE_ENABLED: false,
+  FEATURE_ENABLED: true,
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_management/trial_license_complete_tier/change_tracking.ts
@@ -49,8 +49,10 @@ export default ({ getService }: FtrProviderContext): void => {
     }
   };
 
-  // Skipped until a feature flag in @kbn/change-history package is enabled
-  describe.skip('@ess @serverless @serverlessQA rule change history', () => {
+  // Skip in Serverless until "xpack.alerting.ruleChangeTracking.enabled" and
+  // xpack.securitySolution.enableExperimental: [ruleChangesHistoryEnabled] feature flags
+  // permanently enabled
+  describe.skip('@ess @skipInServerless rule change history', () => {
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
       await deleteAllPrebuiltRuleAssets(es, log);


### PR DESCRIPTION
**Epic: https://github.com/elastic/security-team/issues/12367** (internal)
**Partially addresses: #270086**

## Summary

Enables the `FLAGS.FEATURE_ENABLED` flag in the `@kbn/change-history` package, making the rule changes history feature active for consumers. We require this for Rule Changes History. Enabling this feature flag significantly simplifies testing and auto-testing.

Cleanup will be performed in a follow up PR when we 100% sure it's good to be gone.