### PR TITLE
[9.3] [Cases] Fix crash on bare ampersands in markdown content (#269844)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/utils/markdown_plugins/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/markdown_plugins/utils.test.ts
@@ -5,9 +5,77 @@
  * 2.0.
  */
 
+let mockParseThrows = false;
+
+jest.mock('unified', () => {
+  const unifiedModule = jest.requireActual('unified');
+  const actualUnified = typeof unifiedModule === 'function' ? unifiedModule : unifiedModule.default;
+
+  return {
+    __esModule: true,
+    default: jest.fn((...args: unknown[]) => {
+      const processor = actualUnified(...args);
+      const originalParse = processor.parse.bind(processor);
+
+      processor.parse = jest.fn((...parseArgs: Parameters<typeof originalParse>) => {
+        if (mockParseThrows) {
+          throw new Error('parse failed');
+        }
+        return originalParse(...parseArgs);
+      });
+
+      return processor;
+    }),
+  };
+});
+
 import { parseCommentString, stringifyMarkdownComment } from './utils';
 
 describe('markdown utils', () => {
+  describe('parseCommentString', () => {
+    afterEach(() => {
+      mockParseThrows = false;
+    });
+
+    it('parses a simple comment into a valid markdown node', () => {
+      const parsed = parseCommentString('hello world');
+
+      expect(parsed.type).toEqual('root');
+      expect(parsed.children?.length).toBeGreaterThan(0);
+    });
+
+    describe('when processor.parse throws', () => {
+      beforeEach(() => {
+        mockParseThrows = true;
+      });
+
+      it('returns a plain text fallback paragraph node', () => {
+        const comment = 'malformed **markdown';
+        const parsed = parseCommentString(comment);
+
+        expect(parsed).toEqual({
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: comment,
+            },
+          ],
+        });
+      });
+
+      it('preserves the original comment content in the fallback node', () => {
+        const comment = '!{lens{"invalid": json}';
+        const parsed = parseCommentString(comment);
+
+        expect(parsed.children?.[0]).toEqual({
+          type: 'text',
+          value: comment,
+        });
+      });
+    });
+  });
+
   describe('stringifyComment', () => {
     it('adds a newline to the end if one does not exist', () => {
       const parsed = parseCommentString('hello');

--- a/x-pack/platform/plugins/shared/cases/common/utils/markdown_plugins/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/markdown_plugins/utils.ts
@@ -39,7 +39,19 @@ export const getLensVisualizations = (parsedComment?: Array<LensMarkdownNode | N
  */
 export const parseCommentString = (comment: string) => {
   const processor = unified().use([[markdown, {}], LensParser, TimelineParser]);
-  return processor.parse(comment) as MarkdownNode;
+  try {
+    return processor.parse(comment) as MarkdownNode;
+  } catch (error) {
+    return {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'text',
+          value: comment,
+        },
+      ],
+    } as unknown as MarkdownNode;
+  }
 };
 
 export const stringifyMarkdownComment = (comment: MarkdownNode) =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Cases] Fix crash on bare ampersands in markdown content (#269844)](https://github.com/elastic/kibana/pull/269844)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mykhailo Kondrat","email":"mykhailo.kondrat@elastic.co"},"sourceCommit":{"committedDate":"2026-05-20T13:08:54Z","message":"[Cases] Fix crash on bare ampersands in markdown content (#269844)\n\n## What & Why\n\nFixes a full-page crash\n([#268564](https://github.com/elastic/kibana/issues/268564)) when case\ncomments contain URLs with bare `&` characters (e.g., `&timestamp=`). An\nSWC minifier bug corrupts `vfile-message` in the production DLL bundle,\ncausing `parse-entities` to throw `ReferenceError: parts is not defined`\nduring markdown parsing in `parseCommentString`. The fix wraps\n`processor.parse()` in a try/catch so that if parsing fails, the comment\nis returned as a plain text node instead of crashing the entire page.\n\n## How to Test\n\n1. Start Kibana, create a case, and add a comment containing a URL with\nquery params:\n`https://example.com/path?index=foo&timestamp=2026-05-08T17:39:26.459Z`\n2. Verify the case view renders without crashing — the comment should\ndisplay correctly\n3. Open the comment for editing — the original content (including\n`&timestamp=`) should be preserved as-is\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0fc19cafa92779a4ac86c0fa9daf06d2053e1151","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","ci:cloud-deploy","ci:project-deploy-security","ci:project-persist-deployment","Team:Cases","v9.5.0"],"title":"[Cases] Fix crash on bare ampersands in markdown content","number":269844,"url":"https://github.com/elastic/kibana/pull/269844","mergeCommit":{"message":"[Cases] Fix crash on bare ampersands in markdown content (#269844)\n\n## What & Why\n\nFixes a full-page crash\n([#268564](https://github.com/elastic/kibana/issues/268564)) when case\ncomments contain URLs with bare `&` characters (e.g., `&timestamp=`). An\nSWC minifier bug corrupts `vfile-message` in the production DLL bundle,\ncausing `parse-entities` to throw `ReferenceError: parts is not defined`\nduring markdown parsing in `parseCommentString`. The fix wraps\n`processor.parse()` in a try/catch so that if parsing fails, the comment\nis returned as a plain text node instead of crashing the entire page.\n\n## How to Test\n\n1. Start Kibana, create a case, and add a comment containing a URL with\nquery params:\n`https://example.com/path?index=foo&timestamp=2026-05-08T17:39:26.459Z`\n2. Verify the case view renders without crashing — the comment should\ndisplay correctly\n3. Open the comment for editing — the original content (including\n`&timestamp=`) should be preserved as-is\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0fc19cafa92779a4ac86c0fa9daf06d2053e1151"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269844","number":269844,"mergeCommit":{"message":"[Cases] Fix crash on bare ampersands in markdown content (#269844)\n\n## What & Why\n\nFixes a full-page crash\n([#268564](https://github.com/elastic/kibana/issues/268564)) when case\ncomments contain URLs with bare `&` characters (e.g., `&timestamp=`). An\nSWC minifier bug corrupts `vfile-message` in the production DLL bundle,\ncausing `parse-entities` to throw `ReferenceError: parts is not defined`\nduring markdown parsing in `parseCommentString`. The fix wraps\n`processor.parse()` in a try/catch so that if parsing fails, the comment\nis returned as a plain text node instead of crashing the entire page.\n\n## How to Test\n\n1. Start Kibana, create a case, and add a comment containing a URL with\nquery params:\n`https://example.com/path?index=foo&timestamp=2026-05-08T17:39:26.459Z`\n2. Verify the case view renders without crashing — the comment should\ndisplay correctly\n3. Open the comment for editing — the original content (including\n`&timestamp=`) should be preserved as-is\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0fc19cafa92779a4ac86c0fa9daf06d2053e1151"}},{"url":"https://github.com/elastic/kibana/pull/270178","number":270178,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->