### PR TITLE
[Cases][Templates] Add markdown support for textarea

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.test.ts
@@ -5,11 +5,17 @@
  * 2.0.
  */
 
-import { RadioGroupFieldSchema } from './fields';
+import { RadioGroupFieldSchema, TextareaFieldSchema } from './fields';
 
 const baseField = {
   name: 'env',
   control: 'RADIO_GROUP' as const,
+  type: 'keyword' as const,
+};
+
+const baseTextareaField = {
+  name: 'details',
+  control: 'TEXTAREA' as const,
   type: 'keyword' as const,
 };
 
@@ -83,5 +89,82 @@ describe('RadioGroupFieldSchema', () => {
         'Default value development is not a valid option.'
       );
     });
+  });
+});
+
+describe('TextareaFieldSchema', () => {
+  it('accepts a TEXTAREA without metadata (backward compatibility)', () => {
+    const result = TextareaFieldSchema.safeParse(baseTextareaField);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts metadata with markdown: true', () => {
+    const result = TextareaFieldSchema.safeParse({
+      ...baseTextareaField,
+      metadata: { markdown: true },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata?.markdown).toBe(true);
+    }
+  });
+
+  it('accepts metadata with markdown: false', () => {
+    const result = TextareaFieldSchema.safeParse({
+      ...baseTextareaField,
+      metadata: { markdown: false },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata?.markdown).toBe(false);
+    }
+  });
+
+  it('accepts metadata with default and markdown together', () => {
+    const result = TextareaFieldSchema.safeParse({
+      ...baseTextareaField,
+      metadata: { default: '## Instructions', markdown: true },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata?.default).toBe('## Instructions');
+      expect(result.data.metadata?.markdown).toBe(true);
+    }
+  });
+
+  it('accepts metadata with only default (no markdown)', () => {
+    const result = TextareaFieldSchema.safeParse({
+      ...baseTextareaField,
+      metadata: { default: 'plain text' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata?.default).toBe('plain text');
+      expect(result.data.metadata?.markdown).toBeUndefined();
+    }
+  });
+
+  it('rejects non-boolean markdown value', () => {
+    const result = TextareaFieldSchema.safeParse({
+      ...baseTextareaField,
+      metadata: { markdown: 'yes' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-string default value', () => {
+    const result = TextareaFieldSchema.safeParse({
+      ...baseTextareaField,
+      metadata: { default: 123 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('preserves unknown metadata keys via catchall', () => {
+    const result = TextareaFieldSchema.safeParse({
+      ...baseTextareaField,
+      metadata: { markdown: true, custom_key: 'value' },
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
@@ -123,6 +123,13 @@ export const SelectBasicFieldSchema = BaseFieldSchema.extend({
 
 export const TextareaFieldSchema = BaseFieldSchema.extend({
   control: z.literal(FieldType.TEXTAREA),
+  metadata: z
+    .object({
+      default: z.string().optional(),
+      markdown: z.boolean().optional(),
+    })
+    .catchall(z.unknown())
+    .optional(),
 });
 
 export const DatePickerFieldSchema = BaseFieldSchema.extend({

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.test.tsx
@@ -18,6 +18,7 @@ jest.mock('@kbn/es-ui-shared-plugin/static/forms/hook_form_lib', () => ({
   ...jest.requireActual('@kbn/es-ui-shared-plugin/static/forms/hook_form_lib'),
   useFormData: (...args: unknown[]) => mockUseFormData(...args),
   useFormContext: () => mockUseFormContext(),
+  UseField: () => null,
 }));
 
 const mockUseTemplateFormSync = jest.fn();

--- a/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/template_fields.tsx
@@ -9,9 +9,11 @@ import React, { useContext, useEffect, useMemo } from 'react';
 import { EuiCallOut, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { FormProvider, useForm } from 'react-hook-form';
 import {
+  UseField,
   useFormContext as useParentFormContext,
   useFormData,
 } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import { HiddenField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { CASE_EXTENDED_FIELDS } from '../../../common/constants';
 import { useTemplateFormSync } from './use_template_form_sync';
 import * as i18n from './translations';
@@ -65,12 +67,13 @@ export const CreateCaseTemplateFields: React.FC = () => {
   }, [resolvedFields]);
 
   if (isLoading || isLoadingFields) {
-    return null;
+    return <UseField path={CASE_EXTENDED_FIELDS} component={HiddenField} />;
   }
 
   if (!templateId || template?.definition?.fields === undefined) {
     return (
       <>
+        <UseField path={CASE_EXTENDED_FIELDS} component={HiddenField} />
         <EuiSpacer />
         <EuiCallOut announceOnMount title={i18n.TEMPLATE_NOT_SELECTED_TITLE} size="s">
           <p>{i18n.TEMPLATE_NOT_SELECTED_DESCRIPTION}</p>
@@ -81,6 +84,7 @@ export const CreateCaseTemplateFields: React.FC = () => {
 
   return (
     <>
+      <UseField path={CASE_EXTENDED_FIELDS} component={HiddenField} />
       <EuiSpacer />
       <EuiTitle size="s">
         <h4>{i18n.EXTENDED_FIELDS_TITLE}</h4>

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/constants.ts
@@ -51,6 +51,28 @@ fields:
     type: keyword
     metadata:
       default: Enter details here...
+  # TEXTAREA with markdown: true renders a markdown editor instead of plain text
+  - name: instructions
+    control: TEXTAREA
+    label: Investigation instructions
+    type: keyword
+    metadata:
+      markdown: true
+      default: |
+        ## Investigation playbook
+
+        Follow these steps when triaging the case:
+
+        1. **Collect evidence** — gather relevant logs and screenshots
+        2. **Identify scope** — determine affected systems and users
+        3. **Escalate** if severity is *critical* or impact is widespread
+
+        ### Useful links
+
+        - [Incident runbook](https://example.com/runbook)
+        - [Escalation matrix](https://example.com/escalation)
+
+        > Remember to update the case status as you progress through each step.
   - name: priority
     control: SELECT_BASIC
     label: Priority

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.test.tsx
@@ -12,26 +12,30 @@ import { useForm, FormProvider } from 'react-hook-form';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { Textarea } from './textarea';
 
-jest.mock('../../../markdown_editor', () => ({
-  MarkdownEditor: ({
-    value,
-    onChange,
-    ariaLabel,
-    'data-test-subj': dataTestSubj,
-  }: {
-    value: string;
-    onChange: (value: string) => void;
-    ariaLabel: string;
-    'data-test-subj': string;
-  }) => (
-    <textarea
-      data-test-subj={dataTestSubj}
-      aria-label={ariaLabel}
-      value={value}
-      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
-    />
-  ),
-}));
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+  return {
+    ...actual,
+    EuiMarkdownEditor: ({
+      value,
+      onChange,
+      'aria-label': ariaLabel,
+      'data-test-subj': dataTestSubj,
+    }: {
+      value: string;
+      onChange: (value: string) => void;
+      'aria-label': string;
+      'data-test-subj': string;
+    }) => (
+      <textarea
+        data-test-subj={dataTestSubj}
+        aria-label={ariaLabel}
+        value={value}
+        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
+      />
+    ),
+  };
+});
 
 interface FormWrapperProps {
   isRequired?: boolean;

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.test.tsx
@@ -1,0 +1,276 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from 'react-hook-form';
+import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { Textarea } from './textarea';
+
+jest.mock('../../../markdown_editor', () => ({
+  MarkdownEditor: ({
+    value,
+    onChange,
+    ariaLabel,
+    'data-test-subj': dataTestSubj,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    ariaLabel: string;
+    'data-test-subj': string;
+  }) => (
+    <textarea
+      data-test-subj={dataTestSubj}
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+interface FormWrapperProps {
+  isRequired?: boolean;
+  markdown?: boolean;
+  initialValue?: string;
+  patternValidation?: { regex: string; message?: string };
+  minLengthValue?: number;
+  maxLengthValue?: number;
+  onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
+}
+
+const FormWrapper: React.FC<FormWrapperProps> = ({
+  isRequired,
+  markdown,
+  initialValue,
+  patternValidation,
+  minLengthValue,
+  maxLengthValue,
+  onSubmitResult,
+}) => {
+  const form = useForm({
+    defaultValues: {
+      [CASE_EXTENDED_FIELDS]: initialValue ? { details_as_keyword: initialValue } : {},
+    },
+  });
+
+  const handleSubmit = form.handleSubmit(
+    (data) => onSubmitResult({ isValid: true, data: data as Record<string, unknown> }),
+    () =>
+      onSubmitResult({
+        isValid: false,
+        data: form.getValues() as Record<string, unknown>,
+      })
+  );
+
+  return (
+    <FormProvider {...form}>
+      <Textarea
+        name="details"
+        control="TEXTAREA"
+        type="keyword"
+        label="Details"
+        isRequired={isRequired}
+        metadata={markdown !== undefined ? { markdown } : undefined}
+        patternValidation={patternValidation}
+        minLength={minLengthValue}
+        maxLength={maxLengthValue}
+      />
+      <button type="button" onClick={handleSubmit}>
+        {'Submit'}
+      </button>
+    </FormProvider>
+  );
+};
+
+describe('Textarea', () => {
+  describe('plain mode (no markdown)', () => {
+    it('renders EuiTextArea when markdown is not set', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper onSubmitResult={onSubmitResult} />);
+
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(screen.queryByTestId('template-field-markdown-editor')).not.toBeInTheDocument();
+    });
+
+    it('renders the label', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper onSubmitResult={onSubmitResult} />);
+
+      expect(screen.getByText('Details')).toBeInTheDocument();
+    });
+
+    it('shows Optional label when isRequired is false', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper isRequired={false} onSubmitResult={onSubmitResult} />);
+
+      expect(screen.getByText('Optional')).toBeInTheDocument();
+    });
+
+    it('does not show Optional label when isRequired is true', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper isRequired onSubmitResult={onSubmitResult} />);
+
+      expect(screen.queryByText('Optional')).not.toBeInTheDocument();
+    });
+
+    it('submits the typed value', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper onSubmitResult={onSubmitResult} />);
+
+      await userEvent.type(screen.getByRole('textbox'), 'Hello world');
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: true }));
+      });
+
+      const { data } = onSubmitResult.mock.calls[0][0];
+      const submittedValue = (data as Record<string, Record<string, unknown>>)[CASE_EXTENDED_FIELDS]
+        ?.details_as_keyword;
+      expect(submittedValue).toBe('Hello world');
+    });
+  });
+
+  describe('markdown mode', () => {
+    it('renders MarkdownEditor when metadata.markdown is true', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper markdown onSubmitResult={onSubmitResult} />);
+
+      expect(screen.getByTestId('template-field-markdown-editor')).toBeInTheDocument();
+    });
+
+    it('renders EuiTextArea when metadata.markdown is false', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper markdown={false} onSubmitResult={onSubmitResult} />);
+
+      expect(screen.queryByTestId('template-field-markdown-editor')).not.toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('submits the typed value from markdown editor', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper markdown onSubmitResult={onSubmitResult} />);
+
+      const editor = screen.getByTestId('template-field-markdown-editor');
+      await userEvent.type(editor, '## Title');
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: true }));
+      });
+
+      const { data } = onSubmitResult.mock.calls[0][0];
+      const submittedValue = (data as Record<string, Record<string, unknown>>)[CASE_EXTENDED_FIELDS]
+        ?.details_as_keyword;
+      expect(submittedValue).toBe('## Title');
+    });
+
+    it('renders with pre-populated value', () => {
+      const onSubmitResult = jest.fn();
+      render(
+        <FormWrapper markdown initialValue="# Existing content" onSubmitResult={onSubmitResult} />
+      );
+
+      const editor = screen.getByTestId('template-field-markdown-editor');
+      expect(editor).toHaveValue('# Existing content');
+    });
+  });
+
+  describe('validation', () => {
+    it('blocks submission when isRequired is true and value is empty', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper isRequired onSubmitResult={onSubmitResult} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: false }));
+      });
+    });
+
+    it('shows error message when required validation fails', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper isRequired onSubmitResult={onSubmitResult} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/required/i)).toBeInTheDocument();
+      });
+    });
+
+    it('blocks submission when isRequired is true and value is empty in markdown mode', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper isRequired markdown onSubmitResult={onSubmitResult} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: false }));
+      });
+    });
+
+    it('allows submission when isRequired is true and value is pre-populated', async () => {
+      const onSubmitResult = jest.fn();
+      render(
+        <FormWrapper isRequired initialValue="Some content" onSubmitResult={onSubmitResult} />
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: true }));
+      });
+    });
+
+    it('validates minLength', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper minLengthValue={10} initialValue="ab" onSubmitResult={onSubmitResult} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: false }));
+      });
+    });
+
+    it('validates maxLength', async () => {
+      const onSubmitResult = jest.fn();
+      render(
+        <FormWrapper
+          maxLengthValue={5}
+          initialValue="too long text"
+          onSubmitResult={onSubmitResult}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: false }));
+      });
+    });
+
+    it('validates pattern', async () => {
+      const onSubmitResult = jest.fn();
+      render(
+        <FormWrapper
+          patternValidation={{ regex: '^[A-Z]', message: 'Must start with uppercase' }}
+          initialValue="lowercase"
+          onSubmitResult={onSubmitResult}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: false }));
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
@@ -8,7 +8,7 @@
 import type { z } from '@kbn/zod/v4';
 import React, { useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { EuiFormRow, EuiTextArea } from '@elastic/eui';
+import { EuiFormRow, EuiTextArea, EuiMarkdownEditor } from '@elastic/eui';
 import { InlineFieldActions } from './inline_field_actions';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { getFieldSnakeKey } from '../../../../../common/utils';
@@ -31,6 +31,7 @@ export const Textarea = ({
   label,
   name,
   type,
+  metadata,
   isRequired,
   patternValidation,
   minLength,
@@ -40,6 +41,7 @@ export const Textarea = ({
   const { control, resetField } = useFormContext();
   const [isFocused, setIsFocused] = useState(false);
   const path = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`;
+  const isMarkdown = metadata?.markdown === true;
 
   const rules = useMemo(() => {
     const validate: Record<string, (value: unknown) => true | string> = {};
@@ -92,19 +94,32 @@ export const Textarea = ({
             error={fieldState.error?.message}
             fullWidth
           >
-            <EuiTextArea
-              inputRef={field.ref}
-              name={field.name}
-              value={(field.value as string) ?? ''}
-              onChange={(e) => field.onChange(e.target.value)}
-              onBlur={() => {
-                field.onBlur();
-                setIsFocused(false);
-              }}
-              onFocus={() => setIsFocused(true)}
-              isInvalid={!!fieldState.error}
-              fullWidth
-            />
+            {isMarkdown ? (
+              <EuiMarkdownEditor
+                value={(field.value as string) ?? ''}
+                onChange={(value) => {
+                  field.onChange(value);
+                  if (!isFocused) setIsFocused(true);
+                }}
+                aria-label={typeof label === 'string' ? label : name}
+                editorId={path}
+                data-test-subj="template-field-markdown-editor"
+              />
+            ) : (
+              <EuiTextArea
+                inputRef={field.ref}
+                name={field.name}
+                value={(field.value as string) ?? ''}
+                onChange={(e) => field.onChange(e.target.value)}
+                onBlur={() => {
+                  field.onBlur();
+                  setIsFocused(false);
+                }}
+                onFocus={() => setIsFocused(true)}
+                isInvalid={!!fieldState.error}
+                fullWidth
+              />
+            )}
           </EuiFormRow>
           {showInlineActions && (
             <InlineFieldActions

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/templates_to_yaml.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/templates_to_yaml.test.ts
@@ -705,6 +705,136 @@ describe('display and validation serialization', () => {
   });
 });
 
+describe('TEXTAREA field serialization', () => {
+  const baseTemplate: ParsedTemplate = {
+    templateId: 'tpl-textarea',
+    name: 'Textarea template',
+    owner: 'securitySolution',
+    tags: [],
+    usageCount: 0,
+    fieldCount: 1,
+    templateVersion: 1,
+    latestVersion: 1,
+    isLatest: true,
+    deletedAt: null,
+    definition: { name: 'Textarea template', fields: [] },
+    definitionString: 'name: Textarea template\nfields: []',
+  };
+
+  it('serializes TEXTAREA with markdown: true', () => {
+    const template: ParsedTemplate = {
+      ...baseTemplate,
+      definition: {
+        name: 'Textarea template',
+        fields: [
+          {
+            name: 'instructions',
+            control: 'TEXTAREA',
+            type: 'keyword',
+            metadata: { markdown: true, default: '## Steps' },
+          },
+        ],
+      },
+    };
+
+    const yaml = templatesToYaml([template]);
+
+    expect(yaml).toContain('      control: "TEXTAREA"');
+    expect(yaml).toContain('      metadata:');
+    expect(yaml).toContain('        default: "## Steps"');
+    expect(yaml).toContain('        markdown: true');
+  });
+
+  it('serializes TEXTAREA with only default (no markdown)', () => {
+    const template: ParsedTemplate = {
+      ...baseTemplate,
+      definition: {
+        name: 'Textarea template',
+        fields: [
+          {
+            name: 'details',
+            control: 'TEXTAREA',
+            type: 'keyword',
+            metadata: { default: 'Enter details here...' },
+          },
+        ],
+      },
+    };
+
+    const yaml = templatesToYaml([template]);
+
+    expect(yaml).toContain('      metadata:');
+    expect(yaml).toContain('        default: "Enter details here..."');
+    expect(yaml).not.toContain('markdown');
+  });
+
+  it('omits metadata block when TEXTAREA has no metadata', () => {
+    const template: ParsedTemplate = {
+      ...baseTemplate,
+      definition: {
+        name: 'Textarea template',
+        fields: [
+          {
+            name: 'notes',
+            control: 'TEXTAREA',
+            type: 'keyword',
+          },
+        ],
+      },
+    };
+
+    const yaml = templatesToYaml([template]);
+
+    expect(yaml).toContain('      control: "TEXTAREA"');
+    expect(yaml).not.toContain('metadata:');
+  });
+
+  it('omits metadata block when markdown is false and no default', () => {
+    const template: ParsedTemplate = {
+      ...baseTemplate,
+      definition: {
+        name: 'Textarea template',
+        fields: [
+          {
+            name: 'notes',
+            control: 'TEXTAREA',
+            type: 'keyword',
+            metadata: { markdown: false },
+          },
+        ],
+      },
+    };
+
+    const yaml = templatesToYaml([template]);
+
+    expect(yaml).not.toContain('metadata:');
+    expect(yaml).not.toContain('markdown');
+  });
+
+  it('serializes TEXTAREA with only markdown: true (no default)', () => {
+    const template: ParsedTemplate = {
+      ...baseTemplate,
+      definition: {
+        name: 'Textarea template',
+        fields: [
+          {
+            name: 'instructions',
+            control: 'TEXTAREA',
+            type: 'keyword',
+            metadata: { markdown: true },
+          },
+        ],
+      },
+    };
+
+    const yaml = templatesToYaml([template]);
+
+    expect(yaml).toContain('      metadata:');
+    expect(yaml).toContain('        markdown: true');
+    expect(yaml).not.toContain('default:');
+  });
+});
+
 describe('templateToYaml', () => {
   it('serializes a single template with a template header', () => {
     const template: ParsedTemplate = {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/templates_to_yaml.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/templates_to_yaml.ts
@@ -110,6 +110,25 @@ const serializeDatePickerMetadata = (
   }
 };
 
+const serializeTextareaMetadata = (
+  out: string[],
+  field: Extract<Field, { control: 'TEXTAREA' }>
+) => {
+  const meta = field.metadata;
+  if (!meta) return;
+  const defaultValue = meta.default;
+  const hasDefault = typeof defaultValue === 'string';
+  const hasMarkdown = meta.markdown === true;
+  if (!hasDefault && !hasMarkdown) return;
+  out.push(`      metadata:`);
+  if (hasDefault) {
+    out.push(`        default: ${yamlString(defaultValue)}`);
+  }
+  if (hasMarkdown) {
+    out.push(`        markdown: true`);
+  }
+};
+
 const serializeCheckboxGroupMetadata = (
   out: string[],
   field: Extract<Field, { control: 'CHECKBOX_GROUP' }>
@@ -180,7 +199,11 @@ const serializeFieldMetadata = (out: string[], field: InlineField) => {
     serializeUserPickerMetadata(out, field);
     return;
   }
-  // INPUT_TEXT, INPUT_NUMBER, TEXTAREA
+  if (field.control === FieldType.TEXTAREA) {
+    serializeTextareaMetadata(out, field);
+    return;
+  }
+  // INPUT_TEXT, INPUT_NUMBER
   const defaultValue = field.metadata?.default;
   if (
     defaultValue !== undefined &&

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.tsx
@@ -11,6 +11,7 @@ import type { SnakeToCamelCase } from '../../../common/types';
 import type { ExtendedFieldsUserAction } from '../../../common/types/domain';
 import type { UserActionBuilder } from './types';
 import { createCommonUpdateUserActionBuilder } from './common';
+import { ScrollableMarkdown } from '../markdown_editor';
 import { PreferenceFormattedDate } from '../formatted_date';
 import * as i18n from './translations';
 import { getMaybeDate } from '../formatted_date/maybe_date';
@@ -23,7 +24,15 @@ const getFieldDisplayName = (key: string): string => {
   return startCase(withoutTypeSuffix);
 };
 
-const getLabelTitle = (userAction: SnakeToCamelCase<ExtendedFieldsUserAction>): React.ReactNode => {
+const isMultilineValue = (value: unknown): value is string =>
+  typeof value === 'string' && value.includes('\n');
+
+interface LabelAndBody {
+  label: React.ReactNode;
+  body?: React.ReactNode;
+}
+
+const getLabelAndBody = (userAction: SnakeToCamelCase<ExtendedFieldsUserAction>): LabelAndBody => {
   const extendedFields = userAction.payload.extendedFields ?? {};
   const entries = Object.entries(extendedFields);
 
@@ -34,19 +43,28 @@ const getLabelTitle = (userAction: SnakeToCamelCase<ExtendedFieldsUserAction>): 
     if (key.endsWith('AsDate') && typeof value === 'string') {
       const maybeDate = getMaybeDate(value);
       if (maybeDate.isValid()) {
-        return (
-          <>
-            {i18n.SET_TEMPLATE_FIELD_LABEL_PREFIX(displayName)}{' '}
-            <PreferenceFormattedDate value={maybeDate.toDate()} stripMs />
-          </>
-        );
+        return {
+          label: (
+            <>
+              {i18n.SET_TEMPLATE_FIELD_LABEL_PREFIX(displayName)}{' '}
+              <PreferenceFormattedDate value={maybeDate.toDate()} stripMs />
+            </>
+          ),
+        };
       }
     }
 
-    return i18n.SET_TEMPLATE_FIELD_LABEL(displayName, String(value));
+    if (isMultilineValue(value)) {
+      return {
+        label: i18n.SET_TEMPLATE_FIELD_LABEL_PREFIX(displayName),
+        body: <ScrollableMarkdown content={value} />,
+      };
+    }
+
+    return { label: i18n.SET_TEMPLATE_FIELD_LABEL(displayName, String(value)) };
   }
 
-  return i18n.UPDATED_TEMPLATE_FIELDS;
+  return { label: i18n.UPDATED_TEMPLATE_FIELDS };
 };
 
 export const createExtendedFieldsUserActionBuilder: UserActionBuilder = ({
@@ -56,7 +74,7 @@ export const createExtendedFieldsUserActionBuilder: UserActionBuilder = ({
 }) => ({
   build: () => {
     const extendedFieldsUserAction = userAction as SnakeToCamelCase<ExtendedFieldsUserAction>;
-    const label = getLabelTitle(extendedFieldsUserAction);
+    const { label, body } = getLabelAndBody(extendedFieldsUserAction);
     const commonBuilder = createCommonUpdateUserActionBuilder({
       userAction,
       userProfiles,
@@ -65,6 +83,12 @@ export const createExtendedFieldsUserActionBuilder: UserActionBuilder = ({
       icon: 'dot',
     });
 
-    return commonBuilder.build();
+    const result = commonBuilder.build();
+
+    if (body) {
+      result[0].children = body;
+    }
+
+    return result;
   },
 });


### PR DESCRIPTION
## What & Why
Adds opt-in markdown support for `TEXTAREA` fields in Cases Templates v2. When a template author sets `metadata.markdown: true` on a textarea field, the UI renders an `EuiMarkdownEditor` (with standard markdown controls only — no timeline or lens buttons) instead of a plain `EuiTextArea`. Multi-line field values are also rendered as markdown in the user actions activity feed via `ScrollableMarkdown`. Additionally fixes a regression from #268510 where `extended_fields` were silently dropped during case creation because the field was never registered with the parent `hook_form_lib` form via `UseField`.
## How to Test
1. Start Kibana with `xpack.cases.templates.enabled: true`, create a template with a `TEXTAREA` field that has `metadata: { markdown: true }` in the YAML definition
2. Create a case from that template — verify the markdown editor appears (bold, italic, lists, links toolbar — no timeline/lens buttons) and that the field value is saved correctly
3. Open the case details page — verify the field renders with the markdown editor and confirm/cancel buttons appear on edit
4. Check the user actions feed — any multi-line field value should render as formatted markdown below the "set {fieldName} to" label
5. Create a case from any template and verify all extended field values are persisted (bug fix — previously they were silently dropped)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



