### PR TITLE
[ES|QL] Handles dom exceptions

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -127,7 +127,6 @@ const ESQLEditorInternal = function ESQLEditor({
   queryStats,
   enableResourceBrowser = false,
 }: ESQLEditorPropsInternal) {
-  console.log(serverErrors);
   const popoverRef = useRef<HTMLDivElement>(null);
   const editorModel = useRef<monaco.editor.ITextModel>();
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -127,6 +127,7 @@ const ESQLEditorInternal = function ESQLEditor({
   queryStats,
   enableResourceBrowser = false,
 }: ESQLEditorPropsInternal) {
+  console.log(serverErrors);
   const popoverRef = useRef<HTMLDivElement>(null);
   const editorModel = useRef<monaco.editor.ITextModel>();
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -126,8 +126,6 @@ describe('helpers', function () {
     });
 
     it('should return a string message when error.message is a non-string (e.g. DOMException from aborted fetch)', function () {
-      // Reproduces the bug from poll_search.ts passing signal.reason (a DOMException) directly
-      // to new AbortError(reason), causing AbortError.message to be a DOMException object.
       const domException = new DOMException('signal is aborted without reason', 'AbortError');
       const error = new Error('placeholder');
       (error as unknown as { message: unknown }).message = domException;

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -124,6 +124,20 @@ describe('helpers', function () {
         },
       ]);
     });
+
+    it('should return a string message when error.message is a non-string (e.g. DOMException from aborted fetch)', function () {
+      // Reproduces the bug from poll_search.ts passing signal.reason (a DOMException) directly
+      // to new AbortError(reason), causing AbortError.message to be a DOMException object.
+      const domException = new DOMException('signal is aborted without reason', 'AbortError');
+      const error = new Error('placeholder');
+      (error as unknown as { message: unknown }).message = domException;
+
+      const result = parseErrors([error], 'FROM logs-*');
+
+      expect(result).toHaveLength(1);
+      expect(typeof result[0].message).toBe('string');
+      expect(result[0].code).toBe('unknownError');
+    });
   });
 
   describe('parseWarning', function () {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -119,14 +119,15 @@ const ES_PROBLEM_MARKER_REGEX = /line (\d+):(\d+):/g;
 
 export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
   return errors.flatMap((error): MonacoMessage[] => {
+    const errorMessage = typeof error.message === 'string' ? error.message : String(error.message);
     try {
       if (
         // Found while testing random commands (as inlinestats)
-        !error.message.includes('esql_illegal_argument_exception') &&
-        error.message.includes('line')
+        !errorMessage.includes('esql_illegal_argument_exception') &&
+        errorMessage.includes('line')
       ) {
         const markers: Array<{ line: number; column: number; end: number; start: number }> = [];
-        for (const match of error.message.matchAll(ES_PROBLEM_MARKER_REGEX)) {
+        for (const match of errorMessage.matchAll(ES_PROBLEM_MARKER_REGEX)) {
           markers.push({
             line: Number(match[1]),
             column: Number(match[2]),
@@ -137,8 +138,8 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
 
         if (markers.length > 0) {
           return markers.map((marker, i) => {
-            const messageEnd = i + 1 < markers.length ? markers[i + 1].start : error.message.length;
-            const message = error.message.slice(marker.end, messageEnd).replace(/\s+$/, '');
+            const messageEnd = i + 1 < markers.length ? markers[i + 1].start : errorMessage.length;
+            const message = errorMessage.slice(marker.end, messageEnd).replace(/\s+$/, '');
             const bracketed = message.match(/\[([^\]]*)\]/);
             const errorLength = bracketed ? bracketed[1].length : 10;
             return {
@@ -154,7 +155,7 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
         }
       }
 
-      if (error.message.includes('expression was aborted')) {
+      if (errorMessage.includes('expression was aborted')) {
         return [
           {
             message: i18n.translate('esqlEditor.query.aborted', {
@@ -172,7 +173,7 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
 
       return [
         {
-          message: error.message,
+          message: errorMessage,
           startColumn: 1,
           startLineNumber: 1,
           endColumn: 10,
@@ -184,7 +185,7 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
     } catch (e) {
       return [
         {
-          message: error.message,
+          message: errorMessage,
           startColumn: 1,
           startLineNumber: 1,
           endColumn: 10,


### PR DESCRIPTION
## Summary

This is a regression caused  by https://github.com/elastic/kibana/pull/242346. It changed the error: from the original throwError(() => new AbortError()) to throwError(() => new AbortError((e.target as AbortSignal)?.reason)), intending to preserve the abort reason in the error.

The editor though was not handling this kind of errors correctly causing the following bug:

- I am in Lens ES|QL
- I cancel the query
- I see an error at the footer of my editor
- I click the error
- 💥 

This PR handles this kind of errors gracefully

<img width="722" height="493" alt="image" src="https://github.com/user-attachments/assets/374eadfd-93e0-47d8-8e2f-a2e2c1e3caaf" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->