### PR TITLE
[9.4] [Dashboards] Address import/export `references` duplication (#270312)

### DIFF
--- a/src/core/packages/saved-objects/base-server-internal/src/validation/schema.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/validation/schema.ts
@@ -29,7 +29,10 @@ const baseSchema = schema.object<SavedObjectSanitizedDocSchema>({
       type: schema.string(),
       id: schema.string(),
     }),
-    { defaultValue: [], maxSize: 1000 }
+    {
+      defaultValue: [],
+      maxSize: 10_000, // needed to allow importing dashboards with duplicate references
+    }
   ),
   namespace: schema.maybe(schema.string()),
   namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),

--- a/src/platform/plugins/shared/dashboard/server/api/transforms/in/transform_dashboard_in.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/in/transform_dashboard_in.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { uniqBy } from 'lodash';
+
 import type { SavedObjectReference } from '@kbn/core-saved-objects-api-server';
 import type { DashboardState } from '../../types';
 import type { DashboardSavedObjectAttributes } from '../../../dashboard_saved_object';
@@ -79,11 +81,9 @@ export const transformDashboardIn = (
 
   return {
     attributes,
-    references: [
-      ...tagReferences,
-      ...panelReferences,
-      ...controlGroupReferences,
-      ...searchSourceReferences,
-    ],
+    references: uniqBy(
+      [...tagReferences, ...panelReferences, ...controlGroupReferences, ...searchSourceReferences],
+      'name'
+    ),
   };
 };

--- a/src/platform/plugins/shared/dashboard/server/dashboard_saved_object/dashboard_saved_object.ts
+++ b/src/platform/plugins/shared/dashboard/server/dashboard_saved_object/dashboard_saved_object.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { uniqBy } from 'lodash';
+
 import { ANALYTICS_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import type { SavedObjectsType } from '@kbn/core/server';
 
@@ -41,6 +43,13 @@ export const createDashboardSavedObjectType = ({
         path: `/app/dashboards#/view/${encodeURIComponent(obj.id)}`,
         uiCapabilitiesPath: 'dashboard_v2.show',
       };
+    },
+    onExport: (ctx, objects) => {
+      // deduplicate references by name
+      return objects.map((obj) => ({
+        ...obj,
+        references: uniqBy(obj.references, 'name'),
+      }));
     },
   },
   modelVersions: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Dashboards] Address import/export `references` duplication (#270312)](https://github.com/elastic/kibana/pull/270312)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2026-05-21T21:40:03Z","message":"[Dashboards] Address import/export `references` duplication (#270312)\n\n## Summary\n\nDeduplicates dashboard `references` `onExport` and on save.\n\nCloses #266543\n\n## Details\n\nAt some point there was mishandling of references, specifically of Lens\nby-ref panels, that lead to duplication of panel references, not just\ndouble but exponential duplication on every save. So saving once you get\n1, then 2, then 4 then 8 and so on.\n\nThis was found to be caused by dashboards passing all references to the\nembeddable ref injection not just the panel references, for\ncompatibility with legacy visualizations. This was addressed in\nhttps://github.com/elastic/kibana/pull/245569 and likely stopped there.\nCould also be related to other issues prior to this not entirely sure.\n\nBut as it stands, we have dashboard SavedObjects that customers want to\nimport that have duplicate refs that far exceed the 1,000 array limit\nset by core on the saved object schema. Since we longer have the ability\nto add a migration, there is no mechanism to correct this issue on\nimport before the input is validated by the schema. So we need to ramp\nup the array limit to 10,000.\n\nAdditionally, the dashboard transform logic injects and extracts the\nreferences which implicitly deduplicates the references. So on the next\nsave, the references will be corrected.\n\nBut if someone were to export the Dashboard saved object, that has yet\nto be saved, they would still get the duplicate references. To fix this\nwe add an `onExport` hook to deduplicate by `name`.\n\nApart from this issue, there seems to be another issue with duplicated\nreferences in #266543. I was not able to reproduce this but as a safe\nguard I think we could just always deduplicate the dashboard references\non save.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"222b6af2298933e03bfa0be2504d067e0e2bbde5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.5.0","v9.4.2"],"title":"[Dashboards] Address import/export `references` duplication","number":270312,"url":"https://github.com/elastic/kibana/pull/270312","mergeCommit":{"message":"[Dashboards] Address import/export `references` duplication (#270312)\n\n## Summary\n\nDeduplicates dashboard `references` `onExport` and on save.\n\nCloses #266543\n\n## Details\n\nAt some point there was mishandling of references, specifically of Lens\nby-ref panels, that lead to duplication of panel references, not just\ndouble but exponential duplication on every save. So saving once you get\n1, then 2, then 4 then 8 and so on.\n\nThis was found to be caused by dashboards passing all references to the\nembeddable ref injection not just the panel references, for\ncompatibility with legacy visualizations. This was addressed in\nhttps://github.com/elastic/kibana/pull/245569 and likely stopped there.\nCould also be related to other issues prior to this not entirely sure.\n\nBut as it stands, we have dashboard SavedObjects that customers want to\nimport that have duplicate refs that far exceed the 1,000 array limit\nset by core on the saved object schema. Since we longer have the ability\nto add a migration, there is no mechanism to correct this issue on\nimport before the input is validated by the schema. So we need to ramp\nup the array limit to 10,000.\n\nAdditionally, the dashboard transform logic injects and extracts the\nreferences which implicitly deduplicates the references. So on the next\nsave, the references will be corrected.\n\nBut if someone were to export the Dashboard saved object, that has yet\nto be saved, they would still get the duplicate references. To fix this\nwe add an `onExport` hook to deduplicate by `name`.\n\nApart from this issue, there seems to be another issue with duplicated\nreferences in #266543. I was not able to reproduce this but as a safe\nguard I think we could just always deduplicate the dashboard references\non save.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"222b6af2298933e03bfa0be2504d067e0e2bbde5"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270312","number":270312,"mergeCommit":{"message":"[Dashboards] Address import/export `references` duplication (#270312)\n\n## Summary\n\nDeduplicates dashboard `references` `onExport` and on save.\n\nCloses #266543\n\n## Details\n\nAt some point there was mishandling of references, specifically of Lens\nby-ref panels, that lead to duplication of panel references, not just\ndouble but exponential duplication on every save. So saving once you get\n1, then 2, then 4 then 8 and so on.\n\nThis was found to be caused by dashboards passing all references to the\nembeddable ref injection not just the panel references, for\ncompatibility with legacy visualizations. This was addressed in\nhttps://github.com/elastic/kibana/pull/245569 and likely stopped there.\nCould also be related to other issues prior to this not entirely sure.\n\nBut as it stands, we have dashboard SavedObjects that customers want to\nimport that have duplicate refs that far exceed the 1,000 array limit\nset by core on the saved object schema. Since we longer have the ability\nto add a migration, there is no mechanism to correct this issue on\nimport before the input is validated by the schema. So we need to ramp\nup the array limit to 10,000.\n\nAdditionally, the dashboard transform logic injects and extracts the\nreferences which implicitly deduplicates the references. So on the next\nsave, the references will be corrected.\n\nBut if someone were to export the Dashboard saved object, that has yet\nto be saved, they would still get the duplicate references. To fix this\nwe add an `onExport` hook to deduplicate by `name`.\n\nApart from this issue, there seems to be another issue with duplicated\nreferences in #266543. I was not able to reproduce this but as a safe\nguard I think we could just always deduplicate the dashboard references\non save.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"222b6af2298933e03bfa0be2504d067e0e2bbde5"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->