### PR TITLE
[Console] Mark invalid request-line methods as errors

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/console_errors_provider.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/console_errors_provider.ts
@@ -32,13 +32,15 @@ export const setupConsoleErrorsProvider = (workerProxyService: ConsoleWorkerProx
     monaco.editor.setModelMarkers(
       model,
       CONSOLE_LANG_ID,
-      errors.map(({ offset, text }) => {
+      errors.map(({ offset, endOffset, text }) => {
         const { column, lineNumber } = model.getPositionAt(offset);
+        const endPosition =
+          endOffset !== undefined ? model.getPositionAt(endOffset) : { column, lineNumber };
         return {
           startLineNumber: lineNumber,
           startColumn: column,
-          endLineNumber: lineNumber,
-          endColumn: column,
+          endLineNumber: endPosition.lineNumber,
+          endColumn: endPosition.column,
           message: text,
           severity: monaco.MarkerSeverity.Error,
         };

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts
@@ -186,6 +186,99 @@ describe('console parser', () => {
     ]);
   });
 
+  describe('request-line method boundary', () => {
+    // The first token of a request line must have one canonical method
+    // interpretation. A valid method prefix followed by non-whitespace
+    // characters (e.g. `GETT`, `POSTS`, `PUThjjkjoj`) must not be silently
+    // accepted as the matching method with a malformed url tail.
+    const methodBoundaryError = 'Expected one of GET/POST/PUT/DELETE/HEAD/PATCH';
+
+    it('rejects a valid method prefix followed by extra letters (`GETT _search`)', () => {
+      const { errors } = parser('GETT _search')!;
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+    });
+
+    it('rejects a valid method prefix followed by an `S` suffix (`POSTS _search`)', () => {
+      const { errors } = parser('POSTS _search')!;
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+    });
+
+    it('rejects a method with arbitrary trailing characters (`PUThjjkjoj /my-index`)', () => {
+      const { errors } = parser('PUThjjkjoj /my-index')!;
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+    });
+
+    it('recovers and continues parsing the next request after an invalid method line', () => {
+      const input = 'GETT _search\nPOST _bulk';
+      const { requests, errors } = parser(input)!;
+      // First request is invalid: errors are recorded
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+      // Second request is parsed correctly
+      const validRequest = requests.find(
+        (r) => r.endOffset !== undefined && r.endOffset >= 'GETT _search\n'.length
+      );
+      expect(validRequest).toBeDefined();
+    });
+
+    it('marks every consecutive invalid-method-prefix line, not only the first', () => {
+      const input = 'PUThjjkjoj /my-index\nGETT _search\nPOSTS _bulk\nGET _ok';
+      const { requests, errors } = parser(input)!;
+      // Each of the three invalid-prefix lines must produce its own marker
+      // so users see them all, not only the first one.
+      const boundaryErrors = errors.filter((e) => e.text === methodBoundaryError);
+      expect(boundaryErrors.length).toBe(3);
+      // The final valid request must also be captured despite the preceding
+      // boundary errors.
+      const validRequest = requests.find(
+        (r) =>
+          r.startOffset === 'PUThjjkjoj /my-index\nGETT _search\nPOSTS _bulk\n'.length &&
+          r.endOffset !== undefined
+      );
+      expect(validRequest).toBeDefined();
+    });
+
+    // The boundary is "next character separates the method from the URL/body".
+    // These tables lock in which inputs are accepted vs rejected.
+    it.each([
+      ['GET_index', 'underscore'],
+      ['GET2 _x', 'digit'],
+      ['GETSomething', 'letter'],
+      ['HEADX _x', 'letter'],
+      ['DELETEX _x', 'letter'],
+      ['PATCHX _x', 'letter'],
+      ['GET/_search', 'slash'],
+      ['GET?q=1', 'question mark'],
+      ['GET-foo', 'dash'],
+      ['GET*', 'star'],
+    ])('rejects invalid method boundary: %s (%s)', (input) => {
+      const { errors } = parser(input)!;
+      expect(errors.length).toBe(1);
+      expect(errors[0].text).toBe(methodBoundaryError);
+      expect(errors[0].offset).toBe(0);
+      expect(errors[0].endOffset).toBe(input.split(/[ \t\r\n]/)[0].length);
+    });
+
+    it.each([
+      ['GET _search', 'space'],
+      ['GET\t_search', 'tab'],
+      ['GET', 'end-of-input'],
+    ])('accepts request-line separator after method: %s (%s)', (input) => {
+      const { errors, requests } = parser(input)!;
+      expect(errors.filter((e) => e.text === methodBoundaryError)).toEqual([]);
+      expect(requests.length).toBe(1);
+    });
+
+    it('does not falsely flag a method whose url contains identifier chars (`GET _index_internal`)', () => {
+      const { errors, requests } = parser('GET _index_internal')!;
+      expect(errors).toEqual([]);
+      expect(requests.length).toBe(1);
+    });
+  });
+
   it('handles # and // comment lines between requests', () => {
     const input = '# c\nGET _search\n// c2\nPOST _test';
     const { requests, errors } = parser(input)!;

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.ts
@@ -32,8 +32,20 @@ export const createParser = (): ConsoleParser => {
   };
   let text = '';
   let errors: ErrorAnnotation[] = [];
-  const addError = function (errorText: string) {
-    errors.push({ text: errorText, offset: at });
+  const addError = function (errorText: string, offset = at, endOffset?: number) {
+    const errorAnnotation: ErrorAnnotation = { text: errorText, offset };
+    if (endOffset !== undefined) {
+      errorAnnotation.endOffset = endOffset;
+    }
+    errors.push(errorAnnotation);
+  };
+  const hasErrorCoveringOffset = function (offset: number) {
+    return errors.some(
+      (errorAnnotation) =>
+        errorAnnotation.endOffset !== undefined &&
+        errorAnnotation.offset <= offset &&
+        offset <= errorAnnotation.endOffset
+    );
   };
   let requests: ParsedRequest[] = [];
   let requestStartOffset: number | undefined;
@@ -57,8 +69,8 @@ export const createParser = (): ConsoleParser => {
     lastRequest.endOffset = requestEndOffset;
     requests.push(lastRequest);
   };
-  const error = function (m: string): never {
-    throw Object.assign(new SyntaxError(m), { at, text });
+  const error = function (m: string, errorAt = at, errorEndAt?: number): never {
+    throw Object.assign(new SyntaxError(m), { at: errorAt, endAt: errorEndAt, text });
   };
   const reset = function (newAt: number) {
     ch = text.charAt(newAt);
@@ -94,6 +106,16 @@ export const createParser = (): ConsoleParser => {
   };
   const peek = function (offset: number) {
     return text.charAt(at + offset);
+  };
+  const isRequestLineSeparator = function (character: string) {
+    return character === ' ' || character === '\t' || character === '\n' || character === '\r';
+  };
+  const readCurrentLineTokenEndOffset = function (startOffset: number) {
+    let tokenEndOffset = startOffset;
+    while (tokenEndOffset < text.length && !isRequestLineSeparator(text[tokenEndOffset])) {
+      tokenEndOffset++;
+    }
+    return tokenEndOffset;
   };
   const number = function () {
     let numString = '';
@@ -234,6 +256,18 @@ export const createParser = (): ConsoleParser => {
     }
     return error("Unexpected '" + ch + "'");
   };
+  // After consuming method letters, the next character must separate the
+  // method from the URL/body: horizontal whitespace, a line break, or
+  // end-of-input. Anything else is part of an invalid method token.
+  const methodBoundary = function () {
+    if (ch && !isRequestLineSeparator(ch)) {
+      error(
+        'Expected one of GET/POST/PUT/DELETE/HEAD/PATCH',
+        requestStartOffset ?? at,
+        readCurrentLineTokenEndOffset(at)
+      );
+    }
+  };
   // parses and returns the method
   const method = function () {
     const upperCaseChar = ch.toUpperCase();
@@ -242,12 +276,14 @@ export const createParser = (): ConsoleParser => {
         nextOneOf(['G', 'g']);
         nextOneOf(['E', 'e']);
         nextOneOf(['T', 't']);
+        methodBoundary();
         return 'GET';
       case 'H':
         nextOneOf(['H', 'h']);
         nextOneOf(['E', 'e']);
         nextOneOf(['A', 'a']);
         nextOneOf(['D', 'd']);
+        methodBoundary();
         return 'HEAD';
       case 'D':
         nextOneOf(['D', 'd']);
@@ -256,6 +292,7 @@ export const createParser = (): ConsoleParser => {
         nextOneOf(['E', 'e']);
         nextOneOf(['T', 't']);
         nextOneOf(['E', 'e']);
+        methodBoundary();
         return 'DELETE';
       case 'P':
         nextOneOf(['P', 'p']);
@@ -266,15 +303,18 @@ export const createParser = (): ConsoleParser => {
             nextOneOf(['T', 't']);
             nextOneOf(['C', 'c']);
             nextOneOf(['H', 'h']);
+            methodBoundary();
             return 'PATCH';
           case 'U':
             nextOneOf(['U', 'u']);
             nextOneOf(['T', 't']);
+            methodBoundary();
             return 'PUT';
           case 'O':
             nextOneOf(['O', 'o']);
             nextOneOf(['S', 's']);
             nextOneOf(['T', 't']);
+            methodBoundary();
             return 'POST';
           default:
             error("Unexpected '" + ch + "'");
@@ -417,10 +457,16 @@ export const createParser = (): ConsoleParser => {
         request();
         white();
       } catch (e: unknown) {
-        addError(getErrorMessage(e));
+        const syntaxError = e as { at?: number; endAt?: number };
+        addError(getErrorMessage(e), syntaxError.at, syntaxError.endAt);
         // snap
         const remainingText = text.substr(at);
-        const nextMethodIndex = remainingText.search(/^\s*(POST|HEAD|GET|PUT|DELETE|PATCH)\b/im);
+        // Match the verb without a trailing `\b` so that lines starting with
+        // a valid method prefix but continuing with identifier characters
+        // (`GETT`, `POSTS`, `PUThjjkjoj`) are picked up as recovery anchors;
+        // `method()` then re-throws at the boundary and an error annotation
+        // is recorded for each such line.
+        const nextMethodIndex = remainingText.search(/^\s*(POST|HEAD|GET|PUT|DELETE|PATCH)/im);
         const nextCommentLine = remainingText.search(/^\s*(#|\/\*|\/\/).*$/m);
         if (nextMethodIndex === -1 && nextCommentLine === -1) {
           // If there are no comments or other requests after the error, there is no point in parsing more so we stop here
@@ -444,7 +490,9 @@ export const createParser = (): ConsoleParser => {
     multiRequest();
     white();
     if (ch) {
-      addError('Syntax error');
+      if (!hasErrorCoveringOffset(at)) {
+        addError('Syntax error');
+      }
     }
 
     const result = { errors, requests };

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/types.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/types.ts
@@ -9,6 +9,7 @@
 
 export interface ErrorAnnotation {
   offset: number;
+  endOffset?: number;
   text: string;
 }
 


### PR DESCRIPTION
Closes #219253

## Summary

Request lines starting with a valid HTTP method prefix followed by extra characters (e.g. `PUThjjkjoj /my-index`, `GETT _search`, `POSTS _bulk`) were silently accepted by the Console Monaco parser — the prefix was consumed as the method and the tail treated as the URL, so no marker was emitted. Each such line is now marked.

## Root cause

In `src/platform/packages/shared/kbn-monaco/src/languages/console/parser.ts`:

1. `method()` greedily consumed the longest matching prefix without checking that the next character was a token boundary, so `PUThjjkjoj` parsed as method `PUT` + URL `hjjkjoj /my-index`.
2. `multiRequest()` recovery used `/^\s*(POST|HEAD|GET|PUT|DELETE|PATCH)\b/im`. With `\b`, consecutive invalid-prefix lines were skipped over, so only the first one in a run could ever be marked.

## Fix

- Add `methodBoundary()` after each matched verb; it errors with `Expected one of GET/POST/PUT/DELETE/HEAD/PATCH` when the next character is not a request-line separator (horizontal whitespace, line break, or end-of-input). This rejects `GETT`, `POSTS`, `PUThjjkjoj`, `GET_index`, `GET2`, and punctuation-glued lines such as `GET/_search`, `GET?q=1`, `GET-foo`, `GET*`.
- Store an explicit `offset..endOffset` range for method-boundary errors and pass it through the Monaco marker provider, so the full invalid method token is underlined consistently (`GETT`, `PUThjjkjoj`, `GET-foo`, etc.).
- Drop `\b` from the recovery anchor regex so each invalid-prefix line is revisited by `request()` and gets its own error annotation.

## Before / After

Input used in both states:

```
PUThjjkjoj /my-index
GETT _search
POSTS _bulk
GET _search
```

### Before

<img width="700" height="220" alt="image" src="https://github.com/user-attachments/assets/f0ebe2c3-9967-42f7-8e0e-922ec945db52" />

All three invalid-prefix lines silently accepted, no markers.

### After

<img width="700" height="200" alt="image" src="https://github.com/user-attachments/assets/cb86d7da-5334-4e31-8693-40b98626f374" />
<img width="700" height="320" alt="image" src="https://github.com/user-attachments/assets/9e55102f-949d-45c2-8aa4-75e63bda9de2" />

Three squigglies, one per invalid-prefix line, spanning the full invalid method token. Hover shows `Expected one of GET/POST/PUT/DELETE/HEAD/PATCH`. `GET _search` still parses cleanly.

## Test plan

- `node scripts/jest --config=src/platform/packages/shared/kbn-monaco/jest.config.js src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts` — 52/52 pass, including `it.each` tables that lock in valid request-line separators (`GET _search`, `GET\t_search`, `GET`) and invalid method boundaries (`GET_index`, `GET2 _x`, `GETSomething`, `HEADX`, `DELETEX`, `PATCHX`, `GET/_search`, `GET?q=1`, `GET-foo`, `GET*`), plus full-token error ranges and the consecutive-invalid-prefix run.
- `node scripts/check_changes.ts` — green.
- Manual on a build of this branch: each invalid input alone produces one marker; `GET _search`, `get _search`, and `GET` (existing missing-URL marker only) unchanged.

## Release note

Marks invalid HTTP methods (e.g. `GETT`, `POSTS`) as errors in the Dev Tools Console.

Assisted with Cursor using Claude Opus 4.7



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->