### PR TITLE
[9.3] [Streams] Handle navigation to missing stream in test (#258889)

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_details_controller/state_machine.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_details_controller/state_machine.ts
@@ -789,8 +789,7 @@ export const createPureDatasetQualityDetailsControllerStateMachine = (
           );
         },
         isDataStreamMissing: (_, event) => {
-          const output =
-            'data' in event ? (event.data as DataStreamSettings) : undefined;
+          const output = 'data' in event ? (event.data as DataStreamSettings) : undefined;
           return !output?.lastBackingIndexName;
         },
         shouldOpenFlyout: (context, _event, meta) => {

--- a/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_details_controller/state_machine.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_details_controller/state_machine.ts
@@ -165,10 +165,16 @@ export const createPureDatasetQualityDetailsControllerStateMachine = (
                 fetchingDataStreamSettings: {
                   invoke: {
                     src: 'loadDataStreamSettings',
-                    onDone: {
-                      target: 'qualityIssues',
-                      actions: ['storeDataStreamSettings'],
-                    },
+                    onDone: [
+                      {
+                        target: '#DatasetQualityDetailsController.indexNotFound',
+                        cond: 'isDataStreamMissing',
+                      },
+                      {
+                        target: 'qualityIssues',
+                        actions: ['storeDataStreamSettings'],
+                      },
+                    ],
                     onError: [
                       {
                         target: '#DatasetQualityDetailsController.indexNotFound',
@@ -781,6 +787,11 @@ export const createPureDatasetQualityDetailsControllerStateMachine = (
               (event.data.originalMessage as string)?.includes('index_not_found_exception')) ??
             false
           );
+        },
+        isDataStreamMissing: (_, event) => {
+          const output =
+            'data' in event ? (event.data as DataStreamSettings) : undefined;
+          return !output?.lastBackingIndexName;
         },
         shouldOpenFlyout: (context, _event, meta) => {
           return (


### PR DESCRIPTION
## Summary

Backport of #258889 to 9.3.

Fixes a flaky/failing FTR test in the serverless environment where navigating to a non-existent data stream did not show the expected empty error prompt.

The fix adds an explicit check in the state machine: if `lastBackingIndexName` is absent after fetching settings, the data stream does not exist and we transition to the `indexNotFound` state via the new `isDataStreamMissing` guard (using xstate v4 `cond` syntax, adapted for the 9.3 branch).

## How to test

1. Navigate to Dataset Quality details for a non-existent data stream (e.g. `logs-non.existent-production`) in both stateful and serverless Kibana.
2. Verify the "Data stream not found" empty prompt is displayed containing the data stream name.
3. Verify that navigating to an existing data stream continues to work as expected.

Made with [Cursor](https://cursor.com)