### PR TITLE
fix: remove more broken API doc links

### DIFF
--- a/dev_docs/key_concepts/persistable_state.mdx
+++ b/dev_docs/key_concepts/persistable_state.mdx
@@ -11,10 +11,10 @@ tags: ['kibana', 'dev', 'contributor', 'api docs']
 
 ## Exposing state that can be persisted
 
-Any plugin that exposes state that another plugin might persist should implement `PersistableStateService` interface on their `setup` contract. This will allow plugins persisting the state to easily access migrations and other utilities.
+Any plugin that exposes state that another plugin might persist should implement PersistableStateService interface on their `setup` contract. This will allow plugins persisting the state to easily access migrations and other utilities.
 
 Example: Data plugin allows you to generate filters. Those filters can be persisted by applications in their saved
-objects or in the URL. In order to allow apps to migrate the filters in case the structure changes in the future, the Data plugin implements `PersistableStateService` on <DocLink id="kibDataQueryPluginApi" section="def-public.FilterManager" text="`data.query.filterManager`"/>.
+objects or in the URL. In order to allow apps to migrate the filters in case the structure changes in the future, the Data plugin implements `PersistableStateService` on `data.query.filterManager`.
 
 note: There is currently no obvious way for a plugin to know which state is safe to persist. The developer must manually look for a matching `PersistableStateService`, or ad-hoc provided migration utilities (as is the case with Rule Type Parameters).
 In the future, we hope to make it easier for producers of state to understand when they need to write a migration with changes, and also make it easier for consumers of such state, to understand whether it is safe to persist.

--- a/src/platform/packages/shared/kbn-tooling-log/README.mdx
+++ b/src/platform/packages/shared/kbn-tooling-log/README.mdx
@@ -20,5 +20,3 @@ run(async ({ flags, log }) => {
   await ...
 });
 ```
-
-API Reference: <DocLink id="kibKbnToolingLogPluginApi" />

--- a/src/platform/plugins/shared/content_management/docs/conent_management_landing.mdx
+++ b/src/platform/plugins/shared/content_management/docs/conent_management_landing.mdx
@@ -19,4 +19,3 @@ and eventually a collection of new features that enhance content items by adding
 ## Links
 
 - <DocLink id="kibDevTutorialsContentManagementOnboarding" text="Content Management onboarding" />
-- <DocLink id="kibContentManagementPluginApi" text="Content Management plugin API reference" />


### PR DESCRIPTION
## Summary

Removes additional broken `<DocLink>` references to API documentation pages that no longer exist, fixing Vercel build failures.

- `dev_docs/key_concepts/persistable_state.mdx` — removed broken `kibDataQueryPluginApi` DocLink, replaced with plain code text
- `src/platform/packages/shared/kbn-tooling-log/README.mdx` — removed broken `kibKbnToolingLogPluginApi` API reference link
- `src/platform/plugins/shared/content_management/docs/conent_management_landing.mdx` — removed broken `kibContentManagementPluginApi` link

## Test plan

- [ ] Confirm Vercel preview build passes without broken link errors for the affected pages (`/kibana-dev-docs/tooling-log`, `/kibana-dev-docs/content-management`, `/kibana-dev-docs/key-concepts/persistable-state-intro`)