### PR TITLE
[Detection Engine] Fix #197355 — add Optional label to Suppress alerts for Threshold rules

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/threshold_alert_suppression_edit.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/threshold_alert_suppression_edit.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { Form, useForm, FIELD_TYPES } from '../../../../shared_imports';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from './fields';
+import { ThresholdAlertSuppressionEdit } from './threshold_alert_suppression_edit';
+
+const FORM_SCHEMA = {
+  [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: { type: FIELD_TYPES.CHECKBOX },
+  alertSuppressionDurationType: {},
+  alertSuppressionDuration: { value: {}, unit: {} },
+};
+
+function TestForm({ labelAppend }: { labelAppend?: React.ReactNode }) {
+  const { form } = useForm({ schema: FORM_SCHEMA });
+
+  return (
+    <I18nProvider>
+      <Form form={form}>
+        <ThresholdAlertSuppressionEdit
+          suppressionFieldNames={undefined}
+          labelAppend={labelAppend}
+        />
+      </Form>
+    </I18nProvider>
+  );
+}
+
+describe('ThresholdAlertSuppressionEdit', () => {
+  it('renders labelAppend when provided', () => {
+    render(<TestForm labelAppend={<span data-test-subj="optional-label">{'Optional'}</span>} />);
+    expect(screen.getByTestId('optional-label')).toBeInTheDocument();
+  });
+
+  it('does not render labelAppend when not provided', () => {
+    render(<TestForm />);
+    expect(screen.queryByTestId('optional-label')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/threshold_alert_suppression_edit.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/threshold_alert_suppression_edit.tsx
@@ -15,18 +15,30 @@ import * as i18n from './translations';
 
 interface ThresholdAlertSuppressionEditProps {
   suppressionFieldNames: string[] | undefined;
+  labelAppend?: React.ReactNode;
   disabled?: boolean;
   disabledText?: string;
 }
 
 export const ThresholdAlertSuppressionEdit = memo(function ThresholdAlertSuppressionEdit({
   suppressionFieldNames,
+  labelAppend,
   disabled,
   disabledText,
 }: ThresholdAlertSuppressionEditProps): JSX.Element {
   const [{ [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: suppressionEnabled }] = useFormData({
     watch: THRESHOLD_ALERT_SUPPRESSION_ENABLED,
   });
+  const labelText = suppressionFieldNames?.length
+    ? i18n.enableSuppressionForFields(suppressionFieldNames)
+    : i18n.SUPPRESS_ALERTS;
+  const checkboxLabel = labelAppend ? (
+    <>
+      {labelText} {labelAppend}
+    </>
+  ) : (
+    labelText
+  );
   const content = (
     <>
       <UseField
@@ -36,12 +48,7 @@ export const ThresholdAlertSuppressionEdit = memo(function ThresholdAlertSuppres
           idAria: 'thresholdAlertSuppressionEnabled',
           'data-test-subj': 'thresholdAlertSuppressionEnabled',
         }}
-        euiFieldProps={{
-          label: suppressionFieldNames?.length
-            ? i18n.enableSuppressionForFields(suppressionFieldNames)
-            : i18n.SUPPRESS_ALERTS,
-          disabled,
-        }}
+        euiFieldProps={{ label: checkboxLabel, disabled }}
       />
       <EuiPanel paddingSize="m" hasShadow={false}>
         <SuppressionDurationSelector

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.tsx
@@ -669,6 +669,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
             {isThresholdRule ? (
               <ThresholdAlertSuppressionEdit
                 suppressionFieldNames={threshold?.field}
+                labelAppend={alertSuppressionFieldsAppendText}
                 disabled={!isAlertSuppressionLicenseValid}
                 disabledText={alertSuppressionUpsellingMessage}
               />


### PR DESCRIPTION
## Summary

The **Suppress alerts** field in the Threshold rule creation form was missing the "Optional" badge that appears for the same field on all other rule types (Custom Query, EQL, New Terms, etc.) and on other optional fields like "Required fields" and "Related integrations" on the same page.

**Root cause**: `ThresholdAlertSuppressionEdit` had no `labelAppend` prop in its interface. In `step_define_rule/index.tsx`, a memoized `alertSuppressionFieldsAppendText` ("Optional" / "Optional (Technical Preview)" depending on tier) is passed as `labelAppend` to `AlertSuppressionEdit` for all non-threshold rule types, but the `ThresholdAlertSuppressionEdit` branch of the same conditional never received it — so the badge was silently dropped.

**Fix**: Added `labelAppend?: React.ReactNode` to `ThresholdAlertSuppressionEditProps`; the prop is embedded inline within the checkbox label node (immediately after the label text). Wired up `alertSuppressionFieldsAppendText` at the call site in `step_define_rule`. This follows the reviewer-approved pattern from the prior attempt (#269662).

**Why this approach**: Embedding `labelAppend` inline in the EUI `EuiCheckbox` label (via `euiFieldProps.label`) is the correct approach for a checkbox-based field, since `EuiFormRow.labelAppend` requires a row-level `label` prop to render. The reviewer on #269662 explicitly approved this visual placement.

## Steps to reproduce (before fix)

1. Go to **Rules → Detection rules (SIEM) → Create new rule**
2. Select **Threshold** rule type
3. Scroll down to the **Suppress alerts** field
4. Observe: no "Optional" label (compare to "Required fields" and "Related integrations" directly below)

## Test plan

- [ ] Bug no longer reproduces: follow the steps above and verify "Optional" appears next to "Suppress alerts"
- [ ] `node scripts/jest x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/threshold_alert_suppression_edit.test.tsx --no-coverage` passes
- [ ] No new browser console errors or network failures

## Related

Fixes #197355
Prior attempt: #269662 (closed due to unrelated bundled changes)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)