### PR TITLE
[Fleet] Remove single input/single datastreams toggle removal

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_config.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_config.tsx
@@ -106,7 +106,6 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
   varGroups?: RegistryVarGroup[];
   varGroupSelections?: VarGroupSelection;
   onVarGroupSelectionChange?: (groupName: string, optionName: string) => void;
-  showDescriptionColumn?: boolean;
   streamAdvancedVars?: StreamAdvancedVarsConfig;
   sections?: RegistrySection[];
   isUpgrade?: boolean;
@@ -122,7 +121,6 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
     varGroups,
     varGroupSelections = {},
     onVarGroupSelectionChange,
-    showDescriptionColumn = true,
     streamAdvancedVars,
     sections,
     isUpgrade = false,
@@ -190,71 +188,69 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
     const flexWidth = isBiggerScreen ? 7 : 5;
 
     return (
-      <EuiFlexGrid columns={showDescriptionColumn ? 2 : 1} gutterSize="l">
-        {showDescriptionColumn ? (
-          <EuiFlexItem>
-            <EuiFlexGroup gutterSize="none" alignItems="flexStart">
-              <EuiFlexItem grow={1} />
-              <EuiFlexItem grow={flexWidth}>
-                <EuiText>
-                  <h4>
-                    <FormattedMessage
-                      id="xpack.fleet.createPackagePolicy.stepConfigure.inputSettingsTitle"
-                      defaultMessage="Settings"
-                    />
-                  </h4>
-                </EuiText>
-                {hasInputStreams ? (
-                  <>
-                    <EuiSpacer size="s" />
-                    <EuiText color="subdued" size="s">
-                      <p>
+      <EuiFlexGrid columns={2} gutterSize="l">
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="none" alignItems="flexStart">
+            <EuiFlexItem grow={1} />
+            <EuiFlexItem grow={flexWidth}>
+              <EuiText>
+                <h4>
+                  <FormattedMessage
+                    id="xpack.fleet.createPackagePolicy.stepConfigure.inputSettingsTitle"
+                    defaultMessage="Settings"
+                  />
+                </h4>
+              </EuiText>
+              {hasInputStreams ? (
+                <>
+                  <EuiSpacer size="s" />
+                  <EuiText color="subdued" size="s">
+                    <p>
+                      <FormattedMessage
+                        id="xpack.fleet.createPackagePolicy.stepConfigure.inputSettingsDescription"
+                        defaultMessage="The following settings are applicable to all inputs below."
+                      />
+                    </p>
+                  </EuiText>
+                </>
+              ) : null}
+              {hasRequiredVarGroupErrors && (
+                <>
+                  <EuiSpacer size="m" />
+                  <EuiAccordion
+                    id={`${packagePolicyInput.type}-required-vars-group-error`}
+                    paddingSize="s"
+                    buttonContent={
+                      <EuiText color="danger" size="s">
                         <FormattedMessage
-                          id="xpack.fleet.createPackagePolicy.stepConfigure.inputSettingsDescription"
-                          defaultMessage="The following settings are applicable to all inputs below."
+                          id="xpack.fleet.createPackagePolicy.stepConfigure.requiredVarsGroupErrorText"
+                          defaultMessage="One of these settings groups is required"
                         />
-                      </p>
-                    </EuiText>
-                  </>
-                ) : null}
-                {hasRequiredVarGroupErrors && (
-                  <>
-                    <EuiSpacer size="m" />
-                    <EuiAccordion
-                      id={`${packagePolicyInput.type}-required-vars-group-error`}
-                      paddingSize="s"
-                      buttonContent={
-                        <EuiText color="danger" size="s">
-                          <FormattedMessage
-                            id="xpack.fleet.createPackagePolicy.stepConfigure.requiredVarsGroupErrorText"
-                            defaultMessage="One of these settings groups is required"
-                          />
-                        </EuiText>
-                      }
-                    >
-                      <EuiText size="xs" color="danger">
-                        {Object.entries(inputValidationResults.required_vars || {}).map(
-                          ([groupName, vars]) => {
-                            return (
-                              <>
-                                <strong>{groupName}</strong>
-                                <ul>
-                                  {vars.map(({ name }) => (
-                                    <li key={`${groupName}-${name}`}>{name}</li>
-                                  ))}
-                                </ul>
-                              </>
-                            );
-                          }
-                        )}
                       </EuiText>
-                    </EuiAccordion>
-                  </>
-                )}
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        ) : null}
+                    }
+                  >
+                    <EuiText size="xs" color="danger">
+                      {Object.entries(inputValidationResults.required_vars || {}).map(
+                        ([groupName, vars]) => {
+                          return (
+                            <>
+                              <strong>{groupName}</strong>
+                              <ul>
+                                {vars.map(({ name }) => (
+                                  <li key={`${groupName}-${name}`}>{name}</li>
+                                ))}
+                              </ul>
+                            </>
+                          );
+                        }
+                      )}
+                    </EuiText>
+                  </EuiAccordion>
+                </>
+              )}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
         <EuiFlexItem>
           <EuiFlexGroup direction="column" gutterSize="m">
             {renderVarsWithSections(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.test.tsx
@@ -765,7 +765,7 @@ describe('PackagePolicyInputPanel', () => {
       });
     });
 
-    it('should render title without toggle switch when isSingleInputAndStreams is true', async () => {
+    it('should render toggle switch when isSingleInputAndStreams is true', async () => {
       const simpleStreams: RegistryStreamWithDataStream[] = [
         {
           input: 'logfile',
@@ -819,11 +819,8 @@ describe('PackagePolicyInputPanel', () => {
       );
       await waitFor(() => {
         expect(
-          renderResult.getByTestId('PackagePolicy.InputStreamConfig.title')
+          renderResult.getByTestId('PackagePolicy.InputStreamConfig.Switch')
         ).toBeInTheDocument();
-        expect(
-          renderResult.queryByTestId('PackagePolicy.InputStreamConfig.Switch')
-        ).not.toBeInTheDocument();
       });
     });
 
@@ -1079,7 +1076,7 @@ describe('PackagePolicyInputPanel', () => {
       streams: [packagePolicyInput.streams[0]],
     } as NewPackagePolicyInput;
 
-    it('should render title without toggle switch when isSingleInputAndStreams is true', async () => {
+    it('should render toggle switch when isSingleInputAndStreams is true', async () => {
       renderResult = testRenderer.render(
         <PackagePolicyInputPanel
           packageInfo={mockPackageInfo}
@@ -1093,11 +1090,8 @@ describe('PackagePolicyInputPanel', () => {
       );
       await waitFor(() => {
         expect(
-          renderResult.getByTestId('PackagePolicy.InputStreamConfig.title')
+          renderResult.getByTestId('PackagePolicy.InputStreamConfig.Switch')
         ).toBeInTheDocument();
-        expect(
-          renderResult.queryByTestId('PackagePolicy.InputStreamConfig.Switch')
-        ).not.toBeInTheDocument();
       });
     });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
@@ -408,28 +408,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
       <>
         {/* Header / input-level toggle */}
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-          {isSingleInputAndStreams ? (
-            <EuiFlexItem grow={false}>
-              <EuiFlexGroup alignItems="center" gutterSize="s">
-                <EuiFlexItem grow={false}>
-                  <EuiTitle size="xs">
-                    <h3
-                      data-test-subj="PackagePolicy.InputStreamConfig.title"
-                      style={
-                        isDeprecatedInput ? { color: theme.euiTheme.colors.textSubdued } : undefined
-                      }
-                    >
-                      {packageInput.title || packageInput.type}
-                    </h3>
-                  </EuiTitle>
-                </EuiFlexItem>
-                {inputReleaseBadge && <EuiFlexItem grow={false}>{inputReleaseBadge}</EuiFlexItem>}
-                {migrationTooltip}
-              </EuiFlexGroup>
-              <EuiSpacer size="s" />
-              {showTopLevelDescription && topLevelDescription}
-            </EuiFlexItem>
-          ) : (
+          {
             <EuiFlexItem grow={false}>
               <EuiSwitch
                 data-test-subj="PackagePolicy.InputStreamConfig.Switch"
@@ -486,7 +465,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
               <EuiSpacer size="s" />
               {showTopLevelDescription && topLevelDescription}
             </EuiFlexItem>
-          )}
+          }
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="s" alignItems="center">
               {/* Bubble up deprecation warning when collapsed and input has deprecated features */}
@@ -519,7 +498,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
                   </EuiText>
                 </EuiFlexItem>
               ) : null}
-              {(!isSingleInputAndStreams || packageInfo.type === 'input') && (
+              {
                 <EuiFlexItem grow={false}>
                   <EuiButtonEmpty
                     color={hasErrors ? 'danger' : 'primary'}
@@ -545,7 +524,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
                     }
                   </EuiButtonEmpty>
                 </EuiFlexItem>
-              )}
+              }
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -572,7 +551,6 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
               varGroups={inputVarGroups}
               varGroupSelections={inputVarGroupSelections}
               onVarGroupSelectionChange={handleInputVarGroupSelectionChange}
-              showDescriptionColumn={!isSingleInputAndStreams}
               streamAdvancedVars={consolidatedStreamAdvancedVars}
               sections={packageInput.sections}
               isUpgrade={isUpgrade}
@@ -600,7 +578,6 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
                     hasStreamToggle={hasStreamToggle}
                     packagePolicyInputStream={packagePolicyInputStream!}
                     inputPolicyTemplate={packagePolicyInput.policy_template}
-                    showDescriptionColumn={!isSingleInputAndStreams}
                     isUpgrade={isUpgrade}
                     updatePackagePolicyInputStream={(
                       updatedStream: Partial<PackagePolicyInputStream>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_stream.tsx
@@ -85,7 +85,6 @@ interface Props {
   isEditPage?: boolean;
   isUpgrade?: boolean;
   hasStreamToggle?: boolean;
-  showDescriptionColumn?: boolean;
   varGroupSelections?: Record<string, string>;
   /** Parent input's `policy_template`; required for correct composable multi-template matching. */
   inputPolicyTemplate?: string;
@@ -102,7 +101,6 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
     isEditPage,
     isUpgrade,
     hasStreamToggle = true,
-    showDescriptionColumn = true,
     varGroupSelections = {},
     inputPolicyTemplate,
   }) => {
@@ -298,119 +296,117 @@ export const PackagePolicyInputStreamConfig = memo<Props>(
     return (
       <>
         <EuiFlexGrid
-          columns={showDescriptionColumn ? 2 : 1}
+          columns={2}
           data-test-subj={`streamOptions.inputStreams.${packageInputStream.data_stream.dataset}`}
         >
           <ScrollAnchor ref={containerRef} />
-          {showDescriptionColumn || hasStreamToggle || hasRequiredVarGroupErrors ? (
-            <EuiFlexItem>
-              <EuiFlexGroup gutterSize="none" alignItems="flexStart">
-                <EuiFlexItem grow={1} />
-                <EuiFlexItem grow={flexWidth}>
-                  {hasStreamToggle && (
-                    <>
-                      <EuiFlexGroup
-                        gutterSize="none"
-                        alignItems="flexStart"
-                        justifyContent="spaceBetween"
-                      >
-                        <EuiFlexItem grow={false}>
-                          <EuiFlexGroup alignItems="center" gutterSize="s">
-                            <EuiFlexItem grow={false}>
-                              <EuiSwitch
-                                data-test-subj="streamOptions.switch"
-                                label={packageInputStream.title}
-                                disabled={packagePolicyInputStream.keep_enabled}
-                                checked={packagePolicyInputStream.enabled}
-                                onChange={(e) => {
-                                  const enabled = e.target.checked;
-                                  updatePackagePolicyInputStream({
-                                    enabled,
-                                  });
-                                }}
-                              />
-                            </EuiFlexItem>
-                            {showStreamDeprecationIcon && (
-                              <EuiFlexItem grow={false}>
-                                <span data-test-subj="streamOptions.deprecatedIcon">
-                                  <EuiIconTip
-                                    type="warning"
-                                    color="warning"
-                                    position="top"
-                                    content={streamDeprecationTooltip}
-                                  />
-                                </span>
-                              </EuiFlexItem>
-                            )}
-                            {isUpgrade &&
-                              packagePolicyInputStream.migrate_from &&
-                              !showStreamDeprecationIcon && (
-                                <MigrationTooltip
-                                  migrateFrom={packagePolicyInputStream.migrate_from}
-                                  isStream
-                                />
-                              )}
-                          </EuiFlexGroup>
-                        </EuiFlexItem>
-                        {packageInputStream.data_stream.release &&
-                        packageInputStream.data_stream.release !== 'ga' ? (
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize="none" alignItems="flexStart">
+              <EuiFlexItem grow={1} />
+              <EuiFlexItem grow={flexWidth}>
+                {hasStreamToggle && (
+                  <>
+                    <EuiFlexGroup
+                      gutterSize="none"
+                      alignItems="flexStart"
+                      justifyContent="spaceBetween"
+                    >
+                      <EuiFlexItem grow={false}>
+                        <EuiFlexGroup alignItems="center" gutterSize="s">
                           <EuiFlexItem grow={false}>
-                            <InlineReleaseBadge
-                              release={mapPackageReleaseToIntegrationCardRelease(
-                                packageInputStream.data_stream.release
-                              )}
+                            <EuiSwitch
+                              data-test-subj="streamOptions.switch"
+                              label={packageInputStream.title}
+                              disabled={packagePolicyInputStream.keep_enabled}
+                              checked={packagePolicyInputStream.enabled}
+                              onChange={(e) => {
+                                const enabled = e.target.checked;
+                                updatePackagePolicyInputStream({
+                                  enabled,
+                                });
+                              }}
                             />
                           </EuiFlexItem>
-                        ) : null}
-                      </EuiFlexGroup>
-                      {packageInputStream.description ? (
-                        <>
-                          <EuiSpacer size="s" />
-                          <EuiText size="s" color="subdued">
-                            <ReactMarkdown>{packageInputStream.description}</ReactMarkdown>
-                          </EuiText>
-                        </>
-                      ) : null}
-                    </>
-                  )}
-                  {hasRequiredVarGroupErrors && (
-                    <>
-                      <EuiSpacer size="m" />
-                      <EuiAccordion
-                        id={`${packageInputStream.data_stream.type}-${packageInputStream.data_stream.dataset}-required-vars-group-error`}
-                        paddingSize="s"
-                        buttonContent={
-                          <EuiText color="danger" size="s">
-                            <FormattedMessage
-                              id="xpack.fleet.createPackagePolicy.stepConfigure.requiredVarsGroupErrorText"
-                              defaultMessage="One of these settings groups is required"
-                            />
-                          </EuiText>
-                        }
-                      >
-                        <EuiText size="xs" color="danger">
-                          {Object.entries(inputStreamValidationResults?.required_vars || {}).map(
-                            ([groupName, vars]) => {
-                              return (
-                                <>
-                                  <strong>{groupName}</strong>
-                                  <ul>
-                                    {vars.map(({ name }) => (
-                                      <li key={`${groupName}-${name}`}>{name}</li>
-                                    ))}
-                                  </ul>
-                                </>
-                              );
-                            }
+                          {showStreamDeprecationIcon && (
+                            <EuiFlexItem grow={false}>
+                              <span data-test-subj="streamOptions.deprecatedIcon">
+                                <EuiIconTip
+                                  type="warning"
+                                  color="warning"
+                                  position="top"
+                                  content={streamDeprecationTooltip}
+                                />
+                              </span>
+                            </EuiFlexItem>
                           )}
+                          {isUpgrade &&
+                            packagePolicyInputStream.migrate_from &&
+                            !showStreamDeprecationIcon && (
+                              <MigrationTooltip
+                                migrateFrom={packagePolicyInputStream.migrate_from}
+                                isStream
+                              />
+                            )}
+                        </EuiFlexGroup>
+                      </EuiFlexItem>
+                      {packageInputStream.data_stream.release &&
+                      packageInputStream.data_stream.release !== 'ga' ? (
+                        <EuiFlexItem grow={false}>
+                          <InlineReleaseBadge
+                            release={mapPackageReleaseToIntegrationCardRelease(
+                              packageInputStream.data_stream.release
+                            )}
+                          />
+                        </EuiFlexItem>
+                      ) : null}
+                    </EuiFlexGroup>
+                    {packageInputStream.description ? (
+                      <>
+                        <EuiSpacer size="s" />
+                        <EuiText size="s" color="subdued">
+                          <ReactMarkdown>{packageInputStream.description}</ReactMarkdown>
                         </EuiText>
-                      </EuiAccordion>
-                    </>
-                  )}
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          ) : null}
+                      </>
+                    ) : null}
+                  </>
+                )}
+                {hasRequiredVarGroupErrors && (
+                  <>
+                    <EuiSpacer size="m" />
+                    <EuiAccordion
+                      id={`${packageInputStream.data_stream.type}-${packageInputStream.data_stream.dataset}-required-vars-group-error`}
+                      paddingSize="s"
+                      buttonContent={
+                        <EuiText color="danger" size="s">
+                          <FormattedMessage
+                            id="xpack.fleet.createPackagePolicy.stepConfigure.requiredVarsGroupErrorText"
+                            defaultMessage="One of these settings groups is required"
+                          />
+                        </EuiText>
+                      }
+                    >
+                      <EuiText size="xs" color="danger">
+                        {Object.entries(inputStreamValidationResults?.required_vars || {}).map(
+                          ([groupName, vars]) => {
+                            return (
+                              <>
+                                <strong>{groupName}</strong>
+                                <ul>
+                                  {vars.map(({ name }) => (
+                                    <li key={`${groupName}-${name}`}>{name}</li>
+                                  ))}
+                                </ul>
+                              </>
+                            );
+                          }
+                        )}
+                      </EuiText>
+                    </EuiAccordion>
+                  </>
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="m">
               {/* Stream-level Var Group Selectors */}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.test.tsx
@@ -711,7 +711,7 @@ describe('isSingleInputAndStreams behavior', () => {
     mockUpdatePackagePolicy.mockClear();
   });
 
-  it('should render title without toggle switch when feature flag is on, single policy template, single input, and single stream', async () => {
+  it('should render toggle switch when feature flag is on, single policy template, single input, and single stream', async () => {
     ExperimentalFeaturesService.init({
       ...allowedExperimentalValues,
       enableSimplifiedAgentlessUX: true,
@@ -733,10 +733,9 @@ describe('isSingleInputAndStreams behavior', () => {
     );
 
     await waitFor(() => {
-      expect(renderResult.getByTestId('PackagePolicy.InputStreamConfig.title')).toBeInTheDocument();
       expect(
-        renderResult.queryByTestId('PackagePolicy.InputStreamConfig.Switch')
-      ).not.toBeInTheDocument();
+        renderResult.getByTestId('PackagePolicy.InputStreamConfig.Switch')
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Revert changes made in https://github.com/elastic/kibana/pull/254721

Even with single input and datastreams the toggle is used by user to configure an integration without sending data, so we should keep it.

as discussed with @nimarezainia 


## UI Changes 

<img width="961" height="488" alt="Screenshot 2026-05-20 at 10 31 24 AM" src="https://github.com/user-attachments/assets/70ddca81-8ca9-4c1e-a3d2-ca43a32415fc" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->