### PR TITLE
[Obs Onboarding] Gate OTel Kubernetes data check on logs arrival

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/build_otel_kubernetes_action_links.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/build_otel_kubernetes_action_links.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildOtelKubernetesActionLinks } from './build_otel_kubernetes_action_links';
+
+const baseParams = {
+  dashboardHref: 'https://example/dashboard',
+  servicesHref: 'https://example/services',
+  logsHref: 'https://example/logs',
+};
+
+describe('buildOtelKubernetesActionLinks', () => {
+  it('declares the logs link with requires: "logs" so the has-data gate waits for logs', () => {
+    const links = buildOtelKubernetesActionLinks({
+      isMetricsOnboardingEnabled: true,
+      ...baseParams,
+    });
+
+    const logsLink = links.find((link) => link.id === 'logs');
+
+    expect(logsLink).toBeDefined();
+    expect(logsLink?.requires).toBe('logs');
+  });
+
+  it('declares dashboard and services links with requires: "metrics"', () => {
+    const links = buildOtelKubernetesActionLinks({
+      isMetricsOnboardingEnabled: true,
+      ...baseParams,
+    });
+
+    const metricsLinks = links.filter((link) => link.id !== 'logs');
+
+    expect(metricsLinks).toHaveLength(2);
+    metricsLinks.forEach((link) => {
+      expect(link.requires).toBe('metrics');
+    });
+  });
+
+  it('omits metrics-gated links when metrics onboarding is disabled but keeps the logs link', () => {
+    const links = buildOtelKubernetesActionLinks({
+      isMetricsOnboardingEnabled: false,
+      ...baseParams,
+    });
+
+    expect(links).toHaveLength(1);
+    expect(links[0].id).toBe('logs');
+    expect(links[0].requires).toBe('logs');
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/build_otel_kubernetes_action_links.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/build_otel_kubernetes_action_links.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { ActionLink } from '../kubernetes/data_ingest_status';
+import { CLUSTER_OVERVIEW_DASHBOARD_ID } from './constants';
+
+export interface BuildOtelKubernetesActionLinksParams {
+  isMetricsOnboardingEnabled: boolean;
+  dashboardHref: string;
+  servicesHref: string;
+  logsHref: string;
+}
+
+/**
+ * Build the action links shown by the OTel Kubernetes onboarding panel.
+ *
+ * The `requires` field on each link drives the `DataIngestStatus` polling
+ * gate: polling continues until every declared data type has arrived. The
+ * logs link must declare `requires: 'logs'` so the gate does not latch on
+ * a metrics-first poll while logs are still pending, mirroring the EA
+ * Kubernetes flow.
+ */
+export const buildOtelKubernetesActionLinks = ({
+  isMetricsOnboardingEnabled,
+  dashboardHref,
+  servicesHref,
+  logsHref,
+}: BuildOtelKubernetesActionLinksParams): ActionLink[] => [
+  ...(isMetricsOnboardingEnabled
+    ? [
+        {
+          id: CLUSTER_OVERVIEW_DASHBOARD_ID,
+          title: i18n.translate(
+            'xpack.observability_onboarding.otelKubernetesPanel.monitoringCluster',
+            { defaultMessage: 'Check your Kubernetes cluster health:' }
+          ),
+          label: i18n.translate(
+            'xpack.observability_onboarding.otelKubernetesPanel.exploreDashboard',
+            { defaultMessage: 'Explore Kubernetes Cluster Dashboard' }
+          ),
+          requires: 'metrics' as const,
+          href: dashboardHref,
+        },
+        {
+          id: 'services',
+          title: i18n.translate(
+            'xpack.observability_onboarding.otelKubernetesPanel.servicesTitle',
+            { defaultMessage: 'Check your application services:' }
+          ),
+          label: i18n.translate(
+            'xpack.observability_onboarding.otelKubernetesPanel.servicesLabel',
+            { defaultMessage: 'Explore Service inventory' }
+          ),
+          requires: 'metrics' as const,
+          href: servicesHref,
+        },
+      ]
+    : []),
+  {
+    id: 'logs',
+    title: i18n.translate('xpack.observability_onboarding.otelKubernetesPanel.logsTitle', {
+      defaultMessage: 'View and analyze your logs:',
+    }),
+    label: i18n.translate('xpack.observability_onboarding.otelKubernetesPanel.logsLabel', {
+      defaultMessage: 'Explore logs',
+    }),
+    requires: 'logs' as const,
+    href: logsHref,
+  },
+];

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -51,6 +51,7 @@ import {
   OTEL_STACK_NAMESPACE,
 } from './constants';
 import { buildValuesFileUrl } from './build_values_file_url';
+import { buildOtelKubernetesActionLinks } from './build_otel_kubernetes_action_links';
 import { useManagedOtlpServiceAvailability } from '../../shared/use_managed_otlp_service_availability';
 import { usePricingFeature } from '../shared/use_pricing_feature';
 import { ManagedOtlpCallout } from '../shared/managed_otlp_callout';
@@ -142,51 +143,13 @@ export const OtelKubernetesPanel: React.FC = () => {
       })
     : undefined;
 
-  const otelKubernetesActionLinks: ActionLink[] = [
-    ...(isMetricsOnboardingEnabled
-      ? [
-          {
-            id: CLUSTER_OVERVIEW_DASHBOARD_ID,
-            title: i18n.translate(
-              'xpack.observability_onboarding.otelKubernetesPanel.monitoringCluster',
-              { defaultMessage: 'Check your Kubernetes cluster health:' }
-            ),
-            label: i18n.translate(
-              'xpack.observability_onboarding.otelKubernetesPanel.exploreDashboard',
-              { defaultMessage: 'Explore Kubernetes Cluster Dashboard' }
-            ),
-            requires: 'metrics' as const,
-            href:
-              dashboardLocator?.getRedirectUrl({
-                dashboardId: CLUSTER_OVERVIEW_DASHBOARD_ID,
-              }) ?? '',
-          },
-          {
-            id: 'services',
-            title: i18n.translate(
-              'xpack.observability_onboarding.otelKubernetesPanel.servicesTitle',
-              { defaultMessage: 'Check your application services:' }
-            ),
-            label: i18n.translate(
-              'xpack.observability_onboarding.otelKubernetesPanel.servicesLabel',
-              { defaultMessage: 'Explore Service inventory' }
-            ),
-            requires: 'metrics' as const,
-            href: apmLocator?.getRedirectUrl({ serviceName: undefined }) ?? '',
-          },
-        ]
-      : []),
-    {
-      id: 'logs',
-      title: i18n.translate('xpack.observability_onboarding.otelKubernetesPanel.logsTitle', {
-        defaultMessage: 'View and analyze your logs:',
-      }),
-      label: i18n.translate('xpack.observability_onboarding.otelKubernetesPanel.logsLabel', {
-        defaultMessage: 'Explore logs',
-      }),
-      href: logsLocator?.getRedirectUrl(logsLocatorParams) ?? '',
-    },
-  ];
+  const otelKubernetesActionLinks: ActionLink[] = buildOtelKubernetesActionLinks({
+    isMetricsOnboardingEnabled,
+    dashboardHref:
+      dashboardLocator?.getRedirectUrl({ dashboardId: CLUSTER_OVERVIEW_DASHBOARD_ID }) ?? '',
+    servicesHref: apmLocator?.getRedirectUrl({ serviceName: undefined }) ?? '',
+    logsHref: logsLocator?.getRedirectUrl(logsLocatorParams) ?? '',
+  });
 
   return (
     <EuiPanel hasBorder paddingSize="xl">


### PR DESCRIPTION
## Summary

The OTel Kubernetes onboarding flow was reporting "We are monitoring your cluster" as soon as metrics arrived, even when logs were still pending. The `DataIngestStatus` polling gate collapsed to a metrics-only check because the logs action link in the panel did not declare `requires: 'logs'`. The first metrics-bearing poll latched the gate green and the flow advanced before logs (and downstream traces) had a chance to arrive.

This change brings the OTel Kubernetes flow in line with the EA Kubernetes flow, which already declares `requires: 'logs'` on its logs action link.

## What changed

- Added `requires: 'logs'` to the OTel Kubernetes logs action link.
- Extracted the action links construction into `build_otel_kubernetes_action_links.ts`, matching the existing `build_*` helper pattern in the same directory.
- Added unit tests that pin the `requires` field on every action link so the gate constraint cannot be silently dropped in future edits.

## Why this matters

The k8s-otel onboarding e2e tests have been intermittently failing on downstream assertions (APM Service Inventory, Cluster Overview dashboard panels, Discover histogram). Captured `/has-data` probe data from recent ensemble runs on a diagnostic branch confirmed at least one failure mode where the assertion advanced with `hasMetrics=true` and `hasLogs=false`, leading to a downstream failure once the test tried to interact with logs-dependent surfaces.

## Expected impact

This fix narrows the failure surface. It does not eliminate every intermittent failure on the k8s-otel lane:

- Will fix: the metrics-only latch class (gate firing before logs arrive).
- Will not fix: trace-ingest lag in APM Service Inventory (independent of this gate, depends on EDOT Java agent startup timing after pod restart).
- Will not fix: the separate "has-data returns false for the full test timeout" stall pattern observed on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)