### PR TITLE
Use p-retry for reporting retries

### DIFF
--- a/x-pack/platform/plugins/private/reporting/server/lib/retry_on_error.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/retry_on_error.ts
@@ -7,6 +7,7 @@
 
 import type { Logger } from '@kbn/core/server';
 import { KibanaShuttingDownError } from '@kbn/reporting-common';
+import pRetry from 'p-retry';
 import type { SavedReport } from './store';
 
 export const MAX_DELAY_SECONDS = 30;
@@ -19,48 +20,59 @@ interface RetryOpts {
   retries: number;
 }
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 export const retryOnError = async ({
   operation,
   retries,
   report,
   logger,
-  attempt = 0,
 }: RetryOpts): Promise<void> => {
-  try {
-    const result = await operation(report);
+  let attempt = 0;
 
-    if (attempt > 0) {
-      logger.info(
-        `Report generation for report[${report._id}] succeeded on attempt ${attempt + 1}.`,
-        { tags: [report._id] }
-      );
-    }
-    return result;
+  try {
+    return await pRetry(
+      async () => {
+        const result = await operation(report);
+
+        if (attempt > 0) {
+          logger.info(
+            `Report generation for report[${report._id}] succeeded on attempt ${attempt + 1}.`,
+            { tags: [report._id] }
+          );
+        }
+
+        return result;
+      },
+      {
+        retries,
+        factor: 2,
+        minTimeout: 2000,
+        maxTimeout: MAX_DELAY_SECONDS * 1000,
+        randomize: true,
+        onFailedAttempt: (err) => {
+          if (err instanceof KibanaShuttingDownError) {
+            throw err;
+          }
+
+          attempt = err.attemptNumber;
+
+          if (err.retriesLeft > 0) {
+            const retryDelaySec: number = Math.min(Math.pow(2, err.attemptNumber), MAX_DELAY_SECONDS);
+
+            logger.error(
+              `Retrying report generation for report[${
+                report._id
+              }] after [${retryDelaySec}s] due to error: ${err.toString()} - attempt ${
+                err.attemptNumber
+              } of ${retries + 1} failed.`,
+              { tags: [report._id], error: { stack_trace: err.stack } }
+            );
+          }
+        },
+      }
+    );
   } catch (err) {
-    // skip retry on certain errors
     if (err instanceof KibanaShuttingDownError) {
       throw err;
-    }
-
-    if (attempt < retries) {
-      const retryCount = attempt + 1;
-      const retryDelaySec: number = Math.min(Math.pow(2, retryCount), MAX_DELAY_SECONDS); // 2s, 4s, 8s, 16s, 30s, 30s, 30s...
-
-      logger.error(
-        `Retrying report generation for report[${
-          report._id
-        }] after [${retryDelaySec}s] due to error: ${err.toString()} - attempt ${retryCount} of ${
-          retries + 1
-        } failed.`,
-        { tags: [report._id], error: { stack_trace: err.stack } }
-      );
-
-      // delay with some randomness
-      // convert delay to milliseconds and multiply by random number between 1.0 and 2.0
-      await delay(retryDelaySec * 1000 * (1 + Math.random()));
-      return retryOnError({ operation, logger, report, retries, attempt: retryCount });
     }
 
     if (retries > 0) {


### PR DESCRIPTION
## Summary

Switches the Reporting retry helper to `p-retry` while keeping the existing retry contract in place:

- exponential backoff from 2s up to 30s
- randomized retry delay
- no retries for `KibanaShuttingDownError`
- existing retry, success, and exhausted-retry log messages

Closes #245437

## Testing

- `git diff --check`

I also tried the focused Jest command for `retry_on_error.test.ts`, but this checkout is not bootstrapped locally and `scripts/jest` failed before running tests because `@kbn/setup-node-env` is missing.