### PR TITLE
[UsageAPI] Make `tls.ca` config optional

### DIFF
--- a/x-pack/platform/plugins/shared/usage_api/server/config.ts
+++ b/x-pack/platform/plugins/shared/usage_api/server/config.ts
@@ -12,7 +12,7 @@ import type { PluginConfigDescriptor } from '@kbn/core/server';
 const tlsConfig = schema.object({
   certificate: schema.string(),
   key: schema.string(),
-  ca: schema.string(),
+  ca: schema.maybe(schema.string()),
 });
 
 const configSchema = schema.object({

--- a/x-pack/platform/plugins/shared/usage_api/server/usage_reporting/usage_reporting_service.test.ts
+++ b/x-pack/platform/plugins/shared/usage_api/server/usage_reporting/usage_reporting_service.test.ts
@@ -269,7 +269,7 @@ describe('UsageReportingService', () => {
       fetchMock.mockResolvedValue(okResponse());
       const service = createService({
         url: 'https://usage-api.local/v1/usage',
-        tls: { certificate: 'cert', key: 'key', ca: 'ca' },
+        tls: { certificate: 'cert', key: 'key' },
       });
 
       await service.reportUsage([createRecord()]);

--- a/x-pack/platform/plugins/shared/usage_api/server/usage_reporting/usage_reporting_service.ts
+++ b/x-pack/platform/plugins/shared/usage_api/server/usage_reporting/usage_reporting_service.ts
@@ -26,7 +26,7 @@ export interface UsageReportingConfig {
   tls?: {
     certificate: string;
     key: string;
-    ca: string;
+    ca?: string;
   };
 }
 

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/config.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/config.ts
@@ -21,7 +21,7 @@ import { METERING_TASK as AI4SOC_METERING_TASK } from './ai4soc/constants/meteri
 const tlsConfig = schema.object({
   certificate: schema.string(),
   key: schema.string(),
-  ca: schema.string(),
+  ca: schema.maybe(schema.string()),
 });
 export type TlsConfigSchema = TypeOf<typeof tlsConfig>;
 


### PR DESCRIPTION
## Summary

Our current config validation is too strict. There are situations where the `tls.ca` is not needed.

This PR avoids future errors like below:

```
FATAL  Error: [config validation of [xpack.usageApi].tls.ca]: expected value of type [string] but got [undefined]
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

