### PR TITLE
[Dashboards] Address import/export `references` duplication

### DIFF
--- a/src/core/packages/saved-objects/base-server-internal/src/validation/schema.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/validation/schema.ts
@@ -29,7 +29,10 @@ const baseSchema = schema.object<SavedObjectSanitizedDocSchema>({
       type: schema.string(),
       id: schema.string(),
     }),
-    { defaultValue: [], maxSize: 1000 }
+    {
+      defaultValue: [],
+      maxSize: 10_000, // needed to allow importing dashboards with duplicate references
+    }
   ),
   namespace: schema.maybe(schema.string()),
   namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),

--- a/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
@@ -26,7 +26,7 @@ import {
   DEFAULT_DASHBOARD_OPTIONS,
 } from '../../common/constants';
 
-const MAX_PANELS = 100;
+const MAX_PANELS = 1_000;
 
 export const panelGridSchema = schema.object(
   {

--- a/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
@@ -26,7 +26,7 @@ import {
   DEFAULT_DASHBOARD_OPTIONS,
 } from '../../common/constants';
 
-const MAX_PANELS = 1_000;
+const MAX_PANELS = 100;
 
 export const panelGridSchema = schema.object(
   {

--- a/src/platform/plugins/shared/dashboard/server/api/transforms/in/transform_dashboard_in.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/in/transform_dashboard_in.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { uniqBy } from 'lodash';
+
 import type { SavedObjectReference } from '@kbn/core-saved-objects-api-server';
 import type { RequestTiming } from '@kbn/core-http-server';
 import type { DashboardState } from '../../types';
@@ -84,12 +86,15 @@ export const transformDashboardIn = (
 
     return {
       attributes,
-      references: [
-        ...tagReferences,
-        ...panelReferences,
-        ...controlGroupReferences,
-        ...searchSourceReferences,
-      ],
+      references: uniqBy(
+        [
+          ...tagReferences,
+          ...panelReferences,
+          ...controlGroupReferences,
+          ...searchSourceReferences,
+        ],
+        'name'
+      ),
     };
   } finally {
     timer?.end();

--- a/src/platform/plugins/shared/dashboard/server/dashboard_saved_object/dashboard_saved_object.ts
+++ b/src/platform/plugins/shared/dashboard/server/dashboard_saved_object/dashboard_saved_object.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { uniqBy } from 'lodash';
+
 import { ANALYTICS_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import type { SavedObjectsType } from '@kbn/core/server';
 
@@ -41,6 +43,13 @@ export const createDashboardSavedObjectType = ({
         path: `/app/dashboards#/view/${encodeURIComponent(obj.id)}`,
         uiCapabilitiesPath: 'dashboard_v2.show',
       };
+    },
+    onExport: (ctx, objects) => {
+      // deduplicate references by name
+      return objects.map((obj) => ({
+        ...obj,
+        references: uniqBy(obj.references, 'name'),
+      }));
     },
   },
   modelVersions: {


### PR DESCRIPTION
## Summary

Deduplicates dashboard `references` `onExport` and on save.

Closes #266543

## Details

At some point there was mishandling of references, specifically of Lens by-ref panels, that lead to duplication of panel references, not just double but exponential duplication on every save. So saving once you get 1, then 2, then 4 then 8 and so on.

This was found to be caused by dashboards passing all references to the embeddable ref injection not just the panel references, for compatibility with legacy visualizations. This was addressed in https://github.com/elastic/kibana/pull/245569 and likely stopped there. Could also be related to other issues prior to this not entirely sure.

But as it stands, we have dashboard SavedObjects that customers want to import that have duplicate refs that far exceed the 1,000 array limit set by core on the saved object schema. Since we longer have the ability to add a migration, there is no mechanism to correct this issue on import before the input is validated by the schema. So we need to ramp up the array limit to 10,000.

Additionally, the dashboard transform logic injects and extracts the references which implicitly deduplicates the references. So on the next save, the references will be corrected.

But if someone were to export the Dashboard saved object, that has yet to be saved, they would still get the duplicate references. To fix this we add an `onExport` hook to deduplicate by `name`.

Apart from this issue, there seems to be another issue with duplicated references in #266543. I was not able to reproduce this but as a safe guard I think we could just always deduplicate the dashboard references on save.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->