### PR TITLE
[Agent Builder] Fix "Conversation not found" errors during first message

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_stale_attachments_check.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_stale_attachments_check.test.tsx
@@ -27,10 +27,17 @@ jest.mock('react-use/lib/useEvent', () => ({
   default: jest.fn(),
 }));
 
+const mockActiveStreams = new Map<string, unknown>();
+
+jest.mock('../context/streaming/streaming_context', () => ({
+  useStreamingContext: () => ({ activeStreams: mockActiveStreams }),
+}));
+
 describe('useStaleAttachments', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAddErrorToast.mockClear();
+    mockActiveStreams.clear();
     jest.useFakeTimers();
   });
 
@@ -46,6 +53,69 @@ describe('useStaleAttachments', () => {
     });
 
     expect(mockCheckStale).not.toHaveBeenCalled();
+  });
+
+  it('does not call checkStale when the conversation is actively streaming', async () => {
+    mockActiveStreams.set('streaming-conv', { type: 'send', agentReasoning: null });
+
+    renderHook(() => useStaleAttachments('streaming-conv'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(mockCheckStale).not.toHaveBeenCalled();
+  });
+
+  it('does not call checkStale when conversationId switches from undefined to a new ID while streaming', async () => {
+    const newConversationId = '098d3181-5c84-491b-9a2d-eeca44a4ffea';
+
+    const { rerender } = renderHook(
+      ({ conversationId }: { conversationId: string | undefined }) =>
+        useStaleAttachments(conversationId),
+      { initialProps: { conversationId: undefined as string | undefined } }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(mockCheckStale).not.toHaveBeenCalled();
+
+    mockActiveStreams.set(newConversationId, { type: 'send', agentReasoning: null });
+    rerender({ conversationId: newConversationId });
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(mockCheckStale).not.toHaveBeenCalled();
+  });
+
+  it('calls checkStale once the stream completes for a new conversation', async () => {
+    const newConversationId = 'new-conv-id';
+    mockCheckStale.mockResolvedValue({ attachments: [] });
+
+    mockActiveStreams.set(newConversationId, { type: 'send', agentReasoning: null });
+
+    const { result } = renderHook(
+      ({ conversationId }: { conversationId: string | undefined }) =>
+        useStaleAttachments(conversationId),
+      { initialProps: { conversationId: newConversationId as string | undefined } }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(mockCheckStale).not.toHaveBeenCalled();
+
+    mockActiveStreams.delete(newConversationId);
+
+    await act(async () => {
+      result.current.scheduleStaleCheck();
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(mockCheckStale).toHaveBeenCalledWith(newConversationId);
   });
 
   it('calls checkStale after debounce when conversationId is set', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_stale_attachments_check.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_stale_attachments_check.ts
@@ -16,6 +16,7 @@ import type { AttachmentInput, StaleAttachment } from '@kbn/agent-builder-common
 import { labels } from '../utils/i18n';
 import { useAgentBuilderServices } from './use_agent_builder_service';
 import { useToasts } from './use_toasts';
+import { useStreamingContext } from '../context/streaming/streaming_context';
 
 const STALE_CHECK_DEBOUNCE_MS = 300;
 const STALE_CHECK_DEBOUNCE_OPTIONS = { wait: STALE_CHECK_DEBOUNCE_MS } as const;
@@ -36,6 +37,7 @@ export const useStaleAttachments = (
 ): UseStaleAttachmentsCheckResult => {
   const { attachmentsService } = useAgentBuilderServices();
   const { addErrorToast } = useToasts();
+  const { activeStreams } = useStreamingContext();
   const [staleAttachments, setStaleAttachments] = useState<AttachmentInput[]>([]);
 
   // Always hold the latest stale attachments to avoid stale-closure issues in the debounced fn.
@@ -45,6 +47,10 @@ export const useStaleAttachments = (
   const { run: scheduleStaleCheck } = useDebounceFn(async () => {
     if (!conversationId) {
       setStaleAttachments([]);
+      return;
+    }
+
+    if (activeStreams.has(conversationId)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes noisy `Conversation not found` errors that spam the server console when chatting with an agent.

**Root cause:** PR #267324 changed new-conversation creation to navigate to `/conversations/<uuid>` **immediately** (client-generated UUID), before the server persists the conversation. The `useStaleAttachments` hook fires a debounced `GET /attachments/stale` call whenever `conversationId` changes, but had no guard for active streams — so it hits the server ~300ms after the ID appears, gets a 404, and logs the error.

**Fix:** Skip the stale-attachment check when the conversation has an active stream, matching the same guard `useConversation` already uses.

**Error before fix:**
```
[ERROR][plugins.agentBuilder] Error: Conversation 098d3181-5c84-491b-9a2d-eeca44a4ffea not found
    at createConversationNotFoundError (errors.ts:208:10)
    at ConversationClientImpl.get (client.ts:102:44)
    at attachments.ts:185:30
    ...
```

### How to test

1. Start Kibana locally with Agent Builder enabled
2. Open Agent Builder and start a **new conversation** (send the first message)
3. Check the server console — no more `Conversation not found` errors
4. Verify attachment staleness still works: open an **existing** conversation with attachments, tab away and back — the stale check should still fire

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

