### PR TITLE
[Dashboard] Update links plugin EuiListGroup style overrides

### DIFF
--- a/src/platform/plugins/private/links/public/components/dashboard_link/dashboard_link_component.tsx
+++ b/src/platform/plugins/private/links/public/components/dashboard_link/dashboard_link_component.tsx
@@ -188,6 +188,11 @@ const styles = ({ euiTheme }: UseEuiTheme) =>
       },
     },
 
+    // vertical layout - current dashboard border offset styles
+    '.verticalLayoutWrapper & .euiListItemLayout__text': {
+      paddingInlineStart: euiTheme.size.s,
+    },
+
     // vertical layout - current dashboard link styles
     '.verticalLayoutWrapper &.linkCurrent': {
       paddingLeft: euiTheme.size.s,

--- a/src/platform/plugins/private/links/public/components/dashboard_link/dashboard_link_component.tsx
+++ b/src/platform/plugins/private/links/public/components/dashboard_link/dashboard_link_component.tsx
@@ -183,7 +183,7 @@ const styles = ({ euiTheme }: UseEuiTheme) =>
     '&.linkCurrent': {
       borderRadius: 0,
       cursor: 'default',
-      '& .euiListGroupItem__text': {
+      '& .euiListItemLayout__text': {
         color: euiTheme.colors.textPrimary,
       },
     },
@@ -204,7 +204,7 @@ const styles = ({ euiTheme }: UseEuiTheme) =>
     // horizontal layout - current dashboard link styles
     '.horizontalLayoutWrapper &.linkCurrent': {
       padding: `0 ${euiTheme.size.s}`,
-      '& .euiListGroupItem__text': {
+      '& .euiListItemLayout__text': {
         // add bottom border for current dashboard
         boxShadow: `${euiTheme.colors.textPrimary} 0 calc(-.5 * ${euiTheme.size.xs}) inset`,
         paddingInline: 0,
@@ -213,7 +213,7 @@ const styles = ({ euiTheme }: UseEuiTheme) =>
 
     // dashboard not found error styles
     '&.dashboardLinkError': {
-      '&.dashboardLinkError--noLabel .euiListGroupItem__text': {
+      '&.dashboardLinkError--noLabel .euiListItemLayout__text': {
         fontStyle: 'italic',
       },
 

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
@@ -288,7 +288,8 @@ const styles = ({ euiTheme }: UseEuiTheme) =>
       paddingBlock: euiTheme.size.xs,
     },
     '&.horizontalLayoutWrapper': {
-      height: '100%',
+      inlineSize: 'max-content',
+      blockSize: '100%',
       display: 'flex',
       flexWrap: 'nowrap',
       alignItems: 'center',
@@ -297,6 +298,6 @@ const styles = ({ euiTheme }: UseEuiTheme) =>
     // The internal list item wrapper has `width: 100%` which needs to be overridden
     // for the horizontal layout to look as expected
     '&.horizontalLayoutWrapper .euiListItemLayout__wrapper': {
-      width: 'auto',
+      inlineSize: 'auto',
     },
   });

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
@@ -293,4 +293,9 @@ const styles = ({ euiTheme }: UseEuiTheme) =>
       alignItems: 'center',
       flexDirection: 'row',
     },
+    // The internal list item wrapper has `width: 100%` which needs to be overridden
+    // for the horizontal layout to look as expected
+    '&.horizontalLayoutWrapper .euiListItemLayout__wrapper': {
+      width: 'auto',
+    },
   });

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
@@ -285,6 +285,7 @@ const styles = ({ euiTheme }: UseEuiTheme) =>
     },
     '&.verticalLayoutWrapper': {
       gap: euiTheme.size.xs,
+      paddingBlock: euiTheme.size.xs,
     },
     '&.horizontalLayoutWrapper': {
       height: '100%',


### PR DESCRIPTION
## Summary

This PR updates EuiListGroup class names used to override certain styles in the links plugin, and adds a couple new styles to make the layout look like before #260949 was merged.

## Screenshots

| `main` (broken) | `9.4` | This PR |
|--------|-------|---------|
| <img width="321" height="178" alt="Screenshot 2026-05-21 at 02 05 23" src="https://github.com/user-attachments/assets/111126ba-7048-481b-86cf-a582c8d5fea8" /> | <img width="338" height="179" alt="9 4 vertical" src="https://github.com/user-attachments/assets/b6590034-0c98-41ce-85fb-3fa9003ecfb1" /> | <img width="294" height="179" alt="PR vertical" src="https://github.com/user-attachments/assets/9f97ad19-cefc-401e-9cef-564178b493f6" /> |
| <img width="1281" height="69" alt="Screenshot 2026-05-21 at 02 05 09" src="https://github.com/user-attachments/assets/a9d6b762-ff94-40c4-9c6e-51a9ae73e7f0" /> | <img width="760" height="70" alt="9 4 horizontal" src="https://github.com/user-attachments/assets/89d39a64-1b6e-4c68-a7ee-c5b96eb20774" /> | <img width="867" height="87" alt="PR horizontal" src="https://github.com/user-attachments/assets/d04c5160-1b95-4798-9e58-75059731c9be" /> |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



