### PR TITLE
[VectorDB] Add Kibana feature permissions setup

### DIFF
--- a/config/serverless.vectordb.yml
+++ b/config/serverless.vectordb.yml
@@ -25,10 +25,6 @@ xpack.features.overrides:
   stackAlerts:
     name: "Alerts"
     category: "enterpriseSearch"
-  ### Observability AI Assistant feature is moved to VectorDB and renamed.
-  observabilityAIAssistant:
-    name: "AI Assistant"
-    category: "enterpriseSearch"
 
 ## Cloud settings
 xpack.cloud.serverless.project_type: vectordb

--- a/config/serverless.vectordb.yml
+++ b/config/serverless.vectordb.yml
@@ -5,6 +5,31 @@ plugins.allowlistPluginGroups: ['platform', 'vectordb']
 
 xpack.osquery.enabled: false
 
+## Fine-tune the vectordb solution feature privileges. Also, refer to `serverless.yml` for the project-agnostic overrides.
+xpack.features.overrides:
+  ### Agent Builder feature is moved from Analytics category to the VectorDB one.
+  agentBuilder.category: 'enterpriseSearch'
+  ### Agent Context Layer should match Agent Builder for role management.
+  agentContextLayer.category: 'enterpriseSearch'
+  ### Workflows Management should be moved from Analytics category to the VectorDB one.
+  workflowsManagement.category: 'enterpriseSearch'
+  ### Dashboards feature is moved from Analytics category to the VectorDB one.
+  dashboard_v2.category: "enterpriseSearch"
+  ### Dev Tools feature is moved from Analytics category to the VectorDB one.
+  dev_tools.category: "enterpriseSearch"
+  ### Discover feature is moved from Analytics category to the VectorDB one.
+  discover_v2.category: "enterpriseSearch"
+  ### Machine Learning feature is moved from Analytics category to the Management one.
+  ml.category: "management"
+  ### Stack Alerts feature is moved from Analytics category to the VectorDB one and renamed to simply `Alerts`.
+  stackAlerts:
+    name: "Alerts"
+    category: "enterpriseSearch"
+  ### Observability AI Assistant feature is moved to VectorDB and renamed.
+  observabilityAIAssistant:
+    name: "AI Assistant"
+    category: "enterpriseSearch"
+
 ## Cloud settings
 xpack.cloud.serverless.project_type: vectordb
 


### PR DESCRIPTION
## Summary

- Add `xpack.features.overrides` configuration to VectorDB serverless config
- Copies feature privilege grouping from ES3 (Search) config for consistent role management UI

## Test plan

- [ ] Spin up a VectorDB serverless project
- [ ] Navigate to Role Management UI
- [ ] Verify features are grouped correctly under the VectorDB/Search category

Made with [Cursor](https://cursor.com)