### PR TITLE
[Scout] Don't create test track if no load candidates are identified

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
@@ -569,19 +569,31 @@ export const createTestTracks: Command<void> = {
             : [...new Set(loads.map((load) => load.config.server.configSet))];
 
         // Each server config set gets its own track
-        return configSets.map((configSet) => {
+        return configSets.flatMap((configSet): TestTrack[] => {
           log.info(
             `Building test track for test target '${target.tag}' with server config set '${configSet}'`
           );
+
+          const enabledLoads = loads.filter(
+            (load) => load.enabled && load.config.server.configSet === configSet
+          );
+
+          if (enabledLoads.length === 0) {
+            log.warning(
+              `No enabled test loads found for test target '${target.tag}' and server config set '${configSet}'`
+            );
+            return [];
+          }
+
           const track = buildTrack(
             Math.max(minimumRuntime, runtimeTarget),
             estimatedLaneSetupDuration,
             target,
-            loads.filter((load) => load.enabled && load.config.server.configSet === configSet),
+            enabledLoads,
             log
           );
           track.metadata.server = { configSet };
-          return track;
+          return [track];
         });
       })
       .toArray();

--- a/src/platform/packages/shared/kbn-scout/src/execution/test_track.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/execution/test_track.test.ts
@@ -19,6 +19,16 @@ describe('TestTrack', () => {
     expect(track.leastLoadedOpenLane).toBe(undefined);
   });
 
+  it('should produce valid stats for an empty track specification', () => {
+    const track = new TestTrack({ runtimeTarget: 10 });
+    const spec = track.specification;
+
+    expect(spec.stats.lane.count).toBe(0);
+    expect(spec.stats.lane.saturationPercent).toBe(0);
+    expect(spec.stats.combinedRuntime.target).toBe(0);
+    expect(spec.lanes).toEqual([]);
+  });
+
   it('closes the lane when one load fills it entirely', () => {
     const track = new TestTrack({ runtimeTarget: 10 });
 

--- a/src/platform/packages/shared/kbn-scout/src/execution/test_track.ts
+++ b/src/platform/packages/shared/kbn-scout/src/execution/test_track.ts
@@ -236,7 +236,10 @@ export class TestTrack {
       stats: {
         lane: {
           count: this.laneCount,
-          saturationPercent: parseFloat(((expectedRuntime / provisionedRuntime) * 100).toFixed(2)),
+          saturationPercent:
+            provisionedRuntime !== 0
+              ? parseFloat(((expectedRuntime / provisionedRuntime) * 100).toFixed(2))
+              : 0,
           longestEstimate: longestLaneEstimate,
           shortestEstimate: shortestLaneEstimate,
         },


### PR DESCRIPTION
Because of selective testing, we can find ourselves in a situation where there are no test loads to distribute.

This PR introduces two changes:
1. `create-test-tracks` CLI will skip track creation for cases where no test loads are identified
2. Guard against zero division issues if we do end up producing test track specifications from empty tracks

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->