### PR TITLE
[Discover][Traces] Fix flaky explore_from_apm Scout test

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/helpers.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/helpers.ts
@@ -19,12 +19,12 @@ import type { TracesExperiencePage } from './page_objects';
 async function waitForTracesProfileApplied(
   pageObjects: PageObjects & { tracesExperience: TracesExperiencePage }
 ) {
-  await pageObjects.discover.waitForDocTableRendered();
   const [firstProfileSpecificColumn] = pageObjects.tracesExperience.grid.profileSpecificColumns;
 
   await expect(pageObjects.discover.getColumnHeader(firstProfileSpecificColumn)).toBeVisible({
     timeout: 30_000,
   });
+  await pageObjects.discover.waitForDocTableRendered();
 }
 
 export async function expectTracesExperienceEnabled(


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/261438

## Summary

Fixes the flaky `explore_from_apm.spec.ts` Scout test by reordering waits in `waitForTracesProfileApplied`.

The traces data-source profile resolves *after* the first data render and swaps default Discover columns for trace-specific ones (`service.name`, etc.). This column swap re-renders the grid, flipping `data-render-complete` back to `false`. Previously, `waitForDocTableRendered()` (which requires `data-render-complete="true"` to hold for 2s) ran *before* the column check — so its stability window was disrupted by the profile-driven column swap, causing timeouts under CI load.

**Fix:** Wait for the profile-specific column to appear first, *then* run the strict 2s stability check — so the grid only needs to be stable after the column swap is complete.

## Test plan

- [ ] Run `node scripts/scout run-tests --arch stateful --domain classic --testFiles src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/explore_from_apm.spec.ts` locally
- [ ] Verify CI passes on stateful and serverless targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)