### PR TITLE
[CI] Fix jest unit test performance degradation

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/const.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/const.ts
@@ -46,7 +46,7 @@
  * overridable via env vars. `TOO_LONG` triggers a warning annotation when exceeded.
  */
 export const MAX_MINUTES = {
-  JEST_UNIT_DEFAULT: 35, // env: JEST_UNIT_MAX_MINUTES
+  JEST_UNIT_DEFAULT: 30, // env: JEST_UNIT_MAX_MINUTES
   JEST_INTEGRATION_DEFAULT: 30, // env: JEST_INTEGRATION_MAX_MINUTES
   FUNCTIONAL_DEFAULT: 30, // env: FUNCTIONAL_MAX_MINUTES
   TOO_LONG: 27,

--- a/src/platform/packages/shared/kbn-test/src/jest/run_all.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_all.test.ts
@@ -106,6 +106,8 @@ describe('run_all.ts', () => {
 
     // Reset process.env
     delete process.env.JEST_MAX_PARALLEL;
+    delete process.env.JEST_LOG_BUFFER;
+    delete process.env.TEST_TYPE;
     delete process.env.BUILDKITE;
     delete process.env.BUILDKITE_STEP_ID;
     delete process.env.BUILDKITE_PARALLEL_JOB;

--- a/src/platform/packages/shared/kbn-test/src/jest/run_all.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_all.ts
@@ -8,11 +8,10 @@
  */
 
 import getopts from 'getopts';
-import { promises as fs, createWriteStream, createReadStream } from 'fs';
+import { promises as fs } from 'fs';
 import { relative } from 'path';
 import { spawn } from 'child_process';
 import { createHash } from 'crypto';
-import { pipeline } from 'stream/promises';
 import Table from 'cli-table3';
 import chalk from 'chalk';
 import { ToolingLog } from '@kbn/tooling-log';
@@ -22,6 +21,7 @@ import { tmpdir } from 'os';
 import { getJestConfigs } from './configs/get_jest_configs';
 import { isInBuildkite, markConfigCompleted, isConfigCompleted } from './buildkite_checkpoint';
 import { parseShardAnnotation, annotateConfigWithShard } from './shard_config';
+import { createLogBuffer } from './util/log_buffer';
 
 interface JestConfigResult {
   config: string;
@@ -227,6 +227,7 @@ async function runConfigs(
 
   const slowTestsDir = `${tmpdir()}/kibana-jest-slow-tests`;
   await fs.mkdir(slowTestsDir, { recursive: true });
+  const logBufferKind = getLogBufferKind();
 
   await new Promise<void>((resolveAll) => {
     const wallStart = Date.now();
@@ -280,26 +281,25 @@ async function runConfigs(
           },
           stdio: ['ignore', 'pipe', 'pipe'],
         });
-        // Buffer output to a per-config temp file rather than an in-memory string;
-        // a noisy Jest run can exceed V8's ~512 MiB string limit (RangeError:
-        // Invalid string length) when concatenated. The file is streamed back out
-        // to log on exit and then unlinked.
-        const outputFile = `${slowTestsDir}/output-${configHash}${shardSuffix}-${Date.now()}.log`;
-        const outputStream = createWriteStream(outputFile);
+        const outputFilePath =
+          logBufferKind === 'file'
+            ? `${slowTestsDir}/output-${configHash}${shardSuffix}-${Date.now()}.log`
+            : '';
+        const logBuffer = createLogBuffer({ kind: logBufferKind, outputFilePath });
         let stdoutEnded = false;
         let stderrEnded = false;
-        let outputClosed = false;
+        let outputFinalized = false;
         const failedTestsCollector = createFailedTestsCollector();
 
         const onChunk = (d: Buffer) => {
-          outputStream.write(d);
+          logBuffer.append(d);
           failedTestsCollector.feed(d);
         };
-        const maybeCloseOutput = () => {
-          if (stdoutEnded && stderrEnded && !outputClosed) {
-            outputClosed = true;
+        const maybeFinalizeOutput = () => {
+          if (stdoutEnded && stderrEnded && !outputFinalized) {
+            outputFinalized = true;
             failedTestsCollector.flush();
-            outputStream.end();
+            void logBuffer.finalize();
           }
         };
 
@@ -307,11 +307,11 @@ async function runConfigs(
         proc.stderr.on('data', onChunk);
         proc.stdout.on('end', () => {
           stdoutEnded = true;
-          maybeCloseOutput();
+          maybeFinalizeOutput();
         });
         proc.stderr.on('end', () => {
           stderrEnded = true;
-          maybeCloseOutput();
+          maybeFinalizeOutput();
         });
 
         // Use 'exit' (not 'close') to avoid hanging if a grandchild process
@@ -330,18 +330,11 @@ async function runConfigs(
             const code = c == null ? 1 : c;
             const durationMs = Date.now() - start;
 
-            // Ensure the write stream is finalized (forces close even if one of
-            // the pipes never emitted 'end' within the drain window).
-            if (!outputClosed) {
-              outputClosed = true;
+            if (!outputFinalized) {
+              outputFinalized = true;
               failedTestsCollector.flush();
-              outputStream.end();
             }
-            await new Promise<void>((res) => {
-              if ((outputStream as any).closed) return res();
-              outputStream.once('finish', () => res());
-              outputStream.once('error', () => res());
-            });
+            await logBuffer.finalize();
 
             const failedTests = code !== 0 ? failedTestsCollector.failedTests : [];
 
@@ -359,17 +352,8 @@ async function runConfigs(
               log.write(`+++ ❌ ${relConfigPath} (${sec}s) - FAILED\n`);
             }
 
-            try {
-              await pipeline(createReadStream(outputFile), process.stdout, { end: false });
-              process.stdout.write('\n');
-            } catch {
-              // Best-effort flush; if the file is missing or unreadable, fall through.
-            }
-            try {
-              await fs.unlink(outputFile);
-            } catch {
-              // Best-effort cleanup.
-            }
+            await logBuffer.writeToLog();
+            await logBuffer.dispose();
 
             const proceed = () => {
               // Log how many configs are left to complete (after checkpoint is written)
@@ -627,4 +611,16 @@ function writeConfigDiscoverySummary(
     'Empty configs:',
     emptyConfigs.map((c) => c)
   );
+}
+
+/**
+ * Jest integration tests might produce a lot of output, so we use a file buffer by default.
+ * @returns 'file' or 'memory'
+ */
+function getLogBufferKind(): 'file' | 'memory' {
+  const override = process.env.JEST_LOG_BUFFER;
+  if (override === 'file' || override === 'memory') {
+    return override;
+  }
+  return process.env.TEST_TYPE === 'integration' ? 'file' : 'memory';
 }

--- a/src/platform/packages/shared/kbn-test/src/jest/run_all.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_all.ts
@@ -229,6 +229,8 @@ async function runConfigs(
   await fs.mkdir(slowTestsDir, { recursive: true });
   const logBufferKind = getLogBufferKind();
 
+  log.info(`Using ${logBufferKind} log buffer for Jest output`);
+
   await new Promise<void>((resolveAll) => {
     const wallStart = Date.now();
 

--- a/src/platform/packages/shared/kbn-test/src/jest/util/log_buffer.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/util/log_buffer.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const mockStdoutWrite = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+jest.mock('fs', () => {
+  const { EventEmitter: EE } = jest.requireActual('events');
+  const makeWriteStream = () => {
+    const s: any = new EE();
+    s.write = jest.fn().mockReturnValue(true);
+    s.end = jest.fn(() => {
+      s.closed = true;
+      process.nextTick(() => s.emit('finish'));
+    });
+    s.closed = false;
+    return s;
+  };
+  const makeReadStream = () => {
+    const s: any = new EE();
+    process.nextTick(() => s.emit('end'));
+    return s;
+  };
+  return {
+    promises: {
+      unlink: jest.fn().mockResolvedValue(undefined),
+    },
+    createWriteStream: jest.fn(makeWriteStream),
+    createReadStream: jest.fn(makeReadStream),
+  };
+});
+
+jest.mock('stream/promises', () => ({
+  pipeline: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { createWriteStream } from 'fs';
+import { pipeline } from 'stream/promises';
+import { createLogBuffer } from './log_buffer';
+
+describe('log_buffer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStdoutWrite.mockClear();
+    delete process.env.TEST_TYPE;
+    delete process.env.JEST_LOG_BUFFER;
+  });
+
+  afterAll(() => {
+    mockStdoutWrite.mockRestore();
+  });
+
+  describe('memory log buffer', () => {
+    it('writes appended output on writeToLog', async () => {
+      const buffer = createLogBuffer({ kind: 'memory', outputFilePath: '' });
+      buffer.append(Buffer.from('hello\n'));
+      await buffer.finalize();
+      await buffer.writeToLog();
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith('hello\n');
+      expect(createWriteStream).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('file log buffer', () => {
+    it('streams from disk on writeToLog', async () => {
+      const buffer = createLogBuffer({ kind: 'file', outputFilePath: '/tmp/out.log' });
+      buffer.append(Buffer.from('chunk'));
+      await buffer.finalize();
+      await buffer.writeToLog();
+      await buffer.dispose();
+
+      expect(createWriteStream).toHaveBeenCalledWith('/tmp/out.log');
+      expect(pipeline).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/util/log_buffer.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/util/log_buffer.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { promises as fs, createWriteStream, createReadStream } from 'fs';
+import { pipeline } from 'stream/promises';
+
+export type LogBufferKind = 'memory' | 'file';
+
+export interface LogBuffer {
+  readonly kind: LogBufferKind;
+  append(chunk: Buffer): void;
+  finalize(): Promise<void>;
+  writeToLog(): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+const MAX_MEMORY_OUTPUT_BYTES = 100 * 1024 * 1024;
+
+export function createLogBuffer(params: {
+  kind: LogBufferKind;
+  outputFilePath: string;
+}): LogBuffer {
+  if (params.kind === 'file') {
+    return createFileLogBuffer(params.outputFilePath);
+  }
+  return createMemoryLogBuffer();
+}
+
+function createMemoryLogBuffer(): LogBuffer {
+  let buffer = '';
+  let bytes = 0;
+  let truncated = false;
+
+  return {
+    kind: 'memory',
+    append(chunk) {
+      if (truncated) {
+        return;
+      }
+      bytes += chunk.length;
+      if (bytes > MAX_MEMORY_OUTPUT_BYTES) {
+        truncated = true;
+        buffer += '\n… output truncated (memory log buffer limit)\n';
+        return;
+      }
+      buffer += chunk.toString();
+    },
+    async finalize() {},
+    async writeToLog() {
+      process.stdout.write(buffer);
+      process.stdout.write('\n');
+    },
+    async dispose() {},
+  };
+}
+
+function createFileLogBuffer(outputFilePath: string): LogBuffer {
+  const stream = createWriteStream(outputFilePath);
+  let finalized = false;
+
+  return {
+    kind: 'file',
+    append(chunk) {
+      stream.write(chunk);
+    },
+    async finalize() {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+      stream.end();
+      await new Promise<void>((resolve) => {
+        if ((stream as NodeJS.WritableStream & { closed?: boolean }).closed) {
+          return resolve();
+        }
+        stream.once('finish', () => resolve());
+        stream.once('error', () => resolve());
+      });
+    },
+    async writeToLog() {
+      try {
+        await pipeline(createReadStream(outputFilePath), process.stdout, { end: false });
+        process.stdout.write('\n');
+      } catch {
+        // Best-effort flush; if the file is missing or unreadable, fall through.
+      }
+    },
+    async dispose() {
+      try {
+        await fs.unlink(outputFilePath);
+      } catch {
+        // Best-effort cleanup.
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
In #269289 we added a fix to prevent some jest tests from accumulating too long of a string in memory causing an error. This however, added some performance hit to cases where we run lots of small tests, and increased the average jest test runtime, some executors started to time out at 50m.

We really only wanted to fix this on jest integration cases, because that's where this was happening.

Solution: fork based on jest test type, revert to using in memory buffer for jest unit tests to avoid performance dent
