### PR TITLE
[kbn-evals] Stop double-registering OTel HTTP/undici instrumentation in eval worker

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/config/require_init_apm.js
+++ b/x-pack/platform/packages/shared/kbn-evals/src/config/require_init_apm.js
@@ -5,19 +5,20 @@
  * 2.0.
  */
 
-// TODO: These instrumentations should eventually be set by initialing
-// OpenTelemetry tracing. Right now they would conflict with Elastic
-// APM. See https://github.com/elastic/kibana/issues/220914
-
-const { UndiciInstrumentation } = require('@opentelemetry/instrumentation-undici');
-const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
-const { registerInstrumentations } = require('@opentelemetry/instrumentation');
-
 require('@kbn/setup-node-env');
 
 // Build synthetic argv from the TRACING_EXPORTERS env var when set.
 // This allows CI (and local users) to configure trace exporters without a kibana.dev.yml.
 // The argv overrides take priority over kibana.dev.yml via applyConfigOverrides.
+//
+// When this flag set enables OTel tracing on the worker, `initTelemetry` will
+// register `@opentelemetry/instrumentation-http` + `@opentelemetry/instrumentation-undici`
+// via `maybeInitAutoInstrumentations` (guarded by a global symbol so it only runs once).
+// We must NOT also register them here, or undici's `request.addHeader('traceparent', …)`
+// (which appends, unlike http's overwrite-by-assignment) would emit two `traceparent`
+// values per request, the W3C extractor on the Kibana side would reject the comma-joined
+// header, and inbound requests would start fresh root traces — disconnecting the
+// worker's task span from the inference plugin's `ChatComplete` span.
 const argv = [];
 const tracingExporters = process.env.TRACING_EXPORTERS;
 if (tracingExporters) {
@@ -42,16 +43,3 @@ if (tracingExporters) {
 // we send an empty process.argv argument (or our synthetic overrides), as playwright
 // uses the same --config flag as kibana, leading it to not read from kibana.{dev.}yml
 require('../../../../../../../src/cli/kibana/apm')('playwright', argv);
-
-registerInstrumentations({
-  instrumentations: [
-    // undici is needed for Elasticsearch
-    new UndiciInstrumentation({
-      requireParentforSpans: true,
-    }),
-    // http is needed for axios etc
-    new HttpInstrumentation({
-      requireParentforOutgoingSpans: true,
-    }),
-  ],
-});


### PR DESCRIPTION
## Summary

Removes the manual registration of `@opentelemetry/instrumentation-http` and `@opentelemetry/instrumentation-undici` from the eval worker's APM bootstrap file (`require_init_apm.js`). These instrumentations are already registered by `initTelemetry` via `maybeInitAutoInstrumentations` when `TRACING_EXPORTERS` environment variable is set, so registering them a second time caused duplicate `traceparent` headers which got rejected.
- Fix: Rely on the single registration path in `initTelemetry` and remove the redundant `registerInstrumentations()` call along with the now-unused imports.


### Testing
1. Running the following with evals CLI
```bash
node scripts/evals init
node scripts/evals start 
```
2. Selecting a suite using trace evaluators (e.g `significant-events`).
3. Ensuring trace evaluators run successfully
4. Viewing the traces and seeing inference spans captured correctly:
<img width="1129" height="570" alt="image" src="https://github.com/user-attachments/assets/c6c58aa2-f406-4739-98b3-a116a2028ddb" />

### Notes:
The hard troubleshooting work was done by @viduni94, commit was cherry-picket from https://github.com/elastic/kibana/pull/267759/commits/143c1f2479af199491c4435b700409da11b64422 to make it to main and unblock internal evals faster than the original pull request where the change was made. 
