### PR TITLE
[Scout] Add to @kbn-scout ListingTable class and integrate into SavedObjectsListingPage

### DIFF
--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -48,6 +48,7 @@ export {
   ContentListWrapper,
   buildContentListSearch,
   buildContentListUrlRegex,
+  ListingTable,
 } from './src/playwright/page_objects';
 export type { ContentListUrlState } from './src/playwright/page_objects';
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
@@ -71,6 +71,7 @@ export * from './ui_components';
 // Page-object wrappers and helpers for shared Kibana surfaces.
 export {
   ContentListWrapper,
+  ListingTable,
   buildContentListSearch,
   buildContentListUrlRegex,
 } from './page_objects';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/index.ts
@@ -35,7 +35,7 @@ import {
 import type { ContentListUrlState } from './content_list';
 import type { KibanaUrl } from '../../common/services/kibana_url';
 
-export { ContentListWrapper, buildContentListSearch, buildContentListUrlRegex };
+export { ContentListWrapper, ListingTable, buildContentListSearch, buildContentListUrlRegex };
 export type { ContentListUrlState };
 
 export interface PageObjectsFixtures {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/listing_table.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/listing_table.ts
@@ -12,9 +12,11 @@ import type { ScoutPage } from '..';
 
 export class ListingTable {
   private readonly table: Locator;
+  private readonly searchBox: Locator;
 
   constructor(private readonly page: ScoutPage) {
     this.table = this.page.testSubj.locator('listingTable-isLoaded');
+    this.searchBox = this.page.testSubj.locator('tableListSearchBox');
   }
 
   async waitUntilTableIsLoaded(options?: { timeout?: number }) {
@@ -24,5 +26,20 @@ export class ListingTable {
   async getAllItemsNames(): Promise<string[]> {
     const links = this.table.locator('.euiTableRow .euiLink');
     return links.allTextContents();
+  }
+
+  async searchFor(text: string) {
+    await this.searchBox.fill(text);
+    await this.page.keyboard.press('Enter');
+    await this.waitUntilTableIsLoaded();
+  }
+
+  async selectFilterTags(...tagNames: string[]) {
+    await this.page.testSubj.click('tagFilterPopoverButton');
+    for (const tagName of tagNames) {
+      await this.page.testSubj.click(`tag-searchbar-option-${tagName.replace(' ', '_')}`);
+    }
+    await this.searchBox.click();
+    await this.waitUntilTableIsLoaded();
   }
 }

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/saved_objects_listing_page.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/fixtures/page_objects/saved_objects_listing_page.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { ScoutPage } from '@kbn/scout';
-import { expect } from '@kbn/scout/ui';
+import type { Locator, ScoutPage } from '@kbn/scout';
+import { ListingTable } from '@kbn/scout';
 
 type AppName = 'dashboard' | 'visualize' | 'map';
 
@@ -16,52 +16,39 @@ const APP_TEST_SUBJECT_PREFIX: Record<AppName, string> = {
   map: 'map',
 };
 
-const toTestSubjFriendly = (value: string) => value.replace(' ', '_');
-
 export class SavedObjectsListingPage {
-  constructor(private readonly page: ScoutPage) {}
+  private readonly listingTable: ListingTable;
+
+  constructor(private readonly page: ScoutPage) {
+    this.listingTable = new ListingTable(page);
+  }
 
   async waitForLoaded() {
-    await this.page.testSubj.locator('listingTable-isLoaded').waitFor({ state: 'visible' });
+    await this.listingTable.waitUntilTableIsLoaded();
   }
 
   async searchForItemWithName(name: string, { escape = true }: { escape?: boolean } = {}) {
-    const searchFilter = this.page.testSubj.locator('tableListSearchBox');
     let filterValue = name;
-
     if (escape) {
       filterValue = filterValue
         .replace('-', ' ')
         // Keep parity with the FTR helper behavior.
         .replace(/ *\[[^)]*\] */g, '');
     }
-
-    await searchFilter.fill(filterValue);
-    await this.page.keyboard.press('Enter');
-    await this.waitForLoaded();
+    await this.listingTable.searchFor(filterValue);
   }
 
   async selectFilterTags(...tagNames: string[]) {
-    await this.page.testSubj.click('tagFilterPopoverButton');
-    for (const tagName of tagNames) {
-      await this.page.testSubj.click(`tag-searchbar-option-${toTestSubjFriendly(tagName)}`);
-    }
-    await this.page.testSubj.click('tableListSearchBox');
-    await this.waitForLoaded();
+    await this.listingTable.selectFilterTags(...tagNames);
   }
 
-  async expectItemsCount(appName: AppName, count: number) {
+  getItemLinks(appName: AppName): Locator {
     const testSubjPrefix = APP_TEST_SUBJECT_PREFIX[appName];
-    await expect(
-      this.page.locator(`[data-test-subj^="${testSubjPrefix}ListingTitleLink-"]`)
-    ).toHaveCount(count);
+    return this.page.locator(`[data-test-subj^="${testSubjPrefix}ListingTitleLink-"]`);
   }
 
-  async getAllItemNames(appName: AppName) {
-    const testSubjPrefix = APP_TEST_SUBJECT_PREFIX[appName];
-    return this.page
-      .locator(`[data-test-subj^="${testSubjPrefix}ListingTitleLink-"]`)
-      .allInnerTexts();
+  async getAllItemNames(appName: AppName): Promise<string[]> {
+    return this.getItemLinks(appName).allInnerTexts();
   }
 
   async clickItemLink(appName: AppName, name: string) {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_dashboard_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_dashboard_integration.spec.ts
@@ -33,7 +33,7 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
     const listingPage = new SavedObjectsListingPage(page);
     await listingPage.searchForItemWithName('tag:(tag-1)', { escape: false });
 
-    await listingPage.expectItemsCount('dashboard', 2);
+    await expect(listingPage.getItemLinks('dashboard')).toHaveCount(2);
     const itemNames = await listingPage.getAllItemNames('dashboard');
     for (const expectedName of [
       'dashboard 3 (tag-1 and tag-3)',
@@ -47,7 +47,7 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
     const listingPage = new SavedObjectsListingPage(page);
     await listingPage.selectFilterTags('tag-3');
 
-    await listingPage.expectItemsCount('dashboard', 2);
+    await expect(listingPage.getItemLinks('dashboard')).toHaveCount(2);
     const itemNames = await listingPage.getAllItemNames('dashboard');
     for (const expectedName of ['dashboard 2 (tag-3)', 'dashboard 3 (tag-1 and tag-3)']) {
       expect(itemNames).toContain(expectedName);
@@ -58,7 +58,7 @@ test.describe('Dashboard integration', { tag: tags.stateful.classic }, () => {
     const listingPage = new SavedObjectsListingPage(page);
     await listingPage.selectFilterTags('tag-2', 'tag-3');
 
-    await listingPage.expectItemsCount('dashboard', 3);
+    await expect(listingPage.getItemLinks('dashboard')).toHaveCount(3);
     const itemNames = await listingPage.getAllItemNames('dashboard');
     for (const expectedName of [
       'dashboard 1 (tag-2)',

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_maps_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_maps_integration.spec.ts
@@ -29,7 +29,7 @@ test.describe('Maps integration', { tag: tags.stateful.classic }, () => {
     const listingPage = new SavedObjectsListingPage(page);
     await listingPage.searchForItemWithName('tag:(tag-1)', { escape: false });
 
-    await listingPage.expectItemsCount('map', 2);
+    await expect(listingPage.getItemLinks('map')).toHaveCount(2);
     const itemNames = await listingPage.getAllItemNames('map');
     for (const expectedName of ['map 3 (tag-1 and tag-3)', 'map 4 (tag-1)']) {
       expect(itemNames).toContain(expectedName);
@@ -40,7 +40,7 @@ test.describe('Maps integration', { tag: tags.stateful.classic }, () => {
     const listingPage = new SavedObjectsListingPage(page);
     await listingPage.selectFilterTags('tag-3');
 
-    await listingPage.expectItemsCount('map', 2);
+    await expect(listingPage.getItemLinks('map')).toHaveCount(2);
     const itemNames = await listingPage.getAllItemNames('map');
     for (const expectedName of ['map 2 (tag-3)', 'map 3 (tag-1 and tag-3)']) {
       expect(itemNames).toContain(expectedName);
@@ -51,7 +51,7 @@ test.describe('Maps integration', { tag: tags.stateful.classic }, () => {
     const listingPage = new SavedObjectsListingPage(page);
     await listingPage.selectFilterTags('tag-2', 'tag-3');
 
-    await listingPage.expectItemsCount('map', 3);
+    await expect(listingPage.getItemLinks('map')).toHaveCount(3);
     const itemNames = await listingPage.getAllItemNames('map');
     for (const expectedName of ['map 1 (tag-2)', 'map 2 (tag-3)', 'map 3 (tag-1 and tag-3)']) {
       expect(itemNames).toContain(expectedName);

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_visualize_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/test/scout/ui/tests/tags_visualize_integration.spec.ts
@@ -32,7 +32,7 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
 
     await listingPage.waitForLoaded();
     await listingPage.searchForItemWithName('tag:(tag-1)', { escape: false });
-    await listingPage.expectItemsCount('visualize', 2);
+    await expect(listingPage.getItemLinks('visualize')).toHaveCount(2);
 
     const itemNames = await listingPage.getAllItemNames('visualize');
     for (const expectedName of ['Visualization 1 (tag-1)', 'Visualization 3 (tag-1 + tag-3)']) {
@@ -46,7 +46,7 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
 
     await listingPage.waitForLoaded();
     await listingPage.selectFilterTags('tag-1');
-    await listingPage.expectItemsCount('visualize', 2);
+    await expect(listingPage.getItemLinks('visualize')).toHaveCount(2);
 
     const itemNames = await listingPage.getAllItemNames('visualize');
     for (const expectedName of ['Visualization 1 (tag-1)', 'Visualization 3 (tag-1 + tag-3)']) {
@@ -60,7 +60,7 @@ test.describe('Visualize integration', { tag: tags.stateful.classic }, () => {
 
     await listingPage.waitForLoaded();
     await listingPage.selectFilterTags('tag-2', 'tag-3');
-    await listingPage.expectItemsCount('visualize', 2);
+    await expect(listingPage.getItemLinks('visualize')).toHaveCount(2);
 
     const itemNames = await listingPage.getAllItemNames('visualize');
     for (const expectedName of ['Visualization 2 (tag-2)', 'Visualization 3 (tag-1 + tag-3)']) {


### PR DESCRIPTION
## Summary

- Added `ListingTable` class to manage table interactions, including search and tag filtering.
- Updated exports in relevant index files to include `ListingTable`.
- Refactored `SavedObjectsListingPage` to utilize `ListingTable` for improved code organization and functionality.
- Adjusted integration tests to reflect changes in method calls for item counting and searching.

This update improves the modularity and maintainability of the codebase.