### PR TITLE
[9.3] [Synthetics] Fix cross-space monitor detail navigation in management list!! (#265647)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/location_status_badges.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/location_status_badges.tsx
@@ -24,10 +24,12 @@ export const LocationStatusBadges = ({
   loading,
   locations,
   configId,
+  spaces,
 }: {
   locations: LocationsStatus;
   loading: boolean;
   configId: string;
+  spaces?: string[];
 }) => {
   const [toDisplay, setToDisplay] = useState(DEFAULT_DISPLAY_COUNT);
 
@@ -55,6 +57,7 @@ export const LocationStatusBadges = ({
             locationId={loc.id}
             locationLabel={loc.label}
             color={loc.color}
+            spaces={spaces}
           />
         </EuiFlexItem>
       ))}
@@ -105,15 +108,18 @@ const MonitorDetailLinkForLocation = ({
   locationId,
   locationLabel,
   color,
+  spaces,
 }: {
   configId: string;
   locationId: string;
   locationLabel: string;
   color: string;
+  spaces?: string[];
 }) => {
   const monitorDetailLinkUrl = useMonitorDetailLocator({
     configId,
     locationId,
+    spaces,
   });
 
   return (

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/columns.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/columns.tsx
@@ -143,6 +143,7 @@ export function useMonitorListColumns({
             monitorId={monitor[ConfigKey.CONFIG_ID] ?? monitor.id}
             locations={locations}
             overviewStatus={overviewStatus}
+            spaces={monitor.spaces}
           />
         ) : null,
     },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_details_link.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_details_link.tsx
@@ -26,6 +26,7 @@ export const MonitorDetailsLink = ({ monitor }: { monitor: EncryptedSyntheticsSa
   const monitorDetailLinkUrl = useMonitorDetailLocator({
     configId: monitor[ConfigKey.CONFIG_ID],
     locationId,
+    spaces: monitor.spaces,
   });
 
   return (

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_locations.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_locations.tsx
@@ -17,9 +17,10 @@ interface Props {
   locations: ServiceLocations;
   monitorId: string;
   overviewStatus: OverviewStatusState | null;
+  spaces?: string[];
 }
 
-export const MonitorLocations = ({ locations, monitorId, overviewStatus }: Props) => {
+export const MonitorLocations = ({ locations, monitorId, overviewStatus, spaces }: Props) => {
   const { euiTheme } = useEuiTheme();
 
   const locationsToDisplay = locations.map((loc) => {
@@ -45,6 +46,11 @@ export const MonitorLocations = ({ locations, monitorId, overviewStatus }: Props
   });
 
   return (
-    <LocationStatusBadges configId={monitorId} locations={locationsToDisplay} loading={false} />
+    <LocationStatusBadges
+      configId={monitorId}
+      locations={locationsToDisplay}
+      loading={false}
+      spaces={spaces}
+    />
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
- [[Synthetics] Fix cross-space monitor detail navigation in management list!! (#265647)](https://github.com/elastic/kibana/pull/265647)

## Why

The original PR was only backported to 9.4 (#265715). This is a prerequisite for backporting follow-up PR [#265748](https://github.com/elastic/kibana/pull/265748) to 9.3.

## Conflicts

None — cherry-picked cleanly.

### Made with [backport](https://github.com/sorenlouv/backport)

Made with [Cursor](https://cursor.com)