### PR TITLE
[Synthetics] Fix clipped test runs value in monitors summary

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_stats.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_stats/monitor_stats.tsx
@@ -73,7 +73,9 @@ export const MonitorStats = ({
           <EuiFlexItem
             css={{ display: 'flex', flexDirection: 'row', gap: euiTheme.size.l, height: '200px' }}
           >
-            <MonitorTestRunsCount />
+            <EuiFlexItem grow={false} css={{ minWidth: 120 }}>
+              <MonitorTestRunsCount />
+            </EuiFlexItem>
             <EuiFlexItem grow={true}>
               <MonitorTestRunsSparkline />
             </EuiFlexItem>


### PR DESCRIPTION
## Summary

Fixes a layout bug on the Synthetics **Monitors** management page where the **Last 30 days** total test runs value was getting clipped (e.g. `5,132` rendered as `5,13⌷`).

### Root cause
In `monitor_stats.tsx`, `MonitorTestRunsCount` was rendered as a bare flex child next to `<EuiFlexItem grow={true}>` for the sparkline. The sparkline (`flex: 1 1 0`) consumed all available space, shrinking the single-metric embeddable down to its `min-width: 80px` (from the `Wrapper` styled component in `exploratory_view/embeddable.tsx`). That's not wide enough for 4–5 digit values at the 27px font the single-metric Lens chart uses, so the number got clipped.

### Fix
Wrap `MonitorTestRunsCount` in an `EuiFlexItem` with `grow={false}` and `minWidth: 120` so the count column always reserves enough room for larger values, while the sparkline still grows to fill the rest.

| Before | After |
| --- | --- |
| `5,132` clipped on the right | Number renders fully |

## Test plan

- [ ] Visit **Synthetics → Monitors** with enough monitor runs to produce a 4+ digit count over the last 30 days.
- [ ] Verify the **Last 30 days** total renders without horizontal clipping.
- [ ] Verify the sparkline next to it still fills the remaining space and there is no awkward gap.
- [ ] Sanity check at narrow viewport widths that the panel still degrades gracefully.


Made with [Cursor](https://cursor.com)