### PR TITLE
[CI] Upload ES cluster logs as artifacts for kibana-elasticsearch-snapshot-verify pipeline

### DIFF
--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -1,5 +1,6 @@
 env:
   IGNORE_SHIP_CI_STATS_ERROR: 'true'
+  UPLOAD_CLUSTER_LOGS: 'true'
 steps:
   - block: 'Verify'
     prompt: "Enter the details for the snapshot you'd like to verify"

--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -49,7 +49,7 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
 
   buildkite-agent artifact upload "$(printf '%s;' "${ARTIFACT_PATTERNS[@]}")"
 
-  if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "kibana-elasticsearch-snapshot-verify" ]]; then
+  if [[ "${UPLOAD_CLUSTER_LOGS:-}" =~ ^(1|true)$ ]]; then
     if compgen -G '.es/*cluster-ftr*/logs' > /dev/null; then
       ARCHIVE=".es/cluster-ftr-logs-${BUILDKITE_JOB_ID}.tar.gz"
       tar -czf "$ARCHIVE" .es/*cluster-ftr*/logs 2>/dev/null || true

--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -50,7 +50,7 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
   buildkite-agent artifact upload "$(printf '%s;' "${ARTIFACT_PATTERNS[@]}")"
 
   if [[ "${UPLOAD_CLUSTER_LOGS:-}" =~ ^(1|true)$ ]]; then
-    if compgen -G '.es/*cluster-ftr*/logs' > /dev/null; then
+    if ls .es/*cluster-ftr*/logs &>/dev/null; then
       ARCHIVE=".es/cluster-ftr-logs-${BUILDKITE_JOB_ID}.tar.gz"
       tar -czf "$ARCHIVE" .es/*cluster-ftr*/logs 2>/dev/null || true
       buildkite-agent artifact upload "$ARCHIVE"

--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -49,6 +49,14 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
 
   buildkite-agent artifact upload "$(printf '%s;' "${ARTIFACT_PATTERNS[@]}")"
 
+  if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "kibana-elasticsearch-snapshot-verify" ]]; then
+    if compgen -G '.es/*cluster-ftr*/logs' > /dev/null; then
+      ARCHIVE=".es/cluster-ftr-logs-${BUILDKITE_JOB_ID}.tar.gz"
+      tar -czf "$ARCHIVE" .es/*cluster-ftr*/logs 2>/dev/null || true
+      buildkite-agent artifact upload "$ARCHIVE"
+    fi
+  fi
+
   if [[ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ]]; then
     if [[ $BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG == 'elasticsearch-serverless-intake' ]]; then
       echo "--- Run Failed Test Reporter (only junit)"


### PR DESCRIPTION
## Summary

The `kibana-elasticsearch-snapshot-verify` pipeline has been failing due to a suspected ES snapshot performance regression. To help the ES team investigate, we need native Elasticsearch cluster logs from failing test runs. Currently these are not captured as artifacts.

This PR uploads the ES cluster log directory (`.es/*cluster-ftr*/logs/`) as a compressed artifact after each test step, including failed runs.

To keep `post_command.sh` pipeline-agnostic, the upload is controlled by an `UPLOAD_CLUSTER_LOGS` env var. This is set to `true` only in `verify.yml`, so no other pipelines are affected.