### PR TITLE
[SharedUX][Chrome Next] Register search button and modal

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -81,7 +81,7 @@ pageLoadAssetSize:
   fleet: 229970
   genAiSettings: 6342
   globalSearch: 6890
-  globalSearchBar: 26122
+  globalSearchBar: 31212
   globalSearchProviders: 4646
   graph: 9924
   grokdebugger: 5469

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/search_button.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/search_button.test.tsx
@@ -24,7 +24,7 @@ const { useKeyboardShortcut } = jest.mocked(
   jest.requireMock('@kbn/shared-ux-utility') as typeof import('@kbn/shared-ux-utility')
 );
 
-const renderButton = (config?: { onClick: () => void; shortcutKey?: string }) => {
+const renderButton = (config?: { onClick: () => void }) => {
   const chrome = chromeServiceMock.createStartContract();
   (chrome.next.globalSearch.get$ as jest.Mock).mockReturnValue(new BehaviorSubject(config));
   return render(
@@ -44,21 +44,21 @@ describe('SearchButton', () => {
   });
 
   it('renders the search button when config is provided', () => {
-    renderButton({ onClick: jest.fn(), shortcutKey: '/' });
+    renderButton({ onClick: jest.fn() });
     expect(screen.getByTestId('chromeNextGlobalHeaderSearchButton')).toBeInTheDocument();
   });
 
   it('calls onClick when clicked', () => {
     const onClick = jest.fn();
-    renderButton({ onClick, shortcutKey: '/' });
+    renderButton({ onClick });
 
     fireEvent.click(screen.getByTestId('chromeNextGlobalHeaderSearchButton'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('registers keyboard shortcut from config', () => {
+  it('registers keyboard shortcut', () => {
     const onClick = jest.fn();
-    renderButton({ onClick, shortcutKey: '/' });
+    renderButton({ onClick });
 
     expect(useKeyboardShortcut).toHaveBeenCalledWith({ key: '/', meta: true }, onClick);
   });

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/search_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/search_button.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
 import { EuiBadge, EuiIcon, useEuiBreakpoint, useEuiFontSize, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -29,6 +29,8 @@ const ARIA_LABEL = i18n.translate('core.ui.chrome.globalHeader.searchButton.aria
 });
 
 const MODIFIER_KEY = isMac ? '⌘' : 'Ctrl';
+
+const SHORTCUT = { key: '/', meta: true };
 
 export const SearchButton = React.memo(() => {
   const config = useGlobalSearch();
@@ -68,17 +70,11 @@ export const SearchButton = React.memo(() => {
     whiteSpace: 'nowrap',
   });
 
-  const shortcut = useMemo(
-    () => (config?.shortcutKey ? { key: config.shortcutKey, meta: true } : undefined),
-    [config?.shortcutKey]
-  );
-  useKeyboardShortcut(shortcut, config?.onClick);
+  const shortcutLabel = `${MODIFIER_KEY} ${SHORTCUT.key}`;
+
+  useKeyboardShortcut(SHORTCUT, config?.onClick);
 
   if (!config) return null;
-
-  const shortcutLabel = config.shortcutKey
-    ? `${MODIFIER_KEY} ${config.shortcutKey.toUpperCase()}`
-    : undefined;
 
   return (
     <button
@@ -96,9 +92,7 @@ export const SearchButton = React.memo(() => {
     >
       <EuiIcon type="search" size="m" color={euiTheme.colors.textParagraph} aria-hidden />
       <span css={[placeholderStyles, collapsibleStyles]}>{PLACEHOLDER}</span>
-      {shortcutLabel && (
-        <EuiBadge css={[shortcutBadgeStyles, collapsibleStyles]}>{shortcutLabel}</EuiBadge>
-      )}
+      <EuiBadge css={[shortcutBadgeStyles, collapsibleStyles]}>{shortcutLabel}</EuiBadge>
     </button>
   );
 });

--- a/src/core/packages/chrome/browser/src/chrome_next/global_search.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/global_search.ts
@@ -14,6 +14,4 @@
 export interface GlobalSearchConfig {
   /** Called when the search button in the global header is clicked. */
   onClick: () => void;
-  /** The keyboard shortcut key (combined with Cmd/Ctrl) to trigger global search. */
-  shortcutKey?: string;
 }

--- a/src/core/packages/overlays/browser/src/modal.ts
+++ b/src/core/packages/overlays/browser/src/modal.ts
@@ -68,4 +68,5 @@ export interface OverlayModalOpenOptions {
   'data-test-subj'?: string;
   maxWidth?: boolean | number | string;
   'aria-labelledby'?: EuiModalProps['aria-labelledby'];
+  outsideClickCloses?: boolean;
 }

--- a/x-pack/platform/plugins/private/global_search_bar/moon.yml
+++ b/x-pack/platform/plugins/private/global_search_bar/moon.yml
@@ -28,6 +28,7 @@ dependsOn:
   - '@kbn/core-chrome-browser'
   - '@kbn/config-schema'
   - '@kbn/shared-ux-utility'
+  - '@kbn/react-kibana-mount'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/char_limit_exceeded_message.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/char_limit_exceeded_message.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiText } from '@elastic/eui';
+import React from 'react';
+import { SearchPlaceholder } from './search_placeholder';
+
+interface CharLimitExceededMessageProps {
+  basePathUrl: string;
+}
+
+export const CharLimitExceededMessage = ({ basePathUrl }: CharLimitExceededMessageProps) => {
+  const charLimitMessage = (
+    <>
+      <EuiText size="m">
+        <p data-test-subj="searchCharLimitExceededMessageHeading">
+          <FormattedMessage
+            id="xpack.globalSearchBar.searchBar.searchCharLimitExceededHeading"
+            defaultMessage="Search character limit exceeded"
+          />
+        </p>
+      </EuiText>
+      <p>
+        <FormattedMessage
+          id="xpack.globalSearchBar.searchBar.searchCharLimitExceeded"
+          defaultMessage="Try searching for applications, dashboards, visualizations, and more."
+        />
+      </p>
+    </>
+  );
+
+  return <SearchPlaceholder basePath={basePathUrl} customPlaceholderMessage={charLimitMessage} />;
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/empty_message.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/empty_message.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
+
+import { EuiFlexGroup } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React from 'react';
+
+export const EmptyMessage = () => {
+  return (
+    <EuiFlexGroup
+      alignItems="center"
+      direction="column"
+      justifyContent="center"
+      css={css`
+        min-height: 300px;
+      `}
+    >
+      <EuiFlexItem grow={false}>
+        <EuiLoadingSpinner size="xl" />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.test.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.test.tsx
@@ -7,19 +7,14 @@
 
 import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import { applicationServiceMock, coreMock } from '@kbn/core/public/mocks';
-import type {
-  GlobalSearchBatchedResults,
-  GlobalSearchResult,
-} from '@kbn/global-search-plugin/public';
 import { globalSearchPluginMock } from '@kbn/global-search-plugin/public/mocks';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
-import { usageCollectionPluginMock } from '@kbn/usage-collection-plugin/public/mocks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { BehaviorSubject, of } from 'rxjs';
-import { filter, map } from 'rxjs';
+import { of } from 'rxjs';
 import { EventReporter } from '../telemetry';
 import { SearchBar } from './search_bar';
+import { usageCollectionPluginMock } from '@kbn/usage-collection-plugin/public/mocks';
 
 jest.mock(
   'react-virtualized-auto-sizer',
@@ -28,250 +23,94 @@ jest.mock(
       children({ height: 600, width: 600 })
 );
 
-type Result = { id: string; type: string } | string;
-
-const createResult = (result: Result): GlobalSearchResult => {
-  const id = typeof result === 'string' ? result : result.id;
-  const type = typeof result === 'string' ? 'application' : result.type;
-  const meta = type === 'application' ? { categoryLabel: 'Kibana' } : { categoryLabel: null };
-
-  return {
-    id,
-    type,
-    title: id,
-    url: `/app/test/${id}`,
-    score: 42,
-    meta,
-  };
-};
-
-const createBatch = (...results: Result[]): GlobalSearchBatchedResults => ({
-  results: results.map(createResult),
-});
-
-const searchCharLimit = 1000;
-
 jest.useFakeTimers({ legacyFakeTimers: true });
 
-describe('SearchBar', () => {
+describe('SearchBar (UI wiring)', () => {
   const usageCollection = usageCollectionPluginMock.createSetupContract();
   const core = coreMock.createStart();
-
   const basePathUrl = '/plugins/globalSearchBar/assets/';
-  const eventReporter = new EventReporter({ analytics: core.analytics, usageCollection });
   let searchService: ReturnType<typeof globalSearchPluginMock.createStartContract>;
   let applications: ReturnType<typeof applicationServiceMock.createStartContract>;
+  let eventReporter: EventReporter;
 
   beforeEach(() => {
     applications = applicationServiceMock.createStartContract();
     searchService = globalSearchPluginMock.createStartContract();
+
+    // Keep the component stable when focus triggers initial load/search
+    (searchService.getSearchableTypes as jest.Mock).mockResolvedValue(['application']);
+    (searchService.find as jest.Mock).mockReturnValue(of({ results: [] }));
+
+    eventReporter = new EventReporter({ analytics: core.analytics, usageCollection });
+    jest.clearAllMocks();
   });
 
-  const update = () => {
+  it('classic: keyboard shortcut focuses the input', async () => {
+    const shortcutUsedSpy = jest.spyOn(eventReporter, 'shortcutUsed');
+    render(
+      <IntlProvider locale="en">
+        <SearchBar
+          globalSearch={{ ...searchService, searchCharLimit: 1000 }}
+          navigateToUrl={applications.navigateToUrl}
+          basePathUrl={basePathUrl}
+          chromeStyle$={of<ChromeStyle>('classic')}
+          reportEvent={eventReporter}
+        />
+      </IntlProvider>
+    );
+
     act(() => {
-      jest.runAllTimers();
+      fireEvent.keyDown(window, { key: '/', ctrlKey: true, metaKey: true });
     });
-  };
-
-  const focusAndUpdate = async () => {
-    await act(async () => {
-      (await screen.findByTestId('nav-search-input')).focus();
-    });
-    act(() => {
-      jest.runAllTimers();
-    });
-  };
-
-  const simulateTypeChar = (text: string) => {
-    fireEvent.input(screen.getByTestId('nav-search-input'), { target: { value: text } });
-    act(() => {
-      jest.runAllTimers();
-    });
-  };
-
-  const assertSearchResults = async (list: string[]) => {
-    for (let i = 0; i < list.length; i++) {
-      expect(await screen.findByTitle(list[i])).toBeInTheDocument();
-    }
-
-    expect(await screen.findAllByTestId('nav-search-option')).toHaveLength(list.length);
-  };
-
-  describe('default behavior', () => {
-    it('displays an error message without making a network call when the search input exceeds the specified char limit', async () => {
-      const chromeStyle$ = of<ChromeStyle>('classic');
-
-      render(
-        <IntlProvider locale="en">
-          <SearchBar
-            globalSearch={{ ...searchService, searchCharLimit }}
-            navigateToUrl={applications.navigateToUrl}
-            basePathUrl={basePathUrl}
-            chromeStyle$={chromeStyle$}
-            reportEvent={eventReporter}
-          />
-        </IntlProvider>
-      );
-
-      expect(searchService.find).toHaveBeenCalledTimes(0);
-
-      await focusAndUpdate();
-
-      expect(searchService.find).toHaveBeenCalledTimes(1);
-
-      simulateTypeChar(Array.from(new Array(searchCharLimit + 1)).reduce((acc) => acc + 'a', ''));
-
-      // we use allBy because EUI renders a screen reader only version, along side the visual one
-      expect(await screen.findAllByTestId('searchCharLimitExceededMessageHeading')).toHaveLength(2);
-
-      expect(searchService.find).toHaveBeenCalledTimes(1);
-    });
+    const input = await screen.findByTestId('nav-search-input');
+    expect(document.activeElement).toEqual(input);
+    expect(shortcutUsedSpy).toHaveBeenCalledTimes(1);
   });
 
-  describe('chromeStyle: classic', () => {
-    const chromeStyle$ = of<ChromeStyle>('classic');
+  it('project: starts collapsed and can be revealed/hidden via buttons', async () => {
+    render(
+      <IntlProvider locale="en">
+        <SearchBar
+          globalSearch={{ ...searchService, searchCharLimit: 1000 }}
+          navigateToUrl={applications.navigateToUrl}
+          basePathUrl={basePathUrl}
+          chromeStyle$={of<ChromeStyle>('project')}
+          reportEvent={eventReporter}
+        />
+      </IntlProvider>
+    );
 
-    it('correctly filters and sorts results', async () => {
-      searchService.find
-        .mockReturnValueOnce(
-          of(
-            createBatch('Discover', 'Canvas'),
-            createBatch({ id: 'Visualize', type: 'test' }, 'Graph')
-          )
-        )
-        .mockReturnValueOnce(of(createBatch('Discover', { id: 'My Dashboard', type: 'test' })));
-
-      render(
-        <IntlProvider locale="en">
-          <SearchBar
-            globalSearch={{ ...searchService, searchCharLimit }}
-            navigateToUrl={applications.navigateToUrl}
-            basePathUrl={basePathUrl}
-            chromeStyle$={chromeStyle$}
-            reportEvent={eventReporter}
-          />
-        </IntlProvider>
-      );
-
-      expect(searchService.find).toHaveBeenCalledTimes(0);
-
-      await focusAndUpdate();
-
-      expect(searchService.find).toHaveBeenCalledTimes(1);
-      expect(searchService.find).toHaveBeenCalledWith({}, {});
-      await assertSearchResults(['Canvas • Kibana', 'Discover • Kibana', 'Graph • Kibana']);
-
-      simulateTypeChar('d');
-
-      await assertSearchResults(['Discover • Kibana', 'My Dashboard • Test']);
-      expect(searchService.find).toHaveBeenCalledTimes(2);
-      expect(searchService.find).toHaveBeenLastCalledWith({ term: 'd' }, {});
-    });
-
-    it('supports keyboard shortcuts', async () => {
-      render(
-        <IntlProvider locale="en">
-          <SearchBar
-            globalSearch={{ ...searchService, searchCharLimit }}
-            navigateToUrl={applications.navigateToUrl}
-            basePathUrl={basePathUrl}
-            chromeStyle$={chromeStyle$}
-            reportEvent={eventReporter}
-          />
-        </IntlProvider>
-      );
-      act(() => {
-        fireEvent.keyDown(window, { key: '/', ctrlKey: true, metaKey: true });
-      });
-
-      const inputElement = await screen.findByTestId('nav-search-input');
-
-      expect(document.activeElement).toEqual(inputElement);
-    });
-
-    it('only display results from the last search', async () => {
-      const firstSearchTrigger = new BehaviorSubject<boolean>(false);
-      const firstSearch = firstSearchTrigger.pipe(
-        filter((event) => event),
-        map(() => {
-          return createBatch('Discover', 'Canvas');
-        })
-      );
-      const secondSearch = of(createBatch('Visualize', 'Map'));
-
-      searchService.find.mockReturnValueOnce(firstSearch).mockReturnValueOnce(secondSearch);
-
-      render(
-        <IntlProvider locale="en">
-          <SearchBar
-            globalSearch={{ ...searchService, searchCharLimit }}
-            navigateToUrl={applications.navigateToUrl}
-            basePathUrl={basePathUrl}
-            chromeStyle$={chromeStyle$}
-            reportEvent={eventReporter}
-          />
-        </IntlProvider>
-      );
-
-      await focusAndUpdate();
-
-      expect(searchService.find).toHaveBeenCalledTimes(1);
-
-      simulateTypeChar('d');
-      await assertSearchResults(['Visualize • Kibana', 'Map • Kibana']);
-
-      firstSearchTrigger.next(true);
-
-      update();
-
-      await assertSearchResults(['Visualize • Kibana', 'Map • Kibana']);
-    });
+    // collapsed state
+    expect(await screen.findByTestId('nav-search-reveal')).toBeInTheDocument();
+    expect(screen.queryByTestId('nav-search-input')).not.toBeInTheDocument();
+    // reveal
+    fireEvent.click(await screen.findByTestId('nav-search-reveal'));
+    expect(await screen.findByTestId('nav-search-input')).toBeInTheDocument();
+    // hide
+    fireEvent.click(await screen.findByTestId('nav-search-conceal'));
+    expect(screen.queryByTestId('nav-search-input')).not.toBeInTheDocument();
   });
 
-  describe('chromeStyle: project', () => {
-    const chromeStyle$ = of<ChromeStyle>('project');
+  it('project: keyboard shortcut reveals and focuses the input when collapsed', async () => {
+    const shortcutUsedSpy = jest.spyOn(eventReporter, 'shortcutUsed');
+    render(
+      <IntlProvider locale="en">
+        <SearchBar
+          globalSearch={{ ...searchService, searchCharLimit: 1000 }}
+          navigateToUrl={applications.navigateToUrl}
+          basePathUrl={basePathUrl}
+          chromeStyle$={of<ChromeStyle>('project')}
+          reportEvent={eventReporter}
+        />
+      </IntlProvider>
+    );
 
-    it('supports keyboard shortcuts', async () => {
-      render(
-        <IntlProvider locale="en">
-          <SearchBar
-            globalSearch={{ ...searchService, searchCharLimit }}
-            navigateToUrl={applications.navigateToUrl}
-            basePathUrl={basePathUrl}
-            chromeStyle$={chromeStyle$}
-            reportEvent={eventReporter}
-          />
-        </IntlProvider>
-      );
-
-      act(() => {
-        fireEvent.keyDown(window, { key: '/', ctrlKey: true, metaKey: true });
-      });
-
-      expect(await screen.findByTestId('nav-search-input')).toEqual(document.activeElement);
-
-      fireEvent.click(await screen.findByTestId('nav-search-conceal'));
-      expect(screen.queryAllByTestId('nav-search-input')).toHaveLength(0);
+    expect(await screen.findByTestId('nav-search-reveal')).toBeInTheDocument();
+    act(() => {
+      fireEvent.keyDown(window, { key: '/', ctrlKey: true, metaKey: true });
     });
-
-    it('supports show/hide', async () => {
-      render(
-        <IntlProvider locale="en">
-          <SearchBar
-            globalSearch={{ ...searchService, searchCharLimit }}
-            navigateToUrl={applications.navigateToUrl}
-            basePathUrl={basePathUrl}
-            chromeStyle$={chromeStyle$}
-            reportEvent={eventReporter}
-          />
-        </IntlProvider>
-      );
-
-      fireEvent.click(await screen.findByTestId('nav-search-reveal'));
-      expect(await screen.findByTestId('nav-search-input')).toBeVisible();
-
-      fireEvent.click(await screen.findByTestId('nav-search-conceal'));
-      expect(screen.queryAllByTestId('nav-search-input')).toHaveLength(0);
-    });
+    const input = await screen.findByTestId('nav-search-input');
+    expect(document.activeElement).toEqual(input);
+    expect(shortcutUsedSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.tsx
@@ -5,16 +5,11 @@
  * 2.0.
  */
 
-import type { EuiSelectableTemplateSitewideOption } from '@elastic/eui';
 import {
   EuiButtonIcon,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiFormLabel,
   EuiHeaderSectionItemButton,
   EuiIcon,
-  EuiText,
-  EuiLoadingSpinner,
   EuiSelectableTemplateSitewide,
   euiSelectableTemplateSitewideRenderOptions,
   useEuiTheme,
@@ -22,72 +17,28 @@ import {
   mathWithUnits,
   useEuiMinBreakpoint,
 } from '@elastic/eui';
-import type { EuiSelectableOnChangeEvent } from '@elastic/eui/src/components/selectable/selectable';
 import { css } from '@emotion/react';
-import { FormattedMessage } from '@kbn/i18n-react';
-import type { GlobalSearchFindParams, GlobalSearchResult } from '@kbn/global-search-plugin/public';
-import type { FC } from 'react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { apm } from '@elastic/apm-rum';
-import useDebounce from 'react-use/lib/useDebounce';
+import React, { useCallback, useRef, useState } from 'react';
 import useEvent from 'react-use/lib/useEvent';
-import useMountedState from 'react-use/lib/useMountedState';
 import useObservable from 'react-use/lib/useObservable';
-import type { Subscription } from 'rxjs';
 import { isMac } from '@kbn/shared-ux-utility';
-import { blurEvent, sort } from '.';
-import { resultToOption, suggestionToOption } from '../lib';
-import { parseSearchParams } from '../search_syntax';
 import { i18nStrings } from '../strings';
-import type { SearchSuggestion } from '../suggestions';
-import { getSuggestions } from '../suggestions';
-import { PopoverFooter } from './popover_footer';
-import { PopoverPlaceholder } from './popover_placeholder';
 import type { SearchBarProps } from './types';
+import { EmptyMessage } from './empty_message';
+import { SearchPlaceholder } from './search_placeholder';
+import { CharLimitExceededMessage } from './char_limit_exceeded_message';
+import { SearchFooter } from './search_footer';
+import { useSearchState } from '../hooks/use_search_state';
+import { blurEvent } from '.';
 
-const SearchCharLimitExceededMessage = (props: { basePathUrl: string }) => {
-  const charLimitMessage = (
-    <>
-      <EuiText size="m">
-        <p data-test-subj="searchCharLimitExceededMessageHeading">
-          <FormattedMessage
-            id="xpack.globalSearchBar.searchBar.searchCharLimitExceededHeading"
-            defaultMessage="Search character limit exceeded"
-          />
-        </p>
-      </EuiText>
-      <p>
-        <FormattedMessage
-          id="xpack.globalSearchBar.searchBar.searchCharLimitExceeded"
-          defaultMessage="Try searching for applications, dashboards, visualizations, and more."
-        />
-      </p>
-    </>
-  );
-
-  return (
-    <PopoverPlaceholder basePath={props.basePathUrl} customPlaceholderMessage={charLimitMessage} />
-  );
-};
-
-const EmptyMessage = () => (
-  <EuiFlexGroup
-    direction="column"
-    justifyContent="center"
-    css={css`
-      min-height: 300px;
-    `}
-  >
-    <EuiFlexItem grow={false}>
-      <EuiLoadingSpinner size="xl" />
-    </EuiFlexItem>
-  </EuiFlexGroup>
-);
-
-export const SearchBar: FC<SearchBarProps> = (opts) => {
-  const { globalSearch, taggingApi, navigateToUrl, reportEvent, chromeStyle$, ...props } = opts;
-
-  const isMounted = useMountedState();
+export const SearchBar = ({
+  globalSearch,
+  taggingApi,
+  navigateToUrl,
+  reportEvent,
+  chromeStyle$,
+  basePathUrl,
+}: SearchBarProps) => {
   const { euiTheme } = useEuiTheme();
   const chromeStyle = useObservable(chromeStyle$);
 
@@ -96,17 +47,32 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
   const visibilityButtonRef = useRef<HTMLButtonElement | null>(null);
 
   // General hooks
-  const [initialLoad, setInitialLoad] = useState(false);
-  const [searchValue, setSearchValue] = useState<string>('');
-  const [searchRef, setSearchRef] = useState<HTMLInputElement | null>(null);
   const [buttonRef, setButtonRef] = useState<HTMLDivElement | null>(null);
-  const searchSubscription = useRef<Subscription | null>(null);
-  const [options, setOptions] = useState<EuiSelectableTemplateSitewideOption[]>([]);
-  const [searchableTypes, setSearchableTypes] = useState<string[]>([]);
   const [showAppend, setShowAppend] = useState<boolean>(true);
-  const UNKNOWN_TAG_ID = '__unknown__';
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [searchCharLimitExceeded, setSearchCharLimitExceeded] = useState(false);
+
+  const {
+    searchValue,
+    setSearchValue,
+    options,
+    isLoading,
+    searchCharLimitExceeded,
+    onChange,
+    setSearchRef,
+    searchRef,
+    triggerInitialLoad,
+  } = useSearchState({
+    globalSearch,
+    taggingApi,
+    navigateToUrl,
+    reportEvent,
+    onResultSelect: () => {
+      (document.activeElement as HTMLElement).blur();
+      if (searchRef.current) {
+        setSearchValue('');
+        searchRef.current.dispatchEvent(blurEvent);
+      }
+    },
+  });
 
   const styles = css({
     [useEuiBreakpoint(['m', 'l'])]: {
@@ -116,130 +82,6 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
       width: mathWithUnits(euiTheme.size.xxl, (x) => x * 15),
     },
   });
-  // Initialize searchableTypes data
-  useEffect(() => {
-    if (initialLoad) {
-      const fetch = async () => {
-        const types = await globalSearch.getSearchableTypes();
-        setSearchableTypes(types);
-      };
-      fetch();
-    }
-  }, [globalSearch, initialLoad]);
-
-  // Whenever searchValue changes, isLoading = true
-  useEffect(() => {
-    setIsLoading(true);
-  }, [searchValue]);
-
-  const loadSuggestions = useCallback(
-    (term: string) => {
-      return getSuggestions({
-        searchTerm: term,
-        searchableTypes,
-        tagCache: taggingApi?.cache,
-      });
-    },
-    [taggingApi, searchableTypes]
-  );
-
-  const setDecoratedOptions = useCallback(
-    (
-      _options: GlobalSearchResult[],
-      suggestions: SearchSuggestion[],
-      searchTagIds: string[] = []
-    ) => {
-      setOptions([
-        ...suggestions.map(suggestionToOption),
-        ..._options.map((option) =>
-          resultToOption(
-            option,
-            searchTagIds?.filter((id) => id !== UNKNOWN_TAG_ID) ?? [],
-            taggingApi?.ui.getTagList
-          )
-        ),
-      ]);
-    },
-    [setOptions, taggingApi]
-  );
-
-  useDebounce(
-    () => {
-      if (initialLoad) {
-        // cancel pending search if not completed yet
-        if (searchSubscription.current) {
-          searchSubscription.current.unsubscribe();
-          searchSubscription.current = null;
-        }
-
-        if (searchValue.length > globalSearch.searchCharLimit) {
-          // setting this will display an error message to the user
-          setSearchCharLimitExceeded(true);
-          return;
-        } else {
-          setSearchCharLimitExceeded(false);
-        }
-
-        const suggestions = loadSuggestions(searchValue.toLowerCase());
-
-        let aggregatedResults: GlobalSearchResult[] = [];
-
-        if (searchValue.length !== 0) {
-          reportEvent.searchRequest();
-        }
-
-        const rawParams = parseSearchParams(searchValue.toLowerCase(), searchableTypes);
-        let tagIds: string[] | undefined;
-        if (taggingApi && rawParams.filters.tags) {
-          tagIds = rawParams.filters.tags.map(
-            (tagName) => taggingApi.ui.getTagIdFromName(tagName) ?? UNKNOWN_TAG_ID
-          );
-        } else {
-          tagIds = undefined;
-        }
-        const searchParams: GlobalSearchFindParams = {
-          term: rawParams.term,
-          types: rawParams.filters.types,
-          tags: tagIds,
-        };
-
-        searchSubscription.current = globalSearch.find(searchParams, {}).subscribe({
-          next: ({ results }) => {
-            if (!isMounted()) {
-              return;
-            }
-
-            if (searchValue.length > 0) {
-              aggregatedResults = [...results, ...aggregatedResults].sort(sort.byScore);
-              setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
-              return;
-            }
-
-            // if searchbar is empty, filter to only applications and sort alphabetically
-            results = results.filter(({ type }: GlobalSearchResult) => type === 'application');
-            aggregatedResults = [...results, ...aggregatedResults].sort(sort.byTitle);
-            setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
-          },
-          error: (err) => {
-            setIsLoading(false);
-
-            // Not doing anything on error right now because it'll either just show the previous
-            // results or empty results which is basically what we want anyways
-            apm.captureError(err, {
-              labels: {
-                SearchValue: searchValue,
-              },
-            });
-          },
-          complete: () => {
-            setIsLoading(false);
-          },
-        });
-      }
-    },
-    350,
-    [searchValue, loadSuggestions, searchableTypes, initialLoad]
-  );
 
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -248,8 +90,8 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
         reportEvent.shortcutUsed();
         if (chromeStyle === 'project' && !isVisible) {
           visibilityButtonRef.current?.click();
-        } else if (searchRef) {
-          searchRef.focus();
+        } else if (searchRef.current) {
+          searchRef.current.focus();
         } else if (buttonRef) {
           (buttonRef.children[0] as HTMLButtonElement).click();
         }
@@ -257,81 +99,6 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
     },
     [chromeStyle, isVisible, buttonRef, searchRef, reportEvent]
   );
-
-  const onChange = useCallback(
-    (selection: EuiSelectableTemplateSitewideOption[], event: EuiSelectableOnChangeEvent) => {
-      let selectedRank: number | null = null;
-      const selected = selection.find(({ checked }, rank) => {
-        const isChecked = checked === 'on';
-        if (isChecked) {
-          selectedRank = rank + 1;
-        }
-        return isChecked;
-      });
-
-      if (!selected) {
-        return;
-      }
-
-      const selectedLabel = selected.label ?? null;
-
-      // @ts-ignore - ts error is "union type is too complex to express"
-      const { url, type, suggestion } = selected;
-
-      // if the type is a suggestion, we change the query on the input and trigger a new search
-      // by setting the searchValue (only setting the field value does not trigger a search)
-      if (type === '__suggestion__') {
-        setSearchValue(suggestion);
-        return;
-      }
-
-      // errors in tracking should not prevent selection behavior
-      try {
-        if (type === 'application') {
-          const key = selected.key ?? 'unknown';
-          const application = `${key.toLowerCase().replaceAll(' ', '_')}`;
-          reportEvent.navigateToApplication({
-            application,
-            searchValue,
-            selectedLabel,
-            selectedRank,
-          });
-        } else {
-          reportEvent.navigateToSavedObject({
-            type,
-            searchValue,
-            selectedLabel,
-            selectedRank,
-          });
-        }
-      } catch (err) {
-        apm.captureError(err, {
-          labels: {
-            SearchValue: searchValue,
-          },
-        });
-        // eslint-disable-next-line no-console
-        console.log('Error trying to track searchbar metrics', err);
-      }
-
-      if (event.shiftKey) {
-        window.open(url);
-      } else if (event.ctrlKey || event.metaKey) {
-        window.open(url, '_blank');
-      } else {
-        navigateToUrl(url);
-      }
-
-      (document.activeElement as HTMLElement).blur();
-      if (searchRef) {
-        clearField();
-        searchRef.dispatchEvent(blurEvent);
-      }
-    },
-    [reportEvent, navigateToUrl, searchRef, searchValue]
-  );
-
-  const clearField = () => setSearchValue('');
 
   const keyboardShortcutTooltip = `${i18nStrings.keyboardShortcutTooltip.prefix}: ${
     isMac ? i18nStrings.keyboardShortcutTooltip.onMac : i18nStrings.keyboardShortcutTooltip.onNotMac
@@ -411,7 +178,7 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
         placeholder: i18nStrings.placeholderText,
         onFocus: () => {
           reportEvent.searchFocus();
-          setInitialLoad(true);
+          triggerInitialLoad();
           setShowAppend(false);
         },
         onBlur: () => {
@@ -421,9 +188,11 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
         fullWidth: true,
         append: getAppendForChromeStyle(),
       }}
-      errorMessage={searchCharLimitExceeded ? <SearchCharLimitExceededMessage {...props} /> : null}
+      errorMessage={
+        searchCharLimitExceeded ? <CharLimitExceededMessage basePathUrl={basePathUrl} /> : null
+      }
       emptyMessage={<EmptyMessage />}
-      noMatchesMessage={<PopoverPlaceholder basePath={props.basePathUrl} />}
+      noMatchesMessage={<SearchPlaceholder basePath={basePathUrl} />}
       popoverProps={{
         zIndex: Number(euiTheme.levels.navigation),
         'data-test-subj': 'nav-search-popover',
@@ -437,7 +206,7 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
           <EuiIcon type="magnify" size="m" aria-hidden={true} />
         </EuiHeaderSectionItemButton>
       }
-      popoverFooter={<PopoverFooter />}
+      popoverFooter={<SearchFooter />}
     />
   );
 };

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_footer.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_footer.tsx
@@ -11,7 +11,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { isMac } from '@kbn/shared-ux-utility';
 
 export const SearchFooter = () => {
-  const shortcutKey = '/';
   return (
     <EuiFlexGroup
       alignItems="center"
@@ -56,14 +55,12 @@ export const SearchFooter = () => {
                     {isMac ? (
                       <FormattedMessage
                         id="xpack.globalSearchBar.searchBar.shortcutDescription.macCommandDescription"
-                        defaultMessage="Command + {key}"
-                        values={{ key: shortcutKey }}
+                        defaultMessage="Command + /"
                       />
                     ) : (
                       <FormattedMessage
                         id="xpack.globalSearchBar.searchBar.shortcutDescription.windowsCommandDescription"
-                        defaultMessage="Control + {key}"
-                        values={{ key: shortcutKey }}
+                        defaultMessage="Control + /"
                       />
                     )}
                   </EuiCode>

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_footer.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_footer.tsx
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import type { FC } from 'react';
 import React from 'react';
 import { EuiCode, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { isMac } from '@kbn/shared-ux-utility';
 
-export const PopoverFooter: FC = () => {
+export const SearchFooter = () => {
+  const shortcutKey = '/';
   return (
     <EuiFlexGroup
       alignItems="center"
@@ -56,12 +56,14 @@ export const PopoverFooter: FC = () => {
                     {isMac ? (
                       <FormattedMessage
                         id="xpack.globalSearchBar.searchBar.shortcutDescription.macCommandDescription"
-                        defaultMessage="Command + /"
+                        defaultMessage="Command + {key}"
+                        values={{ key: shortcutKey }}
                       />
                     ) : (
                       <FormattedMessage
                         id="xpack.globalSearchBar.searchBar.shortcutDescription.windowsCommandDescription"
-                        defaultMessage="Control + /"
+                        defaultMessage="Control + {key}"
+                        values={{ key: shortcutKey }}
                       />
                     )}
                   </EuiCode>

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css, Global } from '@emotion/react';
+import { dynamic } from '@kbn/shared-ux-utility';
+import { EuiLoadingSpinner, EuiFlexGroup, EuiFlexItem, useEuiBreakpoint } from '@elastic/eui';
+import type { SearchModalProps } from './types';
+import {
+  SEARCH_MODAL_SELECTOR_PREFIX,
+  SEARCH_MODAL_HEIGHT_VH,
+  SEARCH_MODAL_WIDTH_PX,
+} from './types';
+
+const LazySearchModal = dynamic(
+  () => import('./search_modal_internal').then((mod) => ({ default: mod.SearchModalInternal })),
+  {
+    fallback: (
+      <EuiFlexGroup justifyContent="center" alignItems="center" style={{ height: '100%' }}>
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="m" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    ),
+  }
+);
+
+export const SearchModal = (props: SearchModalProps) => {
+  const mediumAndUpBreakpoint = useEuiBreakpoint(['m', 'l', 'xl']);
+
+  const modalOverlayStyles = css`
+    .${SEARCH_MODAL_SELECTOR_PREFIX} {
+      ${mediumAndUpBreakpoint} {
+        .euiModal__closeIcon {
+          display: none;
+        }
+        block-size: ${SEARCH_MODAL_HEIGHT_VH}vh;
+        inline-size: ${SEARCH_MODAL_WIDTH_PX}px;
+      }
+    }
+  `;
+
+  return (
+    <>
+      <Global styles={modalOverlayStyles} />
+      <LazySearchModal {...props} />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal_internal.test.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal_internal.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { applicationServiceMock, coreMock } from '@kbn/core/public/mocks';
+import { globalSearchPluginMock } from '@kbn/global-search-plugin/public/mocks';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { of } from 'rxjs';
+import { usageCollectionPluginMock } from '@kbn/usage-collection-plugin/public/mocks';
+import { EventReporter } from '../telemetry';
+import { SearchModalInternal } from './search_modal_internal';
+
+jest.mock(
+  'react-virtualized-auto-sizer',
+  () =>
+    ({ children }: any) =>
+      children({ height: 600, width: 600 })
+);
+
+jest.useFakeTimers({ legacyFakeTimers: true });
+
+describe('SearchModalInternal', () => {
+  const usageCollection = usageCollectionPluginMock.createSetupContract();
+  const core = coreMock.createStart();
+  const basePathUrl = '/plugins/globalSearchBar/assets/';
+  let searchService: ReturnType<typeof globalSearchPluginMock.createStartContract>;
+  let applications: ReturnType<typeof applicationServiceMock.createStartContract>;
+  let eventReporter: EventReporter;
+
+  beforeEach(() => {
+    applications = applicationServiceMock.createStartContract();
+    searchService = globalSearchPluginMock.createStartContract();
+
+    (searchService.getSearchableTypes as jest.Mock).mockResolvedValue(['application']);
+    (searchService.find as jest.Mock).mockReturnValue(of({ results: [] }));
+
+    eventReporter = new EventReporter({ analytics: core.analytics, usageCollection });
+    jest.clearAllMocks();
+  });
+
+  it('renders the search input and footer', () => {
+    render(
+      <IntlProvider locale="en">
+        <SearchModalInternal
+          globalSearch={{ ...searchService, searchCharLimit: 1000 }}
+          navigateToUrl={applications.navigateToUrl}
+          basePathUrl={basePathUrl}
+          reportEvent={eventReporter}
+          onClose={jest.fn()}
+        />
+      </IntlProvider>
+    );
+
+    expect(screen.getByTestId('chromeProjectNextSearchModalInput')).toBeInTheDocument();
+    expect(screen.getByTestId('chromeProjectNextSearchModalFooter')).toBeInTheDocument();
+  });
+
+  it('reports searchFocus on mount and searchBlur on unmount', () => {
+    const focusSpy = jest.spyOn(eventReporter, 'searchFocus');
+    const blurSpy = jest.spyOn(eventReporter, 'searchBlur');
+
+    const { unmount } = render(
+      <IntlProvider locale="en">
+        <SearchModalInternal
+          globalSearch={{ ...searchService, searchCharLimit: 1000 }}
+          navigateToUrl={applications.navigateToUrl}
+          basePathUrl={basePathUrl}
+          reportEvent={eventReporter}
+          onClose={jest.fn()}
+        />
+      </IntlProvider>
+    );
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(blurSpy).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(blurSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal_internal.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal_internal.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiSelectable,
+  euiSelectableTemplateSitewideRenderOptions,
+  useEuiBreakpoint,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useEffect } from 'react';
+import { i18nStrings } from '../strings';
+import { SearchFooter } from './search_footer';
+import { SearchPlaceholder } from './search_placeholder';
+import { useSearchState } from '../hooks/use_search_state';
+import type { SearchModalProps } from './types';
+import { EmptyMessage } from './empty_message';
+import { SEARCH_MODAL_ROW_HEIGHT_PX, SEARCH_MODAL_SELECTOR_PREFIX } from './types';
+import { CharLimitExceededMessage } from './char_limit_exceeded_message';
+
+export const SearchModalInternal = ({
+  globalSearch,
+  taggingApi,
+  navigateToUrl,
+  reportEvent,
+  basePathUrl,
+  onClose,
+}: SearchModalProps) => {
+  const { euiTheme } = useEuiTheme();
+  const mediumAndUpBreakpoint = useEuiBreakpoint(['m', 'l', 'xl']);
+
+  const {
+    searchValue,
+    setSearchValue,
+    options,
+    isLoading,
+    searchCharLimitExceeded,
+    onChange,
+    setSearchRef,
+    triggerInitialLoad,
+  } = useSearchState({
+    globalSearch,
+    taggingApi,
+    navigateToUrl,
+    reportEvent,
+    onResultSelect: onClose,
+  });
+
+  useEffect(() => {
+    triggerInitialLoad();
+    reportEvent.searchFocus();
+    return () => {
+      reportEvent.searchBlur();
+    };
+  }, [triggerInitialLoad, reportEvent]);
+
+  const formattedOptions = options.map((option) => ({
+    ...option,
+    prepend: option.icon ? <EuiIcon color="subdued" size="l" {...option.icon} /> : option.prepend,
+  }));
+
+  const headerStyles = css`
+    ${mediumAndUpBreakpoint} {
+      padding-block: ${euiTheme.size.base};
+      padding-inline: ${euiTheme.size.base};
+    }
+  `;
+
+  const bodyStyles = css`
+    .euiModalBody__overflow {
+      padding-inline: ${euiTheme.size.s};
+      display: flex;
+      flex-direction: column;
+      justify-content: ${isLoading || options.length === 0 ? 'center' : 'flex-start'};
+    }
+  `;
+
+  const footerStyles = css`
+    padding-block: ${euiTheme.size.s};
+    padding-inline: ${euiTheme.size.base};
+  `;
+
+  return (
+    <EuiSelectable
+      isLoading={isLoading}
+      isPreFiltered
+      onChange={onChange}
+      options={formattedOptions}
+      singleSelection={true}
+      renderOption={(option) => euiSelectableTemplateSitewideRenderOptions(option, searchValue)}
+      listProps={{
+        rowHeight: SEARCH_MODAL_ROW_HEIGHT_PX,
+        showIcons: false,
+      }}
+      height="full"
+      searchProps={{
+        autoFocus: true,
+        value: searchValue,
+        onInput: (e: React.UIEvent<HTMLInputElement>) => setSearchValue(e.currentTarget.value),
+        'data-test-subj': `${SEARCH_MODAL_SELECTOR_PREFIX}Input`,
+        inputRef: setSearchRef,
+        compressed: false,
+        'aria-label': i18nStrings.placeholderText,
+        placeholder: i18nStrings.placeholderText,
+        fullWidth: true,
+        isClearable: true,
+      }}
+      errorMessage={
+        searchCharLimitExceeded ? <CharLimitExceededMessage basePathUrl={basePathUrl} /> : null
+      }
+      emptyMessage={<EmptyMessage />}
+      noMatchesMessage={<SearchPlaceholder basePath={basePathUrl} />}
+      searchable
+    >
+      {(list, search) => (
+        <>
+          <EuiModalHeader css={headerStyles}>{search}</EuiModalHeader>
+          <EuiHorizontalRule margin="none" />
+          <EuiModalBody css={bodyStyles}>{list}</EuiModalBody>
+          <EuiHorizontalRule margin="none" />
+          <EuiModalFooter
+            css={footerStyles}
+            data-test-subj={`${SEARCH_MODAL_SELECTOR_PREFIX}Footer`}
+          >
+            <SearchFooter />
+          </EuiModalFooter>
+        </>
+      )}
+    </EuiSelectable>
+  );
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_placeholder.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_placeholder.tsx
@@ -5,21 +5,20 @@
  * 2.0.
  */
 
-import type { FC } from 'react';
 import React from 'react';
 import { EuiImage, EuiText, EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-interface PopoverPlaceholderProps {
+interface SearchPlaceholderProps {
   basePath: string;
   customPlaceholderMessage?: React.ReactNode;
 }
 
-export const PopoverPlaceholder: FC<PopoverPlaceholderProps> = ({
+export const SearchPlaceholder = ({
   basePath,
   customPlaceholderMessage,
-}) => {
+}: SearchPlaceholderProps) => {
   const { colorMode } = useEuiTheme();
 
   return (

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/types.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/types.ts
@@ -12,12 +12,26 @@ import type { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-p
 import type { Observable } from 'rxjs';
 import type { EventReporter } from '../telemetry';
 
+export const SEARCH_MODAL_SELECTOR_PREFIX = 'chromeProjectNextSearchModal';
+export const SEARCH_MODAL_HEIGHT_VH = 50;
+export const SEARCH_MODAL_WIDTH_PX = 800;
+export const SEARCH_MODAL_ROW_HEIGHT_PX = 68;
+
 /* @internal */
-export interface SearchBarProps {
+export interface SearchProps {
   globalSearch: GlobalSearchPluginStart & { searchCharLimit: number };
   navigateToUrl: ApplicationStart['navigateToUrl'];
   reportEvent: EventReporter;
   taggingApi?: SavedObjectTaggingPluginStart;
   basePathUrl: string;
+}
+
+/* @internal */
+export interface SearchBarProps extends SearchProps {
   chromeStyle$: Observable<ChromeStyle>;
+}
+
+/* @internal */
+export interface SearchModalProps extends SearchProps {
+  onClose: () => void;
 }

--- a/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.test.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.test.ts
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  GlobalSearchBatchedResults,
+  GlobalSearchResult,
+} from '@kbn/global-search-plugin/public';
+import { act, renderHook } from '@testing-library/react';
+import { Subject, of } from 'rxjs';
+import { useSearchState } from './use_search_state';
+
+jest.mock('@elastic/apm-rum', () => ({
+  apm: {
+    captureError: jest.fn(),
+  },
+}));
+
+jest.mock('../suggestions', () => ({
+  getSuggestions: jest.fn(() => []),
+}));
+
+jest.mock('../lib', () => ({
+  resultToOption: jest.fn((r: { id: string; title: string; url: string; type: string }) => ({
+    key: r.id,
+    label: r.title,
+    url: r.url,
+    type: r.type,
+  })),
+  suggestionToOption: jest.fn((s: { suggestion: string }) => ({
+    label: s.suggestion,
+    type: '__suggestion__',
+    suggestion: s.suggestion,
+  })),
+}));
+
+jest.mock('../search_syntax', () => ({
+  parseSearchParams: jest.fn((value: string) => ({
+    term: value,
+    filters: { types: [], tags: [] },
+  })),
+}));
+
+type Result =
+  | string
+  | {
+      id: string;
+      type?: string;
+      score?: number;
+      categoryLabel?: string | null;
+    };
+
+const createResult = (result: Result): GlobalSearchResult => {
+  const id = typeof result === 'string' ? result : result.id;
+  const type = typeof result === 'string' ? 'application' : result.type ?? 'application';
+  const score = typeof result === 'string' ? 42 : result.score ?? 42;
+
+  const categoryLabel =
+    typeof result === 'string'
+      ? 'Kibana'
+      : result.categoryLabel !== undefined
+      ? result.categoryLabel
+      : type === 'application'
+      ? 'Kibana'
+      : 'Test';
+
+  return {
+    id,
+    type,
+    title: id,
+    url: `/app/test/${id}`,
+    score,
+    meta: { categoryLabel },
+  };
+};
+
+const createBatch = (...results: Result[]): GlobalSearchBatchedResults => ({
+  results: results.map(createResult),
+});
+
+describe('useSearchState', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const makeDeps = (overrides?: { searchCharLimit?: number }) => {
+    const globalSearch = {
+      searchCharLimit: overrides?.searchCharLimit ?? 1000,
+      getSearchableTypes: jest.fn().mockResolvedValue(['application', 'test']),
+      find: jest.fn().mockReturnValue(of(createBatch())),
+    } as any;
+
+    const navigateToUrl = jest.fn();
+    const reportEvent = {
+      searchRequest: jest.fn(),
+      navigateToApplication: jest.fn(),
+      navigateToSavedObject: jest.fn(),
+    } as any;
+
+    return { globalSearch, navigateToUrl, reportEvent };
+  };
+
+  const triggerInitialLoadAndRunDebounce = async (result: { current: any }) => {
+    act(() => {
+      result.current.triggerInitialLoad();
+    });
+
+    // allow getSearchableTypes async effect to resolve
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+  };
+
+  it('displays an error state and does not search again when the search input exceeds the specified char limit', async () => {
+    const { globalSearch, navigateToUrl, reportEvent } = makeDeps({ searchCharLimit: 1 });
+
+    const { result } = renderHook(() =>
+      useSearchState({
+        globalSearch,
+        navigateToUrl,
+        reportEvent,
+      })
+    );
+
+    // Initial load triggers the first (empty) search
+    await triggerInitialLoadAndRunDebounce(result);
+
+    expect(globalSearch.find).toHaveBeenCalledTimes(1);
+
+    // Exceed the limit
+    act(() => {
+      result.current.setSearchValue('aaa');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    expect(result.current.searchCharLimitExceeded).toBe(true);
+    expect(globalSearch.find).toHaveBeenCalledTimes(1); // no additional search calls
+  });
+
+  it('correctly filters and sorts results by title when the search value is empty', async () => {
+    const { globalSearch, navigateToUrl, reportEvent } = makeDeps();
+
+    globalSearch.find.mockReturnValueOnce(
+      of(createBatch('Discover', 'Canvas'), createBatch({ id: 'Visualize', type: 'test' }, 'Graph'))
+    );
+
+    const { result } = renderHook(() =>
+      useSearchState({
+        globalSearch,
+        navigateToUrl,
+        reportEvent,
+      })
+    );
+
+    await triggerInitialLoadAndRunDebounce(result);
+
+    const labels = result.current.options.map((o: any) => o.label);
+    expect(labels).toEqual(['Canvas', 'Discover', 'Graph']); // Visualize (type=test) filtered out
+  });
+
+  it('search term triggers searchRequest and sorts results by score (descending)', async () => {
+    const { globalSearch, navigateToUrl, reportEvent } = makeDeps();
+
+    // first call = initial empty load
+    globalSearch.find.mockReturnValueOnce(of(createBatch('Discover')));
+
+    // second call = user typed search
+    globalSearch.find.mockReturnValueOnce(
+      of(
+        createBatch(
+          { id: 'Lowest score', type: 'application', score: 1 },
+          { id: 'Highest score', type: 'application', score: 100 }
+        )
+      )
+    );
+
+    const { result } = renderHook(() =>
+      useSearchState({
+        globalSearch,
+        navigateToUrl,
+        reportEvent,
+      })
+    );
+
+    await triggerInitialLoadAndRunDebounce(result);
+
+    act(() => {
+      result.current.setSearchValue('d');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    expect(reportEvent.searchRequest).toHaveBeenCalledTimes(1);
+
+    const labels = result.current.options.map((o: any) => o.label);
+    expect(labels).toEqual(['Highest score', 'Lowest score']);
+  });
+
+  it('only displays results from the last search', async () => {
+    const { globalSearch, navigateToUrl, reportEvent } = makeDeps();
+
+    const firstSearch$ = new Subject<GlobalSearchBatchedResults>();
+
+    // first call = initial empty load
+    globalSearch.find.mockReturnValueOnce(firstSearch$);
+
+    // second call = user typed search
+    globalSearch.find.mockReturnValueOnce(
+      of(
+        createBatch(
+          { id: 'Visualize', type: 'application', score: 10 },
+          { id: 'Map', type: 'application', score: 20 }
+        )
+      )
+    );
+
+    const { result } = renderHook(() =>
+      useSearchState({
+        globalSearch,
+        navigateToUrl,
+        reportEvent,
+      })
+    );
+
+    await triggerInitialLoadAndRunDebounce(result);
+    expect(globalSearch.find).toHaveBeenCalledTimes(1);
+
+    // New query -> should cancel previous subscription + set new results
+    act(() => {
+      result.current.setSearchValue('d');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    expect(globalSearch.find).toHaveBeenCalledTimes(2);
+
+    const lastLabels = result.current.options.map((o: any) => o.label);
+    expect(lastLabels).toEqual(['Map', 'Visualize']);
+
+    // Late emission from first search should NOT override
+    act(() => {
+      firstSearch$.next(createBatch('Discover', 'Canvas'));
+      firstSearch$.complete();
+    });
+
+    const labelsAfterLateEmit = result.current.options.map((o: any) => o.label);
+    expect(labelsAfterLateEmit).toEqual(['Map', 'Visualize']);
+  });
+});

--- a/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiSelectableTemplateSitewideOption } from '@elastic/eui';
+import type { EuiSelectableOnChangeEvent } from '@elastic/eui/src/components/selectable/selectable';
+import type { RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Subscription } from 'rxjs';
+import type { GlobalSearchFindParams, GlobalSearchResult } from '@kbn/global-search-plugin/public';
+import useDebounce from 'react-use/lib/useDebounce';
+import { apm } from '@elastic/apm-rum';
+import useMountedState from 'react-use/lib/useMountedState';
+import type { SearchSuggestion } from '../suggestions';
+import { getSuggestions } from '../suggestions';
+import type { SearchProps } from '../components/types';
+import { resultToOption, suggestionToOption } from '../lib';
+import { parseSearchParams } from '../search_syntax';
+import { sort } from '../components';
+
+const UNKNOWN_TAG_ID = '__unknown__';
+
+interface UseSearchStateOptions extends Omit<SearchProps, 'basePathUrl'> {
+  /** Called after a result is selected and navigation is triggered. */
+  onResultSelect?: () => void;
+}
+
+export interface SearchStateResult {
+  searchValue: string;
+  setSearchValue: (value: string) => void;
+  options: EuiSelectableTemplateSitewideOption[];
+  isLoading: boolean;
+  searchCharLimitExceeded: boolean;
+  searchRef: RefObject<HTMLInputElement | null>;
+  setSearchRef: (ref: HTMLInputElement | null) => void;
+  triggerInitialLoad: () => void;
+  onChange: (
+    selection: EuiSelectableTemplateSitewideOption[],
+    event: EuiSelectableOnChangeEvent
+  ) => void;
+}
+
+export const useSearchState = ({
+  globalSearch,
+  taggingApi,
+  navigateToUrl,
+  reportEvent,
+  onResultSelect,
+}: UseSearchStateOptions): SearchStateResult => {
+  const isMounted = useMountedState();
+
+  const [initialLoad, setInitialLoad] = useState(false);
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [options, setOptions] = useState<EuiSelectableTemplateSitewideOption[]>([]);
+  const [searchableTypes, setSearchableTypes] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [searchCharLimitExceeded, setSearchCharLimitExceeded] = useState(false);
+
+  const searchSubscription = useRef<Subscription | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  const setSearchRef = useCallback((ref: HTMLInputElement | null) => {
+    searchRef.current = ref;
+  }, []);
+
+  // Initialize searchableTypes data
+  useEffect(() => {
+    if (initialLoad) {
+      const fetch = async () => {
+        const types = await globalSearch.getSearchableTypes();
+        setSearchableTypes(types);
+      };
+      fetch();
+    }
+  }, [globalSearch, initialLoad]);
+
+  // Whenever searchValue changes, isLoading = true
+  useEffect(() => {
+    setIsLoading(true);
+  }, [searchValue]);
+
+  // Cleanup subscription when component unmounts
+  useEffect(() => {
+    return () => {
+      searchSubscription.current?.unsubscribe();
+    };
+  }, []);
+
+  const triggerInitialLoad = useCallback(() => {
+    setInitialLoad(true);
+  }, []);
+
+  const loadSuggestions = useCallback(
+    (term: string) => {
+      return getSuggestions({
+        searchTerm: term,
+        searchableTypes,
+        tagCache: taggingApi?.cache,
+      });
+    },
+    [taggingApi, searchableTypes]
+  );
+
+  const setDecoratedOptions = useCallback(
+    (
+      _options: GlobalSearchResult[],
+      suggestions: SearchSuggestion[],
+      searchTagIds: string[] = []
+    ) => {
+      setOptions([
+        ...suggestions.map(suggestionToOption),
+        ..._options.map((option) =>
+          resultToOption(
+            option,
+            searchTagIds?.filter((id) => id !== UNKNOWN_TAG_ID) ?? [],
+            taggingApi?.ui.getTagList
+          )
+        ),
+      ]);
+    },
+    [setOptions, taggingApi]
+  );
+
+  useDebounce(
+    () => {
+      if (initialLoad) {
+        // cancel pending search if not completed yet
+        if (searchSubscription.current) {
+          searchSubscription.current.unsubscribe();
+          searchSubscription.current = null;
+        }
+
+        if (searchValue.length > globalSearch.searchCharLimit) {
+          // setting this will display an error message to the user
+          setSearchCharLimitExceeded(true);
+          return;
+        } else {
+          setSearchCharLimitExceeded(false);
+        }
+
+        const suggestions = loadSuggestions(searchValue.toLowerCase());
+
+        let aggregatedResults: GlobalSearchResult[] = [];
+
+        if (searchValue.length !== 0) {
+          reportEvent.searchRequest();
+        }
+
+        const rawParams = parseSearchParams(searchValue.toLowerCase(), searchableTypes);
+        let tagIds: string[] | undefined;
+        if (taggingApi && rawParams.filters.tags) {
+          tagIds = rawParams.filters.tags.map(
+            (tagName) => taggingApi.ui.getTagIdFromName(tagName) ?? UNKNOWN_TAG_ID
+          );
+        } else {
+          tagIds = undefined;
+        }
+        const searchParams: GlobalSearchFindParams = {
+          term: rawParams.term,
+          types: rawParams.filters.types,
+          tags: tagIds,
+        };
+
+        searchSubscription.current = globalSearch.find(searchParams, {}).subscribe({
+          next: ({ results }) => {
+            if (!isMounted()) {
+              return;
+            }
+
+            if (searchValue.length > 0) {
+              aggregatedResults = [...results, ...aggregatedResults].sort(sort.byScore);
+              setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
+              return;
+            }
+
+            // if searchbar is empty, filter to only applications and sort alphabetically
+            results = results.filter(({ type }: GlobalSearchResult) => type === 'application');
+            aggregatedResults = [...results, ...aggregatedResults].sort(sort.byTitle);
+            setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
+          },
+          error: (err) => {
+            setIsLoading(false);
+
+            // Not doing anything on error right now because it'll either just show the previous
+            // results or empty results which is basically what we want anyways
+            apm.captureError(err, {
+              labels: {
+                SearchValue: searchValue,
+              },
+            });
+          },
+          complete: () => {
+            setIsLoading(false);
+          },
+        });
+      }
+    },
+    350,
+    [searchValue, loadSuggestions, searchableTypes, initialLoad]
+  );
+
+  const onResultSelectRef = useRef(onResultSelect);
+  onResultSelectRef.current = onResultSelect;
+
+  const onChange = useCallback(
+    (selection: EuiSelectableTemplateSitewideOption[], event: EuiSelectableOnChangeEvent) => {
+      let selectedRank: number | null = null;
+      const selected = selection.find(({ checked }, rank) => {
+        const isChecked = checked === 'on';
+        if (isChecked) {
+          selectedRank = rank + 1;
+        }
+        return isChecked;
+      });
+
+      if (!selected) {
+        return;
+      }
+
+      const selectedLabel = selected.label ?? null;
+
+      // @ts-ignore - ts error is "union type is too complex to express"
+      const { url, type, suggestion } = selected;
+
+      // if the type is a suggestion, we change the query on the input and trigger a new search
+      // by setting the searchValue (only setting the field value does not trigger a search)
+      if (type === '__suggestion__') {
+        setSearchValue(suggestion);
+        return;
+      }
+
+      // errors in tracking should not prevent selection behavior
+      try {
+        if (type === 'application') {
+          const key = selected.key ?? 'unknown';
+          const application = `${key.toLowerCase().replaceAll(' ', '_')}`;
+          reportEvent.navigateToApplication({
+            application,
+            searchValue,
+            selectedLabel,
+            selectedRank,
+          });
+        } else {
+          reportEvent.navigateToSavedObject({
+            type,
+            searchValue,
+            selectedLabel,
+            selectedRank,
+          });
+        }
+      } catch (err) {
+        apm.captureError(err, {
+          labels: {
+            SearchValue: searchValue,
+          },
+        });
+        // eslint-disable-next-line no-console
+        console.log('Error trying to track searchbar metrics', err);
+      }
+
+      if (event.shiftKey) {
+        window.open(url);
+      } else if (event.ctrlKey || event.metaKey) {
+        window.open(url, '_blank');
+      } else {
+        navigateToUrl(url);
+      }
+
+      onResultSelectRef.current?.();
+    },
+    [reportEvent, navigateToUrl, searchValue]
+  );
+
+  return {
+    searchValue,
+    setSearchValue,
+    options,
+    isLoading,
+    searchCharLimitExceeded,
+    onChange,
+    setSearchRef,
+    searchRef,
+    triggerInitialLoad,
+  };
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/plugin.test.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/plugin.test.ts
@@ -11,14 +11,18 @@ import { GlobalSearchBarPlugin } from './plugin';
 
 describe('GlobalSearchBarPlugin', () => {
   describe('start', () => {
-    it('registers nav controls', async () => {
-      const coreSetup = coreMock.createSetup();
-
-      const service = new GlobalSearchBarPlugin(
+    const createPlugin = () => {
+      return new GlobalSearchBarPlugin(
         coreMock.createPluginInitializerContext({
           input_max_limit: 2000,
         })
       );
+    };
+
+    it('registers nav controls', async () => {
+      const coreSetup = coreMock.createSetup();
+
+      const service = createPlugin();
 
       service.setup(coreSetup);
 
@@ -33,6 +37,25 @@ describe('GlobalSearchBarPlugin', () => {
       expect(start).toEqual({});
 
       expect(navControlsRegisterSpy).toHaveBeenCalled();
+    });
+
+    it('registers Chrome Next globalSearch when next is enabled', () => {
+      const coreSetup = coreMock.createSetup();
+
+      const service = createPlugin();
+
+      service.setup(coreSetup);
+
+      const coreStart = coreMock.createStart();
+      jest.spyOn(coreStart.chrome.next, 'isEnabled', 'get').mockReturnValue(true);
+
+      const setSpy = jest.spyOn(coreStart.chrome.next.globalSearch, 'set');
+
+      service.start(coreStart, {
+        globalSearch: globalSearchPluginMock.createStartContract(),
+      });
+
+      expect(setSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/x-pack/platform/plugins/private/global_search_bar/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/plugin.tsx
@@ -5,14 +5,24 @@
  * 2.0.
  */
 
-import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+import type {
+  CoreSetup,
+  CoreStart,
+  OverlayRef,
+  Plugin,
+  PluginInitializerContext,
+} from '@kbn/core/public';
 import type { GlobalSearchPluginStart } from '@kbn/global-search-plugin/public';
 import type { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-plugin/public';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import React from 'react';
+import { toMountPoint } from '@kbn/react-kibana-mount';
 import { SearchBar } from './components/search_bar';
 import type { GlobalSearchBarConfigType } from './types';
 import { EventReporter, eventTypes } from './telemetry';
+import type { SearchProps } from './components/types';
+import { SEARCH_MODAL_SELECTOR_PREFIX } from './components/types';
+import { SearchModal } from './components/search_modal';
 
 export interface GlobalSearchBarPluginStartDeps {
   globalSearch: GlobalSearchPluginStart;
@@ -40,18 +50,57 @@ export class GlobalSearchBarPlugin implements Plugin<{}, {}, {}, GlobalSearchBar
     const { application, http } = core;
     const reportEvent = new EventReporter({ analytics: core.analytics, usageCollection });
 
+    const searchProps: SearchProps = {
+      globalSearch: { ...globalSearch, searchCharLimit: this.config.input_max_limit },
+      navigateToUrl: application.navigateToUrl,
+      taggingApi: savedObjectsTagging,
+      basePathUrl: http.basePath.prepend('/plugins/globalSearchBar/assets/'),
+      reportEvent,
+    };
+
+    let activeModalRef: OverlayRef | null = null;
+
+    const closeModal = () => {
+      activeModalRef?.close();
+      activeModalRef = null;
+    };
+
+    const toggleSearchModal = () => {
+      if (activeModalRef) {
+        closeModal();
+        return;
+      }
+
+      activeModalRef = core.overlays.openModal(
+        toMountPoint(
+          <SearchModal
+            {...searchProps}
+            onClose={() => {
+              closeModal();
+            }}
+          />,
+          core
+        ),
+        {
+          className: SEARCH_MODAL_SELECTOR_PREFIX,
+          'data-test-subj': SEARCH_MODAL_SELECTOR_PREFIX,
+          outsideClickCloses: true,
+        }
+      );
+      activeModalRef.onClose.then(() => {
+        activeModalRef = null;
+      });
+    };
+
+    if (core.chrome.next.isEnabled) {
+      core.chrome.next.globalSearch.set({
+        onClick: toggleSearchModal,
+      });
+    }
+
     core.chrome.navControls.registerCenter({
       order: 1000,
-      content: (
-        <SearchBar
-          globalSearch={{ ...globalSearch, searchCharLimit: this.config.input_max_limit }}
-          navigateToUrl={application.navigateToUrl}
-          taggingApi={savedObjectsTagging}
-          basePathUrl={http.basePath.prepend('/plugins/globalSearchBar/assets/')}
-          chromeStyle$={core.chrome.getChromeStyle$()}
-          reportEvent={reportEvent}
-        />
-      ),
+      content: <SearchBar {...searchProps} chromeStyle$={core.chrome.getChromeStyle$()} />,
     });
 
     return {};

--- a/x-pack/platform/plugins/private/global_search_bar/tsconfig.json
+++ b/x-pack/platform/plugins/private/global_search_bar/tsconfig.json
@@ -15,7 +15,8 @@
     "@kbn/saved-objects-tagging-oss-plugin",
     "@kbn/core-chrome-browser",
     "@kbn/config-schema",
-    "@kbn/shared-ux-utility"
+    "@kbn/shared-ux-utility",
+    "@kbn/react-kibana-mount"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/3409
Closes https://github.com/elastic/kibana/issues/262986

## Summary
Extracted from [347f37c](https://github.com/elastic/kibana/pull/261952) from `feature/chrome-next` with modifications.
- Adds the global search modal for Chrome Next (related PR introducing the search input button: https://github.com/elastic/kibana/pull/270187)
- Extracts `useSearchState` hook: shared search logic (debounced API calls, result sorting, telemetry, navigation) consumed by both the new modal and the classic `SearchBar` and common UI components (e.g. `EmptyMessage`).

Changes from the original commit
- Removed `shortcutKey` from search config
- Applied EUI tokens and breakpoints for responsive modal sizing
- Added RTL unit tests

## Testing
```
feature_flags.overrides:
  core.chrome.next: true
```

On first open:

<img width="1310" height="1088" alt="Screenshot 2026-05-25 at 10 47 50" src="https://github.com/user-attachments/assets/24c62bf0-a6ae-434d-84a0-35263713b9cd" />

On not found:

<img width="796" height="678" alt="Screenshot 2026-05-25 at 10 48 23" src="https://github.com/user-attachments/assets/2a51a03d-cc91-4154-9b82-8c9dcb8effc6" />

On char limit exceeded:

<img width="794" height="675" alt="Screenshot 2026-05-25 at 10 48 42" src="https://github.com/user-attachments/assets/d8b4bd10-d99e-4cdd-b66c-32c8b4553343" />

On `type` filter:

<img width="799" height="672" alt="Screenshot 2026-05-25 at 10 50 07" src="https://github.com/user-attachments/assets/ab6b9c11-0c89-4a74-aa8e-bc3b2ef4c65b" />

