### PR TITLE
[One Workflow] Remove existing global timeout resume tasks if they exist before forcing the execution of idle tasks

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -78,7 +78,10 @@ import {
   WORKFLOW_RUN_TASK_TYPE,
   WORKFLOW_SCHEDULED_TASK_TYPE,
 } from './workflow_task_manager/types';
-import { WorkflowTaskManager } from './workflow_task_manager/workflow_task_manager';
+import {
+  getWorkflowGlobalTimeoutResumeTaskId,
+  WorkflowTaskManager,
+} from './workflow_task_manager/workflow_task_manager';
 import { createWorkflowTaskAbortController } from './workflow_task_shutdown';
 import { createIndexes } from '../common';
 
@@ -1277,6 +1280,16 @@ export class WorkflowsExecutionEnginePlugin
         spaceId,
         fakeRequest: request,
       });
+
+      await plugins.taskManager
+        .removeIfExists(getWorkflowGlobalTimeoutResumeTaskId(executionId))
+        .catch((error: unknown) => {
+          this.logger.warn(
+            `Failed to remove idle-timeout resume task (execution=${executionId}): ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        });
 
       // Same idea as cancel: nudge TM so the resume task runs as soon as possible
       await workflowTaskManager.forceRunIdleTasks(executionId);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.test.ts
@@ -465,5 +465,62 @@ describe('WorkflowTaskManager', () => {
         expect(mockTaskManager.runSoon).toHaveBeenCalledWith(task.id);
       });
     });
+
+    it('should not runSoon workflow-global-timeout idle task', async () => {
+      const globalTimeoutTaskId = getWorkflowGlobalTimeoutResumeTaskId(workflowExecutionId);
+      const mockIdleTasks = [
+        {
+          id: globalTimeoutTaskId,
+          taskType: WORKFLOW_RESUME_TASK_TYPE,
+          params: { workflowRunId: workflowExecutionId, spaceId: 'default' },
+          state: {},
+          scope: [`workflow:execution:${workflowExecutionId}`],
+          runAt: new Date('2099-01-01T00:00:00.000Z'),
+        },
+        {
+          id: 'immediate-resume-uuid',
+          taskType: WORKFLOW_RESUME_TASK_TYPE,
+          params: { workflowRunId: workflowExecutionId, spaceId: 'default' },
+          state: {},
+          scope: [`workflow:execution:${workflowExecutionId}`],
+        },
+      ];
+
+      mockTaskManager.fetch.mockResolvedValue({ docs: mockIdleTasks } as any);
+
+      await workflowTaskManager.forceRunIdleTasks(workflowExecutionId);
+
+      expect(mockTaskManager.runSoon).toHaveBeenCalledTimes(1);
+      expect(mockTaskManager.runSoon).toHaveBeenCalledWith('immediate-resume-uuid');
+      expect(mockTaskManager.runSoon).not.toHaveBeenCalledWith(globalTimeoutTaskId);
+    });
+
+    it('should schedule immediate resume when only workflow-global-timeout is idle', async () => {
+      const globalTimeoutTaskId = getWorkflowGlobalTimeoutResumeTaskId(workflowExecutionId);
+      mockTaskManager.fetch
+        .mockResolvedValueOnce({
+          docs: [
+            {
+              id: globalTimeoutTaskId,
+              taskType: WORKFLOW_RESUME_TASK_TYPE,
+              params: { workflowRunId: workflowExecutionId, spaceId: 'default' },
+              state: {},
+              scope: [`workflow:execution:${workflowExecutionId}`],
+              runAt: new Date('2099-01-01T00:00:00.000Z'),
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce({ docs: [] } as any);
+      mockTaskManager.schedule.mockResolvedValue({ id: 'new-resume-task' } as any);
+
+      await workflowTaskManager.forceRunIdleTasks(workflowExecutionId, {
+        spaceId: 'default',
+        fakeRequest,
+      });
+
+      expect(mockTaskManager.runSoon).not.toHaveBeenCalledWith(globalTimeoutTaskId);
+      expect(mockTaskManager.schedule).toHaveBeenCalledTimes(1);
+      expect(mockTaskManager.runSoon).toHaveBeenCalledWith('new-resume-task');
+    });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.ts
@@ -166,9 +166,13 @@ export class WorkflowTaskManager {
       },
     });
 
-    if (idleTasks.length) {
+    const idleTasksToRun = idleTasks.filter(
+      (idleTask) => idleTask.id !== getWorkflowGlobalTimeoutResumeTaskId(workflowExecutionId)
+    );
+
+    if (idleTasksToRun.length) {
       // TODO: To use bulkRunSoon once available
-      await Promise.all(idleTasks.map((idleTask) => this.taskManager.runSoon(idleTask.id)));
+      await Promise.all(idleTasksToRun.map((idleTask) => this.taskManager.runSoon(idleTask.id)));
       return;
     }
 


### PR DESCRIPTION
## Summary

closes: https://github.com/elastic/security-team/issues/17538

Fixes a race where child-completion (and other explicit resume) paths could run two `workflow:resume` tasks against the same parent execution, causing `version_conflict_engine_exception` on the workflow execution document ([security-team#17538](https://github.com/elastic/security-team/issues/17538)).

When a parent waits on a sync child with a workflow-level timeout, Task Manager keeps an idle `workflow-global-timeout-${executionId}` task. `internalResumeWorkflowExecution` schedules an immediate resume and then calls `forceRunIdleTasks`, which previously `runSoon`'d **all** idle scoped tasks—including that deadline-driven timeout task—alongside the immediate resume.

## Changes

- **`forceRunIdleTasks`**: skip `runSoon` for the stable global-timeout task id; other idle resume tasks and the cancel fallback (`scheduleImmediateResume` when `spaceId` is set) are unchanged.
- **`internalResumeWorkflowExecution`**: remove the global-timeout task after scheduling immediate resume so a stale timeout cannot fire later.

## Test plan

- [x] `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.test.ts`
- [x] `node scripts/check_changes.ts`
