### PR TITLE
[Alerting v2] Fix YAML mode toggle side-effects on kind checkbox and nav buttons

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.tsx
@@ -392,7 +392,9 @@ export const ComposeDiscoverFlyout: React.FC<ComposeDiscoverFlyoutProps> = ({
           const compose = formValuesFromYamlToCompose(result.values);
           methods.reset(compose);
           syncSandbox();
-          dispatch({ type: 'COMMIT_QUERY' });
+          if (getBreachQuery(compose.query).trim()) {
+            dispatch({ type: 'COMMIT_QUERY' });
+          }
         }
         // No syncSandbox() on parse-failure path: the debounced parse always calls
         // methods.reset() + syncSandbox() together, so RHF and sandbox state are already in

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.test.ts
@@ -121,6 +121,24 @@ describe('reducer', () => {
     });
   });
 
+  describe('SET_YAML_MODE', () => {
+    it('opens child when enabling yaml mode', () => {
+      const state = createState({ childOpen: false, yamlMode: false });
+      const next = reducer(state, { type: 'SET_YAML_MODE', enabled: true });
+
+      expect(next.yamlMode).toBe(true);
+      expect(next.childOpen).toBe(true);
+    });
+
+    it('closes child when disabling yaml mode', () => {
+      const state = createState({ childOpen: true, yamlMode: true });
+      const next = reducer(state, { type: 'SET_YAML_MODE', enabled: false });
+
+      expect(next.yamlMode).toBe(false);
+      expect(next.childOpen).toBe(false);
+    });
+  });
+
   describe('CLOSE_CHILD', () => {
     it('sets childOpen false without changing other fields', () => {
       const state = createState({ childOpen: true, queryCommitted: true });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_compose_discover_state.ts
@@ -123,7 +123,7 @@ export function reducer(
       return {
         ...state,
         yamlMode: action.enabled,
-        childOpen: true,
+        childOpen: action.enabled,
       };
     default:
       return state;


### PR DESCRIPTION
## Summary

Fixes two YAML round-trip bugs in the Compose Discover flyout.

Closes #270361
Closes #270363

### Bug 1 — Kind checkbox incorrectly enabled after YAML round-trip

In create mode, toggling to YAML view and back enables the "Track active and recovered state over time" checkbox even when no query has been written. 

**Root cause:** `handleToggleYamlMode(false)` unconditionally dispatches `COMMIT_QUERY` when the YAML parse succeeds — including when the parsed query is the empty default (`breach: ''`).

**Fix:** Gate `COMMIT_QUERY` on whether the parsed query has actual content via `getBreachQuery()`.

### Bug 2 — Back/Next buttons disabled after YAML round-trip on non-query steps

When the user is on Details & Artifacts or Notifications and toggles YAML on then off, Back and Next become disabled. The sandbox flyout opens on a step where it's irrelevant.

**Root cause:** The `SET_YAML_MODE` reducer unconditionally sets `childOpen: true`, even when disabling YAML mode. The footer buttons are gated on `isDisabled={uiState.childOpen}`.

**Fix:** `SET_YAML_MODE` now sets `childOpen: action.enabled` — opens the sandbox when entering YAML, closes it when leaving.

## Test plan

**Bug 1:**
1. Open flyout in create mode
2. Observe tracking toggle is disabled
3. Toggle to YAML view, then back to form view without editing
4. Tracking toggle should remain disabled

**Bug 2:**
1. Open flyout, commit a query, advance to Details & Artifacts
2. Toggle to YAML view, then back to form view
3. Back and Next should be enabled
4. Repeat from Notifications step — Back should be enabled