### PR TITLE
[Security Solution][Detection Engine] Fix EQL enrichment tests under entity store v2 (MKI)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/entity_store_v2_setup.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/entity_store_v2_setup.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/common';
+import type { FtrProviderContext } from '../../../../../../ftr_provider_context';
+
+const PUBLIC_API_HEADERS: ReadonlyArray<[string, string]> = [
+  ['kbn-xsrf', 'true'],
+  ['x-elastic-internal-origin', 'Kibana'],
+  ['elastic-api-version', '2023-10-31'],
+];
+
+const withHeaders = <T extends { set: (key: string, value: string) => T }>(req: T): T =>
+  PUBLIC_API_HEADERS.reduce((acc, [k, v]) => acc.set(k, v), req);
+
+export const EntityStoreV2EnrichmentSetup = (getService: FtrProviderContext['getService']) => {
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+  const log = getService('log');
+
+  /**
+   * Installs Entity Store v2 (host engine) and creates a host entity used by alert enrichment.
+   *
+   * Returns `true` if v2 was installed (e.g. in MKI where the feature flag is enabled by
+   * default), or `false` if the `entityAnalyticsEntityStoreV2` experimental flag is disabled
+   * (local CI configs pass `disable:entityAnalyticsEntityStoreV2`). When `false`, callers
+   * should rely on the legacy risk/asset-criticality archive load for enrichment.
+   */
+  const setupHostEntity = async (hostEntity: Record<string, unknown>): Promise<boolean> => {
+    await supertest
+      .post('/internal/kibana/settings')
+      .set('kbn-xsrf', 'true')
+      .set('x-elastic-internal-origin', 'Kibana')
+      .send({ changes: { [FF_ENABLE_ENTITY_STORE_V2]: true } });
+
+    const installRes = await withHeaders(supertest.post('/api/security/entity_store/install')).send(
+      { entityTypes: ['host'] }
+    );
+
+    if (installRes.status === 403) {
+      log.info(
+        'Entity store v2 is disabled in this Kibana; skipping v2 enrichment setup and falling back to legacy archive.'
+      );
+      return false;
+    }
+    if (installRes.status !== 200 && installRes.status !== 201) {
+      throw new Error(
+        `Entity store v2 install failed (status ${installRes.status}): ${JSON.stringify(
+          installRes.body
+        )}`
+      );
+    }
+
+    await retry.waitForWithTimeout('entity store v2 to be ready', 60_000, async () => {
+      const res = await withHeaders(supertest.get('/api/security/entity_store/status'));
+      if (res.body.status === 'error') {
+        throw new Error(`Entity store v2 install errored: ${JSON.stringify(res.body)}`);
+      }
+      return res.body.status === 'running' || res.body.status === 'stopped';
+    });
+
+    const createRes = await withHeaders(
+      supertest.post('/api/security/entity_store/entities/host')
+    ).send(hostEntity);
+    if (createRes.status !== 200) {
+      throw new Error(
+        `Create host entity failed (status ${createRes.status}): ${JSON.stringify(createRes.body)}`
+      );
+    }
+
+    return true;
+  };
+
+  const teardown = async (): Promise<void> => {
+    try {
+      await withHeaders(supertest.post('/api/security/entity_store/uninstall')).send({
+        entityTypes: ['user', 'host', 'service'],
+      });
+    } catch (err) {
+      log.debug(`Entity store v2 uninstall skipped: ${err instanceof Error ? err.message : err}`);
+    }
+  };
+
+  return { setupHostEntity, teardown };
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
@@ -63,6 +63,7 @@ import {
 import type { FtrProviderContext } from '../../../../../../ftr_provider_context';
 import { EsArchivePathBuilder } from '../../../../../../es_archive_path_builder';
 import { getMetricsRequest, getMetricsWithRetry } from '../../utils';
+import { EntityStoreV2EnrichmentSetup } from './entity_store_v2_setup';
 
 /**
  * Specific AGENT_ID to use for some of the tests. If the archiver changes and you see errors
@@ -71,12 +72,19 @@ import { getMetricsRequest, getMetricsWithRetry } from '../../utils';
 const AGENT_ID = 'a1d7b39c-f898-4dbe-a761-efb61939302d';
 const specificQueryForTests = `configuration where agent.id=="${AGENT_ID}"`;
 
+// host.id / host.name of the auditbeat record matched by `specificQueryForTests`.
+// EUID priority is host.id, so the entity EUID is `host:${ENRICHMENT_HOST_ID}`.
+const ENRICHMENT_HOST_ID = '8cc95778cce5407c809480e8e32ad76b';
+const ENRICHMENT_HOST_NAME = 'suricata-zeek-sensor-toronto';
+const ENRICHMENT_HOST_EUID = `host:${ENRICHMENT_HOST_ID}`;
+
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
   const es = getService('es');
   const log = getService('log');
   const retry = getService('retry');
+  const entityStoreV2Setup = EntityStoreV2EnrichmentSetup(getService);
 
   // TODO: add a new service for loading archiver files similar to "getService('es')"
   const config = getService('config');
@@ -783,11 +791,24 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('with host risk index', () => {
+      let entityStoreV2Installed = false;
+
       before(async () => {
         await esArchiver.load('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
+        entityStoreV2Installed = await entityStoreV2Setup.setupHostEntity({
+          host: { name: ENRICHMENT_HOST_NAME, id: [ENRICHMENT_HOST_ID] },
+          entity: {
+            id: ENRICHMENT_HOST_EUID,
+            type: 'host',
+            risk: { calculated_level: 'Critical', calculated_score_norm: 96 },
+          },
+        });
       });
 
       after(async () => {
+        if (entityStoreV2Installed) {
+          await entityStoreV2Setup.teardown();
+        }
         await esArchiver.unload('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
 
@@ -809,13 +830,23 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('with asset criticality', () => {
+      let entityStoreV2Installed = false;
+
       before(async () => {
         await esArchiver.load(
           'x-pack/solutions/security/test/fixtures/es_archives/asset_criticality'
         );
+        entityStoreV2Installed = await entityStoreV2Setup.setupHostEntity({
+          host: { name: ENRICHMENT_HOST_NAME, id: [ENRICHMENT_HOST_ID] },
+          entity: { id: ENRICHMENT_HOST_EUID, type: 'host' },
+          asset: { criticality: 'high_impact' },
+        });
       });
 
       after(async () => {
+        if (entityStoreV2Installed) {
+          await entityStoreV2Setup.teardown();
+        }
         await esArchiver.unload(
           'x-pack/solutions/security/test/fixtures/es_archives/asset_criticality'
         );


### PR DESCRIPTION
## Problem

[#269976](https://github.com/elastic/kibana/pull/269976) enabled `entityAnalyticsEntityStoreV2` by default. Alert enrichment in [`enrichments/index.ts`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/enrichments/index.ts#L120) now routes through entity store v2 (queries `entityStoreCrudClient.listEntities` by EUID) instead of the legacy risk-score / asset-criticality indices. Two MKI tests in [`eql.ts`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts) seed data via `esArchiver` into the legacy indices, so v2 finds no matching entity and `host.risk.calculated_level` / `host.asset.criticality` come back `undefined`. Local CI papers over this with `disable:entityAnalyticsEntityStoreV2`; MKI bypasses that flag because the cloud project is already running.

## Fix

Targeted, dual-path (see [PR #270939 files](https://github.com/elastic/kibana/pull/270939/files)):

- New helper `entity_store_v2_setup.ts` next to `eql.ts`. Installs v2 host engine, seeds the host entity (`host:8cc95778cce5407c809480e8e32ad76b`) with `entity.risk` / `asset.criticality`, tears down after.
- Both failing describes call the helper in `before` and `teardown` in `after`. Legacy `esArchiver.load` stays in place so local CI (v2 still disabled) continues to work via the legacy path.