### PR TITLE
[One Workflow] Centralize managed workflow field helpers

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/utils/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/index.ts
@@ -30,3 +30,10 @@ export {
   LIQUID_ALLOWED_TAGS,
   createWorkflowLiquidEngine,
 } from './create_workflow_liquid_engine/create_workflow_liquid_engine';
+export {
+  pickManagedWorkflowFields,
+  toManagedWorkflowTelemetryFields,
+  type ManagedWorkflowFields,
+  type ManagedWorkflowFieldsSource,
+  type ManagedWorkflowTelemetryFields,
+} from './pick_managed_workflow_fields/pick_managed_workflow_fields';

--- a/src/platform/packages/shared/kbn-workflows/common/utils/pick_managed_workflow_fields/pick_managed_workflow_fields.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/pick_managed_workflow_fields/pick_managed_workflow_fields.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  pickManagedWorkflowFields,
+  toManagedWorkflowTelemetryFields,
+} from './pick_managed_workflow_fields';
+
+describe('pickManagedWorkflowFields', () => {
+  it('returns managed workflow fields when present', () => {
+    expect(
+      pickManagedWorkflowFields({
+        managed: true,
+        managedBy: 'security',
+        originManagedWorkflowId: 'system-parent',
+        managedVersion: 2,
+      })
+    ).toEqual({
+      managed: true,
+      managedBy: 'security',
+      originManagedWorkflowId: 'system-parent',
+      managedVersion: 2,
+    });
+  });
+
+  it('omits null and undefined managed workflow fields', () => {
+    expect(
+      pickManagedWorkflowFields({
+        managed: false,
+        managedBy: null,
+        originManagedWorkflowId: undefined,
+        managedVersion: null,
+      })
+    ).toEqual({});
+  });
+
+  it('returns an empty object for missing source', () => {
+    expect(pickManagedWorkflowFields(undefined)).toEqual({});
+  });
+});
+
+describe('toManagedWorkflowTelemetryFields', () => {
+  it('maps managed workflow fields to telemetry shape', () => {
+    expect(
+      toManagedWorkflowTelemetryFields({
+        managed: true,
+        managedBy: 'security',
+        originManagedWorkflowId: 'system-parent',
+        managedVersion: 2,
+      })
+    ).toEqual({
+      isManaged: true,
+      managedBy: 'security',
+      originManagedWorkflowId: 'system-parent',
+      managedVersion: 2,
+    });
+  });
+
+  it('omits nullable telemetry fields', () => {
+    expect(
+      toManagedWorkflowTelemetryFields({
+        managed: true,
+        managedBy: null,
+        originManagedWorkflowId: null,
+        managedVersion: null,
+      })
+    ).toEqual({
+      isManaged: true,
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-workflows/common/utils/pick_managed_workflow_fields/pick_managed_workflow_fields.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/pick_managed_workflow_fields/pick_managed_workflow_fields.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EsWorkflowExecution } from '../../../types/v1';
+
+export type ManagedWorkflowFieldsSource = Pick<
+  EsWorkflowExecution,
+  'managed' | 'managedBy' | 'originManagedWorkflowId' | 'managedVersion'
+>;
+
+export interface ManagedWorkflowFields {
+  managed?: true;
+  managedBy?: string;
+  originManagedWorkflowId?: string;
+  managedVersion?: number;
+}
+
+/**
+ * Strips null managed-workflow fields for execution, API, and persistence payloads.
+ */
+export const pickManagedWorkflowFields = (
+  source: ManagedWorkflowFieldsSource | null | undefined
+): Partial<ManagedWorkflowFields> => {
+  if (!source) {
+    return {};
+  }
+
+  return {
+    ...(source.managed === true ? { managed: true } : {}),
+    ...(source.managedBy != null ? { managedBy: source.managedBy } : {}),
+    ...(source.originManagedWorkflowId != null
+      ? { originManagedWorkflowId: source.originManagedWorkflowId }
+      : {}),
+    ...(source.managedVersion != null ? { managedVersion: source.managedVersion } : {}),
+  };
+};
+
+export interface ManagedWorkflowTelemetryFields {
+  isManaged: boolean;
+  managedBy?: string;
+  originManagedWorkflowId?: string;
+  managedVersion?: number;
+}
+
+/**
+ * Maps managed-workflow source fields to telemetry event shape.
+ */
+export const toManagedWorkflowTelemetryFields = (
+  source: ManagedWorkflowFieldsSource | null | undefined
+): ManagedWorkflowTelemetryFields => {
+  const fields = pickManagedWorkflowFields(source);
+
+  return {
+    isManaged: fields.managed === true,
+    ...(fields.managedBy !== undefined ? { managedBy: fields.managedBy } : {}),
+    ...(fields.originManagedWorkflowId !== undefined
+      ? { originManagedWorkflowId: fields.originManagedWorkflowId }
+      : {}),
+    ...(fields.managedVersion !== undefined ? { managedVersion: fields.managedVersion } : {}),
+  };
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/schedule_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/schedule_workflow.ts
@@ -11,7 +11,7 @@ import { v4 as generateUuid } from 'uuid';
 import type { Logger } from '@kbn/core/server';
 import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import type { EsWorkflowExecution, WorkflowExecutionEngineModel } from '@kbn/workflows';
-import { ExecutionStatus } from '@kbn/workflows';
+import { ExecutionStatus, pickManagedWorkflowFields } from '@kbn/workflows';
 
 import { markExecutionFailedTaskRecovery, taskRecoveryMessages } from '../lib/task_recovery';
 import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
@@ -105,14 +105,7 @@ export async function checkAndSkipIfExistingScheduledExecution(
       id: generateUuid(),
       spaceId,
       workflowId: workflow.id,
-      ...(workflow.managed === true ? { managed: true } : {}),
-      ...(typeof workflow.managedBy === 'string' ? { managedBy: workflow.managedBy } : {}),
-      ...(typeof workflow.originManagedWorkflowId === 'string'
-        ? { originManagedWorkflowId: workflow.originManagedWorkflowId }
-        : {}),
-      ...(typeof workflow.managedVersion === 'number'
-        ? { managedVersion: workflow.managedVersion }
-        : {}),
+      ...pickManagedWorkflowFields(workflow),
       isTestRun: workflow.isTestRun,
       workflowDefinition: workflow.definition,
       yaml: workflow.yaml,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.ts
@@ -17,6 +17,7 @@ import {
   ExecutionStatus,
   isEventDrivenWorkflowTriggerSource,
   isWellKnownWorkflowTriggerSource,
+  toManagedWorkflowTelemetryFields,
 } from '@kbn/workflows';
 import {
   workflowExecutionEventNames,
@@ -167,6 +168,7 @@ function buildBaseExecutionTelemetryFields(
   const { triggerType, eventTriggerId } = resolveExecutionTriggerTelemetry(
     workflowExecution.triggeredBy
   );
+  const managedWorkflowFields = toManagedWorkflowTelemetryFields(workflowExecution);
   return {
     workflowExecutionId: workflowExecution.id,
     workflowId: workflowExecution.workflowId,
@@ -174,16 +176,7 @@ function buildBaseExecutionTelemetryFields(
     triggerType,
     ...(eventTriggerId !== undefined ? { eventTriggerId } : {}),
     isTestRun: workflowExecution.isTestRun || false,
-    isManaged: workflowExecution.managed === true,
-    ...(typeof workflowExecution.managedBy === 'string' && {
-      managedBy: workflowExecution.managedBy,
-    }),
-    ...(typeof workflowExecution.originManagedWorkflowId === 'string' && {
-      originManagedWorkflowId: workflowExecution.originManagedWorkflowId,
-    }),
-    ...(typeof workflowExecution.managedVersion === 'number' && {
-      managedVersion: workflowExecution.managedVersion,
-    }),
+    ...managedWorkflowFields,
     ...(executionMetadata.ruleId && { ruleId: executionMetadata.ruleId }),
     ...(executionMetadata.compositionDepth !== undefined && {
       compositionDepth: executionMetadata.compositionDepth,
@@ -404,6 +397,7 @@ export class WorkflowExecutionTelemetryClient {
     const { triggerType, eventTriggerId } = resolveExecutionTriggerTelemetry(
       workflowExecution.triggeredBy
     );
+    const managedWorkflowFields = toManagedWorkflowTelemetryFields(workflowExecution);
 
     const eventData: EventDrivenExecutionSuppressedParams = {
       eventName:
@@ -416,16 +410,7 @@ export class WorkflowExecutionTelemetryClient {
       triggerType,
       ...(eventTriggerId !== undefined ? { eventTriggerId } : {}),
       isTestRun: workflowExecution.isTestRun || false,
-      isManaged: workflowExecution.managed === true,
-      ...(typeof workflowExecution.managedBy === 'string' && {
-        managedBy: workflowExecution.managedBy,
-      }),
-      ...(typeof workflowExecution.originManagedWorkflowId === 'string' && {
-        originManagedWorkflowId: workflowExecution.originManagedWorkflowId,
-      }),
-      ...(typeof workflowExecution.managedVersion === 'number' && {
-        managedVersion: workflowExecution.managedVersion,
-      }),
+      ...managedWorkflowFields,
       ...(executionMetadata.ruleId && { ruleId: executionMetadata.ruleId }),
       ...(executionMetadata.eventChainDepth !== undefined && {
         eventChainDepth: executionMetadata.eventChainDepth,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/metering/metering_service.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/metering/metering_service.ts
@@ -11,7 +11,7 @@ import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { Logger } from '@kbn/core/server';
 import type { UsageRecord, UsageReportingService } from '@kbn/usage-api-plugin/server';
 import type { EsWorkflowExecution } from '@kbn/workflows';
-import { ExecutionStatus, isTerminalStatus } from '@kbn/workflows';
+import { ExecutionStatus, isTerminalStatus, pickManagedWorkflowFields } from '@kbn/workflows';
 
 import { BUCKET_SIZE_MS, METERING_SOURCE_ID, WORKFLOWS_USAGE_TYPE } from './constants';
 
@@ -91,6 +91,8 @@ export class WorkflowsMeteringService {
     const stepTypes = this.extractStepTypes(execution);
     const stepCount = Object.values(stepTypes).reduce((sum, count) => sum + count, 0);
 
+    const managedWorkflowFields = pickManagedWorkflowFields(execution);
+
     const metadata: Record<string, string> = {
       duration_ms: String(durationMs),
       duration_minutes: String(durationMinutes),
@@ -98,18 +100,18 @@ export class WorkflowsMeteringService {
       status: execution.status,
       triggered_by: execution.triggeredBy || 'unknown',
       is_test_run: String(execution.isTestRun),
-      is_managed: String(execution.managed === true),
+      is_managed: String(managedWorkflowFields.managed === true),
       workflow_id: execution.workflowId,
       space_id: execution.spaceId,
       step_count: String(stepCount),
     };
 
-    if (typeof execution.managedBy === 'string') {
-      metadata.managed_by = execution.managedBy;
+    if (managedWorkflowFields.managedBy !== undefined) {
+      metadata.managed_by = managedWorkflowFields.managedBy;
     }
 
-    if (typeof execution.originManagedWorkflowId === 'string') {
-      metadata.origin_managed_workflow_id = execution.originManagedWorkflowId;
+    if (managedWorkflowFields.originManagedWorkflowId !== undefined) {
+      metadata.origin_managed_workflow_id = managedWorkflowFields.originManagedWorkflowId;
     }
 
     if (Object.keys(stepTypes).length > 0) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -17,7 +17,7 @@ import type {
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/server';
-import { ExecutionStatus, WorkflowRepository } from '@kbn/workflows';
+import { ExecutionStatus, pickManagedWorkflowFields, WorkflowRepository } from '@kbn/workflows';
 import type {
   BulkScheduleWorkflowResult,
   ConcurrencySettings,
@@ -106,10 +106,6 @@ const WORKFLOW_RESUME_TASK_MAX_ATTEMPTS = 3;
 const BULK_CANCEL_PAGE_SIZE = 10;
 
 type SetupDependencies = Pick<ContextDependencies, 'cloudSetup'>;
-type ManagedWorkflowExecutionMetadata = Pick<
-  EsWorkflowExecution,
-  'managed' | 'managedBy' | 'originManagedWorkflowId' | 'managedVersion'
->;
 
 export class WorkflowsExecutionEnginePlugin
   implements
@@ -519,7 +515,7 @@ export class WorkflowsExecutionEnginePlugin
                 id: generateUuid(),
                 spaceId,
                 workflowId: workflow.id,
-                ...this.buildManagedWorkflowExecutionMetadata(workflow),
+                ...pickManagedWorkflowFields(workflow),
                 isTestRun: false,
                 workflowDefinition: workflow.definition,
                 yaml: workflow.yaml,
@@ -687,7 +683,7 @@ export class WorkflowsExecutionEnginePlugin
         id: generateUuid(),
         spaceId,
         workflowId: workflow.id,
-        ...this.buildManagedWorkflowExecutionMetadata(workflow),
+        ...pickManagedWorkflowFields(workflow),
         isTestRun: workflow.isTestRun,
         workflowDefinition: workflow.definition,
         yaml: workflow.yaml,
@@ -1106,7 +1102,7 @@ export class WorkflowsExecutionEnginePlugin
         spaceId: workflow.spaceId,
         stepId,
         workflowId: workflow.id,
-        ...this.buildManagedWorkflowExecutionMetadata(workflow),
+        ...pickManagedWorkflowFields(workflow),
         isTestRun: workflow.isTestRun,
         workflowDefinition: workflow.definition,
         yaml: workflow.yaml,
@@ -1387,33 +1383,6 @@ export class WorkflowsExecutionEnginePlugin
       concurrencySettings,
       buildWorkflowContext(normalizedWorkflowExecution, coreStart, dependencies)
     );
-  }
-
-  private buildManagedWorkflowExecutionMetadata(
-    workflow: Pick<
-      WorkflowExecutionEngineModel,
-      'managed' | 'managedBy' | 'originManagedWorkflowId' | 'managedVersion'
-    >
-  ): Partial<ManagedWorkflowExecutionMetadata> {
-    const managedMetadata: Partial<ManagedWorkflowExecutionMetadata> = {};
-
-    if (workflow.managed === true) {
-      managedMetadata.managed = true;
-    }
-
-    if (typeof workflow.managedBy === 'string') {
-      managedMetadata.managedBy = workflow.managedBy;
-    }
-
-    if (typeof workflow.originManagedWorkflowId === 'string') {
-      managedMetadata.originManagedWorkflowId = workflow.originManagedWorkflowId;
-    }
-
-    if (typeof workflow.managedVersion === 'number') {
-      managedMetadata.managedVersion = workflow.managedVersion;
-    }
-
-    return managedMetadata;
   }
 
   /**

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/utils.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/utils.ts
@@ -8,6 +8,7 @@
  */
 
 import type { EsWorkflow, WorkflowExecutionEngineModel } from '@kbn/workflows';
+import { pickManagedWorkflowFields } from '@kbn/workflows';
 
 export function toExecutionModel(
   workflow: EsWorkflow,
@@ -19,14 +20,7 @@ export function toExecutionModel(
     enabled: workflow.enabled,
     definition: workflow.definition,
     yaml: workflow.yaml,
-    ...(workflow.managed === true ? { managed: true } : {}),
-    ...(typeof workflow.managedBy === 'string' ? { managedBy: workflow.managedBy } : {}),
-    ...(typeof workflow.originManagedWorkflowId === 'string'
-      ? { originManagedWorkflowId: workflow.originManagedWorkflowId }
-      : {}),
-    ...(typeof workflow.managedVersion === 'number'
-      ? { managedVersion: workflow.managedVersion }
-      : {}),
+    ...pickManagedWorkflowFields(workflow),
     isTestRun,
   };
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/trigger_event_handler.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/trigger_events/trigger_event_handler.ts
@@ -17,6 +17,7 @@ import type {
   WorkflowDetailDto,
   WorkflowExecutionEngineModel,
 } from '@kbn/workflows';
+import { pickManagedWorkflowFields } from '@kbn/workflows';
 import { validateWorkflowForExecution, type WorkflowRepository } from '@kbn/workflows/server';
 import type { WorkflowsExtensionsServerPluginStart } from '@kbn/workflows-extensions/server';
 import {
@@ -510,14 +511,7 @@ export class TriggerEventHandler {
               enabled: workflow.enabled,
               definition: workflow.definition,
               yaml: workflow.yaml,
-              ...(workflow.managed === true ? { managed: true } : {}),
-              ...(typeof workflow.managedBy === 'string' ? { managedBy: workflow.managedBy } : {}),
-              ...(typeof workflow.originManagedWorkflowId === 'string'
-                ? { originManagedWorkflowId: workflow.originManagedWorkflowId }
-                : {}),
-              ...(typeof workflow.managedVersion === 'number'
-                ? { managedVersion: workflow.managedVersion }
-                : {}),
+              ...pickManagedWorkflowFields(workflow),
             };
             const context: Record<string, unknown> = {
               event: scheduleResult.event,

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
@@ -10,6 +10,7 @@
 import path from 'path';
 import { schema } from '@kbn/config-schema';
 import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
+import { pickManagedWorkflowFields } from '@kbn/workflows';
 import { preprocessAlertInputs } from './utils/preprocess_alert_inputs';
 import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
@@ -94,14 +95,7 @@ export function registerRunWorkflowRoute(deps: RouteDependencies) {
             enabled: workflow.enabled,
             definition: workflow.definition,
             yaml: workflow.yaml,
-            ...(workflow.managed === true ? { managed: true } : {}),
-            ...(typeof workflow.managedBy === 'string' ? { managedBy: workflow.managedBy } : {}),
-            ...(typeof workflow.originManagedWorkflowId === 'string'
-              ? { originManagedWorkflowId: workflow.originManagedWorkflowId }
-              : {}),
-            ...(typeof workflow.managedVersion === 'number'
-              ? { managedVersion: workflow.managedVersion }
-              : {}),
+            ...pickManagedWorkflowFields(workflow),
           };
           const workflowExecutionId = await api.runWorkflow(
             workflowForExecution,

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -15,7 +15,11 @@ import type {
 } from '@kbn/agent-context-layer-plugin/server';
 import type { KibanaRequest, Logger } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
-import { getWorkflowJsonSchema, transformWorkflowYamlJsontoEsWorkflow } from '@kbn/workflows';
+import {
+  getWorkflowJsonSchema,
+  pickManagedWorkflowFields,
+  transformWorkflowYamlJsontoEsWorkflow,
+} from '@kbn/workflows';
 import type {
   BulkScheduleWorkflowResult,
   CreateWorkflowCommand,
@@ -150,24 +154,6 @@ export interface BulkScheduleWorkflowItem {
   triggeredBy: string;
   metadata?: WorkflowExecutionEventDispatchMetadata;
 }
-
-const buildManagedWorkflowExecutionMetadata = (
-  workflow: WorkflowDetailDto | null | undefined
-): Partial<
-  Pick<
-    WorkflowExecutionEngineModel,
-    'managed' | 'managedBy' | 'originManagedWorkflowId' | 'managedVersion'
-  >
-> => ({
-  ...(workflow?.managed === true ? { managed: true } : {}),
-  ...(typeof workflow?.managedBy === 'string' ? { managedBy: workflow.managedBy } : {}),
-  ...(typeof workflow?.originManagedWorkflowId === 'string'
-    ? { originManagedWorkflowId: workflow.originManagedWorkflowId }
-    : {}),
-  ...(typeof workflow?.managedVersion === 'number'
-    ? { managedVersion: workflow.managedVersion }
-    : {}),
-});
 
 export class WorkflowsManagementApi {
   private smlIndexAttachment: SmlIndexAttachmentFn | null = null;
@@ -473,7 +459,7 @@ export class WorkflowsManagementApi {
         definition: workflowJson.definition,
         yaml: resolvedYaml,
         isTestRun: true,
-        ...buildManagedWorkflowExecutionMetadata(existingWorkflow),
+        ...pickManagedWorkflowFields(existingWorkflow),
       },
       context,
       request

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.ts
@@ -16,6 +16,7 @@ import type {
 import type { ConnectorAdapter } from '@kbn/alerting-plugin/server';
 import type { KibanaRequest } from '@kbn/core/server';
 import type { TriggerType, WorkflowExecutionEngineModel } from '@kbn/workflows';
+import { pickManagedWorkflowFields } from '@kbn/workflows';
 import { validateWorkflowForExecution } from '@kbn/workflows/server';
 import { z } from '@kbn/zod/v4';
 import { api } from './api';
@@ -105,14 +106,7 @@ function getWorkflowsConnectorTypeArgs(
         enabled: workflow.enabled,
         definition: workflow.definition,
         yaml: workflow.yaml,
-        ...(workflow.managed === true ? { managed: true } : {}),
-        ...(typeof workflow.managedBy === 'string' ? { managedBy: workflow.managedBy } : {}),
-        ...(typeof workflow.originManagedWorkflowId === 'string'
-          ? { originManagedWorkflowId: workflow.originManagedWorkflowId }
-          : {}),
-        ...(typeof workflow.managedVersion === 'number'
-          ? { managedVersion: workflow.managedVersion }
-          : {}),
+        ...pickManagedWorkflowFields(workflow),
       };
 
       // Run the workflow, @tb: maybe switch to scheduler?
@@ -142,14 +136,7 @@ function getWorkflowsConnectorTypeArgs(
         enabled: workflow.enabled,
         definition: workflow.definition,
         yaml: workflow.yaml,
-        ...(workflow.managed === true ? { managed: true } : {}),
-        ...(typeof workflow.managedBy === 'string' ? { managedBy: workflow.managedBy } : {}),
-        ...(typeof workflow.originManagedWorkflowId === 'string'
-          ? { originManagedWorkflowId: workflow.originManagedWorkflowId }
-          : {}),
-        ...(typeof workflow.managedVersion === 'number'
-          ? { managedVersion: workflow.managedVersion }
-          : {}),
+        ...pickManagedWorkflowFields(workflow),
       };
 
       return workflowsManagementApi.scheduleWorkflow(

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
@@ -9,6 +9,7 @@
 
 import { createHash } from 'node:crypto';
 import type { KibanaRequest, Logger } from '@kbn/core/server';
+import { pickManagedWorkflowFields } from '@kbn/workflows';
 import {
   getManagedWorkflowDefinition,
   getManagedWorkflowDefinitions,
@@ -300,14 +301,7 @@ export class ManagedWorkflowsService {
         enabled: existing.enabled,
         definition: existing.definition,
         yaml: existing.yaml,
-        ...(existing.managed === true ? { managed: true } : {}),
-        ...(typeof existing.managedBy === 'string' ? { managedBy: existing.managedBy } : {}),
-        ...(typeof existing.originManagedWorkflowId === 'string'
-          ? { originManagedWorkflowId: existing.originManagedWorkflowId }
-          : {}),
-        ...(typeof existing.managedVersion === 'number'
-          ? { managedVersion: existing.managedVersion }
-          : {}),
+        ...pickManagedWorkflowFields(existing),
       },
       context,
       request


### PR DESCRIPTION
## Summary

- Add `pickManagedWorkflowFields` and `toManagedWorkflowTelemetryFields` in `@kbn/workflows` to strip nullable managed-workflow fields in one place
- Replace duplicated `typeof` null-guards across telemetry, metering, and execution paths
- Follow-up to review feedback on #269618

## Test plan

- [x] `node scripts/jest src/platform/packages/shared/kbn-workflows/common/utils/pick_managed_workflow_fields/pick_managed_workflow_fields.test.ts`
- [x] `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/metering/metering_service.test.ts`
- [x] `node scripts/check_changes.ts`