### PR TITLE
[Discover][Metrics] Add IndexKind type alias and narrow MatchedItem.Tag.key

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_metric_source_kind.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_metric_source_kind.test.tsx
@@ -9,7 +9,11 @@
 
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import type { DataViewsPublicPluginStart, MatchedItem } from '@kbn/data-views-plugin/public';
+import {
+  INDEX_KIND,
+  type DataViewsPublicPluginStart,
+  type MatchedItem,
+} from '@kbn/data-views-plugin/public';
 import {
   ExternalServicesProvider,
   type ExternalServices,
@@ -35,7 +39,7 @@ const mockedUseMetricsExperienceState = useMetricsExperienceState as jest.Mock;
 const mockedUseReportChartSectionError = useReportChartSectionError as jest.Mock;
 const TEST_PROFILE_ID = 'metrics-data-source-profile';
 
-const matchedItem = (name: string, key: 'data_stream' | 'index'): MatchedItem =>
+const matchedItem = (name: string, key: INDEX_KIND): MatchedItem =>
   ({
     name,
     tags: [{ key, name: key, color: 'default' }],
@@ -93,7 +97,9 @@ describe('useMetricSourceKind', () => {
   });
 
   it('returns INDEX when getIndices matches a plain index by tag key', async () => {
-    const getIndices = jest.fn().mockResolvedValue([matchedItem('metrics-plain-index', 'index')]);
+    const getIndices = jest
+      .fn()
+      .mockResolvedValue([matchedItem('metrics-plain-index', INDEX_KIND.INDEX)]);
     const { result } = renderHook(
       () =>
         useMetricSourceKind({
@@ -112,7 +118,9 @@ describe('useMetricSourceKind', () => {
   });
 
   it('returns DATA_STREAM when getIndices matches a data stream', async () => {
-    const getIndices = jest.fn().mockResolvedValue([matchedItem('logs-ds', 'data_stream')]);
+    const getIndices = jest
+      .fn()
+      .mockResolvedValue([matchedItem('logs-ds', INDEX_KIND.DATA_STREAM)]);
     const { result } = renderHook(
       () => useMetricSourceKind({ name: 'logs-ds', fallback: METRIC_SOURCE_KIND.INDEX }),
       { wrapper: buildWrapper({ dataViews: buildDataViews(getIndices) }) }
@@ -122,7 +130,9 @@ describe('useMetricSourceKind', () => {
   });
 
   it('falls back to the provided fallback when the name is not in the response', async () => {
-    const getIndices = jest.fn().mockResolvedValue([matchedItem('other-source', 'index')]);
+    const getIndices = jest
+      .fn()
+      .mockResolvedValue([matchedItem('other-source', INDEX_KIND.INDEX)]);
     const { result } = renderHook(
       () =>
         useMetricSourceKind({ name: 'not-in-response', fallback: METRIC_SOURCE_KIND.DATA_STREAM }),
@@ -137,7 +147,7 @@ describe('useMetricSourceKind', () => {
     const getIndices = jest
       .fn()
       .mockRejectedValueOnce(new Error('boom'))
-      .mockResolvedValueOnce([matchedItem('retry-source', 'index')]);
+      .mockResolvedValueOnce([matchedItem('retry-source', INDEX_KIND.INDEX)]);
     const wrapper = buildWrapper({ dataViews: buildDataViews(getIndices) });
 
     const first = renderHook(
@@ -159,7 +169,7 @@ describe('useMetricSourceKind', () => {
     const getIndices = jest
       .fn()
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([matchedItem('eventually-found', 'data_stream')]);
+      .mockResolvedValueOnce([matchedItem('eventually-found', INDEX_KIND.DATA_STREAM)]);
     const wrapper = buildWrapper({ dataViews: buildDataViews(getIndices) });
 
     const first = renderHook(
@@ -178,7 +188,9 @@ describe('useMetricSourceKind', () => {
   });
 
   it('deduplicates concurrent requests for the same name (cache)', async () => {
-    const getIndices = jest.fn().mockResolvedValue([matchedItem('dedup-source', 'index')]);
+    const getIndices = jest
+      .fn()
+      .mockResolvedValue([matchedItem('dedup-source', INDEX_KIND.INDEX)]);
     const wrapper = buildWrapper({ dataViews: buildDataViews(getIndices) });
 
     const a = renderHook(
@@ -198,7 +210,7 @@ describe('useMetricSourceKind', () => {
   it('does not expose the previous source kind when the name changes (stale guard)', async () => {
     const getIndices = jest.fn(async (args: { pattern: string }) =>
       args.pattern === 'first-source'
-        ? [matchedItem('first-source', 'index')]
+        ? [matchedItem('first-source', INDEX_KIND.INDEX)]
         : new Promise(() => {})
     );
 

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_metric_source_kind.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_metric_source_kind.test.tsx
@@ -9,10 +9,10 @@
 
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import {
-  INDEX_KIND,
-  type DataViewsPublicPluginStart,
-  type MatchedItem,
+import type {
+  DataViewsPublicPluginStart,
+  IndexKind,
+  MatchedItem,
 } from '@kbn/data-views-plugin/public';
 import {
   ExternalServicesProvider,
@@ -39,7 +39,7 @@ const mockedUseMetricsExperienceState = useMetricsExperienceState as jest.Mock;
 const mockedUseReportChartSectionError = useReportChartSectionError as jest.Mock;
 const TEST_PROFILE_ID = 'metrics-data-source-profile';
 
-const matchedItem = (name: string, key: INDEX_KIND): MatchedItem =>
+const matchedItem = (name: string, key: IndexKind): MatchedItem =>
   ({
     name,
     tags: [{ key, name: key, color: 'default' }],
@@ -97,9 +97,7 @@ describe('useMetricSourceKind', () => {
   });
 
   it('returns INDEX when getIndices matches a plain index by tag key', async () => {
-    const getIndices = jest
-      .fn()
-      .mockResolvedValue([matchedItem('metrics-plain-index', INDEX_KIND.INDEX)]);
+    const getIndices = jest.fn().mockResolvedValue([matchedItem('metrics-plain-index', 'index')]);
     const { result } = renderHook(
       () =>
         useMetricSourceKind({
@@ -118,9 +116,7 @@ describe('useMetricSourceKind', () => {
   });
 
   it('returns DATA_STREAM when getIndices matches a data stream', async () => {
-    const getIndices = jest
-      .fn()
-      .mockResolvedValue([matchedItem('logs-ds', INDEX_KIND.DATA_STREAM)]);
+    const getIndices = jest.fn().mockResolvedValue([matchedItem('logs-ds', 'data_stream')]);
     const { result } = renderHook(
       () => useMetricSourceKind({ name: 'logs-ds', fallback: METRIC_SOURCE_KIND.INDEX }),
       { wrapper: buildWrapper({ dataViews: buildDataViews(getIndices) }) }
@@ -130,9 +126,7 @@ describe('useMetricSourceKind', () => {
   });
 
   it('falls back to the provided fallback when the name is not in the response', async () => {
-    const getIndices = jest
-      .fn()
-      .mockResolvedValue([matchedItem('other-source', INDEX_KIND.INDEX)]);
+    const getIndices = jest.fn().mockResolvedValue([matchedItem('other-source', 'index')]);
     const { result } = renderHook(
       () =>
         useMetricSourceKind({ name: 'not-in-response', fallback: METRIC_SOURCE_KIND.DATA_STREAM }),
@@ -147,7 +141,7 @@ describe('useMetricSourceKind', () => {
     const getIndices = jest
       .fn()
       .mockRejectedValueOnce(new Error('boom'))
-      .mockResolvedValueOnce([matchedItem('retry-source', INDEX_KIND.INDEX)]);
+      .mockResolvedValueOnce([matchedItem('retry-source', 'index')]);
     const wrapper = buildWrapper({ dataViews: buildDataViews(getIndices) });
 
     const first = renderHook(
@@ -169,7 +163,7 @@ describe('useMetricSourceKind', () => {
     const getIndices = jest
       .fn()
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([matchedItem('eventually-found', INDEX_KIND.DATA_STREAM)]);
+      .mockResolvedValueOnce([matchedItem('eventually-found', 'data_stream')]);
     const wrapper = buildWrapper({ dataViews: buildDataViews(getIndices) });
 
     const first = renderHook(
@@ -188,9 +182,7 @@ describe('useMetricSourceKind', () => {
   });
 
   it('deduplicates concurrent requests for the same name (cache)', async () => {
-    const getIndices = jest
-      .fn()
-      .mockResolvedValue([matchedItem('dedup-source', INDEX_KIND.INDEX)]);
+    const getIndices = jest.fn().mockResolvedValue([matchedItem('dedup-source', 'index')]);
     const wrapper = buildWrapper({ dataViews: buildDataViews(getIndices) });
 
     const a = renderHook(
@@ -210,7 +202,7 @@ describe('useMetricSourceKind', () => {
   it('does not expose the previous source kind when the name changes (stale guard)', async () => {
     const getIndices = jest.fn(async (args: { pattern: string }) =>
       args.pattern === 'first-source'
-        ? [matchedItem('first-source', INDEX_KIND.INDEX)]
+        ? [matchedItem('first-source', 'index')]
         : new Promise(() => {})
     );
 

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_metric_source_kind.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_metric_source_kind.ts
@@ -8,7 +8,6 @@
  */
 
 import type { DataViewsPublicPluginStart, MatchedItem } from '@kbn/data-views-plugin/public';
-import { INDEX_KIND } from '@kbn/data-views-plugin/public';
 import { useAbortableAsync } from '@kbn/react-hooks';
 import { useExternalServices } from '../../../context/external_services';
 import { useReportChartSectionError } from '../../chart/hooks/use_report_chart_section_error';
@@ -125,7 +124,7 @@ const fetchSourceKind = async (
   });
   const item = matched.find((m) => m.name === name);
   if (!item) return undefined;
-  return item.tags.some((t) => t.key === INDEX_KIND.INDEX)
+  return item.tags.some((t) => t.key === 'index')
     ? METRIC_SOURCE_KIND.INDEX
     : METRIC_SOURCE_KIND.DATA_STREAM;
 };

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_metric_source_kind.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/flyout/hooks/use_metric_source_kind.ts
@@ -8,16 +8,11 @@
  */
 
 import type { DataViewsPublicPluginStart, MatchedItem } from '@kbn/data-views-plugin/public';
+import { INDEX_KIND } from '@kbn/data-views-plugin/public';
 import { useAbortableAsync } from '@kbn/react-hooks';
 import { useExternalServices } from '../../../context/external_services';
 import { useReportChartSectionError } from '../../chart/hooks/use_report_chart_section_error';
 import { useMetricsExperienceState } from '../../observability/metrics/context/metrics_experience_state_provider';
-
-// Tag key emitted by data_views.getIndices() / responseToItemArray for plain
-// indices (vs data streams). Coupled to that plugin's response shape.
-// TODO: import from @kbn/data-views-plugin once exported
-// (https://github.com/elastic/kibana/issues/265126).
-const DATA_VIEWS_INDEX_TAG_KEY = 'index';
 
 export const METRIC_SOURCE_KIND = {
   DATA_STREAM: 'data_stream',
@@ -130,7 +125,7 @@ const fetchSourceKind = async (
   });
   const item = matched.find((m) => m.name === name);
   if (!item) return undefined;
-  return item.tags.some((t) => t.key === DATA_VIEWS_INDEX_TAG_KEY)
+  return item.tags.some((t) => t.key === INDEX_KIND.INDEX)
     ? METRIC_SOURCE_KIND.INDEX
     : METRIC_SOURCE_KIND.DATA_STREAM;
 };

--- a/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index_selection_handler.test.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index_selection_handler.test.ts
@@ -8,21 +8,22 @@
  */
 
 import type { MatchedItem } from '@kbn/data-views-plugin/public';
+import { INDEX_KIND } from '@kbn/data-views-plugin/public';
 import type { SelectionContext } from '@kbn/workflows/types/latest';
 import {
   getIndexSelectionHandler,
   type IndexSelectionHandlerServices,
 } from './index_selection_handler';
 
-type IndexKind = 'index' | 'alias' | 'data_stream';
+type SelectableKind = INDEX_KIND.INDEX | INDEX_KIND.ALIAS | INDEX_KIND.DATA_STREAM;
 
-const TAG_LABELS: Record<IndexKind, string> = {
-  index: 'Index',
-  alias: 'Alias',
-  data_stream: 'Data stream',
+const TAG_LABELS: Record<SelectableKind, string> = {
+  [INDEX_KIND.INDEX]: 'Index',
+  [INDEX_KIND.ALIAS]: 'Alias',
+  [INDEX_KIND.DATA_STREAM]: 'Data stream',
 };
 
-function buildMatchedItem(name: string, kind: IndexKind = 'index'): MatchedItem {
+function buildMatchedItem(name: string, kind: SelectableKind = INDEX_KIND.INDEX): MatchedItem {
   return {
     name,
     tags: [{ key: kind, name: TAG_LABELS[kind], color: 'default' }],
@@ -101,9 +102,9 @@ describe('getIndexSelectionHandler', () => {
     it('maps tag kinds to readable descriptions', async () => {
       const { services, dataViews } = createServices();
       dataViews.getIndices.mockResolvedValue([
-        buildMatchedItem('metrics-index', 'index'),
-        buildMatchedItem('metrics-alias', 'alias'),
-        buildMatchedItem('metrics-stream', 'data_stream'),
+        buildMatchedItem('metrics-index', INDEX_KIND.INDEX),
+        buildMatchedItem('metrics-alias', INDEX_KIND.ALIAS),
+        buildMatchedItem('metrics-stream', INDEX_KIND.DATA_STREAM),
       ]);
 
       const handler = getIndexSelectionHandler(services);
@@ -267,7 +268,9 @@ describe('getIndexSelectionHandler', () => {
 
     it('returns the matched item when exactly one source matches the value', async () => {
       const { services, dataViews } = createServices();
-      dataViews.getIndices.mockResolvedValue([buildMatchedItem('.alerts-default', 'index')]);
+      dataViews.getIndices.mockResolvedValue([
+        buildMatchedItem('.alerts-default', INDEX_KIND.INDEX),
+      ]);
 
       const handler = getIndexSelectionHandler(services);
       const result = await handler.resolve('.alerts-default', EMPTY_CONTEXT);
@@ -322,7 +325,7 @@ describe('getIndexSelectionHandler', () => {
 
       it('still returns a single matched item when allowWildcard is true and only one source matches', async () => {
         const { services, dataViews } = createServices();
-        dataViews.getIndices.mockResolvedValue([buildMatchedItem('logs-app-1', 'index')]);
+        dataViews.getIndices.mockResolvedValue([buildMatchedItem('logs-app-1', INDEX_KIND.INDEX)]);
 
         const handler = getIndexSelectionHandler(services, { allowWildcard: true });
         const result = await handler.resolve('logs-*', EMPTY_CONTEXT);

--- a/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index_selection_handler.test.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index_selection_handler.test.ts
@@ -7,23 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { MatchedItem } from '@kbn/data-views-plugin/public';
-import { INDEX_KIND } from '@kbn/data-views-plugin/public';
+import type { IndexKind, MatchedItem } from '@kbn/data-views-plugin/public';
 import type { SelectionContext } from '@kbn/workflows/types/latest';
 import {
   getIndexSelectionHandler,
   type IndexSelectionHandlerServices,
 } from './index_selection_handler';
 
-type SelectableKind = INDEX_KIND.INDEX | INDEX_KIND.ALIAS | INDEX_KIND.DATA_STREAM;
+type SelectableKind = Extract<IndexKind, 'index' | 'alias' | 'data_stream'>;
 
 const TAG_LABELS: Record<SelectableKind, string> = {
-  [INDEX_KIND.INDEX]: 'Index',
-  [INDEX_KIND.ALIAS]: 'Alias',
-  [INDEX_KIND.DATA_STREAM]: 'Data stream',
+  index: 'Index',
+  alias: 'Alias',
+  data_stream: 'Data stream',
 };
 
-function buildMatchedItem(name: string, kind: SelectableKind = INDEX_KIND.INDEX): MatchedItem {
+function buildMatchedItem(name: string, kind: SelectableKind = 'index'): MatchedItem {
   return {
     name,
     tags: [{ key: kind, name: TAG_LABELS[kind], color: 'default' }],
@@ -102,9 +101,9 @@ describe('getIndexSelectionHandler', () => {
     it('maps tag kinds to readable descriptions', async () => {
       const { services, dataViews } = createServices();
       dataViews.getIndices.mockResolvedValue([
-        buildMatchedItem('metrics-index', INDEX_KIND.INDEX),
-        buildMatchedItem('metrics-alias', INDEX_KIND.ALIAS),
-        buildMatchedItem('metrics-stream', INDEX_KIND.DATA_STREAM),
+        buildMatchedItem('metrics-index', 'index'),
+        buildMatchedItem('metrics-alias', 'alias'),
+        buildMatchedItem('metrics-stream', 'data_stream'),
       ]);
 
       const handler = getIndexSelectionHandler(services);
@@ -268,9 +267,7 @@ describe('getIndexSelectionHandler', () => {
 
     it('returns the matched item when exactly one source matches the value', async () => {
       const { services, dataViews } = createServices();
-      dataViews.getIndices.mockResolvedValue([
-        buildMatchedItem('.alerts-default', INDEX_KIND.INDEX),
-      ]);
+      dataViews.getIndices.mockResolvedValue([buildMatchedItem('.alerts-default', 'index')]);
 
       const handler = getIndexSelectionHandler(services);
       const result = await handler.resolve('.alerts-default', EMPTY_CONTEXT);
@@ -325,7 +322,7 @@ describe('getIndexSelectionHandler', () => {
 
       it('still returns a single matched item when allowWildcard is true and only one source matches', async () => {
         const { services, dataViews } = createServices();
-        dataViews.getIndices.mockResolvedValue([buildMatchedItem('logs-app-1', INDEX_KIND.INDEX)]);
+        dataViews.getIndices.mockResolvedValue([buildMatchedItem('logs-app-1', 'index')]);
 
         const handler = getIndexSelectionHandler(services, { allowWildcard: true });
         const result = await handler.resolve('logs-*', EMPTY_CONTEXT);

--- a/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index_selection_handler.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index_selection_handler.ts
@@ -9,7 +9,6 @@
 
 import type { ApplicationStart } from '@kbn/core/public';
 import type { DataViewsContract, MatchedItem } from '@kbn/data-views-plugin/public';
-import { INDEX_KIND } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
 import type { PropertySelectionHandler, SelectionOption } from '@kbn/workflows/types/latest';
 
@@ -43,15 +42,12 @@ const dataStreamLabel = i18n.translate('workflows.indexSelection.kindDataStream'
 
 function getKindFromTags(item: MatchedItem): string {
   const primary = item.tags.find(
-    (tag) =>
-      tag.key === INDEX_KIND.INDEX ||
-      tag.key === INDEX_KIND.ALIAS ||
-      tag.key === INDEX_KIND.DATA_STREAM
+    (tag) => tag.key === 'index' || tag.key === 'alias' || tag.key === 'data_stream'
   );
   switch (primary?.key) {
-    case INDEX_KIND.ALIAS:
+    case 'alias':
       return aliasLabel;
-    case INDEX_KIND.DATA_STREAM:
+    case 'data_stream':
       return dataStreamLabel;
     default:
       return indexLabel;

--- a/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index_selection_handler.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index_selection_handler.ts
@@ -9,6 +9,7 @@
 
 import type { ApplicationStart } from '@kbn/core/public';
 import type { DataViewsContract, MatchedItem } from '@kbn/data-views-plugin/public';
+import { INDEX_KIND } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
 import type { PropertySelectionHandler, SelectionOption } from '@kbn/workflows/types/latest';
 
@@ -41,15 +42,16 @@ const dataStreamLabel = i18n.translate('workflows.indexSelection.kindDataStream'
 });
 
 function getKindFromTags(item: MatchedItem): string {
-  // Tag keys produced by `responseToItemArray` in @kbn/data-views-plugin:
-  // 'index' | 'alias' | 'data_stream' (+ optional 'frozen', 'rollup').
   const primary = item.tags.find(
-    (tag) => tag.key === 'index' || tag.key === 'alias' || tag.key === 'data_stream'
+    (tag) =>
+      tag.key === INDEX_KIND.INDEX ||
+      tag.key === INDEX_KIND.ALIAS ||
+      tag.key === INDEX_KIND.DATA_STREAM
   );
   switch (primary?.key) {
-    case 'alias':
+    case INDEX_KIND.ALIAS:
       return aliasLabel;
-    case 'data_stream':
+    case INDEX_KIND.DATA_STREAM:
       return dataStreamLabel;
     default:
       return indexLabel;

--- a/src/platform/plugins/shared/data_view_editor/public/components/preview_panel/indices_list/indices_list.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/preview_panel/indices_list/indices_list.tsx
@@ -24,7 +24,7 @@ import { i18n } from '@kbn/i18n';
 import { Pager } from '@elastic/eui';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { MatchedItem, Tag } from '@kbn/data-views-plugin/public';
-import { INDEX_PATTERN_TYPE } from '@kbn/data-views-plugin/public';
+import { INDEX_KIND } from '@kbn/data-views-plugin/public';
 import { RollupDeprecationTooltip } from '@kbn/rollup';
 
 export interface IndicesListProps {
@@ -164,7 +164,7 @@ export class IndicesList extends React.Component<IndicesListProps, IndicesListSt
                 </EuiBadge>
               );
 
-              return tag.key === INDEX_PATTERN_TYPE.ROLLUP ? (
+              return tag.key === INDEX_KIND.ROLLUP ? (
                 <>
                   &nbsp;<RollupDeprecationTooltip>{badge}</RollupDeprecationTooltip>
                 </>

--- a/src/platform/plugins/shared/data_view_editor/public/components/preview_panel/indices_list/indices_list.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/preview_panel/indices_list/indices_list.tsx
@@ -24,7 +24,6 @@ import { i18n } from '@kbn/i18n';
 import { Pager } from '@elastic/eui';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { MatchedItem, Tag } from '@kbn/data-views-plugin/public';
-import { INDEX_KIND } from '@kbn/data-views-plugin/public';
 import { RollupDeprecationTooltip } from '@kbn/rollup';
 
 export interface IndicesListProps {
@@ -164,7 +163,7 @@ export class IndicesList extends React.Component<IndicesListProps, IndicesListSt
                 </EuiBadge>
               );
 
-              return tag.key === INDEX_KIND.ROLLUP ? (
+              return tag.key === 'rollup' ? (
                 <>
                   &nbsp;<RollupDeprecationTooltip>{badge}</RollupDeprecationTooltip>
                 </>

--- a/src/platform/plugins/shared/data_views/public/index.ts
+++ b/src/platform/plugins/shared/data_views/public/index.ts
@@ -42,7 +42,8 @@ export type {
   Tag,
 } from './types';
 
-export { INDEX_PATTERN_TYPE, INDEX_KIND } from './types';
+export { INDEX_PATTERN_TYPE } from './types';
+export type { IndexKind } from './types';
 
 export type {
   DataViewsServicePublic,

--- a/src/platform/plugins/shared/data_views/public/index.ts
+++ b/src/platform/plugins/shared/data_views/public/index.ts
@@ -42,7 +42,7 @@ export type {
   Tag,
 } from './types';
 
-export { INDEX_PATTERN_TYPE } from './types';
+export { INDEX_PATTERN_TYPE, INDEX_KIND } from './types';
 
 export type {
   DataViewsServicePublic,

--- a/src/platform/plugins/shared/data_views/public/services/get_indices.ts
+++ b/src/platform/plugins/shared/data_views/public/services/get_indices.ts
@@ -11,7 +11,7 @@ import { sortBy } from 'lodash';
 import type { HttpStart } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import type { Tag } from '../types';
-import { INDEX_PATTERN_TYPE } from '../types';
+import { INDEX_KIND } from '../types';
 import type { MatchedItem, ResolveIndexResponse } from '../types';
 import { ResolveIndexResponseItemIndexAttrs } from '../types';
 
@@ -36,7 +36,7 @@ const getIndexTags = (isRollupIndex: (indexName: string) => boolean) => (indexNa
   isRollupIndex(indexName)
     ? [
         {
-          key: INDEX_PATTERN_TYPE.ROLLUP,
+          key: INDEX_KIND.ROLLUP,
           name: rollupLabel,
           color: 'warning',
         },
@@ -129,7 +129,9 @@ export const responseToItemArray = (
   const source: MatchedItem[] = [];
 
   (response.indices || []).forEach((index) => {
-    const tags: MatchedItem['tags'] = [{ key: 'index', name: indexLabel, color: 'default' }];
+    const tags: MatchedItem['tags'] = [
+      { key: INDEX_KIND.INDEX, name: indexLabel, color: 'default' },
+    ];
     const isFrozen = (index.attributes || []).includes(ResolveIndexResponseItemIndexAttrs.FROZEN);
 
     tags.push(...getTags(index.name));
@@ -137,7 +139,7 @@ export const responseToItemArray = (
       tags.push(...getTags(alias));
     });
     if (isFrozen) {
-      tags.push({ name: frozenLabel, key: 'frozen', color: 'danger' });
+      tags.push({ name: frozenLabel, key: INDEX_KIND.FROZEN, color: 'danger' });
     }
 
     source.push({
@@ -149,7 +151,7 @@ export const responseToItemArray = (
   (response.aliases || []).forEach((alias) => {
     const item = {
       name: alias.name,
-      tags: [{ key: 'alias', name: aliasLabel, color: 'default' }],
+      tags: [{ key: INDEX_KIND.ALIAS, name: aliasLabel, color: 'default' }],
       item: alias,
     };
     // we only need to check the first index to see if its a rollup since there can only be one alias match
@@ -160,7 +162,7 @@ export const responseToItemArray = (
   (response.data_streams || []).forEach((dataStream) => {
     source.push({
       name: dataStream.name,
-      tags: [{ key: 'data_stream', name: dataStreamLabel, color: 'primary' }],
+      tags: [{ key: INDEX_KIND.DATA_STREAM, name: dataStreamLabel, color: 'primary' }],
       item: dataStream,
     });
   });

--- a/src/platform/plugins/shared/data_views/public/services/get_indices.ts
+++ b/src/platform/plugins/shared/data_views/public/services/get_indices.ts
@@ -10,9 +10,7 @@
 import { sortBy } from 'lodash';
 import type { HttpStart } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
-import type { Tag } from '../types';
-import { INDEX_KIND } from '../types';
-import type { MatchedItem, ResolveIndexResponse } from '../types';
+import type { Tag, MatchedItem, ResolveIndexResponse } from '../types';
 import { ResolveIndexResponseItemIndexAttrs } from '../types';
 
 const aliasLabel = i18n.translate('dataViews.aliasLabel', { defaultMessage: 'Alias' });
@@ -32,16 +30,18 @@ const rollupLabel = i18n.translate('dataViews.rollupLabel', {
   defaultMessage: 'Rollup (deprecated)',
 });
 
-const getIndexTags = (isRollupIndex: (indexName: string) => boolean) => (indexName: string) =>
-  isRollupIndex(indexName)
-    ? [
-        {
-          key: INDEX_KIND.ROLLUP,
-          name: rollupLabel,
-          color: 'warning',
-        },
-      ]
-    : [];
+const getIndexTags =
+  (isRollupIndex: (indexName: string) => boolean) =>
+  (indexName: string): Tag[] =>
+    isRollupIndex(indexName)
+      ? [
+          {
+            key: 'rollup',
+            name: rollupLabel,
+            color: 'warning',
+          },
+        ]
+      : [];
 
 export const getIndicesViaResolve = async ({
   http,
@@ -129,9 +129,7 @@ export const responseToItemArray = (
   const source: MatchedItem[] = [];
 
   (response.indices || []).forEach((index) => {
-    const tags: MatchedItem['tags'] = [
-      { key: INDEX_KIND.INDEX, name: indexLabel, color: 'default' },
-    ];
+    const tags: MatchedItem['tags'] = [{ key: 'index', name: indexLabel, color: 'default' }];
     const isFrozen = (index.attributes || []).includes(ResolveIndexResponseItemIndexAttrs.FROZEN);
 
     tags.push(...getTags(index.name));
@@ -139,7 +137,7 @@ export const responseToItemArray = (
       tags.push(...getTags(alias));
     });
     if (isFrozen) {
-      tags.push({ name: frozenLabel, key: INDEX_KIND.FROZEN, color: 'danger' });
+      tags.push({ name: frozenLabel, key: 'frozen', color: 'danger' });
     }
 
     source.push({
@@ -149,9 +147,9 @@ export const responseToItemArray = (
     });
   });
   (response.aliases || []).forEach((alias) => {
-    const item = {
+    const item: MatchedItem = {
       name: alias.name,
-      tags: [{ key: INDEX_KIND.ALIAS, name: aliasLabel, color: 'default' }],
+      tags: [{ key: 'alias', name: aliasLabel, color: 'default' }],
       item: alias,
     };
     // we only need to check the first index to see if its a rollup since there can only be one alias match
@@ -162,7 +160,7 @@ export const responseToItemArray = (
   (response.data_streams || []).forEach((dataStream) => {
     source.push({
       name: dataStream.name,
-      tags: [{ key: INDEX_KIND.DATA_STREAM, name: dataStreamLabel, color: 'primary' }],
+      tags: [{ key: 'data_stream', name: dataStreamLabel, color: 'primary' }],
       item: dataStream,
     });
   });

--- a/src/platform/plugins/shared/data_views/public/types.ts
+++ b/src/platform/plugins/shared/data_views/public/types.ts
@@ -22,6 +22,20 @@ export enum INDEX_PATTERN_TYPE {
   DEFAULT = 'default',
 }
 
+/**
+ * Discriminator for the entries returned by `dataViews.getIndices()` (backed by
+ * the Elasticsearch `_resolve/index` endpoint). Written to each
+ * `MatchedItem.tags[].key`; consumers should compare against these members
+ * instead of magic strings.
+ */
+export enum INDEX_KIND {
+  INDEX = 'index',
+  ALIAS = 'alias',
+  DATA_STREAM = 'data_stream',
+  FROZEN = 'frozen',
+  ROLLUP = 'rollup',
+}
+
 export enum IndicesResponseItemIndexAttrs {
   OPEN = 'open',
   CLOSED = 'closed',
@@ -188,7 +202,7 @@ export interface ResolveIndexResponseItemIndex extends ResolveIndexResponseItem 
 
 export interface Tag {
   name: string;
-  key: string;
+  key: INDEX_KIND;
   color: string;
 }
 export enum ResolveIndexResponseItemIndexAttrs {

--- a/src/platform/plugins/shared/data_views/public/types.ts
+++ b/src/platform/plugins/shared/data_views/public/types.ts
@@ -200,6 +200,11 @@ export interface ResolveIndexResponseItemIndex extends ResolveIndexResponseItem 
   data_stream?: string;
 }
 
+/**
+ * UI tag attached to each entry returned by `dataViews.getIndices()`.
+ *
+ * @see INDEX_KIND for the discriminator written to `key`.
+ */
 export interface Tag {
   name: string;
   key: INDEX_KIND;

--- a/src/platform/plugins/shared/data_views/public/types.ts
+++ b/src/platform/plugins/shared/data_views/public/types.ts
@@ -23,18 +23,12 @@ export enum INDEX_PATTERN_TYPE {
 }
 
 /**
- * Discriminator for the entries returned by `dataViews.getIndices()` (backed by
- * the Elasticsearch `_resolve/index` endpoint). Written to each
- * `MatchedItem.tags[].key`; consumers should compare against these members
- * instead of magic strings.
+ * Discriminator for the entries returned by `dataViews.getIndices()` (backed
+ * by the Elasticsearch `_resolve/index` endpoint). Written to each
+ * `MatchedItem.tags[].key`. Exported as a type-only union so consumers can
+ * narrow against it without forcing a runtime dependency on `dataViews`.
  */
-export enum INDEX_KIND {
-  INDEX = 'index',
-  ALIAS = 'alias',
-  DATA_STREAM = 'data_stream',
-  FROZEN = 'frozen',
-  ROLLUP = 'rollup',
-}
+export type IndexKind = 'index' | 'alias' | 'data_stream' | 'frozen' | 'rollup';
 
 export enum IndicesResponseItemIndexAttrs {
   OPEN = 'open',
@@ -203,11 +197,11 @@ export interface ResolveIndexResponseItemIndex extends ResolveIndexResponseItem 
 /**
  * UI tag attached to each entry returned by `dataViews.getIndices()`.
  *
- * @see INDEX_KIND for the discriminator written to `key`.
+ * @see IndexKind for the discriminator written to `key`.
  */
 export interface Tag {
   name: string;
-  key: INDEX_KIND;
+  key: IndexKind;
   color: string;
 }
 export enum ResolveIndexResponseItemIndexAttrs {


### PR DESCRIPTION
Closes #265126

## Summary

Adds an `IndexKind` type alias to the `data_views` public API that captures
the five possible discriminators emitted on `MatchedItem.tags[].key` by
`dataViews.getIndices()` (backed by the Elasticsearch `_resolve/index`
endpoint): `'index'`, `'alias'`, `'data_stream'`, `'frozen'`, `'rollup'`.

`Tag.key` is narrowed from `string` to `IndexKind`, so typos in comparisons
become compile-time errors. `IndexKind` is exported as a pure type
(erased at compile time), so consumers can use it without forcing a runtime
dependency on the `dataViews` plugin.

This replaces ad-hoc local constants such as `DATA_VIEWS_INDEX_TAG_KEY = 'index'`
that several consumers (`@kbn/unified-chart-section-viewer`, `data_view_editor`,
`@kbn/workflows-ui`) had been duplicating, with a single typed contract owned
by the `data_views` plugin.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



