### PR TITLE
[One Workflow] Workflows list: reintroduce Tags column, fix triggers/steps icon alignment

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list_table.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list_table.tsx
@@ -14,7 +14,6 @@ import {
   EuiBasicTable,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiLink,
   EuiPopover,
   EuiPopoverTitle,
@@ -33,6 +32,8 @@ import { WorkflowTriggersAndSteps } from './workflow_triggers_and_steps';
 import { getRunTooltipContent, StatusBadge, WorkflowStatus } from '../../../shared/ui';
 import { NextExecutionTime } from '../../../shared/ui/next_execution_time';
 import { WORKFLOWS_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
+
+const MAX_VISIBLE_TAGS = 2;
 
 export interface WorkflowListTableProps {
   items: WorkflowListItemDto[];
@@ -135,7 +136,6 @@ export const WorkflowListTable = ({
                       </EuiText>
                     )}
                   </EuiFlexItem>
-                  <WorkflowTagsBadge tags={item.definition?.tags} />
                 </EuiFlexGroup>
               </EuiFlexItem>
               <EuiFlexItem>
@@ -162,6 +162,16 @@ export const WorkflowListTable = ({
               </EuiFlexItem>
             </EuiFlexGroup>
           </div>
+        ),
+      },
+      {
+        field: 'tags',
+        name: i18n.translate('workflows.workflowList.column.tags', {
+          defaultMessage: 'Tags',
+        }),
+        width: '18%',
+        render: (value: unknown, item: WorkflowListItemDto) => (
+          <WorkflowTagsCell tags={item.definition?.tags} />
         ),
       },
       {
@@ -387,60 +397,87 @@ export const WorkflowListTable = ({
   );
 };
 
-const WorkflowTagsBadge = ({ tags }: { tags: readonly string[] | undefined }) => {
+const tagsRowStyle = css`
+  flex-wrap: nowrap;
+  min-width: 0;
+`;
+
+const visibleTagStyle = css`
+  min-width: 0;
+
+  .euiBadge {
+    max-width: 100%;
+  }
+`;
+
+const overflowPopoverStyle = css`
+  max-height: 200px;
+  max-width: 320px;
+  overflow: auto;
+`;
+
+const WorkflowTagsCell = ({ tags }: { tags: readonly string[] | undefined }) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
   const close = useCallback(() => setIsOpen(false), []);
 
   if (!tags || tags.length === 0) return null;
 
+  const visible = tags.slice(0, MAX_VISIBLE_TAGS);
+  const hidden = tags.slice(MAX_VISIBLE_TAGS);
+
   return (
-    <EuiFlexItem grow={false}>
-      <EuiPopover
-        ownFocus
-        isOpen={isOpen}
-        closePopover={close}
-        aria-label={i18n.translate('workflows.workflowList.tags.ariaLabel', {
-          defaultMessage: 'View tags',
-        })}
-        button={
-          <EuiBadge
-            color="hollow"
-            onClick={toggle}
-            onClickAriaLabel={i18n.translate('workflows.workflowList.tags.ariaLabel', {
-              defaultMessage: 'View tags',
-            })}
-            data-test-subj="workflowTagsBadge"
-          >
-            <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <EuiIcon type="tag" size="s" aria-hidden={true} />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>{tags.length}</EuiFlexItem>
-            </EuiFlexGroup>
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="xs"
+      responsive={false}
+      css={tagsRowStyle}
+      data-test-subj="workflowTags"
+    >
+      {visible.map((tag) => (
+        <EuiFlexItem key={tag} grow={false} css={visibleTagStyle}>
+          <EuiBadge color="hollow" title={tag}>
+            {tag}
           </EuiBadge>
-        }
-      >
-        <EuiPopoverTitle>
-          {i18n.translate('workflows.workflowList.tags.popoverTitle', {
-            defaultMessage: 'Tags',
-          })}
-        </EuiPopoverTitle>
-        <EuiBadgeGroup
-          gutterSize="xs"
-          css={css`
-            max-height: 200px;
-            max-width: 400px;
-            overflow: auto;
-          `}
-        >
-          {tags.map((tag) => (
-            <EuiBadge key={tag} color="hollow">
-              {tag}
-            </EuiBadge>
-          ))}
-        </EuiBadgeGroup>
-      </EuiPopover>
-    </EuiFlexItem>
+        </EuiFlexItem>
+      ))}
+      {hidden.length > 0 && (
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            ownFocus
+            isOpen={isOpen}
+            closePopover={close}
+            aria-label={i18n.translate('workflows.workflowList.tags.popoverTitle', {
+              defaultMessage: 'Tags',
+            })}
+            button={
+              <EuiBadge
+                color="hollow"
+                onClick={toggle}
+                onClickAriaLabel={i18n.translate('workflows.workflowList.tags.moreAriaLabel', {
+                  defaultMessage: 'View more tags',
+                })}
+                data-test-subj="workflowTagsOverflowBadge"
+              >
+                {`+${hidden.length}`}
+              </EuiBadge>
+            }
+          >
+            <EuiPopoverTitle>
+              {i18n.translate('workflows.workflowList.tags.popoverTitle', {
+                defaultMessage: 'Tags',
+              })}
+            </EuiPopoverTitle>
+            <EuiBadgeGroup gutterSize="xs" css={overflowPopoverStyle}>
+              {hidden.map((tag) => (
+                <EuiBadge key={tag} color="hollow">
+                  {tag}
+                </EuiBadge>
+              ))}
+            </EuiBadgeGroup>
+          </EuiPopover>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
   );
 };

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_triggers_and_steps.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_triggers_and_steps.tsx
@@ -202,7 +202,7 @@ export const WorkflowTriggersAndSteps = ({ triggers, steps }: Props) => {
                 <EuiFlexGroup
                   key={`${baseType}-${idx}`}
                   alignItems="center"
-                  gutterSize="s"
+                  gutterSize="xs"
                   responsive={false}
                 >
                   <EuiFlexItem grow={false}>

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/index.ts
@@ -20,3 +20,4 @@ export {
   getSaveWorkflowTooltipContent,
 } from './workflow_action_buttons/get_workflow_tooltip_content';
 export { FormattedRelativeEnhanced } from './formatted_relative_enhanced/formatted_relative_enhanced';
+export { withTooltip } from './with_tooltip';

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/step_icon.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/step_icon.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { EuiIconProps, IconType } from '@elastic/eui';
-import { EuiIcon, EuiLoadingSpinner, EuiToken, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { EuiIcon, EuiLoadingSpinner, EuiToken, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { Suspense } from 'react';
 import type { TypeRegistry } from '@kbn/alerts-ui-shared/lib';
@@ -22,6 +22,7 @@ import { getStepIconType, getTriggerTypeIconType } from './get_step_icon_type';
 import { HardcodedIcons } from './hardcoded_icons';
 import { useKibana } from '../../../hooks/use_kibana';
 import { getExecutionStatusColors, getExecutionStatusIcon } from '../status_badge';
+import { withTooltip } from '../with_tooltip';
 
 // Category icons for bare base types (e.g. `ai.prompt` + `ai.agent` → `ai`) applied
 // before extension-family inheritance, so the aggregated row icon stays stable
@@ -36,23 +37,6 @@ interface StepIconProps extends Omit<EuiIconProps, 'type'> {
   executionStatus: ExecutionStatus | null | undefined;
   onClick?: React.MouseEventHandler;
 }
-
-// EuiToolTip clones its child to attach hover handlers, so anchor it to a plain
-// span — works uniformly for EuiIcon, EuiToken, Suspense, and the masked-span glyph.
-const tooltipAnchorStyle = css({
-  display: 'inline-flex',
-  alignItems: 'center',
-  lineHeight: 0,
-});
-
-const withTooltip = (content: React.ReactElement, title?: string): React.ReactElement =>
-  title ? (
-    <EuiToolTip content={title}>
-      <span css={tooltipAnchorStyle}>{content}</span>
-    </EuiToolTip>
-  ) : (
-    content
-  );
 
 export const StepIcon = React.memo(
   ({ stepType, executionStatus, onClick, title, ...rest }: StepIconProps) => {

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/with_tooltip.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/with_tooltip.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiToolTip } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React from 'react';
+
+/*
+ * EuiToolTip clones its child to attach hover handlers, so anchor it to a plain
+ * span — works uniformly for EuiIcon, EuiToken, Suspense, and the masked-span glyph.
+ */
+const tooltipAnchorStyle = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  lineHeight: 0,
+});
+
+export const withTooltip = (content: React.ReactElement, title?: string): React.ReactElement =>
+  title ? (
+    <EuiToolTip
+      id={title}
+      content={title}
+      anchorProps={{
+        css: css`
+          display: inline-flex;
+        `,
+      }}
+    >
+      <span tabIndex={0} css={tooltipAnchorStyle}>
+        {content}
+      </span>
+    </EuiToolTip>
+  ) : (
+    content
+  );

--- a/src/platform/plugins/shared/workflows_management/public/widgets/worflows_triggers_list/popover_items/index.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/worflows_triggers_list/popover_items/index.tsx
@@ -102,6 +102,9 @@ const PopoverItemsComponent = <T extends unknown>({
         ownFocus
         data-test-subj={`${dataTestPrefix}DisplayPopover`}
         aria-label={popoverTitle ?? popoverButtonTitle}
+        css={css`
+          display: inline-flex;
+        `}
         button={
           <EuiBadge
             iconType={popoverButtonIcon}
@@ -122,7 +125,7 @@ const PopoverItemsComponent = <T extends unknown>({
             {popoverTitle}
           </EuiPopoverTitle>
         ) : null}
-        <PopoverWrapper data-test-subj={`${dataTestPrefix}DisplayPopoverWrapper`}>
+        <PopoverWrapper data-test-subj={`${dataTestPrefix}DisplayPopoverWrapper`} gutterSize="s">
           <OverflowList items={items.slice(numberOfItemsToDisplay)} />
         </PopoverWrapper>
       </EuiPopover>

--- a/src/platform/plugins/shared/workflows_management/public/widgets/worflows_triggers_list/worflows_triggers_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/worflows_triggers_list/worflows_triggers_list.tsx
@@ -14,7 +14,7 @@ import React, { Suspense } from 'react';
 import { isTriggerType } from '@kbn/workflows';
 import { PopoverItems } from './popover_items';
 import * as i18n from '../../../common/translations';
-import { withTooltip } from '../../shared/ui';
+import { withTooltip } from '../../shared/ui/with_tooltip';
 import { triggerSchemas } from '../../trigger_schemas';
 
 interface WorkflowsTriggersListProps {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/worflows_triggers_list/worflows_triggers_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/worflows_triggers_list/worflows_triggers_list.tsx
@@ -14,6 +14,7 @@ import React, { Suspense } from 'react';
 import { isTriggerType } from '@kbn/workflows';
 import { PopoverItems } from './popover_items';
 import * as i18n from '../../../common/translations';
+import { withTooltip } from '../../shared/ui';
 import { triggerSchemas } from '../../trigger_schemas';
 
 interface WorkflowsTriggersListProps {
@@ -34,7 +35,6 @@ const triggersListStyles = {
   container: css({
     maxWidth: '100%',
     minWidth: 0,
-    backgroundColor: 'blue',
   }),
   textContainer: css({
     minWidth: 0,
@@ -84,7 +84,7 @@ export function TriggerIcon({ triggerType }: { triggerType: string }) {
         <EuiIcon type={icon} size="m" title={label} />
       </Suspense>
     );
-  return <span css={triggerIconAnchorStyle}>{iconNode}</span>;
+  return <span css={triggerIconAnchorStyle}>{withTooltip(iconNode, label)}</span>;
 }
 
 export const WorkflowsTriggersList = ({ triggers }: WorkflowsTriggersListProps) => {


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/17005

## Summary

Two changes to the Workflows list view that the issue tracks together:

1. **Fix triggers/steps icon alignment in the "Triggers and Steps" column.** Trigger icons rendered 3px lower than step icons (no shared anchor wrapper). Wrap `TriggerIcon` in the same `withTooltip` anchor used by `StepIcon`, extract that helper into a shared module, and tighten `inline-flex` on the popover overflow chip and inner trigger group. Also drops a stray `backgroundColor: 'blue'` debug style from `triggersListStyles.container`.
2. **Bring back the standalone Tags column.** Replaces the inline "View tags" count badge in the Name column with a dedicated Tags column that renders the first 2 tags as pill chips and collapses the rest into a `+N` overflow chip (click for the full list).

## Before / After

### Tags column

![tags before / after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260525/iphe6jiw-tags-side-by-side.webp)

<details>
<summary>Standalone tags screenshots</summary>

**Before:** ![tags before](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260525/if8rcj0n-tags-before-clean.webp)

**After:** ![tags after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260525/md68kosy-tags-after-clean.webp)

</details>

### Triggers/steps icon alignment

Purple lines mark where icons sit on the fix branch. On `main`, step icons sit just above the upper line — visibly misaligned with the trigger icon on the left. After this fix, triggers, steps, and the `+N` overflow chip all sit flush between the lines.

![alignment before / after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260525/rpoyty0s-side-by-side-icons.png)

<details>
<summary>Standalone alignment screenshots</summary>

**Before:** ![alignment before](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260525/s3uhvrgz-before-icons.webp)

**After:** ![alignment after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260525/6ctvv3so-after-icons.png)

</details>

## Verification

- Open the Workflows list with workflows that have varied tag counts and trigger/step mixes.
- Tags column: first 2 tags render as pill chips; remaining tags are reachable via `+N` chip; workflows with no tags show an empty cell.
- Triggers and Steps column: trigger and step icon top/bottom edges align within a row; `+N` overflow chip sits on the same baseline.

Screenshots captured from the `workflows_management` Storybook (`Workflow List Table → Default`).


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->