### PR TITLE
[EARS] Make EARS feature-flag gate functionality per-provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2531,6 +2531,10 @@ x-pack/platform/plugins/shared/actions/server/lib/ears @elastic/workchat-eng
 x-pack/platform/plugins/shared/actions/server/lib/axios_auth_strategies/ears_strategy.ts @elastic/workchat-eng @elastic/response-ops
 x-pack/platform/plugins/shared/actions/server/lib/axios_auth_strategies/ears_strategy.test.ts @elastic/workchat-eng @elastic/response-ops
 src/platform/packages/shared/kbn-connector-specs/src/auth_types/ears.ts @elastic/workchat-eng
+src/platform/packages/shared/kbn-connector-specs/src/lib/ears_experimental_utils.ts @elastic/workchat-eng
+src/platform/packages/shared/kbn-connector-specs/src/lib/ears_experimental_utils.test.ts @elastic/workchat-eng
+src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.ts @elastic/workchat-eng @elastic/response-ops
+src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.test.ts @elastic/workchat-eng @elastic/response-ops
 
 
 # Connector Specs

--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -34,7 +34,7 @@ export {
   ESTIMATED_JSON_OUTPUT_OVERHEAD_BYTES,
 } from './src/connector_utils';
 export { normalizeAuthorizationHeaderValue } from './src/auth_types/oauth_authz_code_and_ears_helpers';
-export { isEarsExperimentalConnector } from './src/lib/is_ears_experimental_connector';
+export { isEarsExperimentalConnector } from './src/lib/ears_experimental_utils';
 
 export { ConnectorAuthorizationError, isConnectorAuthorizationError } from './src/errors';
 export type { ConnectorAuthorizationReason } from './src/errors';

--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -34,6 +34,7 @@ export {
   ESTIMATED_JSON_OUTPUT_OVERHEAD_BYTES,
 } from './src/connector_utils';
 export { normalizeAuthorizationHeaderValue } from './src/auth_types/oauth_authz_code_and_ears_helpers';
+export { isEarsExperimentalConnector } from './src/lib/is_ears_experimental_connector';
 
 export { ConnectorAuthorizationError, isConnectorAuthorizationError } from './src/errors';
 export type { ConnectorAuthorizationReason } from './src/errors';

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -267,6 +267,7 @@ export interface ConnectorTest {
 
 export interface AuthTypeDef {
   type: string;
+  experimental?: boolean;
   defaults: Record<string, unknown>;
   overrides?: {
     meta?: Record<string, Record<string, unknown>>;

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -267,7 +267,7 @@ export interface ConnectorTest {
 
 export interface AuthTypeDef {
   type: string;
-  experimental?: boolean;
+  isExperimental?: boolean;
   defaults: Record<string, unknown>;
   overrides?: {
     meta?: Record<string, Record<string, unknown>>;

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/ears_experimental_utils.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/ears_experimental_utils.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isEarsExperimentalConnector } from './is_ears_experimental_connector';
+import { isEarsExperimentalConnector } from './ears_experimental_utils';
 
 describe('isEarsExperimentalConnector', () => {
   test('returns true for connector types whose EARS auth is marked experimental', () => {

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/ears_experimental_utils.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/ears_experimental_utils.ts
@@ -12,16 +12,14 @@ import * as allSpecs from '../all_specs';
 import { EARS_AUTH_ID } from '../auth_types/ears';
 import type { AuthTypeDef } from '../connector_spec';
 
+export const isEarsExperimentalAuthType = (authType: string | AuthTypeDef): authType is AuthTypeDef =>
+  !isString(authType) &&
+  authType.type === EARS_AUTH_ID &&
+  authType.isExperimental === true;
+
 const experimentalEarsConnectorIds = new Set(
   Object.values(allSpecs)
-    .filter((spec) =>
-      spec.auth?.types.some(
-        (authType) =>
-          !isString(authType) &&
-          (authType as AuthTypeDef).type === EARS_AUTH_ID &&
-          (authType as AuthTypeDef).experimental === true
-      )
-    )
+    .filter((spec) => spec.auth?.types.some(isEarsExperimentalAuthType))
     .map((spec) => spec.metadata.id)
 );
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/ears_experimental_utils.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/ears_experimental_utils.ts
@@ -12,10 +12,10 @@ import * as allSpecs from '../all_specs';
 import { EARS_AUTH_ID } from '../auth_types/ears';
 import type { AuthTypeDef } from '../connector_spec';
 
-export const isEarsExperimentalAuthType = (authType: string | AuthTypeDef): authType is AuthTypeDef =>
-  !isString(authType) &&
-  authType.type === EARS_AUTH_ID &&
-  authType.isExperimental === true;
+export const isEarsExperimentalAuthType = (
+  authType: string | AuthTypeDef
+): authType is AuthTypeDef =>
+  !isString(authType) && authType.type === EARS_AUTH_ID && authType.isExperimental === true;
 
 const experimentalEarsConnectorIds = new Set(
   Object.values(allSpecs)

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.test.ts
@@ -126,6 +126,97 @@ describe('generateSecretsSchemaFromSpec', () => {
     expect(authTypes).toContain('oauth_authorization_code');
   });
 
+  describe('experimental EARS filtering', () => {
+    const authSpecWithExperimentalEars = {
+      types: [
+        'bearer',
+        {
+          type: 'ears',
+          experimental: true,
+          defaults: { provider: 'google', scope: 'https://www.googleapis.com/auth/calendar' },
+        },
+      ],
+    };
+
+    const authSpecWithStableEars = {
+      types: [
+        'bearer',
+        {
+          type: 'ears',
+          defaults: { provider: 'slack', scope: 'channels:read' },
+        },
+      ],
+    };
+
+    test('excludes experimental EARS when isEarsEnabled but isEarsExperimentalEnabled is false', () => {
+      const schema = generateSecretsSchemaFromSpec(authSpecWithExperimentalEars, {
+        isEarsEnabled: true,
+        isEarsExperimentalEnabled: false,
+      });
+      const jsonSchema = z.toJSONSchema(schema) as {
+        oneOf?: Array<{ properties?: { authType?: { const?: string } } }>;
+      };
+      const oneOfOptions = jsonSchema.oneOf || [];
+      const authTypes = oneOfOptions
+        .map((opt) => opt.properties?.authType?.const)
+        .filter(Boolean) as string[];
+
+      expect(authTypes).toContain('bearer');
+      expect(authTypes).not.toContain('ears');
+    });
+
+    test('includes experimental EARS when both isEarsEnabled and isEarsExperimentalEnabled are true', () => {
+      const schema = generateSecretsSchemaFromSpec(authSpecWithExperimentalEars, {
+        isEarsEnabled: true,
+        isEarsExperimentalEnabled: true,
+      });
+      const jsonSchema = z.toJSONSchema(schema) as {
+        oneOf?: Array<{ properties?: { authType?: { const?: string } } }>;
+      };
+      const oneOfOptions = jsonSchema.oneOf || [];
+      const authTypes = oneOfOptions
+        .map((opt) => opt.properties?.authType?.const)
+        .filter(Boolean) as string[];
+
+      expect(authTypes).toContain('bearer');
+      expect(authTypes).toContain('ears');
+    });
+
+    test('includes stable EARS when isEarsEnabled is true regardless of isEarsExperimentalEnabled', () => {
+      const schema = generateSecretsSchemaFromSpec(authSpecWithStableEars, {
+        isEarsEnabled: true,
+        isEarsExperimentalEnabled: false,
+      });
+      const jsonSchema = z.toJSONSchema(schema) as {
+        oneOf?: Array<{ properties?: { authType?: { const?: string } } }>;
+      };
+      const oneOfOptions = jsonSchema.oneOf || [];
+      const authTypes = oneOfOptions
+        .map((opt) => opt.properties?.authType?.const)
+        .filter(Boolean) as string[];
+
+      expect(authTypes).toContain('bearer');
+      expect(authTypes).toContain('ears');
+    });
+
+    test('excludes all EARS when isEarsEnabled is false even if isEarsExperimentalEnabled is true', () => {
+      const schema = generateSecretsSchemaFromSpec(authSpecWithExperimentalEars, {
+        isEarsEnabled: false,
+        isEarsExperimentalEnabled: true,
+      });
+      const jsonSchema = z.toJSONSchema(schema) as {
+        oneOf?: Array<{ properties?: { authType?: { const?: string } } }>;
+      };
+      const oneOfOptions = jsonSchema.oneOf || [];
+      const authTypes = oneOfOptions
+        .map((opt) => opt.properties?.authType?.const)
+        .filter(Boolean) as string[];
+
+      expect(authTypes).toContain('bearer');
+      expect(authTypes).not.toContain('ears');
+    });
+  });
+
   describe('runtime parse behavior', () => {
     test('parses valid secrets for none auth type', () => {
       const schema = generateSecretsSchemaFromSpec({ types: ['none'] });

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.test.ts
@@ -132,7 +132,7 @@ describe('generateSecretsSchemaFromSpec', () => {
         'bearer',
         {
           type: 'ears',
-          experimental: true,
+          isExperimental: true,
           defaults: { provider: 'google', scope: 'https://www.googleapis.com/auth/calendar' },
         },
       ],

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.ts
@@ -8,10 +8,10 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { isString } from 'lodash';
-import type { AuthMode, AuthTypeDef, ConnectorSpec } from '../connector_spec';
+import type { AuthMode, ConnectorSpec } from '../connector_spec';
 import * as authTypeSpecs from '../all_auth_types';
 import { getSchemaForAuthType } from '.';
+import { isEarsExperimentalAuthType } from './ears_experimental_utils';
 
 interface GenerateOptions {
   isPfxEnabled?: boolean;
@@ -38,8 +38,7 @@ export const generateSecretsSchemaFromSpec = (
       if (!isEarsEnabled) {
         continue;
       }
-      const isExperimental = !isString(authType) && (authType as AuthTypeDef).experimental === true;
-      if (isExperimental && !isEarsExperimentalEnabled) {
+      if (isEarsExperimentalAuthType(authType) && !isEarsExperimentalEnabled) {
         continue;
       }
     }

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/generate_secrets_schema_from_spec.ts
@@ -8,21 +8,24 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import type { AuthMode, ConnectorSpec } from '../connector_spec';
+import { isString } from 'lodash';
+import type { AuthMode, AuthTypeDef, ConnectorSpec } from '../connector_spec';
 import * as authTypeSpecs from '../all_auth_types';
 import { getSchemaForAuthType } from '.';
 
 interface GenerateOptions {
   isPfxEnabled?: boolean;
   isEarsEnabled?: boolean;
+  isEarsExperimentalEnabled?: boolean;
   authMode?: AuthMode | '';
 }
 
 export const generateSecretsSchemaFromSpec = (
   authSpec: ConnectorSpec['auth'],
-  { isPfxEnabled, isEarsEnabled, authMode }: GenerateOptions = {
+  { isPfxEnabled, isEarsEnabled, isEarsExperimentalEnabled, authMode }: GenerateOptions = {
     isPfxEnabled: true,
     isEarsEnabled: false,
+    isEarsExperimentalEnabled: false,
   }
 ) => {
   const secretSchemas: z.core.$ZodTypeDiscriminable[] = [];
@@ -31,8 +34,14 @@ export const generateSecretsSchemaFromSpec = (
     if (schema.id === 'pfx_certificate' && !isPfxEnabled) {
       continue;
     }
-    if (schema.id === 'ears' && !isEarsEnabled) {
-      continue;
+    if (schema.id === 'ears') {
+      if (!isEarsEnabled) {
+        continue;
+      }
+      const isExperimental = !isString(authType) && (authType as AuthTypeDef).experimental === true;
+      if (isExperimental && !isEarsExperimentalEnabled) {
+        continue;
+      }
     }
 
     const authTypeSpec = Object.values(authTypeSpecs).find((spec) => spec.id === schema.id);

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/is_ears_experimental_connector.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/is_ears_experimental_connector.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isEarsExperimentalConnector } from './is_ears_experimental_connector';
+
+describe('isEarsExperimentalConnector', () => {
+  test('returns true for connector types whose EARS auth is marked experimental', () => {
+    // Google connectors have experimental: true on their EARS auth type
+    expect(isEarsExperimentalConnector('.google_calendar')).toBe(true);
+    expect(isEarsExperimentalConnector('.gmail')).toBe(true);
+    expect(isEarsExperimentalConnector('.google_drive')).toBe(true);
+  });
+
+  test('returns false for connector types whose EARS auth is stable', () => {
+    // Microsoft and Slack connectors have EARS without experimental flag
+    expect(isEarsExperimentalConnector('.microsoft_teams')).toBe(false);
+    expect(isEarsExperimentalConnector('.slack')).toBe(false);
+    expect(isEarsExperimentalConnector('.sharepoint_online')).toBe(false);
+  });
+
+  test('returns false for connector types with no EARS auth', () => {
+    expect(isEarsExperimentalConnector('.alienvault-otx')).toBe(false);
+  });
+
+  test('returns false for unknown connector types', () => {
+    expect(isEarsExperimentalConnector('.nonexistent')).toBe(false);
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/is_ears_experimental_connector.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/is_ears_experimental_connector.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isString } from 'lodash';
+import * as allSpecs from '../all_specs';
+import { EARS_AUTH_ID } from '../auth_types/ears';
+import type { AuthTypeDef } from '../connector_spec';
+
+const experimentalEarsConnectorIds = new Set(
+  Object.values(allSpecs)
+    .filter((spec) =>
+      spec.auth?.types.some(
+        (authType) =>
+          !isString(authType) &&
+          (authType as AuthTypeDef).type === EARS_AUTH_ID &&
+          (authType as AuthTypeDef).experimental === true
+      )
+    )
+    .map((spec) => spec.metadata.id)
+);
+
+export const isEarsExperimentalConnector = (connectorTypeId: string): boolean =>
+  experimentalEarsConnectorIds.has(connectorTypeId);

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/serialize_connector_spec.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/serialize_connector_spec.test.ts
@@ -267,11 +267,16 @@ describe('serializeConnectorSpec', () => {
 
       const spy = jest.spyOn(generateSecretsModule, 'generateSecretsSchemaFromSpec');
 
-      serializeConnectorSpec(spec, { isPfxEnabled: false, isEarsEnabled: false });
+      serializeConnectorSpec(spec, {
+        isPfxEnabled: false,
+        isEarsEnabled: false,
+        isEarsExperimentalEnabled: false,
+      });
 
       expect(spy).toHaveBeenCalledWith(spec.auth, {
         isPfxEnabled: false,
         isEarsEnabled: false,
+        isEarsExperimentalEnabled: false,
       });
 
       spy.mockRestore();
@@ -298,7 +303,11 @@ describe('serializeConnectorSpec', () => {
       };
 
       const defaultEars = serializeConnectorSpec(spec);
-      const earsOn = serializeConnectorSpec(spec, { isPfxEnabled: true, isEarsEnabled: true });
+      const earsOn = serializeConnectorSpec(spec, {
+        isPfxEnabled: true,
+        isEarsEnabled: true,
+        isEarsExperimentalEnabled: false,
+      });
       interface SecretBranch {
         properties?: { authType?: { const?: string } };
       }
@@ -390,6 +399,55 @@ describe('serializeConnectorSpec', () => {
         const spec = connectorsSpecs[specName as keyof typeof connectorsSpecs];
         expect(() => serializeConnectorSpec(spec)).not.toThrow();
       }
+    });
+  });
+
+  describe('experimental EARS filtering', () => {
+    test('excludes experimental EARS auth when isEarsExperimentalEnabled is false', () => {
+      const testSpec = {
+        metadata: {
+          id: '.test-experimental-ears',
+          displayName: 'Test',
+          description: 'Test connector',
+          minimumLicense: 'basic' as const,
+          supportedFeatureIds: ['alerting' as const],
+        },
+        auth: {
+          types: [
+            'bearer',
+            {
+              type: 'ears',
+              experimental: true,
+              defaults: { provider: 'google', scope: 'test-scope' },
+            },
+          ],
+        },
+        actions: {
+          test: {
+            input: z.object({}),
+            handler: async () => ({ success: true }),
+          },
+        },
+      };
+
+      const result = serializeConnectorSpec(testSpec, {
+        isPfxEnabled: true,
+        isEarsEnabled: true,
+        isEarsExperimentalEnabled: false,
+      });
+
+      const schemaJson = result.schema as {
+        properties?: {
+          secrets?: { oneOf?: Array<{ properties?: { authType?: { const?: string } } }> };
+        };
+      };
+      const secretsOneOf = schemaJson.properties?.secrets?.oneOf || [];
+      const authTypes = secretsOneOf
+        .map((opt) => opt.properties?.authType?.const)
+        .filter(Boolean) as string[];
+
+      expect(authTypes).toContain('bearer');
+      expect(authTypes).not.toContain('ears');
     });
   });
 });

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/serialize_connector_spec.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/serialize_connector_spec.test.ts
@@ -417,7 +417,7 @@ describe('serializeConnectorSpec', () => {
             'bearer',
             {
               type: 'ears',
-              experimental: true,
+              isExperimental: true,
               defaults: { provider: 'google', scope: 'test-scope' },
             },
           ],

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/serialize_connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/serialize_connector_spec.ts
@@ -14,6 +14,7 @@ import { generateSecretsSchemaFromSpec } from './generate_secrets_schema_from_sp
 export interface SerializeConnectorSpecOptions {
   isPfxEnabled: boolean;
   isEarsEnabled: boolean;
+  isEarsExperimentalEnabled: boolean;
 }
 
 export function serializeConnectorSpec(

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/gmail/gmail.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/gmail/gmail.ts
@@ -58,6 +58,7 @@ export const GmailConnector: ConnectorSpec = {
       },
       {
         type: 'ears',
+        experimental: true,
         overrides: {
           meta: { scope: { disabled: true } },
         },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/gmail/gmail.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/gmail/gmail.ts
@@ -58,7 +58,7 @@ export const GmailConnector: ConnectorSpec = {
       },
       {
         type: 'ears',
-        experimental: true,
+        isExperimental: true,
         overrides: {
           meta: { scope: { disabled: true } },
         },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/google_calendar.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/google_calendar.ts
@@ -69,7 +69,7 @@ export const GoogleCalendar: ConnectorSpec = {
       },
       {
         type: 'ears',
-        experimental: true,
+        isExperimental: true,
         overrides: {
           meta: { scope: { disabled: true } },
         },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/google_calendar.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/google_calendar.ts
@@ -69,6 +69,7 @@ export const GoogleCalendar: ConnectorSpec = {
       },
       {
         type: 'ears',
+        experimental: true,
         overrides: {
           meta: { scope: { disabled: true } },
         },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/google_drive/google_drive.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/google_drive/google_drive.ts
@@ -93,6 +93,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
       },
       {
         type: 'ears',
+        experimental: true,
         overrides: {
           meta: { scope: { disabled: true } },
         },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/google_drive/google_drive.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/google_drive/google_drive.ts
@@ -93,7 +93,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
       },
       {
         type: 'ears',
-        experimental: true,
+        isExperimental: true,
         overrides: {
           meta: { scope: { disabled: true } },
         },

--- a/x-pack/platform/plugins/shared/actions/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/public/plugin.ts
@@ -17,6 +17,7 @@ export interface ActionsPublicPluginSetup {
   enabledEmailServices: string[];
   isWebhookSslWithPfxEnabled?: boolean;
   isEarsEnabled: boolean;
+  isEarsExperimentalEnabled: boolean;
 }
 
 export interface Config {
@@ -36,6 +37,7 @@ export interface Config {
   auth?: {
     ears?: {
       enabled: boolean;
+      enableExperimental: boolean;
     };
   };
 }
@@ -45,6 +47,7 @@ export class Plugin implements CorePlugin<ActionsPublicPluginSetup> {
   private readonly enabledEmailServices: string[];
   private readonly webhookSslWithPfxEnabled: boolean;
   private readonly earsEnabled: boolean;
+  private readonly earsExperimentalEnabled: boolean;
 
   constructor(ctx: PluginInitializerContext<Config>) {
     const config = ctx.config.get();
@@ -52,6 +55,7 @@ export class Plugin implements CorePlugin<ActionsPublicPluginSetup> {
     this.enabledEmailServices = Array.from(new Set(config.email?.services?.enabled || ['*']));
     this.webhookSslWithPfxEnabled = config.webhook?.ssl.pfx.enabled ?? true;
     this.earsEnabled = config.auth?.ears?.enabled ?? false;
+    this.earsExperimentalEnabled = config.auth?.ears?.enableExperimental ?? false;
   }
 
   public setup(): ActionsPublicPluginSetup {
@@ -61,6 +65,7 @@ export class Plugin implements CorePlugin<ActionsPublicPluginSetup> {
       enabledEmailServices: this.enabledEmailServices,
       isWebhookSslWithPfxEnabled: this.webhookSslWithPfxEnabled,
       isEarsEnabled: this.earsEnabled,
+      isEarsExperimentalEnabled: this.earsExperimentalEnabled,
     };
   }
 

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.mock.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.mock.ts
@@ -49,6 +49,7 @@ const createActionsConfigMock = () => {
     getMaxEmailBodyLength: jest.fn().mockReturnValue(DEFAULT_EMAIL_BODY_LENGTH),
     getEarsUrl: jest.fn().mockReturnValue(undefined),
     isEarsEnabled: jest.fn().mockReturnValue(false),
+    isEarsExperimentalEnabled: jest.fn().mockReturnValue(false),
   };
   return mocked;
 };

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.test.ts
@@ -49,7 +49,7 @@ const defaultActionsConfig: ActionsConfig = {
         callback: { lookbackWindow: '1h', limit: 100 },
       },
     },
-    ears: { enabled: false },
+    ears: { enabled: false, enableExperimental: false },
   },
 };
 
@@ -788,7 +788,7 @@ describe('getEarsUrl()', () => {
       ...defaultActionsConfig,
       auth: {
         ...defaultActionsConfig.auth,
-        ears: { enabled: false, url: 'https://ears.example.com' },
+        ears: { enabled: false, enableExperimental: false, url: 'https://ears.example.com' },
       },
     });
     expect(acu.getEarsUrl()).toBe('https://ears.example.com');
@@ -806,10 +806,28 @@ describe('isEarsEnabled()', () => {
       ...defaultActionsConfig,
       auth: {
         ...defaultActionsConfig.auth,
-        ears: { enabled: true },
+        ears: { enabled: true, enableExperimental: false },
       },
     });
     expect(acu.isEarsEnabled()).toBe(true);
+  });
+});
+
+describe('isEarsExperimentalEnabled()', () => {
+  test('returns false when neither config key is set', () => {
+    const acu = getActionsConfigurationUtilities(defaultActionsConfig);
+    expect(acu.isEarsExperimentalEnabled()).toBe(false);
+  });
+
+  test('returns true when auth.ears.enableExperimental is true', () => {
+    const acu = getActionsConfigurationUtilities({
+      ...defaultActionsConfig,
+      auth: {
+        ...defaultActionsConfig.auth,
+        ears: { enabled: true, enableExperimental: true },
+      },
+    });
+    expect(acu.isEarsExperimentalEnabled()).toBe(true);
   });
 });
 

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.ts
@@ -77,6 +77,7 @@ export interface ActionsConfigurationUtilities {
   getMaxEmailBodyLength: () => number;
   getEarsUrl: () => string | undefined;
   isEarsEnabled: () => boolean;
+  isEarsExperimentalEnabled: () => boolean;
 }
 
 function allowListErrorMessage(field: AllowListingField, value: string) {
@@ -283,5 +284,6 @@ export function getActionsConfigurationUtilities(
     },
     getEarsUrl: () => config.auth.ears?.url,
     isEarsEnabled: () => config.auth.ears?.enabled ?? false,
+    isEarsExperimentalEnabled: () => config.auth.ears?.enableExperimental ?? false,
   };
 }

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_connector_spec/get_connector_spec.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_connector_spec/get_connector_spec.test.ts
@@ -129,6 +129,32 @@ describe('getConnectorSpecAsJsonSchema', () => {
     expect(authTypes).not.toContain('ears');
   });
 
+  it('includes stable (non-experimental) EARS auth types even when isEarsExperimentalEnabled is false', async () => {
+    const earsEnabledUtils = {
+      getWebhookSettings: () => ({ ssl: { pfx: { enabled: true } } }),
+      isEarsEnabled: () => true,
+      isEarsExperimentalEnabled: () => false,
+    } as unknown as ActionsConfigurationUtilities;
+
+    const result = await getConnectorSpecAsJsonSchema({
+      context: createContext(),
+      id: '.microsoft-teams',
+      configurationUtilities: earsEnabledUtils,
+    });
+
+    const schemaJson = result.schema as {
+      properties?: {
+        secrets?: { oneOf?: Array<{ properties?: { authType?: { const?: string } } }> };
+      };
+    };
+    const secretsOneOf = schemaJson.properties?.secrets?.oneOf || [];
+    const authTypes = secretsOneOf
+      .map((opt) => opt.properties?.authType?.const)
+      .filter(Boolean) as string[];
+
+    expect(authTypes).toContain('ears');
+  });
+
   it('includes experimental EARS auth types when isEarsExperimentalEnabled is true', async () => {
     const earsEnabledUtils = {
       getWebhookSettings: () => ({ ssl: { pfx: { enabled: true } } }),

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_connector_spec/get_connector_spec.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_connector_spec/get_connector_spec.test.ts
@@ -17,6 +17,7 @@ const auditLogger = auditLoggerMock.create();
 const configurationUtilities = {
   getWebhookSettings: () => ({ ssl: { pfx: { enabled: true } } }),
   isEarsEnabled: () => false,
+  isEarsExperimentalEnabled: () => false,
 } as unknown as ActionsConfigurationUtilities;
 
 function createContext(): ActionsClientContext {
@@ -100,5 +101,57 @@ describe('getConnectorSpecAsJsonSchema', () => {
         configurationUtilities,
       })
     ).rejects.toMatchObject({ output: { statusCode: 404 } });
+  });
+
+  it('excludes experimental EARS auth types when isEarsExperimentalEnabled is false', async () => {
+    const earsEnabledUtils = {
+      getWebhookSettings: () => ({ ssl: { pfx: { enabled: true } } }),
+      isEarsEnabled: () => true,
+      isEarsExperimentalEnabled: () => false,
+    } as unknown as ActionsConfigurationUtilities;
+
+    const result = await getConnectorSpecAsJsonSchema({
+      context: createContext(),
+      id: '.google_calendar',
+      configurationUtilities: earsEnabledUtils,
+    });
+
+    const schemaJson = result.schema as {
+      properties?: {
+        secrets?: { oneOf?: Array<{ properties?: { authType?: { const?: string } } }> };
+      };
+    };
+    const secretsOneOf = schemaJson.properties?.secrets?.oneOf || [];
+    const authTypes = secretsOneOf
+      .map((opt) => opt.properties?.authType?.const)
+      .filter(Boolean) as string[];
+
+    expect(authTypes).not.toContain('ears');
+  });
+
+  it('includes experimental EARS auth types when isEarsExperimentalEnabled is true', async () => {
+    const earsEnabledUtils = {
+      getWebhookSettings: () => ({ ssl: { pfx: { enabled: true } } }),
+      isEarsEnabled: () => true,
+      isEarsExperimentalEnabled: () => true,
+    } as unknown as ActionsConfigurationUtilities;
+
+    const result = await getConnectorSpecAsJsonSchema({
+      context: createContext(),
+      id: '.google_calendar',
+      configurationUtilities: earsEnabledUtils,
+    });
+
+    const schemaJson = result.schema as {
+      properties?: {
+        secrets?: { oneOf?: Array<{ properties?: { authType?: { const?: string } } }> };
+      };
+    };
+    const secretsOneOf = schemaJson.properties?.secrets?.oneOf || [];
+    const authTypes = secretsOneOf
+      .map((opt) => opt.properties?.authType?.const)
+      .filter(Boolean) as string[];
+
+    expect(authTypes).toContain('ears');
   });
 });

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_connector_spec/get_connector_spec.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_connector_spec/get_connector_spec.ts
@@ -42,7 +42,12 @@ export async function getConnectorSpecAsJsonSchema({
     const webhookSettings = configurationUtilities.getWebhookSettings();
     const isPfxEnabled = webhookSettings.ssl.pfx.enabled;
     const isEarsEnabled = configurationUtilities.isEarsEnabled();
-    const serialized = serializeConnectorSpec(spec, { isPfxEnabled, isEarsEnabled });
+    const isEarsExperimentalEnabled = configurationUtilities.isEarsExperimentalEnabled();
+    const serialized = serializeConnectorSpec(spec, {
+      isPfxEnabled,
+      isEarsEnabled,
+      isEarsExperimentalEnabled,
+    });
     return {
       metadata: serialized.metadata,
       schema: serialized.schema,

--- a/x-pack/platform/plugins/shared/actions/server/config.ts
+++ b/x-pack/platform/plugins/shared/actions/server/config.ts
@@ -219,6 +219,7 @@ export const configSchema = schema.object({
     ears: schema.maybe(
       schema.object({
         enabled: schema.boolean({ defaultValue: false }),
+        enableExperimental: schema.boolean({ defaultValue: false }),
         url: schema.maybe(schema.uri({ scheme: ['https'] })),
       })
     ),

--- a/x-pack/platform/plugins/shared/actions/server/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/index.ts
@@ -60,7 +60,7 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
     // recipient_allowlist is not exposed because it may contain sensitive information
     email: { domain_allowlist: true, recipient_allowlist: false, services: { enabled: true } },
     webhook: { ssl: { pfx: { enabled: true } } },
-    auth: { ears: { enabled: true } },
+    auth: { ears: { enabled: true, enableExperimental: true } },
   },
 };
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_secrets_schema.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_secrets_schema.test.ts
@@ -139,6 +139,61 @@ describe('generateSecretsSchema', () => {
     });
   });
 
+  describe('customValidator - experimental EARS auth gating', () => {
+    const experimentalEarsAuthSpec: ConnectorSpec['auth'] = {
+      types: [
+        'none',
+        {
+          type: 'ears',
+          experimental: true,
+          defaults: { provider: 'google', scope: 'https://www.googleapis.com/auth/calendar' },
+        },
+      ],
+    };
+
+    const stableEarsAuthSpec: ConnectorSpec['auth'] = {
+      types: [
+        'none',
+        {
+          type: 'ears',
+          defaults: { provider: 'slack', scope: 'channels:read' },
+        },
+      ],
+    };
+
+    it('throws when EARS is enabled but experimental is disabled for an experimental provider', () => {
+      mockConfigUtils.isEarsEnabled.mockReturnValue(true);
+      mockConfigUtils.isEarsExperimentalEnabled.mockReturnValue(false);
+      const validator = generateSecretsSchema(experimentalEarsAuthSpec, mockConfigUtils);
+
+      expect(() =>
+        validator.customValidator!({ authType: 'ears', provider: 'google' }, validatorServices)
+      ).toThrow(
+        'EARS OAuth authentication is not enabled for this provider. Enable it via xpack.actions.auth.ears.enableExperimental in kibana.yml.'
+      );
+    });
+
+    it('does not throw when both EARS and experimental are enabled for an experimental provider', () => {
+      mockConfigUtils.isEarsEnabled.mockReturnValue(true);
+      mockConfigUtils.isEarsExperimentalEnabled.mockReturnValue(true);
+      const validator = generateSecretsSchema(experimentalEarsAuthSpec, mockConfigUtils);
+
+      expect(() =>
+        validator.customValidator!({ authType: 'ears', provider: 'google' }, validatorServices)
+      ).not.toThrow();
+    });
+
+    it('does not throw for stable EARS providers when experimental is disabled', () => {
+      mockConfigUtils.isEarsEnabled.mockReturnValue(true);
+      mockConfigUtils.isEarsExperimentalEnabled.mockReturnValue(false);
+      const validator = generateSecretsSchema(stableEarsAuthSpec, mockConfigUtils);
+
+      expect(() =>
+        validator.customValidator!({ authType: 'ears', provider: 'slack' }, validatorServices)
+      ).not.toThrow();
+    });
+  });
+
   describe('customValidator - allowedHosts validation for URL fields', () => {
     const oauthAuthSpec = {
       types: [

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_secrets_schema.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_secrets_schema.test.ts
@@ -145,7 +145,7 @@ describe('generateSecretsSchema', () => {
         'none',
         {
           type: 'ears',
-          experimental: true,
+          isExperimental: true,
           defaults: { provider: 'google', scope: 'https://www.googleapis.com/auth/calendar' },
         },
       ],
@@ -169,7 +169,7 @@ describe('generateSecretsSchema', () => {
       expect(() =>
         validator.customValidator!({ authType: 'ears', provider: 'google' }, validatorServices)
       ).toThrow(
-        'EARS OAuth authentication is not enabled for this provider. Enable it via xpack.actions.auth.ears.enableExperimental in kibana.yml.'
+        'EARS OAuth authentication is not enabled for the "google" provider. Enable it via xpack.actions.auth.ears.enableExperimental in kibana.yml.'
       );
     });
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_secrets_schema.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_secrets_schema.ts
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-import { isString } from 'lodash';
-import type { AuthTypeDef, ConnectorSpec } from '@kbn/connector-specs';
-import { EARS_AUTH_ID } from '@kbn/connector-specs';
+import type { ConnectorSpec } from '@kbn/connector-specs';
 import { generateSecretsSchemaFromSpec } from '@kbn/connector-specs/src/lib/generate_secrets_schema_from_spec';
+import { isEarsExperimentalAuthType } from '@kbn/connector-specs/src/lib/ears_experimental_utils';
 import { getSchemaForAuthType } from '@kbn/connector-specs/src/lib/get_schema_for_auth_type';
 import type { ActionTypeSecrets, ValidatorType, ValidatorServices } from '../../types';
 import type { ActionsConfigurationUtilities } from '../../actions_config';
@@ -43,13 +42,11 @@ export const generateSecretsSchema = (
     isEarsExperimentalEnabled: true,
   });
 
-  const hasExperimentalEars =
-    authSpec?.types.some(
-      (authType) =>
-        !isString(authType) &&
-        (authType as AuthTypeDef).type === EARS_AUTH_ID &&
-        (authType as AuthTypeDef).experimental === true
-    ) ?? false;
+  const experimentalEarsAuthType = authSpec?.types.find(isEarsExperimentalAuthType);
+  const hasExperimentalEarsAuthType = experimentalEarsAuthType !== undefined;
+  const experimentalEarsProvider = hasExperimentalEarsAuthType
+    ? String(experimentalEarsAuthType.defaults?.provider ?? 'unknown')
+    : 'unknown';
 
   const allowedHostsFieldsByAuthType = buildAllowedHostsFieldsByAuthType(authSpec);
 
@@ -71,11 +68,11 @@ export const generateSecretsSchema = (
 
       if (
         authType === 'ears' &&
-        hasExperimentalEars &&
+        hasExperimentalEarsAuthType &&
         !configurationUtilities.isEarsExperimentalEnabled()
       ) {
         throw new Error(
-          'EARS OAuth authentication is not enabled for this provider. Enable it via xpack.actions.auth.ears.enableExperimental in kibana.yml.'
+          `EARS OAuth authentication is not enabled for the "${experimentalEarsProvider}" provider. Enable it via xpack.actions.auth.ears.enableExperimental in kibana.yml.`
         );
       }
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_secrets_schema.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_secrets_schema.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import type { ConnectorSpec } from '@kbn/connector-specs';
+import { isString } from 'lodash';
+import type { AuthTypeDef, ConnectorSpec } from '@kbn/connector-specs';
+import { EARS_AUTH_ID } from '@kbn/connector-specs';
 import { generateSecretsSchemaFromSpec } from '@kbn/connector-specs/src/lib/generate_secrets_schema_from_spec';
 import { getSchemaForAuthType } from '@kbn/connector-specs/src/lib/get_schema_for_auth_type';
 import type { ActionTypeSecrets, ValidatorType, ValidatorServices } from '../../types';
@@ -32,10 +34,22 @@ export const generateSecretsSchema = (
 ): ValidatorType<ActionTypeSecrets> => {
   const settings = configUtils.getWebhookSettings();
   const isPfxEnabled = settings.ssl.pfx.enabled;
-  // Always include EARS in the static schema regardless of the feature flag.
+  // Always include EARS in the static schema regardless of feature flags.
   // This lets the customValidator (below) return a readable error message when EARS is
   // disabled, instead of a cryptic Zod union discriminator error.
-  const schema = generateSecretsSchemaFromSpec(authSpec, { isPfxEnabled, isEarsEnabled: true });
+  const schema = generateSecretsSchemaFromSpec(authSpec, {
+    isPfxEnabled,
+    isEarsEnabled: true,
+    isEarsExperimentalEnabled: true,
+  });
+
+  const hasExperimentalEars =
+    authSpec?.types.some(
+      (authType) =>
+        !isString(authType) &&
+        (authType as AuthTypeDef).type === EARS_AUTH_ID &&
+        (authType as AuthTypeDef).experimental === true
+    ) ?? false;
 
   const allowedHostsFieldsByAuthType = buildAllowedHostsFieldsByAuthType(authSpec);
 
@@ -52,6 +66,16 @@ export const generateSecretsSchema = (
       if (authType === 'ears' && !configurationUtilities.isEarsEnabled()) {
         throw new Error(
           'EARS OAuth authentication is not enabled. Enable it via xpack.actions.auth.ears.enabled in kibana.yml.'
+        );
+      }
+
+      if (
+        authType === 'ears' &&
+        hasExperimentalEars &&
+        !configurationUtilities.isEarsExperimentalEnabled()
+      ) {
+        throw new Error(
+          'EARS OAuth authentication is not enabled for this provider. Enable it via xpack.actions.auth.ears.enableExperimental in kibana.yml.'
         );
       }
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table.tsx
@@ -9,6 +9,7 @@ import type { CriteriaWithPagination } from '@elastic/eui';
 import { EuiInMemoryTable, EuiSkeletonText, EuiText, useEuiTheme } from '@elastic/eui';
 import React, { memo, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
+import { isEarsExperimentalConnector } from '@kbn/connector-specs';
 import type { ConnectorItem } from '../../../../../common/http_api/tools';
 import { useListConnectors } from '../../../hooks/tools/use_mcp_connectors';
 import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
@@ -31,10 +32,15 @@ export const AgentBuilderConnectorsTable = memo(() => {
   }, [tableConnectors]);
 
   const { euiTheme } = useEuiTheme();
-  const { isEarsEnabled } = useAgentBuilderServices();
+  const { isEarsEnabled, isEarsExperimentalEnabled } = useAgentBuilderServices();
 
-  const isDisabledEarsConnector = (connector: ConnectorItem): boolean =>
-    !isEarsEnabled && connector.config?.authType === 'ears';
+  const isDisabledEarsConnector = (connector: ConnectorItem): boolean => {
+    if (connector.config?.authType !== 'ears') return false;
+    if (!isEarsEnabled) return true;
+    if (isEarsExperimentalConnector(connector.actionTypeId) && !isEarsExperimentalEnabled)
+      return true;
+    return false;
+  };
 
   const disabledRowCss = css({ backgroundColor: euiTheme.colors.lightestShade });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table_columns.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table_columns.tsx
@@ -20,6 +20,7 @@ import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import { getEbtProps } from '@kbn/ebt-click';
 import { useConnectorOAuthConnect, OAuthRedirectMode } from '@kbn/response-ops-oauth-hooks';
 import React, { useMemo } from 'react';
+import { isEarsExperimentalConnector } from '@kbn/connector-specs';
 import type { ConnectorItem } from '../../../../../common/http_api/tools';
 import { OAUTH_STATUS } from '../../../../../common/http_api/tools';
 import { useConnectorsActions } from '../../../context/connectors_provider';
@@ -92,11 +93,13 @@ export const useConnectorsTableColumns = (): Array<EuiBasicTableColumn<Connector
   const canDelete = application.capabilities.actions?.delete === true;
   const { actionTypeRegistry } = triggersActionsUi;
 
-  const { isEarsEnabled } = useAgentBuilderServices();
+  const { isEarsEnabled, isEarsExperimentalEnabled } = useAgentBuilderServices();
 
   return useMemo(() => {
     const isDisabledEarsConnector = (connector: ConnectorItem): boolean =>
-      !isEarsEnabled && connector.config?.authType === 'ears';
+      connector.config?.authType === 'ears' &&
+      (!isEarsEnabled ||
+        (isEarsExperimentalConnector(connector.actionTypeId) && !isEarsExperimentalEnabled));
 
     return [
       {
@@ -199,5 +202,5 @@ export const useConnectorsTableColumns = (): Array<EuiBasicTableColumn<Connector
         ),
       },
     ];
-  }, [editConnector, actionTypeRegistry, canDelete, isEarsEnabled]);
+  }, [editConnector, actionTypeRegistry, canDelete, isEarsEnabled, isEarsExperimentalEnabled]);
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table_context_menu.tsx
@@ -11,6 +11,7 @@ import {
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiPopover,
+  EuiToolTip,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useConnectorOAuthDisconnect } from '@kbn/response-ops-oauth-hooks';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table_context_menu.tsx
@@ -121,11 +121,16 @@ export const ConnectorContextMenu = ({ connector }: ConnectorContextMenuProps) =
         aria-label={labels.connectors.connectorContextMenuButtonLabel}
         panelPaddingSize="s"
         button={
-          <EuiButtonIcon
-            iconType="boxesVertical"
-            onClick={() => setIsOpen((openState) => !openState)}
-            aria-label={labels.connectors.connectorContextMenuButtonLabel}
-          />
+          <EuiToolTip
+            content={labels.connectors.connectorContextMenuButtonLabel}
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              iconType="boxesVertical"
+              onClick={() => setIsOpen((openState) => !openState)}
+              aria-label={labels.connectors.connectorContextMenuButtonLabel}
+            />
+          </EuiToolTip>
         }
         isOpen={isOpen}
         closePopover={closeMenu}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/table/connectors_table_context_menu.tsx
@@ -15,6 +15,7 @@ import {
 } from '@elastic/eui';
 import { useConnectorOAuthDisconnect } from '@kbn/response-ops-oauth-hooks';
 import React, { useCallback, useState } from 'react';
+import { isEarsExperimentalConnector } from '@kbn/connector-specs';
 import { AGENT_BUILDER_EVENT_TYPES, AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import type { ConnectorItem } from '../../../../../common/http_api/tools';
 import { OAUTH_STATUS } from '../../../../../common/http_api/tools';
@@ -105,8 +106,11 @@ export const ConnectorContextMenu = ({ connector }: ConnectorContextMenuProps) =
     services: { application },
   } = useKibana();
   const canDelete = application.capabilities.actions?.delete === true;
-  const { isEarsEnabled } = useAgentBuilderServices();
-  const isEarsDisabled = !isEarsEnabled && connector.config?.authType === 'ears';
+  const { isEarsEnabled, isEarsExperimentalEnabled } = useAgentBuilderServices();
+  const isEarsDisabled =
+    connector.config?.authType === 'ears' &&
+    (!isEarsEnabled ||
+      (isEarsExperimentalConnector(connector.actionTypeId) && !isEarsExperimentalEnabled));
   const isAuthorized = connector.oauthStatus === OAUTH_STATUS.AUTHORIZED;
   const closeMenu = () => setIsOpen(false);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -93,6 +93,7 @@ export class AgentBuilderPlugin
   } | null = null;
   private appUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
   private isEarsEnabled = false;
+  private isEarsExperimentalEnabled = false;
   private experimentalDeepLinksSubscription?: Subscription;
 
   constructor(context: PluginInitializerContext<ConfigSchema>) {
@@ -109,6 +110,7 @@ export class AgentBuilderPlugin
 
     this.setupServices = { navigationService, usageCollection: deps.usageCollection };
     this.isEarsEnabled = deps.actions.isEarsEnabled;
+    this.isEarsExperimentalEnabled = deps.actions.isEarsExperimentalEnabled;
 
     registerApp({
       core,
@@ -234,6 +236,7 @@ export class AgentBuilderPlugin
       accessChecker,
       eventsService,
       isEarsEnabled: this.isEarsEnabled,
+      isEarsExperimentalEnabled: this.isEarsExperimentalEnabled,
       openSidebarConversation: (options?: OpenSidebarInternalOptions) => {
         return openSidebarInternal(options);
       },

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
@@ -39,5 +39,6 @@ export interface AgentBuilderInternalService {
   accessChecker: AgentBuilderAccessChecker;
   eventsService: EventsService;
   isEarsEnabled: boolean;
+  isEarsExperimentalEnabled: boolean;
   openSidebarConversation: (options?: OpenSidebarInternalOptions) => OpenConversationSidebarReturn;
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/generate_schema.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/generate_schema.ts
@@ -14,11 +14,22 @@ export const generateSchema = (
   {
     isPfxEnabled,
     isEarsEnabled,
+    isEarsExperimentalEnabled,
     authMode,
-  }: { isPfxEnabled?: boolean; isEarsEnabled?: boolean; authMode?: AuthMode } = {}
+  }: {
+    isPfxEnabled?: boolean;
+    isEarsEnabled?: boolean;
+    isEarsExperimentalEnabled?: boolean;
+    authMode?: AuthMode;
+  } = {}
 ) => {
   return z.object({
     config: spec.schema ?? z.object({}),
-    secrets: generateSecretsSchemaFromSpec(spec.auth, { isPfxEnabled, isEarsEnabled, authMode }),
+    secrets: generateSecretsSchemaFromSpec(spec.auth, {
+      isPfxEnabled,
+      isEarsEnabled,
+      isEarsExperimentalEnabled,
+      authMode,
+    }),
   });
 };

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/register_from_spec.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/register_from_spec.test.ts
@@ -98,6 +98,7 @@ describe('registerConnectorTypesFromSpecs', () => {
         connectorTypeRegistry as unknown as TriggersAndActionsUIPublicPluginSetup['actionTypeRegistry'],
       uiSettingsPromise,
       isEarsEnabled: false,
+      isEarsExperimentalEnabled: false,
     });
 
     // Wait for the async import to complete
@@ -140,6 +141,7 @@ describe('registerConnectorTypesFromSpecs', () => {
         connectorTypeRegistry as unknown as TriggersAndActionsUIPublicPluginSetup['actionTypeRegistry'],
       uiSettingsPromise,
       isEarsEnabled: false,
+      isEarsExperimentalEnabled: false,
     });
 
     // Wait for the async import and uiSettings promise to complete
@@ -176,6 +178,7 @@ describe('registerConnectorTypesFromSpecs', () => {
         connectorTypeRegistry as unknown as TriggersAndActionsUIPublicPluginSetup['actionTypeRegistry'],
       uiSettingsPromise,
       isEarsEnabled: false,
+      isEarsExperimentalEnabled: false,
     });
 
     // Wait for the async import and uiSettings promise to complete
@@ -211,6 +214,7 @@ describe('registerConnectorTypesFromSpecs', () => {
         connectorTypeRegistry as unknown as TriggersAndActionsUIPublicPluginSetup['actionTypeRegistry'],
       uiSettingsPromise,
       isEarsEnabled: false,
+      isEarsExperimentalEnabled: false,
     });
 
     // Wait for the async import to complete
@@ -242,6 +246,7 @@ describe('registerConnectorTypesFromSpecs', () => {
         connectorTypeRegistry as unknown as TriggersAndActionsUIPublicPluginSetup['actionTypeRegistry'],
       uiSettingsPromise,
       isEarsEnabled: false,
+      isEarsExperimentalEnabled: false,
     });
 
     // Wait for the async import to complete
@@ -260,6 +265,7 @@ describe('registerConnectorTypesFromSpecs', () => {
         connectorTypeRegistry as unknown as TriggersAndActionsUIPublicPluginSetup['actionTypeRegistry'],
       uiSettingsPromise,
       isEarsEnabled: false,
+      isEarsExperimentalEnabled: false,
     });
 
     // Wait for the async import to complete
@@ -277,6 +283,7 @@ describe('registerConnectorTypesFromSpecs', () => {
           connectorTypeRegistry as unknown as TriggersAndActionsUIPublicPluginSetup['actionTypeRegistry'],
         uiSettingsPromise,
         isEarsEnabled: false,
+        isEarsExperimentalEnabled: false,
       });
 
       await new Promise((resolve) => setTimeout(resolve, 0));

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/register_from_spec.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/register_from_spec.ts
@@ -22,10 +22,12 @@ export function registerConnectorTypesFromSpecs({
   connectorTypeRegistry,
   uiSettingsPromise,
   isEarsEnabled,
+  isEarsExperimentalEnabled,
 }: {
   connectorTypeRegistry: TriggersAndActionsUIPublicPluginSetup['actionTypeRegistry'];
   uiSettingsPromise: Promise<IUiSettingsClient>;
   isEarsEnabled: boolean;
+  isEarsExperimentalEnabled: boolean;
 }) {
   // TODO: Clean this up when workflows:ui:enabled setting is removed.
   // This is a workaround to avoid making the whole thing async.
@@ -54,7 +56,14 @@ export function registerConnectorTypesFromSpecs({
   ]).then(([{ connectorsSpecs }, { generateFormFields }, { generateSchema }]) => {
     for (const spec of Object.values(connectorsSpecs)) {
       connectorTypeRegistry.register(
-        createConnectorTypeFromSpec(spec, ref, generateFormFields, generateSchema, isEarsEnabled)
+        createConnectorTypeFromSpec(
+          spec,
+          ref,
+          generateFormFields,
+          generateSchema,
+          isEarsEnabled,
+          isEarsExperimentalEnabled
+        )
       );
     }
   });
@@ -64,11 +73,17 @@ const createConnectorFields = (
   spec: ConnectorSpec,
   generateFormFields: typeof import('@kbn/response-ops-form-generator').generateFormFields,
   generateSchema: typeof import('./generate_schema').generateSchema,
-  isEarsEnabled: boolean
+  isEarsEnabled: boolean,
+  isEarsExperimentalEnabled: boolean
 ) => {
   const ConnectorFields = (props: ActionConnectorFieldsProps) => {
     const schema = useMemo(
-      () => generateSchema(spec, { isEarsEnabled, authMode: props.authMode }),
+      () =>
+        generateSchema(spec, {
+          isEarsEnabled,
+          isEarsExperimentalEnabled,
+          authMode: props.authMode,
+        }),
       [props.authMode]
     );
 
@@ -86,9 +101,10 @@ const createConnectorTypeFromSpec = (
   ref: { uiSettings?: IUiSettingsClient },
   generateFormFields: typeof import('@kbn/response-ops-form-generator').generateFormFields,
   generateSchema: typeof import('./generate_schema').generateSchema,
-  isEarsEnabled: boolean
+  isEarsEnabled: boolean,
+  isEarsExperimentalEnabled: boolean
 ): ActionTypeModel => {
-  const schema = generateSchema(spec, { isEarsEnabled });
+  const schema = generateSchema(spec, { isEarsEnabled, isEarsExperimentalEnabled });
 
   return {
     id: spec.metadata.id,
@@ -109,7 +125,13 @@ const createConnectorTypeFromSpec = (
     },
     actionConnectorFields: lazy(() =>
       Promise.resolve({
-        default: createConnectorFields(spec, generateFormFields, generateSchema, isEarsEnabled),
+        default: createConnectorFields(
+          spec,
+          generateFormFields,
+          generateSchema,
+          isEarsEnabled,
+          isEarsExperimentalEnabled
+        ),
       })
     ),
     actionParamsFields: lazy(() => Promise.resolve({ default: () => null })),

--- a/x-pack/platform/plugins/shared/stack_connectors/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/plugin.ts
@@ -50,6 +50,7 @@ export class StackConnectorsPublicPlugin
         connectorTypeRegistry: triggersActionsUi.actionTypeRegistry,
         uiSettingsPromise: core.getStartServices().then(([coreStart]) => coreStart.uiSettings),
         isEarsEnabled: actions.isEarsEnabled,
+        isEarsExperimentalEnabled: actions.isEarsExperimentalEnabled,
       });
     }
   }

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/moon.yml
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/moon.yml
@@ -106,6 +106,7 @@ dependsOn:
   - '@kbn/std'
   - '@kbn/lens-common'
   - '@kbn/inspector-plugin'
+  - '@kbn/connector-specs'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_list.tsx
@@ -32,6 +32,7 @@ import { getConnectorCompatibility } from '@kbn/actions-plugin/common';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { checkActionTypeEnabled } from '@kbn/alerts-ui-shared/src/check_action_type_enabled';
 import { ACTION_TYPE_SOURCES } from '@kbn/actions-types';
+import { isEarsExperimentalConnector } from '@kbn/connector-specs';
 import {
   DEPRECATED_CONNECTOR_TOOLTIP_CONTENT,
   DEPRECATED_LABEL,
@@ -105,7 +106,7 @@ const ActionsConnectorsList = ({
     setBreadcrumbs,
     chrome,
     docLinks,
-    actions: { isEarsEnabled },
+    actions: { isEarsEnabled, isEarsExperimentalEnabled },
   } = useKibana().services;
 
   const { euiTheme } = useEuiTheme();
@@ -115,11 +116,15 @@ const ActionsConnectorsList = ({
   const canDelete = hasDeleteActionsCapability(capabilities);
   const canSave = hasSaveActionsCapability(capabilities);
   const isDisabledEarsConnector = useCallback(
-    (item: ActionConnectorTableItem | ActionConnector) =>
-      !isEarsEnabled &&
-      'config' in item &&
-      (item.config as Record<string, unknown>)?.authType === 'ears',
-    [isEarsEnabled]
+    (item: ActionConnectorTableItem | ActionConnector) => {
+      if (!('config' in item) || (item.config as Record<string, unknown>)?.authType !== 'ears') {
+        return false;
+      }
+      if (!isEarsEnabled) return true;
+      if (isEarsExperimentalConnector(item.actionTypeId) && !isEarsExperimentalEnabled) return true;
+      return false;
+    },
+    [isEarsEnabled, isEarsExperimentalEnabled]
   );
 
   const [actionTypesIndex, setActionTypesIndex] = useState<ActionTypeIndex | undefined>(undefined);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/lib/kibana/kibana_react.mock.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/lib/kibana/kibana_react.mock.ts
@@ -32,6 +32,7 @@ export const createStartServicesMock = (): TriggersAndActionsUiServices => {
       validateEmailAddresses: jest.fn(),
       enabledEmailServices: ['*'],
       isEarsEnabled: false,
+      isEarsExperimentalEnabled: false,
     },
     ruleTypeRegistry: {
       has: jest.fn(),

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
@@ -100,7 +100,8 @@
     "@kbn/security-plugin",
     "@kbn/std",
     "@kbn/lens-common",
-    "@kbn/inspector-plugin"
+    "@kbn/inspector-plugin",
+    "@kbn/connector-specs"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/search-team/issues/14522

Adds per-provider EARS feature flagging via a two-tier system:
- **Stable providers** (Microsoft, Slack): enabled whenever `xpack.actions.auth.ears.enabled: true`
- **Experimental providers** (Google): only enabled when *both* `ears.enabled: true` **and** `ears.enableExperimental: true`

This allows us to ship EARS for verified OAuth providers while keeping unverified ones (Google, pending app verification) available only for internal dogfooding.

### How it works

- Each connector spec's EARS auth type entry can declare `experimental: true` (Google Calendar, Gmail, Google Drive do this)
- A new `xpack.actions.auth.ears.enableExperimental` boolean config controls whether experimental EARS providers are available
- The filtering happens at schema generation time (`generateSecretsSchemaFromSpec`), so both the UI and API are gated
- Existing EARS connectors for experimental providers show as disabled in the connectors table when `enableExperimental` is off

### Promotion flow

When Google's OAuth app verification completes:
1. Remove `experimental: true` from the 3 Google specs (one-line diff each)
2. **No deployment config changes needed** — Google EARS "just works" for everyone

### Config

```yaml
# kibana.yml
xpack.actions.auth.ears:
  enabled: true                # global EARS gate (existing)
  enableExperimental: true     # opt-in for unverified providers (new)
```

### Changes

| Area | What |
|------|------|
| `kbn-connector-specs` | `AuthTypeDef.experimental` flag, filtering in `generateSecretsSchemaFromSpec`, `isEarsExperimentalConnector` helper |
| `actions` plugin | `ears.enableExperimental` config, `isEarsExperimentalEnabled()` utility, exposed to browser |
| `stack_connectors` | Thread `isEarsExperimentalEnabled` through client-side schema generation |
| `agent_builder` | Per-provider disabled check in connectors table |
| `triggers_actions_ui` | Per-provider disabled check in connectors list |
| Google specs | `experimental: true` on EARS auth type (google_calendar, gmail, google_drive) |

## Test plan

- [ ] With `ears.enabled: true` and no `enableExperimental`: Microsoft/Slack connectors show EARS option, Google connectors do not
- [ ] With `ears.enabled: true` and `enableExperimental: true`: all connectors show EARS option
- [ ] With `ears.enabled: false`: no connectors show EARS option regardless of `enableExperimental`
- [ ] Creating a Google EARS connector via API fails when `enableExperimental` is off
- [ ] Previously created Google EARS connectors show as disabled when `enableExperimental` is turned off
- [ ] Unit tests pass: `node scripts/jest src/platform/packages/shared/kbn-connector-specs/`
- [ ] Unit tests pass: `node scripts/jest x-pack/platform/plugins/shared/actions/server/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)