### PR TITLE
[Search][Getting Started] Chat first view

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -154,7 +154,7 @@ pageLoadAssetSize:
   screenshotMode: 2351
   screenshotting: 3252
   searchAssistant: 7079
-  searchGettingStarted: 6678
+  searchGettingStarted: 7548
   searchHomepage: 9005
   searchInferenceEndpoints: 9765
   searchNavigation: 8900

--- a/x-pack/platform/plugins/shared/agent_builder/public/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/index.ts
@@ -16,6 +16,7 @@ import type {
 import { AgentBuilderPlugin } from './plugin';
 import { AGENTBUILDER_FEATURE_ID, AGENTBUILDER_APP_ID, uiPrivileges } from '../common/features';
 import { type CreateSkillResponse, SKILLS_API_PATH } from '../common/http_api/skills';
+import { MCP_SERVER_PATH } from '../common/mcp';
 
 export type {
   AgentBuilderPluginSetup,
@@ -23,7 +24,7 @@ export type {
   PublicEmbeddableConversationProps,
 } from './types';
 export type { EmbeddableConversationProps } from './embeddable/types';
-export { AGENTBUILDER_FEATURE_ID, AGENTBUILDER_APP_ID, uiPrivileges };
+export { AGENTBUILDER_FEATURE_ID, AGENTBUILDER_APP_ID, uiPrivileges, MCP_SERVER_PATH };
 export { type CreateSkillResponse, SKILLS_API_PATH };
 export { ConversationInputShell } from '@kbn/agent-builder-browser';
 export type { ConversationInputShellProps } from '@kbn/agent-builder-browser';

--- a/x-pack/solutions/search/plugins/search_getting_started/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_getting_started/kibana.jsonc
@@ -20,10 +20,13 @@
       "cloud",
       "console",
       "searchNavigation",
+      "spaces",
       "usageCollection"
     ],
     "requiredBundles": [
-      "kibanaReact"
+      "agentBuilder",
+      "kibanaReact",
+      "spaces",
     ]
   }
 }

--- a/x-pack/solutions/search/plugins/search_getting_started/moon.yml
+++ b/x-pack/solutions/search/plugins/search_getting_started/moon.yml
@@ -45,6 +45,9 @@ dependsOn:
   - '@kbn/scout-search'
   - '@kbn/search-agent'
   - '@kbn/shared-ux-ai-components'
+  - '@kbn/agent-builder-plugin'
+  - '@kbn/core-chrome-layout-constants'
+  - '@kbn/spaces-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/search_getting_started/moon.yml
+++ b/x-pack/solutions/search/plugins/search_getting_started/moon.yml
@@ -46,8 +46,9 @@ dependsOn:
   - '@kbn/search-agent'
   - '@kbn/shared-ux-ai-components'
   - '@kbn/agent-builder-plugin'
-  - '@kbn/core-chrome-layout-constants'
   - '@kbn/spaces-plugin'
+  - '@kbn/deeplinks-agent-builder'
+  - '@kbn/agent-builder-common'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.test.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { GettingStartedAgentPrompt } from './agent_prompt';
+import { useUsageTracker } from '../../contexts/usage_tracker_context';
+
+jest.mock('../../contexts/usage_tracker_context', () => ({
+  useUsageTracker: jest.fn(),
+}));
+
+const mockUseUsageTracker = useUsageTracker as jest.Mock;
+
+const renderComponent = () =>
+  render(
+    <I18nProvider>
+      <EuiThemeProvider>
+        <GettingStartedAgentPrompt />
+      </EuiThemeProvider>
+    </I18nProvider>
+  );
+
+describe('GettingStartedAgentPrompt', () => {
+  beforeEach(() => {
+    mockUseUsageTracker.mockReturnValue({ click: jest.fn(), count: jest.fn(), load: jest.fn() });
+  });
+
+  it('does not render the modal on initial mount', () => {
+    renderComponent();
+
+    expect(screen.queryByTestId('promptModalCode')).not.toBeInTheDocument();
+  });
+
+  it('opens the modal when the Copy prompt button is clicked', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('chatFirstAgentInstallBtn'));
+
+    expect(screen.getByTestId('promptModalCode')).toBeInTheDocument();
+  });
+
+  it('renders the modal with prompt content when opened', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('chatFirstAgentInstallBtn'));
+
+    expect(screen.getByTestId('promptModalCode')).not.toBeEmptyDOMElement();
+  });
+
+  it('closes the modal when the Close button is clicked', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('chatFirstAgentInstallBtn'));
+    expect(screen.getByTestId('promptModalCode')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('promptModalCloseBtn'));
+    expect(screen.queryByTestId('promptModalCode')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { buildPrompt } from '../agent_install/util';
+import { PromptModal } from '../agent_install/prompt_modal';
+
+export const GettingStartedAgentPrompt = () => {
+  const [isPromptModalOpen, setIsPromptModalOpen] = useState(false);
+  const [modalPrompt, setModalPrompt] = useState('');
+  const handleOpenInAgentWorkflow = useCallback(() => {
+    const prompt = buildPrompt('cli');
+    // Show a modal with the Claude/CLI prompt for the selected use case
+    setIsPromptModalOpen(true);
+    setModalPrompt(prompt);
+  }, []);
+  const closePromptModal = useCallback(() => setIsPromptModalOpen(false), []);
+
+  return (
+    <>
+      <EuiFlexGroup direction="column" gutterSize="xs">
+        <EuiFlexItem>
+          <EuiTitle size="xxs">
+            <h5>
+              {i18n.translate('xpack.search.gettingStarted.chat.agentPrompt.title', {
+                defaultMessage: 'Prompt your agent',
+              })}
+            </h5>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText color="subdued" size="xs">
+            <p>
+              {i18n.translate('xpack.search.gettingStarted.chat.agentPrompt.description', {
+                defaultMessage:
+                  'Setup our official optimized Elasticsearch skills in your preferred agentic code workflow.',
+              })}
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiSpacer size="s" />
+        <EuiFlexItem>
+          <span>
+            <EuiButton
+              color="text"
+              onClick={handleOpenInAgentWorkflow}
+              iconType="copy"
+              size="s"
+              data-test-subj="chatFirstAgentInstallBtn"
+            >
+              {i18n.translate('xpack.search.gettingStarted.chat.agentPrompt.cta', {
+                defaultMessage: 'Copy prompt',
+              })}
+            </EuiButton>
+          </span>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {isPromptModalOpen && <PromptModal prompt={modalPrompt} onClose={closePromptModal} />}
+    </>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -14,14 +14,6 @@ import { PromptModal } from '../agent_install/prompt_modal';
 
 export const GettingStartedAgentPrompt = () => {
   const [isPromptModalOpen, setIsPromptModalOpen] = useState(false);
-  const [modalPrompt, setModalPrompt] = useState('');
-  const handleOpenInAgentWorkflow = useCallback(() => {
-    const prompt = buildPrompt('cli');
-    // Show a modal with the Claude/CLI prompt for the selected use case
-    setIsPromptModalOpen(true);
-    setModalPrompt(prompt);
-  }, []);
-  const closePromptModal = useCallback(() => setIsPromptModalOpen(false), []);
 
   return (
     <>
@@ -50,7 +42,7 @@ export const GettingStartedAgentPrompt = () => {
           <span>
             <EuiButton
               color="text"
-              onClick={handleOpenInAgentWorkflow}
+              onClick={() => setIsPromptModalOpen(true)}
               iconType="copy"
               size="s"
               data-test-subj="chatFirstAgentInstallBtn"
@@ -62,7 +54,9 @@ export const GettingStartedAgentPrompt = () => {
           </span>
         </EuiFlexItem>
       </EuiFlexGroup>
-      {isPromptModalOpen && <PromptModal prompt={modalPrompt} onClose={closePromptModal} />}
+      {isPromptModalOpen && (
+        <PromptModal prompt={buildPrompt('cli')} onClose={() => setIsPromptModalOpen(false)} />
+      )}
     </>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/agent_prompt.tsx
@@ -32,7 +32,7 @@ export const GettingStartedAgentPrompt = () => {
             <p>
               {i18n.translate('xpack.search.gettingStarted.chat.agentPrompt.description', {
                 defaultMessage:
-                  'Setup our official optimized Elasticsearch skills in your preferred agentic code workflow.',
+                  'Set up our official optimized Elasticsearch skills in your preferred agentic code workflow.',
               })}
             </p>
           </EuiText>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_content.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_content.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiPageTemplate } from '@elastic/eui';
+
+import { ChatElasticsearchConnectionDetails } from './connection_details';
+import { ConversationPrompt } from './conversation_prompt';
+import { ChatContentSeparator } from './styles';
+import { GettingStartedAgentPrompt } from './agent_prompt';
+
+export const GettingStartedChatContent = () => {
+  return (
+    <EuiPageTemplate.Section data-test-subj="gettingStartedChatContent">
+      <EuiFlexGroup>
+        <EuiFlexItem grow={4} css={[ChatContentSeparator]}>
+          <ConversationPrompt />
+        </EuiFlexItem>
+        <EuiFlexItem grow={2}>
+          <EuiFlexGroup direction="column" gutterSize="l">
+            <ChatElasticsearchConnectionDetails />
+            <GettingStartedAgentPrompt />
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPageTemplate.Section>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_content.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_content.tsx
@@ -6,27 +6,29 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPageTemplate } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { ChatElasticsearchConnectionDetails } from './connection_details';
 import { ConversationPrompt } from './conversation_prompt';
-import { ChatContentSeparator } from './styles';
+import { ChatColumnsGrid, ChatContentSeparator } from './styles';
 import { GettingStartedAgentPrompt } from './agent_prompt';
 
 export const GettingStartedChatContent = () => {
   return (
-    <EuiPageTemplate.Section data-test-subj="gettingStartedChatContent">
-      <EuiFlexGroup>
-        <EuiFlexItem grow={4} css={[ChatContentSeparator]}>
-          <ConversationPrompt />
-        </EuiFlexItem>
-        <EuiFlexItem grow={2}>
-          <EuiFlexGroup direction="column" gutterSize="l">
+    <EuiFlexGrid data-test-subj="gettingStartedChatContent" columns={2} css={ChatColumnsGrid}>
+      <EuiFlexItem css={ChatContentSeparator}>
+        <ConversationPrompt />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGroup direction="column" gutterSize="l">
+          <EuiFlexItem>
             <ChatElasticsearchConnectionDetails />
+          </EuiFlexItem>
+          <EuiFlexItem>
             <GettingStartedAgentPrompt />
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPageTemplate.Section>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGrid>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_header.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_header.tsx
@@ -6,42 +6,31 @@
  */
 
 import React from 'react';
-import { css } from '@emotion/react';
-import { EuiFlexGroup, EuiFlexItem, EuiPageTemplate, EuiTitle } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { DeploymentStatusBadges } from '../header/deployment_status_badges';
+import { ChatColumnsGrid, ChatStretchedFlexItem } from './styles';
 
 export const ChatHeader = () => {
   return (
-    <EuiPageTemplate.Section data-test-subj="gettingStartedChatHeader" grow={false}>
-      <EuiFlexGroup gutterSize="l" alignItems="flexStart" direction="column">
-        <EuiFlexItem
-          css={css({
-            // ensures the trial badge and version badge fill parent with space between
-            alignSelf: 'stretch',
-          })}
-        >
-          <DeploymentStatusBadges />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiFlexGroup>
-            <EuiFlexItem grow={4}>
-              <EuiTitle size="l">
-                <h1>
-                  {i18n.translate('xpack.search.gettingStarted.chatPage.title', {
-                    defaultMessage:
-                      'Bring your data and start building your next search experience.',
-                  })}
-                </h1>
-              </EuiTitle>
-            </EuiFlexItem>
-            <EuiFlexItem grow={2}>
-              <span />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPageTemplate.Section>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" direction="column">
+      <EuiFlexItem css={ChatStretchedFlexItem}>
+        <DeploymentStatusBadges />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGrid columns={2} css={ChatColumnsGrid}>
+          <EuiFlexItem>
+            <EuiTitle size="l">
+              <h1>
+                {i18n.translate('xpack.search.gettingStarted.chatPage.title', {
+                  defaultMessage: 'Bring your data and start building your next search experience.',
+                })}
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGrid>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_header.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/chat_header.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css } from '@emotion/react';
+import { EuiFlexGroup, EuiFlexItem, EuiPageTemplate, EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { DeploymentStatusBadges } from '../header/deployment_status_badges';
+
+export const ChatHeader = () => {
+  return (
+    <EuiPageTemplate.Section data-test-subj="gettingStartedChatHeader" grow={false}>
+      <EuiFlexGroup gutterSize="l" alignItems="flexStart" direction="column">
+        <EuiFlexItem
+          css={css({
+            // ensures the trial badge and version badge fill parent with space between
+            alignSelf: 'stretch',
+          })}
+        >
+          <DeploymentStatusBadges />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup>
+            <EuiFlexItem grow={4}>
+              <EuiTitle size="l">
+                <h1>
+                  {i18n.translate('xpack.search.gettingStarted.chatPage.title', {
+                    defaultMessage:
+                      'Bring your data and start building your next search experience.',
+                  })}
+                </h1>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={2}>
+              <span />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPageTemplate.Section>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/connection_details.test.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/connection_details.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { ChatElasticsearchConnectionDetails } from './connection_details';
+import { useElasticsearchUrl } from '../../hooks/use_elasticsearch_url';
+import { useAgentBuilderMcpUrl } from '../../hooks/use_mcp_url';
+
+jest.mock('../../hooks/use_elasticsearch_url');
+jest.mock('../../hooks/use_mcp_url');
+jest.mock('@kbn/search-api-keys-components', () => ({
+  ApiKeyForm: () => <div data-test-subj="apiKeyForm" />,
+}));
+
+const mockUseElasticsearchUrl = useElasticsearchUrl as jest.Mock;
+const mockUseAgentBuilderMcpUrl = useAgentBuilderMcpUrl as jest.Mock;
+
+const MOCK_ES_URL = 'https://my-deployment.es.us-east-1.aws.elastic.cloud';
+const MOCK_MCP_URL = 'https://my-kibana.kb.us-east-1.aws.elastic.cloud/api/agent_builder/mcp';
+
+const renderComponent = () =>
+  render(
+    <I18nProvider>
+      <EuiThemeProvider>
+        <ChatElasticsearchConnectionDetails />
+      </EuiThemeProvider>
+    </I18nProvider>
+  );
+
+describe('ChatElasticsearchConnectionDetails', () => {
+  beforeEach(() => {
+    mockUseElasticsearchUrl.mockReturnValue(MOCK_ES_URL);
+    mockUseAgentBuilderMcpUrl.mockReturnValue(MOCK_MCP_URL);
+  });
+
+  it('shows the Elasticsearch URL by default', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('endpointValueField')).toHaveTextContent(MOCK_ES_URL);
+    expect(screen.queryByTestId('mcpEndpointValueField')).not.toBeInTheDocument();
+  });
+
+  it('switches to the MCP URL when the MCP badge is clicked', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('viewMCPUrlBtn'));
+
+    expect(screen.getByTestId('mcpEndpointValueField')).toHaveTextContent(MOCK_MCP_URL);
+    expect(screen.queryByTestId('endpointValueField')).not.toBeInTheDocument();
+  });
+
+  it('switches back to the Elasticsearch URL when the Elasticsearch badge is clicked', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('viewMCPUrlBtn'));
+    fireEvent.click(screen.getByTestId('viewElasticsearchUrlBtn'));
+
+    expect(screen.getByTestId('endpointValueField')).toHaveTextContent(MOCK_ES_URL);
+    expect(screen.queryByTestId('mcpEndpointValueField')).not.toBeInTheDocument();
+  });
+
+  describe('badge colors', () => {
+    it('Elasticsearch badge is default color and MCP badge is hollow on initial render', () => {
+      renderComponent();
+
+      const esBadge = screen.getByTestId('viewElasticsearchUrlBtn');
+      const mcpBadge = screen.getByTestId('viewMCPUrlBtn');
+
+      // EuiBadge uses CSS-in-JS; check the className string for the variant name
+      expect(esBadge.closest('.euiBadge')?.className).not.toContain('hollow');
+      expect(mcpBadge.closest('.euiBadge')?.className).toContain('hollow');
+    });
+
+    it('MCP badge becomes default color and Elasticsearch badge becomes hollow after switching', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByTestId('viewMCPUrlBtn'));
+
+      const esBadge = screen.getByTestId('viewElasticsearchUrlBtn');
+      const mcpBadge = screen.getByTestId('viewMCPUrlBtn');
+
+      expect(mcpBadge.closest('.euiBadge')?.className).not.toContain('hollow');
+      expect(esBadge.closest('.euiBadge')?.className).toContain('hollow');
+    });
+  });
+
+  it('always renders the ApiKeyForm regardless of URL view', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('apiKeyForm')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('viewMCPUrlBtn'));
+
+    expect(screen.getByTestId('apiKeyForm')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/connection_details.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/connection_details.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { EuiBadge, EuiBadgeGroup, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { ApiKeyForm } from '@kbn/search-api-keys-components';
+import { FormInfoField } from '@kbn/search-shared-ui';
+import { useElasticsearchUrl } from '../../hooks/use_elasticsearch_url';
+import { useAgentBuilderMcpUrl } from '../../hooks/use_mcp_url';
+
+enum UrlView {
+  elasticsearch = 'es',
+  mcp = 'mcp',
+}
+
+export const ChatElasticsearchConnectionDetails = () => {
+  const [urlView, setUrlView] = useState<UrlView>(UrlView.elasticsearch);
+  const elasticsearchUrl = useElasticsearchUrl();
+  const mcpServerUrl = useAgentBuilderMcpUrl();
+
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <EuiTitle size="xxs">
+          <h5>
+            {i18n.translate(
+              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.serverless.title',
+              {
+                defaultMessage: 'Connector to your project',
+              }
+            )}
+          </h5>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiBadgeGroup>
+          <EuiBadge
+            color={urlView !== UrlView.elasticsearch ? 'hollow' : 'default'}
+            onClick={() => setUrlView(UrlView.elasticsearch)}
+            data-test-subj="viewElasticsearchUrlBtn"
+            onClickAriaLabel={i18n.translate(
+              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.mcp.aria',
+              {
+                defaultMessage: 'View the elasticsearch endpoint url',
+              }
+            )}
+          >
+            {i18n.translate(
+              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.elasticsearch',
+              {
+                defaultMessage: 'Elasticsearch',
+              }
+            )}
+          </EuiBadge>
+          <EuiBadge
+            color={urlView !== UrlView.mcp ? 'hollow' : 'default'}
+            onClick={() => setUrlView(UrlView.mcp)}
+            data-test-subj="viewMCPUrlBtn"
+            onClickAriaLabel={i18n.translate(
+              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.mcp.aria',
+              {
+                defaultMessage: 'View the model context protocol server url',
+              }
+            )}
+          >
+            {i18n.translate(
+              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.mcp',
+              {
+                defaultMessage: 'MCP',
+              }
+            )}
+          </EuiBadge>
+        </EuiBadgeGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        {urlView === UrlView.elasticsearch && (
+          <FormInfoField
+            value={elasticsearchUrl}
+            copyValue={elasticsearchUrl}
+            dataTestSubj="endpointValueField"
+            copyValueDataTestSubj="copyEndpointButton"
+          />
+        )}
+        {urlView === UrlView.mcp && (
+          <FormInfoField
+            value={mcpServerUrl}
+            copyValue={mcpServerUrl}
+            dataTestSubj="mcpEndpointValueField"
+            copyValueDataTestSubj="copyMcpEndpointButton"
+          />
+        )}
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <ApiKeyForm />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/connection_details.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/connection_details.tsx
@@ -15,7 +15,7 @@ import { useElasticsearchUrl } from '../../hooks/use_elasticsearch_url';
 import { useAgentBuilderMcpUrl } from '../../hooks/use_mcp_url';
 
 enum UrlView {
-  elasticsearch = 'es',
+  elasticsearch = 'elasticsearch',
   mcp = 'mcp',
 }
 
@@ -39,13 +39,21 @@ export const ChatElasticsearchConnectionDetails = () => {
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiBadgeGroup>
+        <EuiBadgeGroup
+          role="group"
+          aria-label={i18n.translate(
+            'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadgeGroup.aria',
+            {
+              defaultMessage: 'Select endpoint type',
+            }
+          )}
+        >
           <EuiBadge
             color={urlView !== UrlView.elasticsearch ? 'hollow' : 'default'}
             onClick={() => setUrlView(UrlView.elasticsearch)}
             data-test-subj="viewElasticsearchUrlBtn"
             onClickAriaLabel={i18n.translate(
-              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.mcp.aria',
+              'xpack.search.gettingStarted.chat.elasticsearchConnectionDetails.urlSelectBadge.elasticsearch.aria',
               {
                 defaultMessage: 'View the elasticsearch endpoint url',
               }

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.test.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { EuiThemeProvider } from '@elastic/eui';
 import { ConversationPrompt } from './conversation_prompt';
@@ -14,26 +14,8 @@ import { useKibana } from '../../hooks/use_kibana';
 
 jest.mock('../../hooks/use_kibana');
 
-jest.mock('@kbn/agent-builder-plugin/public', () => {
-  const { forwardRef } = require('react');
-  return {
-    ConversationInputShell: forwardRef(
-      ({ children }: { children: React.ReactNode }, ref: React.Ref<HTMLDivElement>) => (
-        <div ref={ref}>{children}</div>
-      )
-    ),
-  };
-});
-
+const mockNavigateToApp = jest.fn();
 const mockUseKibana = useKibana as jest.Mock;
-
-const MockEmbeddableConversation = ({ onClose }: { onClose: () => void }) => (
-  <div data-test-subj="embeddableConversation">
-    <button data-test-subj="embeddableConversationClose" onClick={onClose}>
-      Close
-    </button>
-  </div>
-);
 
 const renderComponent = () =>
   render(
@@ -46,51 +28,64 @@ const renderComponent = () =>
 
 describe('ConversationPrompt', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    mockNavigateToApp.mockClear();
     mockUseKibana.mockReturnValue({
-      services: { agentBuilder: { EmbeddableConversation: MockEmbeddableConversation } },
+      services: { application: { navigateToApp: mockNavigateToApp } },
     });
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
+  it('renders the textarea and send button', () => {
+    renderComponent();
+    expect(screen.getByTestId('searchGettingStartedChatPromptInput')).toBeInTheDocument();
+    expect(screen.getByTestId('searchGettingStartedChatPromptSend')).toBeInTheDocument();
   });
 
-  it('does not show the overlay on initial mount', () => {
+  it('send button is disabled when the input is empty', () => {
     renderComponent();
-
-    expect(
-      screen.queryByTestId('searchGettingStartedChatNewConversationOverlay')
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('searchGettingStartedChatPromptSend')).toBeDisabled();
   });
 
-  it('shows the overlay and mounts EmbeddableConversation when the prompt is activated', () => {
+  it('send button is enabled after typing a message', () => {
     renderComponent();
+    fireEvent.change(screen.getByTestId('searchGettingStartedChatPromptInput'), {
+      target: { value: 'Hello' },
+    });
+    expect(screen.getByTestId('searchGettingStartedChatPromptSend')).not.toBeDisabled();
+  });
 
+  it('navigates to agent builder with the message when send is clicked', () => {
+    renderComponent();
+    fireEvent.change(screen.getByTestId('searchGettingStartedChatPromptInput'), {
+      target: { value: 'Help me get started' },
+    });
     fireEvent.click(screen.getByTestId('searchGettingStartedChatPromptSend'));
-
-    expect(
-      screen.getByTestId('searchGettingStartedChatNewConversationOverlay')
-    ).toBeInTheDocument();
-    expect(screen.getByTestId('embeddableConversation')).toBeInTheDocument();
+    expect(mockNavigateToApp).toHaveBeenCalledWith(
+      'agent_builder',
+      expect.objectContaining({
+        state: expect.objectContaining({ initialMessage: 'Help me get started' }),
+      })
+    );
   });
 
-  it('hides the overlay after EmbeddableConversation calls onClose', () => {
+  it('navigates to agent builder when Enter is pressed', () => {
     renderComponent();
+    const input = screen.getByTestId('searchGettingStartedChatPromptInput');
+    fireEvent.change(input, { target: { value: 'Hello' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockNavigateToApp).toHaveBeenCalled();
+  });
 
-    // Open and advance to the Open phase so collapseConversation's guard passes
-    fireEvent.click(screen.getByTestId('searchGettingStartedChatPromptSend'));
-    act(() => {
-      jest.runAllTimers();
-    });
+  it('does not navigate when Shift+Enter is pressed', () => {
+    renderComponent();
+    const input = screen.getByTestId('searchGettingStartedChatPromptInput');
+    fireEvent.change(input, { target: { value: 'Hello' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(mockNavigateToApp).not.toHaveBeenCalled();
+  });
 
-    fireEvent.click(screen.getByTestId('embeddableConversationClose'));
-    act(() => {
-      jest.runAllTimers();
-    });
-
-    expect(
-      screen.queryByTestId('searchGettingStartedChatNewConversationOverlay')
-    ).not.toBeInTheDocument();
+  it('does not navigate when the message is blank', () => {
+    renderComponent();
+    fireEvent.keyDown(screen.getByTestId('searchGettingStartedChatPromptInput'), { key: 'Enter' });
+    expect(mockNavigateToApp).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.test.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { ConversationPrompt } from './conversation_prompt';
+import { useKibana } from '../../hooks/use_kibana';
+
+jest.mock('../../hooks/use_kibana');
+
+jest.mock('@kbn/agent-builder-plugin/public', () => {
+  const { forwardRef } = require('react');
+  return {
+    ConversationInputShell: forwardRef(
+      ({ children }: { children: React.ReactNode }, ref: React.Ref<HTMLDivElement>) => (
+        <div ref={ref}>{children}</div>
+      )
+    ),
+  };
+});
+
+const mockUseKibana = useKibana as jest.Mock;
+
+const MockEmbeddableConversation = ({ onClose }: { onClose: () => void }) => (
+  <div data-test-subj="embeddableConversation">
+    <button data-test-subj="embeddableConversationClose" onClick={onClose}>
+      Close
+    </button>
+  </div>
+);
+
+const renderComponent = () =>
+  render(
+    <I18nProvider>
+      <EuiThemeProvider>
+        <ConversationPrompt />
+      </EuiThemeProvider>
+    </I18nProvider>
+  );
+
+describe('ConversationPrompt', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockUseKibana.mockReturnValue({
+      services: { agentBuilder: { EmbeddableConversation: MockEmbeddableConversation } },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not show the overlay on initial mount', () => {
+    renderComponent();
+
+    expect(
+      screen.queryByTestId('searchGettingStartedChatNewConversationOverlay')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the overlay and mounts EmbeddableConversation when the prompt is activated', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('searchGettingStartedChatPromptSend'));
+
+    expect(
+      screen.getByTestId('searchGettingStartedChatNewConversationOverlay')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('embeddableConversation')).toBeInTheDocument();
+  });
+
+  it('hides the overlay after EmbeddableConversation calls onClose', () => {
+    renderComponent();
+
+    // Open and advance to the Open phase so collapseConversation's guard passes
+    fireEvent.click(screen.getByTestId('searchGettingStartedChatPromptSend'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    fireEvent.click(screen.getByTestId('embeddableConversationClose'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(
+      screen.queryByTestId('searchGettingStartedChatNewConversationOverlay')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -5,127 +5,81 @@
  * 2.0.
  */
 
-import React, { useCallback, useRef, useState } from 'react';
-import { EuiButtonIcon } from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
+import { EuiButtonIcon, keys } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { ConversationInputShell } from '@kbn/agent-builder-plugin/public';
 import { useKibana } from '../../hooks/use_kibana';
 
 import {
-  CONVERSATION_ANIMATION_MS,
-  ConversationOverlayBaseStyles,
-  ConversationOverlayOpeningStyle,
-  ConversationOverlayOpenStyle,
-  ConversationStyle,
   NewConversationTextArea,
   NewConversationSendButton,
   NewConversationContainer,
 } from './styles';
 
-enum ConversationPhase {
-  Closed = 'closed',
-  Opening = 'opening',
-  Open = 'open',
-  Closing = 'closing',
-}
-
 export const ConversationPrompt = () => {
   const {
-    services: { agentBuilder },
+    services: { application },
   } = useKibana();
-  const promptLauncherRef = useRef<HTMLDivElement>(null);
-  const [launcherRect, setLauncherRect] = useState<DOMRect | null>(null);
-  const [chatPhase, setChatPhase] = useState<ConversationPhase>(ConversationPhase.Closed);
-  const expandConversation = useCallback(() => {
-    if (chatPhase !== ConversationPhase.Closed) return;
-    if (promptLauncherRef.current) {
-      setLauncherRect(promptLauncherRef.current.getBoundingClientRect());
-    }
-    setChatPhase(ConversationPhase.Opening);
-    // Two rAF calls: the first lets the browser paint the Opening state (small rect),
-    // and the second triggers the transition to Open so CSS animates between them.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => setChatPhase(ConversationPhase.Open));
+  const [initialMessage, setInitialMessage] = useState<string>('');
+  const openConversation = useCallback(() => {
+    if (initialMessage.trim().length === 0) return;
+    application.navigateToApp(AGENT_BUILDER_APP_ID, {
+      path: `/agents/${agentBuilderDefaultAgentId}/conversations/new`,
+      state: {
+        initialMessage,
+        entryPointSource: 'search_getting_started',
+      },
     });
-  }, [chatPhase]);
-  const collapseConversation = useCallback(() => {
-    if (chatPhase !== ConversationPhase.Open) return;
-    if (promptLauncherRef.current) {
-      setLauncherRect(promptLauncherRef.current.getBoundingClientRect());
-    }
-    setChatPhase(ConversationPhase.Closing);
-    setTimeout(() => {
-      setChatPhase(ConversationPhase.Closed);
-      setLauncherRect(null);
-    }, CONVERSATION_ANIMATION_MS);
-  }, [chatPhase]);
-
-  const isOverlayVisible = chatPhase !== ConversationPhase.Closed;
-  const isConversationOverlayOpen = chatPhase === ConversationPhase.Open;
-  // agentBuilder === undefined handled by useGettingStartChatEnabled
-  const { EmbeddableConversation } = agentBuilder!;
+  }, [application, initialMessage]);
+  const onInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === keys.ENTER && !event.shiftKey) {
+        event.preventDefault();
+        openConversation();
+      }
+    },
+    [openConversation]
+  );
 
   return (
-    <>
-      <div css={NewConversationContainer}>
-        <ConversationInputShell ref={promptLauncherRef} css={NewConversationTextArea}>
-          <textarea
-            data-test-subj="searchGettingStartedChatPromptInput"
-            placeholder={i18n.translate(
-              'xpack.search.gettingStarted.chat.conversationPrompt.placeholder',
-              { defaultMessage: 'How can I help you get started today?' }
-            )}
-            aria-hidden
-            readOnly
-            rows={3}
-            onFocus={expandConversation}
-            onMouseDown={(e) => {
-              e.preventDefault();
-              expandConversation();
-            }}
+    <div css={NewConversationContainer}>
+      <ConversationInputShell>
+        <textarea
+          css={NewConversationTextArea}
+          name="searchGettingStartedChatPromptInput"
+          data-test-subj="searchGettingStartedChatPromptInput"
+          placeholder={i18n.translate(
+            'xpack.search.gettingStarted.chat.conversationPrompt.placeholder',
+            { defaultMessage: 'How can I help you get started today?' }
+          )}
+          aria-label={i18n.translate(
+            'xpack.search.gettingStarted.chat.conversationPrompt.input.aria',
+            {
+              defaultMessage: 'Ask the AI assistant a question to get started',
+            }
+          )}
+          rows={3}
+          value={initialMessage}
+          onChange={(e) => setInitialMessage(e.currentTarget.value)}
+          onKeyDown={onInputKeyDown}
+        />
+        <div css={NewConversationSendButton}>
+          <EuiButtonIcon
+            iconType="kqlFunction"
+            display="fill"
+            size="m"
+            disabled={initialMessage.trim().length === 0}
+            onClick={openConversation}
+            aria-label={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.send', {
+              defaultMessage: 'Open the AI assistant chat',
+            })}
+            data-test-subj="searchGettingStartedChatPromptSend"
           />
-          <div css={NewConversationSendButton}>
-            <EuiToolTip
-              content={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.send', {
-                defaultMessage: 'Open the AI agent chat',
-              })}
-            >
-              <EuiButtonIcon
-                iconType="kqlFunction"
-                display="fill"
-                size="m"
-                onClick={expandConversation}
-                aria-label={i18n.translate(
-                  'xpack.search.gettingStarted.chat.conversationPrompt.send',
-                  {
-                    defaultMessage: 'Open the AI agent chat',
-                  }
-                )}
-                data-test-subj="searchGettingStartedChatPromptSend"
-              />
-            </EuiToolTip>
-          </div>
-        </ConversationInputShell>
-      </div>
-      {isOverlayVisible ? (
-        <div
-          css={[
-            ConversationOverlayBaseStyles,
-            !isConversationOverlayOpen && launcherRect
-              ? ConversationOverlayOpeningStyle(launcherRect)
-              : ConversationOverlayOpenStyle,
-          ]}
-          data-test-subj="searchGettingStartedChatNewConversationOverlay"
-        >
-          <div css={ConversationStyle(isConversationOverlayOpen)}>
-            <EmbeddableConversation
-              sessionTag="search-getting-started"
-              onClose={collapseConversation}
-              ariaLabelledBy="search-getting-started-embeddable-conversation"
-            />
-          </div>
         </div>
-      ) : null}
-    </>
+      </ConversationInputShell>
+    </div>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -12,6 +12,7 @@ import { ConversationInputShell } from '@kbn/agent-builder-plugin/public';
 import { useKibana } from '../../hooks/use_kibana';
 
 import {
+  CONVERSATION_ANIMATION_MS,
   ConversationOverlayBaseStyles,
   ConversationOverlayOpeningStyle,
   ConversationOverlayOpenStyle,
@@ -20,8 +21,6 @@ import {
   NewConversationSendButton,
   NewConversationContainer,
 } from './styles';
-
-const CONVERSATION_ANIMATION_MS = 500; // 500ms euiTheme.animation.extraSlow
 
 enum ConversationPhase {
   Closed = 'closed',
@@ -37,11 +36,6 @@ export const ConversationPrompt = () => {
   const promptLauncherRef = useRef<HTMLDivElement>(null);
   const [launcherRect, setLauncherRect] = useState<DOMRect | null>(null);
   const [chatPhase, setChatPhase] = useState<ConversationPhase>(ConversationPhase.Closed);
-  const isOverlayVisible = chatPhase !== ConversationPhase.Closed;
-  const isAnimatingToFull = chatPhase === ConversationPhase.Open;
-  // agentBuilder === undefined handled by useGettingStartChatEnabled
-  const { EmbeddableConversation } = agentBuilder!;
-
   const expandConversation = useCallback(() => {
     if (chatPhase !== ConversationPhase.Closed) return;
     if (promptLauncherRef.current) {
@@ -64,6 +58,11 @@ export const ConversationPrompt = () => {
     }, CONVERSATION_ANIMATION_MS);
   }, [chatPhase]);
 
+  const isOverlayVisible = chatPhase !== ConversationPhase.Closed;
+  const isConversationOverlayOpen = chatPhase === ConversationPhase.Open;
+  // agentBuilder === undefined handled by useGettingStartChatEnabled
+  const { EmbeddableConversation } = agentBuilder!;
+
   return (
     <>
       <div css={NewConversationContainer}>
@@ -74,9 +73,7 @@ export const ConversationPrompt = () => {
               'xpack.search.gettingStarted.chat.conversationPrompt.placeholder',
               { defaultMessage: 'How can I help you get started today?' }
             )}
-            aria-label={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.aria', {
-              defaultMessage: 'Open the AI agent chat',
-            })}
+            aria-hidden
             readOnly
             rows={3}
             onFocus={expandConversation}
@@ -106,14 +103,14 @@ export const ConversationPrompt = () => {
         <div
           css={[
             ConversationOverlayBaseStyles,
-            !isAnimatingToFull && launcherRect
+            !isConversationOverlayOpen && launcherRect
               ? ConversationOverlayOpeningStyle(launcherRect)
               : ConversationOverlayOpenStyle,
           ]}
           data-test-subj="searchGettingStartedChatNewConversationOverlay"
         >
-          <div css={ConversationStyle(isAnimatingToFull)}>
-            {isAnimatingToFull && (
+          <div css={ConversationStyle(isConversationOverlayOpen)}>
+            {isOverlayVisible && (
               <EmbeddableConversation
                 sessionTag="search-getting-started"
                 onClose={collapseConversation}

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -67,17 +67,27 @@ export const ConversationPrompt = () => {
           onKeyDown={onInputKeyDown}
         />
         <div css={NewConversationSendButton}>
-          <EuiButtonIcon
-            iconType="kqlFunction"
-            display="fill"
-            size="m"
-            disabled={initialMessage.trim().length === 0}
-            onClick={openConversation}
-            aria-label={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.send', {
+          <EuiToolTip
+            content={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.send', {
               defaultMessage: 'Open the AI assistant chat',
             })}
-            data-test-subj="searchGettingStartedChatPromptSend"
-          />
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              iconType="kqlFunction"
+              display="fill"
+              size="m"
+              disabled={initialMessage.trim().length === 0}
+              onClick={openConversation}
+              aria-label={i18n.translate(
+                'xpack.search.gettingStarted.chat.conversationPrompt.send',
+                {
+                  defaultMessage: 'Open the AI assistant chat',
+                }
+              )}
+              data-test-subj="searchGettingStartedChatPromptSend"
+            />
+          </EuiToolTip>
         </div>
       </ConversationInputShell>
     </div>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+import { EuiButtonIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { ConversationInputShell } from '@kbn/agent-builder-plugin/public';
+import { useKibana } from '../../hooks/use_kibana';
+
+import {
+  ConversationOverlayBaseStyles,
+  ConversationOverlayOpeningStyle,
+  ConversationOverlayOpenStyle,
+  ConversationStyle,
+  NewConversationTextArea,
+  NewConversationSendButton,
+  NewConversationContainer,
+} from './styles';
+
+const CONVERSATION_ANIMATION_MS = 500; // 500ms euiTheme.animation.extraSlow
+
+enum ConversationPhase {
+  Closed = 'closed',
+  Opening = 'opening',
+  Open = 'open',
+  Closing = 'closing',
+}
+
+export const ConversationPrompt = () => {
+  const {
+    services: { agentBuilder },
+  } = useKibana();
+  const promptLauncherRef = useRef<HTMLDivElement>(null);
+  const [launcherRect, setLauncherRect] = useState<DOMRect | null>(null);
+  const [chatPhase, setChatPhase] = useState<ConversationPhase>(ConversationPhase.Closed);
+  const isOverlayVisible = chatPhase !== ConversationPhase.Closed;
+  const isAnimatingToFull = chatPhase === ConversationPhase.Open;
+  // agentBuilder === undefined handled by useGettingStartChatEnabled
+  const { EmbeddableConversation } = agentBuilder!;
+
+  const expandConversation = useCallback(() => {
+    if (chatPhase !== ConversationPhase.Closed) return;
+    if (promptLauncherRef.current) {
+      setLauncherRect(promptLauncherRef.current.getBoundingClientRect());
+    }
+    setChatPhase(ConversationPhase.Opening);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => setChatPhase(ConversationPhase.Open));
+    });
+  }, [chatPhase]);
+  const collapseConversation = useCallback(() => {
+    if (chatPhase !== ConversationPhase.Open) return;
+    if (promptLauncherRef.current) {
+      setLauncherRect(promptLauncherRef.current.getBoundingClientRect());
+    }
+    setChatPhase(ConversationPhase.Closing);
+    setTimeout(() => {
+      setChatPhase(ConversationPhase.Closed);
+      setLauncherRect(null);
+    }, CONVERSATION_ANIMATION_MS);
+  }, [chatPhase]);
+
+  return (
+    <>
+      <div css={NewConversationContainer}>
+        <ConversationInputShell ref={promptLauncherRef} css={NewConversationTextArea}>
+          <textarea
+            data-test-subj="searchGettingStartedChatPromptInput"
+            placeholder={i18n.translate(
+              'xpack.search.gettingStarted.chat.conversationPrompt.placeholder',
+              { defaultMessage: 'How can I help you get started today?' }
+            )}
+            aria-label={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.aria', {
+              defaultMessage: 'Open the AI agent chat',
+            })}
+            readOnly
+            rows={3}
+            onFocus={expandConversation}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              expandConversation();
+            }}
+          />
+          <div css={NewConversationSendButton}>
+            <EuiButtonIcon
+              iconType="kqlFunction"
+              display="fill"
+              size="m"
+              onClick={expandConversation}
+              aria-label={i18n.translate(
+                'xpack.search.gettingStarted.chat.conversationPrompt.send',
+                {
+                  defaultMessage: 'Open the AI agent chat',
+                }
+              )}
+              data-test-subj="searchGettingStartedChatPromptSend"
+            />
+          </div>
+        </ConversationInputShell>
+      </div>
+      {isOverlayVisible ? (
+        <div
+          css={[
+            ConversationOverlayBaseStyles,
+            !isAnimatingToFull && launcherRect
+              ? ConversationOverlayOpeningStyle(launcherRect)
+              : ConversationOverlayOpenStyle,
+          ]}
+          data-test-subj="searchGettingStartedChatNewConversationOverlay"
+        >
+          <div css={ConversationStyle(isAnimatingToFull)}>
+            {isAnimatingToFull && (
+              <EmbeddableConversation
+                sessionTag="search-getting-started"
+                onClose={collapseConversation}
+                ariaLabelledBy="search-getting-started-embeddable-conversation"
+              />
+            )}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -85,19 +85,25 @@ export const ConversationPrompt = () => {
             }}
           />
           <div css={NewConversationSendButton}>
-            <EuiButtonIcon
-              iconType="kqlFunction"
-              display="fill"
-              size="m"
-              onClick={expandConversation}
-              aria-label={i18n.translate(
-                'xpack.search.gettingStarted.chat.conversationPrompt.send',
-                {
-                  defaultMessage: 'Open the AI agent chat',
-                }
-              )}
-              data-test-subj="searchGettingStartedChatPromptSend"
-            />
+            <EuiToolTip
+              content={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.send', {
+                defaultMessage: 'Open the AI agent chat',
+              })}
+            >
+              <EuiButtonIcon
+                iconType="kqlFunction"
+                display="fill"
+                size="m"
+                onClick={expandConversation}
+                aria-label={i18n.translate(
+                  'xpack.search.gettingStarted.chat.conversationPrompt.send',
+                  {
+                    defaultMessage: 'Open the AI agent chat',
+                  }
+                )}
+                data-test-subj="searchGettingStartedChatPromptSend"
+              />
+            </EuiToolTip>
           </div>
         </ConversationInputShell>
       </div>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -42,6 +42,8 @@ export const ConversationPrompt = () => {
       setLauncherRect(promptLauncherRef.current.getBoundingClientRect());
     }
     setChatPhase(ConversationPhase.Opening);
+    // Two rAF calls: the first lets the browser paint the Opening state (small rect),
+    // and the second triggers the transition to Open so CSS animates between them.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => setChatPhase(ConversationPhase.Open));
     });
@@ -110,13 +112,11 @@ export const ConversationPrompt = () => {
           data-test-subj="searchGettingStartedChatNewConversationOverlay"
         >
           <div css={ConversationStyle(isConversationOverlayOpen)}>
-            {isOverlayVisible && (
-              <EmbeddableConversation
-                sessionTag="search-getting-started"
-                onClose={collapseConversation}
-                ariaLabelledBy="search-getting-started-embeddable-conversation"
-              />
-            )}
+            <EmbeddableConversation
+              sessionTag="search-getting-started"
+              onClose={collapseConversation}
+              ariaLabelledBy="search-getting-started-embeddable-conversation"
+            />
           </div>
         </div>
       ) : null}

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/conversation_prompt.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { EuiButtonIcon, keys } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip, keys } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
@@ -68,9 +68,12 @@ export const ConversationPrompt = () => {
         />
         <div css={NewConversationSendButton}>
           <EuiToolTip
-            content={i18n.translate('xpack.search.gettingStarted.chat.conversationPrompt.send', {
-              defaultMessage: 'Open the AI assistant chat',
-            })}
+            content={i18n.translate(
+              'xpack.search.gettingStarted.chat.conversationPrompt.send.tooltip',
+              {
+                defaultMessage: 'Open the AI assistant chat',
+              }
+            )}
             disableScreenReaderOutput
           >
             <EuiButtonIcon

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
@@ -12,7 +12,7 @@ import { layoutVar } from '@kbn/core-chrome-layout-constants';
 export function ChatContentSeparator({ euiTheme }: UseEuiTheme) {
   return css({
     borderRight: euiTheme.border.thin,
-    [`@media (max-width: ${euiTheme.breakpoint.m}px)`]: {
+    [`@media (max-width: ${euiTheme.breakpoint.l}px)`]: {
       borderRight: 'none',
     },
   });
@@ -49,12 +49,18 @@ export const NewConversationContainer = ({ euiTheme }: UseEuiTheme) =>
     paddingRight: euiTheme.size.l,
   });
 
-export const ChatColumnsGrid = css({ gridTemplateColumns: '4fr 2fr' });
+export const ChatColumnsGrid = ({ euiTheme }: UseEuiTheme) =>
+  css({
+    gridTemplateColumns: '4fr 2fr',
+    [`@media (max-width: ${euiTheme.breakpoint.l}px)`]: {
+      gridTemplateColumns: '1fr',
+    },
+  });
 
 export const ChatStretchedFlexItem = ({ euiTheme }: UseEuiTheme) =>
   css({
     alignSelf: 'stretch',
-    [`@media (max-width: ${euiTheme.breakpoint.m}px)`]: {
+    [`@media (max-width: ${euiTheme.breakpoint.l}px)`]: {
       alignSelf: 'flex-start',
     },
   });
@@ -96,14 +102,16 @@ export const ConversationOverlayOpenStyle = ({ euiTheme }: UseEuiTheme) =>
     borderColor: 'transparent',
   });
 
-export const ConversationOverlayOpeningStyle = (promptLaunchRect: DOMRect) =>
-  css({
-    top: `${promptLaunchRect.top}px`,
-    left: `${promptLaunchRect.left}px`,
-    width: `${promptLaunchRect.width}px`,
-    height: `${promptLaunchRect.height}px`,
-    borderRadius: 16,
-  });
+export const ConversationOverlayOpeningStyle =
+  (promptLaunchRect: DOMRect) =>
+  ({ euiTheme }: UseEuiTheme) =>
+    css({
+      top: `${promptLaunchRect.top}px`,
+      left: `${promptLaunchRect.left}px`,
+      width: `${promptLaunchRect.width}px`,
+      height: `${promptLaunchRect.height}px`,
+      borderRadius: euiTheme.size.base,
+    });
 
 export const ConversationStyle =
   (isAnimatingToFull: boolean) =>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
@@ -7,7 +7,6 @@
 
 import { css } from '@emotion/react';
 import { euiFontSizeFromScale, euiLineHeightFromBaseline, type UseEuiTheme } from '@elastic/eui';
-import { layoutVar } from '@kbn/core-chrome-layout-constants';
 
 export function ChatContentSeparator({ euiTheme }: UseEuiTheme) {
   return css({
@@ -20,21 +19,21 @@ export function ChatContentSeparator({ euiTheme }: UseEuiTheme) {
 
 export function NewConversationTextArea({ euiTheme }: UseEuiTheme) {
   return css({
+    flex: 1,
     cursor: 'text',
-    textarea: {
-      flex: 1,
-      cursor: 'text',
-      background: 'transparent',
-      border: 'none',
-      outline: 'none',
-      resize: 'none',
-      fontSize: euiFontSizeFromScale('m', euiTheme),
-      lineHeight: euiLineHeightFromBaseline('m', euiTheme),
-      color: euiTheme.colors.textParagraph,
-      fontFamily: 'inherit',
-      '&::placeholder': {
-        color: euiTheme.colors.textDisabled,
-      },
+    background: 'transparent',
+    border: 'none',
+    outline: 'none',
+    resize: 'none',
+    fontSize: euiFontSizeFromScale('m', euiTheme),
+    lineHeight: euiLineHeightFromBaseline('m', euiTheme),
+    color: euiTheme.colors.textParagraph,
+    fontFamily: 'inherit',
+    '&::placeholder': {
+      color: euiTheme.colors.textDisabled,
+    },
+    ':focus:focus-visible': {
+      outlineStyle: 'none',
     },
   });
 }
@@ -64,63 +63,3 @@ export const ChatStretchedFlexItem = ({ euiTheme }: UseEuiTheme) =>
       alignSelf: 'flex-start',
     },
   });
-
-// Constant for animation time, used to transition state in component.
-// Defined here to make it easier to ensure it stays in sync with animation duration
-// used in the style without having to parse a string at runtime.
-export const CONVERSATION_ANIMATION_MS = 500; // 500ms euiTheme.animation.extraSlow
-export const ConversationOverlayBaseStyles = ({ euiTheme }: UseEuiTheme) => {
-  return css({
-    position: 'fixed',
-    zIndex: euiTheme.levels.flyout,
-    background: euiTheme.colors.emptyShade,
-    display: 'flex',
-    flexDirection: 'column',
-    overflow: 'hidden',
-    border: euiTheme.border.thin,
-    borderColor: euiTheme.colors.borderBaseSubdued,
-    transition: ['top', 'left', 'width', 'height', 'border-radius', 'border-color']
-      .map((p) => `${p} ${euiTheme.animation.extraSlow} ease`)
-      .join(', '),
-    willChange: 'top, left, width, height, border-radius, border-color',
-  });
-};
-
-export const ConversationOverlayOpenStyle = ({ euiTheme }: UseEuiTheme) =>
-  css({
-    top: layoutVar('application.content.top', '0px'),
-    left: `calc(var(--euiCollapsibleNavOffset, 0) + ${layoutVar(
-      'application.content.left',
-      '0px'
-    )})`,
-    width: `calc(100vw - var(--euiCollapsibleNavOffset, 0) - ${layoutVar(
-      'application.content.left',
-      '0px'
-    )} - ${layoutVar('application.content.right', '0px')})`,
-    height: `calc(${layoutVar('application.content.height', '100vh')} - ${euiTheme.size.xxl})`,
-    borderRadius: 0,
-    borderColor: 'transparent',
-  });
-
-export const ConversationOverlayOpeningStyle =
-  (promptLaunchRect: DOMRect) =>
-  ({ euiTheme }: UseEuiTheme) =>
-    css({
-      top: `${promptLaunchRect.top}px`,
-      left: `${promptLaunchRect.left}px`,
-      width: `${promptLaunchRect.width}px`,
-      height: `${promptLaunchRect.height}px`,
-      borderRadius: euiTheme.size.base,
-    });
-
-export const ConversationStyle =
-  (isAnimatingToFull: boolean) =>
-  ({ euiTheme }: UseEuiTheme) =>
-    css({
-      flex: 1,
-      minHeight: 0,
-      display: 'flex',
-      flexDirection: 'column',
-      transition: `opacity ${euiTheme.animation.extraSlow} ease`,
-      opacity: isAnimatingToFull ? 1 : 0,
-    });

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
@@ -12,28 +12,31 @@ import { layoutVar } from '@kbn/core-chrome-layout-constants';
 export function ChatContentSeparator({ euiTheme }: UseEuiTheme) {
   return css({
     borderRight: euiTheme.border.thin,
+    [`@media (max-width: ${euiTheme.breakpoint.m}px)`]: {
+      borderRight: 'none',
+    },
   });
 }
 
 export function NewConversationTextArea({ euiTheme }: UseEuiTheme) {
-  return css`
-    cursor: text;
-    textarea {
-      flex: 1;
-      cursor: text;
-      background: transparent;
-      border: none;
-      outline: none;
-      resize: none;
-      font-size: ${euiFontSizeFromScale('m', euiTheme)};
-      line-height: ${euiLineHeightFromBaseline('m', euiTheme)};
-      color: ${euiTheme.colors.textParagraph};
-      font-family: inherit;
-      &::placeholder {
-        color: ${euiTheme.colors.textDisabled};
-      }
-    }
-  `;
+  return css({
+    cursor: 'text',
+    textarea: {
+      flex: 1,
+      cursor: 'text',
+      background: 'transparent',
+      border: 'none',
+      outline: 'none',
+      resize: 'none',
+      fontSize: euiFontSizeFromScale('m', euiTheme),
+      lineHeight: euiLineHeightFromBaseline('m', euiTheme),
+      color: euiTheme.colors.textParagraph,
+      fontFamily: 'inherit',
+      '&::placeholder': {
+        color: euiTheme.colors.textDisabled,
+      },
+    },
+  });
 }
 
 export const NewConversationSendButton = css({
@@ -46,50 +49,70 @@ export const NewConversationContainer = ({ euiTheme }: UseEuiTheme) =>
     paddingRight: euiTheme.size.l,
   });
 
-export const ConversationOverlayBaseStyles = ({ euiTheme }: UseEuiTheme) => css`
-  position: fixed;
-  z-index: ${euiTheme.levels.flyout};
-  background: ${euiTheme.colors.emptyShade};
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  border: ${euiTheme.border.thin};
-  border-color: ${euiTheme.colors.borderBaseSubdued};
-  transition: top ${euiTheme.animation.extraSlow} ease, left ${euiTheme.animation.extraSlow} ease,
-    width ${euiTheme.animation.extraSlow} ease, height ${euiTheme.animation.extraSlow} ease,
-    border-radius ${euiTheme.animation.extraSlow} ease,
-    border-color ${euiTheme.animation.extraSlow} ease;
-  will-change: top, left, width, height, border-radius;
-`;
+export const ChatColumnsGrid = css({ gridTemplateColumns: '4fr 2fr' });
 
-export const ConversationOverlayOpenStyle = ({ euiTheme }: UseEuiTheme) => css`
-  top: ${layoutVar('application.content.top', '0px')};
-  left: calc(var(--euiCollapsibleNavOffset, 0) + ${layoutVar('application.content.left', '0px')});
-  width: calc(
-    100vw - var(--euiCollapsibleNavOffset, 0) - ${layoutVar('application.content.left', '0px')} -
-      ${layoutVar('application.content.right', '0px')}
-  );
-  height: calc(${layoutVar('application.content.height', '100vh')} - ${euiTheme.size.xxl});
-  border-radius: 0;
-  border-color: transparent;
-`;
+export const ChatStretchedFlexItem = ({ euiTheme }: UseEuiTheme) =>
+  css({
+    alignSelf: 'stretch',
+    [`@media (max-width: ${euiTheme.breakpoint.m}px)`]: {
+      alignSelf: 'flex-start',
+    },
+  });
 
-export const ConversationOverlayOpeningStyle = (promptLaunchRect: DOMRect) => css`
-  top: ${promptLaunchRect.top}px;
-  left: ${promptLaunchRect.left}px;
-  width: ${promptLaunchRect.width}px;
-  height: ${promptLaunchRect.height}px;
-  border-radius: 16px;
-`;
+// Constant for animation time, used to transition state in component.
+// Defined here to make it easier to ensure it stays in sync with animation duration
+// used in the style without having to parse a string at runtime.
+export const CONVERSATION_ANIMATION_MS = 500; // 500ms euiTheme.animation.extraSlow
+export const ConversationOverlayBaseStyles = ({ euiTheme }: UseEuiTheme) => {
+  return css({
+    position: 'fixed',
+    zIndex: euiTheme.levels.flyout,
+    background: euiTheme.colors.emptyShade,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    border: euiTheme.border.thin,
+    borderColor: euiTheme.colors.borderBaseSubdued,
+    transition: ['top', 'left', 'width', 'height', 'border-radius', 'border-color']
+      .map((p) => `${p} ${euiTheme.animation.extraSlow} ease`)
+      .join(', '),
+    willChange: 'top, left, width, height, border-radius, border-color',
+  });
+};
+
+export const ConversationOverlayOpenStyle = ({ euiTheme }: UseEuiTheme) =>
+  css({
+    top: layoutVar('application.content.top', '0px'),
+    left: `calc(var(--euiCollapsibleNavOffset, 0) + ${layoutVar(
+      'application.content.left',
+      '0px'
+    )})`,
+    width: `calc(100vw - var(--euiCollapsibleNavOffset, 0) - ${layoutVar(
+      'application.content.left',
+      '0px'
+    )} - ${layoutVar('application.content.right', '0px')})`,
+    height: `calc(${layoutVar('application.content.height', '100vh')} - ${euiTheme.size.xxl})`,
+    borderRadius: 0,
+    borderColor: 'transparent',
+  });
+
+export const ConversationOverlayOpeningStyle = (promptLaunchRect: DOMRect) =>
+  css({
+    top: `${promptLaunchRect.top}px`,
+    left: `${promptLaunchRect.left}px`,
+    width: `${promptLaunchRect.width}px`,
+    height: `${promptLaunchRect.height}px`,
+    borderRadius: 16,
+  });
 
 export const ConversationStyle =
   (isAnimatingToFull: boolean) =>
   ({ euiTheme }: UseEuiTheme) =>
-    css`
-      flex: 1;
-      min-height: 0;
-      display: flex;
-      flex-direction: column;
-      transition: opacity ${euiTheme.animation.extraSlow} ease;
-      opacity: ${isAnimatingToFull ? 1 : 0};
-    `;
+    css({
+      flex: 1,
+      minHeight: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      transition: `opacity ${euiTheme.animation.extraSlow} ease`,
+      opacity: isAnimatingToFull ? 1 : 0,
+    });

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/chat/styles.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { css } from '@emotion/react';
+import { euiFontSizeFromScale, euiLineHeightFromBaseline, type UseEuiTheme } from '@elastic/eui';
+import { layoutVar } from '@kbn/core-chrome-layout-constants';
+
+export function ChatContentSeparator({ euiTheme }: UseEuiTheme) {
+  return css({
+    borderRight: euiTheme.border.thin,
+  });
+}
+
+export function NewConversationTextArea({ euiTheme }: UseEuiTheme) {
+  return css`
+    cursor: text;
+    textarea {
+      flex: 1;
+      cursor: text;
+      background: transparent;
+      border: none;
+      outline: none;
+      resize: none;
+      font-size: ${euiFontSizeFromScale('m', euiTheme)};
+      line-height: ${euiLineHeightFromBaseline('m', euiTheme)};
+      color: ${euiTheme.colors.textParagraph};
+      font-family: inherit;
+      &::placeholder {
+        color: ${euiTheme.colors.textDisabled};
+      }
+    }
+  `;
+}
+
+export const NewConversationSendButton = css({
+  display: 'flex',
+  justifyContent: 'flex-end',
+});
+
+export const NewConversationContainer = ({ euiTheme }: UseEuiTheme) =>
+  css({
+    paddingRight: euiTheme.size.l,
+  });
+
+export const ConversationOverlayBaseStyles = ({ euiTheme }: UseEuiTheme) => css`
+  position: fixed;
+  z-index: ${euiTheme.levels.flyout};
+  background: ${euiTheme.colors.emptyShade};
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: ${euiTheme.border.thin};
+  border-color: ${euiTheme.colors.borderBaseSubdued};
+  transition: top ${euiTheme.animation.extraSlow} ease, left ${euiTheme.animation.extraSlow} ease,
+    width ${euiTheme.animation.extraSlow} ease, height ${euiTheme.animation.extraSlow} ease,
+    border-radius ${euiTheme.animation.extraSlow} ease,
+    border-color ${euiTheme.animation.extraSlow} ease;
+  will-change: top, left, width, height, border-radius;
+`;
+
+export const ConversationOverlayOpenStyle = ({ euiTheme }: UseEuiTheme) => css`
+  top: ${layoutVar('application.content.top', '0px')};
+  left: calc(var(--euiCollapsibleNavOffset, 0) + ${layoutVar('application.content.left', '0px')});
+  width: calc(
+    100vw - var(--euiCollapsibleNavOffset, 0) - ${layoutVar('application.content.left', '0px')} -
+      ${layoutVar('application.content.right', '0px')}
+  );
+  height: calc(${layoutVar('application.content.height', '100vh')} - ${euiTheme.size.xxl});
+  border-radius: 0;
+  border-color: transparent;
+`;
+
+export const ConversationOverlayOpeningStyle = (promptLaunchRect: DOMRect) => css`
+  top: ${promptLaunchRect.top}px;
+  left: ${promptLaunchRect.left}px;
+  width: ${promptLaunchRect.width}px;
+  height: ${promptLaunchRect.height}px;
+  border-radius: 16px;
+`;
+
+export const ConversationStyle =
+  (isAnimatingToFull: boolean) =>
+  ({ euiTheme }: UseEuiTheme) =>
+    css`
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      transition: opacity ${euiTheme.animation.extraSlow} ease;
+      opacity: ${isAnimatingToFull ? 1 : 0};
+    `;

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/deployment_status_badges.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/deployment_status_badges.tsx
@@ -20,7 +20,11 @@ export const DeploymentStatusBadges: React.FC = () => {
   const isTrial = cloud?.isInTrial() ?? false;
 
   return (
-    <EuiFlexGroup alignItems="center" justifyContent={isTrial ? 'spaceBetween' : 'flexEnd'}>
+    <EuiFlexGroup
+      alignItems="center"
+      justifyContent={isTrial ? 'spaceBetween' : 'flexEnd'}
+      responsive={false}
+    >
       {isTrial && cloud && (
         <EuiFlexItem grow={false}>
           <TrialUsageBadge cloud={cloud} />

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/deployment_status_badges.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/deployment_status_badges.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { KibanaVersionBadge, TrialUsageBadge } from '@kbn/search-shared-ui';
+
+import { docLinks } from '../../common/doc_links';
+import { useKibana } from '../../hooks/use_kibana';
+
+export const DeploymentStatusBadges: React.FC = () => {
+  const {
+    services: { cloud, kibanaVersion },
+  } = useKibana();
+  const isTrial = cloud?.isInTrial() ?? false;
+
+  return (
+    <EuiFlexGroup alignItems="center" justifyContent={isTrial ? 'spaceBetween' : 'flexEnd'}>
+      {isTrial && cloud && (
+        <EuiFlexItem grow={false}>
+          <TrialUsageBadge cloud={cloud} />
+        </EuiFlexItem>
+      )}
+      <EuiFlexItem grow={false}>
+        <KibanaVersionBadge
+          docLink={
+            cloud?.isServerlessEnabled
+              ? docLinks.serverlessReleaseNotes
+              : cloud?.isCloudEnabled
+              ? docLinks.hostedCloudReleaseNotes
+              : docLinks.releaseNotes
+          }
+          kibanaVersion={
+            !cloud?.isServerlessEnabled
+              ? `v${kibanaVersion}`
+              : i18n.translate('xpack.search.gettingStarted.changelog', {
+                  defaultMessage: 'Changelog',
+                })
+          }
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/header/index.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/header/index.tsx
@@ -15,18 +15,12 @@ import {
   useCurrentEuiBreakpoint,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { KibanaVersionBadge, TrialUsageBadge } from '@kbn/search-shared-ui';
 
-import { docLinks } from '../../common/doc_links';
-import { useKibana } from '../../hooks/use_kibana';
 import { ElasticsearchConnectionDetails } from '../elasticsearch_connection_details';
+import { DeploymentStatusBadges } from './deployment_status_badges';
 
 export const SearchGettingStartedHeader: React.FC = () => {
   const currentBreakpoint = useCurrentEuiBreakpoint();
-  const {
-    services: { cloud, kibanaVersion },
-  } = useKibana();
-  const isTrial = cloud?.isInTrial() ?? false;
 
   return (
     <EuiFlexGroup gutterSize={currentBreakpoint === 'xl' ? 'l' : 'xl'} direction="column">
@@ -37,31 +31,7 @@ export const SearchGettingStartedHeader: React.FC = () => {
             alignSelf: 'stretch',
           })}
         >
-          <EuiFlexGroup alignItems="center" justifyContent={isTrial ? 'spaceBetween' : 'flexEnd'}>
-            {isTrial && cloud && (
-              <EuiFlexItem grow={false}>
-                <TrialUsageBadge cloud={cloud} />
-              </EuiFlexItem>
-            )}
-            <EuiFlexItem grow={false}>
-              <KibanaVersionBadge
-                docLink={
-                  cloud?.isServerlessEnabled
-                    ? docLinks.serverlessReleaseNotes
-                    : cloud?.isCloudEnabled
-                    ? docLinks.hostedCloudReleaseNotes
-                    : docLinks.releaseNotes
-                }
-                kibanaVersion={
-                  !cloud?.isServerlessEnabled
-                    ? `v${kibanaVersion}`
-                    : i18n.translate('xpack.search.gettingStarted.changelog', {
-                        defaultMessage: 'Changelog',
-                      })
-                }
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          <DeploymentStatusBadges />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiTitle size="l">

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -16,11 +16,9 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { GETTING_STARTED_SESSIONSTORAGE_KEY } from '@kbn/search-shared-ui';
 
 import { useKibana } from '../hooks/use_kibana';
-import { useUsageTracker } from '../contexts/usage_tracker_context';
-import { AnalyticsEvents } from '../../common';
+import { useGettingStartedLoaded } from '../hooks/use_getting_started_loaded';
 import { SearchGettingStartedPageTemplate } from '../layout/page_template';
 import { ConsoleTutorialsGroup } from './tutorials/console_tutorials_group';
 import { AgentInstallSection } from './agent_install/agent_install';
@@ -31,11 +29,7 @@ export const SearchGettingStartedPage: React.FC = () => {
   const {
     services: { application },
   } = useKibana();
-  const usageTracker = useUsageTracker();
-  useEffect(() => {
-    usageTracker.load(AnalyticsEvents.gettingStartedLoaded);
-    sessionStorage.setItem(GETTING_STARTED_SESSIONSTORAGE_KEY, 'true');
-  }, [usageTracker]);
+  useGettingStartedLoaded();
 
   return (
     <SearchGettingStartedPageTemplate>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started_chat.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started_chat.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
+import { EuiPageTemplate, EuiSpacer } from '@elastic/eui';
 import { GETTING_STARTED_SESSIONSTORAGE_KEY } from '@kbn/search-shared-ui';
 
 import { AnalyticsEvents } from '../../common';
@@ -24,8 +25,11 @@ export const SearchGettingStartedChatPage = () => {
 
   return (
     <SearchGettingStartedPageTemplate>
-      <ChatHeader />
-      <GettingStartedChatContent />
+      <EuiPageTemplate.Section data-test-subj="gettingStartedChatSection" grow alignment="center">
+        <ChatHeader />
+        <EuiSpacer size="l" />
+        <GettingStartedChatContent />
+      </EuiPageTemplate.Section>
     </SearchGettingStartedPageTemplate>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started_chat.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started_chat.tsx
@@ -6,12 +6,14 @@
  */
 
 import React, { useEffect } from 'react';
-import { EuiLoadingSpinner, EuiPageTemplate } from '@elastic/eui';
 import { GETTING_STARTED_SESSIONSTORAGE_KEY } from '@kbn/search-shared-ui';
 
 import { AnalyticsEvents } from '../../common';
 import { useUsageTracker } from '../contexts/usage_tracker_context';
 import { SearchGettingStartedPageTemplate } from '../layout/page_template';
+
+import { ChatHeader } from './chat/chat_header';
+import { GettingStartedChatContent } from './chat/chat_content';
 
 export const SearchGettingStartedChatPage = () => {
   const usageTracker = useUsageTracker();
@@ -22,9 +24,8 @@ export const SearchGettingStartedChatPage = () => {
 
   return (
     <SearchGettingStartedPageTemplate>
-      <EuiPageTemplate.Section data-test-subj="gettingStartedChat">
-        <EuiLoadingSpinner />
-      </EuiPageTemplate.Section>
+      <ChatHeader />
+      <GettingStartedChatContent />
     </SearchGettingStartedPageTemplate>
   );
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started_chat.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/search_getting_started_chat.tsx
@@ -5,23 +5,18 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { EuiPageTemplate, EuiSpacer } from '@elastic/eui';
-import { GETTING_STARTED_SESSIONSTORAGE_KEY } from '@kbn/search-shared-ui';
 
 import { AnalyticsEvents } from '../../common';
-import { useUsageTracker } from '../contexts/usage_tracker_context';
+import { useGettingStartedLoaded } from '../hooks/use_getting_started_loaded';
 import { SearchGettingStartedPageTemplate } from '../layout/page_template';
 
 import { ChatHeader } from './chat/chat_header';
 import { GettingStartedChatContent } from './chat/chat_content';
 
 export const SearchGettingStartedChatPage = () => {
-  const usageTracker = useUsageTracker();
-  useEffect(() => {
-    usageTracker.load(AnalyticsEvents.gettingStartedChatLoaded);
-    sessionStorage.setItem(GETTING_STARTED_SESSIONSTORAGE_KEY, 'true');
-  }, [usageTracker]);
+  useGettingStartedLoaded(AnalyticsEvents.gettingStartedChatLoaded);
 
   return (
     <SearchGettingStartedPageTemplate>

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_chat_enabled.test.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_chat_enabled.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useGettingStartChatEnabled } from './use_chat_enabled';
+import { useKibana } from './use_kibana';
+import { SEARCH_GETTING_STARTED_CHAT_FEATURE_FLAG } from '@kbn/search-shared-ui';
+
+jest.mock('./use_kibana');
+
+const mockUseKibana = useKibana as jest.Mock;
+
+const mockServices = (
+  overrides: Partial<{
+    agentBuilder: object | undefined;
+    isServerlessEnabled: boolean;
+    featureFlagValue: boolean;
+  }> = {}
+) => {
+  const agentBuilder = 'agentBuilder' in overrides ? overrides.agentBuilder : {};
+  const isServerlessEnabled = overrides.isServerlessEnabled ?? true;
+  const featureFlagValue = overrides.featureFlagValue ?? true;
+  mockUseKibana.mockReturnValue({
+    services: {
+      agentBuilder,
+      cloud: { isServerlessEnabled },
+      featureFlags: {
+        getBooleanValue: jest
+          .fn()
+          .mockImplementation((flag: string, defaultValue: boolean) =>
+            flag === SEARCH_GETTING_STARTED_CHAT_FEATURE_FLAG ? featureFlagValue : defaultValue
+          ),
+      },
+    },
+  });
+};
+
+describe('useGettingStartChatEnabled', () => {
+  it('returns true when serverless is enabled, agentBuilder is present, and feature flag is on', () => {
+    mockServices();
+
+    const { result } = renderHook(() => useGettingStartChatEnabled());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when cloud is not available', () => {
+    mockUseKibana.mockReturnValue({
+      services: {
+        agentBuilder: {},
+        cloud: undefined,
+        featureFlags: { getBooleanValue: jest.fn().mockReturnValue(true) },
+      },
+    });
+
+    const { result } = renderHook(() => useGettingStartChatEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when agentBuilder is not available', () => {
+    mockServices({ agentBuilder: undefined });
+
+    const { result } = renderHook(() => useGettingStartChatEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when cloud.isServerlessEnabled is false', () => {
+    mockServices({ isServerlessEnabled: false });
+
+    const { result } = renderHook(() => useGettingStartChatEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the feature flag is disabled', () => {
+    mockServices({ featureFlagValue: false });
+
+    const { result } = renderHook(() => useGettingStartChatEnabled());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_chat_enabled.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_chat_enabled.ts
@@ -10,11 +10,12 @@ import { useKibana } from './use_kibana';
 
 export const useGettingStartChatEnabled = () => {
   const {
-    services: { cloud, featureFlags },
+    services: { agentBuilder, cloud, featureFlags },
   } = useKibana();
 
+  if (!cloud || !agentBuilder) return false;
+
   return (
-    cloud &&
     cloud.isServerlessEnabled &&
     featureFlags.getBooleanValue(SEARCH_GETTING_STARTED_CHAT_FEATURE_FLAG, false)
   );

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_getting_started_loaded.test.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_getting_started_loaded.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { GETTING_STARTED_SESSIONSTORAGE_KEY } from '@kbn/search-shared-ui';
+import { useGettingStartedLoaded } from './use_getting_started_loaded';
+import { useUsageTracker } from '../contexts/usage_tracker_context';
+import { AnalyticsEvents } from '../../common';
+
+jest.mock('../contexts/usage_tracker_context', () => ({
+  useUsageTracker: jest.fn(),
+}));
+
+const mockUseUsageTracker = useUsageTracker as jest.Mock;
+
+describe('useGettingStartedLoaded', () => {
+  const mockLoad = jest.fn();
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockLoad.mockReset();
+    mockUseUsageTracker.mockReturnValue({ load: mockLoad, click: jest.fn(), count: jest.fn() });
+  });
+
+  it('fires gettingStartedLoaded by default', () => {
+    renderHook(() => useGettingStartedLoaded());
+
+    expect(mockLoad).toHaveBeenCalledWith(AnalyticsEvents.gettingStartedLoaded);
+  });
+
+  it('fires a custom event when one is provided', () => {
+    renderHook(() => useGettingStartedLoaded(AnalyticsEvents.gettingStartedChatLoaded));
+
+    expect(mockLoad).toHaveBeenCalledWith(AnalyticsEvents.gettingStartedChatLoaded);
+  });
+
+  it('sets the getting started session storage key', () => {
+    renderHook(() => useGettingStartedLoaded());
+
+    expect(sessionStorage.getItem(GETTING_STARTED_SESSIONSTORAGE_KEY)).toBe('true');
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_getting_started_loaded.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_getting_started_loaded.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { GETTING_STARTED_SESSIONSTORAGE_KEY } from '@kbn/search-shared-ui';
+import { AnalyticsEvents } from '../../common';
+import { useUsageTracker } from '../contexts/usage_tracker_context';
+
+export const useGettingStartedLoaded = (event: string = AnalyticsEvents.gettingStartedLoaded) => {
+  const usageTracker = useUsageTracker();
+  useEffect(() => {
+    usageTracker.load(event);
+    sessionStorage.setItem(GETTING_STARTED_SESSIONSTORAGE_KEY, 'true');
+  }, [usageTracker, event]);
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_kibana_url.test.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_kibana_url.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { getFallbackKibanaUrl, useKibanaUrl } from './use_kibana_url';
+import { useKibana } from './use_kibana';
+import { useSpaceId } from './use_space_id';
+
+jest.mock('./use_kibana');
+jest.mock('./use_space_id');
+
+const mockUseKibana = useKibana as jest.Mock;
+const mockUseSpaceId = useSpaceId as jest.Mock;
+
+const mockHttp = (publicBaseUrl: string | undefined, serverBasePath = '') => ({
+  basePath: {
+    publicBaseUrl,
+    serverBasePath,
+    get: jest.fn().mockReturnValue('/base'),
+  },
+});
+
+describe('getFallbackKibanaUrl', () => {
+  it('returns window.location.origin combined with the base path', () => {
+    const http = { basePath: { get: jest.fn().mockReturnValue('/base') } } as any;
+    expect(getFallbackKibanaUrl(http)).toBe(`${window.location.origin}/base`);
+  });
+
+  it('handles an empty base path', () => {
+    const http = { basePath: { get: jest.fn().mockReturnValue('') } } as any;
+    expect(getFallbackKibanaUrl(http)).toBe(window.location.origin);
+  });
+});
+
+describe('useKibanaUrl', () => {
+  describe('base URL priority', () => {
+    it('prefers publicBaseUrl over cloud.kibanaUrl', () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          http: mockHttp('https://public.example.com'),
+          cloud: { kibanaUrl: 'https://cloud.example.com' },
+        },
+      });
+      mockUseSpaceId.mockReturnValue('default');
+
+      const { result } = renderHook(() => useKibanaUrl());
+
+      expect(result.current.kibanaUrl).toBe('https://public.example.com');
+    });
+
+    it('falls back to cloud.kibanaUrl when publicBaseUrl is not set', () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          http: mockHttp(undefined),
+          cloud: { kibanaUrl: 'https://cloud.example.com' },
+        },
+      });
+      mockUseSpaceId.mockReturnValue('default');
+
+      const { result } = renderHook(() => useKibanaUrl());
+
+      expect(result.current.kibanaUrl).toBe('https://cloud.example.com');
+    });
+
+    it('falls back to getFallbackKibanaUrl when neither publicBaseUrl nor cloud are available', () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          http: mockHttp(undefined),
+          cloud: undefined,
+        },
+      });
+      mockUseSpaceId.mockReturnValue('default');
+
+      const { result } = renderHook(() => useKibanaUrl());
+
+      expect(result.current.kibanaUrl).toBe(`${window.location.origin}/base`);
+    });
+  });
+
+  describe('space path handling', () => {
+    it('appends the space path when the base URL has no explicit space identifier', () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          http: mockHttp('https://kibana.example.com'),
+          cloud: undefined,
+        },
+      });
+      mockUseSpaceId.mockReturnValue('my-space');
+
+      const { result } = renderHook(() => useKibanaUrl());
+
+      expect(result.current.kibanaUrl).toBe('https://kibana.example.com/s/my-space');
+    });
+
+    it('returns the base URL unchanged when it already contains an explicit space identifier', () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          http: mockHttp('https://kibana.example.com/s/existing-space'),
+          cloud: undefined,
+        },
+      });
+      mockUseSpaceId.mockReturnValue('existing-space');
+
+      const { result } = renderHook(() => useKibanaUrl());
+
+      expect(result.current.kibanaUrl).toBe('https://kibana.example.com/s/existing-space');
+    });
+
+    it('does not append a space path when spaceId is undefined', () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          http: mockHttp('https://kibana.example.com'),
+          cloud: undefined,
+        },
+      });
+      mockUseSpaceId.mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useKibanaUrl());
+
+      expect(result.current.kibanaUrl).toBe('https://kibana.example.com');
+    });
+
+    it('does not append a path for the default space', () => {
+      mockUseKibana.mockReturnValue({
+        services: {
+          http: mockHttp('https://kibana.example.com'),
+          cloud: undefined,
+        },
+      });
+      mockUseSpaceId.mockReturnValue('default');
+
+      const { result } = renderHook(() => useKibanaUrl());
+
+      expect(result.current.kibanaUrl).toBe('https://kibana.example.com');
+    });
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_kibana_url.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_kibana_url.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useMemo } from 'react';
+import type { HttpSetup } from '@kbn/core/public';
+import { getSpaceIdFromPath, addSpaceIdToPath } from '@kbn/spaces-plugin/common';
+import { useKibana } from './use_kibana';
+import { useSpaceId } from './use_space_id';
+
+export const useKibanaUrl = () => {
+  const {
+    services: { cloud, http },
+  } = useKibana();
+  const spaceId = useSpaceId();
+
+  const kibanaUrl = useMemo(() => {
+    const baseUrl = http.basePath.publicBaseUrl ?? cloud?.kibanaUrl ?? getFallbackKibanaUrl(http);
+
+    const pathname = new URL(baseUrl).pathname;
+    const serverBasePath = http.basePath.serverBasePath;
+    const { pathHasExplicitSpaceIdentifier } = getSpaceIdFromPath(pathname, serverBasePath);
+
+    if (!pathHasExplicitSpaceIdentifier) {
+      return addSpaceIdToPath(baseUrl, spaceId);
+    }
+
+    return baseUrl;
+  }, [cloud, http, spaceId]);
+
+  return { kibanaUrl };
+};
+
+export function getFallbackKibanaUrl(http: HttpSetup) {
+  return `${window.location.origin}${http.basePath.get()}`;
+}

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_mcp_url.test.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_mcp_url.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useAgentBuilderMcpUrl } from './use_mcp_url';
+import { useKibanaUrl } from './use_kibana_url';
+import { MCP_SERVER_PATH } from '@kbn/agent-builder-plugin/public';
+
+jest.mock('./use_kibana_url');
+
+const mockUseKibanaUrl = useKibanaUrl as jest.Mock;
+
+describe('useAgentBuilderMcpUrl', () => {
+  it('appends MCP_SERVER_PATH to the kibana URL', () => {
+    mockUseKibanaUrl.mockReturnValue({ kibanaUrl: 'https://kibana.example.com' });
+
+    const { result } = renderHook(() => useAgentBuilderMcpUrl());
+
+    expect(result.current).toBe(`https://kibana.example.com${MCP_SERVER_PATH}`);
+  });
+
+  it('handles a kibana URL with a space path', () => {
+    mockUseKibanaUrl.mockReturnValue({ kibanaUrl: 'https://kibana.example.com/s/my-space' });
+
+    const { result } = renderHook(() => useAgentBuilderMcpUrl());
+
+    expect(result.current).toBe(`https://kibana.example.com/s/my-space${MCP_SERVER_PATH}`);
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_mcp_url.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_mcp_url.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MCP_SERVER_PATH } from '@kbn/agent-builder-plugin/public';
+
+import { useKibanaUrl } from './use_kibana_url';
+
+export const useAgentBuilderMcpUrl = (): string => {
+  const { kibanaUrl } = useKibanaUrl();
+  const mcpServerUrl = `${kibanaUrl}${MCP_SERVER_PATH}`;
+  return mcpServerUrl;
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_mcp_url.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_mcp_url.ts
@@ -11,6 +11,5 @@ import { useKibanaUrl } from './use_kibana_url';
 
 export const useAgentBuilderMcpUrl = (): string => {
   const { kibanaUrl } = useKibanaUrl();
-  const mcpServerUrl = `${kibanaUrl}${MCP_SERVER_PATH}`;
-  return mcpServerUrl;
+  return `${kibanaUrl}${MCP_SERVER_PATH}`;
 };

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_space_id.test.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_space_id.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSpaceId } from './use_space_id';
+import { useKibana } from './use_kibana';
+
+jest.mock('./use_kibana');
+
+const mockUseKibana = useKibana as jest.Mock;
+
+describe('useSpaceId', () => {
+  it('returns undefined before the async call resolves', () => {
+    mockUseKibana.mockReturnValue({
+      services: {
+        spaces: {
+          // Never resolves so no state update fires during the synchronous assertion.
+          getActiveSpace: jest.fn().mockReturnValue(new Promise(() => {})),
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSpaceId());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the active space id after resolving', async () => {
+    mockUseKibana.mockReturnValue({
+      services: {
+        spaces: {
+          getActiveSpace: jest.fn().mockResolvedValue({ id: 'my-space' }),
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSpaceId());
+
+    await waitFor(() => expect(result.current).toBe('my-space'));
+  });
+
+  it('returns undefined when the spaces plugin is not available', async () => {
+    mockUseKibana.mockReturnValue({
+      services: { spaces: undefined },
+    });
+
+    const { result } = renderHook(() => useSpaceId());
+
+    expect(result.current).toBeUndefined();
+    // No async call is made when spaces is unavailable; state stays undefined.
+    await waitFor(() => expect(result.current).toBeUndefined());
+  });
+});

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_space_id.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_space_id.ts
@@ -16,7 +16,11 @@ export const useSpaceId = () => {
 
   useEffect(() => {
     if (spaces) {
-      spaces.getActiveSpace().then((space) => setSpaceId(space.id));
+      spaces
+        .getActiveSpace()
+        .then((space) => setSpaceId(space.id))
+        // ignore exceptions and default to no space
+        .catch(() => {});
     }
   }, [spaces]);
 

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_space_id.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_space_id.ts
@@ -12,7 +12,7 @@ export const useSpaceId = () => {
   const {
     services: { spaces },
   } = useKibana();
-  const [spaceId, setSpaceId] = useState<string>('');
+  const [spaceId, setSpaceId] = useState<string | undefined>();
 
   useEffect(() => {
     if (spaces) {

--- a/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_space_id.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/hooks/use_space_id.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useState, useEffect } from 'react';
+
+import { useKibana } from './use_kibana';
+
+export const useSpaceId = () => {
+  const {
+    services: { spaces },
+  } = useKibana();
+  const [spaceId, setSpaceId] = useState<string>('');
+
+  useEffect(() => {
+    if (spaces) {
+      spaces.getActiveSpace().then((space) => setSpaceId(space.id));
+    }
+  }, [spaces]);
+
+  return spaceId;
+};

--- a/x-pack/solutions/search/plugins/search_getting_started/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/types.ts
@@ -13,6 +13,7 @@ import type { CloudStart } from '@kbn/cloud-plugin/public';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchGettingStartedPluginSetup {}
@@ -27,6 +28,7 @@ export interface SearchGettingStartedAppPluginStartDependencies {
   searchNavigation?: SearchNavigationPluginStart;
   serverless?: ServerlessPluginStart;
   share: SharePluginStart;
+  spaces?: SpacesPluginStart;
 }
 
 export type SearchGettingStartedServicesContextDeps =

--- a/x-pack/solutions/search/plugins/search_getting_started/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_getting_started/tsconfig.json
@@ -37,7 +37,10 @@
     "@kbn/agent-builder-server",
     "@kbn/scout-search",
     "@kbn/search-agent",
-    "@kbn/shared-ux-ai-components"
+    "@kbn/shared-ux-ai-components",
+    "@kbn/agent-builder-plugin",
+    "@kbn/core-chrome-layout-constants",
+    "@kbn/spaces-plugin"
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/solutions/search/plugins/search_getting_started/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_getting_started/tsconfig.json
@@ -39,8 +39,9 @@
     "@kbn/search-agent",
     "@kbn/shared-ux-ai-components",
     "@kbn/agent-builder-plugin",
-    "@kbn/core-chrome-layout-constants",
-    "@kbn/spaces-plugin"
+    "@kbn/spaces-plugin",
+    "@kbn/deeplinks-agent-builder",
+    "@kbn/agent-builder-common"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
## Summary

Implementing a chat first approach for the search solution getting started page.

Note: this page is only visible when the feature flag is enabled, which it is currently off for everyone.

### Screenshots
<img width="1465" height="810" alt="image" src="https://github.com/user-attachments/assets/5d4d872d-6f9d-4bdf-85e9-b3661b5a4b67" />
<img width="1465" height="810" alt="image" src="https://github.com/user-attachments/assets/41af62c0-f95a-4bbd-bbe5-0dd7fe76023f" />
<img width="1465" height="810" alt="image" src="https://github.com/user-attachments/assets/b7722ab3-6b1f-478c-beb7-4e2966f3a2bb" />

### Testing

1. Run Kibana with serverless elasticsearch & eis enabled
2. Enabled the feature flag in kibana.dev.yaml:
```yaml
feature_flags.overrides:
  searchSolution.gettingStartedChatEnabled: true
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~



