### PR TITLE
[ResponseOps][Alerting V2] SuggestUserProfilesRoute uses /api/.../internal/... instead of /internal/... prefix

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-constants/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-constants/index.ts
@@ -17,4 +17,4 @@ export const ALERTING_V2_ACTION_POLICY_EXECUTION_HISTORY_COUNT_API_PATH =
 export const ALERTING_V2_MATCHER_VALUE_SUGGESTIONS_API_PATH =
   '/internal/action_policies/suggestions/values' as const;
 export const ALERTING_V2_INTERNAL_SUGGEST_USER_PROFILES_API_PATH =
-  '/api/alerting/v2/internal/user_profiles/_suggest' as const;
+  '/internal/alerting/v2/user_profiles/_suggest' as const;


### PR DESCRIPTION
Closes https://github.com/elastic/rna-program/issues/450

## Summary
- changed `SuggestUserProfilesRoute` from `'/api/alerting/v2/internal/user_profiles/_suggest'` to `'/internal/alerting/v2/user_profiles/_suggest'
`
