### PR TITLE
Switch Kibana vectordb project to using the vectordb serverless profile

### DIFF
--- a/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
@@ -316,8 +316,7 @@ const normalizeProjectType = (projectType: string) => {
   }
 
   if (projectType === 'vectordb') {
-    // return 'vectordb' here once stateless ES and UIAM supports it
-    return 'elasticsearch';
+    return 'vectordb';
   }
 
   return projectType;

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -121,15 +121,13 @@ export const esProjectTypeFromKbn = new Map<string, string>([
   ['oblt', 'observability'],
   ['security', 'security'],
   ['workplaceai', 'workplaceai'],
-  // replace with 'vectordb' once stateless ES supports it
-  ['vectordb', 'elasticsearch_vector'],
+  ['vectordb', 'vectordb'],
 ]);
 
 // ES operator/settings.json expects 'elasticsearch' for all `elasticsearch_*` project types.
 export const esSettingsProjectTypeFromKbn = new Map<string, string>([
   ...esProjectTypeFromKbn.entries(),
   ['es', 'elasticsearch'],
-  ['vectordb', 'elasticsearch'],
 ]);
 
 export const kbnProjectTypeFromEs = new Map<string, string>([
@@ -139,6 +137,7 @@ export const kbnProjectTypeFromEs = new Map<string, string>([
   ['observability', 'oblt'],
   ['security', 'security'],
   ['workplaceai', 'workplaceai'],
+  ['vectordb', 'vectordb'],
 ]);
 
 export interface DockerOptions extends EsClusterExecOptions, BaseOptions {


### PR DESCRIPTION
## Summary

Switches the Kibana Vector DB project from using the Elasticsearch Serverless profile to the native Vector DB Serverless profile.

Previously, the Vector DB project was configured to use `elasticsearch_vector/elasticsearch` as a workaround while the Vector DB profile was being developed in ES Serverless. Now that ES Serverless supports the native `vectordb` project type, this PR removes the workaround and configures Vector DB to use its own profile.

### Testing

- Run `yarn es serverless --projectType vectordb` and verify ES starts with the vectordb profile
- Run `yarn serverless vectordb` to start a Vector DB project in Kibana
- Open the Kibana app and verify it starts up with the Vector DB project


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~


