### PR TITLE
[Fleet] Show policy ID in tooltip instead of inline on agent list

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_policy_summary_line.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_policy_summary_line.test.tsx
@@ -125,4 +125,48 @@ describe('AgentPolicySummaryLine', () => {
     expect(results.container.textContent).not.toContain('Incompatible integrations');
     expect(results.container.textContent).not.toContain('warnings');
   });
+
+  describe('showPolicyId', () => {
+    const renderWithPolicyId = (showPolicyId: boolean) =>
+      testRenderer.render(
+        <AgentPolicySummaryLine
+          policy={{ id: 'policy-id-123', name: 'My Policy', revision: 1 } as AgentPolicy}
+          showPolicyId={showPolicyId}
+        />
+      );
+
+    test('it should not show the policy ID inline by default', () => {
+      const results = renderWithPolicyId(false);
+      expect(results.container.textContent).not.toContain('policy-id-123');
+      expect(results.container.textContent).toContain('My Policy');
+    });
+
+    test('it should show only the policy name inline when showPolicyId is true', () => {
+      const results = renderWithPolicyId(true);
+      expect(results.container.textContent).not.toContain('policy-id-123');
+      expect(results.container.textContent).toContain('My Policy');
+    });
+
+    test('it should render a tooltip with the policy ID when showPolicyId is true', () => {
+      const results = renderWithPolicyId(true);
+      expect(results.getByTitle('My Policy').closest('[data-popover-open]')).toBeDefined();
+      const tooltipAnchor = results.container.querySelector(
+        '[data-test-subj="agentPolicyNameLink"]'
+      );
+      expect(tooltipAnchor).not.toBeNull();
+      // The EuiToolTip wrapper is present (it wraps the link when showPolicyId && name)
+      const tooltipWrapper = tooltipAnchor?.closest('.euiToolTipAnchor');
+      expect(tooltipWrapper).not.toBeNull();
+    });
+
+    test('it should fall back to showing the ID inline when the policy has no name', () => {
+      const results = testRenderer.render(
+        <AgentPolicySummaryLine
+          policy={{ id: 'policy-id-123', revision: 1 } as AgentPolicy}
+          showPolicyId={true}
+        />
+      );
+      expect(results.container.textContent).toContain('policy-id-123');
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_policy_summary_line.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_policy_summary_line.tsx
@@ -32,7 +32,7 @@ export const AgentPolicySummaryLine = memo<{
   agent?: Agent;
   direction?: 'column' | 'row';
   withDescription?: boolean;
-  /** When true (e.g. in agent list/details), show policy id in parentheses: "Policy Name (policy_id)" */
+  /** When true (e.g. in agent list/details), show policy ID in a tooltip on hover instead of inline. */
   showPolicyId?: boolean;
   isVersionSpecific?: boolean;
 }>(
@@ -46,7 +46,7 @@ export const AgentPolicySummaryLine = memo<{
   }) => {
     const { getHref } = useLink();
     const { name, id, is_managed: isManaged, description } = policy;
-    const policyDisplayName = showPolicyId && name ? `${name} (${id})` : name || id;
+    const policyDisplayName = name || id;
 
     const revision = agent ? agent.policy_revision : policy.revision;
     const isOutdated = agent?.policy_revision && policy.revision > agent.policy_revision;
@@ -157,14 +157,26 @@ export const AgentPolicySummaryLine = memo<{
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false} css={MIN_WIDTH}>
-              <EuiLink
-                className="eui-textBreakWord"
-                href={getHref('policy_details', { policyId: id })}
-                title={policyDisplayName}
-                data-test-subj="agentPolicyNameLink"
+              <EuiToolTip
+                content={
+                  showPolicyId && name ? (
+                    <FormattedMessage
+                      id="xpack.fleet.agentPolicySummaryLine.policyIdTooltip"
+                      defaultMessage="ID: {id}"
+                      values={{ id }}
+                    />
+                  ) : undefined
+                }
               >
-                {policyDisplayName}
-              </EuiLink>
+                <EuiLink
+                  className="eui-textBreakWord"
+                  href={getHref('policy_details', { policyId: id })}
+                  title={policyDisplayName}
+                  data-test-subj="agentPolicyNameLink"
+                >
+                  {policyDisplayName}
+                </EuiLink>
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>


### PR DESCRIPTION
## Summary

Closes #269646

Moves the policy ID from an inline `"Policy Name (policy_id)"` format to an `EuiToolTip` that displays `"ID: {id}"` on hover. This keeps the agent list clean while still making the policy ID accessible.

- When `showPolicyId={true}` and the policy has a name, the name is shown inline and the ID appears in a tooltip on hover
- When the policy has no name, the ID is shown inline as a fallback (unchanged behaviour)
- When `showPolicyId={false}` (default), no ID is shown at all (unchanged behaviour)

## Test plan

- [ ] In the agent list, hover over a policy name link — tooltip should show `ID: <policy_id>`
- [ ] Policy name is no longer shown as `"Name (id)"` inline
- [ ] Unit tests: `yarn jest agent_policy_summary_line.test.tsx --no-coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1557" height="541" alt="image" src="https://github.com/user-attachments/assets/9f6255a5-ad82-4175-8050-9c00c28d9fb5" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->