### PR TITLE
Fix validate-oas skill drift: add missing include-paths and bundling steps

### DIFF
--- a/.agents/skills/validate-oas/SKILL.md
+++ b/.agents/skills/validate-oas/SKILL.md
@@ -54,10 +54,19 @@ node scripts/capture_oas_snapshot \
   --include-path /api/maintenance_window \
   --include-path /api/agent_builder \
   --include-path /api/workflows \
-  --include-path /api/security/entity_store
+  --include-path /api/security/entity_store \
+  --include-path /api/dashboards \
+  --include-path /api/visualizations
 ```
 
-3. Rebuild the final OAS documents:
+3. Run the OpenAPI bundling scripts:
+
+```bash
+bash .buildkite/scripts/steps/openapi_bundling/security_solution_openapi_bundling.sh
+bash .buildkite/scripts/steps/openapi_bundling/final_merge.sh
+```
+
+4. Rebuild the final OAS documents:
 
 ```bash
 cd oas_docs && make api-docs
@@ -67,6 +76,7 @@ After this refresh flow completes, run the scoped validation command.
 
 Source of truth:
 - Keep the `capture_oas_snapshot` include-path list aligned with `.buildkite/scripts/steps/checks/capture_oas_snapshot.sh`.
+- Keep the openapi_bundling step list aligned with `.buildkite/scripts/steps/openapi_bundling/`.
 - If the Buildkite command changes, update this skill to match it.
 
 ## Required interaction flow
@@ -108,7 +118,11 @@ node scripts/capture_oas_snapshot \
   --include-path /api/maintenance_window \
   --include-path /api/agent_builder \
   --include-path /api/workflows \
-  --include-path /api/security/entity_store
+  --include-path /api/security/entity_store \
+  --include-path /api/dashboards \
+  --include-path /api/visualizations
+bash .buildkite/scripts/steps/openapi_bundling/security_solution_openapi_bundling.sh
+bash .buildkite/scripts/steps/openapi_bundling/final_merge.sh
 cd oas_docs && make api-docs
 ```
 


### PR DESCRIPTION
Syncs the `validate-oas` skill with the Buildkite capture script.

Adds missing (`/api/dashboards`, `/api/visualizations`) `--include-path` entries, and OpenAPI bundling scripts to the refresh flow. Missing entries caused destructive diffs (~50K line deletions) when the skill is used to refresh OAS locally.

Fixes the Refresh flow section, the Commands reference block, and the source-of-truth note.

Co-Authored-By: Claude Sonnet 4.6