### PR TITLE
[Scout] Register ingest_hub plugin in scout_ci_config.yml

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -29,6 +29,7 @@ plugins:
     - grokdebugger
     - index_management
     - infra
+    - ingest_hub
     - ingest_pipelines
     - intercepts
     - home


### PR DESCRIPTION
## Summary

Registers the `ingest_hub` plugin in `.buildkite/scout_ci_config.yml` under `plugins.enabled`.

The plugin has Scout UI tests that were picked up by the automated manifest update PR #270872, but the plugin was missing from the CI config, causing the `check_scout_config` quick-check to fail with:

```
ERROR The following plugin(s)/package(s) are not registered in Scout CI config:
      - ingest_hub (plugin)
```

## Test plan
- [ ] CI `check_scout_config` quick-check passes