### PR TITLE
[8.19] [Synthetics] Fix cross-space monitor detail navigation in management list!! (#265647)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/location_status_badges.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/location_status_badges.tsx
@@ -24,10 +24,12 @@ export const LocationStatusBadges = ({
   loading,
   locations,
   configId,
+  spaces,
 }: {
   locations: LocationsStatus;
   loading: boolean;
   configId: string;
+  spaces?: string[];
 }) => {
   const [toDisplay, setToDisplay] = useState(DEFAULT_DISPLAY_COUNT);
 
@@ -55,6 +57,7 @@ export const LocationStatusBadges = ({
             locationId={loc.id}
             locationLabel={loc.label}
             color={loc.color}
+            spaces={spaces}
           />
         </EuiFlexItem>
       ))}
@@ -105,15 +108,18 @@ const MonitorDetailLinkForLocation = ({
   locationId,
   locationLabel,
   color,
+  spaces,
 }: {
   configId: string;
   locationId: string;
   locationLabel: string;
   color: string;
+  spaces?: string[];
 }) => {
   const monitorDetailLinkUrl = useMonitorDetailLocator({
     configId,
     locationId,
+    spaces,
   });
 
   return (

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/columns.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/columns.tsx
@@ -142,6 +142,7 @@ export function useMonitorListColumns({
             monitorId={monitor[ConfigKey.CONFIG_ID] ?? monitor.id}
             locations={locations}
             overviewStatus={overviewStatus}
+            spaces={monitor.spaces}
           />
         ) : null,
     },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_details_link.tsx
@@ -28,6 +28,7 @@ export const MonitorDetailsLink = ({ monitor }: { monitor: EncryptedSyntheticsSa
   const monitorDetailLinkUrl = useMonitorDetailLocator({
     configId: monitor[ConfigKey.CONFIG_ID],
     locationId,
+    spaces: monitor.spaces,
   });
 
   return (

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_locations.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_locations.tsx
@@ -14,9 +14,10 @@ interface Props {
   locations: ServiceLocations;
   monitorId: string;
   overviewStatus: OverviewStatusState | null;
+  spaces?: string[];
 }
 
-export const MonitorLocations = ({ locations, monitorId, overviewStatus }: Props) => {
+export const MonitorLocations = ({ locations, monitorId, overviewStatus, spaces }: Props) => {
   const {
     eui: { euiColorVis9, euiColorVis0, euiColorDisabled },
   } = useTheme();
@@ -44,6 +45,11 @@ export const MonitorLocations = ({ locations, monitorId, overviewStatus }: Props
   });
 
   return (
-    <LocationStatusBadges configId={monitorId} locations={locationsToDisplay} loading={false} />
+    <LocationStatusBadges
+      configId={monitorId}
+      locations={locationsToDisplay}
+      loading={false}
+      spaces={spaces}
+    />
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
- [[Synthetics] Fix cross-space monitor detail navigation in management list!! (#265647)](https://github.com/elastic/kibana/pull/265647)

## Why

The original PR was labeled `v8.19.10` but the auto-backport never landed on `8.19`. This is a prerequisite for backporting follow-up PR [#265748](https://github.com/elastic/kibana/pull/265748) (which also auto-backport-failed to 8.19 because the foundation was missing).

## Conflicts

One trivial conflict in `monitor_locations.tsx`: 8.19 still uses `useTheme()` from `@kbn/observability-shared-plugin` (destructuring `euiColorVis9/0/Disabled` from `eui`), whereas main moved to `useEuiTheme()`. Kept the 8.19 theme code unchanged; only added `spaces` to the destructured props. All other files auto-merged cleanly.

`useMonitorDetailLocator` on 8.19 already accepts the optional `spaces` parameter and uses `getMonitorSpaceToAppend`, so the threading works end-to-end without further changes.

### Made with [backport](https://github.com/sorenlouv/backport)

Made with [Cursor](https://cursor.com)