### PR TITLE
[9.4] [Search] Fix breadcrumbs for Index Management, Playground, and Model Management pages (#269163)

### DIFF
--- a/src/platform/plugins/shared/management/public/plugin.tsx
+++ b/src/platform/plugins/shared/management/public/plugin.tsx
@@ -170,9 +170,19 @@ export class ManagementPlugin
               const [, ...trailingBreadcrumbs] = newBreadcrumbs;
               deps.serverless.setBreadcrumbs(trailingBreadcrumbs);
             } else {
-              coreStart.chrome.setBreadcrumbs(newBreadcrumbs, {
-                project: { value: newBreadcrumbs, absolute: true },
-              });
+              const chromeStyle = coreStart.chrome.getChromeStyle();
+              if (chromeStyle === 'project') {
+                // Project chrome (solution spaces): the navigation tree provides "Stack Management > App".
+                // Management apps provide breadcrumbs as [Stack Management, App, ...details].
+                // We drop the first two and append the rest to the nav tree path.
+                const [, , ...trailingBreadcrumbs] = newBreadcrumbs;
+                coreStart.chrome.setBreadcrumbs([], {
+                  project: { value: trailingBreadcrumbs },
+                });
+              } else {
+                // Classic chrome: use full breadcrumb trail as-is
+                coreStart.chrome.setBreadcrumbs(newBreadcrumbs);
+              }
             }
           },
           isSidebarEnabled$: managementPlugin.isSidebarEnabled$,

--- a/src/platform/test/functional/page_objects/solution_navigation.ts
+++ b/src/platform/test/functional/page_objects/solution_navigation.ts
@@ -498,7 +498,10 @@ export function SolutionNavigationProvider(ctx: Pick<FtrProviderContext, 'getSer
           });
         }
       },
-      async expectBreadcrumbTexts(expectedBreadcrumbTexts: string[]) {
+      async expectBreadcrumbTexts(
+        expectedBreadcrumbTexts: string[],
+        options?: { removeProjectName?: boolean }
+      ) {
         log.debug(
           'SolutionNavigation.breadcrumbs.expectBreadcrumbTexts',
           JSON.stringify(expectedBreadcrumbTexts)
@@ -506,9 +509,11 @@ export function SolutionNavigationProvider(ctx: Pick<FtrProviderContext, 'getSer
         await retry.try(async () => {
           const breadcrumbsContainer = await testSubjects.find('breadcrumbs', TIMEOUT_CHECK);
           const breadcrumbs = await breadcrumbsContainer.findAllByTestSubject('~breadcrumb');
-          breadcrumbs.shift(); // remove home
-          expect(expectedBreadcrumbTexts.length).to.eql(breadcrumbs.length);
           const texts = await Promise.all(breadcrumbs.map((b) => b.getVisibleText()));
+          if (options?.removeProjectName) {
+            texts.shift(); // remove project name breadcrumb in serverless
+          }
+          expect(expectedBreadcrumbTexts.length).to.eql(texts.length);
           expect(expectedBreadcrumbTexts).to.eql(texts);
         });
       },

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/common/translations.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/common/translations.ts
@@ -83,13 +83,6 @@ export const BREADCRUMB_RELEVANCE = i18n.translate(
   }
 );
 
-export const BREADCRUMB_INFERENCE_ENDPOINTS = i18n.translate(
-  'xpack.searchInferenceEndpoints.breadcrumbs.inferenceEndpoints',
-  {
-    defaultMessage: 'Inference endpoints',
-  }
-);
-
 export const ENDPOINT_COPY_SUCCESS = (inferenceId: string) =>
   i18n.translate('xpack.searchInferenceEndpoints.actions.copyIDSuccess', {
     defaultMessage: 'Inference endpoint ID {inferenceId} copied',

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/elastic_inference_service.tsx
@@ -11,8 +11,12 @@ import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { EuiPageTemplate } from '@elastic/eui';
 import { ElasticInferenceServiceModelsHeader } from './elastic_inference_service/header';
 import { ElasticInferenceServiceModelsPage } from './elastic_inference_service/elastic_inference_service_models_page';
+import { useBreadcrumbs } from '../hooks/use_breadcrumbs';
+import { ELASTIC_INFERENCE_SERVICE_BREADCRUMB } from '../translations';
 
 export const ElasticInferenceService = () => {
+  useBreadcrumbs(ELASTIC_INFERENCE_SERVICE_BREADCRUMB);
+
   return (
     <KibanaPageTemplate
       offset={0}

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_breadcrumbs.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/hooks/use_breadcrumbs.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+
+import { useKibana } from './use_kibana';
+
+/**
+ * Sets breadcrumbs for the Search Inference Endpoints pages.
+ *
+ * In project chrome (serverless or solution spaces), the navigation tree provides
+ * the base path automatically. In classic chrome, we need to set the breadcrumbs manually.
+ */
+export const useBreadcrumbs = (breadcrumbText: string) => {
+  const { setBreadcrumbs, chrome } = useKibana().services;
+  const chromeStyle = chrome.getChromeStyle();
+
+  useEffect(() => {
+    if (chromeStyle !== 'classic') {
+      return;
+    }
+
+    setBreadcrumbs([{ text: breadcrumbText }]);
+  }, [setBreadcrumbs, chromeStyle, breadcrumbText]);
+};

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/inference_endpoints_overview.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/inference_endpoints_overview.tsx
@@ -9,13 +9,17 @@ import React, { useMemo } from 'react';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
 import { App } from './components/app';
+import { useBreadcrumbs } from './hooks/use_breadcrumbs';
 import { useKibana } from './hooks/use_kibana';
 import { InferenceEndpointsProvider } from './providers/inference_endpoints_provider';
+import { INFERENCE_ENDPOINTS_BREADCRUMB } from './translations';
 
 export const InferenceEndpointsOverview: React.FC = () => {
   const {
     services: { console: consolePlugin },
   } = useKibana();
+
+  useBreadcrumbs(INFERENCE_ENDPOINTS_BREADCRUMB);
 
   const embeddableConsole = useMemo(
     () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/model_settings_overview.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/model_settings_overview.tsx
@@ -9,13 +9,17 @@ import React, { useMemo } from 'react';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
 import { ModelSettings } from './components/settings/model_settings';
+import { useBreadcrumbs } from './hooks/use_breadcrumbs';
 import { useKibana } from './hooks/use_kibana';
 import { InferenceEndpointsProvider } from './providers/inference_endpoints_provider';
+import { MODEL_SETTINGS_BREADCRUMB } from './translations';
 
 export const ModelSettingsOverview: React.FC = () => {
   const {
     services: { console: consolePlugin },
   } = useKibana();
+
+  useBreadcrumbs(MODEL_SETTINGS_BREADCRUMB);
 
   const embeddableConsole = useMemo(
     () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/plugin.ts
@@ -59,12 +59,13 @@ export class SearchInferenceEndpointsPlugin
               defaultMessage: 'Inference endpoints',
             }),
         order: 2,
-        async mount({ element, history }: ManagementAppMountParams) {
+        async mount({ element, history, setBreadcrumbs }: ManagementAppMountParams) {
           const { renderInferenceEndpointsMgmtApp } = await import('./application');
           const [coreStart, depsStart] = await core.getStartServices();
           const startDeps: AppPluginStartDependencies = {
             ...depsStart,
             history,
+            setBreadcrumbs,
           };
 
           return renderInferenceEndpointsMgmtApp(coreStart, startDeps, element);
@@ -79,12 +80,13 @@ export class SearchInferenceEndpointsPlugin
         }),
         order: 3,
 
-        async mount({ element, history }: ManagementAppMountParams) {
+        async mount({ element, history, setBreadcrumbs }: ManagementAppMountParams) {
           const { renderSettingsMgmtApp } = await import('./application');
           const [coreStart, depsStart] = await core.getStartServices();
           const startDeps: AppPluginStartDependencies = {
             ...depsStart,
             history,
+            setBreadcrumbs,
           };
 
           return renderSettingsMgmtApp(coreStart, startDeps, element);

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/translations.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/translations.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const INFERENCE_ENDPOINTS_BREADCRUMB = i18n.translate(
+  'xpack.searchInferenceEndpoints.breadcrumbs.inferenceEndpoints',
+  {
+    defaultMessage: 'External Inference',
+  }
+);
+
+export const ELASTIC_INFERENCE_SERVICE_BREADCRUMB = i18n.translate(
+  'xpack.searchInferenceEndpoints.breadcrumbs.elasticInferenceService',
+  {
+    defaultMessage: 'Elastic Inference',
+  }
+);
+
+export const MODEL_SETTINGS_BREADCRUMB = i18n.translate(
+  'xpack.searchInferenceEndpoints.breadcrumbs.modelSettings',
+  {
+    defaultMessage: 'Feature Settings',
+  }
+);

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/types.ts
@@ -9,6 +9,7 @@ import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import type { ActionsPublicPluginSetup } from '@kbn/actions-plugin/public';
 import type { ConsolePluginSetup, ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
+import type { ManagementAppMountParams } from '@kbn/management-plugin/public';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/public';
 import type { ManagementSetup } from '@kbn/management-plugin/public';
@@ -32,6 +33,7 @@ export interface SearchInferenceEndpointsPluginStart {}
 
 export interface AppPluginStartDependencies {
   history: AppMountParameters['history'];
+  setBreadcrumbs: ManagementAppMountParams['setBreadcrumbs'];
   share: SharePluginStart;
   console?: ConsolePluginStart;
   licensing: LicensingPluginStart;

--- a/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
@@ -135,12 +135,18 @@ export class SearchNavigationPlugin
     if (forClassicChromeStyle === true && this.currentChromeStyle !== 'classic') return;
 
     if (this.pluginsStart?.serverless) {
+      // Serverless: use the serverless plugin's breadcrumb API
       this.pluginsStart.serverless.setBreadcrumbs(breadcrumbs);
-    } else {
-      const searchBreadcrumbs = [this.getSearchHomeBreadcrumb(), ...breadcrumbs];
-      this.coreStart?.chrome.setBreadcrumbs(searchBreadcrumbs, {
-        project: { value: breadcrumbs, absolute: true },
+    } else if (this.currentChromeStyle === 'project') {
+      // Project chrome (solution spaces): the navigation tree provides the base path.
+      // Breadcrumbs are appended to the nav-tree-generated path.
+      this.coreStart?.chrome.setBreadcrumbs([], {
+        project: { value: breadcrumbs },
       });
+    } else {
+      // Classic chrome: prepend the Elasticsearch home breadcrumb
+      const searchBreadcrumbs = [this.getSearchHomeBreadcrumb(), ...breadcrumbs];
+      this.coreStart?.chrome.setBreadcrumbs(searchBreadcrumbs);
     }
   }
 

--- a/x-pack/solutions/search/plugins/search_playground/moon.yml
+++ b/x-pack/solutions/search/plugins/search_playground/moon.yml
@@ -68,6 +68,8 @@ dependsOn:
   - '@kbn/license-management-plugin'
   - '@kbn/connector-schemas'
   - '@kbn/react-query'
+  - '@kbn/evals-plugin'
+  - '@kbn/core-chrome-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_playground_breadcrumbs.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_playground_breadcrumbs.ts
@@ -8,43 +8,51 @@
 import { useEffect } from 'react';
 
 import { i18n } from '@kbn/i18n';
+import type { ChromeBreadcrumb } from '@kbn/core-chrome-browser';
 
 import { PLUGIN_PATH } from '../../common';
 import { useKibana } from './use_kibana';
 
+/**
+ * Sets breadcrumbs for the Playground app.
+ *
+ * In project chrome (serverless or solution spaces), the navigation tree provides
+ * the base path (e.g., "Data management > Relevance > Playground").
+ * In classic chrome, we need to set the full path manually.
+ */
 export const usePlaygroundBreadcrumbs = (playgroundName?: string) => {
-  const { cloud, http, searchNavigation } = useKibana().services;
-  const isServerless = cloud?.isServerlessEnabled ?? false;
+  const { http, searchNavigation, chrome } = useKibana().services;
+  const chromeStyle = chrome.getChromeStyle();
 
   useEffect(() => {
-    searchNavigation?.breadcrumbs.setSearchBreadCrumbs([
-      ...(isServerless
-        ? [] // Serverless is setting Build breadcrumb automatically
-        : [
-            {
-              text: i18n.translate('xpack.searchPlayground.breadcrumbs.build', {
-                defaultMessage: 'Build',
-              }),
-            },
-          ]),
-      {
+    const breadcrumbs: ChromeBreadcrumb[] = [];
+
+    // In classic chrome, we need to provide the full breadcrumb path.
+    // In project chrome, the navigation tree handles the base path automatically.
+    if (chromeStyle === 'classic') {
+      breadcrumbs.push({
+        text: i18n.translate('xpack.searchPlayground.breadcrumbs.build', {
+          defaultMessage: 'Build',
+        }),
+      });
+      breadcrumbs.push({
         text: i18n.translate('xpack.searchPlayground.breadcrumbs.playground', {
           defaultMessage: 'Playground',
         }),
         href: playgroundName !== undefined ? http.basePath.prepend(PLUGIN_PATH) : undefined,
-      },
-      ...(playgroundName !== undefined
-        ? [
-            {
-              text: playgroundName,
-            },
-          ]
-        : []),
-    ]);
+      });
+    }
+
+    if (playgroundName !== undefined) {
+      breadcrumbs.push({ text: playgroundName });
+    }
+
+    if (breadcrumbs.length > 0) {
+      searchNavigation?.breadcrumbs.setSearchBreadCrumbs(breadcrumbs);
+    }
 
     return () => {
-      // Clear breadcrumbs on unmount;
       searchNavigation?.breadcrumbs.clearBreadcrumbs();
     };
-  }, [http, searchNavigation, isServerless, playgroundName]);
+  }, [http, searchNavigation, chromeStyle, playgroundName]);
 };

--- a/x-pack/solutions/search/plugins/search_playground/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_playground/tsconfig.json
@@ -60,7 +60,9 @@
     "@kbn/search-shared-ui",
     "@kbn/license-management-plugin",
     "@kbn/connector-schemas",
-    "@kbn/react-query"
+    "@kbn/react-query",
+    "@kbn/evals-plugin",
+    "@kbn/core-chrome-browser"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/solutions/search/plugins/search_playground/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_playground/tsconfig.json
@@ -61,7 +61,6 @@
     "@kbn/license-management-plugin",
     "@kbn/connector-schemas",
     "@kbn/react-query",
-    "@kbn/evals-plugin",
     "@kbn/core-chrome-browser"
   ],
   "exclude": [

--- a/x-pack/solutions/search/plugins/search_query_rules/moon.yml
+++ b/x-pack/solutions/search/plugins/search_query_rules/moon.yml
@@ -41,6 +41,7 @@ dependsOn:
   - '@kbn/usage-collection-plugin'
   - '@kbn/cloud-plugin'
   - '@kbn/react-query'
+  - '@kbn/core-chrome-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/overview/overview.test.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/overview/overview.test.tsx
@@ -12,6 +12,25 @@ import { QueryRulesOverview } from './overview';
 import { I18nProvider } from '@kbn/i18n-react';
 import { useFetchQueryRulesSets } from '../../hooks/use_fetch_query_rules_sets';
 
+jest.mock('../../hooks/use_kibana', () => ({
+  useKibana: jest.fn().mockReturnValue({
+    services: {
+      console: undefined,
+      history: { push: jest.fn(), location: { search: '' } },
+      searchNavigation: {
+        useClassicNavigation: jest.fn(),
+        breadcrumbs: {
+          setSearchBreadCrumbs: jest.fn(),
+          clearBreadcrumbs: jest.fn(),
+        },
+      },
+      chrome: {
+        getChromeStyle: jest.fn().mockReturnValue('classic'),
+      },
+    },
+  }),
+}));
+
 jest.mock('../../hooks/use_fetch_query_rules_sets', () => ({
   useFetchQueryRulesSets: jest.fn(() => ({
     data: undefined,

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.test.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_ruleset_detail.test.tsx
@@ -70,10 +70,21 @@ jest.mock('../../hooks/use_kibana', () => {
         history: {
           block: jest.fn().mockReturnValue(jest.fn()),
           listen: jest.fn().mockReturnValue(jest.fn()),
+          createHref: jest.fn().mockImplementation((location) => location.pathname || '/'),
         },
         console: {},
         share: {},
         notifications: notificationServiceMock.createStartContract(),
+        searchNavigation: {
+          useClassicNavigation: jest.fn(),
+          breadcrumbs: {
+            setSearchBreadCrumbs: jest.fn(),
+            clearBreadcrumbs: jest.fn(),
+          },
+        },
+        chrome: {
+          getChromeStyle: jest.fn().mockReturnValue('classic'),
+        },
       },
     }),
   };

--- a/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_query_rules_breadcrumbs.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/hooks/use_query_rules_breadcrumbs.tsx
@@ -7,6 +7,7 @@
 
 import { useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
+import type { ChromeBreadcrumb } from '@kbn/core-chrome-browser';
 import { reactRouterNavigate } from '@kbn/kibana-react-plugin/public';
 import { useKibana } from './use_kibana';
 
@@ -17,47 +18,44 @@ const QUERY_RULES_BREADCRUMB_TEXT = i18n.translate(
   }
 );
 
+/**
+ * Sets breadcrumbs for the Query Rules app.
+ *
+ * In project chrome (serverless or solution spaces), the navigation tree provides
+ * the base path (e.g., "Data management > Relevance > Query rules").
+ * In classic chrome, we need to set the full path manually.
+ */
 export const useQueryRulesBreadcrumbs = (rulesetId?: string) => {
-  const { searchNavigation, history, cloud } = useKibana().services;
-  const isServerless = cloud?.isServerlessEnabled ?? false;
+  const { searchNavigation, history, chrome } = useKibana().services;
+  const chromeStyle = chrome.getChromeStyle();
 
   useEffect(() => {
-    if (!isServerless) {
-      searchNavigation?.breadcrumbs.setSearchBreadCrumbs([
-        {
-          text: i18n.translate('xpack.searchQueryRules.breadcrumbs.relevance', {
-            defaultMessage: 'Relevance',
-          }),
-        },
-        ...(rulesetId && rulesetId.trim().length > 0
-          ? [
-              {
-                text: QUERY_RULES_BREADCRUMB_TEXT,
-                ...reactRouterNavigate(history, '/'),
-              },
-              {
-                text: rulesetId,
-              },
-            ]
-          : [
-              {
-                text: QUERY_RULES_BREADCRUMB_TEXT,
-              },
-            ]),
-      ]);
-    } else {
-      if (rulesetId && rulesetId.trim().length > 0) {
-        searchNavigation?.breadcrumbs.setSearchBreadCrumbs([
-          {
-            text: rulesetId,
-          },
-        ]);
-      }
+    const breadcrumbs: ChromeBreadcrumb[] = [];
+
+    // In classic chrome, we need to provide the full breadcrumb path.
+    // In project chrome, the navigation tree handles the base path automatically.
+    if (chromeStyle === 'classic') {
+      breadcrumbs.push({
+        text: i18n.translate('xpack.searchQueryRules.breadcrumbs.relevance', {
+          defaultMessage: 'Relevance',
+        }),
+      });
+      breadcrumbs.push({
+        text: QUERY_RULES_BREADCRUMB_TEXT,
+        ...(rulesetId && rulesetId.trim().length > 0 ? reactRouterNavigate(history, '/') : {}),
+      });
+    }
+
+    if (rulesetId && rulesetId.trim().length > 0) {
+      breadcrumbs.push({ text: rulesetId });
+    }
+
+    if (breadcrumbs.length > 0) {
+      searchNavigation?.breadcrumbs.setSearchBreadCrumbs(breadcrumbs);
     }
 
     return () => {
-      // Clear breadcrumbs on unmount;
       searchNavigation?.breadcrumbs.clearBreadcrumbs();
     };
-  }, [searchNavigation, history, rulesetId, isServerless]);
+  }, [searchNavigation, history, rulesetId, chromeStyle]);
 };

--- a/x-pack/solutions/search/plugins/search_query_rules/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_query_rules/tsconfig.json
@@ -34,6 +34,7 @@
     "@kbn/usage-collection-plugin",
     "@kbn/cloud-plugin",
     "@kbn/react-query",
+    "@kbn/core-chrome-browser",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/overview/overview.test.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/overview/overview.test.tsx
@@ -12,6 +12,25 @@ import { SearchSynonymsOverview } from './overview';
 import { I18nProvider } from '@kbn/i18n-react';
 import { useFetchSynonymsSets } from '../../hooks/use_fetch_synonyms_sets';
 
+jest.mock('../../hooks/use_kibana', () => ({
+  useKibana: jest.fn().mockReturnValue({
+    services: {
+      console: undefined,
+      history: { push: jest.fn(), location: { search: '' } },
+      searchNavigation: {
+        useClassicNavigation: jest.fn(),
+        breadcrumbs: {
+          setSearchBreadCrumbs: jest.fn(),
+          clearBreadcrumbs: jest.fn(),
+        },
+      },
+      chrome: {
+        getChromeStyle: jest.fn().mockReturnValue('classic'),
+      },
+    },
+  }),
+}));
+
 jest.mock('../../hooks/use_fetch_synonyms_sets', () => ({
   useFetchSynonymsSets: jest.fn(() => ({
     data: undefined,

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_synonyms_breadcrumbs.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_synonyms_breadcrumbs.tsx
@@ -12,39 +12,46 @@ import { i18n } from '@kbn/i18n';
 
 import { useKibana } from './use_kibana';
 
+/**
+ * Sets breadcrumbs for the Synonyms app.
+ *
+ * In project chrome (serverless or solution spaces), the navigation tree provides
+ * the base path (e.g., "Data management > Relevance > Synonyms").
+ * In classic chrome, we need to set the full path manually.
+ */
 export const useSynonymsBreadcrumbs = (setName?: string) => {
-  const { history, searchNavigation } = useKibana().services;
+  const { history, searchNavigation, chrome } = useKibana().services;
+  const chromeStyle = chrome.getChromeStyle();
 
   useEffect(() => {
-    const breadcrumbs: ChromeBreadcrumb[] = [
-      {
+    const breadcrumbs: ChromeBreadcrumb[] = [];
+
+    // In classic chrome, we need to provide the full breadcrumb path.
+    // In project chrome, the navigation tree handles the base path automatically.
+    if (chromeStyle === 'classic') {
+      breadcrumbs.push({
         text: i18n.translate('xpack.searchSynonyms.breadcrumbs.relevance.title', {
           defaultMessage: 'Relevance',
         }),
-      },
-    ];
-    if (setName) {
+      });
       breadcrumbs.push({
         text: i18n.translate('xpack.searchSynonyms.breadcrumbs.synonyms.title', {
           defaultMessage: 'Synonyms',
         }),
-        ...reactRouterNavigate(history, '/'),
-      });
-      breadcrumbs.push({
-        text: setName,
-      });
-    } else {
-      breadcrumbs.push({
-        text: i18n.translate('xpack.searchSynonyms.breadcrumbs.synonyms.title', {
-          defaultMessage: 'Synonyms',
-        }),
+        ...(setName ? reactRouterNavigate(history, '/') : {}),
       });
     }
-    searchNavigation?.breadcrumbs.setSearchBreadCrumbs(breadcrumbs);
+
+    if (setName) {
+      breadcrumbs.push({ text: setName });
+    }
+
+    if (breadcrumbs.length > 0) {
+      searchNavigation?.breadcrumbs.setSearchBreadCrumbs(breadcrumbs);
+    }
 
     return () => {
-      // Clear breadcrumbs on unmount;
       searchNavigation?.breadcrumbs.clearBreadcrumbs();
     };
-  }, [searchNavigation, history, setName]);
+  }, [searchNavigation, history, setName, chromeStyle]);
 };

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -184,12 +184,11 @@ export function createNavigationTree({
           },
           {
             children: [
-              { link: 'searchSynonyms:synonyms', breadcrumbStatus: 'hidden' },
+              { link: 'searchSynonyms:synonyms' },
               { link: 'searchQueryRules' },
               { link: 'searchPlayground' },
             ],
             id: 'search_relevance',
-            breadcrumbStatus: 'hidden',
             title: i18n.translate('xpack.serverlessSearch.nav.ingest.relevance.title', {
               defaultMessage: 'Relevance',
             }),

--- a/x-pack/solutions/search/test/functional_search/tests/index_management.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/index_management.ts
@@ -11,6 +11,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     'header',
     'common',
     'indexManagement',
+    'solutionNavigation',
   ]);
   const es = getService('es');
   const searchSpace = getService('searchSpace');
@@ -76,6 +77,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             );
             await pageObjects.searchIndexDetailsPage.expectIndexDetailPageHeader();
             await pageObjects.searchIndexDetailsPage.expectSearchIndexDetailsTabsExists();
+          });
+        });
+        describe('breadcrumbs', function () {
+          it('displays correct breadcrumbs on index list page', async () => {
+            await pageObjects.solutionNavigation.breadcrumbs.expectBreadcrumbTexts([
+              'Data management',
+              'Indices and data streams',
+              'Index Management',
+              'Indices',
+            ]);
           });
         });
       });

--- a/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/solution_navigation.ts
@@ -124,5 +124,28 @@ export default function searchSolutionNavigation({
         { checkOrder: false }
       );
     });
+
+    it('navigates to data management and query rules with correct breadcrumbs', async () => {
+      await solutionNavigation.sidenav.openPanel('data_management');
+      await solutionNavigation.sidenav.expectLinkActive({
+        deepLinkId: 'management:index_management',
+      });
+      await solutionNavigation.breadcrumbs.expectBreadcrumbTexts([
+        'Data management',
+        'Indices and data streams',
+        'Index Management',
+        'Indices',
+      ]);
+
+      await solutionNavigation.sidenav.clickLink({
+        deepLinkId: 'searchQueryRules',
+      });
+      await testSubjects.existOrFail('queryRulesBasePage');
+      await solutionNavigation.breadcrumbs.expectBreadcrumbTexts([
+        'Data management',
+        'Relevance',
+        'Query rules',
+      ]);
+    });
   });
 }

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/navigation.ts
@@ -128,7 +128,18 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await solutionNavigation.sidenav.expectLinkActive({
         deepLinkId: 'management:index_management',
       });
-      await svlCommonNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Index Management' });
+      await solutionNavigation.breadcrumbs.expectBreadcrumbTexts(
+        ['Data management', 'Indices and data streams', 'Index Management', 'Indices'],
+        { removeProjectName: true }
+      );
+
+      await solutionNavigation.sidenav.clickLink({
+        deepLinkId: 'searchQueryRules',
+      });
+      await solutionNavigation.breadcrumbs.expectBreadcrumbTexts(
+        ['Data management', 'Relevance', 'Query rules'],
+        { removeProjectName: true }
+      );
     });
 
     it('navigate using search', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Search] Fix breadcrumbs for Index Management, Playground, and Model Management pages (#269163)](https://github.com/elastic/kibana/pull/269163)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2026-05-18T09:05:36Z","message":"[Search] Fix breadcrumbs for Index Management, Playground, and Model Management pages (#269163)\n\n## Summary\nWhen using solution navigation (project chrome), Management apps and\nSearch apps (Playground, Query Rules, Synonyms) were incorrectly\noverriding the navigation tree breadcrumbs with their own paths. This\ncaused users to see breadcrumbs like `Stack Management > Index\nManagement > Indices` instead of the expected `Data Management > Indices\nand data streams > Index Management > Indices`.\n\nAdditionally, Model Management pages (Elastic Inference, External\nInference, Feature Settings) were not setting breadcrumbs in classic\nnavigation, resulting in only `Kibana` being displayed.\n\n### Changes\n**Management plugin** (`src/platform/plugins/shared/management/public/`)\n- In project chrome, remove `absolute: true` when setting breadcrumbs,\nallowing them to append to the navigation tree path instead of replacing\nit\n- Drop the first two breadcrumbs (Stack Management and app name) in\nproject chrome since the navigation tree provides these\n\n**Search Navigation plugin**\n(`x-pack/solutions/search/plugins/search_navigation/public/`)\n- In project chrome, remove `absolute: true` to append breadcrumbs to\nthe navigation tree path\n- Classic chrome continues to prepend the Elasticsearch home breadcrumb\n\n**Serverless Search plugin**\n(`x-pack/solutions/search/plugins/serverless_search/public/`)\n- Remove `breadcrumbStatus: 'hidden'` from the Relevance nav section,\nallowing the navigation tree to provide breadcrumbs for Synonyms, Query\nRules, and Playground\n\n**Search plugins breadcrumb hooks** (Playground, Query Rules, Synonyms)\n- Refactor to check `chrome.getChromeStyle()` instead of\n`cloud?.isServerlessEnabled`\n- In project chrome, only provide detail-level breadcrumbs (e.g.,\nruleset name); the navigation tree handles the base path\n\n**Search Inference Endpoints plugin**\n(`x-pack/platform/plugins/shared/search_inference_endpoints/public/`)\n- Add setBreadcrumbs calls for classic chrome to show proper breadcrumb\ntext instead of just `Kibana`\n\n### Screenshots\n\n**Index Management**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1504\" alt=\"Screenshot 2026-05-13 at 14 46 55\"\nsrc=\"https://github.com/user-attachments/assets/12841e33-d808-4863-a367-b3caa04510cf\"\n/> | <img width=\"1506\" alt=\"Screenshot 2026-05-15 at 09 30 24\"\nsrc=\"https://github.com/user-attachments/assets/f2462076-8fe3-4b4f-8ffa-93b4e6ed4c54\"\n/> |\n\n**Playground**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1507\" height=\"861\" alt=\"Screenshot 2026-05-13 at 14 47 07\"\nsrc=\"https://github.com/user-attachments/assets/82e884af-b95f-49cf-ae4d-3c5b8e419c49\"\n/> | <img width=\"1509\" height=\"852\" alt=\"Screenshot 2026-05-13 at 14 50\n06\"\nsrc=\"https://github.com/user-attachments/assets/b6f1551c-9d2b-461f-85fd-fc836d8da060\"\n/> |\n\n**Elastic Inference**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1509\" height=\"855\" alt=\"Screenshot 2026-05-13 at 14 48 02\"\nsrc=\"https://github.com/user-attachments/assets/9d0d0775-117d-49d8-8ef8-abf27ab0ad27\"\n/> | <img width=\"1509\" height=\"858\" alt=\"Screenshot 2026-05-13 at 14 50\n39\"\nsrc=\"https://github.com/user-attachments/assets/55bac2a7-6789-429c-9b7e-937468dff493\"\n/> |\n\n\n### Testing\n**In Elasticsearch solution space:**\n- [ ] Navigate to Index Management and verify breadcrumbs show the\ncorrect navigation tree path: `Data Management > Indices and data\nstreams > Index Management > Indices`\n- [ ] Navigate to Playground and verify breadcrumbs show `Relevance`,\nnot `Build`\n- [ ] Navigate to the Query rules and Synonyms pages and verify\nbreadcrumbs show `Data Management > Relevance` and the name of the page\n\n**In a classic navigation space:**\n- [ ] Navigate to Model Management pages (Elastic Inference, External\nInference, Feature Settings) and verify breadcrumbs are displayed:\n`Stack Management > Elastic Inference`\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f74d105f8ee975ff08f45af5a6e01d2ee54a3168","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Search","backport:version","v9.5.0","v9.4.2"],"title":"[Search] Fix breadcrumbs for Index Management, Playground, and Model Management pages","number":269163,"url":"https://github.com/elastic/kibana/pull/269163","mergeCommit":{"message":"[Search] Fix breadcrumbs for Index Management, Playground, and Model Management pages (#269163)\n\n## Summary\nWhen using solution navigation (project chrome), Management apps and\nSearch apps (Playground, Query Rules, Synonyms) were incorrectly\noverriding the navigation tree breadcrumbs with their own paths. This\ncaused users to see breadcrumbs like `Stack Management > Index\nManagement > Indices` instead of the expected `Data Management > Indices\nand data streams > Index Management > Indices`.\n\nAdditionally, Model Management pages (Elastic Inference, External\nInference, Feature Settings) were not setting breadcrumbs in classic\nnavigation, resulting in only `Kibana` being displayed.\n\n### Changes\n**Management plugin** (`src/platform/plugins/shared/management/public/`)\n- In project chrome, remove `absolute: true` when setting breadcrumbs,\nallowing them to append to the navigation tree path instead of replacing\nit\n- Drop the first two breadcrumbs (Stack Management and app name) in\nproject chrome since the navigation tree provides these\n\n**Search Navigation plugin**\n(`x-pack/solutions/search/plugins/search_navigation/public/`)\n- In project chrome, remove `absolute: true` to append breadcrumbs to\nthe navigation tree path\n- Classic chrome continues to prepend the Elasticsearch home breadcrumb\n\n**Serverless Search plugin**\n(`x-pack/solutions/search/plugins/serverless_search/public/`)\n- Remove `breadcrumbStatus: 'hidden'` from the Relevance nav section,\nallowing the navigation tree to provide breadcrumbs for Synonyms, Query\nRules, and Playground\n\n**Search plugins breadcrumb hooks** (Playground, Query Rules, Synonyms)\n- Refactor to check `chrome.getChromeStyle()` instead of\n`cloud?.isServerlessEnabled`\n- In project chrome, only provide detail-level breadcrumbs (e.g.,\nruleset name); the navigation tree handles the base path\n\n**Search Inference Endpoints plugin**\n(`x-pack/platform/plugins/shared/search_inference_endpoints/public/`)\n- Add setBreadcrumbs calls for classic chrome to show proper breadcrumb\ntext instead of just `Kibana`\n\n### Screenshots\n\n**Index Management**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1504\" alt=\"Screenshot 2026-05-13 at 14 46 55\"\nsrc=\"https://github.com/user-attachments/assets/12841e33-d808-4863-a367-b3caa04510cf\"\n/> | <img width=\"1506\" alt=\"Screenshot 2026-05-15 at 09 30 24\"\nsrc=\"https://github.com/user-attachments/assets/f2462076-8fe3-4b4f-8ffa-93b4e6ed4c54\"\n/> |\n\n**Playground**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1507\" height=\"861\" alt=\"Screenshot 2026-05-13 at 14 47 07\"\nsrc=\"https://github.com/user-attachments/assets/82e884af-b95f-49cf-ae4d-3c5b8e419c49\"\n/> | <img width=\"1509\" height=\"852\" alt=\"Screenshot 2026-05-13 at 14 50\n06\"\nsrc=\"https://github.com/user-attachments/assets/b6f1551c-9d2b-461f-85fd-fc836d8da060\"\n/> |\n\n**Elastic Inference**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1509\" height=\"855\" alt=\"Screenshot 2026-05-13 at 14 48 02\"\nsrc=\"https://github.com/user-attachments/assets/9d0d0775-117d-49d8-8ef8-abf27ab0ad27\"\n/> | <img width=\"1509\" height=\"858\" alt=\"Screenshot 2026-05-13 at 14 50\n39\"\nsrc=\"https://github.com/user-attachments/assets/55bac2a7-6789-429c-9b7e-937468dff493\"\n/> |\n\n\n### Testing\n**In Elasticsearch solution space:**\n- [ ] Navigate to Index Management and verify breadcrumbs show the\ncorrect navigation tree path: `Data Management > Indices and data\nstreams > Index Management > Indices`\n- [ ] Navigate to Playground and verify breadcrumbs show `Relevance`,\nnot `Build`\n- [ ] Navigate to the Query rules and Synonyms pages and verify\nbreadcrumbs show `Data Management > Relevance` and the name of the page\n\n**In a classic navigation space:**\n- [ ] Navigate to Model Management pages (Elastic Inference, External\nInference, Feature Settings) and verify breadcrumbs are displayed:\n`Stack Management > Elastic Inference`\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f74d105f8ee975ff08f45af5a6e01d2ee54a3168"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269163","number":269163,"mergeCommit":{"message":"[Search] Fix breadcrumbs for Index Management, Playground, and Model Management pages (#269163)\n\n## Summary\nWhen using solution navigation (project chrome), Management apps and\nSearch apps (Playground, Query Rules, Synonyms) were incorrectly\noverriding the navigation tree breadcrumbs with their own paths. This\ncaused users to see breadcrumbs like `Stack Management > Index\nManagement > Indices` instead of the expected `Data Management > Indices\nand data streams > Index Management > Indices`.\n\nAdditionally, Model Management pages (Elastic Inference, External\nInference, Feature Settings) were not setting breadcrumbs in classic\nnavigation, resulting in only `Kibana` being displayed.\n\n### Changes\n**Management plugin** (`src/platform/plugins/shared/management/public/`)\n- In project chrome, remove `absolute: true` when setting breadcrumbs,\nallowing them to append to the navigation tree path instead of replacing\nit\n- Drop the first two breadcrumbs (Stack Management and app name) in\nproject chrome since the navigation tree provides these\n\n**Search Navigation plugin**\n(`x-pack/solutions/search/plugins/search_navigation/public/`)\n- In project chrome, remove `absolute: true` to append breadcrumbs to\nthe navigation tree path\n- Classic chrome continues to prepend the Elasticsearch home breadcrumb\n\n**Serverless Search plugin**\n(`x-pack/solutions/search/plugins/serverless_search/public/`)\n- Remove `breadcrumbStatus: 'hidden'` from the Relevance nav section,\nallowing the navigation tree to provide breadcrumbs for Synonyms, Query\nRules, and Playground\n\n**Search plugins breadcrumb hooks** (Playground, Query Rules, Synonyms)\n- Refactor to check `chrome.getChromeStyle()` instead of\n`cloud?.isServerlessEnabled`\n- In project chrome, only provide detail-level breadcrumbs (e.g.,\nruleset name); the navigation tree handles the base path\n\n**Search Inference Endpoints plugin**\n(`x-pack/platform/plugins/shared/search_inference_endpoints/public/`)\n- Add setBreadcrumbs calls for classic chrome to show proper breadcrumb\ntext instead of just `Kibana`\n\n### Screenshots\n\n**Index Management**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1504\" alt=\"Screenshot 2026-05-13 at 14 46 55\"\nsrc=\"https://github.com/user-attachments/assets/12841e33-d808-4863-a367-b3caa04510cf\"\n/> | <img width=\"1506\" alt=\"Screenshot 2026-05-15 at 09 30 24\"\nsrc=\"https://github.com/user-attachments/assets/f2462076-8fe3-4b4f-8ffa-93b4e6ed4c54\"\n/> |\n\n**Playground**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1507\" height=\"861\" alt=\"Screenshot 2026-05-13 at 14 47 07\"\nsrc=\"https://github.com/user-attachments/assets/82e884af-b95f-49cf-ae4d-3c5b8e419c49\"\n/> | <img width=\"1509\" height=\"852\" alt=\"Screenshot 2026-05-13 at 14 50\n06\"\nsrc=\"https://github.com/user-attachments/assets/b6f1551c-9d2b-461f-85fd-fc836d8da060\"\n/> |\n\n**Elastic Inference**\n| Before | After |\n\n|---------------------------------------------------------------------|----------|\n| <img width=\"1509\" height=\"855\" alt=\"Screenshot 2026-05-13 at 14 48 02\"\nsrc=\"https://github.com/user-attachments/assets/9d0d0775-117d-49d8-8ef8-abf27ab0ad27\"\n/> | <img width=\"1509\" height=\"858\" alt=\"Screenshot 2026-05-13 at 14 50\n39\"\nsrc=\"https://github.com/user-attachments/assets/55bac2a7-6789-429c-9b7e-937468dff493\"\n/> |\n\n\n### Testing\n**In Elasticsearch solution space:**\n- [ ] Navigate to Index Management and verify breadcrumbs show the\ncorrect navigation tree path: `Data Management > Indices and data\nstreams > Index Management > Indices`\n- [ ] Navigate to Playground and verify breadcrumbs show `Relevance`,\nnot `Build`\n- [ ] Navigate to the Query rules and Synonyms pages and verify\nbreadcrumbs show `Data Management > Relevance` and the name of the page\n\n**In a classic navigation space:**\n- [ ] Navigate to Model Management pages (Elastic Inference, External\nInference, Feature Settings) and verify breadcrumbs are displayed:\n`Stack Management > Elastic Inference`\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f74d105f8ee975ff08f45af5a6e01d2ee54a3168"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->