### PR TITLE
[9.4] Fix `@elastic/eui/callout-announce-on-mount` lint violations in APM plugin (#269445)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/diagnostics/import_export_tab.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/diagnostics/import_export_tab.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import {
   EuiButton,
   EuiCard,
@@ -44,14 +45,19 @@ function ExportCard() {
     <EuiCard
       isDisabled={isImported}
       icon={<EuiIcon size="xxl" type="download" aria-hidden={true} />}
-      title="Export"
+      title={i18n.translate('xpack.apm.exportCard.euiCard.exportLabel', {
+        defaultMessage: 'Export',
+      })}
       description="Export the diagnostics report in order to provide it to Elastic Support"
       footer={
         <div>
           <EuiButton
             isDisabled={isImported}
             data-test-subj="apmDiagnosticsImportExportGoForItButton"
-            aria-label="Export diagnostics report"
+            aria-label={i18n.translate(
+              'xpack.apm.exportCard.euiButton.exportDiagnosticsReportLabel',
+              { defaultMessage: 'Export diagnostics report' }
+            )}
             onClick={() => {
               if (!diagnosticsBundle) {
                 return;
@@ -69,7 +75,7 @@ function ExportCard() {
               link.click();
             }}
           >
-            Export
+            {i18n.translate('xpack.apm.exportCard.exportButtonLabel', { defaultMessage: 'Export' })}
           </EuiButton>
         </div>
       }
@@ -88,7 +94,9 @@ function ImportCard() {
   return (
     <EuiCard
       icon={<EuiIcon size="xxl" type="upload" aria-hidden={true} />}
-      title="Import diagnostics report"
+      title={i18n.translate('xpack.apm.importCard.euiCard.importDiagnosticsReportLabel', {
+        defaultMessage: 'Import diagnostics report',
+      })}
       description={
         isImported
           ? 'Diagnostics report was imported'
@@ -102,14 +110,19 @@ function ImportCard() {
               onClick={() => setImportedDiagnosticsBundle(undefined)}
               color="danger"
             >
-              Remove report
+              {i18n.translate('xpack.apm.importCard.removeReportButtonLabel', {
+                defaultMessage: 'Remove report',
+              })}
             </EuiButton>
           ) : (
             <>
               {!importStatus.isValid && (
                 <>
-                  <EuiCallOut color="danger" iconType="warning">
-                    The uploaded file could not be parsed: {importStatus.errorMessage}
+                  <EuiCallOut announceOnMount color="danger" iconType="warning">
+                    {i18n.translate('xpack.apm.importCard.theUploadedFileCouldCallOutLabel', {
+                      defaultMessage: 'The uploaded file could not be parsed:',
+                    })}
+                    {importStatus.errorMessage}
                   </EuiCallOut>
                   <EuiSpacer />
                 </>

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/api_key_callout.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/api_key_callout.tsx
@@ -22,6 +22,7 @@ export function ApiKeyCallout({
     return (
       <>
         <EuiCallOut
+          announceOnMount
           title={i18n.translate('xpack.apm.onboarding.apiKey.success.calloutTitle', {
             defaultMessage: 'API key created',
           })}
@@ -43,6 +44,7 @@ export function ApiKeyCallout({
   if (isInsufficientPermissionsError) {
     return (
       <EuiCallOut
+        announceOnMount
         title={i18n.translate('xpack.apm.onboarding.apiKey.warning.calloutTitle', {
           defaultMessage: 'User does not have permissions to create API Key',
         })}
@@ -63,6 +65,7 @@ export function ApiKeyCallout({
 
   return (
     <EuiCallOut
+      announceOnMount
       title={i18n.translate('xpack.apm.onboarding.apiKey.error.calloutTitle', {
         defaultMessage: 'Failed to create API key',
       })}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix `@elastic/eui/callout-announce-on-mount` lint violations in APM plugin (#269445)](https://github.com/elastic/kibana/pull/269445)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-15T10:53:35Z","message":"Fix `@elastic/eui/callout-announce-on-mount` lint violations in APM plugin (#269445)\n\nAdds `announceOnMount` prop to conditionally rendered `EuiCallOut`\ncomponents so screen readers announce them when they appear dynamically.\n\n- **`import_export_tab.tsx`**: `announceOnMount` on file parse error\ncallout\n- **`api_key_callout.tsx`**: `announceOnMount` on all three callouts\n(success/warning/error) — all rendered after user-initiated API key\ncreation\n- **`settings_page.tsx`**: `announceOnMount={false}` on OTel\ndocumentation callout — state-driven condition, not action feedback\n\n```tsx\n// Action result → announce\n{hasError && <EuiCallOut announceOnMount title=\"...\" color=\"danger\" />}\n\n// State condition → explicit opt-out\n{isOtelAgent && <EuiCallOut announceOnMount={false} title=\"...\" />}\n```\n\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f50df7e9a5d3ce857e632903c09da0900821df53","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","v9.4.0","Team:obs-presentation","a11y:agent-pr","v9.5.0","v9.3.5"],"title":"Fix `@elastic/eui/callout-announce-on-mount` lint violations in APM plugin","number":269445,"url":"https://github.com/elastic/kibana/pull/269445","mergeCommit":{"message":"Fix `@elastic/eui/callout-announce-on-mount` lint violations in APM plugin (#269445)\n\nAdds `announceOnMount` prop to conditionally rendered `EuiCallOut`\ncomponents so screen readers announce them when they appear dynamically.\n\n- **`import_export_tab.tsx`**: `announceOnMount` on file parse error\ncallout\n- **`api_key_callout.tsx`**: `announceOnMount` on all three callouts\n(success/warning/error) — all rendered after user-initiated API key\ncreation\n- **`settings_page.tsx`**: `announceOnMount={false}` on OTel\ndocumentation callout — state-driven condition, not action feedback\n\n```tsx\n// Action result → announce\n{hasError && <EuiCallOut announceOnMount title=\"...\" color=\"danger\" />}\n\n// State condition → explicit opt-out\n{isOtelAgent && <EuiCallOut announceOnMount={false} title=\"...\" />}\n```\n\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f50df7e9a5d3ce857e632903c09da0900821df53"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269445","number":269445,"mergeCommit":{"message":"Fix `@elastic/eui/callout-announce-on-mount` lint violations in APM plugin (#269445)\n\nAdds `announceOnMount` prop to conditionally rendered `EuiCallOut`\ncomponents so screen readers announce them when they appear dynamically.\n\n- **`import_export_tab.tsx`**: `announceOnMount` on file parse error\ncallout\n- **`api_key_callout.tsx`**: `announceOnMount` on all three callouts\n(success/warning/error) — all rendered after user-initiated API key\ncreation\n- **`settings_page.tsx`**: `announceOnMount={false}` on OTel\ndocumentation callout — state-driven condition, not action feedback\n\n```tsx\n// Action result → announce\n{hasError && <EuiCallOut announceOnMount title=\"...\" color=\"danger\" />}\n\n// State condition → explicit opt-out\n{isOtelAgent && <EuiCallOut announceOnMount={false} title=\"...\" />}\n```\n\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] Fixed all files\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f50df7e9a5d3ce857e632903c09da0900821df53"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->