### PR TITLE
[Search] Update vectordb sidenav and data view

### DIFF
--- a/config/serverless.vectordb.yml
+++ b/config/serverless.vectordb.yml
@@ -19,8 +19,6 @@ xpack.features.overrides:
   dev_tools.category: "enterpriseSearch"
   ### Discover feature is moved from Analytics category to the VectorDB one.
   discover_v2.category: "enterpriseSearch"
-  ### Machine Learning feature is moved from Analytics category to the Management one.
-  ml.category: "management"
   ### Stack Alerts feature is moved from Analytics category to the VectorDB one and renamed to simply `Alerts`.
   stackAlerts:
     name: "Alerts"
@@ -37,3 +35,7 @@ uiSettings.overrides.defaultRoute: /app/vectordb
 
 # Specify in telemetry the project type
 telemetry.labels.serverless: vectordb
+
+xpack.ml.ad.enabled: false    # Disables Anomaly Detection
+xpack.ml.dfa.enabled: false   # Disables Data Frame Analytics
+xpack.ml.nlp.enabled: false   # Disables NLP/Trained Models

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -171,7 +171,7 @@ pageLoadAssetSize:
   serverless: 7412
   serverlessObservability: 21437
   serverlessSearch: 26287
-  serverlessVectordb: 7618
+  serverlessVectordb: 11999
   serverlessWorkplaceAI: 4855
   sessionView: 47912
   share: 64059

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/kibana.jsonc
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/kibana.jsonc
@@ -17,6 +17,7 @@
       "vectordb"
     ],
     "requiredPlugins": [
+      "dataViews",
       "serverless",
       "share",
       "agentBuilder"

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/moon.yml
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/moon.yml
@@ -33,6 +33,11 @@ dependsOn:
   - '@kbn/vectordb-onboarding'
   - '@kbn/react-query'
   - '@kbn/i18n'
+  - '@kbn/core-application-browser'
+  - '@kbn/deeplinks-management'
+  - '@kbn/ai-assistant-common'
+  - '@kbn/management-settings-ids'
+  - '@kbn/data-views-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/navigation_tree.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/navigation_tree.ts
@@ -37,9 +37,6 @@ const ALERTS_AND_INSIGHTS_TITLE = i18n.translate(
     defaultMessage: 'Alerts and insights',
   }
 );
-const MACHINE_LEARNING_TITLE = i18n.translate('xpack.serverlessVectordb.nav.machineLearning', {
-  defaultMessage: 'Machine Learning',
-});
 const ACCESS_TITLE = i18n.translate('xpack.serverlessVectordb.nav.mngt.access', {
   defaultMessage: 'Access',
 });
@@ -116,65 +113,6 @@ export function createNavigationTree({
             title: i18n.translate('xpack.serverlessVectordb.nav.ingest.pipelines.title', {
               defaultMessage: 'Ingest',
             }),
-          },
-          {
-            id: 'ml_overview',
-            title: MACHINE_LEARNING_TITLE,
-            children: [
-              { link: 'ml:overview' },
-              { link: 'ml:dataVisualizer' },
-              { link: 'ml:dataDrift', sideNavStatus: 'hidden' },
-              { link: 'ml:dataDriftPage', sideNavStatus: 'hidden' },
-              { link: 'ml:fileUpload', sideNavStatus: 'hidden' },
-              { link: 'ml:indexDataVisualizer', sideNavStatus: 'hidden' },
-              { link: 'ml:indexDataVisualizerPage', sideNavStatus: 'hidden' },
-            ],
-          },
-          {
-            id: 'category-anomaly_detection',
-            title: i18n.translate('xpack.serverlessVectordb.nav.machineLearning.anomalyDetection', {
-              defaultMessage: 'Anomaly detection',
-            }),
-            breadcrumbStatus: 'hidden',
-            children: [
-              {
-                link: 'management:anomaly_detection',
-                title: i18n.translate(
-                  'xpack.serverlessVectordb.nav.machineLearning.anomalyDetection.manageJobs',
-                  {
-                    defaultMessage: 'Manage jobs',
-                  }
-                ),
-              },
-              { link: 'ml:anomalyExplorer' },
-              { link: 'ml:singleMetricViewer' },
-            ],
-          },
-          {
-            id: 'category-data_frame analytics',
-            title: i18n.translate(
-              'xpack.serverlessVectordb.nav.machineLearning.dataFrameAnalytics',
-              {
-                defaultMessage: 'Data frame analytics',
-              }
-            ),
-            breadcrumbStatus: 'hidden',
-            children: [{ link: 'ml:resultExplorer' }, { link: 'ml:analyticsMap' }],
-          },
-          {
-            id: 'category-aiops_labs',
-            title: i18n.translate('xpack.serverlessVectordb.nav.machineLearning.aiops_labs', {
-              defaultMessage: 'AIOps labs',
-            }),
-            breadcrumbStatus: 'hidden',
-            children: [
-              { link: 'ml:logRateAnalysis' },
-              { link: 'ml:logRateAnalysisPage', sideNavStatus: 'hidden' },
-              { link: 'ml:logPatternAnalysis' },
-              { link: 'ml:logPatternAnalysisPage', sideNavStatus: 'hidden' },
-              { link: 'ml:changePointDetections' },
-              { link: 'ml:changePointDetectionsPage', sideNavStatus: 'hidden' },
-            ],
           },
         ],
         icon: 'database',
@@ -289,16 +227,6 @@ export function createNavigationTree({
                 breadcrumbStatus: 'hidden',
                 badgeType: 'new',
               },
-            ],
-          },
-          {
-            id: 'settings_ml',
-            title: MACHINE_LEARNING_TITLE,
-            children: [
-              { link: 'management:overview', breadcrumbStatus: 'hidden' },
-              { link: 'management:trained_models', breadcrumbStatus: 'hidden' },
-              { link: 'management:anomaly_detection' },
-              { link: 'management:analytics' },
             ],
           },
           {

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/navigation_tree.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/navigation_tree.ts
@@ -75,6 +75,10 @@ export function createNavigationTree({
         breadcrumbStatus: 'hidden',
       },
       {
+        icon: 'productAgent',
+        link: 'agent_builder',
+      },
+      {
         link: 'discover',
         icon: 'productDiscover',
       },
@@ -86,17 +90,36 @@ export function createNavigationTree({
           isEditingFromDashboard(location, pathNameSerialized, prepend),
       },
       {
-        icon: 'productAgent',
-        link: 'agent_builder',
-      },
-      {
         link: 'workflows',
       },
       {
         children: [
           {
+            children: [
+              { link: 'management:index_management', breadcrumbStatus: 'hidden' },
+              { link: 'management:index_lifecycle_management', breadcrumbStatus: 'hidden' },
+              { link: 'management:snapshot_restore', breadcrumbStatus: 'hidden' },
+              { link: 'management:transform', breadcrumbStatus: 'hidden' },
+              { link: 'management:rollup_jobs', breadcrumbStatus: 'hidden' },
+              { link: 'management:data_quality', breadcrumbStatus: 'hidden' },
+              { link: 'management:data_usage', breadcrumbStatus: 'hidden' },
+            ],
+            title: i18n.translate('xpack.serverlessVectordb.nav.ingest.indices.title', {
+              defaultMessage: 'Indices and data streams',
+            }),
+          },
+          {
+            children: [
+              { link: 'management:ingest_pipelines', breadcrumbStatus: 'hidden' },
+              { link: 'management:pipelines', breadcrumbStatus: 'hidden' },
+            ],
+            title: i18n.translate('xpack.serverlessVectordb.nav.ingest.pipelines.title', {
+              defaultMessage: 'Ingest',
+            }),
+          },
+          {
             id: 'ml_overview',
-            title: '',
+            title: MACHINE_LEARNING_TITLE,
             children: [
               { link: 'ml:overview' },
               { link: 'ml:dataVisualizer' },
@@ -152,48 +175,6 @@ export function createNavigationTree({
               { link: 'ml:changePointDetections' },
               { link: 'ml:changePointDetectionsPage', sideNavStatus: 'hidden' },
             ],
-          },
-        ],
-        icon: 'productML',
-        id: 'machine_learning',
-        renderAs: 'panelOpener',
-        title: MACHINE_LEARNING_TITLE,
-      },
-      {
-        children: [
-          {
-            children: [
-              { link: 'management:index_management', breadcrumbStatus: 'hidden' },
-              { link: 'management:index_lifecycle_management', breadcrumbStatus: 'hidden' },
-              { link: 'management:snapshot_restore', breadcrumbStatus: 'hidden' },
-              { link: 'management:transform', breadcrumbStatus: 'hidden' },
-              { link: 'management:rollup_jobs', breadcrumbStatus: 'hidden' },
-              { link: 'management:data_quality', breadcrumbStatus: 'hidden' },
-              { link: 'management:data_usage', breadcrumbStatus: 'hidden' },
-            ],
-            title: i18n.translate('xpack.serverlessVectordb.nav.ingest.indices.title', {
-              defaultMessage: 'Indices and data streams',
-            }),
-          },
-          {
-            children: [
-              { link: 'management:ingest_pipelines', breadcrumbStatus: 'hidden' },
-              { link: 'management:pipelines', breadcrumbStatus: 'hidden' },
-            ],
-            title: i18n.translate('xpack.serverlessVectordb.nav.ingest.pipelines.title', {
-              defaultMessage: 'Ingest',
-            }),
-          },
-          {
-            children: [
-              { link: 'searchSynonyms:synonyms' },
-              { link: 'searchQueryRules' },
-              { link: 'searchPlayground' },
-            ],
-            id: 'search_relevance',
-            title: i18n.translate('xpack.serverlessVectordb.nav.ingest.relevance.title', {
-              defaultMessage: 'Relevance',
-            }),
           },
         ],
         icon: 'database',

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/navigation_tree.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/navigation_tree.ts
@@ -5,116 +5,382 @@
  * 2.0.
  */
 
+import type { Location } from 'history';
+
+import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { NavigationTreeDefinition } from '@kbn/core-chrome-browser';
+import { DATA_MANAGEMENT_NAV_ID } from '@kbn/deeplinks-management';
 import { i18n } from '@kbn/i18n';
 
-export const createNavigationTree = (): NavigationTreeDefinition => ({
-  body: [
-    {
-      link: 'vectordb',
-      title: i18n.translate('xpack.serverlessVectordb.nav.title', {
-        defaultMessage: 'Vector DB',
-      }),
-      icon: 'logoElasticsearch',
-      renderAs: 'home',
-      breadcrumbStatus: 'hidden',
-    },
-    {
-      link: 'agent_builder',
-      icon: 'productAgent',
-    },
-    {
-      link: 'workflows',
-    },
-    {
-      id: 'dataManagement',
-      title: i18n.translate('xpack.serverlessVectordb.nav.dataManagement', {
-        defaultMessage: 'Data management',
-      }),
-      icon: 'database',
-      renderAs: 'panelOpener',
-      children: [
-        {
-          title: i18n.translate('xpack.serverlessVectordb.nav.dataManagement.explore', {
-            defaultMessage: 'Explore',
-          }),
-          breadcrumbStatus: 'hidden',
-          children: [
-            { link: 'discover', breadcrumbStatus: 'hidden' },
-            { link: 'dashboards', breadcrumbStatus: 'hidden' },
-          ],
-        },
-        {
-          title: i18n.translate('xpack.serverlessVectordb.nav.dataManagement.indices', {
-            defaultMessage: 'Indices and data streams',
-          }),
-          breadcrumbStatus: 'hidden',
-          children: [
-            { link: 'management:index_management', breadcrumbStatus: 'hidden' },
-            { link: 'management:transform', breadcrumbStatus: 'hidden' },
-          ],
-        },
-        {
-          title: i18n.translate('xpack.serverlessVectordb.nav.dataManagement.ingest', {
-            defaultMessage: 'Ingest',
-          }),
-          breadcrumbStatus: 'hidden',
-          children: [{ link: 'management:ingest_pipelines', breadcrumbStatus: 'hidden' }],
-        },
-        {
-          title: i18n.translate('xpack.serverlessVectordb.nav.dataManagement.dataViews', {
-            defaultMessage: 'Data views',
-          }),
-          breadcrumbStatus: 'hidden',
-          children: [{ link: 'management:dataViews', breadcrumbStatus: 'hidden' }],
-        },
-      ],
-    },
-  ],
-  footer: [
-    {
-      id: 'tutorials',
-      title: i18n.translate('xpack.serverlessVectordb.nav.tutorials', {
-        defaultMessage: 'Getting started',
-      }),
-      link: 'vectordb:tutorials',
-      icon: 'rocket',
-    },
-    {
-      id: 'devTools',
-      title: i18n.translate('xpack.serverlessVectordb.nav.devTools', {
-        defaultMessage: 'Developer tools',
-      }),
-      link: 'dev_tools',
-      icon: 'code',
-    },
-    {
-      id: 'management',
-      title: i18n.translate('xpack.serverlessVectordb.nav.management', {
-        defaultMessage: 'Management',
-      }),
-      icon: 'gear',
-      renderAs: 'panelOpener',
-      children: [
-        {
-          title: i18n.translate('xpack.serverlessVectordb.nav.management.access', {
-            defaultMessage: 'Access',
-          }),
-          breadcrumbStatus: 'hidden',
-          children: [{ link: 'management:api_keys', breadcrumbStatus: 'hidden' }],
-        },
-        {
-          title: i18n.translate('xpack.serverlessVectordb.nav.management.content', {
-            defaultMessage: 'Content',
-          }),
-          breadcrumbStatus: 'hidden',
-          children: [
-            { link: 'management:spaces', breadcrumbStatus: 'hidden' },
-            { link: 'management:objects', breadcrumbStatus: 'hidden' },
-            { link: 'management:settings', breadcrumbStatus: 'hidden' },
-          ],
-        },
-      ],
-    },
-  ],
+function isEditingFromDashboard(
+  location: Location,
+  pathNameSerialized: string,
+  prepend: (path: string) => string
+): boolean {
+  const vizApps = ['/app/visualize', '/app/maps', '/app/lens'];
+  const isVizApp = vizApps.some((app) => pathNameSerialized.startsWith(prepend(app)));
+  const hasOriginatingApp =
+    location.search.includes('originatingApp=dashboards') ||
+    location.hash.includes('originatingApp=dashboards');
+  return isVizApp && hasOriginatingApp;
+}
+
+const NAV_TITLE = i18n.translate('xpack.serverlessVectordb.nav.title', {
+  defaultMessage: 'Vector DB',
 });
+const PERFORMANCE_TITLE = i18n.translate('xpack.serverlessVectordb.nav.performance', {
+  defaultMessage: 'Performance',
+});
+const ALERTS_AND_INSIGHTS_TITLE = i18n.translate(
+  'xpack.serverlessVectordb.nav.mngt.alertsAndInsights',
+  {
+    defaultMessage: 'Alerts and insights',
+  }
+);
+const MACHINE_LEARNING_TITLE = i18n.translate('xpack.serverlessVectordb.nav.machineLearning', {
+  defaultMessage: 'Machine Learning',
+});
+const ACCESS_TITLE = i18n.translate('xpack.serverlessVectordb.nav.mngt.access', {
+  defaultMessage: 'Access',
+});
+const CONTENT_TITLE = i18n.translate('xpack.serverlessVectordb.nav.mngt.content', {
+  defaultMessage: 'Content',
+});
+
+const AI_TITLE = i18n.translate('xpack.serverlessVectordb.nav.adminAndSettings.ai.title', {
+  defaultMessage: 'AI',
+});
+
+const PROJECT_PERFORMANCE_TITLE = i18n.translate(
+  'xpack.serverlessVectordb.nav.adminAndSettings.projectPerformance.title',
+  {
+    defaultMessage: 'Project performance',
+  }
+);
+
+export function createNavigationTree({
+  showAiAssistant = true,
+  showAlertingV2 = false,
+}: ApplicationStart & {
+  showAiAssistant?: boolean;
+  showAlertingV2?: boolean;
+}): NavigationTreeDefinition {
+  return {
+    body: [
+      {
+        icon: 'logoElasticsearch',
+        link: 'vectordb',
+        renderAs: 'home',
+        title: NAV_TITLE,
+        breadcrumbStatus: 'hidden',
+      },
+      {
+        link: 'discover',
+        icon: 'productDiscover',
+      },
+      {
+        link: 'dashboards',
+        icon: 'productDashboard',
+        getIsActive: ({ pathNameSerialized, prepend, location }) =>
+          pathNameSerialized.startsWith(prepend('/app/dashboards')) ||
+          isEditingFromDashboard(location, pathNameSerialized, prepend),
+      },
+      {
+        icon: 'productAgent',
+        link: 'agent_builder',
+      },
+      {
+        link: 'workflows',
+      },
+      {
+        children: [
+          {
+            id: 'ml_overview',
+            title: '',
+            children: [
+              { link: 'ml:overview' },
+              { link: 'ml:dataVisualizer' },
+              { link: 'ml:dataDrift', sideNavStatus: 'hidden' },
+              { link: 'ml:dataDriftPage', sideNavStatus: 'hidden' },
+              { link: 'ml:fileUpload', sideNavStatus: 'hidden' },
+              { link: 'ml:indexDataVisualizer', sideNavStatus: 'hidden' },
+              { link: 'ml:indexDataVisualizerPage', sideNavStatus: 'hidden' },
+            ],
+          },
+          {
+            id: 'category-anomaly_detection',
+            title: i18n.translate('xpack.serverlessVectordb.nav.machineLearning.anomalyDetection', {
+              defaultMessage: 'Anomaly detection',
+            }),
+            breadcrumbStatus: 'hidden',
+            children: [
+              {
+                link: 'management:anomaly_detection',
+                title: i18n.translate(
+                  'xpack.serverlessVectordb.nav.machineLearning.anomalyDetection.manageJobs',
+                  {
+                    defaultMessage: 'Manage jobs',
+                  }
+                ),
+              },
+              { link: 'ml:anomalyExplorer' },
+              { link: 'ml:singleMetricViewer' },
+            ],
+          },
+          {
+            id: 'category-data_frame analytics',
+            title: i18n.translate(
+              'xpack.serverlessVectordb.nav.machineLearning.dataFrameAnalytics',
+              {
+                defaultMessage: 'Data frame analytics',
+              }
+            ),
+            breadcrumbStatus: 'hidden',
+            children: [{ link: 'ml:resultExplorer' }, { link: 'ml:analyticsMap' }],
+          },
+          {
+            id: 'category-aiops_labs',
+            title: i18n.translate('xpack.serverlessVectordb.nav.machineLearning.aiops_labs', {
+              defaultMessage: 'AIOps labs',
+            }),
+            breadcrumbStatus: 'hidden',
+            children: [
+              { link: 'ml:logRateAnalysis' },
+              { link: 'ml:logRateAnalysisPage', sideNavStatus: 'hidden' },
+              { link: 'ml:logPatternAnalysis' },
+              { link: 'ml:logPatternAnalysisPage', sideNavStatus: 'hidden' },
+              { link: 'ml:changePointDetections' },
+              { link: 'ml:changePointDetectionsPage', sideNavStatus: 'hidden' },
+            ],
+          },
+        ],
+        icon: 'productML',
+        id: 'machine_learning',
+        renderAs: 'panelOpener',
+        title: MACHINE_LEARNING_TITLE,
+      },
+      {
+        children: [
+          {
+            children: [
+              { link: 'management:index_management', breadcrumbStatus: 'hidden' },
+              { link: 'management:index_lifecycle_management', breadcrumbStatus: 'hidden' },
+              { link: 'management:snapshot_restore', breadcrumbStatus: 'hidden' },
+              { link: 'management:transform', breadcrumbStatus: 'hidden' },
+              { link: 'management:rollup_jobs', breadcrumbStatus: 'hidden' },
+              { link: 'management:data_quality', breadcrumbStatus: 'hidden' },
+              { link: 'management:data_usage', breadcrumbStatus: 'hidden' },
+            ],
+            title: i18n.translate('xpack.serverlessVectordb.nav.ingest.indices.title', {
+              defaultMessage: 'Indices and data streams',
+            }),
+          },
+          {
+            children: [
+              { link: 'management:ingest_pipelines', breadcrumbStatus: 'hidden' },
+              { link: 'management:pipelines', breadcrumbStatus: 'hidden' },
+            ],
+            title: i18n.translate('xpack.serverlessVectordb.nav.ingest.pipelines.title', {
+              defaultMessage: 'Ingest',
+            }),
+          },
+          {
+            children: [
+              { link: 'searchSynonyms:synonyms' },
+              { link: 'searchQueryRules' },
+              { link: 'searchPlayground' },
+            ],
+            id: 'search_relevance',
+            title: i18n.translate('xpack.serverlessVectordb.nav.ingest.relevance.title', {
+              defaultMessage: 'Relevance',
+            }),
+          },
+        ],
+        icon: 'database',
+        id: DATA_MANAGEMENT_NAV_ID,
+        renderAs: 'panelOpener',
+        title: i18n.translate('xpack.serverlessVectordb.nav.dataManagement', {
+          defaultMessage: 'Data management',
+        }),
+      },
+    ],
+    footer: [
+      {
+        id: 'vectordb_getting_started',
+        icon: 'rocket',
+        link: 'vectordb:tutorials',
+        title: i18n.translate('xpack.serverlessVectordb.nav.tutorials', {
+          defaultMessage: 'Getting started',
+        }),
+      },
+      {
+        id: 'dev_tools',
+        title: i18n.translate('xpack.serverlessVectordb.nav.developerTools', {
+          defaultMessage: 'Developer Tools',
+        }),
+        icon: 'code',
+        link: 'dev_tools:console',
+        getIsActive: ({ pathNameSerialized, prepend }) => {
+          return pathNameSerialized.startsWith(prepend('/app/dev_tools'));
+        },
+      },
+      {
+        id: 'admin_and_settings',
+        title: i18n.translate('xpack.serverlessVectordb.nav.adminAndSettings', {
+          defaultMessage: 'Admin and Settings',
+        }),
+        icon: 'gear',
+        breadcrumbStatus: 'hidden',
+        renderAs: 'panelOpener',
+        children: [
+          {
+            id: 'settings_access',
+            title: ACCESS_TITLE,
+            children: [
+              { link: 'management:api_keys', breadcrumbStatus: 'hidden' },
+              { link: 'management:roles', breadcrumbStatus: 'hidden' },
+            ],
+          },
+          {
+            id: 'organization',
+            title: i18n.translate('xpack.serverlessVectordb.nav.adminAndSettings.org.title', {
+              defaultMessage: 'Organization',
+            }),
+            children: [
+              {
+                id: 'cloudLinkBilling',
+                cloudLink: 'billingAndSub',
+              },
+              {
+                id: 'cloudLinkDeployment',
+                cloudLink: 'deployment',
+                title: PERFORMANCE_TITLE,
+              },
+              {
+                cloudLink: 'userAndRoles',
+              },
+            ],
+          },
+          ...(showAlertingV2
+            ? [
+                {
+                  id: 'v2_alerting_preview',
+                  title: i18n.translate(
+                    'xpack.serverlessVectordb.nav.management.v2AlertingPreview',
+                    {
+                      defaultMessage: 'V2 Alerting Preview',
+                    }
+                  ),
+                  renderAs: 'panelOpener' as const,
+                  breadcrumbStatus: 'hidden' as const,
+                  children: [
+                    { link: 'management:rules' as const, breadcrumbStatus: 'hidden' as const },
+                    { link: 'management:episodes' as const, breadcrumbStatus: 'hidden' as const },
+                    {
+                      link: 'management:action_policies' as const,
+                      breadcrumbStatus: 'hidden' as const,
+                    },
+                    {
+                      link: 'management:execution_history' as const,
+                      breadcrumbStatus: 'hidden' as const,
+                    },
+                  ],
+                },
+              ]
+            : []),
+          {
+            id: 'settings_alerts',
+            title: ALERTS_AND_INSIGHTS_TITLE,
+            breadcrumbStatus: 'hidden',
+            children: [
+              { link: 'management:triggersActionsAlerts', breadcrumbStatus: 'hidden' },
+              { link: 'rules', breadcrumbStatus: 'hidden' },
+              { link: 'management:triggersActionsConnectors', breadcrumbStatus: 'hidden' },
+            ],
+          },
+          {
+            id: 'settings_project_performance',
+            title: PROJECT_PERFORMANCE_TITLE,
+            breadcrumbStatus: 'hidden',
+            children: [
+              {
+                link: 'management:queryActivity',
+                breadcrumbStatus: 'hidden',
+                badgeType: 'new',
+              },
+            ],
+          },
+          {
+            id: 'settings_ml',
+            title: MACHINE_LEARNING_TITLE,
+            children: [
+              { link: 'management:overview', breadcrumbStatus: 'hidden' },
+              { link: 'management:trained_models', breadcrumbStatus: 'hidden' },
+              { link: 'management:anomaly_detection' },
+              { link: 'management:analytics' },
+            ],
+          },
+          {
+            id: 'settings_model_management',
+            title: i18n.translate('xpack.serverlessVectordb.nav.adminAndSettings.modelManagement', {
+              defaultMessage: 'Model Management',
+            }),
+            children: [
+              {
+                id: 'searchInferenceEndpointsElasticInferenceService',
+                link: 'management:elastic_inference_service',
+              },
+              {
+                id: 'searchInferenceEndpoints',
+                link: 'management:inference_endpoints',
+              },
+              {
+                id: 'searchInferenceEndpointsModelSettings',
+                link: 'management:model_settings',
+              },
+            ],
+          },
+          {
+            id: 'settings_ai',
+            title: AI_TITLE,
+            children: [
+              { link: 'management:genAiSettings', breadcrumbStatus: 'hidden' },
+              { link: 'management:evals', breadcrumbStatus: 'hidden' },
+              ...(showAiAssistant
+                ? [
+                    {
+                      link: 'management:observabilityAiAssistantManagement' as const,
+                      breadcrumbStatus: 'hidden' as const,
+                    },
+                  ]
+                : []),
+            ],
+          },
+          {
+            id: 'settings_content',
+            title: CONTENT_TITLE,
+            children: [
+              { link: 'management:dataViews', breadcrumbStatus: 'hidden' },
+              { link: 'management:spaces', breadcrumbStatus: 'hidden' },
+              { link: 'management:objects', breadcrumbStatus: 'hidden' },
+              { link: 'management:filesManagement', breadcrumbStatus: 'hidden' },
+              { link: 'management:reporting', breadcrumbStatus: 'hidden' },
+              { link: 'management:tags', breadcrumbStatus: 'hidden' },
+            ],
+          },
+          {
+            title: i18n.translate('xpack.serverlessVectordb.nav.adminAndSettings.settings.title', {
+              defaultMessage: 'Settings',
+            }),
+            breadcrumbStatus: 'hidden',
+            children: [{ link: 'management:settings', breadcrumbStatus: 'hidden' }],
+          },
+          {
+            link: 'management',
+            sideNavStatus: 'hidden',
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/plugin.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/public/plugin.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { of } from 'rxjs';
+import { combineLatest, map, of } from 'rxjs';
 import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
+import { AIChatExperience } from '@kbn/ai-assistant-common';
+import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
 import { VECTORDB_APP_ID, TUTORIALS_DEEP_LINK_ID } from '../common/constants';
 import { createNavigationTree } from './navigation_tree';
 import type {
@@ -67,10 +69,22 @@ export class ServerlessVectordbPlugin
   }
 
   public start(
-    _core: CoreStart,
+    core: CoreStart,
     { serverless }: ServerlessVectordbStartDependencies
   ): ServerlessVectordbPluginStart {
-    serverless.initNavigation('vectordb', of(createNavigationTree()));
+    const chatExperience$ = core.settings.client.get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE);
+
+    const navigationTree$ = combineLatest([of(core.application), chatExperience$]).pipe(
+      map(([application, chatExperience]) => {
+        const showAiAssistant = chatExperience !== AIChatExperience.Agent;
+        return createNavigationTree({
+          ...application,
+          showAiAssistant,
+          showAlertingV2: Boolean(application.capabilities.alertingVTwo),
+        });
+      })
+    );
+    serverless.initNavigation('vectordb', navigationTree$);
     return {};
   }
 

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/plugin.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/plugin.ts
@@ -12,6 +12,7 @@ import type {
   CoreSetup,
   CoreStart,
 } from '@kbn/core/server';
+import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import { VECTORDB_PROJECT_SETTINGS } from '@kbn/serverless-vectordb-settings';
 
 import type { ServerlessVectordbConfig } from './config';
@@ -52,8 +53,30 @@ export class ServerlessVectordbPlugin
     return {};
   }
 
-  public start(core: CoreStart) {
+  public start(core: CoreStart, { dataViews }: StartDependencies) {
+    this.createDefaultDataView(core, dataViews).catch(() => {});
     return {};
+  }
+
+  private async createDefaultDataView(core: CoreStart, dataViews: DataViewsServerPluginStart) {
+    const dataViewsService = await dataViews.dataViewsServiceFactory(
+      core.savedObjects.createInternalRepository(),
+      core.elasticsearch.client.asInternalUser,
+      undefined,
+      true
+    );
+    const dataViewExists = await dataViewsService.get('default_all_data_id').catch(() => false);
+    if (!dataViewExists) {
+      const defaultDataViewExists = await dataViewsService.defaultDataViewExists();
+      if (!defaultDataViewExists) {
+        await dataViewsService.createAndSave({
+          allowNoIndex: false,
+          name: 'default:all-data',
+          title: '*,-.*',
+          id: 'default_all_data_id',
+        });
+      }
+    }
   }
 
   public stop() {}

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/types.ts
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/server/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import type { ServerlessPluginSetup } from '@kbn/serverless/server';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -16,5 +17,6 @@ export interface SetupDependencies {
   serverless: ServerlessPluginSetup;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface StartDependencies {}
+export interface StartDependencies {
+  dataViews: DataViewsServerPluginStart;
+}

--- a/x-pack/solutions/vectordb/plugins/serverless_vectordb/tsconfig.json
+++ b/x-pack/solutions/vectordb/plugins/serverless_vectordb/tsconfig.json
@@ -31,5 +31,10 @@
     "@kbn/vectordb-onboarding",
     "@kbn/react-query",
     "@kbn/i18n",
+    "@kbn/core-application-browser",
+    "@kbn/deeplinks-management",
+    "@kbn/ai-assistant-common",
+    "@kbn/management-settings-ids",
+    "@kbn/data-views-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

Implements the initial side-nav structure for the Vector DB project type. The ES3 navigation was used as a base and then customized for vector workloads.

**Key changes:**

- **Restructured primary navigation:** Made Agent Builder, Discover, Dashboards, and Workflows top-level nav items
- **Expanded navigation panels:** Added Data Management and Admin and Settings panels based on ES3 navigation structure
- **Disabled ML features:** Added config to disable Anomaly Detection, Data Frame Analytics, and NLP/Trained Models via `xpack.ml.*.enabled: false` settings
- **Dynamic navigation:** Navigation tree now reacts to AI chat experience setting and alerting v2 capability
- **Added tutorials deep link visibility:** Made getting started/tutorials visible in projectSideNav
- **Added default data view**: Creates a default *,-.* data view on startup so Discover and Dashboards work out of the box without requiring users to create one manually

### Screenshots
<img width="600" alt="FireShot Capture 055 - Elastic -  localhost" src="https://github.com/user-attachments/assets/95ec1b15-5bb3-4981-bd5e-4fa642e7385b" />
<img width="600" alt="FireShot Capture 056 - Index Management - Elastic -  localhost" src="https://github.com/user-attachments/assets/71c28737-3273-448e-bef6-4f7aff0abb71" />
<img width="600" alt="FireShot Capture 058 - Spaces - Elastic -  localhost" src="https://github.com/user-attachments/assets/40a58982-1097-4df1-991f-8df9545b16f7" />

## Test plan

- [ ] Start the Vector DB serverless project locally with EIS
  - ES: `yarn es serverless --projectType vectordb`
  - Kibana: `yarn serverless vectordb`
- [ ] Verify all expected sidenav items are available and working
- [ ] Verify ML apps are not accessible in the Vector DB project type
- [ ] Verify Getting Started and Developer Tools appear in the footer
- [ ] Verify Discover and Dashboards load without prompting to create a data view (default *,-.* pattern should be present)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~


