### PR TITLE
[One Workflow] live progress fix

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
@@ -41,6 +41,10 @@ const makeParams = (): jest.Mocked<WorkflowExecutionLoopParams> =>
     },
     workflowLogger: {
       logWarn: jest.fn(),
+      flushEvents: jest.fn().mockResolvedValue(undefined),
+    },
+    stepIoService: {
+      flush: jest.fn().mockResolvedValue(undefined),
     },
   } as unknown as jest.Mocked<WorkflowExecutionLoopParams>);
 
@@ -364,6 +368,7 @@ describe('handleExecutionDelay', () => {
 
       await handleExecutionDelay(params, stepRuntime);
 
+      expect(params.stepIoService.flush).toHaveBeenCalled();
       expect(params.workflowTaskManager.scheduleResumeTask).toHaveBeenCalledTimes(1);
       const call = (params.workflowTaskManager.scheduleResumeTask as jest.Mock).mock.calls[0][0];
       expect(call.workflowExecution).toEqual(expect.objectContaining({ id: 'exec-parent' }));

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
@@ -10,6 +10,7 @@
 import type { EsWorkflowExecution } from '@kbn/workflows';
 import { ExecutionStatus } from '@kbn/workflows';
 import { isEnterStepTimeoutZone } from '@kbn/workflows/graph';
+import { flushState } from './persistence_loop';
 import type { WorkflowExecutionLoopParams } from './types';
 import { abortableTimeout, parseDuration, TimeoutAbortedError } from '../utils';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
@@ -101,6 +102,7 @@ export async function handleExecutionDelay(
   const resumeAt = new Date(resumeAtFromState);
   const now = new Date();
   const diff = resumeAt.getTime() - now.getTime();
+  await flushState(params);
   params.workflowExecutionState.updateWorkflowExecution({
     status: ExecutionStatus.WAITING,
   });


### PR DESCRIPTION
### dets

Call `flushState()` in `handleExecutionDelay` immediately before setting the workflow to `waiting` for timer-based `wait` steps. That writes step execution documents and updates `stepExecutionIds` on the execution document while the execution loop is still active, so the execution detail UI and `GET /executions/{id}` polling show step progress during runs with waits.

### res

https://github.com/user-attachments/assets/b561b753-63eb-4144-a10e-deb7561fa6f1


Fixes: https://github.com/elastic/security-team/issues/17543


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->