### PR TITLE
[Core] Add per-request timing to elasticsearch.query logger

### DIFF
--- a/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.test.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.test.ts
@@ -107,6 +107,29 @@ describe('instrumentQueryAndDeprecationLogger', () => {
     expect(logger.get).toHaveBeenCalledWith('query', 'test123');
   });
 
+  it('includes per-request duration in the log message', () => {
+    instrumentEsQueryAndDeprecationLogger({
+      logger,
+      client,
+      type: 'test type',
+      apisToRedactInLogs: [],
+    });
+
+    const event = createApiResponse({
+      body: {},
+      statusCode: 200,
+      params: { method: 'GET', path: '/foo' },
+    });
+    // Attach an id so request and response events can be correlated
+    (event.meta.request as any).id = 'req-timing-test';
+
+    client.diagnostic.emit('request', null, event);
+    client.diagnostic.emit('response', null, event);
+
+    // Duration is appended as `- <N>ms` after the response size
+    expect(loggingSystemMock.collect(logger).debug[0][0]).toMatch(/- \d+ms/);
+  });
+
   describe('logs each query', () => {
     it('when request body is an object', () => {
       instrumentEsQueryAndDeprecationLogger({

--- a/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { performance } from 'perf_hooks';
 import type { IncomingHttpHeaders } from 'http';
 import { Buffer } from 'buffer';
 import { stringify } from 'querystring';
@@ -118,11 +119,12 @@ function getContentLength(headers?: IncomingHttpHeaders): number | undefined {
 function getResponseMessage(
   event: DiagnosticResult,
   bytesMsg: string,
-  apisToRedactInLogs: ElasticsearchApiToRedactInLogs[]
+  apisToRedactInLogs: ElasticsearchApiToRedactInLogs[],
+  durationMsg: string
 ): string {
   const debugMeta = getRequestDebugMeta(event, apisToRedactInLogs);
   const body = debugMeta.body ? `\n${debugMeta.body}` : '';
-  return `${debugMeta.statusCode}${bytesMsg}\n${debugMeta.method} ${debugMeta.url}${body}`;
+  return `${debugMeta.statusCode}${bytesMsg}${durationMsg}\n${debugMeta.method} ${debugMeta.url}${body}`;
 }
 
 /**
@@ -160,17 +162,24 @@ function getQueryMessage(
   bytes: number | undefined,
   error: errors.ElasticsearchClientError | errors.ResponseError | null,
   event: DiagnosticResult<unknown, unknown>,
-  apisToRedactInLogs: ElasticsearchApiToRedactInLogs[]
+  apisToRedactInLogs: ElasticsearchApiToRedactInLogs[],
+  duration?: number
 ) {
   const bytesMsg = bytes ? ` - ${numeral(bytes).format('0.0b')}` : '';
+  const durationMsg = duration !== undefined ? ` - ${duration}ms` : '';
   if (error) {
     if (error instanceof errors.ResponseError) {
-      return `${getResponseMessage(event, bytesMsg, apisToRedactInLogs)} ${getErrorMessage(error)}`;
+      return `${getResponseMessage(
+        event,
+        bytesMsg,
+        apisToRedactInLogs,
+        durationMsg
+      )} ${getErrorMessage(error)}`;
     } else {
       return getErrorMessage(error);
     }
   } else {
-    return getResponseMessage(event, bytesMsg, apisToRedactInLogs);
+    return getResponseMessage(event, bytesMsg, apisToRedactInLogs, durationMsg);
   }
 }
 
@@ -199,6 +208,14 @@ export const instrumentEsQueryAndDeprecationLogger = ({
   const deprecationLogger = logger.get('deprecation');
   const warningLogger = logger.get('warnings'); // elasticsearch.warnings
 
+  const requestStartTimes = new Map<string | number, number>();
+
+  client.diagnostic.on('request', (_error, event) => {
+    if (event?.meta?.request?.id != null) {
+      requestStartTimes.set(event.meta.request.id, performance.now());
+    }
+  });
+
   client.diagnostic.on('response', (error, event) => {
     const requestLoggingOptions = event?.meta?.request?.options?.context?.loggingOptions as
       | ElasticsearchRequestLoggingOptions
@@ -216,9 +233,19 @@ export const instrumentEsQueryAndDeprecationLogger = ({
       warningLogger.warn(getResponseSizeExceededErrorMessage(error));
     }
 
+    let duration: number | undefined;
+    const requestId = event?.meta?.request?.id;
+    if (requestId != null) {
+      const startTime = requestStartTimes.get(requestId);
+      if (startTime !== undefined) {
+        duration = Math.round(performance.now() - startTime);
+        requestStartTimes.delete(requestId);
+      }
+    }
+
     if (event && (logQuery || logDeprecation)) {
       const bytes = getContentLength(event.headers);
-      const queryMsg = getQueryMessage(bytes, error, event, apisToRedactInLogs);
+      const queryMsg = getQueryMessage(bytes, error, event, apisToRedactInLogs, duration);
 
       if (logQuery) {
         const meta = getEcsResponseLog(event, bytes);

--- a/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.ts
+++ b/src/core/packages/elasticsearch/client-server-internal/src/log_query_and_deprecation.ts
@@ -210,11 +210,13 @@ export const instrumentEsQueryAndDeprecationLogger = ({
 
   const requestStartTimes = new Map<string | number, number>();
 
-  client.diagnostic.on('request', (_error, event) => {
-    if (event?.meta?.request?.id != null) {
-      requestStartTimes.set(event.meta.request.id, performance.now());
-    }
-  });
+  if (queryLogger.isLevelEnabled('debug') || deprecationLogger.isLevelEnabled('debug')) {
+    client.diagnostic.on('request', (_error, event) => {
+      if (event?.meta?.request?.id != null) {
+        requestStartTimes.set(event.meta.request.id, performance.now());
+      }
+    });
+  }
 
   client.diagnostic.on('response', (error, event) => {
     const requestLoggingOptions = event?.meta?.request?.options?.context?.loggingOptions as


### PR DESCRIPTION
## Summary

- Tracks request start time via `client.diagnostic.on('request', ...)` keyed by `event.meta.request.id`
- Computes elapsed milliseconds in the `response` handler and appends it to each query log line
- Log format changes from `200 - 73.0B\nGET /path` to `200 - 73.0B - 45ms\nGET /path`
- Map cleanup always happens outside the logging guard to prevent memory growth when debug logging is disabled

## Context

Companion to #270397, which enables the `elasticsearch.query` debug logger for the `ess_air_gapped_with_bundled_large_package` FTR test. Without per-request timings the logs lack the data needed to diagnose a performance regression in `kibana-elasticsearch-snapshot-verify`.