### PR TITLE
[Obs Onboarding] Improve navigation test robustness

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/fixtures/page_objects/onboarding_app.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/fixtures/page_objects/onboarding_app.ts
@@ -157,13 +157,10 @@ export class OnboardingApp {
     } else {
       await card.click();
     }
+  }
 
-    // For flows that have the ingestion selector, wait for it to be visible
-    const flowsWithIngestionSelector =
-      /(auto-detect-logs|kubernetes-quick-start|otel-logs|otel-kubernetes)/;
-    if (flowsWithIngestionSelector.test(cardSelector)) {
-      await this.ingestionModeSelector.waitFor({ state: 'visible', timeout: 30000 });
-    }
+  async waitForIngestionModeSelector(timeout = 30_000) {
+    await this.ingestionModeSelector.waitFor({ state: 'visible', timeout });
   }
 
   async getGridColumnCount() {

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_auto_detect.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_auto_detect.spec.ts
@@ -29,6 +29,7 @@ test.describe(
       await test.step('navigate to Auto-detect flow', async () => {
         await pageObjects.onboarding.selectHostUseCase();
         await pageObjects.onboarding.clickIntegrationCard('integration-card:auto-detect-logs');
+        await pageObjects.onboarding.waitForIngestionModeSelector();
       });
 
       await test.step('ingestion selector is visible with both options', async () => {
@@ -49,6 +50,7 @@ test.describe(
     test('can switch to Wired Streams mode', async ({ pageObjects }) => {
       await pageObjects.onboarding.selectHostUseCase();
       await pageObjects.onboarding.clickIntegrationCard('integration-card:auto-detect-logs');
+      await pageObjects.onboarding.waitForIngestionModeSelector();
 
       await pageObjects.onboarding.selectWiredStreams();
 
@@ -63,6 +65,7 @@ test.describe(
     }) => {
       await pageObjects.onboarding.selectHostUseCase();
       await pageObjects.onboarding.clickIntegrationCard('integration-card:auto-detect-logs');
+      await pageObjects.onboarding.waitForIngestionModeSelector();
 
       await test.step('command does NOT include wired streams flag in Classic mode', async () => {
         const classicCommand = await pageObjects.onboarding.getAutoDetectCommandContent();

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_elastic_agent_kubernetes.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_elastic_agent_kubernetes.spec.ts
@@ -31,6 +31,7 @@ test.describe(
         await pageObjects.onboarding.clickIntegrationCard(
           'integration-card:kubernetes-quick-start'
         );
+        await pageObjects.onboarding.waitForIngestionModeSelector();
       });
 
       await test.step('ingestion selector is visible with both options', async () => {
@@ -53,6 +54,7 @@ test.describe(
     }) => {
       await pageObjects.onboarding.selectKubernetesUseCase();
       await pageObjects.onboarding.clickIntegrationCard('integration-card:kubernetes-quick-start');
+      await pageObjects.onboarding.waitForIngestionModeSelector();
 
       await test.step('command does NOT include wired streams config in Classic mode', async () => {
         const classicCommand = await pageObjects.onboarding.getKubernetesCommandContent();

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_enable_modal.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_enable_modal.spec.ts
@@ -40,6 +40,7 @@ test.describe(
       await test.step('navigate to Auto-detect flow', async () => {
         await pageObjects.onboarding.selectHostUseCase();
         await pageObjects.onboarding.clickIntegrationCard('integration-card:auto-detect-logs');
+        await pageObjects.onboarding.waitForIngestionModeSelector();
       });
 
       await test.step('Classic ingestion is selected by default', async () => {
@@ -60,6 +61,7 @@ test.describe(
     test('canceling the modal keeps Classic ingestion selected', async ({ pageObjects }) => {
       await pageObjects.onboarding.selectHostUseCase();
       await pageObjects.onboarding.clickIntegrationCard('integration-card:auto-detect-logs');
+      await pageObjects.onboarding.waitForIngestionModeSelector();
 
       await test.step('open modal and cancel', async () => {
         await pageObjects.onboarding.selectWiredStreams();
@@ -85,6 +87,7 @@ test.describe(
     }) => {
       await pageObjects.onboarding.selectHostUseCase();
       await pageObjects.onboarding.clickIntegrationCard('integration-card:auto-detect-logs');
+      await pageObjects.onboarding.waitForIngestionModeSelector();
 
       await test.step('open modal and confirm', async () => {
         await pageObjects.onboarding.selectWiredStreams();
@@ -125,6 +128,7 @@ test.describe(
 
       await pageObjects.onboarding.selectHostUseCase();
       await pageObjects.onboarding.clickIntegrationCard('integration-card:auto-detect-logs');
+      await pageObjects.onboarding.waitForIngestionModeSelector();
 
       await test.step('clicking Wired Streams switches directly without modal', async () => {
         await pageObjects.onboarding.selectWiredStreams();

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_otel_host.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_otel_host.spec.ts
@@ -29,6 +29,7 @@ test.describe(
       await test.step('navigate to OTel Host flow', async () => {
         await pageObjects.onboarding.selectHostUseCase();
         await pageObjects.onboarding.clickIntegrationCard('integration-card:otel-logs');
+        await pageObjects.onboarding.waitForIngestionModeSelector();
       });
 
       await test.step('ingestion selector is visible', async () => {
@@ -52,6 +53,7 @@ test.describe(
     test('can switch between ingestion modes', async ({ pageObjects }) => {
       await pageObjects.onboarding.selectHostUseCase();
       await pageObjects.onboarding.clickIntegrationCard('integration-card:otel-logs');
+      await pageObjects.onboarding.waitForIngestionModeSelector();
 
       await test.step('select Wired Streams', async () => {
         await pageObjects.onboarding.selectWiredStreams();

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_otel_kubernetes.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/tests/wired_streams_otel_kubernetes.spec.ts
@@ -29,6 +29,7 @@ test.describe(
       await test.step('navigate to OTel Kubernetes flow', async () => {
         await pageObjects.onboarding.selectKubernetesUseCase();
         await pageObjects.onboarding.clickIntegrationCard('integration-card:otel-kubernetes');
+        await pageObjects.onboarding.waitForIngestionModeSelector();
       });
 
       await test.step('ingestion selector is visible with both options', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/248276

This change decouples the testing for Ingestion Selector visibility from card navigation. This removes the need to wait for the selector in cases where we want to test the navigation only and gives more granular controls for assertions in tests.