### PR TITLE
[kbn-ui] Use kv read instead of kv get

### DIFF
--- a/.buildkite/scripts/common/vault_fns.sh
+++ b/.buildkite/scripts/common/vault_fns.sh
@@ -64,9 +64,9 @@ vault_kv_get() {
   local field=${2:-}
 
   if [[ -z "$field" || "$field" =~ ^-.* ]]; then
-    retry 5 5 vault kv get "$kv_path" "${@:2}"
+    retry 5 5 vault read "$kv_path" "${@:2}"
   else
-    retry 5 5 vault kv get -field="$field" "$kv_path" "${@:3}"
+    retry 5 5 vault read -field="$field" "$kv_path" "${@:3}"
   fi
 }
 


### PR DESCRIPTION
## Summary

With https://github.com/elastic/kibana/pull/269329 we introduced a few changes related to how we consume the npm_token in the kbn-ui pipeline. This had an unfortunate error: `vault kv get <path>` rewrites the URL to `/v1/<mount>/data/<subpath>` automatically for KV v2 semantics. The actual secret is stored without that `/data/` segment, so vault read (which issues a direct `GET /v1/<path>`) is the right command we should be using here. 
