### PR TITLE
[APM] Fix Jest setup breaking service map unit test mocks

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/.storybook/jest_preview.ts
+++ b/x-pack/solutions/observability/plugins/apm/.storybook/jest_preview.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Minimal Storybook annotations for Jest. Do not import `./preview` here:
+ * the full preview eagerly loads `apmRouter` and the route tree (including
+ * `ServiceMapGraph`), which prevents per-test `jest.mock()` from replacing
+ * modules that graph.tsx already closed over.
+ */
+import { EuiThemeProviderDecorator } from '@kbn/kibana-react-plugin/common';
+import * as jest from 'jest-mock';
+
+(window as any).jest = jest;
+
+export const decorators = [EuiThemeProviderDecorator];

--- a/x-pack/solutions/observability/plugins/apm/.storybook/jest_setup.ts
+++ b/x-pack/solutions/observability/plugins/apm/.storybook/jest_setup.ts
@@ -6,6 +6,6 @@
  */
 
 import { setProjectAnnotations } from '@storybook/react';
-import * as globalStorybookConfig from './preview';
+import * as globalStorybookConfig from './jest_preview';
 
 setProjectAnnotations(globalStorybookConfig);

--- a/x-pack/solutions/observability/plugins/apm/jest.config.js
+++ b/x-pack/solutions/observability/plugins/apm/jest.config.js
@@ -11,9 +11,7 @@ module.exports = {
   preset: '@kbn/test',
   rootDir: path.resolve(__dirname, '../../../../..'),
   roots: ['<rootDir>/x-pack/solutions/observability/plugins/apm'],
-  setupFilesAfterEnv: [
-    '<rootDir>/x-pack/solutions/observability/plugins/apm/.storybook/jest_setup.ts',
-  ],
+  setupFiles: ['<rootDir>/x-pack/solutions/observability/plugins/apm/.storybook/jest_setup.ts'],
   coverageDirectory:
     '<rootDir>/target/kibana-coverage/jest/x-pack/solutions/observability/plugins/apm',
   coverageReporters: ['text', 'html'],


### PR DESCRIPTION
## Summary

- Add a minimal `jest_preview.ts` for APM Jest runs so setup no longer imports the full Storybook `preview.tsx`
- Point `jest_setup.ts` at the minimal preview and restore `setupFiles` (instead of `setupFilesAfterEnv`) in `jest.config.js`

## Background

Two recent changes combined to break APM unit tests that mock router-dependent hooks:

1. **#268859** — `ServiceMapGraph` started calling `useServiceMapAlertsNavigateFactory()`, which depends on `useApmRouter()` / `useRouter()`. Graph tests added a shared `use_service_map_alerts_tab_href.test_mock` stub to avoid needing a real router context. That mock worked as long as Jest setup did not pre-load `graph.tsx`.

2. **#270531** — APM Jest setup was changed to import the full Storybook `preview.tsx` via `setupFilesAfterEnv`. That preview eagerly loads `apmRouter` and the route tree (`preview.tsx` → `apmRouter` → `mobile_service_detail` → `service_map/index.tsx` → `graph.tsx` → real `use_service_map_alerts_tab_href.ts`).

Because that import chain runs during Jest setup—before each test file's hoisted `jest.mock()` calls—`graph.tsx` is cached with bindings to the **real** hooks. Later mocks of `use_service_map_alerts_tab_href` or `use_apm_router` no longer apply, and tests fail with errors like `Router not found in context`.

This PR decouples Jest setup from the full Storybook preview (restoring the pre-#270531 pattern of a minimal preview for Jest only). Storybook itself continues to use the full `preview.tsx`.

## Test plan

- [x] `node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_screen_reader.test.tsx`
- [x] `node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/app/service_map/use_service_map_alerts_tab_href.test.ts`
- [x] `node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_controls.test.tsx`
- [x] `node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph_minimap.test.tsx`
- [x] `node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover.test.tsx`
- [x] `node scripts/check_changes.ts`