### PR TITLE
[Fleet] Filter OPAMP agents out of agent table

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.test.tsx
@@ -177,7 +177,7 @@ describe('useFetchAgentsData', () => {
       },
     });
     expect(result?.current.kuery).toEqual(
-      'status:online or (status:error or status:degraded) or status:orphaned or (status:updating or status:unenrolling or status:enrolling) or status:offline'
+      '(status:online or (status:error or status:degraded) or status:orphaned or (status:updating or status:unenrolling or status:enrolling) or status:offline) and NOT type:OPAMP'
     );
 
     expect(result?.current.page).toEqual({ index: 0, size: 20 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
@@ -18,54 +18,56 @@ describe('getKuery', () => {
   const inactiveStatuses = ['unhealthy', 'offline', 'inactive', 'unenrolled'];
 
   it('should return a kuery with base search', () => {
-    expect(getKuery({ search })).toEqual('base search');
+    expect(getKuery({ search })).toEqual('(base search) and NOT type:OPAMP');
   });
 
   it('should return a kuery with selected tags', () => {
     expect(getKuery({ selectedTags })).toEqual(
-      'fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")'
+      '(fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")) and NOT type:OPAMP'
     );
   });
   it('should return a kuery for no tags if selected', () => {
-    expect(getKuery({ selectedTags: noTags })).toEqual('((NOT fleet-agents.tags : (*)))');
+    expect(getKuery({ selectedTags: noTags })).toEqual(
+      '(((NOT fleet-agents.tags : (*)))) and NOT type:OPAMP'
+    );
   });
   it('should return a kuery for no tags and other tags when multiple are selected', () => {
     expect(getKuery({ selectedTags: [...noTags, ...selectedTags] })).toEqual(
-      '((NOT fleet-agents.tags : (*)) or fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3"))'
+      '(((NOT fleet-agents.tags : (*)) or fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3"))) and NOT type:OPAMP'
     );
   });
 
   it('should return a kuery with selected agent policies', () => {
     expect(getKuery({ selectedAgentPolicies })).toEqual(
-      'fleet-agents.policy_id : ("policy1" or "policy2" or "policy3")'
+      '(fleet-agents.policy_id : ("policy1" or "policy2" or "policy3")) and NOT type:OPAMP'
     );
   });
 
   it('should return a kuery with selected agent ids', () => {
     expect(getKuery({ selectedAgentIds })).toEqual(
-      'fleet-agents.agent.id : ("agent_id1" or "agent_id2")'
+      '(fleet-agents.agent.id : ("agent_id1" or "agent_id2")) and NOT type:OPAMP'
     );
   });
 
   it('should return a kuery with healthy selected status', () => {
     expect(getKuery({ selectedStatus: healthyStatuses })).toEqual(
-      'status:online or (status:updating or status:unenrolling or status:enrolling)'
+      '(status:online or (status:updating or status:unenrolling or status:enrolling)) and NOT type:OPAMP'
     );
   });
 
   it('should return a kuery with unhealthy selected status', () => {
     expect(getKuery({ selectedStatus: inactiveStatuses })).toEqual(
-      '(status:error or status:degraded) or status:offline or status:inactive or status:unenrolled'
+      '((status:error or status:degraded) or status:offline or status:inactive or status:unenrolled) and NOT type:OPAMP'
     );
   });
 
   it('should return a kuery with a combination of previous kueries', () => {
     expect(getKuery({ search, selectedTags, selectedStatus })).toEqual(
-      '((base search) and fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")) and (status:online or (status:error or status:degraded))'
+      '(((base search) and fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")) and (status:online or (status:error or status:degraded))) and NOT type:OPAMP'
     );
   });
 
-  it('should return empty string if nothing is passed', () => {
-    expect(getKuery({})).toEqual('');
+  it('should exclude OpAMP agents even when no filters are passed', () => {
+    expect(getKuery({})).toEqual('NOT type:OPAMP');
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -6,6 +6,7 @@
  */
 import { i18n } from '@kbn/i18n';
 
+import { AGENT_TYPE_OPAMP } from '../../../../../../../common/constants';
 import { AgentStatusKueryHelper } from '../../../../services';
 import { AGENTS_PREFIX } from '../../../../constants';
 
@@ -101,5 +102,13 @@ export const getKuery = ({
       kueryBuilder = kueryStatus;
     }
   }
-  return kueryBuilder.trim();
+  const excludeOpamp = `NOT type:${AGENT_TYPE_OPAMP}`;
+  const trimmed = kueryBuilder.trim();
+  if (trimmed) {
+    kueryBuilder = `(${trimmed}) and ${excludeOpamp}`;
+  } else {
+    kueryBuilder = excludeOpamp;
+  }
+
+  return kueryBuilder;
 };


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/ingest-dev/issues/7065 

Do not display OPamp agents in agent table

## UI Changes

With opamp agents, they are only displayed in the collector tab

<img width="800" alt="Screenshot 2026-05-20 at 1 10 53 PM" src="https://github.com/user-attachments/assets/778ac748-f4a2-4818-96bc-fe7bcf25fae0" />
<img width="800"  alt="Screenshot 2026-05-20 at 1 10 48 PM" src="https://github.com/user-attachments/assets/1b30b8a1-3d61-4ebe-bc3a-0c3785e80f4b" />
