### PR TITLE
fix: remove broken kibKbnRecentlyAccessedPluginApi doc links

### DIFF
--- a/dev_docs/shared_ux/chrome_recently_accessed/chrome_recently_accessed.mdx
+++ b/dev_docs/shared_ux/chrome_recently_accessed/chrome_recently_accessed.mdx
@@ -59,8 +59,7 @@ coreStart.chrome.recentlyAccessed.add(
 
 ## Implementation details
 
-The `ChromeRecentlyAccessed` services is based on <DocLink id="kibKbnRecentlyAccessedPluginApi" text="@kbn/recently-accessed"/> package. This package provides a `RecentlyAccessedService` that uses browser local storage to manage records of recently accessed objects. Internally it implements the queue with a maximum length of 20 items. When the queue is full, the oldest item is removed.
+The `ChromeRecentlyAccessed` services is based on @kbn/recently-accessed package. This package provides a `RecentlyAccessedService` that uses browser local storage to manage records of recently accessed objects. Internally it implements the queue with a maximum length of 20 items. When the queue is full, the oldest item is removed.
 Applications can create their own instance of `RecentlyAccessedService` to manage their own list of recently accessed items scoped to their application.
 
 - `ChromeRecentlyAccessed` is a service available via `coreStart.chrome.recentlyAccessed` and should be used to add items to chrome's sidenav.
-- <DocLink id="kibKbnRecentlyAccessedPluginApi" text="@kbn/recently-accessed"/> is package that `ChromeRecentlyAccessed` is using internally and the package can be used to create your own instance and manage your own list of recently accessed items that is independent for chrome's sidenav.


### PR DESCRIPTION
## Summary

Removes broken `<DocLink>` references to `kibKbnRecentlyAccessedPluginApi` in the chrome recently accessed doc page, fixing Vercel build failures.

- `dev_docs/shared_ux/chrome_recently_accessed/chrome_recently_accessed.mdx` — removed two broken DocLinks for `@kbn/recently-accessed`, replaced with plain text

## Test plan

- [ ] Confirm Vercel preview build passes without broken link errors for `/kibana-dev-docs/chrome/recently-accessed`