### PR TITLE
[Discover][ES|QL] Histogram comparison

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/breakdown_field_selector.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/breakdown_field_selector.tsx
@@ -33,6 +33,7 @@ export interface BreakdownFieldSelectorProps {
   breakdown: UnifiedHistogramBreakdownContext;
   esqlColumns?: DatatableColumn[];
   onBreakdownFieldChange?: (breakdownField: DataViewField | undefined) => void;
+  disabled?: boolean;
 }
 
 const mapToDropdownFields = (dataView: DataView, esqlColumns?: DatatableColumn[]) => {
@@ -53,6 +54,7 @@ export const BreakdownFieldSelector = ({
   breakdown,
   esqlColumns,
   onBreakdownFieldChange,
+  disabled,
 }: BreakdownFieldSelectorProps) => {
   const fields = useMemo(() => mapToDropdownFields(dataView, esqlColumns), [dataView, esqlColumns]);
   const fieldOptions: SelectableEntry[] = useMemo(() => {
@@ -106,6 +108,7 @@ export const BreakdownFieldSelector = ({
     <ToolbarSelector
       data-test-subj="unifiedHistogramBreakdownSelector"
       data-selected-value={breakdown?.field?.name}
+      disabled={disabled}
       searchable
       buttonLabel={
         breakdown?.field?.displayName

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
@@ -73,6 +73,7 @@ export interface UnifiedHistogramChartProps {
   onFilter?: LensEmbeddableInput['onFilter'];
   onBrushEnd?: LensEmbeddableInput['onBrushEnd'];
   withDefaultActions?: EmbeddableComponentProps['withDefaultActions'];
+  renderTimeComparison?: React.ReactNode;
 }
 
 const RequestStatusError: typeof RequestStatus.ERROR = 2;
@@ -96,6 +97,7 @@ export function UnifiedHistogramChart({
   onBreakdownFieldChange,
   onTotalHitsChange,
   onChartLoad,
+  renderTimeComparison,
   ...histogramProps
 }: UnifiedHistogramChartProps) {
   const lensVisServiceCurrentSuggestionContext = lensVisServiceState.currentSuggestionContext;
@@ -241,9 +243,11 @@ export function UnifiedHistogramChart({
             breakdown={breakdown}
             onBreakdownFieldChange={onBreakdownFieldChange}
             esqlColumns={isPlainRecord ? columns : undefined}
+            disabled={!onBreakdownFieldChange}
           />
         )}
       </div>,
+      renderTimeComparison ?? null,
     ],
     [
       chartVisible,
@@ -254,6 +258,7 @@ export function UnifiedHistogramChart({
       dataView,
       onBreakdownFieldChange,
       columns,
+      renderTimeComparison,
     ]
   );
 

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/hooks/use_lens_props.ts
@@ -27,6 +27,7 @@ export type LensProps = Pick<
   | 'executionContext'
   | 'onLoad'
   | 'lastReloadRequestTime'
+  | 'overrides'
 >;
 
 export const useLensProps = ({
@@ -50,6 +51,7 @@ export const useLensProps = ({
         lensProps: getLensProps({
           searchSessionId: fetchParams.searchSessionId,
           timeRange: fetchParams.timeRange,
+          displayTimeRange: fetchParams.displayTimeRange,
           esqlVariables: fetchParams.esqlVariables,
           attributes,
           onLoad,
@@ -78,6 +80,7 @@ export const useLensProps = ({
 export const getLensProps = ({
   searchSessionId,
   timeRange,
+  displayTimeRange,
   attributes,
   esqlVariables,
   onLoad,
@@ -85,6 +88,7 @@ export const getLensProps = ({
 }: {
   searchSessionId: string | undefined;
   timeRange: TimeRange;
+  displayTimeRange?: TimeRange;
   attributes: TypedLensByValueInput['attributes'];
   esqlVariables: ESQLControlVariable[] | undefined;
   onLoad: (isLoading: boolean, adapters: Partial<DefaultInspectorAdapters> | undefined) => void;
@@ -102,4 +106,14 @@ export const getLensProps = ({
   },
   onLoad,
   lastReloadRequestTime,
+  overrides: displayTimeRange
+    ? {
+        settings: {
+          xDomain: {
+            min: new Date(displayTimeRange.from).getTime(),
+            max: new Date(displayTimeRange.to).getTime(),
+          },
+        },
+      }
+    : undefined,
 });

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
@@ -135,6 +135,10 @@ export const useUnifiedHistogram = (props: UseUnifiedHistogramProps): UseUnified
           isChartAvailable,
           lensVisService,
           lensVisServiceState,
+          // preserve undefined when the original prop is absent so chart.tsx can derive disabled state
+          onBreakdownFieldChange: props.onBreakdownFieldChange
+            ? stateProps.onBreakdownFieldChange
+            : undefined,
         }
       : undefined;
   }, [

--- a/src/platform/packages/shared/kbn-unified-histogram/index.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/index.ts
@@ -14,7 +14,11 @@ export type {
   UnifiedHistogramVisContext,
   UnifiedHistogramFetchParamsExternal,
 } from './types';
-export { UnifiedHistogramFetchStatus, UnifiedHistogramExternalVisContextStatus } from './types';
+export {
+  UnifiedHistogramFetchStatus,
+  UnifiedHistogramExternalVisContextStatus,
+  UnifiedHistogramSuggestionType,
+} from './types';
 
 export {
   UnifiedBreakdownFieldSelector,

--- a/src/platform/packages/shared/kbn-unified-histogram/types.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/types.ts
@@ -214,6 +214,12 @@ export interface UnifiedHistogramFetchParamsExternal {
    */
   relativeTimeRange?: TimeRange;
   /**
+   * Override for the time range used by the Lens embeddable for x-axis display.
+   * When set, Lens uses this for the chart's x-axis domain instead of timeRange.
+   * Useful when timeRange is intentionally wider than the desired display window.
+   */
+  displayTimeRange?: TimeRange;
+  /**
    * The ES|QL variables to use for the chart
    */
   esqlVariables?: ESQLControlVariable[];

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
@@ -46,6 +46,7 @@ import type {
   ChartSectionConfiguration,
 } from '../../../../context_awareness/types';
 import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
+import { TimeComparisonSelector } from './time_comparison_selector';
 
 export type ChartPortalNode = HtmlPortalNode;
 export type ChartPortalNodes = Record<string, ChartPortalNode>;
@@ -205,6 +206,7 @@ const ChartsWrapper = ({ panelsToggle }: UnifiedHistogramChartProps) => {
 
 const UnifiedHistogramWrapper = ({ panelsToggle }: UnifiedHistogramChartProps) => {
   const { currentTabId, unifiedHistogramProps } = useUnifiedHistogramRuntimeState();
+  const isEsqlMode = useIsEsqlMode();
 
   const { setUnifiedHistogramApi } = unifiedHistogramProps;
   const unifiedHistogram = useUnifiedHistogram(unifiedHistogramProps);
@@ -227,6 +229,7 @@ const UnifiedHistogramWrapper = ({ panelsToggle }: UnifiedHistogramChartProps) =
     <UnifiedHistogramChart
       {...unifiedHistogram.chartProps}
       renderToggleActions={renderToggleActions}
+      renderTimeComparison={isEsqlMode ? <TimeComparisonSelector /> : undefined}
     />
   );
 };

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/time_comparison_selector.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/time_comparison_selector.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  internalStateActions,
+  useAppStateSelector,
+  useCurrentTabAction,
+  useInternalStateDispatch,
+} from '../../state_management/redux';
+
+export const TimeComparisonSelector = () => {
+  const dispatch = useInternalStateDispatch();
+  const updateAppState = useCurrentTabAction(internalStateActions.updateAppState);
+  const timeComparisonEnabled = useAppStateSelector((state) => state.timeComparisonEnabled ?? false);
+
+  const onToggle = useCallback(() => {
+    dispatch(
+      updateAppState({ appState: { timeComparisonEnabled: !timeComparisonEnabled || undefined } })
+    );
+  }, [dispatch, updateAppState, timeComparisonEnabled]);
+
+  if (timeComparisonEnabled) {
+    return (
+      <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('discover.timeComparison.prefixLabel', {
+              defaultMessage: 'Comparison:',
+            })}
+            &nbsp;
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            size="xs"
+            color="primary"
+            iconType="visLine"
+            onClick={onToggle}
+            isSelected
+            data-test-subj="discoverTimeComparisonToggle"
+          >
+            {i18n.translate('discover.timeComparison.previousPeriodLabel', {
+              defaultMessage: 'Previous period',
+            })}
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  return (
+    <EuiButtonEmpty
+      size="xs"
+      color="text"
+      iconType="visLine"
+      onClick={onToggle}
+      data-test-subj="discoverTimeComparisonToggle"
+    >
+      {i18n.translate('discover.timeComparison.inactiveLabel', {
+        defaultMessage: 'Comparison',
+      })}
+    </EuiButtonEmpty>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
@@ -17,6 +17,7 @@ import {
   canImportVisContext,
   UnifiedHistogramExternalVisContextStatus,
   UnifiedHistogramFetchStatus,
+  UnifiedHistogramSuggestionType,
   type UnifiedHistogramFetchParamsExternal,
 } from '@kbn/unified-histogram';
 import { intersection } from 'lodash';
@@ -27,6 +28,12 @@ import useLatest from 'react-use/lib/useLatest';
 import type { RequestAdapter } from '@kbn/inspector-plugin/common';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import { ESQL_TABLE_TYPE } from '@kbn/data-plugin/common';
+import { isOfAggregateQueryType } from '@kbn/es-query';
+import {
+  buildForkFilterQuery,
+  computeComparisonTimeRange,
+  toAbsoluteRange,
+} from '../../utils/build_fork_comparison_query';
 import { useProfileAccessor } from '../../../../context_awareness';
 import { useDiscoverCustomization } from '../../../../customizations';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
@@ -206,15 +213,67 @@ export const useDiscoverHistogram = (
   const filters = useCurrentTabSelector(selectTabCombinedFilters);
   const timeInterval = useAppStateSelector((state) => state.interval);
   const breakdownField = useAppStateSelector((state) => state.breakdownField);
+  const timeComparisonEnabled = useAppStateSelector((state) => state.timeComparisonEnabled);
   const esqlVariables = useCurrentTabSelector((tab) => tab.esqlVariables);
   const visContext = useCurrentTabSelector((tab) => tab.attributes.visContext);
+  const comparisonData = useMemo(() => {
+    if (
+      !isEsqlMode ||
+      !timeComparisonEnabled ||
+      !query ||
+      !isOfAggregateQueryType(query) ||
+      !dataView.timeFieldName ||
+      !timeRange
+    ) {
+      return null;
+    }
+    try {
+      const absRange = toAbsoluteRange(timeRange);
+      const previous = computeComparisonTimeRange(absRange);
+      return {
+        forkQuery: buildForkFilterQuery({
+          userQuery: query.esql,
+          timeField: dataView.timeFieldName,
+          current: absRange,
+          previous,
+        }),
+        // DSL prefilter from Lens uses timeRange; expand it to cover both periods so
+        // the previous period rows aren't filtered out before FORK runs.
+        combinedTimeRange: { from: previous.from, to: absRange.to },
+      };
+    } catch {
+      return null;
+    }
+  }, [isEsqlMode, timeComparisonEnabled, timeRange, query, dataView]);
 
   const getModifiedVisAttributesAccessor = useProfileAccessor('getModifiedVisAttributes');
   const getModifiedVisAttributes = useCallback<
     NonNullable<UnifiedHistogramFetchParamsExternal['getModifiedVisAttributes']>
   >(
-    (attributes) => getModifiedVisAttributesAccessor((params) => params.attributes)({ attributes }),
-    [getModifiedVisAttributesAccessor]
+    (attributes) => {
+      let result = getModifiedVisAttributesAccessor((params) => params.attributes)({ attributes });
+      if (comparisonData && result.visualizationType === 'lnsXY') {
+        const viz = result.state.visualization as {
+          preferredSeriesType?: string;
+          layers?: Array<Record<string, unknown>>;
+        };
+        result = {
+          ...result,
+          state: {
+            ...result.state,
+            visualization: {
+              ...viz,
+              preferredSeriesType: 'line',
+              layers: Array.isArray(viz?.layers)
+                ? viz.layers.map((layer) => ({ ...layer, seriesType: 'line' }))
+                : viz?.layers,
+            },
+          },
+        };
+      }
+      return result;
+    },
+    [comparisonData, getModifiedVisAttributesAccessor]
   );
 
   const collectedFetchParams: UnifiedHistogramFetchParamsExternal | undefined = useMemo(() => {
@@ -222,20 +281,21 @@ export const useDiscoverHistogram = (
       searchSessionId,
       requestAdapter: inspectorAdapters.requests,
       dataView,
-      query,
+      query: comparisonData ? { esql: comparisonData.forkQuery } : query,
       filters,
-      timeRange,
+      timeRange: comparisonData ? comparisonData.combinedTimeRange : timeRange,
+      displayTimeRange: comparisonData ? timeRange : undefined,
       relativeTimeRange,
-      breakdownField,
+      breakdownField: comparisonData ? '_fork' : breakdownField,
       timeInterval,
       esqlVariables,
       controlsState: getDefinedControlGroupState(currentTabControlState),
-      // visContext should be in sync with current query
       externalVisContext: isEsqlMode && canImportVisContext(visContext) ? visContext : undefined,
       getModifiedVisAttributes,
     };
   }, [
     breakdownField,
+    comparisonData,
     timeInterval,
     currentTabControlState,
     dataView,
@@ -251,7 +311,11 @@ export const useDiscoverHistogram = (
     getModifiedVisAttributes,
   ]);
 
+  const prevComparisonEnabledRef = useRef(!!comparisonData);
+
   const previousFetchParamsRef = useRef<UnifiedHistogramFetchParamsExternal | null>(null);
+
+  const forkColumn: DatatableColumn = { id: '_fork', name: '_fork', meta: { type: 'string' } };
 
   const triggerUnifiedHistogramFetch = useLatest(
     (latestFetchDetails: DiscoverLatestFetchDetails | undefined) => {
@@ -260,16 +324,30 @@ export const useDiscoverHistogram = (
         isEsqlMode,
       });
 
+      const columns = isEsqlMode
+        ? comparisonData
+          ? [...(esqlQueryColumns ?? []), forkColumn]
+          : esqlQueryColumns
+        : undefined;
+
       const nextFetchParams = {
         ...collectedFetchParams,
         abortController: latestFetchDetails?.abortController ?? getAbortController(),
-        columns: isEsqlMode ? esqlQueryColumns : undefined,
+        columns,
         table: isEsqlMode ? table : undefined,
       };
       previousFetchParamsRef.current = nextFetchParams;
       unifiedHistogramApi?.fetch(nextFetchParams);
     }
   );
+
+  useEffect(() => {
+    const isEnabled = !!comparisonData;
+    if (prevComparisonEnabledRef.current !== isEnabled) {
+      prevComparisonEnabledRef.current = isEnabled;
+      triggerUnifiedHistogramFetch.current(undefined);
+    }
+  }, [comparisonData, triggerUnifiedHistogramFetch]);
 
   /**
    * Data fetching
@@ -318,18 +396,41 @@ export const useDiscoverHistogram = (
     internalStateActions.setOverriddenVisContextAfterInvalidation
   );
 
+  // Tracks the most recent live vis context (including auto-generated ones not persisted to Redux).
+  // Needed for patching bar→line changes in comparison mode where Redux visContext is undefined
+  // until the user first saves manually.
+  const liveVisContextRef = useRef<UnifiedHistogramVisContext | undefined>(undefined);
+
   const onVisContextChanged = useCallback(
     (
       nextVisContext: UnifiedHistogramVisContext | undefined,
       externalVisContextStatus: UnifiedHistogramExternalVisContextStatus
     ) => {
       switch (externalVisContextStatus) {
-        case UnifiedHistogramExternalVisContextStatus.manuallyCustomized:
+        case UnifiedHistogramExternalVisContextStatus.manuallyCustomized: {
           // if user customized the visualization manually
           // (only this action should trigger Unsaved changes badge)
+          let contextToSave = nextVisContext;
+          if (
+            comparisonData &&
+            canImportVisContext(nextVisContext) &&
+            canImportVisContext(liveVisContextRef.current)
+          ) {
+            contextToSave = {
+              ...nextVisContext,
+              suggestionType: UnifiedHistogramSuggestionType.histogramForESQL,
+              attributes: {
+                ...nextVisContext.attributes,
+                state: {
+                  ...nextVisContext.attributes.state,
+                  query: liveVisContextRef.current.attributes.state.query,
+                },
+              },
+            };
+          }
           dispatch(
             updateAttributes({
-              attributes: { visContext: nextVisContext },
+              attributes: { visContext: contextToSave },
             })
           );
           dispatch(
@@ -338,6 +439,7 @@ export const useDiscoverHistogram = (
             })
           );
           break;
+        }
         case UnifiedHistogramExternalVisContextStatus.automaticallyOverridden:
           // if the visualization was invalidated as incompatible and rebuilt
           // (it will be used later for saving the visualization via Save button)
@@ -355,6 +457,10 @@ export const useDiscoverHistogram = (
               overriddenVisContextAfterInvalidation: undefined,
             })
           );
+          // track the live chart query so manuallyCustomized can patch it in comparison mode
+          if (canImportVisContext(nextVisContext)) {
+            liveVisContextRef.current = nextVisContext;
+          }
           break;
         case UnifiedHistogramExternalVisContextStatus.unknown:
           // using `{}` to overwrite the value inside the saved search SO during saving
@@ -366,18 +472,19 @@ export const useDiscoverHistogram = (
           break;
       }
     },
-    [dispatch, setOverriddenVisContextAfterInvalidation, updateAttributes]
+    [comparisonData, dispatch, setOverriddenVisContextAfterInvalidation, updateAttributes]
   );
 
   const onBreakdownFieldChange = useCallback<
     NonNullable<UseUnifiedHistogramProps['onBreakdownFieldChange']>
   >(
     (nextBreakdownField) => {
+      if (comparisonData) return;
       if (nextBreakdownField !== breakdownField) {
         dispatch(updateAppState({ appState: { breakdownField: nextBreakdownField } }));
       }
     },
-    [breakdownField, dispatch, updateAppState]
+    [breakdownField, comparisonData, dispatch, updateAppState]
   );
 
   const onTimeIntervalChange = useCallback<
@@ -409,7 +516,7 @@ export const useDiscoverHistogram = (
       disabledActions: histogramCustomization?.disabledActions,
       isChartLoading,
       onVisContextChanged: isEsqlMode ? onVisContextChanged : undefined,
-      onBreakdownFieldChange,
+      onBreakdownFieldChange: comparisonData ? undefined : onBreakdownFieldChange,
       onTimeIntervalChange,
     }),
     [

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -124,6 +124,7 @@ export interface DiscoverAppState {
    * Density of table
    */
   density?: DataGridDensity;
+  timeComparisonEnabled?: boolean;
 }
 
 export interface CascadedDocumentsState {

--- a/src/platform/plugins/shared/discover/public/application/main/utils/build_fork_comparison_query.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/utils/build_fork_comparison_query.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import DateMath from '@kbn/datemath';
+import type { TimeRange } from '@kbn/es-query';
+import { hasTransformationalCommand } from '@kbn/esql-utils';
+
+export interface AbsoluteRange {
+  from: string;
+  to: string;
+}
+
+export function toAbsoluteRange(timeRange: TimeRange): AbsoluteRange {
+  const from = DateMath.parse(timeRange.from)?.toISOString();
+  const to = DateMath.parse(timeRange.to, { roundUp: true })?.toISOString();
+  if (!from || !to) {
+    throw new Error(`Unable to parse time range: ${timeRange.from} - ${timeRange.to}`);
+  }
+  return { from, to };
+}
+
+export function computeComparisonTimeRange(current: AbsoluteRange): AbsoluteRange {
+  const fromMs = new Date(current.from).getTime();
+  const toMs = new Date(current.to).getTime();
+  const durationMs = toMs - fromMs;
+  return {
+    from: new Date(fromMs - durationMs).toISOString(),
+    to: new Date(toMs - durationMs).toISOString(),
+  };
+}
+
+export function extractSourceFromEsqlQuery(query: string): string {
+  if (!hasTransformationalCommand(query)) {
+    return query.trim();
+  }
+  const pipeIndex = query.search(/\|\s*(stats|keep|promql)\b/i);
+  return pipeIndex !== -1 ? query.slice(0, pipeIndex).replace(/\|\s*$/, '').trim() : query.trim();
+}
+
+export function buildForkFilterQuery({
+  userQuery,
+  timeField,
+  current,
+  previous,
+}: {
+  userQuery: string;
+  timeField: string;
+  current: AbsoluteRange;
+  previous: AbsoluteRange;
+}): string {
+  const source = extractSourceFromEsqlQuery(userQuery);
+  const shiftMs = new Date(current.from).getTime() - new Date(previous.from).getTime();
+  return [
+    source,
+    `| FORK`,
+    `  (WHERE ${timeField} >= "${current.from}" AND ${timeField} < "${current.to}")`,
+    `  (WHERE ${timeField} >= "${previous.from}" AND ${timeField} < "${previous.to}" | EVAL ${timeField} = ${timeField} + ${shiftMs} milliseconds)`,
+  ].join('\n');
+}

--- a/src/platform/plugins/shared/discover/server/agent_builder/register_skill.ts
+++ b/src/platform/plugins/shared/discover/server/agent_builder/register_skill.ts
@@ -100,9 +100,23 @@ When responding to an on-demand request, return ONLY the requested analysis. Do 
 
 #### Time-over-Time Comparison (only when asked)
 When the user asks to compare time periods (e.g. "compare with last week", "how does today compare to yesterday"):
-1. Use generateEsql to produce a SINGLE query that buckets by week (or appropriate period) so both time periods appear in one result. For example: STATS count = COUNT(*) BY BUCKET(@timestamp, 1 week), SORT bucket, LIMIT 10. This avoids running two separate queries.
-2. Execute it and compare the buckets: highlight absolute values, differences, and what grew or shrank.
-3. Calculate percentage changes yourself in the response text.
+1. Read the current time range from the attached ES|QL query results (the "from" and "to" values as ISO-8601 strings). Compute:
+   - current_start_ms and current_end_ms (epoch milliseconds of the current period boundaries)
+   - shift_ms = current_start_ms - previous_start_ms = duration of the period in milliseconds (current_end_ms - current_start_ms)
+   - previous_start = ISO string of (current_start_ms - shift_ms)
+   - previous_end = ISO string of (current_end_ms - shift_ms)
+2. Build the FORK query yourself using this exact structure (do NOT use generateEsql for the structure, only use the correct field names and computed values):
+   \`\`\`esql
+   FROM <index>
+   | FORK
+     (WHERE <timeField> >= "<current_start>" AND <timeField> < "<current_end>" | EVAL period = "Current period")
+     (WHERE <timeField> >= "<previous_start>" AND <timeField> < "<previous_end>" | EVAL period = "Previous period" | EVAL <timeField> = <timeField> + <shift_ms> milliseconds)
+   | STATS count = COUNT(*) BY timestamp = BUCKET(<timeField>, <interval>), period
+   | SORT timestamp ASC
+   \`\`\`
+   The EVAL <timeField> = <timeField> + <shift_ms> milliseconds line is critical — it shifts the previous period timestamps forward so both series land on the same time axis positions and can be overlaid for comparison. Use an interval appropriate to the time span (e.g. 5 minutes for a 30 min window, 1 hour for a 24 h window, 1 day for a week).
+3. Execute the FORK query with executeEsql and compare the two periods: highlight absolute values, differences, and what grew or shrank. Calculate percentage changes yourself in the response text.
+4. IMPORTANT: Immediately after the analysis, call createVisualization with the FORK query as the esql parameter, chartType "xy", and query "line chart with timestamp on the x-axis and period as the series breakdown, comparing Current period vs Previous period". This renders both periods as separate lines overlaid on the same time axis — do NOT skip this step.
 
 #### Field Statistics (only when asked)
 When the user asks about field statistics, field distributions, or cardinality (e.g. "show field stats", "what are the top values?"):


### PR DESCRIPTION
## Summary

Adds the ability to render the histogram of a previous period shifted on the current period (defined by the timepicker). This is very useful for comparing 2 periods, one next to each other (i.e. today - yesterday, this year - last year)

<img width="2507" height="620" alt="image" src="https://github.com/user-attachments/assets/ec3abdce-8f74-4dd5-b4a2-be7467cf652f" />


Also added the same capability to the agent builder.

<img width="734" height="743" alt="image" src="https://github.com/user-attachments/assets/f8edd505-3cfe-4659-9b3c-d94befd23ca6" />


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



