### PR TITLE
[Discover] Add warning after exceeding tab limit on tabs group restoration

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.test.tsx
@@ -29,6 +29,7 @@ describe('TabbedContent', () => {
     createItem,
     onChanged,
     onEBTEvent,
+    onTabLimitReached,
     disableRenderContent = false,
   }: {
     initialItems: TabbedContentProps['items'];
@@ -38,6 +39,7 @@ describe('TabbedContent', () => {
     createItem?: TabbedContentProps['createItem'];
     onChanged: TabbedContentProps['onChanged'];
     onEBTEvent: TabbedContentProps['onEBTEvent'];
+    onTabLimitReached?: TabbedContentProps['onTabLimitReached'];
     disableRenderContent?: boolean;
   }) => {
     const [{ managedItems, managedSelectedItemId }, setState] = useState<{
@@ -64,6 +66,7 @@ describe('TabbedContent', () => {
           });
         }}
         onEBTEvent={onEBTEvent}
+        onTabLimitReached={onTabLimitReached}
         onClearRecentlyClosed={jest.fn()}
         renderContent={
           !disableRenderContent
@@ -158,6 +161,47 @@ describe('TabbedContent', () => {
     expect(onEBTEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ eventName: 'tabSelectRecentlyClosed' })
     );
+  });
+
+  it('calls onTabLimitReached when restoring a group exceeds the max tab limit', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const initialItems = [
+      { id: 'tab1', label: 'Tab 1' },
+      { id: 'tab2', label: 'Tab 2' },
+    ];
+    const onChanged = jest.fn();
+    const onEBTEvent = jest.fn();
+    const onTabLimitReached = jest.fn();
+    const createItem = jest.fn(() => NEW_TAB);
+
+    const closedAt = Date.now() - 60_000;
+    const recentlyClosedItems = [
+      { id: 'closed1', label: 'Closed Tab 1', closedAt },
+      { id: 'closed2', label: 'Closed Tab 2', closedAt },
+    ];
+
+    render(
+      <TabsWrapper
+        initialItems={initialItems}
+        initialSelectedItemId={initialItems[0].id}
+        recentlyClosedItems={recentlyClosedItems}
+        maxItemsCount={initialItems.length + 1}
+        createItem={createItem}
+        onChanged={onChanged}
+        onEBTEvent={onEBTEvent}
+        onTabLimitReached={onTabLimitReached}
+      />
+    );
+
+    await user.click(screen.getByTestId('unifiedTabs_tabsBarMenuButton'));
+    await user.click(screen.getByText('2 tabs'));
+    await user.click(await screen.findByTestId('unifiedTabs_tabsMenu_restoreAllTabs'));
+
+    await waitFor(() => {
+      expect(onTabLimitReached).toHaveBeenCalledWith(1);
+    });
+
+    expect(onChanged).toHaveBeenCalled();
   });
 
   it('can create a new tab and sends tabCreated EBT event', async () => {

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabbed_content/tabbed_content.tsx
@@ -67,6 +67,8 @@ export interface TabbedContentProps
   getTopTabMenuItems?: (item: TabItem) => TabMenuItem[];
   /** Optional function to provide additional menu items placed at the end of the menu */
   getAdditionalTabMenuItems?: (item: TabItem) => TabMenuItem[];
+  /** Optional callback invoked when tabs are dropped due to the max tab limit */
+  onTabLimitReached?: (droppedCount: number) => void;
 }
 
 export interface TabbedContentState {
@@ -111,6 +113,7 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
   appendRight,
   getTopTabMenuItems,
   getAdditionalTabMenuItems,
+  onTabLimitReached,
 }) => {
   const { euiTheme } = useEuiTheme();
   const tabsBarApi = useRef<TabsBarApi | null>(null);
@@ -229,6 +232,9 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
           ? Math.max(0, maxItemsCount - prevState.items.length)
           : itemsToRestore.length;
 
+        const droppedCount =
+          itemsToRestore.length - Math.min(itemsToRestore.length, remainingCapacity);
+
         const restoredItems = itemsToRestore.slice(0, remainingCapacity).map((item) => {
           const newItem = createItem();
           return { ...omit(item, 'closedAt'), id: newItem.id, restoredFromId: item.id };
@@ -236,6 +242,10 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
 
         if (restoredItems.length === 0) {
           return prevState;
+        }
+
+        if (droppedCount > 0) {
+          onTabLimitReached?.(droppedCount);
         }
 
         const nextSelectedItem = restoredItems.at(0) ?? prevState.selectedItem;
@@ -257,7 +267,7 @@ export const TabbedContent: React.FC<TabbedContentProps> = ({
         };
       });
     },
-    [changeState, createItem, maxItemsCount, onEBTEvent]
+    [changeState, createItem, maxItemsCount, onEBTEvent, onTabLimitReached]
   );
 
   const onClose = useCallback(

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
@@ -10,6 +10,7 @@
 import React, { useCallback } from 'react';
 import { EuiResizeObserver } from '@elastic/eui';
 import { UnifiedTabs, type UnifiedTabsProps } from '@kbn/unified-tabs';
+import { i18n } from '@kbn/i18n';
 import { AppMenuComponent } from '@kbn/core-chrome-app-menu-components';
 import { SingleTabView, type SingleTabViewProps } from '../single_tab_view';
 import {
@@ -75,6 +76,22 @@ export const TabsView = (props: SingleTabViewProps) => {
     [currentTabId, props]
   );
 
+  const onTabLimitReached: UnifiedTabsProps['onTabLimitReached'] = useCallback(
+    (droppedCount: number) => {
+      services.toastNotifications.addWarning({
+        title: i18n.translate('discover.tabs.tabLimitReachedWarningTitle', {
+          defaultMessage: 'Tab limit reached',
+        }),
+        text: i18n.translate('discover.tabs.tabLimitReachedWarningText', {
+          defaultMessage:
+            'The last {droppedCount, plural, one {# tab} other {# tabs}} in the group {droppedCount, plural, one {was} other {were}} not restored because the maximum number of {maxTabs} tabs has been reached.',
+          values: { droppedCount, maxTabs: MAX_TABS_COUNT },
+        }),
+      });
+    },
+    [services.toastNotifications]
+  );
+
   return (
     /**
      * AppMenuComponent handles responsiveness on its own, however, there are some edge cases e.g opening push flyout
@@ -97,6 +114,7 @@ export const TabsView = (props: SingleTabViewProps) => {
             onChanged={onChanged}
             onEBTEvent={onEvent}
             onClearRecentlyClosed={onClearRecentlyClosed}
+            onTabLimitReached={onTabLimitReached}
             getTopTabMenuItems={getTopTabMenuItems}
             getAdditionalTabMenuItems={getAdditionalTabMenuItems}
             appendRight={


### PR DESCRIPTION
## Summary

Closes #257679

This PR adds a warning toast if user exceeds tabs limit while restoring tabs group.

<img width="1278" height="1239" alt="Screenshot 2026-05-21 at 17 04 59" src="https://github.com/user-attachments/assets/d74d2abd-972e-495b-b467-fd8bf38aabdc" />


https://github.com/user-attachments/assets/f64d9f42-155f-48f2-b932-1c9e9b8dfbc8


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->