### PR TITLE
fix: remove broken API doc links from dev_docs

### DIFF
--- a/dev_docs/contributing/best_practices.mdx
+++ b/dev_docs/contributing/best_practices.mdx
@@ -117,7 +117,7 @@ const dataView = savedObjectsClient.get(dataViewId) as DataView;
 
 ## Resusable react components
 
-Use [EUI](https://elastic.github.io/eui) for all your basic UI components to create a consistent UI experience. We also have generic UI components offered from the <DocLink id="kibKibanaReactPluginApi" text="kibana_react" /> plugin.
+Use [EUI](https://elastic.github.io/eui) for all your basic UI components to create a consistent UI experience. We also have generic UI components offered from the `kibana_react` plugin.
 
 ## Don't export code that doesn't need to be public
 

--- a/dev_docs/key_concepts/persistable_state.mdx
+++ b/dev_docs/key_concepts/persistable_state.mdx
@@ -11,7 +11,7 @@ tags: ['kibana', 'dev', 'contributor', 'api docs']
 
 ## Exposing state that can be persisted
 
-Any plugin that exposes state that another plugin might persist should implement <DocLink id="kibKibanaUtilsPluginApi" section="def-common.PersistableStateService" text="`PersistableStateService`"/> interface on their `setup` contract. This will allow plugins persisting the state to easily access migrations and other utilities.
+Any plugin that exposes state that another plugin might persist should implement `PersistableStateService` interface on their `setup` contract. This will allow plugins persisting the state to easily access migrations and other utilities.
 
 Example: Data plugin allows you to generate filters. Those filters can be persisted by applications in their saved
 objects or in the URL. In order to allow apps to migrate the filters in case the structure changes in the future, the Data plugin implements `PersistableStateService` on <DocLink id="kibDataQueryPluginApi" section="def-public.FilterManager" text="`data.query.filterManager`"/>.
@@ -22,7 +22,7 @@ In the future, we hope to make it easier for producers of state to understand wh
 ## Exposing state that can be persisted but is not owned by plugin exposing it (registry)
 
 Any plugin that owns collection of items (registry) whose state/configuration can be persisted should implement `PersistableStateService`
-interface on their `setup` contract and each item in the collection should implement <DocLink id="kibKibanaUtilsPluginApi" section="def-common.PersistableStateDefinition" text="`PersistableStateDefinition`"/> interface.
+interface on their `setup` contract and each item in the collection should implement `PersistableStateDefinition` interface.
 
 Note: if your plugin doesn't expose the state (it is the only one storing state), the plugin doesn't need to implement the `PersistableStateService` interface.
 If the state your plugin is storing can be provided by other plugins (your plugin owns a registry) items in that registry still need to implement `PersistableStateDefinition` interface.
@@ -46,7 +46,7 @@ note: Currently there is no recommended way on how to store version in url and i
 ### Extraction/Injection of References
 
 In order to support import and export, and space-sharing capabilities, Saved Objects need to explicitly list any references they contain to other Saved Objects.
-To support persisting your state in saved objects owned by another plugin, the <DocLink id="kibKibanaUtilsPluginApi" section="def-common.PersistableState.extract" text="`extract`"/> and <DocLink id="kibKibanaUtilsPluginApi" section="def-common.PersistableState.inject" text="`inject`"/> methods of Persistable State interface should be implemented.
+To support persisting your state in saved objects owned by another plugin, the `extract` and `inject` methods of Persistable State interface should be implemented.
 
 <DocLink
   id="kibDevTutorialSavedObject"

--- a/dev_docs/shared_ux/chrome_recently_accessed/chrome_recently_accessed.mdx
+++ b/dev_docs/shared_ux/chrome_recently_accessed/chrome_recently_accessed.mdx
@@ -9,13 +9,13 @@ tags: ['kibana', 'dev', 'contributor', 'chrome', 'navigation', 'shared-ux']
 
 ## Introduction
 
-The <DocLink id="kibKbnCoreChromeBrowserPluginApi" section="def-public.ChromeRecentlyAccessed" text="ChromeRecentlyAccessed" /> service allows applications to register recently visited objects. These items are displayed in the "Recently Viewed" section of a side navigation menu, providing users with quick access to their previously visited resources. This service includes methods for adding, retrieving, and subscribing to the recently accessed history.
+The `ChromeRecentlyAccessed` service allows applications to register recently visited objects. These items are displayed in the "Recently Viewed" section of a side navigation menu, providing users with quick access to their previously visited resources. This service includes methods for adding, retrieving, and subscribing to the recently accessed history.
 
 ![Recently viewed section in the sidenav](./chrome_recently_accessed.png)
 
 ## Guidelines
 
-The <DocLink id="kibKbnCoreChromeBrowserPluginApi" section="def-public.ChromeRecentlyAccessed" text="ChromeRecentlyAccessed" /> service should be used thoughtfully to provide users with easy access to key resources they've interacted with. Unlike browser history, this feature is for important items that users may want to revisit.
+The `ChromeRecentlyAccessed` service should be used thoughtfully to provide users with easy access to key resources they've interacted with. Unlike browser history, this feature is for important items that users may want to revisit.
 
 ### DOs
 
@@ -59,8 +59,8 @@ coreStart.chrome.recentlyAccessed.add(
 
 ## Implementation details
 
-The <DocLink id="kibKbnCoreChromeBrowserPluginApi" section="def-public.ChromeRecentlyAccessed" text="ChromeRecentlyAccessed" /> services is based on <DocLink id="kibKbnRecentlyAccessedPluginApi" text="@kbn/recently-accessed"/> package. This package provides a `RecentlyAccessedService` that uses browser local storage to manage records of recently accessed objects. Internally it implements the queue with a maximum length of 20 items. When the queue is full, the oldest item is removed.
+The `ChromeRecentlyAccessed` services is based on <DocLink id="kibKbnRecentlyAccessedPluginApi" text="@kbn/recently-accessed"/> package. This package provides a `RecentlyAccessedService` that uses browser local storage to manage records of recently accessed objects. Internally it implements the queue with a maximum length of 20 items. When the queue is full, the oldest item is removed.
 Applications can create their own instance of `RecentlyAccessedService` to manage their own list of recently accessed items scoped to their application.
 
-- <DocLink id="kibKbnCoreChromeBrowserPluginApi" section="def-public.ChromeRecentlyAccessed" text="ChromeRecentlyAccessed" /> is a service available via `coreStart.chrome.recentlyAccessed` and should be used to add items to chrome's sidenav.
+- `ChromeRecentlyAccessed` is a service available via `coreStart.chrome.recentlyAccessed` and should be used to add items to chrome's sidenav.
 - <DocLink id="kibKbnRecentlyAccessedPluginApi" text="@kbn/recently-accessed"/> is package that `ChromeRecentlyAccessed` is using internally and the package can be used to create your own instance and manage your own list of recently accessed items that is independent for chrome's sidenav.

--- a/dev_docs/tutorials/expressions.mdx
+++ b/dev_docs/tutorials/expressions.mdx
@@ -56,9 +56,6 @@ const executionContract = expressions.execute(expression, input);
 const result = await executionContract.getData();
 ```
 
-<DocCallOut>
-  Check the full spec of execute function <DocLink id="kibExpressionsPluginApi" section="def-common.ExpressionsService.execute" text="here" />
-</DocCallOut>
 
 In addition, on the browser side, there are two additional ways to run expressions and render the results.
 
@@ -70,9 +67,6 @@ This is the easiest way to get expressions rendered inside your application.
 <ReactExpressionRenderer expression={expression} />
 ```
 
-<DocCallOut>
-  Check the full spec of ReactExpressionRenderer component props <DocLink id="kibExpressionsPluginApi" section="def-public.ReactExpressionRendererProps" text="here" />
-</DocCallOut>
 
 #### Expression loader
 
@@ -82,9 +76,6 @@ If you are not using React, you can use the loader expression service provides t
 const handler = loader(domElement, expression, params);
 ```
 
-<DocCallOut>
-  Check the full spec of expression loader params <DocLink id="kibExpressionsPluginApi" section="def-public.IExpressionLoaderParams" text="here" />
-</DocCallOut>
 
 ### Creating new expression functions
 
@@ -105,9 +96,6 @@ const functionDefinition = {
 expressions.registerFunction(functionDefinition);
 ```
 
-<DocCallOut>
-  Check the full interface of ExpressionFuntionDefinition <DocLink id="kibExpressionsPluginApi" section="def-common.ExpressionFunctionDefinition" text="here" />
-</DocCallOut>
 
 ### Creating new expression renderers
 
@@ -127,6 +115,3 @@ const rendererDefinition = {
 expressions.registerRenderer(rendererDefinition);
 ```
 
-<DocCallOut>
-  Check the full interface of ExpressionRendererDefinition <DocLink id="kibExpressionsPluginApi" section="def-common.ExpressionRenderDefinition" text="here" />
-</DocCallOut>

--- a/dev_docs/tutorials/screenshotting/screenshotting.mdx
+++ b/dev_docs/tutorials/screenshotting/screenshotting.mdx
@@ -82,6 +82,3 @@ export function plugin() {
 }
 ```
 
-<DocCallOut>
-  Check the complete API reference <DocLink id="kibScreenshottingPluginApi" text="here" />.
-</DocCallOut>


### PR DESCRIPTION
## Summary

Removes broken `<DocLink>` references to API documentation pages that no longer exist. These broken links were causing Vercel build failures.

- `contributing/best_practices.mdx` — replaced `kibana_react` DocLink with plain code text
- `key_concepts/persistable_state.mdx` — replaced 3 DocLinks for `PersistableStateService`, `PersistableStateDefinition`, `extract`/`inject` with plain code text
- `shared_ux/chrome_recently_accessed/chrome_recently_accessed.mdx` — replaced 4 DocLinks for `ChromeRecentlyAccessed` with plain code text
- `tutorials/expressions.mdx` — removed 5 dead-end `<DocCallOut>` blocks containing broken "here" links
- `tutorials/screenshotting/screenshotting.mdx` — removed 1 dead-end `<DocCallOut>` block with a broken "here" link

## Test plan

- [ ] Confirm Vercel preview build passes without broken link errors for the affected pages