### PR TITLE
[Synthetics] CCS for monitor details - Step Details

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useNetworkTimings } from './use_network_timings';
+import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+
+const mockUseReduxEsSearch = jest.fn();
+jest.mock('../../../hooks/use_redux_es_search', () => ({
+  useReduxEsSearch: (...args: any[]) => mockUseReduxEsSearch(...args),
+}));
+
+const mockUrlParams = jest.fn();
+jest.mock('../../../hooks', () => ({
+  useGetUrlParams: () => mockUrlParams(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ checkGroupId: 'cg-1', stepIndex: '2', monitorId: 'monitor-1' }),
+}));
+
+describe('useNetworkTimings', () => {
+  beforeEach(() => {
+    mockUrlParams.mockReturnValue({});
+    mockUseReduxEsSearch.mockReturnValue({ data: undefined, loading: false });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('queries the local synthetics index pattern when no remoteName is provided', () => {
+    renderHook(() => useNetworkTimings());
+
+    expect(mockUseReduxEsSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ index: SYNTHETICS_INDEX_PATTERN }),
+      [undefined],
+      expect.any(Object)
+    );
+  });
+
+  it('queries the CCS-prefixed index when remoteName is in the URL', () => {
+    mockUrlParams.mockReturnValue({ remoteName: 'remote-a' });
+
+    renderHook(() => useNetworkTimings());
+
+    expect(mockUseReduxEsSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ index: `remote-a:${SYNTHETICS_INDEX_PATTERN}` }),
+      expect.arrayContaining(['remote-a']),
+      expect.any(Object)
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings.ts
@@ -18,7 +18,7 @@ import {
   SYNTHETICS_TOTAL_TIMINGS,
   SYNTHETICS_WAIT_TIMINGS,
 } from '@kbn/observability-shared-plugin/common';
-import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+import { getSyntheticsCcsIndex } from '../../../../../../common/get_synthetics_indices';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
 import { useGetUrlParams } from '../../../hooks';
 
@@ -44,7 +44,7 @@ export const useNetworkTimings = (checkGroupIdArg?: string, stepIndexArg?: numbe
   const stepIndex = stepIndexArg ?? Number(params.stepIndex);
 
   const { remoteName } = useGetUrlParams();
-  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+  const index = getSyntheticsCcsIndex(remoteName);
 
   const runTimeMappings = NETWORK_TIMINGS_FIELDS.reduce(
     (acc, field) => ({

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings.ts
@@ -20,6 +20,7 @@ import {
 } from '@kbn/observability-shared-plugin/common';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
+import { useGetUrlParams } from '../../../hooks';
 
 export const useStepFilters = (checkGroupId: string, stepIndex: number) => {
   return [
@@ -42,6 +43,9 @@ export const useNetworkTimings = (checkGroupIdArg?: string, stepIndexArg?: numbe
   const checkGroupId = checkGroupIdArg ?? params.checkGroupId;
   const stepIndex = stepIndexArg ?? Number(params.stepIndex);
 
+  const { remoteName } = useGetUrlParams();
+  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+
   const runTimeMappings = NETWORK_TIMINGS_FIELDS.reduce(
     (acc, field) => ({
       ...acc,
@@ -54,7 +58,7 @@ export const useNetworkTimings = (checkGroupIdArg?: string, stepIndexArg?: numbe
 
   const { data } = useReduxEsSearch(
     {
-      index: SYNTHETICS_INDEX_PATTERN,
+      index,
       size: 0,
       runtime_mappings: runTimeMappings,
 
@@ -113,7 +117,7 @@ export const useNetworkTimings = (checkGroupIdArg?: string, stepIndexArg?: numbe
         },
       },
     },
-    [],
+    [remoteName],
     { name: `stepNetworkTimingsMetrics/${checkGroupId}/${stepIndex}` }
   );
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings_prev.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings_prev.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useNetworkTimingsPrevious24Hours } from './use_network_timings_prev';
+import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+
+const mockUseReduxEsSearch = jest.fn();
+jest.mock('../../../hooks/use_redux_es_search', () => ({
+  useReduxEsSearch: (...args: any[]) => mockUseReduxEsSearch(...args),
+}));
+
+const mockUrlParams = jest.fn();
+jest.mock('../../../hooks', () => ({
+  useGetUrlParams: () => mockUrlParams(),
+}));
+
+jest.mock('../../monitor_details/hooks/use_journey_steps', () => ({
+  useJourneySteps: () => ({
+    currentStep: { '@timestamp': '2024-01-01T00:00:00.000Z' },
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ checkGroupId: 'cg-1', stepIndex: '2', monitorId: 'monitor-1' }),
+}));
+
+describe('useNetworkTimingsPrevious24Hours', () => {
+  beforeEach(() => {
+    mockUrlParams.mockReturnValue({});
+    mockUseReduxEsSearch.mockReturnValue({ data: undefined, loading: false });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('queries the local synthetics index pattern when no remoteName is provided', () => {
+    renderHook(() => useNetworkTimingsPrevious24Hours());
+
+    expect(mockUseReduxEsSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ index: SYNTHETICS_INDEX_PATTERN }),
+      [undefined],
+      expect.any(Object)
+    );
+  });
+
+  it('queries the CCS-prefixed index when remoteName is in the URL', () => {
+    mockUrlParams.mockReturnValue({ remoteName: 'remote-a' });
+
+    renderHook(() => useNetworkTimingsPrevious24Hours());
+
+    expect(mockUseReduxEsSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ index: `remote-a:${SYNTHETICS_INDEX_PATTERN}` }),
+      expect.arrayContaining(['remote-a']),
+      expect.any(Object)
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings_prev.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings_prev.ts
@@ -22,6 +22,7 @@ import moment from 'moment';
 import { useJourneySteps } from '../../monitor_details/hooks/use_journey_steps';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
+import { useGetUrlParams } from '../../../hooks';
 import { getTimingWithLabels } from './use_network_timings';
 
 export const useStepFilters = (checkGroupId: string, stepIndex: number) => {
@@ -54,6 +55,9 @@ export const useNetworkTimingsPrevious24Hours = (
 
   const timestamp = timestampArg ?? currentStep?.['@timestamp'];
 
+  const { remoteName } = useGetUrlParams();
+  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+
   const runTimeMappings = NETWORK_TIMINGS_FIELDS.reduce(
     (acc, field) => ({
       ...acc,
@@ -66,7 +70,7 @@ export const useNetworkTimingsPrevious24Hours = (
 
   const { data, loading } = useReduxEsSearch(
     {
-      index: SYNTHETICS_INDEX_PATTERN,
+      index,
       size: 0,
       runtime_mappings: runTimeMappings,
       query: {
@@ -156,7 +160,7 @@ export const useNetworkTimingsPrevious24Hours = (
         },
       },
     },
-    [],
+    [remoteName],
     {
       name: `stepNetworkPreviousTimings/${configId}/${checkGroupId}/${stepIndex}`,
       isRequestReady: Boolean(timestamp),

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings_prev.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_network_timings_prev.ts
@@ -20,7 +20,7 @@ import {
 } from '@kbn/observability-shared-plugin/common';
 import moment from 'moment';
 import { useJourneySteps } from '../../monitor_details/hooks/use_journey_steps';
-import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+import { getSyntheticsCcsIndex } from '../../../../../../common/get_synthetics_indices';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
 import { useGetUrlParams } from '../../../hooks';
 import { getTimingWithLabels } from './use_network_timings';
@@ -56,7 +56,7 @@ export const useNetworkTimingsPrevious24Hours = (
   const timestamp = timestampArg ?? currentStep?.['@timestamp'];
 
   const { remoteName } = useGetUrlParams();
-  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+  const index = getSyntheticsCcsIndex(remoteName);
 
   const runTimeMappings = NETWORK_TIMINGS_FIELDS.reduce(
     (acc, field) => ({

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_prev_object_metrics.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_prev_object_metrics.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { usePreviousObjectMetrics } from './use_prev_object_metrics';
+import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+
+const mockUseReduxEsSearch = jest.fn();
+jest.mock('../../../hooks/use_redux_es_search', () => ({
+  useReduxEsSearch: (...args: any[]) => mockUseReduxEsSearch(...args),
+}));
+
+const mockUrlParams = jest.fn();
+jest.mock('../../../hooks', () => ({
+  useGetUrlParams: () => mockUrlParams(),
+}));
+
+jest.mock('../../monitor_details/hooks/use_journey_steps', () => ({
+  useJourneySteps: () => ({
+    data: { details: { timestamp: '2024-01-01T00:00:00.000Z' } },
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ checkGroupId: 'cg-1', stepIndex: '2', monitorId: 'monitor-1' }),
+}));
+
+describe('usePreviousObjectMetrics', () => {
+  beforeEach(() => {
+    mockUrlParams.mockReturnValue({});
+    mockUseReduxEsSearch.mockReturnValue({ data: undefined, loading: false });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('queries the local synthetics index pattern when no remoteName is provided', () => {
+    renderHook(() => usePreviousObjectMetrics());
+
+    expect(mockUseReduxEsSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ index: SYNTHETICS_INDEX_PATTERN }),
+      expect.anything(),
+      expect.any(Object)
+    );
+  });
+
+  it('queries the CCS-prefixed index when remoteName is in the URL', () => {
+    mockUrlParams.mockReturnValue({ remoteName: 'remote-a' });
+
+    renderHook(() => usePreviousObjectMetrics());
+
+    expect(mockUseReduxEsSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ index: `remote-a:${SYNTHETICS_INDEX_PATTERN}` }),
+      expect.arrayContaining(['remote-a']),
+      expect.any(Object)
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_prev_object_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_prev_object_metrics.ts
@@ -10,7 +10,7 @@ import moment from 'moment';
 import { useJourneySteps } from '../../monitor_details/hooks/use_journey_steps';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
 import { useGetUrlParams } from '../../../hooks';
-import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+import { getSyntheticsCcsIndex } from '../../../../../../common/get_synthetics_indices';
 
 export const MONITOR_DURATION_US = 'monitor.duration.us';
 export const SYNTHETICS_CLS = 'browser.experience.cls';
@@ -35,7 +35,7 @@ export const usePreviousObjectMetrics = () => {
   const timestamp = data?.details?.timestamp;
 
   const { remoteName } = useGetUrlParams();
-  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+  const index = getSyntheticsCcsIndex(remoteName);
 
   const { data: prevObjectMetrics } = useReduxEsSearch(
     {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_prev_object_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_prev_object_metrics.ts
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom';
 import moment from 'moment';
 import { useJourneySteps } from '../../monitor_details/hooks/use_journey_steps';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
+import { useGetUrlParams } from '../../../hooks';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
 
 export const MONITOR_DURATION_US = 'monitor.duration.us';
@@ -33,9 +34,12 @@ export const usePreviousObjectMetrics = () => {
 
   const timestamp = data?.details?.timestamp;
 
+  const { remoteName } = useGetUrlParams();
+  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+
   const { data: prevObjectMetrics } = useReduxEsSearch(
     {
-      index: SYNTHETICS_INDEX_PATTERN,
+      index,
       track_total_hits: false,
       sort: [
         {
@@ -117,7 +121,7 @@ export const usePreviousObjectMetrics = () => {
         },
       },
     },
-    [stepIndex, monitorId, checkGroupId],
+    [stepIndex, monitorId, checkGroupId, remoteName],
     {
       name: `previousObjectMetrics/${monitorId}/${checkGroupId}/${stepIndex}/`,
       isRequestReady: !!timestamp,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_metrics.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_metrics.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useStepMetrics } from './use_step_metrics';
+import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+
+const mockUseReduxEsSearch = jest.fn();
+jest.mock('../../../hooks/use_redux_es_search', () => ({
+  useReduxEsSearch: (...args: any[]) => mockUseReduxEsSearch(...args),
+}));
+
+const mockUrlParams = jest.fn();
+jest.mock('../../../hooks', () => ({
+  useGetUrlParams: () => mockUrlParams(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ checkGroupId: 'cg-1', stepIndex: '2' }),
+}));
+
+describe('useStepMetrics', () => {
+  beforeEach(() => {
+    mockUrlParams.mockReturnValue({});
+    mockUseReduxEsSearch.mockReturnValue({ data: undefined, loading: false });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('queries the local synthetics index pattern when no remoteName is provided', () => {
+    renderHook(() => useStepMetrics());
+
+    expect(mockUseReduxEsSearch).toHaveBeenCalledTimes(2);
+    expect(mockUseReduxEsSearch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ index: SYNTHETICS_INDEX_PATTERN }),
+      [undefined],
+      expect.any(Object)
+    );
+    expect(mockUseReduxEsSearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ index: SYNTHETICS_INDEX_PATTERN }),
+      [undefined],
+      expect.any(Object)
+    );
+  });
+
+  it('queries the CCS-prefixed index when remoteName is in the URL', () => {
+    mockUrlParams.mockReturnValue({ remoteName: 'remote-a' });
+
+    renderHook(() => useStepMetrics());
+
+    expect(mockUseReduxEsSearch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ index: `remote-a:${SYNTHETICS_INDEX_PATTERN}` }),
+      expect.arrayContaining(['remote-a']),
+      expect.any(Object)
+    );
+    expect(mockUseReduxEsSearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ index: `remote-a:${SYNTHETICS_INDEX_PATTERN}` }),
+      expect.arrayContaining(['remote-a']),
+      expect.any(Object)
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_metrics.ts
@@ -8,6 +8,7 @@
 import { useParams } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
+import { useGetUrlParams } from '../../../hooks';
 import { formatBytes } from './use_object_metrics';
 import { formatMillisecond } from '../step_metrics/step_metrics';
 import {
@@ -36,9 +37,12 @@ export const useStepMetrics = (step?: JourneyStep) => {
   const checkGroupId = step?.monitor.check_group ?? urlParams.checkGroupId;
   const stepIndex = step?.synthetics.step?.index ?? urlParams.stepIndex;
 
+  const { remoteName } = useGetUrlParams();
+  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+
   const { data } = useReduxEsSearch(
     {
-      index: SYNTHETICS_INDEX_PATTERN,
+      index,
       size: 0,
       query: {
         bool: {
@@ -89,13 +93,13 @@ export const useStepMetrics = (step?: JourneyStep) => {
         },
       },
     },
-    [],
+    [remoteName],
     { name: `stepMetrics/${checkGroupId}/${stepIndex}` }
   );
 
   const { data: transferData } = useReduxEsSearch(
     {
-      index: SYNTHETICS_INDEX_PATTERN,
+      index,
       size: 0,
       runtime_mappings: {
         'synthetics.payload.transfer_size': {
@@ -131,7 +135,7 @@ export const useStepMetrics = (step?: JourneyStep) => {
         },
       },
     },
-    [],
+    [remoteName],
     {
       name: `stepMetricsFromNetworkInfos/${checkGroupId}/${stepIndex}`,
     }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_metrics.ts
@@ -18,7 +18,7 @@ import {
   LCP_HELP_LABEL,
   TRANSFER_SIZE_HELP,
 } from '../step_metrics/labels';
-import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+import { getSyntheticsCcsIndex } from '../../../../../../common/get_synthetics_indices';
 import type { JourneyStep } from '../../../../../../common/runtime_types';
 
 export const MONITOR_DURATION_US = 'monitor.duration.us';
@@ -38,7 +38,7 @@ export const useStepMetrics = (step?: JourneyStep) => {
   const stepIndex = step?.synthetics.step?.index ?? urlParams.stepIndex;
 
   const { remoteName } = useGetUrlParams();
-  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+  const index = getSyntheticsCcsIndex(remoteName);
 
   const { data } = useReduxEsSearch(
     {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_prev_metrics.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_prev_metrics.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useStepPrevMetrics } from './use_step_prev_metrics';
+import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+
+const mockUseReduxEsSearch = jest.fn();
+jest.mock('../../../hooks/use_redux_es_search', () => ({
+  useReduxEsSearch: (...args: any[]) => mockUseReduxEsSearch(...args),
+}));
+
+const mockUrlParams = jest.fn();
+jest.mock('../../../hooks', () => ({
+  useGetUrlParams: () => mockUrlParams(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ checkGroupId: 'cg-1', stepIndex: '2', monitorId: 'monitor-1' }),
+}));
+
+describe('useStepPrevMetrics', () => {
+  beforeEach(() => {
+    mockUrlParams.mockReturnValue({});
+    mockUseReduxEsSearch.mockReturnValue({ data: undefined, loading: false });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('queries the local synthetics index pattern when no remoteName is provided', () => {
+    renderHook(() => useStepPrevMetrics());
+
+    expect(mockUseReduxEsSearch).toHaveBeenCalledTimes(2);
+    expect(mockUseReduxEsSearch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ index: SYNTHETICS_INDEX_PATTERN }),
+      [undefined],
+      expect.any(Object)
+    );
+    expect(mockUseReduxEsSearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ index: SYNTHETICS_INDEX_PATTERN }),
+      [undefined],
+      expect.any(Object)
+    );
+  });
+
+  it('queries the CCS-prefixed index when remoteName is in the URL', () => {
+    mockUrlParams.mockReturnValue({ remoteName: 'remote-a' });
+
+    renderHook(() => useStepPrevMetrics());
+
+    expect(mockUseReduxEsSearch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ index: `remote-a:${SYNTHETICS_INDEX_PATTERN}` }),
+      expect.arrayContaining(['remote-a']),
+      expect.any(Object)
+    );
+    expect(mockUseReduxEsSearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ index: `remote-a:${SYNTHETICS_INDEX_PATTERN}` }),
+      expect.arrayContaining(['remote-a']),
+      expect.any(Object)
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_prev_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_prev_metrics.ts
@@ -18,7 +18,7 @@ import {
 } from './use_step_metrics';
 import type { JourneyStep } from '../../../../../../common/runtime_types';
 import { median } from './use_network_timings_prev';
-import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+import { getSyntheticsCcsIndex } from '../../../../../../common/get_synthetics_indices';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
 import { useGetUrlParams } from '../../../hooks';
 
@@ -43,7 +43,7 @@ export const useStepPrevMetrics = (step?: JourneyStep) => {
   const stepIndex = step?.synthetics.step?.index ?? urlParams.stepIndex;
 
   const { remoteName } = useGetUrlParams();
-  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+  const index = getSyntheticsCcsIndex(remoteName);
 
   const { data, loading } = useReduxEsSearch(
     {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_prev_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/hooks/use_step_prev_metrics.ts
@@ -20,6 +20,7 @@ import type { JourneyStep } from '../../../../../../common/runtime_types';
 import { median } from './use_network_timings_prev';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
 import { useReduxEsSearch } from '../../../hooks/use_redux_es_search';
+import { useGetUrlParams } from '../../../hooks';
 
 export const MONITOR_DURATION_US = 'monitor.duration.us';
 export const SYNTHETICS_CLS = 'browser.experience.cls';
@@ -41,9 +42,12 @@ export const useStepPrevMetrics = (step?: JourneyStep) => {
   const checkGroupId = step?.monitor.check_group ?? urlParams.checkGroupId;
   const stepIndex = step?.synthetics.step?.index ?? urlParams.stepIndex;
 
+  const { remoteName } = useGetUrlParams();
+  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+
   const { data, loading } = useReduxEsSearch(
     {
-      index: SYNTHETICS_INDEX_PATTERN,
+      index,
       size: 0,
       query: {
         bool: {
@@ -110,12 +114,12 @@ export const useStepPrevMetrics = (step?: JourneyStep) => {
         },
       },
     },
-    [],
+    [remoteName],
     { name: `previousStepMetrics/${monitorId}/${checkGroupId}/${stepIndex}` }
   );
   const { data: transferData } = useReduxEsSearch(
     {
-      index: SYNTHETICS_INDEX_PATTERN,
+      index,
       size: 0,
       runtime_mappings: {
         'synthetics.payload.transfer_size': {
@@ -170,7 +174,7 @@ export const useStepPrevMetrics = (step?: JourneyStep) => {
         },
       },
     },
-    [],
+    [remoteName],
     {
       name: `previousStepMetricsFromNetworkInfos/${monitorId}/${checkGroupId}/${stepIndex}`,
     }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_detail_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_detail_page.tsx
@@ -15,6 +15,7 @@ import { useStepDetailsBreadcrumbs } from './hooks/use_step_details_breadcrumbs'
 import { WaterfallChartContainer } from './step_waterfall_chart/waterfall/waterfall_chart_container';
 import { NetworkTimingsDonut } from './step_timing_breakdown/network_timings_donut';
 import { useJourneySteps } from '../monitor_details/hooks/use_journey_steps';
+import { useGetUrlParams } from '../../hooks';
 import { getNetworkEvents } from '../../state/network_events/actions';
 import { ObjectWeightList } from './step_objects/object_weight_list';
 import { StepMetrics } from './step_metrics/step_metrics';
@@ -36,14 +37,17 @@ export const StepDetailPage = () => {
 
   const dispatch = useDispatch();
 
+  const { remoteName } = useGetUrlParams();
+
   useEffect(() => {
     dispatch(
       getNetworkEvents.get({
         checkGroup: checkGroupId,
         stepIndex: Number(stepIndex),
+        remoteName,
       })
     );
-  }, [dispatch, stepIndex, checkGroupId]);
+  }, [dispatch, stepIndex, checkGroupId, remoteName]);
 
   return (
     <>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/use_step_waterfall_metrics.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/use_step_waterfall_metrics.test.tsx
@@ -15,7 +15,18 @@ import {
 import * as searchHooks from '@kbn/observability-shared-plugin/public/hooks/use_es_search';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
 
+const mockUrlParams = jest.fn();
+jest.mock('../../../hooks', () => ({
+  useGetUrlParams: () => mockUrlParams(),
+}));
+
 describe('useStepWaterfallMetrics', () => {
+  beforeEach(() => {
+    mockUrlParams.mockReturnValue({});
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
   it('returns result as expected', () => {
     const searchHook = jest.spyOn(searchHooks, 'useEsSearch').mockReturnValue({
       loading: false,
@@ -80,7 +91,7 @@ describe('useStepWaterfallMetrics', () => {
         size: 1000,
         index: SYNTHETICS_INDEX_PATTERN,
       },
-      ['44D-444FFF-444-FFF-3333', true],
+      ['44D-444FFF-444-FFF-3333', true, undefined],
       { name: 'getWaterfallStepMetrics' }
     );
     expect(result.current).toEqual({
@@ -92,5 +103,27 @@ describe('useStepWaterfallMetrics', () => {
         },
       ],
     });
+  });
+
+  it('queries the CCS-prefixed index when remoteName is in the URL', () => {
+    mockUrlParams.mockReturnValue({ remoteName: 'remote-a' });
+
+    const searchHook = jest
+      .spyOn(searchHooks, 'useEsSearch')
+      .mockReturnValue({ loading: false, data: undefined } as any);
+
+    renderHook(() =>
+      useStepWaterfallMetrics({
+        checkGroup: 'cg-1',
+        hasNavigationRequest: true,
+        stepIndex: 1,
+      })
+    );
+
+    expect(searchHook).toHaveBeenCalledWith(
+      expect.objectContaining({ index: `remote-a:${SYNTHETICS_INDEX_PATTERN}` }),
+      expect.arrayContaining(['remote-a']),
+      expect.any(Object)
+    );
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/use_step_waterfall_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/use_step_waterfall_metrics.ts
@@ -7,6 +7,7 @@
 
 import { createEsParams, useEsSearch } from '@kbn/observability-shared-plugin/public';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+import { useGetUrlParams } from '../../../hooks';
 import type { MarkerItems } from './waterfall/context/waterfall_context';
 
 export interface Props {
@@ -20,10 +21,13 @@ export const BROWSER_TRACE_START = 'browser.relative_trace.start.us';
 export const NAVIGATION_START = 'navigationStart';
 
 export const useStepWaterfallMetrics = ({ checkGroup, hasNavigationRequest, stepIndex }: Props) => {
+  const { remoteName } = useGetUrlParams();
+  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+
   const { data, loading } = useEsSearch(
     hasNavigationRequest
       ? createEsParams({
-          index: SYNTHETICS_INDEX_PATTERN,
+          index,
           query: {
             bool: {
               filter: [
@@ -50,7 +54,7 @@ export const useStepWaterfallMetrics = ({ checkGroup, hasNavigationRequest, step
           _source: false,
         })
       : {},
-    [checkGroup, hasNavigationRequest],
+    [checkGroup, hasNavigationRequest, remoteName],
     {
       name: 'getWaterfallStepMetrics',
     }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/use_step_waterfall_metrics.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/use_step_waterfall_metrics.ts
@@ -6,7 +6,7 @@
  */
 
 import { createEsParams, useEsSearch } from '@kbn/observability-shared-plugin/public';
-import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+import { getSyntheticsCcsIndex } from '../../../../../../common/get_synthetics_indices';
 import { useGetUrlParams } from '../../../hooks';
 import type { MarkerItems } from './waterfall/context/waterfall_context';
 
@@ -22,7 +22,7 @@ export const NAVIGATION_START = 'navigationStart';
 
 export const useStepWaterfallMetrics = ({ checkGroup, hasNavigationRequest, stepIndex }: Props) => {
   const { remoteName } = useGetUrlParams();
-  const index = remoteName ? `${remoteName}:${SYNTHETICS_INDEX_PATTERN}` : SYNTHETICS_INDEX_PATTERN;
+  const index = getSyntheticsCcsIndex(remoteName);
 
   const { data, loading } = useEsSearch(
     hasNavigationRequest

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/network_events/actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/network_events/actions.ts
@@ -11,6 +11,7 @@ import type { SyntheticsNetworkEventsApiResponse } from '../../../../../common/r
 export interface FetchNetworkEventsParams {
   checkGroup: string;
   stepIndex: number;
+  remoteName?: string;
 }
 
 export interface FetchNetworkEventsFailPayload {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/network_events/api.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/network_events/api.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fetchNetworkEvents } from './api';
+import { SYNTHETICS_API_URLS } from '../../../../../common/constants';
+import { apiService } from '../../../../utils/api_service';
+
+jest.mock('../../../../utils/api_service', () => ({
+  apiService: { get: jest.fn() },
+}));
+
+describe('fetchNetworkEvents remoteName plumbing', () => {
+  const mockGet = apiService.get as jest.Mock;
+
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockGet.mockResolvedValue({ events: [], total: 0 });
+  });
+
+  it('omits the remoteName query param for local monitors', async () => {
+    await fetchNetworkEvents({ checkGroup: 'cg-1', stepIndex: 2 });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      SYNTHETICS_API_URLS.NETWORK_EVENTS,
+      { checkGroup: 'cg-1', stepIndex: 2 },
+      expect.anything()
+    );
+  });
+
+  it('forwards remoteName to apiService.get when present', async () => {
+    await fetchNetworkEvents({ checkGroup: 'cg-1', stepIndex: 2, remoteName: 'remote-a' });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      SYNTHETICS_API_URLS.NETWORK_EVENTS,
+      { checkGroup: 'cg-1', stepIndex: 2, remoteName: 'remote-a' },
+      expect.anything()
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/network_events/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/network_events/api.ts
@@ -19,6 +19,7 @@ export async function fetchNetworkEvents(
     {
       checkGroup: params.checkGroup,
       stepIndex: params.stepIndex,
+      ...(params.remoteName ? { remoteName: params.remoteName } : {}),
     },
     SyntheticsNetworkEventsApiResponseType
   )) as SyntheticsNetworkEventsApiResponse;

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.test.ts
@@ -307,4 +307,42 @@ describe('getNetworkEvents', () => {
       }
     `);
   });
+
+  describe('remoteName CCS index override', () => {
+    const emptyResponse = {
+      hits: {
+        total: { value: 0 },
+        hits: [],
+      },
+    } as any;
+
+    it('does not override the index when remoteName is absent', async () => {
+      const { esClient: mockEsClient, syntheticsEsClient } = getUptimeESMockClient();
+      mockEsClient.search.mockResponseOnce(emptyResponse);
+
+      await getNetworkEvents({
+        syntheticsEsClient,
+        checkGroup: 'my-fake-group',
+        stepIndex: '1',
+      });
+
+      const call: any = mockEsClient.search.mock.calls[0][0];
+      expect(call.index).toBe(syntheticsEsClient.heartbeatIndices);
+    });
+
+    it('prefixes the index with remoteName when present', async () => {
+      const { esClient: mockEsClient, syntheticsEsClient } = getUptimeESMockClient();
+      mockEsClient.search.mockResponseOnce(emptyResponse);
+
+      await getNetworkEvents({
+        syntheticsEsClient,
+        checkGroup: 'my-fake-group',
+        stepIndex: '1',
+        remoteName: 'cluster1',
+      });
+
+      const call: any = mockEsClient.search.mock.calls[0][0];
+      expect(call.index).toBe(`cluster1:${syntheticsEsClient.heartbeatIndices}`);
+    });
+  });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.ts
@@ -6,6 +6,7 @@
  */
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { getSyntheticsCcsIndex } from '../../common/get_synthetics_indices';
 import type { SyntheticsEsClient } from '../lib';
 import type { NetworkEvent } from '../../common/runtime_types';
 
@@ -32,16 +33,8 @@ export const getNetworkEvents = async ({
   isWaterfallSupported: boolean;
   hasNavigationRequest: boolean;
 }> => {
-  // For network events belonging to a journey on a remote cluster, target
-  // `${remoteName}:synthetics-*` via Cross-Cluster Search. When `remoteName`
-  // is absent we let SyntheticsEsClient.search fall back to its default
-  // (local) heartbeat indices.
-  const remoteIndex = remoteName
-    ? `${remoteName}:${syntheticsEsClient.heartbeatIndices}`
-    : undefined;
-
   const params = {
-    ...(remoteIndex ? { index: remoteIndex } : {}),
+    index: getSyntheticsCcsIndex(remoteName, syntheticsEsClient.heartbeatIndices),
     track_total_hits: true,
     query: {
       bool: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_network_events.ts
@@ -12,6 +12,7 @@ import type { NetworkEvent } from '../../common/runtime_types';
 export interface GetNetworkEventsParams {
   checkGroup: string;
   stepIndex: string;
+  remoteName?: string;
 }
 
 export const secondsToMillis = (seconds: number) =>
@@ -22,6 +23,7 @@ export const getNetworkEvents = async ({
   syntheticsEsClient,
   checkGroup,
   stepIndex,
+  remoteName,
 }: GetNetworkEventsParams & {
   syntheticsEsClient: SyntheticsEsClient;
 }): Promise<{
@@ -30,7 +32,16 @@ export const getNetworkEvents = async ({
   isWaterfallSupported: boolean;
   hasNavigationRequest: boolean;
 }> => {
+  // For network events belonging to a journey on a remote cluster, target
+  // `${remoteName}:synthetics-*` via Cross-Cluster Search. When `remoteName`
+  // is absent we let SyntheticsEsClient.search fall back to its default
+  // (local) heartbeat indices.
+  const remoteIndex = remoteName
+    ? `${remoteName}:${syntheticsEsClient.heartbeatIndices}`
+    : undefined;
+
   const params = {
+    ...(remoteIndex ? { index: remoteIndex } : {}),
     track_total_hits: true,
     query: {
       bool: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/network_events/get_network_events.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/network_events/get_network_events.ts
@@ -17,15 +17,17 @@ export const createNetworkEventsRoute: SyntheticsRestApiRouteFactory = () => ({
     query: schema.object({
       checkGroup: schema.string(),
       stepIndex: schema.number(),
+      remoteName: schema.maybe(schema.string()),
     }),
   },
   handler: async ({ syntheticsEsClient, request }): Promise<any> => {
-    const { checkGroup, stepIndex } = request.query;
+    const { checkGroup, stepIndex, remoteName } = request.query;
 
     return await getNetworkEvents({
       syntheticsEsClient,
       checkGroup,
-      stepIndex,
+      stepIndex: String(stepIndex),
+      remoteName,
     });
   },
 });


### PR DESCRIPTION
Built on top of https://github.com/elastic/kibana/pull/270559, will be rebased onto main once above PR is merged.

## Summary

Closes the Cross-Cluster Search (CCS) gap on the **Step Details** page of the monitor detail view — the deepest drill-in from a journey (`Monitor detail → Errors / History / Test run → Step Details`). When the URL carries `?remoteName=<cluster>`, every Step-Details query — server-side ES, client-side direct ES, and the network-events redux pipeline — now targets `${remoteName}:synthetics-*` instead of the local heartbeat indices.

No behavior change for local monitors.

### Scope

| Layer | Change |
|---|---|
| **Server query / route** | `get_network_events` accepts an optional `remoteName` and forwards it as an explicit index override to `SyntheticsEsClient.search`. `GET /internal/synthetics/network_events` accepts `remoteName` as a query parameter. |
| **Direct-ES hooks** (6) | `useStepMetrics`, `useStepPrevMetrics`, `usePreviousObjectMetrics`, `useNetworkTimings`, `useNetworkTimingsPrevious24Hours`, and `useStepWaterfallMetrics` all read `remoteName` from `useGetUrlParams` and prefix the index with `${remoteName}:` when present. `remoteName` is folded into each hook's dependency array so cluster switches invalidate the cached search. |
| **Network-events redux pipeline** | `FetchNetworkEventsParams` gains an optional `remoteName?: string`. `fetchNetworkEvents` forwards it to `apiService.get` as a query param. `StepDetailPage` reads `remoteName` from `useGetUrlParams` and folds it into the `getNetworkEvents.get(...)` dispatch payload and the effect's dependency array. The reducer keys events by `checkGroup` (a UUID), so no reducer change is required. |

### Commits

1. **Server** — `get_network_events` query + route plumb an optional `remoteName` (+ 2 new server tests)
2. **Client — direct-ES hooks** — 6 hooks updated + 5 new spec files + 1 augmented spec (12 new client tests)
3. **Client — network-events redux** — `actions.ts`, `api.ts`, `step_detail_page.tsx` + new `api.test.ts` (2 new client tests)

### Testing
- Manual verification on a local monitor and a remote (CCS) monitor:
  - **Step Details waterfall** renders network events from the correct cluster
  - **Network timings donut + breakdown** populates from the correct cluster
  - **Step metrics** (current + previous 24h median) populates from the correct cluster
  - **Object weight / count lists** populate from the correct cluster
  - **Waterfall markers** (navigationStart, domContentLoaded, etc.) render from the correct cluster

### Identify risks

- Low. The change is additive — every `remoteName` parameter is optional and existing call sites that omit it preserve the current behavior.
- The reducer keys events by `checkGroup` only; cross-cluster `checkGroup` UUID collisions are astronomically unlikely (and a collision would only cause a transient cache hit, not a data leak).
