### PR TITLE
[one-console] Few QOL improvements 

### DIFF
--- a/src/platform/plugins/shared/console/packaging/react/index.tsx
+++ b/src/platform/plugins/shared/console/packaging/react/index.tsx
@@ -82,6 +82,7 @@ export const OneConsole = ({
   http: customHttp,
   notifications: customNotifications,
   storagePrefix,
+  defaultEditorContent,
 }: OneConsoleProps) => {
   const [apiLoaded, setApiLoaded] = useState(false);
 
@@ -260,6 +261,7 @@ export const OneConsole = ({
           config: {
             isDevMode: false,
             isPackagedEnvironment: true,
+            defaultEditorContent,
           },
         }}
       >

--- a/src/platform/plugins/shared/console/packaging/react/index.tsx
+++ b/src/platform/plugins/shared/console/packaging/react/index.tsx
@@ -81,6 +81,7 @@ export const OneConsole = ({
   lang = 'en',
   http: customHttp,
   notifications: customNotifications,
+  storagePrefix,
 }: OneConsoleProps) => {
   const [apiLoaded, setApiLoaded] = useState(false);
 
@@ -143,9 +144,18 @@ export const OneConsole = ({
     });
     setStorage(storage);
 
-    const storageHistory = createHistory({ storage });
+    // When a storagePrefix is provided (e.g. a per-deployment ID from cloud-ui),
+    // history and the editor buffer are stored under that prefix so each
+    // deployment gets its own isolated state. Settings, variables, and panel
+    // sizes always use the shared 'sense:' prefix via the singleton above.
+    const scopedStorage =
+      storagePrefix && storagePrefix !== 'sense:'
+        ? createStorage({ engine: window.localStorage, prefix: storagePrefix })
+        : storage;
+
+    const storageHistory = createHistory({ storage: scopedStorage });
     const settings = createSettings({ storage });
-    const objectStorageClient = localStorageObjectClient.create(storage);
+    const objectStorageClient = localStorageObjectClient.create(scopedStorage);
     const api = createApi({ http });
     const esHostService = createEsHostService({ api });
 

--- a/src/platform/plugins/shared/console/packaging/react/types.ts
+++ b/src/platform/plugins/shared/console/packaging/react/types.ts
@@ -47,4 +47,12 @@ export interface OneConsoleProps {
   lang?: 'en' | 'fr-FR' | 'ja-JP' | 'zh-CN';
   http?: Partial<HttpSetup>;
   notifications: NotificationCallbacks;
+  /**
+   * Literal localStorage key prefix for per-instance state (request history
+   * and the in-progress editor buffer). Pass a per-deployment value so each
+   * deployment keeps its own history and editor buffer isolated. Defaults to
+   * `'sense:'`. User settings, variables, and panel sizes are NOT scoped by
+   * this prefix — they remain shared across deployments.
+   */
+  storagePrefix?: string;
 }

--- a/src/platform/plugins/shared/console/packaging/react/types.ts
+++ b/src/platform/plugins/shared/console/packaging/react/types.ts
@@ -55,4 +55,11 @@ export interface OneConsoleProps {
    * this prefix — they remain shared across deployments.
    */
   storagePrefix?: string;
+  /**
+   * Text shown in the editor when no buffer is saved for this instance
+   * (first mount, or after the user clears everything and remounts). Defaults
+   * to Kibana's built-in welcome message. Consumers can pass a custom string
+   * to show product- or deployment-specific placeholder commands instead.
+   */
+  defaultEditorContent?: string;
 }

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
@@ -14,7 +14,7 @@ import { decompressFromEncodedURIComponent } from 'lz-string';
 import { i18n } from '@kbn/i18n';
 import { useEffect, useRef } from 'react';
 import { DEFAULT_INPUT_VALUE } from '../../../../../common/constants';
-import { useEditorActionContext, useServicesContext } from '../../../contexts';
+import { useEditorActionContext } from '../../../contexts';
 
 const httpsProtocol = 'https:';
 const elasticHostname = 'www.elastic.co';
@@ -30,6 +30,8 @@ interface SetInitialValueParams {
   setValue: (value: string) => void;
   /** The toasts service. */
   toasts: IToasts;
+  /** Optional override for the default editor content shown when no saved buffer exists. */
+  defaultEditorContent?: string;
 }
 
 /**
@@ -49,10 +51,9 @@ export const readLoadFromParam = () => {
  * @param params The {@link SetInitialValueParams} to use.
  */
 export const useSetInitialValue = (params: SetInitialValueParams) => {
-  const { localStorageValue, setValue, toasts } = params;
+  const { localStorageValue, setValue, toasts, defaultEditorContent } = params;
   const isInitialValueSet = useRef<boolean>(false);
   const editorDispatch = useEditorActionContext();
-  const { config } = useServicesContext();
 
   useEffect(() => {
     const ALLOWED_PATHS = ['/guide/', '/docs/'];
@@ -124,7 +125,7 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
     // Only set the value in the editor if an initial value hasn't been set yet
     if (!isInitialValueSet.current) {
       // Only set to default input value if the localstorage value is undefined
-      setValue(localStorageValue ?? config.defaultEditorContent ?? DEFAULT_INPUT_VALUE);
+      setValue(localStorageValue ?? defaultEditorContent ?? DEFAULT_INPUT_VALUE);
       loadFromUrl();
       isInitialValueSet.current = true;
     }
@@ -132,5 +133,5 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
     return () => {
       window.removeEventListener('hashchange', loadFromUrl);
     };
-  }, [localStorageValue, setValue, toasts, editorDispatch]);
+  }, [localStorageValue, setValue, toasts, editorDispatch, defaultEditorContent]);
 };

--- a/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/hooks/use_set_initial_value.ts
@@ -14,7 +14,7 @@ import { decompressFromEncodedURIComponent } from 'lz-string';
 import { i18n } from '@kbn/i18n';
 import { useEffect, useRef } from 'react';
 import { DEFAULT_INPUT_VALUE } from '../../../../../common/constants';
-import { useEditorActionContext } from '../../../contexts';
+import { useEditorActionContext, useServicesContext } from '../../../contexts';
 
 const httpsProtocol = 'https:';
 const elasticHostname = 'www.elastic.co';
@@ -52,6 +52,7 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
   const { localStorageValue, setValue, toasts } = params;
   const isInitialValueSet = useRef<boolean>(false);
   const editorDispatch = useEditorActionContext();
+  const { config } = useServicesContext();
 
   useEffect(() => {
     const ALLOWED_PATHS = ['/guide/', '/docs/'];
@@ -123,7 +124,7 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
     // Only set the value in the editor if an initial value hasn't been set yet
     if (!isInitialValueSet.current) {
       // Only set to default input value if the localstorage value is undefined
-      setValue(localStorageValue ?? DEFAULT_INPUT_VALUE);
+      setValue(localStorageValue ?? config.defaultEditorContent ?? DEFAULT_INPUT_VALUE);
       loadFromUrl();
       isInitialValueSet.current = true;
     }

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
@@ -78,6 +78,7 @@ export const MonacoEditor = ({
       application,
     },
     docLinkVersion,
+    config: { defaultEditorContent },
   } = context;
   const { toasts } = notifications;
   const {
@@ -200,7 +201,7 @@ export const MonacoEditor = ({
     [esqlCallbacks]
   );
 
-  useSetInitialValue({ localStorageValue, setValue, toasts });
+  useSetInitialValue({ localStorageValue, setValue, toasts, defaultEditorContent });
 
   useSetupAutocompletePolling({ autocompleteInfo, settingsService });
 

--- a/src/platform/plugins/shared/console/public/application/contexts/services_context.tsx
+++ b/src/platform/plugins/shared/console/public/application/contexts/services_context.tsx
@@ -42,6 +42,7 @@ export interface ContextValue extends ConsoleStartServices {
   config: {
     isDevMode: boolean;
     isPackagedEnvironment?: boolean;
+    defaultEditorContent?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

This PR adds the possibility for consumers to:

* Have console history and editor state have a custom prefix (used in localstorage) so that we could support per deployment console state and history in cloud ui.
* Have a custom initial editor state that can be configured