### PR TITLE
[dev-utils] Prefer native tar when available

### DIFF
--- a/src/platform/packages/shared/kbn-dev-utils/src/extract.test.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/extract.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Fs from 'fs/promises';
+import Os from 'os';
+import Path from 'path';
+
+import execa from 'execa';
+import * as tar from 'tar';
+
+import { extract } from './extract';
+
+jest.mock('execa');
+jest.mock('tar', () => ({
+  extract: jest.fn(),
+}));
+
+const mockExeca = execa as unknown as jest.Mock;
+const mockTarExtract = tar.extract as unknown as jest.Mock;
+
+describe('extract', () => {
+  let targetDir: string;
+
+  beforeEach(async () => {
+    targetDir = await Fs.mkdtemp(Path.join(Os.tmpdir(), 'kbn-dev-utils-extract-test-'));
+
+    mockExeca.mockReset();
+    mockExeca.mockResolvedValue({});
+
+    mockTarExtract.mockReset();
+    mockTarExtract.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await Fs.rm(targetDir, { recursive: true, force: true });
+  });
+
+  it('uses native tar for tar.gz archives', async () => {
+    await extract({
+      archivePath: '/tmp/elasticsearch.tar.gz',
+      targetDir,
+      stripComponents: 1,
+    });
+
+    expect(mockExeca).toHaveBeenNthCalledWith(1, 'tar', [
+      '--use-compress-program=pigz',
+      '-xf',
+      '/tmp/elasticsearch.tar.gz',
+      '-C',
+      targetDir,
+      '--strip-components=1',
+    ]);
+    expect(mockTarExtract).not.toHaveBeenCalled();
+  });
+
+  it('falls back to regular native tar when parallel gzip extraction fails', async () => {
+    mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args[0] === '--use-compress-program=pigz') {
+        throw new Error('unsupported option');
+      }
+
+      return {};
+    });
+
+    await extract({
+      archivePath: '/tmp/elasticsearch.tar.gz',
+      targetDir,
+      stripComponents: 1,
+    });
+
+    expect(mockExeca).toHaveBeenLastCalledWith('tar', [
+      '-xzf',
+      '/tmp/elasticsearch.tar.gz',
+      '-C',
+      targetDir,
+      '--strip-components=1',
+    ]);
+    expect(mockTarExtract).not.toHaveBeenCalled();
+  });
+
+  it('uses native tar for uncompressed tar archives', async () => {
+    await extract({
+      archivePath: '/tmp/elasticsearch.tar',
+      targetDir,
+      stripComponents: 0,
+    });
+
+    expect(mockExeca).toHaveBeenCalledWith('tar', [
+      '-xf',
+      '/tmp/elasticsearch.tar',
+      '-C',
+      targetDir,
+      '--strip-components=0',
+    ]);
+    expect(mockTarExtract).not.toHaveBeenCalled();
+  });
+
+  it('falls back to node tar when native tar fails', async () => {
+    mockExeca.mockRejectedValue(new Error('tar failed'));
+
+    await extract({
+      archivePath: '/tmp/elasticsearch.tar.gz',
+      targetDir,
+      stripComponents: 1,
+    });
+
+    expect(mockExeca).toHaveBeenCalledTimes(2);
+    expect(mockTarExtract).toHaveBeenCalledWith({
+      file: '/tmp/elasticsearch.tar.gz',
+      cwd: targetDir,
+      stripComponents: 1,
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-dev-utils/src/extract.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/extract.ts
@@ -13,6 +13,7 @@ import Path from 'path';
 import { pipeline } from 'stream';
 import { promisify } from 'util';
 
+import execa from 'execa';
 import * as tar from 'tar';
 import type { ZipFile, Entry } from 'yauzl';
 import Yauzl from 'yauzl';
@@ -25,6 +26,52 @@ const strComplete = (obs: Rx.Observable<unknown>) =>
   });
 
 const asyncPipeline = promisify(pipeline);
+
+const getNativeTarArgsList = ({
+  archivePath,
+  targetDir,
+  stripComponents,
+}: Pick<Options, 'archivePath' | 'targetDir'> & { stripComponents: number }) => {
+  const commonArgs = [archivePath, '-C', targetDir, `--strip-components=${stripComponents}`];
+
+  if (!archivePath.endsWith('.tar.gz')) {
+    return [['-xf', ...commonArgs]];
+  }
+
+  return [
+    ['--use-compress-program=pigz', '-xf', ...commonArgs],
+    ['-xzf', ...commonArgs],
+  ];
+};
+
+const extractWithNativeTar = async ({
+  archivePath,
+  targetDir,
+  stripComponents,
+}: Pick<Options, 'archivePath' | 'targetDir'> & { stripComponents: number }) => {
+  for (const args of getNativeTarArgsList({ archivePath, targetDir, stripComponents })) {
+    try {
+      await execa('tar', args);
+      return true;
+    } catch {
+      // Try the next native tar strategy, then fall back to node tar.
+    }
+  }
+
+  return false;
+};
+
+const extractWithNodeTar = async ({
+  archivePath,
+  targetDir,
+  stripComponents,
+}: Pick<Options, 'archivePath' | 'targetDir'> & { stripComponents: number }) => {
+  await tar.extract({
+    file: archivePath,
+    cwd: targetDir,
+    stripComponents,
+  });
+};
 
 interface Options {
   /**
@@ -63,11 +110,11 @@ export async function extract({
   await Fs.mkdir(targetDir, { recursive: true });
 
   if (archivePath.endsWith('.tar') || archivePath.endsWith('.tar.gz')) {
-    return await tar.extract({
-      file: archivePath,
-      cwd: targetDir,
-      stripComponents,
-    });
+    if (await extractWithNativeTar({ archivePath, targetDir, stripComponents })) {
+      return;
+    }
+
+    return await extractWithNodeTar({ archivePath, targetDir, stripComponents });
   }
 
   if (!archivePath.endsWith('.zip')) {


### PR DESCRIPTION
On CI, this runs ~twice as fast as the js implementation.  

This method is used for every stateful ftr suite to extract es (-7 seconds), and to load es data folders when applicable.