### PR TITLE
[9.3] [Dataset Quality] Handle `index_not_found_exception` from missing backing indices (#267994)

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
@@ -326,7 +326,6 @@ describe('getDataStreamDetails', () => {
           start: 1234567890,
           end: 1234567900,
           isServerless: false,
-          isSecurityEnabled: true,
         });
 
         expect(result).toEqual({});
@@ -347,7 +346,6 @@ describe('getDataStreamDetails', () => {
           start: 1234567890,
           end: 1234567900,
           isServerless: false,
-          isSecurityEnabled: true,
         });
 
         expect(mockDatasetQualityESClient.fieldCaps).toHaveBeenCalledWith({
@@ -385,7 +383,6 @@ describe('getDataStreamDetails', () => {
           start: 1234567890,
           end: 1234567900,
           isServerless: false,
-          isSecurityEnabled: true,
         });
 
         expect(result.docsCount).toBe(1000);

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
@@ -56,7 +56,8 @@ describe('getDataStreamDetails', () => {
   let esClient: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
   let mockESClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
   let mockDatasetQualityESClient: {
-    search: jest.MockedFunction<any>;
+    search: jest.MockedFunction<ReturnType<typeof createDatasetQualityESClient>['search']>;
+    fieldCaps: jest.MockedFunction<ReturnType<typeof createDatasetQualityESClient>['fieldCaps']>;
   };
 
   beforeEach(() => {
@@ -64,6 +65,7 @@ describe('getDataStreamDetails', () => {
     mockESClient = elasticsearchServiceMock.createElasticsearchClient();
     mockDatasetQualityESClient = {
       search: jest.fn(),
+      fieldCaps: jest.fn(),
     };
     esClient.asCurrentUser = mockESClient;
 
@@ -117,7 +119,7 @@ describe('getDataStreamDetails', () => {
       },
     } as any);
 
-    mockESClient.fieldCaps.mockResolvedValue({
+    mockDatasetQualityESClient.fieldCaps.mockResolvedValue({
       fields: {
         'host.name': {
           keyword: { type: 'keyword', aggregatable: true },
@@ -296,6 +298,99 @@ describe('getDataStreamDetails', () => {
         });
 
         expect(result).toEqual({});
+      });
+
+      it('returns empty object when ES surfaces index_not_found_exception as 500 (e.g. partial-restored backing index)', async () => {
+        mockDatasetQualityPrivileges.getHasIndexPrivileges.mockResolvedValue({
+          'logs-test-default': {
+            monitor: true,
+            read_failure_store: true,
+            manage_failure_store: true,
+          },
+        });
+
+        const error = new Error(
+          'index_not_found_exception: no such index [partial-.ds-logs-test-default-2026.03.21-000001]'
+        );
+        (
+          error as Error & { statusCode?: number; body?: { error?: { type?: string } } }
+        ).statusCode = 500;
+        (error as Error & { body?: { error?: { type?: string } } }).body = {
+          error: { type: 'index_not_found_exception' },
+        };
+        mockDatasetQualityESClient.search.mockRejectedValue(error);
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+          isSecurityEnabled: true,
+        });
+
+        expect(result).toEqual({});
+      });
+
+      it('calls the wrapped fieldCaps (not the raw esClient.fieldCaps) so ignore_unavailable is applied', async () => {
+        mockDatasetQualityPrivileges.getHasIndexPrivileges.mockResolvedValue({
+          'logs-test-default': {
+            monitor: true,
+            read_failure_store: true,
+            manage_failure_store: true,
+          },
+        });
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+          isSecurityEnabled: true,
+        });
+
+        expect(mockDatasetQualityESClient.fieldCaps).toHaveBeenCalledWith({
+          index: 'logs-test-default',
+          fields: ['*'],
+          include_unmapped: false,
+        });
+        expect(mockESClient.fieldCaps).not.toHaveBeenCalled();
+        expect(result).toEqual(detailsObject);
+      });
+
+      it('returns docs/services/hosts but sizeBytes=0 when indices.stats throws index_not_found_exception', async () => {
+        mockDatasetQualityPrivileges.getHasIndexPrivileges.mockResolvedValue({
+          'logs-test-default': {
+            monitor: true,
+            read_failure_store: true,
+            manage_failure_store: true,
+          },
+        });
+
+        const error = new Error(
+          'index_not_found_exception: no such index [partial-.ds-logs-test-default-2026.03.21-000001]'
+        );
+        (
+          error as Error & { statusCode?: number; body?: { error?: { type?: string } } }
+        ).statusCode = 500;
+        (error as Error & { body?: { error?: { type?: string } } }).body = {
+          error: { type: 'index_not_found_exception' },
+        };
+        mockESClient.indices.stats.mockRejectedValue(error);
+
+        const result = await getDataStreamDetails({
+          esClient,
+          dataStream: 'logs-test-default',
+          start: 1234567890,
+          end: 1234567900,
+          isServerless: false,
+          isSecurityEnabled: true,
+        });
+
+        expect(result.docsCount).toBe(1000);
+        expect(result.sizeBytes).toBe(0);
+        expect(result.services).toEqual({ 'service.name': ['service1', 'service2'] });
       });
 
       it('throws error for other types of errors', async () => {

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/index.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/index.ts
@@ -101,8 +101,13 @@ export async function getDataStreamDetails({
       defaultRetentionPeriod: esDataStream?.defaultRetentionPeriod,
     };
   } catch (e) {
-    // Respond with empty object if data stream does not exist
-    if (e.statusCode === 404 || e.body?.error?.type === 'index_closed_exception') {
+    // ES surfaces `index_not_found_exception` as a 500 when triggered
+    // mid-search (e.g. a missing backing index), so check the error type too.
+    if (
+      e.statusCode === 404 ||
+      e.body?.error?.type === 'index_closed_exception' ||
+      e.body?.error?.type === 'index_not_found_exception'
+    ) {
       return {};
     }
     throw e;
@@ -153,7 +158,7 @@ async function getDataStreamSummaryStats(
 }> {
   const datasetQualityESClient = createDatasetQualityESClient(esClient);
 
-  const fieldCapsResponse = await esClient.fieldCaps({
+  const fieldCapsResponse = await datasetQualityESClient.fieldCaps({
     index: dataStream,
     fields: ['*'],
     include_unmapped: false,
@@ -209,7 +214,20 @@ async function getMeteringAvgDocSizeInBytes(esClient: ElasticsearchClient, index
 }
 
 async function getAvgDocSizeInBytes(esClient: ElasticsearchClient, index: string) {
-  const indexStats = await esClient.indices.stats({ index, forbid_closed_indices: false });
+  // `indices.stats` does not support `ignore_unavailable`, so if any backing
+  // index of the data stream is missing (e.g. a `partial-` index from a
+  // partial snapshot restore, or a legacy time-based index deleted by ILM)
+  // it throws `index_not_found_exception`. Treat that as "no size info" so we
+  // do not lose the rest of the details payload.
+  let indexStats: Awaited<ReturnType<ElasticsearchClient['indices']['stats']>>;
+  try {
+    indexStats = await esClient.indices.stats({ index, forbid_closed_indices: false });
+  } catch (e) {
+    if (e.body?.error?.type === 'index_not_found_exception' || e.statusCode === 404) {
+      return 0;
+    }
+    throw e;
+  }
   const docCount = indexStats._all.total?.docs?.count ?? 0;
   const sizeInBytes = indexStats._all.total?.store?.size_in_bytes ?? 0;
 

--- a/x-pack/platform/plugins/shared/dataset_quality/server/utils/create_dataset_quality_es_client.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/utils/create_dataset_quality_es_client.ts
@@ -34,6 +34,9 @@ export function createDatasetQualityESClient(esClient: ElasticsearchClient) {
       searchParams: TParams
     ): Promise<InferSearchResponseOf<TDocument, TParams>> {
       return esClient.search<TDocument>({
+        ignore_unavailable: true,
+        allow_no_indices: true,
+        expand_wildcards: ['open', 'hidden'],
         ...searchParams,
       }) as Promise<any>;
     },

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/data_stream_details.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/data_stream_details.ts
@@ -118,11 +118,16 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(resp.body.message.indexOf(expectedMessage)).to.greaterThan(-1);
       });
 
-      it('returns {} if matching data stream is not available', async () => {
+      it('returns an empty-data details payload when matching data stream is not available', async () => {
         const nonExistentDataSet = 'Non-existent';
         const nonExistentDataStream = `${type}-${nonExistentDataSet}-${namespace}`;
         const resp = await callApiAs(supertestEditorWithCookieCredentials, nonExistentDataStream);
-        expect(resp.body).empty();
+        expect(resp.status).to.be(200);
+        expect(resp.body.docsCount).to.be(0);
+        expect(resp.body.degradedDocsCount).to.be(0);
+        expect(resp.body.services).to.eql({});
+        expect(resp.body.hosts).to.eql({});
+        expect(resp.body.sizeBytes).to.be(0);
       });
 
       it('returns service.name and host.name correctly', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Dataset Quality] Handle `index_not_found_exception` from missing backing indices (#267994)](https://github.com/elastic/kibana/pull/267994)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Stelmach","email":"60304951+rStelmach@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-13T15:50:54Z","message":"[Dataset Quality] Handle `index_not_found_exception` from missing backing indices (#267994)\n\nCloses https://github.com/elastic/observability-error-backlog/issues/769\n\n## Summary\n\nThe Dataset Quality server logs ~3-5 `index_not_found_exception` errors\nper day across ~50 production clusters (8.19.x and 9.x). The errors come\nfrom data streams whose backing indices are missing, typically\n`partial-.ds-…` indices left over from a partial snapshot restore, or\nlegacy time-based indices (e.g. `metricbeat-7.13.3-…`) that ILM has\nalready deleted.\n\nElasticsearch surfaces this as `index_not_found_exception` with HTTP\nstatus **500** (not 404) when it happens mid-search, and our route\nhandlers were only catching 404s, so the error bubbled up and was logged\nat ERROR level by the generic route handler.\n\n## What changed\n\nThree small server-side fixes:\n\n1. **`create_dataset_quality_es_client.ts`** – the shared `search()`\nwrapper now passes `ignore_unavailable: true`, `allow_no_indices: true`,\nand `expand_wildcards: ['open', 'hidden']`, mirroring what we already do\nfor `fieldCaps()`. This covers `getDataStreamSummaryStats` and\n`getDegradedFields` in one place.\n2. **`get_data_stream_details/index.ts`** – the outer `catch` now also\ntreats `index_not_found_exception` as \"data stream not found\" and\nreturns `{}`, alongside the existing 404 / `index_closed_exception`\nhandling.\n3. **`get_data_stream_details/index.ts`** – `indices.stats()` (used for\nnon-serverless avg doc size) doesn't support `ignore_unavailable`, so\nit's now wrapped in a small try/catch. If a backing index is missing we\nreturn size = 0 instead of failing the whole details response, so the\nuser still sees docs/services/hosts.\n\n## Why this is safe\n\n- The catch blocks only swallow the specific \"missing index\" error\ntypes; any other ES error still propagates as before.\n- The client-side state machine\n(`dataset_quality_details_controller/state_machine.ts`) already detects\nthis exact error and shows an \"Index Not Found\" prompt, so returning\n`{}` is the response shape the UI already expects.\n- `ignore_unavailable: true` is already used by `fieldCaps()` in the\nsame file","sha":"86f94f57a7710e6334f2a5f3efeeddf5f9fdebce","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-onboarding","Feature:Dataset Health","v9.5.0"],"title":"[Dataset Quality] Handle `index_not_found_exception` from missing backing indices","number":267994,"url":"https://github.com/elastic/kibana/pull/267994","mergeCommit":{"message":"[Dataset Quality] Handle `index_not_found_exception` from missing backing indices (#267994)\n\nCloses https://github.com/elastic/observability-error-backlog/issues/769\n\n## Summary\n\nThe Dataset Quality server logs ~3-5 `index_not_found_exception` errors\nper day across ~50 production clusters (8.19.x and 9.x). The errors come\nfrom data streams whose backing indices are missing, typically\n`partial-.ds-…` indices left over from a partial snapshot restore, or\nlegacy time-based indices (e.g. `metricbeat-7.13.3-…`) that ILM has\nalready deleted.\n\nElasticsearch surfaces this as `index_not_found_exception` with HTTP\nstatus **500** (not 404) when it happens mid-search, and our route\nhandlers were only catching 404s, so the error bubbled up and was logged\nat ERROR level by the generic route handler.\n\n## What changed\n\nThree small server-side fixes:\n\n1. **`create_dataset_quality_es_client.ts`** – the shared `search()`\nwrapper now passes `ignore_unavailable: true`, `allow_no_indices: true`,\nand `expand_wildcards: ['open', 'hidden']`, mirroring what we already do\nfor `fieldCaps()`. This covers `getDataStreamSummaryStats` and\n`getDegradedFields` in one place.\n2. **`get_data_stream_details/index.ts`** – the outer `catch` now also\ntreats `index_not_found_exception` as \"data stream not found\" and\nreturns `{}`, alongside the existing 404 / `index_closed_exception`\nhandling.\n3. **`get_data_stream_details/index.ts`** – `indices.stats()` (used for\nnon-serverless avg doc size) doesn't support `ignore_unavailable`, so\nit's now wrapped in a small try/catch. If a backing index is missing we\nreturn size = 0 instead of failing the whole details response, so the\nuser still sees docs/services/hosts.\n\n## Why this is safe\n\n- The catch blocks only swallow the specific \"missing index\" error\ntypes; any other ES error still propagates as before.\n- The client-side state machine\n(`dataset_quality_details_controller/state_machine.ts`) already detects\nthis exact error and shows an \"Index Not Found\" prompt, so returning\n`{}` is the response shape the UI already expects.\n- `ignore_unavailable: true` is already used by `fieldCaps()` in the\nsame file","sha":"86f94f57a7710e6334f2a5f3efeeddf5f9fdebce"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267994","number":267994,"mergeCommit":{"message":"[Dataset Quality] Handle `index_not_found_exception` from missing backing indices (#267994)\n\nCloses https://github.com/elastic/observability-error-backlog/issues/769\n\n## Summary\n\nThe Dataset Quality server logs ~3-5 `index_not_found_exception` errors\nper day across ~50 production clusters (8.19.x and 9.x). The errors come\nfrom data streams whose backing indices are missing, typically\n`partial-.ds-…` indices left over from a partial snapshot restore, or\nlegacy time-based indices (e.g. `metricbeat-7.13.3-…`) that ILM has\nalready deleted.\n\nElasticsearch surfaces this as `index_not_found_exception` with HTTP\nstatus **500** (not 404) when it happens mid-search, and our route\nhandlers were only catching 404s, so the error bubbled up and was logged\nat ERROR level by the generic route handler.\n\n## What changed\n\nThree small server-side fixes:\n\n1. **`create_dataset_quality_es_client.ts`** – the shared `search()`\nwrapper now passes `ignore_unavailable: true`, `allow_no_indices: true`,\nand `expand_wildcards: ['open', 'hidden']`, mirroring what we already do\nfor `fieldCaps()`. This covers `getDataStreamSummaryStats` and\n`getDegradedFields` in one place.\n2. **`get_data_stream_details/index.ts`** – the outer `catch` now also\ntreats `index_not_found_exception` as \"data stream not found\" and\nreturns `{}`, alongside the existing 404 / `index_closed_exception`\nhandling.\n3. **`get_data_stream_details/index.ts`** – `indices.stats()` (used for\nnon-serverless avg doc size) doesn't support `ignore_unavailable`, so\nit's now wrapped in a small try/catch. If a backing index is missing we\nreturn size = 0 instead of failing the whole details response, so the\nuser still sees docs/services/hosts.\n\n## Why this is safe\n\n- The catch blocks only swallow the specific \"missing index\" error\ntypes; any other ES error still propagates as before.\n- The client-side state machine\n(`dataset_quality_details_controller/state_machine.ts`) already detects\nthis exact error and shows an \"Index Not Found\" prompt, so returning\n`{}` is the response shape the UI already expects.\n- `ignore_unavailable: true` is already used by `fieldCaps()` in the\nsame file","sha":"86f94f57a7710e6334f2a5f3efeeddf5f9fdebce"}}]}] BACKPORT-->