### PR TITLE
[Discover] Fix indexOf exception

### DIFF
--- a/src/platform/plugins/shared/field_formats/common/content_types/html_content_type.test.ts
+++ b/src/platform/plugins/shared/field_formats/common/content_types/html_content_type.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FieldFormat } from '../field_format';
+import { asPrettyString } from '../utils';
+import type { HtmlContextTypeConvert, TextContextTypeConvert } from '../types';
+
+const createFormat = (htmlConvert?: (...args: unknown[]) => string) =>
+  new (class TestFormat extends FieldFormat {
+    static id = 'test-html-content';
+    static title = 'Test HTML Content';
+    textConvert: TextContextTypeConvert = (val) => asPrettyString(val);
+    htmlConvert: HtmlContextTypeConvert | undefined = htmlConvert as
+      | HtmlContextTypeConvert
+      | undefined;
+  })({}, jest.fn());
+
+describe('html_content_type setup', () => {
+  test('does not throw when array contains non-string values from ignored_field_values', () => {
+    const format = createFormat();
+    const result = format.convert(['valid', true, { message: 'error' }], 'html');
+    expect(result).toMatchInlineSnapshot(`
+      "<span class=\\"ffArray__highlight\\">[</span>
+        valid<span class=\\"ffArray__highlight\\">,</span>
+        true<span class=\\"ffArray__highlight\\">,</span>
+        {
+          &quot;message&quot;: &quot;error&quot;
+        }
+      <span class=\\"ffArray__highlight\\">]</span>"
+    `);
+  });
+
+  test('does not throw when custom htmlConvert returns a non-string', () => {
+    const format = createFormat(() => true as unknown as string);
+    const result = format.convert([1, 2], 'html');
+    expect(result).toMatchInlineSnapshot(
+      `"<span class=\\"ffArray__highlight\\">[</span>true<span class=\\"ffArray__highlight\\">,</span> true<span class=\\"ffArray__highlight\\">]</span>"`
+    );
+  });
+});

--- a/src/platform/plugins/shared/field_formats/common/content_types/html_content_type.ts
+++ b/src/platform/plugins/shared/field_formats/common/content_types/html_content_type.ts
@@ -47,7 +47,9 @@ export const setup = (
     }
 
     const subValues = value.map((v: unknown) => recurse(v, options));
-    const useMultiLine = subValues.some((sub: string) => sub.indexOf('\n') > -1);
+    const useMultiLine = subValues.some(
+      (sub: string) => typeof sub === 'string' && sub.indexOf('\n') > -1
+    );
 
     return subValues.join(highlight(',') + (useMultiLine ? '\n' : ' '));
   };
@@ -59,7 +61,7 @@ export const setup = (
       return convertedValue;
     }
 
-    if (convertedValue.includes('\n')) {
+    if (typeof convertedValue === 'string' && convertedValue.includes('\n')) {
       const indentedValue = convertedValue.replaceAll(/(\n+)/g, '$1  ');
 
       return highlight('[') + `\n  ${indentedValue}\n` + highlight(']');


### PR DESCRIPTION
- Resolves https://github.com/elastic/kibana/issues/270351

## Summary

This PR prevents exceptions when rendering documents with ignored values of unexpected type.

<img width="1424" height="729" alt="Screenshot 2026-05-21 at 10 37 56" src="https://github.com/user-attachments/assets/f44d203b-3d62-47b8-88db-b93505e079d6" />



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


