### PR TITLE
[Dashboards] Fix links panel flyout height in both Solution and Classic views

### DIFF
--- a/src/platform/plugins/private/links/public/components/editor/links_editor.tsx
+++ b/src/platform/plugins/private/links/public/components/editor/links_editor.tsx
@@ -347,7 +347,7 @@ const styles = {
     return css({
       '.linkEditor': {
         maxInlineSize: `calc(${euiTheme.size.xs} * 125)`,
-        height: 'var(--kbn-application--content-height)',
+        height: 'var(--kbn-layout--application-height)',
         position: 'fixed',
         display: 'flex',
         inlineSize: '50vw',


### PR DESCRIPTION
Resolves #266415 #249260

This PR fixes the Links panel flyout height issue in both Solution View and Classic Dashboard View.

### Summary of the fix:
Updated the Links editor flyout height to use `--kbn-layout--application-height` instead of `--kbn-application--content-height`.
The nested link editor used `--kbn-application--content-height `(content area only, excluding the 48px Solution app top bar), so it was shorter than the parent EuiFlyout sized to the full application area (`--kbn-layout--application-height`), leaving the panel footer visible underneath.


The issue has appeared multiple times over time, so for reference I’m attaching links to previous related issues and fixes:

Issues: https://github.com/elastic/kibana/issues/249260, https://github.com/elastic/kibana/issues/266415
Fixes: https://github.com/elastic/kibana/pull/228730, https://github.com/elastic/kibana/pull/249294

Based on current testing, the Links panel layout height is now rendered correctly in both views. See the video:

https://github.com/user-attachments/assets/36edbaa1-2cbc-4325-8892-da8de64b84c3


**Adding this note for future monitoring:** when making changes related to Links panel flyout sizing, please verify the behavior in both Solution View and Classic Dashboard View, as the layouts differ and regressions may appear only in one of them.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->