### PR TITLE
Revert "[CI] Rescue ES Docker container logs on failed snapshot-verify steps"

### DIFF
--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -47,23 +47,6 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
     '.es/uiam*.log'
   )
 
-  if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "kibana-elasticsearch-snapshot-verify" ]]; then
-    # Rescue ES Docker container logs the in-process teardown may have missed.
-    if command -v docker >/dev/null 2>&1; then
-      for cname in es01 es02 es03 es01-linked es02-linked es03-linked; do
-        if ! docker container inspect "$cname" >/dev/null 2>&1; then
-          continue
-        fi
-        cid=$(docker inspect --format '{{.Id}}' "$cname" 2>/dev/null | cut -c1-12)
-        out=".es/${cname}-${cid}.log"
-        if [[ -n "$cid" && ! -s "$out" ]]; then
-          mkdir -p .es
-          docker logs "$cname" > "$out" 2>&1 || true
-        fi
-      done
-    fi
-  fi
-
   buildkite-agent artifact upload "$(printf '%s;' "${ARTIFACT_PATTERNS[@]}")"
 
   if [[ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ]]; then


### PR DESCRIPTION
Reverts #270460.

## Why

In review, @delanni [asked](https://elastic.slack.com/archives/C01EMR8S1KN/p1779437352066069?thread_ts=1779263228.414439&cid=C01EMR8S1KN) for the rescue capture in `post_command.sh` to be temporary while we investigate the underlying [kibana-elasticsearch-snapshot-verify](https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify/builds?branch=main) failures. 

This PR removes the temporary block so `.buildkite/scripts/lifecycle/post_command.sh` returns to its pre-#270460 state.

## What changed

Removes the `kibana-elasticsearch-snapshot-verify`-scoped `docker logs` rescue block from `.buildkite/scripts/lifecycle/post_command.sh` (17 lines deleted, no other files affected).

## Risk

Low to none - revert for pipeline-scoped behavior. Matching the pre-#270460 baseline.
