### PR TITLE
[Uptime] Fix Scout certificates spec navigating with stale 2019 date range !!

### DIFF
--- a/x-pack/solutions/observability/plugins/uptime/test/scout/ui/tests/certificates.spec.ts
+++ b/x-pack/solutions/observability/plugins/uptime/test/scout/ui/tests/certificates.spec.ts
@@ -10,7 +10,7 @@ import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
 import { expect } from '@kbn/scout-oblt/ui';
 import { DYNAMIC_SETTINGS_DEFAULTS } from '../../../../common/constants';
-import { test, testData } from '../fixtures';
+import { test } from '../fixtures';
 
 const BLANK_ARCHIVE = 'x-pack/solutions/observability/test/fixtures/es_archives/uptime/blank';
 const GENERATED_INDEX = 'heartbeat-8-generated-test';
@@ -117,7 +117,7 @@ test.describe('Uptime certificates', { tag: ['@local-stateful-classic'] }, () =>
   });
 
   test('navigates to cert page and displays certificates', async ({ pageObjects }) => {
-    await pageObjects.uptimeApp.navigateToOverview(testData.DEFAULT_NAVIGATION_SEARCH);
+    await pageObjects.uptimeApp.navigateToOverview();
     await pageObjects.uptimeApp.waitForDataLoaded();
 
     await test.step('cert button visible and navigates to cert page', async () => {
@@ -145,7 +145,7 @@ test.describe('Uptime certificates', { tag: ['@local-stateful-classic'] }, () =>
       refresh: 'wait_for',
     });
 
-    await pageObjects.uptimeApp.navigateToOverview(testData.DEFAULT_NAVIGATION_SEARCH);
+    await pageObjects.uptimeApp.navigateToOverview();
     await pageObjects.uptimeApp.navigateToCertificates();
 
     await expect(async () => {
@@ -167,7 +167,7 @@ test.describe('Uptime certificates', { tag: ['@local-stateful-classic'] }, () =>
       refresh: 'wait_for',
     });
 
-    await pageObjects.uptimeApp.navigateToOverview(testData.DEFAULT_NAVIGATION_SEARCH);
+    await pageObjects.uptimeApp.navigateToOverview();
     await pageObjects.uptimeApp.navigateToCertificates();
 
     await expect(async () => {

--- a/x-pack/solutions/observability/plugins/uptime/test/scout/ui/tests/certificates.spec.ts
+++ b/x-pack/solutions/observability/plugins/uptime/test/scout/ui/tests/certificates.spec.ts
@@ -117,6 +117,9 @@ test.describe('Uptime certificates', { tag: ['@local-stateful-classic'] }, () =>
   });
 
   test('navigates to cert page and displays certificates', async ({ pageObjects }) => {
+    // No date range arg on purpose: this spec indexes a live doc at `new Date()` instead of
+    // loading the 2019 FULL_HEARTBEAT archive. Passing DEFAULT_NAVIGATION_SEARCH would pin the
+    // picker to 2019 and the certs query would always exclude the doc.
     await pageObjects.uptimeApp.navigateToOverview();
     await pageObjects.uptimeApp.waitForDataLoaded();
 


### PR DESCRIPTION
## Summary

Fixes #270114 — the recently-migrated Scout uptime `certificates.spec.ts` was failing on every `kibana-on-merge / main` run since it landed (13+ deterministic failures, all `Expected: >= 1, Received: 0`).

### Root cause

`certificates.spec.ts` (introduced in #269985) navigates the overview / certificates pages with:

```ts
await pageObjects.uptimeApp.navigateToOverview(testData.DEFAULT_NAVIGATION_SEARCH);
```

That constant hard-codes the date picker to a Sep 10–11 **2019** window:

```
dateRangeEnd=2019-09-11T19:40:08.078Z&dateRangeStart=2019-09-10T12:40:08.078Z
```

It was authored for the other Scout uptime specs (`overview`, `settings`, `ml_anomaly`) that load the `FULL_HEARTBEAT` archive (which contains 2019 docs), but `certificates.spec.ts` is the only spec that uses the `BLANK` archive plus a runtime-indexed TLS doc at `new Date()` (today).

The certs API (`get_certs_request_body.ts`) adds a `range` filter on `monitor.timespan` against the picker bounds, so the 2026 doc is always excluded and `uptimeCertTotal` stays at `0` for the full 60s `toPass` retry window. `refreshApp()` is `page.reload()`, which preserves the bad URL state on every retry, so this is a hard failure, not flake/timing.

### Fix

Drop the `DEFAULT_NAVIGATION_SEARCH` argument from all three `navigateToOverview` call sites. With no `dateRangeStart`/`dateRangeEnd` URL params, the Uptime app falls back to its default `now-15m..now` relative range (per `CLIENT_DEFAULTS` in `x-pack/solutions/observability/plugins/uptime/common/constants/client_defaults.ts`), which is exactly what the deleted FTR equivalent relied on via `uptimeService.navigation.goToUptime()`.

## Test plan

- [x] Verified all three tests in `certificates.spec.ts` pass locally:

  ```
  npx playwright test x-pack/solutions/observability/plugins/uptime/test/scout/ui/tests/certificates.spec.ts \
    --config x-pack/solutions/observability/plugins/uptime/test/scout/ui/playwright.config.ts \
    --project local
  ```

  ```
  Running 4 tests using 1 worker
    [setup-local] Ingest uptime test data
    [local] Uptime certificates › navigates to cert page and displays certificates
    [local] Uptime certificates › displays specific certificate
    [local] Uptime certificates › performs search against monitor id
    4 passed (1.2m)
  ```

- [ ] CI passes

Made with [Cursor](https://cursor.com)