### PR TITLE
[Discover] [Tabs] Recheck overflow state on tabs group restoration

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/hooks/use_responsive_tabs.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/hooks/use_responsive_tabs.tsx
@@ -73,7 +73,9 @@ export const useResponsiveTabs = ({
   useEffect(() => {
     onScroll();
     // `dimensions.width` added here to trigger in cases when the container width changes
-  }, [onScroll, dimensions.width]);
+    // `tabsSizeConfig.isScrollable` added here to trigger scroll state recalculation
+    // when items are added/removed and scrollability changes (e.g. after tab restoration)
+  }, [onScroll, dimensions.width, tabsSizeConfig.isScrollable]);
 
   const scrollLeft = useCallback(() => {
     if (tabsContainerElement) {


### PR DESCRIPTION
## Summary
Closes #270547

**Problem:** If user restores a tabs group, which will overflow the tabs bar, the overflow check fails and the scroll buttons are disabled, causing the overflowed tabs unaccessible. If user deletes right amount of tabs to fit on a screen and add some more, the arrows are clickable.

**Root cause:** When tabs are restored `tabsSizeConfig.isScrollable` correctly flips to `true`, so it's rendering the scroll buttons as expected. They're not clickable though, because the `useEffect` that calculates `scrollState` doesn't re-run.

**Solution:** This PR adds `tabsSizeConfig.isScrollable` to the dependencies array, so the scroll arrows get correct boolean value about their `disable` state.

Old:

https://github.com/user-attachments/assets/b1eec74b-956b-4a95-b7fd-aad7c9d3aef6

New:

https://github.com/user-attachments/assets/aea0acc2-f2ca-47a2-a121-ebbfdd77b080


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->