### PR TITLE
[9.4] [One Workflow] live progress fix (#270900)

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
@@ -19,9 +19,13 @@ const makeParams = (): jest.Mocked<WorkflowExecutionLoopParams> =>
     },
     workflowExecutionState: {
       updateWorkflowExecution: jest.fn(),
+      flush: jest.fn().mockResolvedValue(undefined),
     },
     workflowTaskManager: {
       scheduleResumeTask: jest.fn().mockResolvedValue(undefined),
+    },
+    workflowLogger: {
+      flushEvents: jest.fn().mockResolvedValue(undefined),
     },
     fakeRequest: {},
   } as unknown as jest.Mocked<WorkflowExecutionLoopParams>);
@@ -81,6 +85,28 @@ describe('handleExecutionDelay', () => {
       await handleExecutionDelay(params, stepRuntime);
 
       expect(params.workflowExecutionState.updateWorkflowExecution).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('long wait (>= 5s) schedules TM resume task', () => {
+    it('flushes state before scheduling resume task', async () => {
+      const params = makeParams();
+      const resumeAt = new Date(Date.now() + 8000).toISOString();
+      const stepRuntime = makeStepRuntime({
+        stepExecution: {
+          status: ExecutionStatus.WAITING,
+          state: { resumeAt },
+        } as any,
+      });
+
+      await handleExecutionDelay(params, stepRuntime);
+
+      expect(params.workflowExecutionState.flush).toHaveBeenCalled();
+      expect(params.workflowLogger.flushEvents).toHaveBeenCalled();
+      expect(params.workflowTaskManager.scheduleResumeTask).toHaveBeenCalledTimes(1);
+      expect(params.workflowExecutionState.updateWorkflowExecution).toHaveBeenCalledWith({
+        status: ExecutionStatus.WAITING,
+      });
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
@@ -8,6 +8,7 @@
  */
 
 import { ExecutionStatus } from '@kbn/workflows';
+import { flushState } from './persistence_loop';
 import type { WorkflowExecutionLoopParams } from './types';
 import { abortableTimeout, TimeoutAbortedError } from '../utils';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
@@ -44,6 +45,7 @@ export async function handleExecutionDelay(
   const resumeAt = new Date(resumeAtFromState);
   const now = new Date();
   const diff = resumeAt.getTime() - now.getTime();
+  await flushState(params);
   params.workflowExecutionState.updateWorkflowExecution({
     status: ExecutionStatus.WAITING,
   });


### PR DESCRIPTION
Backport of #270900 to 9.4.

### dets

Call `flushState()` in `handleExecutionDelay` immediately before setting the workflow to `waiting` for timer-based `wait` steps. That writes step execution documents and updates `stepExecutionIds` on the execution document while the execution loop is still active, so the execution detail UI and `GET /executions/{id}` polling show step progress during runs with waits.

Fixes: https://github.com/elastic/security-team/issues/17543

Made with Cursor

<!--BACKPORT cfa694dda1f9b805e06a7f1d9fed86f23f12862c BACKPORT-->