### PR TITLE
[8.19] Fix Console to preserve repeated query parameters in Kibana API requests (#249135)

### DIFF
--- a/src/platform/plugins/shared/console/public/lib/es/es.test.ts
+++ b/src/platform/plugins/shared/console/public/lib/es/es.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { httpServiceMock } from '@kbn/core/public/mocks';
+import { send } from './es';
+import { KIBANA_API_PREFIX } from '../../../common/constants';
+
+describe('es', () => {
+  describe('send', () => {
+    describe('query params handling for Kibana API requests', () => {
+      it('should handle repeated keys with different values as an array', async () => {
+        const mockHttp = httpServiceMock.createSetupContract();
+
+        await send({
+          http: mockHttp,
+          method: 'GET',
+          path: `${KIBANA_API_PREFIX}/api/test?tag=first&tag=second&tag=third`,
+        });
+
+        expect(mockHttp.get).toHaveBeenCalledWith(
+          '/api/test',
+          expect.objectContaining({
+            query: { tag: ['first', 'second', 'third'] },
+          })
+        );
+      });
+
+      it('should handle repeated keys with duplicate values as an array', async () => {
+        const mockHttp = httpServiceMock.createSetupContract();
+
+        await send({
+          http: mockHttp,
+          method: 'GET',
+          path: `${KIBANA_API_PREFIX}/api/test?tag=same&tag=same`,
+        });
+
+        expect(mockHttp.get).toHaveBeenCalledWith(
+          '/api/test',
+          expect.objectContaining({
+            query: { tag: ['same', 'same'] },
+          })
+        );
+      });
+
+      it('should handle mixed single and repeated keys', async () => {
+        const mockHttp = httpServiceMock.createSetupContract();
+
+        await send({
+          http: mockHttp,
+          method: 'GET',
+          path: `${KIBANA_API_PREFIX}/api/test?single=value&multi=first&multi=second`,
+        });
+
+        expect(mockHttp.get).toHaveBeenCalledWith(
+          '/api/test',
+          expect.objectContaining({
+            query: { single: 'value', multi: ['first', 'second'] },
+          })
+        );
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/console/public/lib/es/es.ts
+++ b/src/platform/plugins/shared/console/public/lib/es/es.ts
@@ -49,7 +49,12 @@ export async function send({
     const httpMethod = method.toLowerCase() as Method;
     const url = new URL(kibanaRequestUrl);
     const { pathname, searchParams } = url;
-    const query = Object.fromEntries(searchParams.entries());
+    const query = Object.fromEntries(
+      [...new Set(searchParams.keys())].map((key) => {
+        const values = searchParams.getAll(key);
+        return [key, values.length === 1 ? values[0] : values];
+      })
+    );
     const body = ['post', 'put', 'patch'].includes(httpMethod) ? data : null;
 
     return await http[httpMethod]<HttpResponse>(pathname, {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix Console to preserve repeated query parameters in Kibana API requests (#249135)](https://github.com/elastic/kibana/pull/249135)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2026-01-21T07:16:21Z","message":"Fix Console to preserve repeated query parameters in Kibana API requests (#249135)\n\n### Summary\n\nUpdates the Console plugin's `send` function to correctly handle\nrepeated query parameters when forwarding requests to Kibana APIs.\n\n### Problem\n\nPreviously, `Object.fromEntries(searchParams.entries())` was used to\nconvert URL search params to a query object. This approach silently\ndrops duplicate keys. For a URL like `?filter=a&filter=b`, only the last\nvalue (`b`) would be preserved.\n\n### Solution\n\nReplaced with logic that:\n1. Iterates over unique keys using `Set(searchParams.keys())`\n2. Uses `getAll(key)` to retrieve all values for each key\n3. Stores single values as strings, multiple values as arrays\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/76b35525-9f90-471a-bf2b-cd501b20af2d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/22c994c0-e8c3-4184-a515-49f9d3d94414","sha":"fadb4603da9f8779353861a07deecc11d79efbde","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.4.0","author:actionable-obs"],"title":"Fix Console to preserve repeated query parameters in Kibana API requests","number":249135,"url":"https://github.com/elastic/kibana/pull/249135","mergeCommit":{"message":"Fix Console to preserve repeated query parameters in Kibana API requests (#249135)\n\n### Summary\n\nUpdates the Console plugin's `send` function to correctly handle\nrepeated query parameters when forwarding requests to Kibana APIs.\n\n### Problem\n\nPreviously, `Object.fromEntries(searchParams.entries())` was used to\nconvert URL search params to a query object. This approach silently\ndrops duplicate keys. For a URL like `?filter=a&filter=b`, only the last\nvalue (`b`) would be preserved.\n\n### Solution\n\nReplaced with logic that:\n1. Iterates over unique keys using `Set(searchParams.keys())`\n2. Uses `getAll(key)` to retrieve all values for each key\n3. Stores single values as strings, multiple values as arrays\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/76b35525-9f90-471a-bf2b-cd501b20af2d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/22c994c0-e8c3-4184-a515-49f9d3d94414","sha":"fadb4603da9f8779353861a07deecc11d79efbde"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249135","number":249135,"mergeCommit":{"message":"Fix Console to preserve repeated query parameters in Kibana API requests (#249135)\n\n### Summary\n\nUpdates the Console plugin's `send` function to correctly handle\nrepeated query parameters when forwarding requests to Kibana APIs.\n\n### Problem\n\nPreviously, `Object.fromEntries(searchParams.entries())` was used to\nconvert URL search params to a query object. This approach silently\ndrops duplicate keys. For a URL like `?filter=a&filter=b`, only the last\nvalue (`b`) would be preserved.\n\n### Solution\n\nReplaced with logic that:\n1. Iterates over unique keys using `Set(searchParams.keys())`\n2. Uses `getAll(key)` to retrieve all values for each key\n3. Stores single values as strings, multiple values as arrays\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/76b35525-9f90-471a-bf2b-cd501b20af2d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/22c994c0-e8c3-4184-a515-49f9d3d94414","sha":"fadb4603da9f8779353861a07deecc11d79efbde"}}]}] BACKPORT-->