### PR TITLE
Revert "[Security Solution] Enable ES query debug logging for large bundled package test (#270397)"

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped_with_bundled_large_package.config.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/configs/edge_cases/ess_air_gapped_with_bundled_large_package.config.ts
@@ -11,7 +11,6 @@ import type { PrebuiltRuleAsset } from '@kbn/security-solution-plugin/server/lib
 import type { FtrConfigProviderContext } from '@kbn/test';
 import { PREBUILT_RULES_PACKAGE_NAME } from '@kbn/security-solution-plugin/common/detection_engine/constants';
 import { generatePrebuiltRulesPackageZipFile } from '@kbn/security-solution-test-api-clients/prebuilt_rules_package_generation';
-import { LOGGING_CONFIG } from '../../../../configs/constants';
 
 const BUNDLED_PACKAGE_DIR = `${os.tmpdir()}/mock_bundled_large_fleet_prebuilt_rules_package`;
 
@@ -37,10 +36,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
          */
         `--xpack.fleet.isAirGapped=true`,
         `--xpack.fleet.developer.bundledPackageLocation=${BUNDLED_PACKAGE_DIR}`,
-        `--logging.loggers=${JSON.stringify([
-          ...LOGGING_CONFIG,
-          { name: 'elasticsearch.query', level: 'debug' },
-        ])}`,
       ],
     },
     junit: {


### PR DESCRIPTION
Reverts #270397.

The `elasticsearch.query` debug logger adds too much noise to the test output and doesn't include per-request timings, which is the critical information needed to diagnose the regression.