### PR TITLE
[8.19] [@kbn/scout] Capture browser console errors in failed test HTML reports (#269608)

### DIFF
--- a/src/platform/packages/private/kbn-scout-info/src/reporting.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/reporting.ts
@@ -27,6 +27,10 @@ export const SCOUT_TEST_EVENTS_INDEX_PATTERN =
 export const SCOUT_TEST_EVENTS_DATA_STREAM_NAME =
   process.env.SCOUT_TEST_EVENTS_DATA_STREAM_NAME || `${SCOUT_TEST_EVENTS_TEMPLATE_NAME}-kibana`;
 
+// Playwright attachment name used to pass browser console errors from the scout page
+// fixture (@kbn/scout) to Scout reporters (@kbn/scout-reporting).
+export const BROWSER_CONSOLE_ERRORS_ATTACHMENT = 'browser-console-errors';
+
 export enum ScoutTestRunConfigCategory {
   UI_TEST = 'ui-test',
   API_TEST = 'api-test',

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.ts
@@ -24,7 +24,11 @@ import {
 import { REPO_ROOT } from '@kbn/repo-info';
 import { ToolingLog } from '@kbn/tooling-log';
 import path from 'node:path';
-import { SCOUT_REPORT_OUTPUT_ROOT, ScoutTestTarget } from '@kbn/scout-info';
+import {
+  BROWSER_CONSOLE_ERRORS_ATTACHMENT,
+  SCOUT_REPORT_OUTPUT_ROOT,
+  ScoutTestTarget,
+} from '@kbn/scout-info';
 import {
   computeTestID,
   excapeHtmlCharacters,
@@ -125,6 +129,11 @@ export class ScoutFailedTestReporter implements Reporter {
     const fullTestTitle = test.titlePath().slice(3).join(' ');
     const testFilePath = path.relative(REPO_ROOT, test.location.file);
 
+    const consoleErrorsAttachment = result.attachments.find(
+      (a) => a.name === BROWSER_CONSOLE_ERRORS_ATTACHMENT
+    );
+    const consoleErrors = consoleErrorsAttachment?.body?.toString('utf-8');
+
     const testFailure: TestFailure = {
       id: computeTestID(testFilePath, fullTestTitle),
       suite: test.parent.title,
@@ -137,11 +146,14 @@ export class ScoutFailedTestReporter implements Reporter {
       duration: result.duration,
       error: this.formatTestError(result),
       stdout: result.stdout ? parseStdout(result.stdout) : undefined,
-      attachments: result.attachments.map((attachment) => ({
-        name: attachment.name,
-        path: attachment.path,
-        contentType: attachment.contentType,
-      })),
+      consoleErrors,
+      attachments: result.attachments
+        .filter((a) => a.name !== BROWSER_CONSOLE_ERRORS_ATTACHMENT)
+        .map((attachment) => ({
+          name: attachment.name,
+          path: attachment.path,
+          contentType: attachment.contentType,
+        })),
     };
 
     this.report.logEvent(testFailure);

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failure_tracking.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failure_tracking.ts
@@ -32,6 +32,7 @@ export interface ScoutFailureTrackingEntry {
     stack_trace?: string;
   };
   stdout?: string;
+  consoleErrors?: string;
   attachments: Array<{
     name: string;
     path?: string;
@@ -73,6 +74,7 @@ export class ScoutFailureTracker {
       duration: failure.duration,
       error: failure.error,
       stdout: failure.stdout,
+      consoleErrors: failure.consoleErrors,
       attachments: failure.attachments,
       timestamp: new Date().toISOString(),
       buildkite: {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/html.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/html.ts
@@ -22,6 +22,7 @@ export const buildFailureHtml = (testFailure: TestFailure): string => {
     duration,
     error,
     stdout,
+    consoleErrors,
     attachments,
   } = testFailure;
 
@@ -149,6 +150,20 @@ export const buildFailureHtml = (testFailure: TestFailure): string => {
       .error-section pre {
         background-color: #fff5f5;
         border-color: #fecaca;
+      }
+
+      /* Console errors section */
+      .console-errors-section {
+        background-color: #fffbeb;
+      }
+
+      .console-errors-section pre {
+        background-color: #fffbeb;
+        border-color: #fcd34d;
+      }
+
+      .console-errors-section summary {
+        color: #92400e;
       }
 
       /* Details and summary */
@@ -374,6 +389,23 @@ export const buildFailureHtml = (testFailure: TestFailure): string => {
             <h5>Error Details</h5>
             <pre>${errorStackTrace}</pre>
         </div>
+
+        ${
+          consoleErrors
+            ? `<div class="section console-errors-section">
+          <h5>Browser Console Errors</h5>
+          <details open>
+            <summary>${consoleErrors.split('\n').length} error(s) captured during test</summary>
+            <pre>${consoleErrors
+              .split('\n')
+              .map((line) =>
+                line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+              )
+              .join('\n')}</pre>
+          </details>
+        </div>`
+            : ''
+        }
 
         <div class="section" id="tracked-branches-status">
           <strong>No failures found in tracked branches</strong>

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/test_failure.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/test_failure.ts
@@ -27,6 +27,7 @@ export interface TestFailure {
     stack_trace?: string;
   };
   stdout?: string;
+  consoleErrors?: string;
   attachments: Array<{
     name: string;
     path?: string;

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/browser_console_errors.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/browser_console_errors.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BROWSER_CONSOLE_ERRORS_ATTACHMENT } from '@kbn/scout-info';
+import type { Page, TestInfo } from '@playwright/test';
+
+// Set SCOUT_REPORT_ALL_CONSOLE_LOGS=true to disable filtering and capture every console error.
+const filteringEnabled = process.env.SCOUT_REPORT_ALL_CONSOLE_LOGS !== 'true';
+
+// Known non-actionable errors that are expected in Kibana's environment and would
+// only add noise to failure reports when no filtering opt-out is set.
+const IGNORED_ERROR_PATTERNS = [
+  // CSP violations from inline scripts are expected in Kibana's dev/test environment
+  'Executing inline script violates the following Content Security Policy directive',
+  // Moment Timezone data is not bundled for all timezones in the test environment
+  'Moment Timezone',
+];
+
+const isIgnored = (message: string) =>
+  IGNORED_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+
+// page fixture has test scope so a new Page instance is created per test — no need to call page.off()
+export const collectBrowserConsoleErrors = (page: Page): string[] => {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    if (filteringEnabled && isIgnored(text)) return;
+    errors.push(`[${new Date().toISOString()}] ${text}`);
+  });
+  return errors;
+};
+
+export const attachBrowserConsoleErrors = async (
+  testInfo: TestInfo,
+  errors: string[]
+): Promise<void> => {
+  if (errors.length === 0) {
+    return;
+  }
+
+  try {
+    await testInfo.attach(BROWSER_CONSOLE_ERRORS_ATTACHMENT, {
+      body: Buffer.from(errors.join('\n')),
+      contentType: 'text/plain',
+    });
+  } catch {
+    // best-effort: don't let attachment failure mask the original test failure
+  }
+};

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/parallel.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/parallel.ts
@@ -7,11 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Page, test as base } from '@playwright/test';
+import { Page, TestInfo, test as base } from '@playwright/test';
 import { PathOptions } from '../../../../../common/services/kibana_url';
 import { ScoutPage } from '.';
 import { KibanaUrl, ScoutLogger } from '../../worker';
 import { ScoutSpaceParallelFixture } from '../../worker/scout_space';
+import { attachBrowserConsoleErrors, collectBrowserConsoleErrors } from './browser_console_errors';
 import { extendPlaywrightPage } from './single_thread';
 
 export const scoutPageParallelFixture = base.extend<
@@ -25,8 +26,11 @@ export const scoutPageParallelFixture = base.extend<
       kbnUrl,
       scoutSpace,
     }: { log: ScoutLogger; page: Page; kbnUrl: KibanaUrl; scoutSpace: ScoutSpaceParallelFixture },
-    use: (extendedPage: ScoutPage) => Promise<void>
+    use: (extendedPage: ScoutPage) => Promise<void>,
+    testInfo: TestInfo
   ) => {
+    const consoleErrors = collectBrowserConsoleErrors(page);
+
     const extendedPage = extendPlaywrightPage({ page, kbnUrl });
 
     // Overriding navigation to specific Kibana apps: url should respect the Kibana Space id
@@ -35,5 +39,7 @@ export const scoutPageParallelFixture = base.extend<
 
     log.serviceLoaded(`scoutPage`);
     await use(extendedPage);
+
+    await attachBrowserConsoleErrors(testInfo, consoleErrors);
   },
 });

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
@@ -8,9 +8,10 @@
  */
 
 import { subj } from '@kbn/test-subj-selector';
-import type { Page } from '@playwright/test';
+import type { Page, TestInfo } from '@playwright/test';
 import { test as base } from '@playwright/test';
 import type { ScoutPage } from '.';
+import { attachBrowserConsoleErrors, collectBrowserConsoleErrors } from './browser_console_errors';
 import type { PathOptions } from '../../../../../common/services/kibana_url';
 import { checkA11y } from '../../../../utils';
 import type { KibanaUrl, ScoutLogger } from '../../worker';
@@ -142,11 +143,15 @@ export const scoutPageFixture = base.extend<
 >({
   page: async (
     { page, kbnUrl, log }: { page: Page; kbnUrl: KibanaUrl; log: ScoutLogger },
-    use: (extendedPage: ScoutPage) => Promise<void>
+    use: (extendedPage: ScoutPage) => Promise<void>,
+    testInfo: TestInfo
   ) => {
+    const consoleErrors = collectBrowserConsoleErrors(page);
     const extendedPage = extendPlaywrightPage({ page, kbnUrl });
 
     log.serviceLoaded('scoutPage');
     await use(extendedPage);
+
+    await attachBrowserConsoleErrors(testInfo, consoleErrors);
   },
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[@kbn/scout] Capture browser console errors in failed test HTML reports (#269608)](https://github.com/elastic/kibana/pull/269608)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-21T07:37:47Z","message":"[@kbn/scout] Capture browser console errors in failed test HTML reports (#269608)\n\n## Summary\n\nDuring each Scout UI test, browser console errors are now collected and\nattached to the test result. When a test fails, the Scout HTML failure\nreport surfaces these errors in a dedicated \"Browser Console Errors\"\nsection, making it faster to diagnose JS errors occurring in the app\nunder test.\n\n## Changes\n\n- **`@kbn/scout-info`**: Added `BROWSER_CONSOLE_ERRORS_ATTACHMENT`\nconstant as the single source of truth for the attachment name shared\nbetween the fixture and reporter\n- **`@kbn/scout`**: Added `browser_console_errors.ts` — extracts\n`collectBrowserConsoleErrors` and `attachBrowserConsoleErrors` helpers;\nwired into both `scoutPageFixture` (single-thread) and\n`scoutPageParallelFixture` keeping fixtures as thin coordinators\n- **`@kbn/scout-reporting`**: Extended `TestFailure` and\n`ScoutFailureTrackingEntry` with `consoleErrors?: string`; reporter\nreads the attachment and filters it from generic attachments; HTML\ntemplate renders an amber \"Browser Console Errors\" `<details>` block\nwhen errors are present\n\n## Screenshots\n\n<img width=\"1222\" height=\"1144\" alt=\"Screenshot 2026-05-20 at 4 34\n30 PM\"\nsrc=\"https://github.com/user-attachments/assets/bb9beeec-af88-4e6e-b170-1e4997aacd93\"\n/>","sha":"208aafbd54e2d6cb3380f904629406e5a5c80d8f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.5.0","v9.3.5","v9.4.2"],"title":"[@kbn/scout] Capture browser console errors in failed test HTML reports","number":269608,"url":"https://github.com/elastic/kibana/pull/269608","mergeCommit":{"message":"[@kbn/scout] Capture browser console errors in failed test HTML reports (#269608)\n\n## Summary\n\nDuring each Scout UI test, browser console errors are now collected and\nattached to the test result. When a test fails, the Scout HTML failure\nreport surfaces these errors in a dedicated \"Browser Console Errors\"\nsection, making it faster to diagnose JS errors occurring in the app\nunder test.\n\n## Changes\n\n- **`@kbn/scout-info`**: Added `BROWSER_CONSOLE_ERRORS_ATTACHMENT`\nconstant as the single source of truth for the attachment name shared\nbetween the fixture and reporter\n- **`@kbn/scout`**: Added `browser_console_errors.ts` — extracts\n`collectBrowserConsoleErrors` and `attachBrowserConsoleErrors` helpers;\nwired into both `scoutPageFixture` (single-thread) and\n`scoutPageParallelFixture` keeping fixtures as thin coordinators\n- **`@kbn/scout-reporting`**: Extended `TestFailure` and\n`ScoutFailureTrackingEntry` with `consoleErrors?: string`; reporter\nreads the attachment and filters it from generic attachments; HTML\ntemplate renders an amber \"Browser Console Errors\" `<details>` block\nwhen errors are present\n\n## Screenshots\n\n<img width=\"1222\" height=\"1144\" alt=\"Screenshot 2026-05-20 at 4 34\n30 PM\"\nsrc=\"https://github.com/user-attachments/assets/bb9beeec-af88-4e6e-b170-1e4997aacd93\"\n/>","sha":"208aafbd54e2d6cb3380f904629406e5a5c80d8f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269608","number":269608,"mergeCommit":{"message":"[@kbn/scout] Capture browser console errors in failed test HTML reports (#269608)\n\n## Summary\n\nDuring each Scout UI test, browser console errors are now collected and\nattached to the test result. When a test fails, the Scout HTML failure\nreport surfaces these errors in a dedicated \"Browser Console Errors\"\nsection, making it faster to diagnose JS errors occurring in the app\nunder test.\n\n## Changes\n\n- **`@kbn/scout-info`**: Added `BROWSER_CONSOLE_ERRORS_ATTACHMENT`\nconstant as the single source of truth for the attachment name shared\nbetween the fixture and reporter\n- **`@kbn/scout`**: Added `browser_console_errors.ts` — extracts\n`collectBrowserConsoleErrors` and `attachBrowserConsoleErrors` helpers;\nwired into both `scoutPageFixture` (single-thread) and\n`scoutPageParallelFixture` keeping fixtures as thin coordinators\n- **`@kbn/scout-reporting`**: Extended `TestFailure` and\n`ScoutFailureTrackingEntry` with `consoleErrors?: string`; reporter\nreads the attachment and filters it from generic attachments; HTML\ntemplate renders an amber \"Browser Console Errors\" `<details>` block\nwhen errors are present\n\n## Screenshots\n\n<img width=\"1222\" height=\"1144\" alt=\"Screenshot 2026-05-20 at 4 34\n30 PM\"\nsrc=\"https://github.com/user-attachments/assets/bb9beeec-af88-4e6e-b170-1e4997aacd93\"\n/>","sha":"208aafbd54e2d6cb3380f904629406e5a5c80d8f"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/270343","number":270343,"state":"MERGED","mergeCommit":{"sha":"11546a81aaedc7b626abaaaafcbda1d7f02c5e21","message":"[9.3] [@kbn/scout] Capture browser console errors in failed test HTML reports (#269608) (#270343)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[@kbn/scout] Capture browser console errors in failed test HTML\nreports (#269608)](https://github.com/elastic/kibana/pull/269608)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Stelios Mavro <81311181+steliosmavro@users.noreply.github.com>"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/270344","number":270344,"state":"MERGED","mergeCommit":{"sha":"a8c54c23a9a66ba1d2f3ace0651a9df081fa6526","message":"[9.4] [@kbn/scout] Capture browser console errors in failed test HTML reports (#269608) (#270344)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[@kbn/scout] Capture browser console errors in failed test HTML\nreports (#269608)](https://github.com/elastic/kibana/pull/269608)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Stelios Mavro <81311181+steliosmavro@users.noreply.github.com>"}}]}] BACKPORT-->