### PR TITLE
[SharedUX][Chrome Next] Add search button to global header

### DIFF
--- a/src/core/packages/chrome/browser-components/moon.yml
+++ b/src/core/packages/chrome/browser-components/moon.yml
@@ -46,6 +46,7 @@ dependsOn:
   - '@kbn/shared-ux-label-formatter'
   - '@kbn/test-jest-helpers'
   - '@kbn/use-observable'
+  - '@kbn/shared-ux-utility'
 tags:
   - shared-browser
   - package

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
@@ -8,11 +8,12 @@
  */
 
 import React from 'react';
-import { ChromeNextGlobalHeaderShell } from './global_header_shell';
 import { ChromeNextGlobalHeaderLogo } from './global_header_logo';
+import { SearchButton } from './search_button';
+import { ChromeNextGlobalHeaderShell } from './global_header_shell';
 
 export const ChromeNextGlobalHeader = React.memo(() => (
-  <ChromeNextGlobalHeaderShell logo={<ChromeNextGlobalHeaderLogo />} />
+  <ChromeNextGlobalHeaderShell logo={<ChromeNextGlobalHeaderLogo />} search={<SearchButton />} />
 ));
 
 ChromeNextGlobalHeader.displayName = 'ChromeNextGlobalHeader';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
@@ -136,7 +136,6 @@ export const ChromeNextGlobalHeaderShell = React.memo<ChromeNextGlobalHeaderShel
         </div>
         <div css={styles.separator} />
         <div css={styles.spacer} />
-        <div css={styles.separator} />
         <div css={styles.rightGroup}>
           {search && (
             <div css={styles.searchSlot} data-test-subj="chromeNextGlobalHeaderSearch">

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/header_action_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/header_action_button.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactNode } from 'react';
+import React from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
+
+export const HEADER_BUTTON_HEIGHT_PX = 32;
+export const HEADER_BUTTON_SQUARE_WIDTH_PX = 32;
+
+export const headerButtonBaseStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  boxSizing: 'border-box',
+  height: `${HEADER_BUTTON_HEIGHT_PX}px`,
+  background: 'transparent',
+  cursor: 'pointer',
+  '&:hover': { background: 'var(--header-btn-hover)' },
+  '&:focus-visible': {
+    outline: '2px solid var(--header-btn-focus)',
+    outlineOffset: -2,
+  },
+});
+
+export const headerButtonBorderedStyles = css({
+  border: '1px solid var(--header-btn-border)',
+});
+
+const plainStyles = css({
+  border: 'none',
+});
+
+const squareStyles = css({
+  width: `${HEADER_BUTTON_SQUARE_WIDTH_PX}px`,
+  padding: 0,
+  justifyContent: 'center',
+});
+
+export const useHeaderButtonStyleVars = () => {
+  const { euiTheme } = useEuiTheme();
+  return {
+    '--header-btn-border': euiTheme.colors.borderBasePlain,
+    '--header-btn-hover': euiTheme.colors.backgroundBaseInteractiveHover,
+    '--header-btn-focus': euiTheme.colors.primary,
+    borderRadius: euiTheme.border.radius.medium,
+  } as React.CSSProperties;
+};
+
+export interface HeaderActionButtonProps
+  extends Pick<React.AriaAttributes, 'aria-expanded' | 'aria-haspopup'> {
+  variant: 'bordered' | 'plain';
+  children: ReactNode;
+  onClick: () => void;
+  'aria-label': string;
+  'data-test-subj'?: string;
+}
+
+export const HeaderActionButton = React.forwardRef<HTMLButtonElement, HeaderActionButtonProps>(
+  (
+    {
+      variant,
+      children,
+      onClick,
+      'aria-label': ariaLabel,
+      'aria-expanded': ariaExpanded,
+      'aria-haspopup': ariaHaspopup,
+      'data-test-subj': dataTestSubj,
+    },
+    ref
+  ) => {
+    const styleVars = useHeaderButtonStyleVars();
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-expanded={ariaExpanded}
+        aria-haspopup={ariaHaspopup}
+        aria-label={ariaLabel}
+        data-test-subj={dataTestSubj}
+        css={[
+          headerButtonBaseStyles,
+          squareStyles,
+          variant === 'bordered' ? headerButtonBorderedStyles : plainStyles,
+        ]}
+        style={styleVars}
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+HeaderActionButton.displayName = 'HeaderActionButton';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/search_button.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/search_button.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
+import { TestChromeProviders } from '../../test_helpers';
+import { SearchButton } from './search_button';
+
+jest.mock('@kbn/shared-ux-utility', () => ({
+  ...jest.requireActual('@kbn/shared-ux-utility'),
+  isMac: true,
+  useKeyboardShortcut: jest.fn(),
+}));
+
+const { useKeyboardShortcut } = jest.mocked(
+  jest.requireMock('@kbn/shared-ux-utility') as typeof import('@kbn/shared-ux-utility')
+);
+
+const renderButton = (config?: { onClick: () => void; shortcutKey?: string }) => {
+  const chrome = chromeServiceMock.createStartContract();
+  (chrome.next.globalSearch.get$ as jest.Mock).mockReturnValue(new BehaviorSubject(config));
+  return render(
+    <TestChromeProviders chrome={chrome}>
+      <SearchButton />
+    </TestChromeProviders>
+  );
+};
+
+describe('SearchButton', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders nothing when no config is set', () => {
+    const { container } = renderButton(undefined);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId('chromeNextGlobalHeaderSearchButton')).not.toBeInTheDocument();
+  });
+
+  it('renders the search button when config is provided', () => {
+    renderButton({ onClick: jest.fn(), shortcutKey: '/' });
+    expect(screen.getByTestId('chromeNextGlobalHeaderSearchButton')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    renderButton({ onClick, shortcutKey: '/' });
+
+    fireEvent.click(screen.getByTestId('chromeNextGlobalHeaderSearchButton'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers keyboard shortcut from config', () => {
+    const onClick = jest.fn();
+    renderButton({ onClick, shortcutKey: '/' });
+
+    expect(useKeyboardShortcut).toHaveBeenCalledWith({ key: '/', meta: true }, onClick);
+  });
+});

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/search_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/search_button.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { EuiBadge, EuiIcon, useEuiBreakpoint, useEuiFontSize, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { isMac, useKeyboardShortcut } from '@kbn/shared-ux-utility';
+import { useGlobalSearch } from '../../shared/chrome_hooks';
+import {
+  HEADER_BUTTON_SQUARE_WIDTH_PX,
+  headerButtonBaseStyles,
+  headerButtonBorderedStyles,
+  useHeaderButtonStyleVars,
+} from './header_action_button';
+
+const PLACEHOLDER = i18n.translate('core.ui.chrome.globalHeader.searchButton.placeholder', {
+  defaultMessage: 'Find content...',
+});
+
+const ARIA_LABEL = i18n.translate('core.ui.chrome.globalHeader.searchButton.ariaLabel', {
+  defaultMessage: 'Search',
+});
+
+const MODIFIER_KEY = isMac ? '⌘' : 'Ctrl';
+
+export const SearchButton = React.memo(() => {
+  const config = useGlobalSearch();
+  const { euiTheme } = useEuiTheme();
+  const euiFontSizeS = useEuiFontSize('s').fontSize;
+  const baseStyleVars = useHeaderButtonStyleVars();
+  const compactQuery = useEuiBreakpoint(['xs', 's']);
+
+  const shortcutBadgeStyles = css({
+    color: euiTheme.colors.textSubdued,
+  });
+
+  const placeholderStyles = css({
+    color: euiTheme.colors.textDisabled,
+    fontSize: euiFontSizeS,
+    userSelect: 'none',
+  });
+
+  const compactButtonStyles = css({
+    [compactQuery]: {
+      width: HEADER_BUTTON_SQUARE_WIDTH_PX,
+      padding: 0,
+      justifyContent: 'center',
+      gap: 0,
+    },
+  });
+
+  const collapsibleStyles = css({
+    [compactQuery]: {
+      display: 'none',
+    },
+  });
+
+  const searchOverrides = css({
+    padding: `0 ${euiTheme.size.s}`,
+    gap: euiTheme.size.s,
+    whiteSpace: 'nowrap',
+  });
+
+  const shortcut = useMemo(
+    () => (config?.shortcutKey ? { key: config.shortcutKey, meta: true } : undefined),
+    [config?.shortcutKey]
+  );
+  useKeyboardShortcut(shortcut, config?.onClick);
+
+  if (!config) return null;
+
+  const shortcutLabel = config.shortcutKey
+    ? `${MODIFIER_KEY} ${config.shortcutKey.toUpperCase()}`
+    : undefined;
+
+  return (
+    <button
+      type="button"
+      aria-label={ARIA_LABEL}
+      data-test-subj="chromeNextGlobalHeaderSearchButton"
+      css={[
+        headerButtonBaseStyles,
+        headerButtonBorderedStyles,
+        searchOverrides,
+        compactButtonStyles,
+      ]}
+      style={baseStyleVars}
+      onClick={config.onClick}
+    >
+      <EuiIcon type="search" size="m" color={euiTheme.colors.textParagraph} aria-hidden />
+      <span css={[placeholderStyles, collapsibleStyles]}>{PLACEHOLDER}</span>
+      {shortcutLabel && (
+        <EuiBadge css={[shortcutBadgeStyles, collapsibleStyles]}>{shortcutLabel}</EuiBadge>
+      )}
+    </button>
+  );
+});
+
+SearchButton.displayName = 'SearchButton';

--- a/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
+++ b/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
@@ -17,6 +17,7 @@ import type {
   ChromeHelpMenuLink,
   ChromeNavControl,
   ChromeNavLink,
+  GlobalSearchConfig,
 } from '@kbn/core-chrome-browser';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { MountPoint } from '@kbn/core-mount-utils-browser';
@@ -278,4 +279,15 @@ export function useHasAppMenu(): boolean {
   const hasLegacyActionMenu = useHasLegacyActionMenu();
   const hasAppMenuConfig = useHasAppMenuConfig();
   return hasLegacyActionMenu || hasAppMenuConfig;
+}
+
+/**
+ * Returns the current global search configuration, or `undefined` if none is set.
+ * Used by `SearchButton` (global header).
+ */
+
+export function useGlobalSearch(): GlobalSearchConfig | undefined {
+  const chrome = useChromeService();
+  const config$ = useMemo(() => chrome.next.globalSearch.get$(), [chrome]);
+  return useObservable(config$, undefined);
 }

--- a/src/core/packages/chrome/browser-components/tsconfig.json
+++ b/src/core/packages/chrome/browser-components/tsconfig.json
@@ -46,5 +46,6 @@
     "@kbn/shared-ux-label-formatter",
     "@kbn/test-jest-helpers",
     "@kbn/use-observable",
+    "@kbn/shared-ux-utility",
   ]
 }

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -178,6 +178,10 @@ export function createChromeApi({
       get isEnabled() {
         return isNextChrome(featureFlags);
       },
+      globalSearch: {
+        get$: () => state.globalSearch.$,
+        set: (config) => state.globalSearch.set(config),
+      },
     },
     sidebar,
   };

--- a/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
@@ -18,6 +18,7 @@ import type {
   ChromeBreadcrumbsBadge,
   ChromeGlobalHelpExtensionMenuLink,
   ChromeHelpExtension,
+  GlobalSearchConfig,
   ChromeNavLink,
   ChromeUserBanner,
 } from '@kbn/core-chrome-browser';
@@ -62,6 +63,7 @@ export interface ChromeState {
   /** UI elements */
   headerBanner: State<ChromeUserBanner | undefined>;
   globalFooter: State<ReactNode>;
+  globalSearch: State<GlobalSearchConfig | undefined>;
   customNavLink: State<ChromeNavLink | undefined>;
   appMenu: State<AppMenuConfig | undefined>;
 
@@ -107,6 +109,7 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
 
   // UI Elements (not reset on app change)
   const globalFooter = createState<ReactNode>(null);
+  const globalSearch = createState<GlobalSearchConfig | undefined>(undefined);
   const customNavLink = createState<ChromeNavLink | undefined>(undefined);
 
   // Help System
@@ -130,6 +133,7 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
     },
     headerBanner,
     globalFooter,
+    globalSearch,
     customNavLink,
     appMenu,
     help: {

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -100,6 +100,10 @@ const createStartContractMock = () => {
     }),
     next: lazyObject({
       isEnabled: false,
+      globalSearch: lazyObject({
+        set: jest.fn(),
+        get$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
+      }),
     }),
     setGlobalFooter: jest.fn(),
     getGlobalFooter$: jest.fn().mockReturnValue(new BehaviorSubject(null)),

--- a/src/core/packages/chrome/browser/index.ts
+++ b/src/core/packages/chrome/browser/index.ts
@@ -55,4 +55,5 @@ export type {
   SidebarAppDefinition,
   SidebarSetup,
   SidebarStart,
+  GlobalSearchConfig,
 } from './src';

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -7,6 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Observable } from 'rxjs';
+import type { GlobalSearchConfig } from './global_search';
+
 /**
  * Chrome Next rollout APIs.
  *
@@ -19,4 +22,15 @@
 export interface ChromeNext {
   /** Whether the Chrome Next feature flag is enabled. */
   readonly isEnabled: boolean;
+  /** Global search configuration. */
+  globalSearch: {
+    /**
+     * Set the global search configuration for the Chrome-Next header.
+     * Chrome renders a search button; clicking it fires `onClick`.
+     * Pass `undefined` to remove. Global — persists across app changes.
+     */
+    set(config?: GlobalSearchConfig): void;
+    /** Observable of the current global search config. */
+    get$(): Observable<GlobalSearchConfig | undefined>;
+  };
 }

--- a/src/core/packages/chrome/browser/src/chrome_next/global_search.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/global_search.ts
@@ -7,5 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { ChromeNext } from './chrome_next';
-export type { GlobalSearchConfig } from './global_search';
+/**
+ * Configuration for the global search button in the global header.
+ * @public
+ */
+export interface GlobalSearchConfig {
+  /** Called when the search button in the global header is clicked. */
+  onClick: () => void;
+  /** The keyboard shortcut key (combined with Cmd/Ctrl) to trigger global search. */
+  shortcutKey?: string;
+}

--- a/src/core/packages/chrome/browser/src/index.ts
+++ b/src/core/packages/chrome/browser/src/index.ts
@@ -59,3 +59,5 @@ export type {
   SidebarSetup,
   SidebarStart,
 } from './sidebar';
+
+export type { GlobalSearchConfig } from './chrome_next/global_search';

--- a/src/platform/packages/shared/kbn-shared-ux-utility/index.ts
+++ b/src/platform/packages/shared/kbn-shared-ux-utility/index.ts
@@ -12,3 +12,4 @@ export { getClosestLink, hasActiveModifierKey } from './src/utils';
 export { withSuspense, type WithSuspenseExtendedDeps } from './src/with_suspense';
 export { dynamic, type DynamicOptions } from './src/dynamic';
 export { isMac, isWindows, isLinux, getPlatform, type Platform } from './src/browser';
+export { useKeyboardShortcut, type KeyboardShortcut } from './src/browser';

--- a/src/platform/packages/shared/kbn-shared-ux-utility/src/browser/index.ts
+++ b/src/platform/packages/shared/kbn-shared-ux-utility/src/browser/index.ts
@@ -9,3 +9,5 @@
 
 export { isMac, isWindows, isLinux, getPlatform } from './platform';
 export type { Platform } from './platform';
+export { useKeyboardShortcut } from './use_keyboard_shortcut';
+export type { KeyboardShortcut } from './use_keyboard_shortcut';

--- a/src/platform/packages/shared/kbn-shared-ux-utility/src/browser/use_keyboard_shortcut.test.ts
+++ b/src/platform/packages/shared/kbn-shared-ux-utility/src/browser/use_keyboard_shortcut.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useKeyboardShortcut } from './use_keyboard_shortcut';
+
+let mockIsMac = true;
+jest.mock('./platform', () => ({
+  get isMac() {
+    return mockIsMac;
+  },
+  getPlatform: () => (mockIsMac ? 'mac' : 'windows'),
+}));
+
+const dispatch = (opts: KeyboardEventInit) => {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...opts });
+  document.dispatchEvent(event);
+  return event;
+};
+
+describe('useKeyboardShortcut', () => {
+  afterEach(() => {
+    mockIsMac = true;
+  });
+
+  it('fires callback on matching meta+key (Mac)', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut({ key: '/', meta: true }, callback));
+
+    dispatch({ key: '/', metaKey: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires callback on matching ctrl+key (Windows)', () => {
+    mockIsMac = false;
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut({ key: '/', meta: true }, callback));
+
+    dispatch({ key: '/', ctrlKey: true });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when key does not match', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut({ key: '/', meta: true }, callback));
+
+    dispatch({ key: 'k', metaKey: true });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on match', () => {
+    const callback = jest.fn();
+    renderHook(() => useKeyboardShortcut({ key: '/', meta: true }, callback));
+
+    const event = dispatch({ key: '/', metaKey: true });
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/src/platform/packages/shared/kbn-shared-ux-utility/src/browser/use_keyboard_shortcut.ts
+++ b/src/platform/packages/shared/kbn-shared-ux-utility/src/browser/use_keyboard_shortcut.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEffect } from 'react';
+import { isMac } from './platform';
+
+export interface KeyboardShortcut {
+  key: string;
+  /** Cmd on Mac, Ctrl on other platforms. */
+  meta?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  /** Literal Ctrl on all platforms (distinct from meta on Mac). */
+  ctrl?: boolean;
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) return true;
+  return target.isContentEditable;
+}
+
+export function useKeyboardShortcut(
+  shortcut: KeyboardShortcut | undefined,
+  callback: (() => void) | undefined
+) {
+  useEffect(() => {
+    if (!shortcut || !callback) return;
+
+    const target = shortcut.key.toLowerCase();
+    const wantMeta = shortcut.meta ?? false;
+    const wantShift = shortcut.shift ?? false;
+    const wantAlt = shortcut.alt ?? false;
+    const wantCtrl = shortcut.ctrl ?? false;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() !== target) return;
+      if (isEditableTarget(e.target)) return;
+
+      if (wantShift !== e.shiftKey) return;
+      if (wantAlt !== e.altKey) return;
+
+      if (isMac) {
+        if (wantMeta !== e.metaKey) return;
+        if (wantCtrl !== e.ctrlKey) return;
+      } else {
+        // On non-Mac, meta and ctrl both map to the physical Ctrl key.
+        // They cannot be distinguished, so either flag claims e.ctrlKey.
+        const wantEither = wantMeta || wantCtrl;
+        if (wantEither !== e.ctrlKey) return;
+        if (e.metaKey) return;
+      }
+
+      e.preventDefault();
+      callback();
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [shortcut, callback]);
+}


### PR DESCRIPTION
Co-authored-by: Anton Dosov <anton.dosov@elastic.co>

Relates to https://github.com/elastic/kibana-team/issues/3409

## Summary

Cherry-pick of [18d5897cae62](https://github.com/elastic/kibana/pull/262997) from `feature/chrome-next` with modifications.
- Adds a search button to the Chrome-Next global header that triggers global search via the `chrome.next.globalSearch` API.
- Styled as a fake search input: bordered button with magnifying glass icon, "Find content..." placeholder, and an `EuiBadge` keyboard shortcut indicator
- Registers a global keyboard shortcut (Cmd/Ctrl + /) via the new `useKeyboardShortcut` utility hook
- Collapses to an icon-only square button on smaller screens

Changes from the original commit
- Adds `chrome.next.globalSearch` API: type (GlobalSearchConfig), state wiring, mocks and hook
- Updated styles to use EUI tokens where possible
- Added RTL unit tests for button and shortcut hook
- Removed unrelated changes (help button, user menu, AI button slot) that belong to other feature slices

## Testing
```
feature_flags.overrides:
  core.chrome.next: true
```

Replace line 34 in `SearchButton` to see the button (follow up PR will register it and open the search modal)
```
  const _config = useGlobalSearch();
  const config = _config ?? { onClick: () => console.log('search clicked'), shortcutKey: '/' };
```

Light mode, full size:
<img width="1235" height="335" alt="Screenshot 2026-05-20 at 15 38 23" src="https://github.com/user-attachments/assets/775d2856-9553-454e-a33c-a0535780f916" />

Light mode, compact square variant: 
<img width="738" height="319" alt="Screenshot 2026-05-20 at 15 37 40" src="https://github.com/user-attachments/assets/cb4f0d1a-63cf-46de-bd97-da1d4e7d0d49" />

Dark mode, full size:
<img width="1242" height="334" alt="Screenshot 2026-05-20 at 15 36 22" src="https://github.com/user-attachments/assets/220d5475-3e27-4ed6-87e0-30857d9cf182" />

Dark mode, compact square variant: 
<img width="739" height="317" alt="Screenshot 2026-05-20 at 15 36 46" src="https://github.com/user-attachments/assets/3297bbc6-ecbd-423f-a269-d37eb53651b4" />

