### PR TITLE
bump protocol-buffers-schema

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -30648,9 +30648,9 @@ protobufjs@^7.0.0, protobufjs@^7.3.0, protobufjs@^7.5.3:
     long "^5.0.0"
 
 protocol-buffers-schema@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz#00434f608b4e8df54c59e070efeefc37fb4bb859"
-  integrity sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w==
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz#fd9a58a5c4e96385b964808f3ddd58f9ef18c3c8"
+  integrity sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==
 
 proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"


### PR DESCRIPTION
## Summary

bump protocol-buffers-schema to 3.6.1

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->