### PR TITLE
[9.4] [Streams] Fix flaky `streams_table_values` should display correct data quality badge test (#267479)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_table_values.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_table_values.spec.ts
@@ -115,29 +115,53 @@ test.describe(
     });
 
     test('should display correct doc count in the table', async ({ pageObjects, page }) => {
-      // Poll until GOOD_QUALITY_STREAM reaches expected count (proxy for indexing completion)
+      // Poll all three counts together: failure-store settling lags indexing on serverless.
       await expect
         .poll(
           async () => {
             await page.reload();
             await pageObjects.streams.expectStreamsTableVisible();
-            return page
-              .locator(`[data-test-subj="streamsDocCount-${GOOD_QUALITY_STREAM}"]`)
-              .textContent();
+            const [good, degraded, poor] = await Promise.all([
+              page
+                .locator(`[data-test-subj="streamsDocCount-${GOOD_QUALITY_STREAM}"]`)
+                .textContent(),
+              page
+                .locator(`[data-test-subj="streamsDocCount-${DEGRADED_QUALITY_STREAM}"]`)
+                .textContent(),
+              page
+                .locator(`[data-test-subj="streamsDocCount-${POOR_QUALITY_STREAM}"]`)
+                .textContent(),
+            ]);
+            return { good, degraded, poor };
           },
           { timeout: 90_000, intervals: [5000] }
         )
-        .toBe('50');
-
-      // Remaining counts are verified on the already-loaded page
-      await pageObjects.streams.verifyDocCount(DEGRADED_QUALITY_STREAM, 52);
-      await pageObjects.streams.verifyDocCount(POOR_QUALITY_STREAM, 60);
+        .toStrictEqual({ good: '50', degraded: '52', poor: '60' });
     });
 
-    test('should display correct data quality badge', async ({ pageObjects }) => {
-      await pageObjects.streams.verifyDataQuality(GOOD_QUALITY_STREAM, 'Good');
-      await pageObjects.streams.verifyDataQuality(DEGRADED_QUALITY_STREAM, 'Degraded');
-      await pageObjects.streams.verifyDataQuality(POOR_QUALITY_STREAM, 'Poor');
+    test('should display correct data quality badge', async ({ pageObjects, page }) => {
+      // Reload between iterations: the list view caches doc-count promises per page mount.
+      await expect
+        .poll(
+          async () => {
+            await page.reload();
+            await pageObjects.streams.expectStreamsTableVisible();
+            const [good, degraded, poor] = await Promise.all([
+              page
+                .locator(`[data-test-subj="dataQualityIndicator-${GOOD_QUALITY_STREAM}"]`)
+                .textContent(),
+              page
+                .locator(`[data-test-subj="dataQualityIndicator-${DEGRADED_QUALITY_STREAM}"]`)
+                .textContent(),
+              page
+                .locator(`[data-test-subj="dataQualityIndicator-${POOR_QUALITY_STREAM}"]`)
+                .textContent(),
+            ]);
+            return { good, degraded, poor };
+          },
+          { timeout: 90_000, intervals: [5000] }
+        )
+        .toStrictEqual({ good: 'Good', degraded: 'Degraded', poor: 'Poor' });
     });
 
     test('should display correct retention in the table', async ({ pageObjects, config }) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Streams] Fix flaky `streams_table_values` should display correct data quality badge test (#267479)](https://github.com/elastic/kibana/pull/267479)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Stelmach","email":"60304951+rStelmach@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-05T09:58:15Z","message":"[Streams] Fix flaky `streams_table_values` should display correct data quality badge test (#267479)\n\ncloses #244894\n\n## Summary\n\nOn serverless, the failure-store contribution to the metering total\nsettles slower than regular indexing, and the streams list view caches\nthe doc-count promises for the lifetime of the page mount. The doc-count\nand data-quality tests assumed the first fetch already saw the final\nstate, so a stale value got locked in.\n\nTwo changes:\n\n1. The doc-count test now polls until **all three** streams report their\nexpected counts together, instead of polling only the good-quality\nstream and asserting the others without retry.\n2. The data-quality badge test now uses the same poll-and-reload pattern\nalready used in `streams_header.spec.ts`, instead of a single\n`toHaveText` against a cached badge value.","sha":"921b8195a7aeb39cfa37e8d0e6e64ea0f8b58269","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-onboarding","Feature:Streams","v9.5.0"],"title":"[Streams] Fix flaky `streams_table_values` should display correct data quality badge test","number":267479,"url":"https://github.com/elastic/kibana/pull/267479","mergeCommit":{"message":"[Streams] Fix flaky `streams_table_values` should display correct data quality badge test (#267479)\n\ncloses #244894\n\n## Summary\n\nOn serverless, the failure-store contribution to the metering total\nsettles slower than regular indexing, and the streams list view caches\nthe doc-count promises for the lifetime of the page mount. The doc-count\nand data-quality tests assumed the first fetch already saw the final\nstate, so a stale value got locked in.\n\nTwo changes:\n\n1. The doc-count test now polls until **all three** streams report their\nexpected counts together, instead of polling only the good-quality\nstream and asserting the others without retry.\n2. The data-quality badge test now uses the same poll-and-reload pattern\nalready used in `streams_header.spec.ts`, instead of a single\n`toHaveText` against a cached badge value.","sha":"921b8195a7aeb39cfa37e8d0e6e64ea0f8b58269"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267479","number":267479,"mergeCommit":{"message":"[Streams] Fix flaky `streams_table_values` should display correct data quality badge test (#267479)\n\ncloses #244894\n\n## Summary\n\nOn serverless, the failure-store contribution to the metering total\nsettles slower than regular indexing, and the streams list view caches\nthe doc-count promises for the lifetime of the page mount. The doc-count\nand data-quality tests assumed the first fetch already saw the final\nstate, so a stale value got locked in.\n\nTwo changes:\n\n1. The doc-count test now polls until **all three** streams report their\nexpected counts together, instead of polling only the good-quality\nstream and asserting the others without retry.\n2. The data-quality badge test now uses the same poll-and-reload pattern\nalready used in `streams_header.spec.ts`, instead of a single\n`toHaveText` against a cached badge value.","sha":"921b8195a7aeb39cfa37e8d0e6e64ea0f8b58269"}}]}] BACKPORT-->