### PR TITLE
[Security Solution][AutoDEX] Improve Rule Creation Skill

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -48,9 +48,17 @@ This covers the rule type ES|QL. Do not create a rule with a rule type other tha
 
 ## Core Workflow
 
-### Step 1: Always Read the Attachment First
+### Determine the path
 
-Before accessing or modifying any rule data, you MUST call \`attachment_read\` on the rule attachment to get the current state. Never assume attachment contents.
+Before doing anything, determine the user's intent and whether a rule attachment exists in the conversation context:
+
+- **Attachment exists in context** → edit path: proceed to Step 1.
+- **No attachment, creation intent** (user wants to build a new rule) → creation path: skip Step 1, go directly to Step 2 then Step 3 (create).
+- **No attachment, edit intent** (user references an existing rule they want to modify) → call \`attachment_list\` to check whether a rule attachment exists in the session but wasn't yet referenced. If one is found, proceed with the edit path. If nothing is found, tell the user that the rule needs to be open as an attachment before it can be edited, and ask them to open it first.
+
+### Step 1: Read the Attachment (edit path only)
+
+Before accessing or modifying any rule data, call \`attachment_read\` on the rule attachment to get the current state. Never assume attachment contents.
 
 ### Step 2: Research Before Creating or Editing
 
@@ -66,41 +74,42 @@ This is especially important when:
 
 ### Step 3: Create or Modify the Rule
 
-If you are creating a new rule, first apply the clarification gate:
+#### Creation path (no attachment in context)
 
-**Clarification gate**: Before calling \`security.create_detection_rule\`, check whether the request is specific enough. A request is specific enough if it includes at least one of:
+Before calling \`security.create_detection_rule\`, apply the clarification gate:
+
+**Clarification gate**: Check whether the request is specific enough. A request is specific enough if it includes at least one of:
 - A concrete behavior or indicator (e.g., "PowerShell spawning cmd.exe", "failed logins from unusual countries")
 - A data source or index hint (e.g., "Windows event logs", "authentication data")
 - A frequency or count condition (e.g., "more than 10 failures in 5 minutes")
 
 If none of the above is present, ask the user one focused question — the single most important missing piece — before generating the rule. Do not ask multiple questions at once.
 
-Once the request is specific enough:
-- **Creating a new rule**: ALWAYS use the \`security.create_detection_rule\` tool. Pass a natural language description of the detection rule to create. The tool handles rule creation AND attachment update automatically. Do NOT call \`attachment_update\`.
-- after calling the \`security.create_detection_rule\` tool, move to step 4.
-- render the latest version of the attachment inline.
+Once the request is specific enough, ALWAYS use the \`security.create_detection_rule\` tool. Pass a natural language description of the detection rule. The tool handles rule creation AND attachment creation automatically. Do NOT call \`attachment_update\`.
 
+After the tool returns, render the attachment inline.
 
-When asked to edit or update the rule or any field of the rule, use the following:
-**Editing an existing rule** (changing fields like tags, severity, description, schedule, MITRE ATT&CK, index patterns, query, etc.):
+---
+
+#### Edit path (attachment in context, or found via attachment_list)
 
 When the user says "add to the rule", "edit the rule", "change the rule", "update the rule", or any variation — they ALWAYS mean the **rule attachment**. The rule lives inside the attachment's \`text\` field as stringified JSON. There is no other rule object.
 
 Follow these steps exactly. Every step is MANDATORY:
 
-1. **Read the latest attachment** — call \`attachment_read\` to get the current version. NEVER skip this, even if you read it before. Always get the latest state.
-2. **Parse** the \`text\` field (stringified JSON of the rule).
-3. **Modify** only the fields the user asked to change. Do not add or remove other fields.
-4. **Re-stringify the ENTIRE rule object** — never send partial updates.
-5. **Call \`attachment_update\`** to persist the change:
+1. **Parse** the \`text\` field from the attachment (stringified JSON of the rule).
+2. **Modify** only the fields the user asked to change. Do not add or remove other fields.
+3. **Re-stringify the ENTIRE rule object** — never send partial updates.
+4. **Call \`attachment_update\`** to persist the change:
 \`\`\`
 attachment_update({ attachment_id: "ATTACHMENT_ID", data: { text: "<full stringified rule JSON>" } })
 \`\`\`
-- Render the latest version of the attachment inline.
+
+After the tool returns, render the attachment inline.
 
 
 Checklist before finishing the answer:
-- [ ] Did I call the tool read attachment first?
+- [ ] (Edit path only) Did I call \`attachment_list\` (if no attachment was in context) and then \`attachment_read\` before modifying?
 - [ ] Did I render inline the latest version of the attachment? ← YOU MUST DO THIS, always render the latest version of the attachment inline.
 
 ---
@@ -322,9 +331,9 @@ User says: "Add the tags Network and Lateral Movement to the rule"
 
 ## CRITICAL INSTRUCTIONS — READ CAREFULLY
 
-1. "The rule" ALWAYS refers to the rule attachment. Any request to add, edit, change, or update the rule means modifying the attachment.
+1. "The rule" ALWAYS refers to the rule attachment. Any request to add, edit, change, or update the rule means modifying the attachment — unless no attachment exists and none can be found via \`attachment_list\`, in which case tell the user to open the rule first.
 2. NEVER just suggest or describe changes — ALWAYS apply them by calling \`attachment_update\` or \`security.create_detection_rule\`. The user expects the rule to be updated, not a description of what to update.
-3. ALWAYS read the attachment before modifying it.
+3. ALWAYS read the attachment before modifying it (edit path only — skip for fresh creation).
 4. ALWAYS re-stringify the FULL rule object — never send partial updates.
 5. **ALWAYS render the attachment inline after EVERY modification** — this is the most important rule. Every single call to \`security.create_detection_rule\` or \`attachment_update\` MUST be followed by \`<render_attachment id="ATTACHMENT_ID" version="VERSION" />\` using the version from the tool result. NEVER omit this. The user cannot see changes without it.
 6. ALWAYS use \`security.create_detection_rule\` when creating a new rule.

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -48,13 +48,16 @@ This covers the rule type ES|QL. Do not create a rule with a rule type other tha
 
 ## Core Workflow
 
-### Determine the path
+### Pre-check: ensure you have what you need
 
-Before doing anything, determine the user's intent and whether a rule attachment exists in the conversation context:
+Before entering either branch, determine intent and resolve prerequisites:
 
-- **Attachment exists in context** → edit path: proceed to Step 1.
-- **No attachment, creation intent** (user wants to build a new rule) → creation path: skip Step 1, go directly to Step 2 then Step 3 (create).
-- **No attachment, edit intent** (user references an existing rule they want to modify) → call \`attachment_list\` to check whether a rule attachment exists in the session but wasn't yet referenced. If one is found, proceed with the edit path. If nothing is found, tell the user that the rule needs to be open as an attachment before it can be edited, and ask them to open it first.
+1. **User wants to create a new rule** → proceed to Step 2 then Step 3 (creation path). No attachment needed.
+2. **User wants to edit an existing rule and an attachment is already in context** → proceed to the edit branch (Step 1 → Step 2 → Step 3, edit path).
+3. **User wants to edit an existing rule but no attachment is in context** → call \`attachment_list\` to check whether a rule attachment exists in the session but wasn't yet referenced.
+   - If one is found → proceed to the edit branch.
+   - If nothing is found → call \`find_rules\` to search for rules matching the user's description. Present any matches to the user and ask them to confirm which rule they mean. Once confirmed, load it as an attachment and proceed to the edit branch.
+   - If no matching rules are found → tell the user no matching rule was found and ask them to clarify the rule name or open it manually.
 
 ### Step 1: Read the Attachment (edit path only)
 
@@ -91,7 +94,7 @@ After the tool returns, render the attachment inline.
 
 ---
 
-#### Edit path (attachment in context, or found via attachment_list)
+#### Edit path
 
 When the user says "add to the rule", "edit the rule", "change the rule", "update the rule", or any variation — they ALWAYS mean the **rule attachment**. The rule lives inside the attachment's \`text\` field as stringified JSON. There is no other rule object.
 
@@ -289,7 +292,11 @@ The lookback should be at least as long as the interval. A common pattern is int
 
 ## Complete Example: Updating Tags Step by Step
 
+_This example assumes the edit path — a rule attachment is already in context._
+
 User says: "Add the tags Network and Lateral Movement to the rule"
+
+Pre-check: attachment exists in context → edit path → proceed to Step 1.
 
 1. Call \`attachment_read\` with the rule attachment ID.
 2. The attachment \`text\` field contains:

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -268,33 +268,9 @@ The lookback should be at least as long as the interval. A common pattern is int
 
 ### Query, Language, and Type
 
-\`query\` (string): The detection query.
-\`language\` (string): Query language.
-\`type\` (string): Rule type.
-
-Always set \`type\` and \`language\` together. Supported languages per rule type:
-
-\`\`\`
-esql           → language: "esql"
-eql            → language: "eql"
-query          → language: "kuery" | "lucene"
-saved_query    → language: "kuery" | "lucene"
-threshold      → language: "kuery" | "lucene"
-threat_match   → language: "kuery" | "lucene"
-new_terms      → language: "kuery" | "lucene"
-machine_learning → no query or language fields
-\`\`\`
-
-**Example** — KQL query rule:
-\`\`\`json
-{
-  "type": "query",
-  "language": "kuery",
-  "query": "process.name: powershell.exe and event.action: start",
-  "index": ["logs-*", "winlogbeat-*"],
-  ...
-}
-\`\`\`
+\`query\` (string): The ES|QL detection query.
+\`language\` (string): Always \`"esql"\`.
+\`type\` (string): Always \`"esql"\`.
 
 ### Index Patterns
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -66,7 +66,16 @@ This is especially important when:
 
 ### Step 3: Create or Modify the Rule
 
-If you are creating a new rule, use the following:
+If you are creating a new rule, first apply the clarification gate:
+
+**Clarification gate**: Before calling \`security.create_detection_rule\`, check whether the request is specific enough. A request is specific enough if it includes at least one of:
+- A concrete behavior or indicator (e.g., "PowerShell spawning cmd.exe", "failed logins from unusual countries")
+- A data source or index hint (e.g., "Windows event logs", "authentication data")
+- A frequency or count condition (e.g., "more than 10 failures in 5 minutes")
+
+If none of the above is present, ask the user one focused question — the single most important missing piece — before generating the rule. Do not ask multiple questions at once.
+
+Once the request is specific enough:
 - **Creating a new rule**: ALWAYS use the \`security.create_detection_rule\` tool. Pass a natural language description of the detection rule to create. The tool handles rule creation AND attachment update automatically. Do NOT call \`attachment_update\`.
 - after calling the \`security.create_detection_rule\` tool, move to step 4.
 - render the latest version of the attachment inline.

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -32,7 +32,7 @@ const SKILL_CONTENT = `# Detection Rule Creation and Editing
 Use this skill when the user asks to:
 - Create a detection rule (e.g., "create a rule that detects ...", "build a SIEM rule for ...", "create a security detection rule to find ...", "create a security detection rule that ...")
 - Edit an existing rule's fields (e.g., "change the severity to high", "update the query", "set the interval to 10m", "add tags to the rule")
-- Modify rule logic or metadata (e.g., "add MITRE ATT&CK mappings", "change the index patterns", "update the description", "add new terms to the query")
+- Modify rule logic or metadata (e.g., "add MITRE ATT&CK mappings", "update the description", "update the query")
 
 Do NOT use this skill when the user:
 - Asks about alerts or alert triage (use the alert analysis skill instead)
@@ -71,7 +71,7 @@ Before creating or editing a rule, use the available research tools to ensure ac
 
 This is especially important when:
 - Creating a new rule from scratch (search for similar detections or threat context).
-- Editing queries or detection logic (verify correct syntax for the rule's language: ES|QL, EQL, KQL, Lucene).
+- Editing queries or detection logic (verify correct ES|QL syntax).
 - Adding MITRE ATT&CK mappings (confirm correct tactic/technique IDs and names).
 - Working with unfamiliar rule types or fields.
 
@@ -274,15 +274,6 @@ The lookback should be at least as long as the interval. A common pattern is int
 \`query\` (string): The ES|QL detection query.
 \`language\` (string): Always \`"esql"\`.
 \`type\` (string): Always \`"esql"\`.
-
-### Index Patterns
-
-\`index\` (string array): Elasticsearch index patterns to search. Not used for ES|QL rules.
-
-**Example**:
-\`\`\`json
-{ "index": ["logs-endpoint.events.*", "winlogbeat-*", "filebeat-*"], ... }
-\`\`\`
 
 ### Enabled
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -310,7 +310,7 @@ User says: "Add the tags Network and Lateral Movement to the rule"
 1. "The rule" ALWAYS refers to the rule attachment. Any request to add, edit, change, or update the rule means modifying the attachment — unless no attachment exists and none can be found via \`attachment_list\`, in which case tell the user to open the rule first.
 2. NEVER just suggest or describe changes — ALWAYS apply them by calling \`attachment_update\` or \`security.create_detection_rule\`. The user expects the rule to be updated, not a description of what to update.
 3. ALWAYS read the attachment before modifying it (edit path only — skip for fresh creation).
-4. ALWAYS re-stringify the FULL rule object — never send partial updates.
+4. (Edit path only) ALWAYS re-stringify the FULL rule object when calling \`attachment_update\` — never send partial updates. On the creation path, pass natural language to \`security.create_detection_rule\`, not JSON.
 5. **ALWAYS render the attachment inline after EVERY modification** — this is the most important rule. Every single call to \`security.create_detection_rule\` or \`attachment_update\` MUST be followed by \`<render_attachment id="ATTACHMENT_ID" version="VERSION" />\` using the version from the tool result. NEVER omit this. The user cannot see changes without it.
 6. ALWAYS use \`security.create_detection_rule\` when creating a new rule.
 7. Use \`attachment_update\` for editing existing rules (field-level changes like tags, severity, schedule, etc.).

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -15,7 +15,7 @@ export const getDetectionRuleEditSkill = () =>
     name: 'detection-rule-edit',
     basePath: 'skills/security/rules',
     description:
-      'Guide to creating and editing security detection rules via the rule attachment. Use when a user asks to create, edit, modify, or update a detection rule or its fields (tags, severity, MITRE ATT&CK, schedule, query, etc.).',
+      'Creates and edits ES|QL security detection rules as persistent rule attachments, including query logic, MITRE ATT&CK mappings, severity, and schedule. Use when the user wants to author or modify a detection rule explicitly ("create a rule that...", "update the severity", "add MITRE mappings") or with implied authoring intent ("how would I detect this?", "can we catch lateral movement?", "I want an alert for privilege escalation"). Not for alert triage or investigation (use alert analysis skill), proactive threat hunting without a rule-creation goal (use threat hunting skill), or general security questions with no authoring intent.',
     content: SKILL_CONTENT,
     getRegistryTools: () => [
       SECURITY_CREATE_DETECTION_RULE_TOOL_ID,
@@ -33,6 +33,12 @@ Use this skill when the user asks to:
 - Create a detection rule (e.g., "create a rule that detects ...", "build a SIEM rule for ...", "create a security detection rule to find ...", "create a security detection rule that ...")
 - Edit an existing rule's fields (e.g., "change the severity to high", "update the query", "set the interval to 10m", "add tags to the rule")
 - Modify rule logic or metadata (e.g., "add MITRE ATT&CK mappings", "change the index patterns", "update the description", "add new terms to the query")
+
+Do NOT use this skill when the user:
+- Asks about alerts or alert triage (use the alert analysis skill instead)
+- Asks about threat hunting without any intent to create or edit a rule
+- Asks a general security question that doesn't imply building or changing a detection (e.g., "what is lateral movement?", "explain MITRE ATT&CK")
+- Asks to enable, disable, or delete an existing rule (no tool support for this yet)
 
 This covers the rule type ES|QL. Do not create a rule with a rule type other than ES|QL. Only create ES|QL rules.
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -44,7 +44,7 @@ This covers the rule type ES|QL. Do not create a rule with a rule type other tha
 
 ## ⚠️ IMPORTANT: "The Rule" Always Means the Rule Attachment
 
-**You MUST apply changes directly to the attachment.** Do NOT just describe or suggest what fields to change in your response text. Every edit request requires you to actually call the tools (\`attachment_update\` or \`security.create_detection_rule\`) to persist the change in the attachment. Describing the change without applying it is not acceptable.
+**You MUST apply changes directly to the attachment.** Do NOT just describe or suggest what fields to change in your response text. Every create or edit request requires you to actually call the tools (\`security.create_detection_rule\` for creation, \`attachment_update\` for edits) to persist the result. Describing the change without applying it is not acceptable.
 
 ## Core Workflow
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_rule_edit/index.ts
@@ -56,7 +56,7 @@ Before entering either branch, determine intent and resolve prerequisites:
 2. **User wants to edit an existing rule and an attachment is already in context** → proceed to the edit branch (Step 1 → Step 2 → Step 3, edit path).
 3. **User wants to edit an existing rule but no attachment is in context** → call \`attachment_list\` to check whether a rule attachment exists in the session but wasn't yet referenced.
    - If one is found → proceed to the edit branch.
-   - If nothing is found → call \`find_rules\` to search for rules matching the user's description. Present any matches to the user and ask them to confirm which rule they mean. Once confirmed, load it as an attachment and proceed to the edit branch.
+   - If nothing is found → call \`security.find_rules\` with \`nameContains\` to search for rules matching the user's description. Present any matches to the user and ask them to confirm which rule they mean. Once confirmed, load it as an attachment and proceed to the edit branch.
    - If no matching rules are found → tell the user no matching rule was found and ask them to clarify the rule name or open it manually.
 
 ### Step 1: Read the Attachment (edit path only)


### PR DESCRIPTION
## Summary

This PR aims to tighten up the Rule Creation Skill. In an effort to reduce hallucinations, prevent misrouting and improve rule creation quality I have implemented the following changes:
- remove documentation about rule types other than ES|QL
- add cases for when NOT to use this skill
- add a precheck to check for rule if none in attachement
- separate create and edit paths
- added a clarification gate to remove ambiguity
- updated description

### Testing
 - "Create a rule" with a vague prompt — confirm the LLM asks one clarifying question before generating
  - "Create a rule" with a specific prompt — confirm it proceeds directly to security.create_detection_rule
  - "Edit the rule" with a rule attachment already in context — confirm it goes straight to attachment_read then attachment_update
  - "Edit the rule" with no attachment in context — confirm it calls attachment_list, then security.find_rules, then prompts the user to confirm
  - "What is lateral movement?" — confirm the skill does not activate / LLM routes elsewhere
  - "Triage this alert" — confirm the skill does not activate



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



