### PR TITLE
[Streams] Increate test timeout for the view toggle button

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -362,7 +362,7 @@ export class StreamsApp {
 
   async switchToColumnsView() {
     // Draft streams fetch samples via ES|QL from the parent, which can be slow
-    await this.page.getByTestId('streamsAppPreviewTableViewModeToggle').click({ timeout: 30_000 });
+    await this.page.getByTestId('streamsAppPreviewTableViewModeToggle').click({ timeout: 60_000 });
   }
 
   async saveRoutingRule() {


### PR DESCRIPTION
The timeout was already set to 30 seconds, but it was still not enough in some cases and [caused test failures](https://github.com/elastic/kibana/issues/269695).