### PR TITLE
feat: add experimental badge support for UiSettings, use it for agentBuilder:experimentalFeatures

### DIFF
--- a/src/core/packages/ui-settings/common/src/ui_settings.ts
+++ b/src/core/packages/ui-settings/common/src/ui_settings.ts
@@ -141,9 +141,11 @@ interface UiSettingsParamsBase<T = unknown> {
 }
 
 /**
+/**
  * UiSettings parameters defined by the plugins.
- * `technicalPreview` and `experimental` are mutually exclusive — a setting should carry at most
- * one maturity badge.
+ * A setting should carry at most one maturity badge — avoid setting both `technicalPreview` and `experimental`.
+ * `@public`
+ * */
  * @public
  * */
 export interface UiSettingsParams<T = unknown> extends UiSettingsParamsBase<T> {

--- a/src/core/packages/ui-settings/common/src/ui_settings.ts
+++ b/src/core/packages/ui-settings/common/src/ui_settings.ts
@@ -141,11 +141,8 @@ interface UiSettingsParamsBase<T = unknown> {
 }
 
 /**
-/**
  * UiSettings parameters defined by the plugins.
  * A setting should carry at most one maturity badge — avoid setting both `technicalPreview` and `experimental`.
- * `@public`
- * */
  * @public
  * */
 export interface UiSettingsParams<T = unknown> extends UiSettingsParamsBase<T> {

--- a/src/core/packages/ui-settings/common/src/ui_settings.ts
+++ b/src/core/packages/ui-settings/common/src/ui_settings.ts
@@ -67,10 +67,10 @@ export interface GetUiSettingsContext {
 export type UiSettingsSolutions = Array<SolutionId | 'classic'>;
 
 /**
- * UiSettings parameters defined by the plugins.
+ * Base UiSettings parameters shared by all settings.
  * @public
  * */
-export interface UiSettingsParams<T = unknown> {
+interface UiSettingsParamsBase<T = unknown> {
   /** title in the UI */
   name?: string;
   /** default value to fall back to if a user doesn't provide any */
@@ -100,8 +100,6 @@ export interface UiSettingsParams<T = unknown> {
   type?: UiSettingsType;
   /** optional deprecation information. Used to generate a deprecation warning. */
   deprecation?: DeprecationSettings;
-  /** A flag indicating that this setting is a technical preview. If true, the setting will display a tech preview badge after the title. */
-  technicalPreview?: TechnicalPreviewSettings;
   /**
    * index of the settings within its category (ascending order, smallest will be displayed first).
    * Used for ordering in the UI.
@@ -140,6 +138,19 @@ export interface UiSettingsParams<T = unknown> {
    * Note: this does not affect serverless settings, since spaces in serverless don't have solution views.
    * */
   solutionViews?: UiSettingsSolutions;
+}
+
+/**
+ * UiSettings parameters defined by the plugins.
+ * `technicalPreview` and `experimental` are mutually exclusive — a setting should carry at most
+ * one maturity badge.
+ * @public
+ * */
+export interface UiSettingsParams<T = unknown> extends UiSettingsParamsBase<T> {
+  /** A flag indicating that this setting is a technical preview. If true, the setting will display a tech preview badge after the title. */
+  technicalPreview?: TechnicalPreviewSettings;
+  /** A flag indicating that this setting is experimental. Displays an experimental badge after the title. Supports the same options as {@link TechnicalPreviewSettings}. */
+  experimental?: TechnicalPreviewSettings;
 }
 
 /**

--- a/src/platform/packages/shared/kbn-management/settings/components/field_row/field_row.test.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/field_row/field_row.test.tsx
@@ -365,6 +365,42 @@ describe('Field', () => {
         expect(queryByText('Technical preview')).not.toBeInTheDocument();
       });
 
+      it('should render experimental badge if it is experimental', () => {
+        const { getByText } = render(
+          wrap(
+            <FieldRow
+              field={getFieldDefinition({
+                id,
+                setting: { ...setting, experimental: true },
+                params: { isCustom: true },
+              })}
+              onFieldChange={handleChange}
+              isSavingEnabled={true}
+            />
+          )
+        );
+
+        expect(getByText('Experimental')).toBeInTheDocument();
+      });
+
+      it('should NOT render experimental badge if experimental is false or unspecified', () => {
+        const { queryByText } = render(
+          wrap(
+            <FieldRow
+              field={getFieldDefinition({
+                id,
+                setting,
+                params: { isCustom: true },
+              })}
+              onFieldChange={handleChange}
+              isSavingEnabled={true}
+            />
+          )
+        );
+
+        expect(queryByText('Experimental')).not.toBeInTheDocument();
+      });
+
       it('should render unsaved value if there are unsaved changes', () => {
         const { getByTestId, getByAltText } = render(
           wrap(

--- a/src/platform/packages/shared/kbn-management/settings/components/field_row/field_row.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/field_row/field_row.tsx
@@ -51,6 +51,7 @@ type Definition<T extends SettingType = SettingType> = Pick<
   | 'savedValue'
   | 'type'
   | 'technicalPreview'
+  | 'experimental'
   | 'unsavedFieldId'
 >;
 

--- a/src/platform/packages/shared/kbn-management/settings/components/field_row/title/experimental_badge.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/field_row/title/experimental_badge.tsx
@@ -14,7 +14,6 @@ import { EuiBetaBadge } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import type { FieldDefinition, SettingType } from '@kbn/management-settings-types';
-import { isBoolean } from 'lodash';
 
 export interface ExperimentalBadgeProps<T extends SettingType> {
   field: Pick<FieldDefinition<T>, 'experimental'>;
@@ -38,29 +37,26 @@ const badgeBaseProps: Pick<EuiBetaBadgeProps, 'alignment' | 'label' | 'size'> = 
 export const FieldTitleExperimentalBadge = <T extends SettingType>({
   field,
 }: ExperimentalBadgeProps<T>) => {
-  if (!field.experimental) {
+  const { experimental } = field;
+
+  if (!experimental) {
     return null;
   }
 
-  if (isBoolean(field.experimental)) {
-    return <EuiBetaBadge {...badgeBaseProps} tooltipContent={defaultTooltip} />;
-  }
+  const isBooleanExperimental = typeof experimental === 'boolean';
+  const tooltipContent =
+    isBooleanExperimental ? defaultTooltip : experimental.message || defaultTooltip;
 
-  if (!field.experimental.docLinksKey) {
+  if (!isBooleanExperimental && experimental.docLinksKey) {
     return (
       <EuiBetaBadge
         {...badgeBaseProps}
-        tooltipContent={field.experimental.message || defaultTooltip}
+        tooltipContent={tooltipContent}
+        href={experimental.docLinksKey}
+        target="_blank"
       />
     );
   }
 
-  return (
-    <EuiBetaBadge
-      {...badgeBaseProps}
-      tooltipContent={field.experimental.message || defaultTooltip}
-      href={field.experimental.docLinksKey}
-      target="_blank"
-    />
-  );
+  return <EuiBetaBadge {...badgeBaseProps} tooltipContent={tooltipContent} />;
 };

--- a/src/platform/packages/shared/kbn-management/settings/components/field_row/title/experimental_badge.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/field_row/title/experimental_badge.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+
+import type { EuiBetaBadgeProps } from '@elastic/eui';
+import { EuiBetaBadge } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import type { FieldDefinition, SettingType } from '@kbn/management-settings-types';
+import { isBoolean } from 'lodash';
+
+export interface ExperimentalBadgeProps<T extends SettingType> {
+  field: Pick<FieldDefinition<T>, 'experimental'>;
+}
+
+const defaultLabel = i18n.translate('management.settings.field.experimentalLabel', {
+  defaultMessage: 'Experimental',
+});
+
+const defaultTooltip = i18n.translate('management.settings.experimentalDefaultTooltip', {
+  defaultMessage:
+    'This functionality is experimental and may be changed or removed in a future release.',
+});
+
+const badgeBaseProps: Pick<EuiBetaBadgeProps, 'alignment' | 'label' | 'size'> = {
+  alignment: 'middle',
+  label: defaultLabel,
+  size: 's',
+};
+
+export const FieldTitleExperimentalBadge = <T extends SettingType>({
+  field,
+}: ExperimentalBadgeProps<T>) => {
+  if (!field.experimental) {
+    return null;
+  }
+
+  if (isBoolean(field.experimental)) {
+    return <EuiBetaBadge {...badgeBaseProps} tooltipContent={defaultTooltip} />;
+  }
+
+  if (!field.experimental.docLinksKey) {
+    return (
+      <EuiBetaBadge
+        {...badgeBaseProps}
+        tooltipContent={field.experimental.message || defaultTooltip}
+      />
+    );
+  }
+
+  return (
+    <EuiBetaBadge
+      {...badgeBaseProps}
+      tooltipContent={field.experimental.message || defaultTooltip}
+      href={field.experimental.docLinksKey}
+      target="_blank"
+    />
+  );
+};

--- a/src/platform/packages/shared/kbn-management/settings/components/field_row/title/experimental_badge.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/field_row/title/experimental_badge.tsx
@@ -44,8 +44,9 @@ export const FieldTitleExperimentalBadge = <T extends SettingType>({
   }
 
   const isBooleanExperimental = typeof experimental === 'boolean';
-  const tooltipContent =
-    isBooleanExperimental ? defaultTooltip : experimental.message || defaultTooltip;
+  const tooltipContent = isBooleanExperimental
+    ? defaultTooltip
+    : experimental.message || defaultTooltip;
 
   if (!isBooleanExperimental && experimental.docLinksKey) {
     return (

--- a/src/platform/packages/shared/kbn-management/settings/components/field_row/title/title.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/field_row/title/title.tsx
@@ -22,6 +22,7 @@ import { useFieldStyles } from '../field_row.styles';
 import { FieldTitleCustomIcon } from './icon_custom';
 import { FieldTitleUnsavedIcon } from './icon_unsaved';
 import { FieldTitleTechnicalPreviewBadge } from './technical_preview_badge';
+import { FieldTitleExperimentalBadge } from './experimental_badge';
 
 /**
  * Props for a {@link FieldTitle} component.
@@ -30,7 +31,14 @@ export interface TitleProps<T extends SettingType> {
   /** The {@link FieldDefinition} corresponding the setting. */
   field: Pick<
     FieldDefinition<T>,
-    'displayName' | 'savedValue' | 'isCustom' | 'id' | 'type' | 'isOverridden' | 'technicalPreview'
+    | 'displayName'
+    | 'savedValue'
+    | 'isCustom'
+    | 'id'
+    | 'type'
+    | 'isOverridden'
+    | 'technicalPreview'
+    | 'experimental'
   >;
   /** Emotion-based `css` for the root React element. */
   css?: Interpolation<Theme>;
@@ -60,6 +68,7 @@ export const FieldTitle = <T extends SettingType>({
         <h3 {...props}>{field.displayName}</h3>
       </EuiFlexItem>
       <FieldTitleTechnicalPreviewBadge {...{ field }} />
+      <FieldTitleExperimentalBadge {...{ field }} />
       <FieldTitleCustomIcon {...{ field }} />
       <FieldTitleUnsavedIcon {...{ field, unsavedChange }} />
     </EuiFlexGroup>

--- a/src/platform/packages/shared/kbn-management/settings/field_definition/get_definition.ts
+++ b/src/platform/packages/shared/kbn-management/settings/field_definition/get_definition.ts
@@ -104,6 +104,7 @@ export const getFieldDefinition = <T extends SettingType>(
     value: defaultValue,
     solutionViews,
     technicalPreview,
+    experimental,
   } = setting;
 
   const { isCustom, isOverridden } = params;
@@ -148,6 +149,7 @@ export const getFieldDefinition = <T extends SettingType>(
     unsavedFieldId: `${id}-unsaved`,
     solutionViews,
     technicalPreview,
+    experimental,
   };
 
   // TODO: clintandrewhall - add validation (e.g. `select` contains non-empty `options`)

--- a/src/platform/packages/shared/kbn-management/settings/types/field_definition.ts
+++ b/src/platform/packages/shared/kbn-management/settings/types/field_definition.ts
@@ -98,10 +98,16 @@ export interface FieldDefinition<
    */
   solutionViews?: UiSettingsSolutions;
   /**
-   * Technical preview information for the field
+   * Technical preview information for the field.
+   * Mutually exclusive with {@link FieldDefinition.experimental}.
    * @see {@link TechnicalPreviewSettings}
    */
   technicalPreview?: TechnicalPreviewSettings;
+  /**
+   * Experimental information for the field. Supports the same options as {@link TechnicalPreviewSettings}.
+   * Mutually exclusive with {@link FieldDefinition.technicalPreview}.
+   */
+  experimental?: TechnicalPreviewSettings;
 }
 
 /**

--- a/src/platform/packages/shared/kbn-management/settings/types/field_definition.ts
+++ b/src/platform/packages/shared/kbn-management/settings/types/field_definition.ts
@@ -99,13 +99,13 @@ export interface FieldDefinition<
   solutionViews?: UiSettingsSolutions;
   /**
    * Technical preview information for the field.
-   * Mutually exclusive with {@link FieldDefinition.experimental}.
+   * A setting should carry at most one maturity badge — avoid setting both this and {@link FieldDefinition.experimental}.
    * @see {@link TechnicalPreviewSettings}
    */
   technicalPreview?: TechnicalPreviewSettings;
   /**
    * Experimental information for the field. Supports the same options as {@link TechnicalPreviewSettings}.
-   * Mutually exclusive with {@link FieldDefinition.technicalPreview}.
+   * A setting should carry at most one maturity badge — avoid setting both this and {@link FieldDefinition.technicalPreview}.
    */
   experimental?: TechnicalPreviewSettings;
 }

--- a/src/platform/plugins/shared/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
+++ b/src/platform/plugins/shared/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
@@ -109,6 +109,7 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
                   </p>
                 </React.Fragment>,
                 "displayName": "Share usage with Elastic",
+                "experimental": undefined,
                 "groupId": "Share usage with Elastic-group",
                 "id": "Usage collection",
                 "isCustom": true,

--- a/src/platform/plugins/shared/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
+++ b/src/platform/plugins/shared/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
@@ -141,7 +141,9 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
 </Fragment>
 `;
 
-exports[`TelemetryManagementSectionComponent renders null because allowChangingOptInStatus is false 1`] = `
+exports[
+  `TelemetryManagementSectionComponent renders null because allowChangingOptInStatus is false 1`
+] = `
 <TelemetryManagementSection
   docLinks={
     Object {

--- a/x-pack/platform/plugins/shared/agent_builder/server/ui_settings.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/ui_settings.ts
@@ -42,7 +42,7 @@ export const registerUISettings = ({ uiSettings }: { uiSettings: UiSettingsServi
       }),
       schema: schema.boolean(),
       value: false,
-      technicalPreview: true,
+      experimental: true,
       requiresPageReload: false,
       readonly: false,
     },


### PR DESCRIPTION
## Summary

- Adds an `experimental` flag to `UiSettingsParams` as a mutually exclusive alternative to `technicalPreview`. TypeScript enforces that a setting can carry at most one maturity badge.
- Introduces a new `FieldTitleExperimentalBadge` component that renders "Experimental" (instead of "Technical preview") in the Advanced Settings UI, wired through `FieldDefinition` and `getFieldDefinition`.
- Switches `agentBuilder:experimentalFeatures` from `technicalPreview: true` to `experimental: true` to align with updated Elastic terminology guidelines ([Slack thread](https://elastic.slack.com/archives/C0A2RUHDJCB/p1779223108141119)).

## Details

The existing `technicalPreview` field on `UiSettingsParams` was a plain `interface` property. To enforce mutual exclusivity with the new `experimental` field, `UiSettingsParams` is now a discriminated union: one branch carries `technicalPreview` with `experimental?: never`, and the other carries `experimental` with `technicalPreview?: never`. TypeScript will error at compile time if both are set.

The new `experimental_badge.tsx` lives alongside the existing `technical_preview_badge.tsx` in `kbn-management/settings/components/field_row/title/`. `title.tsx` renders whichever badge is applicable (at most one, by type constraint).

## Screenshots

### Current
<img width="1910" height="184" alt="Screenshot 2026-05-19 at 3 34 58 PM" src="https://github.com/user-attachments/assets/745136b2-5b97-483e-93e4-bd1044346155" />


### Updated
<img width="941" height="130" alt="Screenshot 2026-05-21 at 2 47 42 PM" src="https://github.com/user-attachments/assets/d06423e5-3e91-4517-9231-fa83cde8b7e9" />
