### PR TITLE
[Design Tools] Fix collectTextNodes capturing screen reader elements

### DIFF
--- a/src/platform/packages/shared/kbn-design-tools/src/edit_engine/collect_text_nodes.test.ts
+++ b/src/platform/packages/shared/kbn-design-tools/src/edit_engine/collect_text_nodes.test.ts
@@ -84,6 +84,22 @@ describe('collectAllTextNodes', () => {
     expect(nodes[0].textContent).toBe('Visible');
   });
 
+  it('should skip Emotion-prefixed euiScreenReaderOnly elements', () => {
+    const el = document.createElement('div');
+    const sr = document.createElement('span');
+    sr.classList.add('css-gb1zbv-euiScreenReaderOnly');
+    sr.textContent = 'ScreenReaderOnly';
+    const visible = document.createElement('span');
+    visible.textContent = 'Visible';
+    el.appendChild(sr);
+    el.appendChild(visible);
+
+    const nodes = collectAllTextNodes(el);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].textContent).toBe('Visible');
+  });
+
   it('should recursively collect from nested elements', () => {
     const el = document.createElement('div');
     el.innerHTML = '<div><div><span>Deep</span></div></div>';

--- a/src/platform/packages/shared/kbn-design-tools/src/edit_engine/collect_text_nodes.ts
+++ b/src/platform/packages/shared/kbn-design-tools/src/edit_engine/collect_text_nodes.ts
@@ -7,9 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { isScreenReaderOnly } from './is_screen_reader_only';
+
 /**
  * Checks whether the element is visually hidden and should be skipped
  * when collecting editable text nodes.
+ *
+ * @param el - The element to check.
+ * @returns Whether the element is hidden.
  */
 const isHiddenElement = (el: Element): boolean => {
   if (!(el instanceof HTMLElement)) return false;
@@ -17,8 +22,7 @@ const isHiddenElement = (el: Element): boolean => {
   if (el.hasAttribute('hidden')) return true;
   const { display, visibility, opacity } = el.style;
   if (display === 'none' || visibility === 'hidden' || opacity === '0') return true;
-  // Screen-reader-only patterns (e.g. EUI's .euiScreenReaderOnly)
-  if (el.classList.contains('euiScreenReaderOnly')) return true;
+  if (isScreenReaderOnly(el)) return true;
   // offsetWidth/offsetHeight are 0 for detached elements; skip this check
   // when the element is not connected to the document (e.g. clones).
   if (el.isConnected && el.offsetWidth === 0 && el.offsetHeight === 0) return true;

--- a/src/platform/packages/shared/kbn-design-tools/src/edit_engine/is_screen_reader_only.ts
+++ b/src/platform/packages/shared/kbn-design-tools/src/edit_engine/is_screen_reader_only.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Returns true when the element has a screen-reader-only class name.
+ * Handles both plain EUI classes (`euiScreenReaderOnly`) and
+ * Emotion-generated variants (`css-<hash>-euiScreenReaderOnly`).
+ *
+ * @param el - The element to check.
+ * @returns Whether the element is screen-reader-only.
+ */
+export const isScreenReaderOnly = (el: Element): boolean => {
+  const cls = (el as HTMLElement)?.className;
+  return typeof cls === 'string' && cls.includes('euiScreenReaderOnly');
+};

--- a/src/platform/packages/shared/kbn-design-tools/src/edit_engine/managed_element.ts
+++ b/src/platform/packages/shared/kbn-design-tools/src/edit_engine/managed_element.ts
@@ -8,6 +8,7 @@
  */
 
 import { DEVTOOL_LIVE_ATTR } from '../lib/constants';
+import { isScreenReaderOnly } from './is_screen_reader_only';
 
 /**
  * Returns the meaningful content root for a managed element.
@@ -39,13 +40,14 @@ export const getContentRoot = (target: HTMLElement): HTMLElement => {
  * Check whether an element is a non-visible helper (screen-reader-only,
  * aria-hidden, or explicitly hidden) that should be skipped when resolving
  * the content root.
+ *
+ * @param el - The element to check.
+ * @returns Whether the element is a hidden helper.
  */
 const isHiddenHelper = (el: HTMLElement): boolean => {
   if (el.getAttribute('aria-hidden') === 'true') return true;
   if (el.hasAttribute('hidden')) return true;
-  // Emotion class names embed the original class: css-xxx-euiScreenReaderOnly
-  const cls = el.className;
-  if (typeof cls === 'string' && cls.includes('euiScreenReaderOnly')) return true;
+  if (isScreenReaderOnly(el)) return true;
   return false;
 };
 


### PR DESCRIPTION
## Summary

This PR:
- fixes `collectAllTextNodes` helper method `isHiddenElement` returning screen reader elements as text nodes because of improperly written check
- adds `isScreenReaderOnly` helper
