### PR TITLE
[CI] correct saved object type count for parallel PRs

### DIFF
--- a/src/core/packages/saved-objects/server-internal/src/object_types/index.ts
+++ b/src/core/packages/saved-objects/server-internal/src/object_types/index.ts
@@ -11,4 +11,4 @@ export { registerCoreObjectTypes } from './registration';
 
 // set minimum number of registered saved objects to ensure no object types are removed after 8.8
 // declared in internal implementation explicitly to prevent unintended changes.
-export const SAVED_OBJECT_TYPES_COUNT = 162 as const;
+export const SAVED_OBJECT_TYPES_COUNT = 163 as const;


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/269250/changes and https://github.com/elastic/kibana/pull/269452/changes arrived in parallel. They both bumped `SAVED_OBJECT_TYPES_COUNT` by one. They checked OK individually, but failed together.