### PR TITLE
[FeatureBranch/DoNotReview] Migrate Streams headers to Chrome Next

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/query_streams/create_query_stream_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/query_streams/create_query_stream_flyout.tsx
@@ -41,7 +41,7 @@ export function CreateQueryStreamFlyout({ onQueryStreamCreated }: CreateQueryStr
   );
 }
 
-const CreateQueryStreamFlyoutContent = ({
+export const CreateQueryStreamFlyoutContent = ({
   onClose,
   onQueryStreamCreated,
 }: {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
@@ -233,7 +233,6 @@ export function LifecycleBadge({
 
 interface DiscoverBadgeButtonBaseProps {
   hasDataStream?: boolean;
-  spellOut?: boolean;
 }
 
 interface DiscoverBadgeButtonIngestProps extends DiscoverBadgeButtonBaseProps {
@@ -246,27 +245,29 @@ interface DiscoverBadgeButtonQueryProps extends DiscoverBadgeButtonBaseProps {
   indexMode?: never;
 }
 
-type DiscoverBadgeButtonProps = DiscoverBadgeButtonIngestProps | DiscoverBadgeButtonQueryProps;
+type DiscoverLinkProps = DiscoverBadgeButtonIngestProps | DiscoverBadgeButtonQueryProps;
 
-export function DiscoverBadgeButton({
-  stream,
-  hasDataStream = false,
-  spellOut = false,
-  indexMode,
-}: DiscoverBadgeButtonProps) {
+type DiscoverBadgeButtonProps = DiscoverLinkProps & {
+  spellOut?: boolean;
+};
+
+export function useDiscoverLink(props?: DiscoverLinkProps) {
   const {
     dependencies: {
       start: { share },
     },
   } = useKibana();
-  const isIngestStream = !Streams.QueryStream.Definition.is(stream);
   const { features } = useStreamsPrivileges();
-  const esqlQuery = getDiscoverEsqlQuery({
-    definition: stream,
-    indexMode: isIngestStream ? indexMode : undefined,
-    includeMetadata: Streams.WiredStream.Definition.is(stream),
-    useViews: features.wiredStreamViews.enabled,
-  });
+  const stream = props?.stream;
+  const isIngestStream = stream ? !Streams.QueryStream.Definition.is(stream) : false;
+  const esqlQuery = stream
+    ? getDiscoverEsqlQuery({
+        definition: stream,
+        indexMode: isIngestStream ? props.indexMode : undefined,
+        includeMetadata: Streams.WiredStream.Definition.is(stream),
+        useViews: features.wiredStreamViews.enabled,
+      })
+    : undefined;
   const useUrl = share.url.locators.useUrl;
 
   const discoverLink = useUrl<DiscoverAppLocatorParams>(
@@ -279,7 +280,18 @@ export function DiscoverBadgeButton({
     [esqlQuery]
   );
 
-  if (!discoverLink || !hasDataStream || !esqlQuery) {
+  if (!discoverLink || !props?.hasDataStream || !esqlQuery) {
+    return undefined;
+  }
+
+  return discoverLink;
+}
+
+export function DiscoverBadgeButton({ spellOut = false, ...linkProps }: DiscoverBadgeButtonProps) {
+  const { stream } = linkProps;
+  const discoverLink = useDiscoverLink(linkProps);
+
+  if (!discoverLink) {
     return null;
   }
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -212,23 +212,31 @@ export function StreamListView() {
 
     if (showQueryStreams) {
       items.push({
-        id: 'createQueryStream',
-        order: 3,
-        label: createQueryStreamLabel,
-        iconType: 'plus',
-        run: () => setIsQueryStreamCreationFlyoutOpen(true),
-        testId: 'streamsAppCreateQueryStreamButton',
-      });
-    }
-
-    return {
-      primaryActionItem: {
         id: 'createClassicStream',
+        order: 3,
         label: createClassicStreamLabel,
         iconType: 'plus',
         run: () => setIsClassicStreamCreationFlyoutOpen(true),
         disableButton: !(canManageStreamsKibana && canManageClassicElasticsearch),
-      },
+      });
+    }
+
+    return {
+      primaryActionItem: showQueryStreams
+        ? {
+            id: 'createQueryStream',
+            label: createQueryStreamLabel,
+            iconType: 'plus',
+            run: () => setIsQueryStreamCreationFlyoutOpen(true),
+            testId: 'streamsAppCreateQueryStreamButton',
+          }
+        : {
+            id: 'createClassicStream',
+            label: createClassicStreamLabel,
+            iconType: 'plus',
+            run: () => setIsClassicStreamCreationFlyoutOpen(true),
+            disableButton: !(canManageStreamsKibana && canManageClassicElasticsearch),
+          },
       items,
     };
   }, [

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -9,13 +9,10 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiEmptyPrompt,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiLink,
   EuiLoadingElastic,
-  useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
+import type { AppHeaderMenu } from '@kbn/app-header';
 import { usePerformanceContext } from '@kbn/ebt-tools';
 import { i18n } from '@kbn/i18n';
 import { Streams } from '@kbn/streams-schema';
@@ -27,18 +24,20 @@ import { useStreamsAppFetch } from '../../hooks/use_streams_app_fetch';
 import { useStreamsAppRouter } from '../../hooks/use_streams_app_router';
 import { useStreamsPrivileges } from '../../hooks/use_streams_privileges';
 import { useTimefilter } from '../../hooks/use_timefilter';
-import { StreamsAppPageTemplate } from '../streams_app_page_template';
+import { StreamsAppHeader, StreamsAppPageTemplate } from '../streams_app_page_template';
 import { WelcomeTourCallout } from '../streams_tour';
 import { ClassicStreamCreationFlyout } from './classic_stream_creation_flyout';
 import { StreamsListEmptyPrompt } from './streams_list_empty_prompt';
 import { StreamsSettingsFlyout } from './streams_settings_flyout';
 import { StreamsTreeTable } from './tree_table';
 import { LegacyLogsDeprecationCallout } from './legacy_logs_deprecation_callout';
-import { CreateQueryStreamFlyout } from '../query_streams/create_query_stream_flyout';
+import {
+  CreateQueryStreamFlyout,
+  CreateQueryStreamFlyoutContent,
+} from '../query_streams/create_query_stream_flyout';
 import { getFormattedError } from '../../util/errors';
 
 export function StreamListView() {
-  const { euiTheme } = useEuiTheme();
   const context = useKibana();
   const {
     dependencies: {
@@ -147,87 +146,163 @@ export function StreamListView() {
   const [isSettingsFlyoutOpen, setIsSettingsFlyoutOpen] = React.useState(false);
   const [isClassicStreamCreationFlyoutOpen, setIsClassicStreamCreationFlyoutOpen] =
     React.useState(false);
+  const [isQueryStreamCreationFlyoutOpen, setIsQueryStreamCreationFlyoutOpen] =
+    React.useState(false);
+
+  const pageTitle = i18n.translate('xpack.streams.streamsListView.pageHeaderTitle', {
+    defaultMessage: 'Streams',
+  });
+  const settingsLabel = i18n.translate('xpack.streams.streamsListView.settingsButtonLabel', {
+    defaultMessage: 'Settings',
+  });
+  const createClassicStreamLabel = i18n.translate(
+    'xpack.streams.streamsListView.createClassicStreamButtonLabel',
+    {
+      defaultMessage: 'Create classic stream',
+    }
+  );
+  const significantEventsLabel = i18n.translate(
+    'xpack.streams.streamsListView.sigEventsDiscoveryButtonLabel',
+    {
+      defaultMessage: 'Significant Events',
+    }
+  );
+  const createQueryStreamLabel = i18n.translate(
+    'xpack.streams.streamsListView.createQueryStreamButtonLabel',
+    {
+      defaultMessage: 'Create Query stream',
+    }
+  );
+  const pageDescription = i18n.translate('xpack.streams.streamsListView.pageHeaderDescription', {
+    defaultMessage:
+      'Manage how your data is ingested, structured, and retained across all your streams.',
+  });
+  const learnMoreLabel = i18n.translate(
+    'xpack.streams.streamsListView.pageHeaderDescriptionLearnMoreLink',
+    {
+      defaultMessage: 'Learn more',
+    }
+  );
+  const showSignificantEventsDiscovery =
+    significantEventsDiscovery?.available && significantEventsDiscovery.enabled;
+  const showQueryStreams = queryStreams?.enabled;
+  const significantEventsDiscoveryHref = router.link('/_discovery');
+
+  const menu = useMemo<AppHeaderMenu>(() => {
+    const items: NonNullable<AppHeaderMenu['items']> = [
+      {
+        id: 'settings',
+        order: 1,
+        label: settingsLabel,
+        iconType: 'gear',
+        run: () => setIsSettingsFlyoutOpen(true),
+      },
+    ];
+
+    if (showSignificantEventsDiscovery) {
+      items.push({
+        id: 'significantEventsDiscovery',
+        order: 2,
+        label: significantEventsLabel,
+        iconType: 'crosshairs',
+        href: significantEventsDiscoveryHref,
+        testId: 'streamsSignificantEventsDiscoveryButton',
+      });
+    }
+
+    if (showQueryStreams) {
+      items.push({
+        id: 'createQueryStream',
+        order: 3,
+        label: createQueryStreamLabel,
+        iconType: 'plus',
+        run: () => setIsQueryStreamCreationFlyoutOpen(true),
+        testId: 'streamsAppCreateQueryStreamButton',
+      });
+    }
+
+    return {
+      primaryActionItem: {
+        id: 'createClassicStream',
+        label: createClassicStreamLabel,
+        iconType: 'plus',
+        run: () => setIsClassicStreamCreationFlyoutOpen(true),
+        disableButton: !(canManageStreamsKibana && canManageClassicElasticsearch),
+      },
+      items,
+    };
+  }, [
+    canManageClassicElasticsearch,
+    canManageStreamsKibana,
+    createClassicStreamLabel,
+    createQueryStreamLabel,
+    settingsLabel,
+    showQueryStreams,
+    showSignificantEventsDiscovery,
+    significantEventsDiscoveryHref,
+    significantEventsLabel,
+  ]);
+
+  const classicHeaderActions = [
+    <EuiButtonEmpty
+      key="settings"
+      iconType="gear"
+      size="s"
+      onClick={() => setIsSettingsFlyoutOpen(true)}
+      aria-label={settingsLabel}
+    >
+      {settingsLabel}
+    </EuiButtonEmpty>,
+    <EuiButton
+      key="createClassicStream"
+      onClick={() => setIsClassicStreamCreationFlyoutOpen(true)}
+      size="s"
+      disabled={!(canManageStreamsKibana && canManageClassicElasticsearch)}
+    >
+      {createClassicStreamLabel}
+    </EuiButton>,
+    ...(showSignificantEventsDiscovery
+      ? [
+          <EuiButton
+            key="significantEventsDiscovery"
+            href={significantEventsDiscoveryHref}
+            iconType="crosshairs"
+            size="s"
+            data-test-subj="streamsSignificantEventsDiscoveryButton"
+          >
+            {significantEventsLabel}
+          </EuiButton>,
+        ]
+      : []),
+    ...(showQueryStreams
+      ? [
+          <CreateQueryStreamFlyout
+            key="createQueryStream"
+            onQueryStreamCreated={streamsListFetch.refresh}
+          />,
+        ]
+      : []),
+  ];
+  const fallbackRightSideItems = [...classicHeaderActions].reverse();
 
   return (
     <>
-      <StreamsAppPageTemplate.Header
-        bottomBorder="extended"
-        css={css`
-          background: ${euiTheme.colors.backgroundBasePlain};
-        `}
-        pageTitle={
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-            gutterSize="s"
-            responsive={false}
-            alignItems="center"
-          >
-            <EuiFlexItem>
-              <EuiFlexGroup alignItems="center" gutterSize="m">
-                {i18n.translate('xpack.streams.streamsListView.pageHeaderTitle', {
-                  defaultMessage: 'Streams',
-                })}
-              </EuiFlexGroup>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                iconType="gear"
-                size="s"
-                onClick={() => setIsSettingsFlyoutOpen(true)}
-                aria-label={i18n.translate('xpack.streams.streamsListView.settingsButtonLabel', {
-                  defaultMessage: 'Settings',
-                })}
-              >
-                {i18n.translate('xpack.streams.streamsListView.settingsButtonLabel', {
-                  defaultMessage: 'Settings',
-                })}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                onClick={() => setIsClassicStreamCreationFlyoutOpen(true)}
-                size="s"
-                disabled={!(canManageStreamsKibana && canManageClassicElasticsearch)}
-              >
-                {i18n.translate('xpack.streams.streamsListView.createClassicStreamButtonLabel', {
-                  defaultMessage: 'Create classic stream',
-                })}
-              </EuiButton>
-            </EuiFlexItem>
-            {significantEventsDiscovery?.available && significantEventsDiscovery.enabled && (
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  href={router.link('/_discovery')}
-                  iconType="crosshairs"
-                  size="s"
-                  data-test-subj="streamsSignificantEventsDiscoveryButton"
-                >
-                  {i18n.translate('xpack.streams.streamsListView.sigEventsDiscoveryButtonLabel', {
-                    defaultMessage: 'Significant Events',
-                  })}
-                </EuiButton>
-              </EuiFlexItem>
-            )}
-            {queryStreams?.enabled && (
-              <EuiFlexItem grow={false}>
-                <CreateQueryStreamFlyout onQueryStreamCreated={streamsListFetch.refresh} />
-              </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-        }
-        description={
-          <>
-            {i18n.translate('xpack.streams.streamsListView.pageHeaderDescription', {
-              defaultMessage:
-                'Manage how your data is ingested, structured, and retained across all your streams.',
-            })}{' '}
-            <EuiLink href={streamsDocsLink} target="_blank">
-              {i18n.translate('xpack.streams.streamsListView.pageHeaderDescriptionLearnMoreLink', {
-                defaultMessage: 'Learn more',
-              })}
-            </EuiLink>
-          </>
-        }
+      <StreamsAppHeader
+        title={pageTitle}
+        menu={menu}
+        docLink={streamsDocsLink}
+        fallback={{
+          pageTitle,
+          rightSideItems: fallbackRightSideItems,
+          description: (
+            <>
+              {pageDescription}{' '}
+              <EuiLink href={streamsDocsLink} target="_blank">
+                {learnMoreLabel}
+              </EuiLink>
+            </>
+          ),
+        }}
       />
       <StreamsAppPageTemplate.Body grow>
         {streamsListFetch.loading && streamsListFetch.value === undefined ? (
@@ -272,6 +347,12 @@ export function StreamListView() {
       )}
       {isClassicStreamCreationFlyoutOpen && (
         <ClassicStreamCreationFlyout onClose={() => setIsClassicStreamCreationFlyoutOpen(false)} />
+      )}
+      {isQueryStreamCreationFlyoutOpen && (
+        <CreateQueryStreamFlyoutContent
+          onClose={() => setIsQueryStreamCreationFlyoutOpen(false)}
+          onQueryStreamCreated={streamsListFetch.refresh}
+        />
       )}
     </>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/classic.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/classic.tsx
@@ -106,11 +106,15 @@ export function ClassicStreamDetailManagement({
     }),
   };
 
+  const lifecycleTabLabel = i18n.translate('xpack.streams.streamDetailView.lifecycleTab', {
+    defaultMessage: 'Data lifecycle',
+  });
   tabs.lifecycle = {
     content: (
       <StreamDetailLifecycle definition={definition} refreshDefinition={refreshDefinition} />
     ),
-    label: (
+    label: lifecycleTabLabel,
+    fallbackLabel: (
       <EuiToolTip
         content={i18n.translate('xpack.streams.managementTab.lifecycle.tooltip', {
           defaultMessage:
@@ -118,9 +122,7 @@ export function ClassicStreamDetailManagement({
         })}
       >
         <span data-test-subj="retentionTab" tabIndex={0}>
-          {i18n.translate('xpack.streams.streamDetailView.lifecycleTab', {
-            defaultMessage: 'Data lifecycle',
-          })}
+          {lifecycleTabLabel}
         </span>
       </EuiToolTip>
     ),
@@ -150,20 +152,22 @@ export function ClassicStreamDetailManagement({
     }),
   };
 
+  const dataQualityTabLabel = i18n.translate('xpack.streams.streamDetailView.qualityTab', {
+    defaultMessage: 'Data quality',
+  });
   tabs.dataQuality = {
     content: (
       <StreamDetailDataQuality definition={definition} refreshDefinition={refreshDefinition} />
     ),
-    label: (
+    label: dataQualityTabLabel,
+    fallbackLabel: (
       <EuiToolTip
         content={i18n.translate('xpack.streams.managementTab.dataQuality.tooltip', {
           defaultMessage: 'View details about this classic stream’s data quality',
         })}
       >
         <span data-test-subj="dataQualityTab" tabIndex={0}>
-          {i18n.translate('xpack.streams.streamDetailView.qualityTab', {
-            defaultMessage: 'Data quality',
-          })}
+          {dataQualityTabLabel}
         </span>
       </EuiToolTip>
     ),
@@ -181,22 +185,22 @@ export function ClassicStreamDetailManagement({
   }
 
   if (definition.privileges.manage || definition.replicated) {
+    const advancedTabLabel = i18n.translate('xpack.streams.streamDetailView.advancedTab', {
+      defaultMessage: 'Advanced',
+    });
     tabs.advanced = {
       content: (
         <ClassicAdvancedView definition={definition} refreshDefinition={refreshDefinition} />
       ),
-      label: (
+      label: advancedTabLabel,
+      fallbackLabel: (
         <EuiToolTip
           content={i18n.translate('xpack.streams.managementTab.advanced.tooltip', {
             defaultMessage:
               'View technical details about this classic stream’s underlying index setup',
           })}
         >
-          <span tabIndex={0}>
-            {i18n.translate('xpack.streams.streamDetailView.advancedTab', {
-              defaultMessage: 'Advanced',
-            })}
-          </span>
+          <span tabIndex={0}>{advancedTabLabel}</span>
         </EuiToolTip>
       ),
     };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/query.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/query.tsx
@@ -96,21 +96,21 @@ export function QueryStreamDetailManagement({
     tabs.significantEvents = significantEvents;
   }
 
+  const advancedTabLabel = i18n.translate('xpack.streams.queryStreamDetailManagement.advancedTab', {
+    defaultMessage: 'Advanced',
+  });
   tabs.advanced = {
     content: (
       <QueryStreamsAdvancedView definition={definition} refreshDefinition={refreshDefinition} />
     ),
-    label: (
+    label: advancedTabLabel,
+    fallbackLabel: (
       <EuiToolTip
         content={i18n.translate('xpack.streams.queryStreamDetailManagement.advanced.tooltip', {
           defaultMessage: 'View technical details about this query stream’s underlying setup',
         })}
       >
-        <span tabIndex={0}>
-          {i18n.translate('xpack.streams.queryStreamDetailManagement.advancedTab', {
-            defaultMessage: 'Advanced',
-          })}
-        </span>
+        <span tabIndex={0}>{advancedTabLabel}</span>
       </EuiToolTip>
     ),
   };
@@ -138,8 +138,8 @@ export function QueryStreamDetailManagement({
             <DiscoverBadgeButton stream={definition.stream} hasDataStream spellOut />
           </EuiFlexGroup>
         }
-        tabs={Object.entries(tabs).map(([tabKey, { label }]) => ({
-          label,
+        tabs={Object.entries(tabs).map(([tabKey, { label, fallbackLabel }]) => ({
+          label: fallbackLabel ?? label,
           href: router.link('/{key}/management/{tab}', {
             path: { key, tab: tabKey },
             query: { rangeFrom, rangeTo },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wired.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wired.tsx
@@ -157,6 +157,13 @@ export function WiredStreamDetailManagement({
     );
   }
 
+  const lifecycleTabLabel = i18n.translate('xpack.streams.streamDetailView.lifecycleTab', {
+    defaultMessage: 'Data lifecycle',
+  });
+  const dataQualityTabLabel = i18n.translate('xpack.streams.streamDetailView.qualityTab', {
+    defaultMessage: 'Data quality',
+  });
+
   const tabs = {
     overview: {
       content: <StreamOverview />,
@@ -173,7 +180,8 @@ export function WiredStreamDetailManagement({
                 refreshDefinition={refreshDefinition}
               />
             ),
-            label: (
+            label: lifecycleTabLabel,
+            fallbackLabel: (
               <EuiToolTip
                 position="top"
                 content={i18n.translate('xpack.streams.managementTab.lifecycle.tooltip', {
@@ -182,9 +190,7 @@ export function WiredStreamDetailManagement({
                 })}
               >
                 <span data-test-subj="retentionTab" tabIndex={0}>
-                  {i18n.translate('xpack.streams.streamDetailView.lifecycleTab', {
-                    defaultMessage: 'Data lifecycle',
-                  })}
+                  {lifecycleTabLabel}
                 </span>
               </EuiToolTip>
             ),
@@ -217,16 +223,15 @@ export function WiredStreamDetailManagement({
                 refreshDefinition={refreshDefinition}
               />
             ),
-            label: (
+            label: dataQualityTabLabel,
+            fallbackLabel: (
               <EuiToolTip
                 content={i18n.translate('xpack.streams.managementTab.dataQuality.wired.tooltip', {
                   defaultMessage: "View details about this stream's data quality",
                 })}
               >
                 <span data-test-subj="dataQualityTab" tabIndex={0}>
-                  {i18n.translate('xpack.streams.streamDetailView.qualityTab', {
-                    defaultMessage: 'Data quality',
-                  })}
+                  {dataQualityTabLabel}
                 </span>
               </EuiToolTip>
             ),

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wrapper.tsx
@@ -168,7 +168,7 @@ export function Wrapper({
   const viewInDiscoverLabel = i18n.translate(
     'xpack.streams.entityDetailViewWithoutParams.openInDiscoverBadgeLabel',
     {
-      defaultMessage: 'View in Discover',
+      defaultMessage: 'Open in Discover',
     }
   );
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wrapper.tsx
@@ -10,12 +10,10 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiPageHeader,
   EuiSpacer,
   EuiTourStep,
-  useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
+import type { AppHeaderBadge, AppHeaderMenu, AppHeaderTab } from '@kbn/app-header';
 import { i18n } from '@kbn/i18n';
 import { DatasetQualityIndicator } from '@kbn/dataset-quality-plugin/public';
 import {
@@ -43,15 +41,17 @@ import {
   LifecycleBadge,
   TimeSeriesBadge,
   WiredStreamBadge,
+  useDiscoverLink,
 } from '../../../stream_badges';
-import { StreamsAppPageTemplate } from '../../../streams_app_page_template';
+import { StreamsAppHeader, StreamsAppPageTemplate } from '../../../streams_app_page_template';
 import { TAB_TO_TOUR_STEP_ID, useStreamsTour } from '../../../streams_tour';
 
 export type ManagementTabs = Record<
   string,
   {
     content: JSX.Element;
-    label: ReactNode;
+    label: string;
+    fallbackLabel?: ReactNode;
   }
 >;
 
@@ -108,6 +108,7 @@ export function Wrapper({
             query: { rangeFrom, rangeTo },
           }),
           label: currentTab.label,
+          fallbackLabel: currentTab.fallbackLabel,
           content: currentTab.content,
         },
       ];
@@ -155,25 +156,47 @@ export function Wrapper({
   const isQualityLoading =
     countResult?.loading || failedDocsResult?.loading || degradedDocsResult.loading;
 
-  const { euiTheme } = useEuiTheme();
+  const discoverLink = useDiscoverLink(
+    Streams.ingest.all.GetResponse.is(definition)
+      ? {
+          stream: definition.stream,
+          hasDataStream: definition.data_stream_exists || isDraft,
+          indexMode: definition.index_mode ?? 'standard',
+        }
+      : undefined
+  );
+  const viewInDiscoverLabel = i18n.translate(
+    'xpack.streams.entityDetailViewWithoutParams.openInDiscoverBadgeLabel',
+    {
+      defaultMessage: 'View in Discover',
+    }
+  );
 
-  const streamBadges: Array<{ key: string; node: ReactNode }> = [];
+  const streamBadges: Array<{ key: string; label: string; node: ReactNode }> = [];
   if (Streams.ClassicStream.GetResponse.is(definition)) {
-    streamBadges.push({ key: 'classic', node: <ClassicStreamBadge /> });
+    streamBadges.push({
+      key: 'classic',
+      label: i18n.translate('xpack.streams.streamDetailHeader.classicBadgeLabel', {
+        defaultMessage: 'Classic',
+      }),
+      node: <ClassicStreamBadge />,
+    });
   }
 
   if (Streams.WiredStream.GetResponse.is(definition)) {
     if (ROOT_STREAM_NAMES.includes(definition.stream.name as RootStreamName)) {
+      const technicalPreviewLabel = i18n.translate('xpack.streams.technicalPreviewLabel', {
+        defaultMessage: 'Technical preview',
+      });
       streamBadges.push({
         key: 'technicalPreview',
+        label: technicalPreviewLabel,
         node: (
           <EuiBetaBadge
             tooltipContent={i18n.translate('xpack.streams.technicalPreviewTooltip', {
               defaultMessage: 'This feature is in technical preview. We are working on it...',
             })}
-            label={i18n.translate('xpack.streams.technicalPreviewLabel', {
-              defaultMessage: 'Technical preview',
-            })}
+            label={technicalPreviewLabel}
             iconType="flask"
             size="s"
             css={{ display: 'block' }}
@@ -181,17 +204,38 @@ export function Wrapper({
         ),
       });
     }
-    streamBadges.push({ key: 'wired', node: <WiredStreamBadge /> });
+    streamBadges.push({
+      key: 'wired',
+      label: i18n.translate('xpack.streams.streamDetailHeader.wiredBadgeLabel', {
+        defaultMessage: 'Wired',
+      }),
+      node: <WiredStreamBadge />,
+    });
     if (isDraft) {
-      streamBadges.push({ key: 'draft', node: <DraftStreamBadge /> });
+      streamBadges.push({
+        key: 'draft',
+        label: i18n.translate('xpack.streams.streamDetailHeader.draftBadgeLabel', {
+          defaultMessage: 'Draft',
+        }),
+        node: <DraftStreamBadge />,
+      });
     }
   }
   if (Streams.ingest.all.GetResponse.is(definition) && !isDraft) {
     if (definition.index_mode === 'time_series') {
-      streamBadges.push({ key: 'timeSeries', node: <TimeSeriesBadge /> });
+      streamBadges.push({
+        key: 'timeSeries',
+        label: i18n.translate('xpack.streams.streamDetailHeader.timeSeriesBadgeLabel', {
+          defaultMessage: 'Time series',
+        }),
+        node: <TimeSeriesBadge />,
+      });
     }
     streamBadges.push({
       key: 'lifecycle',
+      label: i18n.translate('xpack.streams.streamDetailHeader.lifecycleBadgeLabel', {
+        defaultMessage: 'Lifecycle',
+      }),
       node: (
         <LifecycleBadge
           lifecycle={definition.effective_lifecycle}
@@ -203,6 +247,9 @@ export function Wrapper({
   if (!isDraft) {
     streamBadges.push({
       key: 'quality',
+      label: i18n.translate('xpack.streams.streamDetailHeader.qualityBadgeLabel', {
+        defaultMessage: 'Quality',
+      }),
       node: (
         <DatasetQualityIndicator
           quality={quality}
@@ -214,22 +261,83 @@ export function Wrapper({
     });
   }
 
+  const appHeaderBadges: AppHeaderBadge[] = streamBadges.map(({ label, node }) => ({
+    label,
+    renderCustomBadge: () => <>{node}</>,
+  }));
+  const appHeaderTabs: AppHeaderTab[] = Object.entries(tabMap).map(([tabKey, { label, href }]) => ({
+    id: tabKey,
+    label,
+    href,
+    isSelected: tab === tabKey,
+  }));
+  const appHeaderMenu: AppHeaderMenu | undefined = discoverLink
+    ? {
+        primaryActionItem: {
+          id: 'viewInDiscover',
+          label: viewInDiscoverLabel,
+          iconType: 'discoverApp',
+          href: discoverLink,
+          testId: `streamsDiscoverActionButton-${definition.stream.name}`,
+        },
+      }
+    : undefined;
+  const fallbackRightSideItems =
+    discoverLink && Streams.ingest.all.GetResponse.is(definition)
+      ? [
+          <DiscoverBadgeButton
+            key="viewInDiscover"
+            stream={definition.stream}
+            hasDataStream={definition.data_stream_exists || isDraft}
+            indexMode={definition.index_mode ?? 'standard'}
+            spellOut
+          />,
+        ]
+      : undefined;
+  const fallbackTabs = Object.entries(tabMap).map(([tabKey, { label, fallbackLabel, href }]) => {
+    const tourStepId = TAB_TO_TOUR_STEP_ID[tabKey];
+    const stepProps = tourStepId ? getStepPropsByStepId(tourStepId) : undefined;
+
+    const wrappedLabel = stepProps ? (
+      <EuiTourStep
+        step={stepProps.step}
+        stepsTotal={stepProps.stepsTotal}
+        title={stepProps.title}
+        subtitle={stepProps.subtitle}
+        content={stepProps.content}
+        anchorPosition={stepProps.anchorPosition}
+        offset={stepProps.offset}
+        maxWidth={stepProps.maxWidth}
+        isStepOpen={stepProps.isStepOpen}
+        footerAction={stepProps.footerAction}
+        onFinish={stepProps.onFinish}
+      >
+        <span>{fallbackLabel ?? label}</span>
+      </EuiTourStep>
+    ) : (
+      fallbackLabel ?? label
+    );
+
+    return {
+      label: wrappedLabel,
+      href,
+      isSelected: tab === tabKey,
+    };
+  });
+  const streamsBackLabel = i18n.translate('xpack.streams.streamDetailHeader.backToStreamsLabel', {
+    defaultMessage: 'Streams',
+  });
+
   return (
     <>
-      <EuiPageHeader
-        paddingSize="l"
-        bottomBorder="extended"
-        css={css`
-          background: ${euiTheme.colors.backgroundBasePlain};
-        `}
-        pageTitle={
-          <EuiFlexGroup
-            direction="row"
-            gutterSize="s"
-            alignItems="center"
-            justifyContent="spaceBetween"
-            wrap
-          >
+      <StreamsAppHeader
+        title={streamId}
+        back={{ href: router.link('/'), label: streamsBackLabel }}
+        badges={appHeaderBadges}
+        tabs={appHeaderTabs}
+        menu={appHeaderMenu}
+        fallback={{
+          pageTitle: (
             <EuiFlexGroup direction="row" gutterSize="s" alignItems="center" wrap>
               <EuiFlexItem grow={false}>{streamId}</EuiFlexItem>
               <EuiFlexGroup alignItems="center" gutterSize="s" wrap responsive={false}>
@@ -240,46 +348,10 @@ export function Wrapper({
                 ))}
               </EuiFlexGroup>
             </EuiFlexGroup>
-            {Streams.ingest.all.GetResponse.is(definition) && (
-              <DiscoverBadgeButton
-                stream={definition.stream}
-                hasDataStream={definition.data_stream_exists || isDraft}
-                indexMode={definition.index_mode ?? 'standard'}
-                spellOut
-              />
-            )}
-          </EuiFlexGroup>
-        }
-        tabs={Object.entries(tabMap).map(([tabKey, { label, href }]) => {
-          const tourStepId = TAB_TO_TOUR_STEP_ID[tabKey];
-          const stepProps = tourStepId ? getStepPropsByStepId(tourStepId) : undefined;
-
-          const wrappedLabel = stepProps ? (
-            <EuiTourStep
-              step={stepProps.step}
-              stepsTotal={stepProps.stepsTotal}
-              title={stepProps.title}
-              subtitle={stepProps.subtitle}
-              content={stepProps.content}
-              anchorPosition={stepProps.anchorPosition}
-              offset={stepProps.offset}
-              maxWidth={stepProps.maxWidth}
-              isStepOpen={stepProps.isStepOpen}
-              footerAction={stepProps.footerAction}
-              onFinish={stepProps.onFinish}
-            >
-              <span>{label}</span>
-            </EuiTourStep>
-          ) : (
-            label
-          );
-
-          return {
-            label: wrappedLabel,
-            href,
-            isSelected: tab === tabKey,
-          };
-        })}
+          ),
+          rightSideItems: fallbackRightSideItems,
+          tabs: fallbackTabs,
+        }}
       />
       <StreamsAppPageTemplate.Body noPadding={tab === 'partitioning' || tab === 'processing'}>
         {topContent}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_template/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_template/index.tsx
@@ -7,8 +7,11 @@
 
 import React from 'react';
 import type { EuiPageSectionProps } from '@elastic/eui';
-import { EuiPageTemplate } from '@elastic/eui';
+import { EuiPageTemplate, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/css';
+import { css as emotionCss } from '@emotion/react';
+import type { AppHeaderProps } from '@kbn/app-header';
+import { AppHeader } from '@kbn/app-header';
 
 export function StreamsAppPageTemplate({ children }: { children: React.ReactNode }) {
   return (
@@ -24,6 +27,30 @@ export function StreamsAppPageTemplate({ children }: { children: React.ReactNode
     </EuiPageTemplate>
   );
 }
+
+export const StreamsAppHeader = ({ fallback, ...props }: AppHeaderProps) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <AppHeader
+      fallback={
+        fallback === null
+          ? null
+          : {
+              paddingSize: 'l',
+              restrictWidth: false,
+              bottomBorder: 'extended',
+              color: 'plain',
+              css: emotionCss`
+                background: ${euiTheme.colors.backgroundBasePlain};
+              `,
+              ...fallback,
+            }
+      }
+      {...props}
+    />
+  );
+};
 
 StreamsAppPageTemplate.Header = EuiPageTemplate.Header;
 StreamsAppPageTemplate.EmptyPrompt = EuiPageTemplate.EmptyPrompt;

--- a/x-pack/platform/plugins/shared/streams_app/tsconfig.json
+++ b/x-pack/platform/plugins/shared/streams_app/tsconfig.json
@@ -15,6 +15,7 @@
   ],
   "exclude": ["target/**/*", ".storybook/**/*.js"],
   "kbn_references": [
+    "@kbn/app-header",
     "@kbn/core",
     "@kbn/data-plugin",
     "@kbn/dataset-quality-plugin",


### PR DESCRIPTION
Part of elastic/kibana-team#3346
Related: elastic/kibana#267691

## Summary

Migrates the Streams listing page and the main classic/wired stream detail header to the Chrome Next app header while keeping classic fallback rendering in place. The migration uses semantic app menu primary actions for the visually primary buttons, preserves the existing classic fallback layout with `rightSideItems`, and keeps Streams-specific header defaults centralized in `StreamsAppHeader`.

During the migration we had to work through a few header API differences: EUI fallback actions need explicit `rightSideItems` ordering, Chrome Next tabs only support string labels, and several Streams detail badges are richer React components rather than plain badge config. The final implementation keeps those richer badges through `renderCustomBadge` and keeps tab tooltip/tour wrappers in fallback only.

Left for follow-up: query stream detail headers, missing/no-privilege/pending detail-state headers, Chrome Next parity for tab tooltips/tour anchors if the app-header API grows support for richer tab labels, and listing-page description parity if product wants that text visible in Chrome Next.

### Streams List

#### before

<img width="1962" height="1119" alt="Screenshot 2026-05-22 at 17 04 59" src="https://github.com/user-attachments/assets/7f9924d4-1f5c-44c2-b4d1-74090f00b5ff" />


#### after

<img width="1962" height="1119" alt="Screenshot 2026-05-22 at 16 58 45" src="https://github.com/user-attachments/assets/b825e037-d447-4496-b002-9139991a1b27" />

### Stream Details

#### before

<img width="1962" height="1119" alt="Screenshot 2026-05-22 at 17 05 08" src="https://github.com/user-attachments/assets/43db98d3-14be-4f35-883a-46cb5dd96ad6" />


#### after

<img width="1962" height="1119" alt="Screenshot 2026-05-22 at 17 05 16" src="https://github.com/user-attachments/assets/1e351ef4-7264-41cc-ab7d-a015f60554ec" />



### Not migrated:


<img width="1962" height="1119" alt="Screenshot 2026-05-22 at 17 05 26" src="https://github.com/user-attachments/assets/3b1354e1-321e-44c2-8fc0-3e9fda0d655c" />

<img width="1962" height="1119" alt="Screenshot 2026-05-22 at 17 05 32" src="https://github.com/user-attachments/assets/098eb510-6ca1-4d20-8f00-32af3007bc87" />

