### PR TITLE
Fix flaky test.

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/muted_alerts.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/muted_alerts.ts
@@ -286,7 +286,7 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
       await alertUtils.getMuteAllRequest(ruleId);
 
       // Run the rule to trigger reconciliation
-      await alertUtils.runSoon(ruleId);
+      await alertUtils.runSoon(ruleId, { force: true });
 
       // Wait for alerts to be muted
       await retry.try(async () => {
@@ -298,7 +298,7 @@ export default function createDisableRuleTests({ getService }: FtrProviderContex
       });
 
       // Now unmute all alerts
-      await alertUtils.getUnmuteAllRequest(ruleId);
+      await alertUtils.unmuteAll(ruleId);
 
       // Run the rule to trigger reconciliation. Use force so we do not get "Rule is already
       // running" without queueing a run; muted flags only reconcile on execution.


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/247714

## Summary

The initial fix worked on main, but the test still timed out a couple of times on 9.4.

I think there was a race condition between `updateByQuery`, task-manager rule execution, and returning the results. Sometimes the FTR `retry.try` limits were exceeded.

The bot suggested changing `updateByQuery` in `alerts_service.ts` but i think that would be too much.

Let's see if this is enough.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->