### PR TITLE
[Do Not Review] [Chrome Next] Update badges overflow

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/app_badge.stories.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_badge.stories.tsx
@@ -24,6 +24,7 @@ import type { AppHeaderBadge } from '../types';
 import { AppBadge } from './app_badge';
 
 const MAX_VISIBLE_BADGES = 2;
+const OVERFLOW_THRESHOLD = 3;
 
 interface AppBadgeStoryProps {
   title: string;
@@ -32,8 +33,9 @@ interface AppBadgeStoryProps {
 
 const HeaderWithBadges = ({ title, badges }: AppBadgeStoryProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const visibleBadges = badges.slice(0, MAX_VISIBLE_BADGES);
-  const overflowBadges = badges.slice(MAX_VISIBLE_BADGES);
+  const shouldOverflow = badges.length > OVERFLOW_THRESHOLD;
+  const visibleBadges = shouldOverflow ? badges.slice(0, MAX_VISIBLE_BADGES) : badges;
+  const overflowBadges = shouldOverflow ? badges.slice(MAX_VISIBLE_BADGES) : [];
 
   return (
     <EuiHeader>
@@ -154,6 +156,27 @@ export const Badges: Story = {
         ],
       },
       { label: 'New', color: 'primary' },
+    ],
+  },
+};
+
+export const ThreeBadges: Story = {
+  name: 'Three badges',
+  args: {
+    title: '[Logs] Web Traffic',
+    badges: [
+      { label: 'Beta' },
+      {
+        label: 'Tech Preview',
+        color: 'warning',
+        tooltip: 'This feature is in tech preview and may change.',
+      },
+      {
+        label: 'Managed',
+        color: 'primary',
+        onClick: action('managed-clicked'),
+        onClickAriaLabel: 'Click to view managed details',
+      },
     ],
   },
 };

--- a/src/core/packages/chrome/app-header/src/app_header/app_badges.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_badges.tsx
@@ -16,6 +16,7 @@ import { AppBadge } from './app_badge';
 import { useResolvedBadges } from './hooks';
 
 const MAX_VISIBLE_BADGES = 2;
+const OVERFLOW_THRESHOLD = 3;
 
 const useBadgesStyle = () => {
   const { euiTheme } = useEuiTheme();
@@ -46,8 +47,9 @@ export const AppBadges = memo<AppBadgesProps>(({ badges: propBadges }) => {
     return null;
   }
 
-  const visibleBadges = badges.slice(0, MAX_VISIBLE_BADGES);
-  const overflowBadges = badges.slice(MAX_VISIBLE_BADGES);
+  const shouldOverflow = badges.length > OVERFLOW_THRESHOLD;
+  const visibleBadges = shouldOverflow ? badges.slice(0, MAX_VISIBLE_BADGES) : badges;
+  const overflowBadges = shouldOverflow ? badges.slice(MAX_VISIBLE_BADGES) : [];
 
   const handleClosePopover = () => {
     setIsPopoverOpen(false);

--- a/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_header.tsx
@@ -56,7 +56,7 @@ export const AppHeaderView = React.memo<AppHeaderViewProps>(
         badges={<AppBadges badges={badges} />}
         titleActions={<TitleActions shareAction={shareAction} favorite={favorite} />}
         trailing={<AppMenu menu={menu} hasExplicitShare={!!onShare} docLink={docLink} />}
-        tabs={tabs?.length ? <AppTabs tabs={tabs} /> : undefined} 
+        tabs={tabs?.length ? <AppTabs tabs={tabs} /> : undefined}
         sticky={sticky}
         padding={padding}
       />

--- a/src/core/packages/chrome/browser-components/src/chrome_next/index.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/index.ts
@@ -7,5 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { ChromeNextGlobalHeader, ChromeNextGlobalHeaderShell, HeaderActionButton } from './global_header';
+export {
+  ChromeNextGlobalHeader,
+  ChromeNextGlobalHeaderShell,
+  HeaderActionButton,
+} from './global_header';
 export type { ChromeNextGlobalHeaderShellProps, HeaderActionButtonProps } from './global_header';

--- a/src/platform/plugins/shared/management/public/plugin.tsx
+++ b/src/platform/plugins/shared/management/public/plugin.tsx
@@ -174,9 +174,9 @@ export class ManagementPlugin
                 // Project chrome (solution spaces): the navigation tree provides "Stack Management > App".
                 // Management apps provide breadcrumbs as [Stack Management, App, ...details].
                 // We drop the first two and append the rest to the nav tree path.
-                const [, , ...trailingBreadcrumbs] = newBreadcrumbs;
+                const [, , ...projectTrailingBreadcrumbs] = newBreadcrumbs;
                 coreStart.chrome.setBreadcrumbs([], {
-                  project: { value: trailingBreadcrumbs },
+                  project: { value: projectTrailingBreadcrumbs },
                 });
               } else {
                 // Classic chrome: use full breadcrumb trail as-is


### PR DESCRIPTION
## Summary

This PR updates the badges overflow logic to match the design.

**3 badges:**
<img width="470" height="77" alt="Screenshot 2026-05-22 at 19 12 41" src="https://github.com/user-attachments/assets/0bf554d9-bab3-4158-b86c-81a437f0c5fe" />

**4 or more badges:**
<img width="424" height="82" alt="Screenshot 2026-05-22 at 19 12 45" src="https://github.com/user-attachments/assets/2dc2087c-5feb-4a79-9a87-e233ef932a01" />
