### PR TITLE
[Agent Builder] Only export AB traces

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_span_processor.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_span_processor.test.ts
@@ -12,6 +12,10 @@ import type { tracing } from '@elastic/opentelemetry-node/sdk';
 import { resources, tracing as elasticTracing } from '@elastic/opentelemetry-node/sdk';
 import { BAGGAGE_TRACKING_BEACON_KEY, BAGGAGE_TRACKING_BEACON_VALUE } from '@kbn/inference-tracing';
 import { AgentBuilderSpanProcessor } from './agent_builder_span_processor';
+import {
+  AGENT_BUILDER_OWNER_BAGGAGE_KEY,
+  AGENT_BUILDER_OWNER_BAGGAGE_VALUE,
+} from './with_agent_builder_context';
 
 const SHOULD_TRACK_ATTR = '_agent_builder_should_track';
 
@@ -48,7 +52,15 @@ describe('AgentBuilderSpanProcessor', () => {
     contextManager.disable();
   });
 
-  function inferenceParentContext(): ReturnType<typeof context.active> {
+  function agentBuilderParentContext(): ReturnType<typeof context.active> {
+    const baggage = propagation.createBaggage({
+      [BAGGAGE_TRACKING_BEACON_KEY]: { value: BAGGAGE_TRACKING_BEACON_VALUE },
+      [AGENT_BUILDER_OWNER_BAGGAGE_KEY]: { value: AGENT_BUILDER_OWNER_BAGGAGE_VALUE },
+    });
+    return propagation.setBaggage(context.active(), baggage);
+  }
+
+  function inferenceOnlyParentContext(): ReturnType<typeof context.active> {
     const baggage = propagation.createBaggage({
       [BAGGAGE_TRACKING_BEACON_KEY]: { value: BAGGAGE_TRACKING_BEACON_VALUE },
     });
@@ -128,7 +140,7 @@ describe('AgentBuilderSpanProcessor', () => {
     };
   }
 
-  it('onStart marks inference spans with attribute when enabled', async () => {
+  it('onStart marks agent builder inference spans with attribute when enabled', async () => {
     const processor = new AgentBuilderSpanProcessor({
       exporter: createExporter(),
       scheduledDelayMillis: 1,
@@ -136,11 +148,26 @@ describe('AgentBuilderSpanProcessor', () => {
     });
 
     const span = createMockSpan('inference');
-    const parentContext = inferenceParentContext();
+    const parentContext = agentBuilderParentContext();
     await processor.onStart(span, parentContext);
 
     expect(span.setAttribute).toHaveBeenCalledWith(SHOULD_TRACK_ATTR, true);
     expect(mockBatch.onStart).toHaveBeenCalledWith(span, parentContext);
+  });
+
+  it('onStart skips inference spans without agent builder baggage', async () => {
+    const processor = new AgentBuilderSpanProcessor({
+      exporter: createExporter(),
+      scheduledDelayMillis: 1,
+      isEnabled: () => true,
+    });
+
+    const span = createMockSpan('inference');
+    const parentContext = inferenceOnlyParentContext();
+    await processor.onStart(span, parentContext);
+
+    expect(span.setAttribute).not.toHaveBeenCalled();
+    expect(mockBatch.onStart).not.toHaveBeenCalled();
   });
 
   it('onStart skips non-inference spans', async () => {
@@ -164,7 +191,7 @@ describe('AgentBuilderSpanProcessor', () => {
     });
 
     const span = createMockSpan('inference');
-    await processor.onStart(span, inferenceParentContext());
+    await processor.onStart(span, agentBuilderParentContext());
 
     expect(span.setAttribute).not.toHaveBeenCalled();
     expect(mockBatch.onStart).not.toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_span_processor.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/agent_builder_span_processor.ts
@@ -7,7 +7,7 @@
 
 import type { api } from '@elastic/opentelemetry-node/sdk';
 import { resources, tracing } from '@elastic/opentelemetry-node/sdk';
-import { isInferenceSpan } from '@kbn/inference-tracing';
+import { isAgentBuilderSpan } from './with_agent_builder_context';
 
 const SHOULD_TRACK_ATTR = '_agent_builder_should_track';
 const AGENT_BUILDER_DATASET_RESOURCE = resources.resourceFromAttributes({
@@ -38,7 +38,7 @@ export class AgentBuilderSpanProcessor implements tracing.SpanProcessor {
     if (!this.isEnabled()) {
       return;
     }
-    if (isInferenceSpan(span, parentContext)) {
+    if (isAgentBuilderSpan(span, parentContext)) {
       span.setAttribute(SHOULD_TRACK_ATTR, true);
       this.batchProcessor.onStart(span, parentContext);
     }

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/index.ts
@@ -8,5 +8,6 @@
 export { AgentBuilderSpanProcessor } from './agent_builder_span_processor';
 export { withAgentSpan } from './with_agent_span';
 export { withConverseSpan } from './with_converse_span';
+export { withAgentBuilderContext } from './with_agent_builder_context';
 export { getCurrentTraceId } from './get_current_trace_id';
 export { OpikDistributedTracingSpanProcessor } from './opik_distributed_tracing';

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_agent_builder_context.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_agent_builder_context.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { api } from '@elastic/opentelemetry-node/sdk';
+import type { tracing } from '@elastic/opentelemetry-node/sdk';
+import { context as otelContext, propagation } from '@opentelemetry/api';
+import { isInferenceSpan } from '@kbn/inference-tracing';
+
+export const AGENT_BUILDER_OWNER_BAGGAGE_KEY = 'kibana.agent_builder';
+export const AGENT_BUILDER_OWNER_BAGGAGE_VALUE = '1';
+
+/**
+ * Executes a function within a context that has the Agent Builder ownership baggage set.
+ * All descendant inference spans created inside this context will be tagged as Agent Builder spans,
+ * allowing the AgentBuilderSpanProcessor to filter them from other inference consumers.
+ */
+export const withAgentBuilderContext = <T>(fn: () => T): T => {
+  const ctx = otelContext.active();
+  const currentBaggage = propagation.getBaggage(ctx) ?? propagation.createBaggage();
+  const updatedBaggage = currentBaggage.setEntry(AGENT_BUILDER_OWNER_BAGGAGE_KEY, {
+    value: AGENT_BUILDER_OWNER_BAGGAGE_VALUE,
+  });
+  const updatedContext = propagation.setBaggage(ctx, updatedBaggage);
+
+  return otelContext.with(updatedContext, fn);
+};
+
+/**
+ * Checks whether a span originates from Agent Builder by inspecting baggage
+ * and verifying it is an inference span.
+ */
+export const isAgentBuilderSpan = (span: tracing.Span, parentContext: api.Context): boolean => {
+  const baggage = propagation.getBaggage(parentContext);
+  const isFromAgentBuilder =
+    baggage?.getEntry(AGENT_BUILDER_OWNER_BAGGAGE_KEY)?.value === AGENT_BUILDER_OWNER_BAGGAGE_VALUE;
+  return isFromAgentBuilder && isInferenceSpan(span, parentContext);
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.ts
@@ -20,6 +20,7 @@ import {
   attachOpikDistributedTrace,
   type OpikDistributedTraceHeaders,
 } from './opik_distributed_tracing';
+import { withAgentBuilderContext } from './with_agent_builder_context';
 
 interface WithConverseSpanOptions {
   agentId: string;
@@ -31,34 +32,36 @@ export function withConverseSpan(
   { agentId, conversationId, opikHeaders }: WithConverseSpanOptions,
   cb: (span?: Span) => Observable<ChatEvent>
 ): Observable<ChatEvent> {
-  return withActiveInferenceSpan(
-    'Converse',
-    {
-      attributes: {
-        [ElasticGenAIAttributes.InferenceSpanKind]: 'CHAIN',
-        [ElasticGenAIAttributes.AgentId]: agentId,
-        [ElasticGenAIAttributes.AgentConversationId]: conversationId,
-        [GenAISemanticConventions.GenAIConversationId]: conversationId,
+  return withAgentBuilderContext(() =>
+    withActiveInferenceSpan(
+      'Converse',
+      {
+        attributes: {
+          [ElasticGenAIAttributes.InferenceSpanKind]: 'CHAIN',
+          [ElasticGenAIAttributes.AgentId]: agentId,
+          [ElasticGenAIAttributes.AgentConversationId]: conversationId,
+          [GenAISemanticConventions.GenAIConversationId]: conversationId,
+        },
       },
-    },
-    (span) => {
-      if (!span) {
-        return cb();
-      }
+      (span) => {
+        if (!span) {
+          return cb();
+        }
 
-      if (opikHeaders) {
-        attachOpikDistributedTrace(span, opikHeaders);
-      }
+        if (opikHeaders) {
+          attachOpikDistributedTrace(span, opikHeaders);
+        }
 
-      return cb(span).pipe(
-        tap({
-          next: (event) => {
-            if (isRoundCompleteEvent(event)) {
-              span.setAttribute('output.value', safeJsonStringify(event.data) ?? 'unknown');
-            }
-          },
-        })
-      );
-    }
+        return cb(span).pipe(
+          tap({
+            next: (event) => {
+              if (isRoundCompleteEvent(event)) {
+                span.setAttribute('output.value', safeJsonStringify(event.data) ?? 'unknown');
+              }
+            },
+          })
+        );
+      }
+    )
   );
 }


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/14600

## Summary

The `AgentBuilderSpanProcessor` was previously exporting **all** inference spans — including those from other Kibana consumers of `@kbn/inference-tracing`. This PR scopes the processor so it only exports spans that originate within an Agent Builder context.

### Architecture

- **New `withAgentBuilderContext`** wrapper sets a `kibana.agent_builder` baggage entry on the OTel context. `withConverseSpan` now wraps its inference span tree inside this context.
- **New `isAgentBuilderSpan`** predicate checks for both the Agent Builder baggage **and** the existing `isInferenceSpan` check, replacing the previous `isInferenceSpan`-only filter in `AgentBuilderSpanProcessor.onStart`.
- No API or config changes.

### How to test

1. Enable Agent Builder tracing (APM or Langfuse/Phoenix exporter).
2. Trigger an Agent Builder conversation — verify its spans appear in the trace backend with `data_stream.dataset: agent_builder`.
3. Trigger an inference call **outside** Agent Builder (e.g. AI Assistant) — verify those spans are **not** exported by the Agent Builder processor.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk. The change narrows the export filter — Agent Builder spans continue to be exported as before; non-AB inference spans are simply no longer picked up by this processor (they were never intended to be).

### Release notes

N/A — internal tracing plumbing, no user-facing change.