### PR TITLE
Scout configurations: fix a jest test assertion

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/detect_custom_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/detect_custom_config.test.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import path from 'path';
+
 import { detectCustomConfigDir, getConfigRootDir } from './detect_custom_config';
 import { ScoutTestTarget } from '@kbn/scout-info';
 
@@ -50,9 +52,7 @@ describe('getConfigRootDir', () => {
     const testTarget = new ScoutTestTarget('local', 'serverless', 'search');
     const result = getConfigRootDir(defaultPlaywrightPath, testTarget);
 
-    expect(result).toContain('default');
-    expect(result).toContain('serverless');
-    expect(result).not.toContain('custom');
+    expect(result).toContain(path.join('config_sets', 'default', 'serverless'));
   });
 
   it('should return default stateful root when playwright path does not contain custom config', () => {
@@ -60,9 +60,7 @@ describe('getConfigRootDir', () => {
     const testTarget = new ScoutTestTarget('local', 'stateful', 'classic');
     const result = getConfigRootDir(defaultPlaywrightPath, testTarget);
 
-    expect(result).toContain('default');
-    expect(result).toContain('stateful');
-    expect(result).not.toContain('custom');
+    expect(result).toContain(path.join('config_sets', 'default', 'stateful'));
   });
 
   it('should return default root when playwright path does not contain custom config', () => {
@@ -70,9 +68,7 @@ describe('getConfigRootDir', () => {
     const testTarget = new ScoutTestTarget('local', 'serverless', 'search');
     const result = getConfigRootDir(playwrightPath, testTarget);
 
-    expect(result).toContain('default');
-    expect(result).toContain('serverless');
-    expect(result).not.toContain('custom');
+    expect(result).toContain(path.join('config_sets', 'default', 'serverless'));
   });
 
   it('should return custom root when playwright path contains custom config for serverless', () => {


### PR DESCRIPTION
Three tests tended to fail in my environment, as they assert `expect(result).not.toContain('custom')`, expecting that the returned path does **not** contain the substring `"custom"`. However, the returned path resolves through `__dirname`, which produces an absolute path based on the local filesystem. This is a problem if a dev is working in a git worktree that has the `custom` string in the path.

The actual path resolved in my test run is:

```
/Users/tsullivan/elastic/kibana-sidenav-customization/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/serverless
```

The problem was that my **worktree directory name** is `kibana-sidenav-customization`, and contains the substring `custom`. The assertion `.not.toContain('custom')` matches against the entire absolute path string, which includes my workspace directory name.

This PR makes the tests resilient to whatever directory/worktree the repo is checked out into.