### PR TITLE
[kbn-check-saved-objects-cli] Improve CI check reporting and error structure

### DIFF
--- a/.buildkite/scripts/steps/checks/notify_saved_objects_changes.test.ts
+++ b/.buildkite/scripts/steps/checks/notify_saved_objects_changes.test.ts
@@ -17,6 +17,7 @@ import {
   buildSuccessBody,
   type SavedObjectsCheckFinding,
   type SavedObjectsCheckReport,
+  type TypeChangeDetails,
 } from './notify_saved_objects_changes';
 
 const finding = (overrides: Partial<SavedObjectsCheckFinding> = {}): SavedObjectsCheckFinding => ({
@@ -86,6 +87,68 @@ describe('buildSuccessBody', () => {
     const body = buildSuccessBody(report({ newTypes: ['shiny-new-type'] }));
     expect(body).not.toMatch(/2-step release/);
     expect(body).toContain('**New types:** `shiny-new-type`');
+  });
+
+  it('renders a new model version line for updated types', () => {
+    const typeChanges: Record<string, TypeChangeDetails> = {
+      task: { newModelVersions: ['10.3.0'], modifiedModelVersions: [] },
+    };
+    const body = buildSuccessBody(report({ updatedTypes: ['task'], typeChanges }));
+    expect(body).toContain('A new model version was introduced for type `task`: `10.3.0`.');
+  });
+
+  it('renders modified model version lines for updated types', () => {
+    const typeChanges: Record<string, TypeChangeDetails> = {
+      config: { newModelVersions: [], modifiedModelVersions: ['10.1.0', '10.2.0'] },
+    };
+    const body = buildSuccessBody(report({ updatedTypes: ['config'], typeChanges }));
+    expect(body).toContain(
+      'The following model versions have been modified for type `config`: `10.1.0`, `10.2.0`.'
+    );
+  });
+
+  it('renders both new and modified version lines when both are present', () => {
+    const typeChanges: Record<string, TypeChangeDetails> = {
+      task: { newModelVersions: ['10.4.0'], modifiedModelVersions: ['10.2.0'] },
+    };
+    const body = buildSuccessBody(report({ updatedTypes: ['task'], typeChanges }));
+    expect(body).toContain('A new model version was introduced for type `task`: `10.4.0`.');
+    expect(body).toContain(
+      'The following model versions have been modified for type `task`: `10.2.0`.'
+    );
+  });
+
+  it('omits the change details section when typeChanges is absent', () => {
+    const body = buildSuccessBody(report({ updatedTypes: ['task'] }));
+    expect(body).not.toContain('model version was introduced');
+    expect(body).not.toContain('model versions have been modified');
+  });
+
+  it('includes the IMPORTANT mappings banner for new types', () => {
+    const body = buildSuccessBody(report({ newTypes: ['shiny-new-type'] }));
+    expect(body).toContain('[!IMPORTANT]');
+    expect(body).toContain('searchable and/or sortable');
+  });
+
+  it('includes the IMPORTANT mappings banner for updated types with a new model version', () => {
+    const typeChanges: Record<string, TypeChangeDetails> = {
+      task: { newModelVersions: ['10.3.0'], modifiedModelVersions: [] },
+    };
+    const body = buildSuccessBody(report({ updatedTypes: ['task'], typeChanges }));
+    expect(body).toContain('[!IMPORTANT]');
+  });
+
+  it('omits the IMPORTANT mappings banner for updated types with only modified model versions', () => {
+    const typeChanges: Record<string, TypeChangeDetails> = {
+      task: { newModelVersions: [], modifiedModelVersions: ['10.2.0'] },
+    };
+    const body = buildSuccessBody(report({ updatedTypes: ['task'], typeChanges }));
+    expect(body).not.toContain('[!IMPORTANT]');
+  });
+
+  it('includes the IMPORTANT mappings banner for updated types when typeChanges is absent (conservative fallback)', () => {
+    const body = buildSuccessBody(report({ updatedTypes: ['task'] }));
+    expect(body).toContain('[!IMPORTANT]');
   });
 });
 

--- a/.buildkite/scripts/steps/checks/notify_saved_objects_changes.ts
+++ b/.buildkite/scripts/steps/checks/notify_saved_objects_changes.ts
@@ -14,12 +14,13 @@ import { upsertComment } from '#pipeline-utils';
 /**
  * SOURCE OF TRUTH: packages/kbn-check-saved-objects-cli/src/findings/types.ts
  *
- * This interface is intentionally inlined rather than imported so that this
+ * These interfaces are intentionally inlined rather than imported so that this
  * Buildkite script keeps the same minimal dependency surface as the other
  * notifiers (only `#pipeline-utils`, no Kibana package deps).
  *
- * When adding, removing, or changing fields in `SavedObjectsCheckFinding` or
- * `SavedObjectsCheckReport` in the canonical file above, mirror the change here.
+ * When adding, removing, or changing fields in `SavedObjectsCheckFinding`,
+ * `TypeChangeDetails`, or `SavedObjectsCheckReport` in the canonical file
+ * above, mirror the changes here.
  */
 export interface SavedObjectsCheckFinding {
   ruleId: string;
@@ -39,6 +40,14 @@ export interface SavedObjectsCheckFinding {
   serverlessBaselineUrl?: string;
 }
 
+/** Per-type model version change details for updated SO types. */
+export interface TypeChangeDetails {
+  /** Model versions added since the baseline, formatted as `10.x.0`. */
+  newModelVersions: string[];
+  /** Existing model versions modified since the baseline, formatted as `10.x.0`. */
+  modifiedModelVersions: string[];
+}
+
 export interface SavedObjectsCheckReport {
   status: 'pass' | 'fail';
   baseline?: string;
@@ -47,6 +56,11 @@ export interface SavedObjectsCheckReport {
   updatedTypes: string[];
   removedTypes: string[];
   findings: SavedObjectsCheckFinding[];
+  /**
+   * Per-type model version change details for updated SO types.
+   * Only present when both `from` and `to` snapshots were available during the check.
+   */
+  typeChanges?: Record<string, TypeChangeDetails>;
 }
 
 const COMMENT_CONTEXT = 'saved-objects-check';
@@ -60,6 +74,50 @@ function hasSoChanges(report: SavedObjectsCheckReport): boolean {
 
 function needsTwoStepReleaseReminder(report: SavedObjectsCheckReport): boolean {
   return report.updatedTypes.length > 0 || report.removedTypes.length > 0;
+}
+
+/**
+ * Returns the list of type names for which mapping changes are being introduced,
+ * triggering the "only map what needs to be searchable" banner.
+ *
+ * - All new types always qualify.
+ * - Updated types qualify when they have at least one new model version (which
+ *   implies new mappings were potentially introduced). When `typeChanges` is
+ *   absent (older report format) we conservatively include all updated types.
+ */
+function typesWithMappingChanges(report: SavedObjectsCheckReport): string[] {
+  const updatedWithNewVersion = report.typeChanges
+    ? report.updatedTypes.filter((t) => (report.typeChanges![t]?.newModelVersions.length ?? 0) > 0)
+    : report.updatedTypes;
+
+  return [...report.newTypes, ...updatedWithNewVersion];
+}
+
+/**
+ * Builds a per-type change-detail section listing new and modified model
+ * versions for each updated type. Returns an empty string when there is
+ * nothing to report.
+ */
+function buildTypeChangeDetails(report: SavedObjectsCheckReport): string {
+  const { typeChanges } = report;
+  if (!typeChanges || Object.keys(typeChanges).length === 0) return '';
+
+  const lines = Object.entries(typeChanges).flatMap(([typeName, details]) => {
+    const result: string[] = [];
+    if (details.newModelVersions.length > 0) {
+      const versions = details.newModelVersions.map((v) => `\`${v}\``).join(', ');
+      result.push(`- A new model version was introduced for type \`${typeName}\`: ${versions}.`);
+    }
+    if (details.modifiedModelVersions.length > 0) {
+      const versions = details.modifiedModelVersions.map((v) => `\`${v}\``).join(', ');
+      result.push(
+        `- The following model versions have been modified for type \`${typeName}\`: ${versions}.`
+      );
+    }
+    return result;
+  });
+
+  return lines.length > 0 ? `\n\n${lines.join('\n')}` : '';
 }
 
 function buildkiteBuildLink(): string {
@@ -152,13 +210,20 @@ export function buildSuccessBody(report: SavedObjectsCheckReport): string {
     .filter(Boolean)
     .join('\n');
 
+  const changeDetails = buildTypeChangeDetails(report);
+
+  const mappingsBanner =
+    typesWithMappingChanges(report).length > 0
+      ? `\n\n> [!IMPORTANT]\n> Only map properties that need to be searchable and/or sortable. There is no need to include all type properties in the mappings.`
+      : '';
+
   const reminder = needsTwoStepReleaseReminder(report)
     ? `\n\n> Some Saved Objects changes (e.g. mapping additions, type removals) require a **2-step release**: ship the change first, then update consumers in a follow-up. Review the [Saved Objects model versions documentation](${MODEL_VERSIONS_URL}) before merging.`
     : '';
 
   return `## Saved Objects CI check passed
 
-${summary}${reminder}`;
+${summary}${changeDetails}${mappingsBanner}${reminder}`;
 }
 
 export function buildCommentBody(report: SavedObjectsCheckReport): string | null {

--- a/packages/kbn-check-saved-objects-cli/src/commands/run_check_saved_objects_cli.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/run_check_saved_objects_cli.ts
@@ -11,10 +11,46 @@ import { writeFileSync } from 'fs';
 import { Listr, PRESET_TIMER } from 'listr2';
 import { run } from '@kbn/dev-cli-runner';
 import { getKibanaServer, startElasticsearch, stopElasticsearch } from '../util';
-import { FindingsCollector, type SavedObjectsCheckReport } from '../findings';
-import { getNewTypes, getUpdatedTypes } from '../snapshots';
+import {
+  FindingsCollector,
+  type SavedObjectsCheckReport,
+  type TypeChangeDetails,
+} from '../findings';
+import { classifyUpdatedTypes, getNewTypes } from '../snapshots';
+import type { MigrationSnapshot } from '../types';
 import type { MigrationAlgorithm, TaskContext } from './types';
 import { automatedRollbackTests, getSnapshots, validateSOChanges, validateTestFlow } from './tasks';
+
+/**
+ * Computes model version change details for a single SO type by diffing the
+ * `from` and `to` snapshots. Returns `undefined` when there is nothing to report.
+ */
+const computeTypeChanges = (
+  typeName: string,
+  from: MigrationSnapshot | undefined,
+  to: MigrationSnapshot
+): TypeChangeDetails | undefined => {
+  const toInfo = to.typeDefinitions[typeName];
+  if (!toInfo) return undefined;
+
+  const fromVersionMap = new Map(
+    (from?.typeDefinitions[typeName]?.modelVersions ?? []).map((v) => [v.version, v])
+  );
+
+  const newModelVersions = toInfo.modelVersions
+    .filter((v) => !fromVersionMap.has(v.version))
+    .map((v) => `10.${v.version}.0`);
+
+  const modifiedModelVersions = toInfo.modelVersions
+    .filter((v) => {
+      const fromVersion = fromVersionMap.get(v.version);
+      return fromVersion !== undefined && fromVersion.modelVersionHash !== v.modelVersionHash;
+    })
+    .map((v) => `10.${v.version}.0`);
+
+  if (newModelVersions.length === 0 && modifiedModelVersions.length === 0) return undefined;
+  return { newModelVersions, modifiedModelVersions };
+};
 
 export function runCheckSavedObjectsCli() {
   let globalTask: Listr<TaskContext, 'default', 'simple'>;
@@ -189,20 +225,31 @@ export function runCheckSavedObjectsCli() {
           try {
             const collector = new FindingsCollector();
             collector.ingestErrors(globalTask?.errors ?? []);
+
+            const newTypes =
+              context.from && context.to ? getNewTypes({ from: context.from, to: context.to }) : [];
+            const { updatedTypes } =
+              context.from && context.to
+                ? classifyUpdatedTypes({ from: context.from, to: context.to })
+                : { updatedTypes: context.updatedTypes.map(({ name }) => name) };
+
+            const typeChanges: Record<string, TypeChangeDetails> = {};
+            if (context.to) {
+              for (const typeName of updatedTypes) {
+                const details = computeTypeChanges(typeName, context.from, context.to);
+                if (details) typeChanges[typeName] = details;
+              }
+            }
+
             const report: SavedObjectsCheckReport = {
               status: exitCode === 0 ? 'pass' : 'fail',
               baseline: gitRev,
               serverlessBaseline: serverlessGitRev,
-              newTypes:
-                context.from && context.to
-                  ? getNewTypes({ from: context.from, to: context.to })
-                  : [],
-              updatedTypes:
-                context.from && context.to
-                  ? getUpdatedTypes({ from: context.from, to: context.to })
-                  : context.updatedTypes.map(({ name }) => name),
+              newTypes,
+              updatedTypes,
               removedTypes: context.newRemovedTypes,
               findings: collector.getFindings(),
+              ...(Object.keys(typeChanges).length > 0 && { typeChanges }),
             };
             writeFileSync(reportPath, JSON.stringify(report, null, 2));
           } catch (writeErr) {

--- a/packages/kbn-check-saved-objects-cli/src/commands/tasks/check_documents.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/tasks/check_documents.ts
@@ -11,6 +11,7 @@ import type { ISavedObjectsRepository } from '@kbn/core-saved-objects-api-server
 import { diff } from 'jest-diff';
 import equal from 'fast-deep-equal';
 import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import { RULE_IDS, SavedObjectsCheckError } from '../../findings';
 import type { Task, FixtureMap } from '../types';
 
 /**
@@ -146,12 +147,14 @@ export function checkDocuments({
         const closestDiff = diffs.reduce((best, current) =>
           current.totalChanges < best.totalChanges ? current : best
         );
-        const messages = [
-          `❌ A document of type '${type}' did NOT match any of the fixtures`,
-          `Closest match: fixtures['${version}'][${closestDiff.index}] (${relativePath})\n`,
-          closestDiff.diffResult,
-        ];
-        throw new Error(messages.join('\n'));
+        throw new SavedObjectsCheckError({
+          ruleId: RULE_IDS.DOCUMENTS_FIXTURE_MISMATCH,
+          severity: 'error',
+          typeName: type,
+          message: `A document of type '${type}' did NOT match any of the fixtures. Closest match: fixtures['${version}'][${closestDiff.index}] (${relativePath})\n${closestDiff.diffResult}`,
+          fixHint: `Update the fixture at '${relativePath}' to match the actual document structure.`,
+          docsAnchor: '#defining-model-versions',
+        });
       }
     });
   };

--- a/packages/kbn-check-saved-objects-cli/src/findings/index.ts
+++ b/packages/kbn-check-saved-objects-cli/src/findings/index.ts
@@ -13,6 +13,7 @@ export type {
   FindingSeverity,
   SavedObjectsCheckFinding,
   SavedObjectsCheckReport,
+  TypeChangeDetails,
 } from './types';
 export { SavedObjectsCheckError, isSavedObjectsCheckError } from './error';
 export { FindingsCollector } from './collector';

--- a/packages/kbn-check-saved-objects-cli/src/findings/types.ts
+++ b/packages/kbn-check-saved-objects-cli/src/findings/types.ts
@@ -26,6 +26,8 @@ export const RULE_IDS = {
   // new types
   NEW_TYPE_LEGACY_MIGRATIONS: 'new-type/legacy-migrations',
   NEW_TYPE_MISSING_INITIAL_MODEL_VERSION: 'new-type/missing-initial-model-version',
+  NEW_TYPE_KEYWORD_MISSING_IGNORE_ABOVE: 'new-type/keyword-missing-ignore-above',
+  NEW_TYPE_INVALID_NAME_TITLE_FIELD_TYPE: 'new-type/invalid-name-title-field-type',
   // model versions (shared)
   INITIAL_MODEL_VERSION_HAS_CHANGES: 'model-version/initial-must-be-schema-only',
   MODEL_VERSION_NUMBERS_INVALID: 'model-version/numbers-must-be-consecutive',
@@ -35,6 +37,10 @@ export const RULE_IDS = {
   MODEL_VERSION_MAPPINGS_NOT_IN_SCHEMA: 'model-version/mappings-not-in-schema',
   MODEL_VERSION_MAPPING_INDEX_FALSE: 'model-version/mapping-index-false',
   MODEL_VERSION_MAPPING_ENABLED_FALSE: 'model-version/mapping-enabled-false',
+  MODEL_VERSION_FIXTURE_MISSING: 'model-version/fixture-missing',
+  MODEL_VERSION_FIXTURE_INVALID: 'model-version/fixture-invalid',
+  // documents
+  DOCUMENTS_FIXTURE_MISMATCH: 'documents/fixture-mismatch',
   // removed types
   REMOVED_TYPE_NAME_REUSED: 'removed-type/name-reused',
   REMOVED_TYPE_NEEDS_UPDATE: 'removed-type/registry-needs-update',
@@ -65,6 +71,14 @@ export interface SavedObjectsCheckFinding {
   serverlessBaselineUrl?: string;
 }
 
+/** Per-type change details included in the report for updated SO types. */
+export interface TypeChangeDetails {
+  /** Model versions added since the baseline, formatted as `10.x.0`. */
+  newModelVersions: string[];
+  /** Existing model versions modified since the baseline, formatted as `10.x.0`. */
+  modifiedModelVersions: string[];
+}
+
 export interface SavedObjectsCheckReport {
   status: 'pass' | 'fail';
   baseline?: string;
@@ -73,4 +87,9 @@ export interface SavedObjectsCheckReport {
   updatedTypes: string[];
   removedTypes: string[];
   findings: SavedObjectsCheckFinding[];
+  /**
+   * Per-type model version change details for updated SO types.
+   * Only present when both `from` and `to` snapshots are available.
+   */
+  typeChanges?: Record<string, TypeChangeDetails>;
 }

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/get_type_fixtures.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/get_type_fixtures.ts
@@ -10,6 +10,7 @@
 import { join } from 'path';
 import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
 import { fileToJson } from '../../util';
+import { RULE_IDS, SavedObjectsCheckError } from '../../findings';
 import type { ModelVersionFixtures } from './types';
 import { FIXTURES_BASE_PATH } from './constants';
 import { createFixtureFile } from './create_fixture_file';
@@ -42,26 +43,33 @@ export async function getTypeFixtures({
         current,
         previous,
       });
-      throw new Error(
-        `❌ '${name}' SO type is missing test fixtures for '${current}'. Please populate sample data on '${path}'.`
-      );
+      throw new SavedObjectsCheckError({
+        ruleId: RULE_IDS.MODEL_VERSION_FIXTURE_MISSING,
+        severity: 'error',
+        typeName: name,
+        message: `'${name}' SO type is missing test fixtures for '${current}'.`,
+        fixHint: `The template file '${path}' has been generated. Populate it with sample documents.`,
+        docsAnchor: '#defining-model-versions',
+      });
     } else {
-      throw new Error(
-        `❌ '${name}' SO type is missing test fixtures for the new modelVersion '${current}'. Please run with --fix to generate '${path}' and then add sample data.`
-      );
+      throw new SavedObjectsCheckError({
+        ruleId: RULE_IDS.MODEL_VERSION_FIXTURE_MISSING,
+        severity: 'error',
+        typeName: name,
+        message: `'${name}' SO type is missing test fixtures for the new modelVersion '${current}'.`,
+        fixHint: `Run with --fix to generate the template file '${path}', then populate it with sample documents.`,
+        docsAnchor: '#defining-model-versions',
+      });
     }
   } else if (!isValidFixtureFile(fixtures, previous, current)) {
-    throw new Error(
-      `❌ The contents of '${path}' are invalid. Please ensure it:
-{
-  "${previous}": [
-    // has one or more documents of type ${name} on version ${previous}
-  ],
-  "${current}": [
-    // what the documents above should look like after migrating them to ${current}
-  ],
-}`
-    );
+    throw new SavedObjectsCheckError({
+      ruleId: RULE_IDS.MODEL_VERSION_FIXTURE_INVALID,
+      severity: 'error',
+      typeName: name,
+      message: `The contents of '${path}' are invalid.`,
+      fixHint: `Ensure the file contains a JSON object with a '${previous}' key (documents of type '${name}' on version ${previous}) and a '${current}' key (those documents after migration to ${current}), each holding a non-empty array.`,
+      docsAnchor: '#defining-model-versions',
+    });
   } else {
     return fixtures;
   }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/fetch_snapshot.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/fetch_snapshot.ts
@@ -24,7 +24,8 @@ export const gcsSnapshotUrl = (rev: string | undefined): string | undefined =>
   rev ? `${SO_MIGRATIONS_BUCKET_PREFIX}/${rev}.json` : undefined;
 
 export async function fetchSnapshot(gitRev: string): Promise<MigrationSnapshot> {
-  const googleCloudUrl = `${SO_MIGRATIONS_BUCKET_PREFIX}/${gitRev}.json`;
+  // gcsSnapshotUrl always returns a string for a non-empty gitRev
+  const googleCloudUrl = gcsSnapshotUrl(gitRev)!;
   const path = await downloadToTemp(googleCloudUrl);
   return await loadSnapshotFromFile(path);
 }
@@ -35,14 +36,10 @@ async function downloadToTemp(googleCloudUrl: string): Promise<string> {
 
   if (existsSync(filePath)) {
     return filePath;
-  } else {
-    try {
-      await downloadFile(googleCloudUrl, filePath);
-      return filePath;
-    } catch (err) {
-      throw err;
-    }
   }
+
+  await downloadFile(googleCloudUrl, filePath);
+  return filePath;
 }
 
 async function loadSnapshotFromFile(filePath: string): Promise<MigrationSnapshot> {

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type_utils.ts
@@ -9,6 +9,7 @@
 
 import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
 import type { MigrationInfoRecord } from '../../types';
+import { RULE_IDS, SavedObjectsCheckError } from '../../findings';
 import {
   getFieldsMissingIgnoreAbove,
   getInvalidNameTitleFields,
@@ -25,12 +26,16 @@ import {
 export function validateIgnoreAboveNewType(name: string, to: MigrationInfoRecord): void {
   const fieldsMissing = getFieldsMissingIgnoreAbove(to.mappings);
   if (fieldsMissing.length > 0) {
-    throw new Error(
-      `❌ The SO type '${name}' has 'keyword' or 'flattened' mapping fields without 'ignore_above': ${fieldsMissing.join(
+    throw new SavedObjectsCheckError({
+      ruleId: RULE_IDS.NEW_TYPE_KEYWORD_MISSING_IGNORE_ABOVE,
+      severity: 'error',
+      typeName: name,
+      message: `The SO type '${name}' has 'keyword' or 'flattened' mapping fields without 'ignore_above': ${fieldsMissing.join(
         ', '
-      )}. ` +
-        `Add 'ignore_above' to prevent Elasticsearch from silently dropping strings that exceed the limit.`
-    );
+      )}.`,
+      fixHint: `Add 'ignore_above: 1024' (or another appropriate limit) to each affected field to prevent Elasticsearch from silently dropping strings that exceed the limit.`,
+      docsAnchor: '#defining-model-versions',
+    });
   }
 }
 
@@ -51,10 +56,15 @@ export function validateNameTitleFieldTypesNewType(
 
   const invalidFields = getInvalidNameTitleFields(to);
   if (invalidFields.length > 0) {
-    throw new Error(
-      `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${invalidFields
+    throw new SavedObjectsCheckError({
+      ruleId: RULE_IDS.NEW_TYPE_INVALID_NAME_TITLE_FIELD_TYPE,
+      severity: 'error',
+      typeName: name,
+      message: `The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${invalidFields
         .map(({ description }) => description)
-        .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
-    );
+        .join(', ')}.`,
+      fixHint: `These fields must be of type 'text' for Search API compatibility.`,
+      docsAnchor: '#defining-model-versions',
+    });
   }
 }


### PR DESCRIPTION
## Summary

- **Structured errors**: migrates all remaining `throw new Error()` validators in `check_documents.ts`, `get_type_fixtures.ts`, and `new_type_utils.ts` to `SavedObjectsCheckError` so every finding flows through the structured reporting pipeline with `ruleId`, `typeName`, `fixHint`, and `docsAnchor`. Adds five new `RULE_IDS` entries.

- **Per-type change details in the report**: extends `SavedObjectsCheckReport` with an optional `typeChanges` field (populated by diffing the `from`/`to` snapshots) that records which model versions were newly introduced and which existing ones were modified for each updated type.

- **Improved PR comment**: the GitHub notifier now renders per-type version change lines (e.g. _"A new model version was introduced for type `foo`: `10.3.0`."_) and adds a `[!IMPORTANT]` mappings banner whenever new SO types are introduced or existing types receive a new model version — reminding contributors to only map properties that need to be searchable/sortable. cc @afharo 

- **`fetchSnapshot` cleanup**: reuses `gcsSnapshotUrl` on line 27 to avoid duplicating the bucket URL template; removes a no-op `try/catch` in `downloadToTemp` (follow-up to [#269900](https://github.com/elastic/kibana/pull/269900#discussion_r3267737033)).

## Test plan

- [ ] All existing tests in `kbn-check-saved-objects-cli` continue to pass (`node scripts/jest packages/kbn-check-saved-objects-cli/src`)
- [ ] New and updated notifier tests pass (`jest scripts/steps/checks/notify_saved_objects_changes.test.ts` from `.buildkite/`)
- [ ] Verify the PR comment renders correctly on a branch that modifies an SO type


Made with [Cursor](https://cursor.com)