### PR TITLE
[Links] Remove unsupported enhancements property in links transformOut

### DIFF
--- a/src/platform/plugins/private/links/common/embeddable/transforms/transform_out.test.ts
+++ b/src/platform/plugins/private/links/common/embeddable/transforms/transform_out.test.ts
@@ -109,6 +109,32 @@ describe('transformOut', () => {
     `);
   });
 
+  test('should strip out unsupported properties from by-value state', () => {
+    const legacyState = {
+      title: 'Custom title',
+      layout: 'vertical',
+      enhancements: {}, // unsupported
+      links: [
+        {
+          type: 'externalLink',
+          destination: 'https://example.com/',
+        },
+      ],
+    } as StoredLinksEmbeddableState;
+    expect(transformOut(legacyState, [])).toMatchInlineSnapshot(`
+      Object {
+        "layout": "vertical",
+        "links": Array [
+          Object {
+            "destination": "https://example.com/",
+            "type": "externalLink",
+          },
+        ],
+        "title": "Custom title",
+      }
+    `);
+  });
+
   test('should inject dashboard references for by-value state', () => {
     const byValueState = {
       title: 'Custom title',

--- a/src/platform/plugins/private/links/common/embeddable/transforms/transform_out.ts
+++ b/src/platform/plugins/private/links/common/embeddable/transforms/transform_out.ts
@@ -19,7 +19,7 @@ export function transformOut(
   storedState: LinksEmbeddableState | StoredLinksEmbeddableState | StoredLinksByValueState910,
   references?: Reference[]
 ) {
-  const latestState = isLegacyState(storedState)
+  const { enhancements, ...latestState } = isLegacyState(storedState)
     ? transformLegacyState(storedState)
     : (storedState as StoredLinksEmbeddableState);
   const state = {

--- a/src/platform/plugins/private/links/common/embeddable/types.ts
+++ b/src/platform/plugins/private/links/common/embeddable/types.ts
@@ -12,4 +12,6 @@ import type { StoredLinksState } from '../../server';
 
 export type { LinksByReferenceState, LinksByValueState, LinksEmbeddableState } from '../../server';
 
-export type StoredLinksEmbeddableState = SerializedTitles & StoredLinksState;
+// links never supported enhancements, but some legacy states serialized an empty enhancements object
+export type StoredLinksEmbeddableState = SerializedTitles &
+  StoredLinksState & { enhancements?: unknown };

--- a/src/platform/plugins/private/links/server/content_management/schema/v1/types.ts
+++ b/src/platform/plugins/private/links/server/content_management/schema/v1/types.ts
@@ -31,6 +31,8 @@ export type LinksState = TypeOf<typeof linksSchema>;
 export type StoredLink = StoredDashboardLink | StoredExternalLink;
 export type StoredLinksState = Omit<LinksState, 'links'> & {
   links?: StoredLink[];
+  // links never supported enhancements, but some legacy states serialized an empty enhancements object
+  enhancements?: object;
 };
 export type StoredDashboardLink = Omit<DashboardLink, 'destination'> &
   DeprecatedLinkProperties & {

--- a/src/platform/plugins/private/links/server/content_management/schema/v1/types.ts
+++ b/src/platform/plugins/private/links/server/content_management/schema/v1/types.ts
@@ -31,8 +31,6 @@ export type LinksState = TypeOf<typeof linksSchema>;
 export type StoredLink = StoredDashboardLink | StoredExternalLink;
 export type StoredLinksState = Omit<LinksState, 'links'> & {
   links?: StoredLink[];
-  // links never supported enhancements, but some legacy states serialized an empty enhancements object
-  enhancements?: object;
 };
 export type StoredDashboardLink = Omit<DashboardLink, 'destination'> &
   DeprecatedLinkProperties & {


### PR DESCRIPTION
Fixes #270190

## Summary

Strips unsupported `enhancements` property from Links embeddable API causing validation errors on integration dashboards.

Some integration dashboards serialized an empty `enhancements` object into the Links embeddable state. Since Links has never supported enhancements, we need to strip this property when transforming to API state. Fixing the integration assets is another option, but that would not resolve the error on existing customer dashboards that were duplicated from the managed integration dashboards.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->