### PR TITLE
[Entity Analytics] Skipping V1 tests in serverless MKI

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
@@ -791,7 +791,7 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
 
-      it('should be enriched with host risk score', async () => {
+      it('@skipInServerlessMKI should be enriched with host risk score', async () => {
         const rule: EqlRuleCreateProps = {
           ...getEqlRuleForAlertTesting(['auditbeat-*']),
           query: specificQueryForTests,
@@ -821,7 +821,7 @@ export default ({ getService }: FtrProviderContext) => {
         );
       });
 
-      it('should be enriched alert with criticality_level', async () => {
+      it('@skipInServerlessMKI should be enriched alert with criticality_level', async () => {
         const rule: EqlRuleCreateProps = {
           ...getEqlRuleForAlertTesting(['auditbeat-*']),
           query: specificQueryForTests,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
@@ -1734,7 +1734,7 @@ export default ({ getService }: FtrProviderContext) => {
           );
         });
 
-        it('suppressed alerts are enriched with host risk score', async () => {
+        it('@skipInServerlessMKI suppressed alerts are enriched with host risk score', async () => {
           const eventId = uuidv4();
           await indexGeneratedSourceDocuments({
             docsCount: 1,
@@ -1763,7 +1763,7 @@ export default ({ getService }: FtrProviderContext) => {
           expect(previewAlerts[0]?._source?.host?.risk?.calculated_score_norm).toBe(96);
         });
 
-        it('suppressed alerts are enriched with criticality_level', async () => {
+        it('@skipInServerlessMKI suppressed alerts are enriched with criticality_level', async () => {
           const id = uuidv4();
           const timestamp = '2020-10-28T06:45:00.000Z';
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql.ts
@@ -1980,7 +1980,7 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
 
-      it('should be enriched with host risk score', async () => {
+      it('@skipInServerlessMKI should be enriched with host risk score', async () => {
         const id = uuidv4();
         const interval: [string, string] = ['2020-10-28T06:00:00.000Z', '2020-10-28T06:10:00.000Z'];
         const doc1 = { host: { name: 'host-0' } };
@@ -2022,7 +2022,7 @@ export default ({ getService }: FtrProviderContext) => {
         );
       });
 
-      it('should be enriched alert with criticality_level', async () => {
+      it('@skipInServerlessMKI should be enriched alert with criticality_level', async () => {
         const id = uuidv4();
         const interval: [string, string] = ['2020-10-28T06:00:00.000Z', '2020-10-28T06:10:00.000Z'];
         const doc1 = { host: { name: 'host-0' } };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/esql/trial_license_complete_tier/esql_suppression.ts
@@ -2032,7 +2032,7 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
 
-      it('should be enriched with host risk score', async () => {
+      it('@skipInServerlessMKI should be enriched with host risk score', async () => {
         const id = uuidv4();
         const interval: [string, string] = ['2020-10-28T06:00:00.000Z', '2020-10-28T06:10:00.000Z'];
         const doc1 = { host: { name: 'host-0' } };
@@ -2078,7 +2078,7 @@ export default ({ getService }: FtrProviderContext) => {
         );
       });
 
-      it('should be enriched alert with criticality_level', async () => {
+      it('@skipInServerlessMKI should be enriched alert with criticality_level', async () => {
         const id = uuidv4();
         const interval: [string, string] = ['2020-10-28T06:00:00.000Z', '2020-10-28T06:10:00.000Z'];
         const doc1 = { host: { name: 'host-0' } };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/indicator_match/trial_license_complete_tier/indicator_match.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/indicator_match/trial_license_complete_tier/indicator_match.ts
@@ -2467,7 +2467,7 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
 
-      it('should be enriched with host risk score', async () => {
+      it('@skipInServerlessMKI should be enriched with host risk score', async () => {
         const rule: ThreatMatchRuleCreateProps = createThreatMatchRule({
           query: '*:*',
           threat_query: 'source.ip: "188.166.120.93"', // narrow things down with a query to a specific source ip
@@ -2515,7 +2515,7 @@ export default ({ getService }: FtrProviderContext) => {
         );
       });
 
-      it('should be enriched alert with criticality_level', async () => {
+      it('@skipInServerlessMKI should be enriched alert with criticality_level', async () => {
         const rule: ThreatMatchRuleCreateProps = createThreatMatchRule({
           query: '*:*',
           threat_query: 'source.ip: "188.166.120.93"', // narrow things down with a query to a specific source ip

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/new_terms/trial_license_complete_tier/new_terms.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/new_terms/trial_license_complete_tier/new_terms.ts
@@ -1048,7 +1048,7 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
 
-      it('should be enriched with host risk score', async () => {
+      it('@skipInServerlessMKI should be enriched with host risk score', async () => {
         const rule: NewTermsRuleCreateProps = {
           ...getCreateNewTermsRulesSchemaMock('rule-1', true),
           new_terms_fields: ['host.name'],
@@ -1089,7 +1089,7 @@ export default ({ getService }: FtrProviderContext) => {
         log,
       });
 
-      it('should be enriched alert with criticality_level', async () => {
+      it('@skipInServerlessMKI should be enriched alert with criticality_level', async () => {
         const id = uuidv4();
         const timestamp = '2020-10-28T06:45:00.000Z';
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/query/trial_license_complete_tier/custom_query.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/query/trial_license_complete_tier/custom_query.ts
@@ -285,7 +285,7 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
 
-      it('should have host and user risk score fields', async () => {
+      it('@skipInServerlessMKI should have host and user risk score fields', async () => {
         const rule: QueryRuleCreateProps = {
           ...getRuleForAlertTesting(['auditbeat-*']),
           query: `_id:${ID}`,
@@ -299,7 +299,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(previewAlerts[0]?._source?.user?.risk?.calculated_score_norm).toEqual(11);
       });
 
-      it('should have host and user risk score fields when suppression enabled on interval', async () => {
+      it('@skipInServerlessMKI should have host and user risk score fields when suppression enabled on interval', async () => {
         const rule: QueryRuleCreateProps = {
           ...getRuleForAlertTesting(['auditbeat-*']),
           query: `_id:${ID}`,
@@ -320,7 +320,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(previewAlerts[0]?._source?.user?.risk?.calculated_score_norm).toEqual(11);
       });
 
-      it('should have host and user risk score fields when suppression enabled on rule execution only', async () => {
+      it('@skipInServerlessMKI should have host and user risk score fields when suppression enabled on rule execution only', async () => {
         const rule: QueryRuleCreateProps = {
           ...getRuleForAlertTesting(['auditbeat-*']),
           query: `_id:${ID}`,
@@ -351,7 +351,7 @@ export default ({ getService }: FtrProviderContext) => {
         );
       });
 
-      it('should be enriched alert with criticality_level', async () => {
+      it('@skipInServerlessMKI should be enriched alert with criticality_level', async () => {
         const rule: QueryRuleCreateProps = {
           ...getRuleForAlertTesting(['auditbeat-*']),
           query: `_id:${ID}`,
@@ -362,7 +362,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(previewAlerts[0]?._source?.['user.asset.criticality']).toEqual('extreme_impact');
       });
 
-      it('should be enriched alert with criticality_level when suppression enabled', async () => {
+      it('@skipInServerlessMKI should be enriched alert with criticality_level when suppression enabled', async () => {
         const rule: QueryRuleCreateProps = {
           ...getRuleForAlertTesting(['auditbeat-*']),
           query: `_id:${ID}`,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/threshold/trial_license_complete_tier/threshold.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/threshold/trial_license_complete_tier/threshold.ts
@@ -435,7 +435,7 @@ export default ({ getService }: FtrProviderContext) => {
         await esArchiver.unload('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
 
-      it('should be enriched with host risk score', async () => {
+      it('@skipInServerlessMKI should be enriched with host risk score', async () => {
         const rule: ThresholdRuleCreateProps = {
           ...getThresholdRuleForAlertTesting(['auditbeat-*']),
           threshold: {
@@ -466,7 +466,7 @@ export default ({ getService }: FtrProviderContext) => {
         );
       });
 
-      it('should be enriched alert with criticality_level', async () => {
+      it('@skipInServerlessMKI should be enriched alert with criticality_level', async () => {
         const rule: ThresholdRuleCreateProps = {
           ...getThresholdRuleForAlertTesting(['auditbeat-*']),
           threshold: {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
@@ -25,7 +25,7 @@ export default ({ getService }: FtrProviderContext) => {
   const riskEngineRoutes = riskEngineRouteHelpersFactory(supertest);
   const riskEngineRoutesWithNamespace = riskEngineRouteHelpersFactory(supertest, customSpaceName);
 
-  describe('@ess @serverless @serverlessQA init_and_status_apis', () => {
+  describe('@ess @serverless @serverlessQA @skipInServerlessMKI init_and_status_apis', () => {
     before(async () => {
       await spaces.create({
         id: customSpaceName,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_engine_cleanup_api.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_engine_cleanup_api.ts
@@ -27,7 +27,7 @@ export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  describe('@ess @ serverless @serverless QA risk_engine_cleanup_api', () => {
+  describe('@ess @ serverless @serverless QA @skipInServerlessMKI risk_engine_cleanup_api', () => {
     const createAndSyncRuleAndAlerts = createAndSyncRuleAndAlertsFactory({ supertest, log });
     const { indexListOfDocuments } = dataGeneratorFactory({
       es,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_engine_schedule_now.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_engine_schedule_now.ts
@@ -30,7 +30,7 @@ export default ({ getService }: FtrProviderContext) => {
     await riskEngineRoutes.cleanUp();
   };
 
-  describe('@ess @serverless @serverlessQA Risk Engine schedule_now', () => {
+  describe('@ess @serverless @serverlessQA @skipInServerlessMKI Risk Engine schedule_now', () => {
     const createAndSyncRuleAndAlerts = createAndSyncRuleAndAlertsFactory({ supertest, log });
     const { indexListOfDocuments } = dataGeneratorFactory({
       es,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_engine_so_config.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_engine_so_config.ts
@@ -25,7 +25,7 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
   const log = getService('log');
 
-  describe('@ess @ serverless @serverless QA risk_engine_so_update_config', () => {
+  describe('@ess @ serverless @serverless QA @skipInServerlessMKI risk_engine_so_update_config', () => {
     before(async () => {
       const soId = await kibanaServer.savedObjects.find({
         type: riskEngineConfigurationTypeName,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
@@ -73,7 +73,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
   };
 
-  describe('@ess @serverless @serverlessQA Risk Scoring Entity Calculation API', function () {
+  describe('@ess @serverless @serverlessQA @skipInServerlessMKI Risk Scoring Entity Calculation API', function () {
     this.tags(['esGate']);
 
     context('with auditbeat data', () => {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_preview.ts
@@ -67,7 +67,7 @@ export default ({ getService }: FtrProviderContext): void => {
     return await previewRiskScores({ body: {} });
   };
 
-  describe('@ess @serverless Risk Scoring Preview API', () => {
+  describe('@ess @serverless @skipInServerlessMKI Risk Scoring Preview API', () => {
     context('with auditbeat data', () => {
       const { indexListOfDocuments } = dataGeneratorFactory({
         es,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
@@ -35,7 +35,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const createAndSyncRuleAndAlerts = createAndSyncRuleAndAlertsFactory({ supertest, log });
   const riskEngineRoutes = riskEngineRouteHelpersFactory(supertest);
 
-  describe('@ess @serverless @serverlessQA Risk Scoring Task Execution', () => {
+  describe('@ess @serverless @serverlessQA @skipInServerlessMKI Risk Scoring Task Execution', () => {
     context('with auditbeat data', () => {
       const { indexListOfDocuments } = dataGeneratorFactory({
         es,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/telemetry_usage.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/telemetry_usage.ts
@@ -28,7 +28,7 @@ export default ({ getService }: FtrProviderContext) => {
   const createAndSyncRuleAndAlerts = createAndSyncRuleAndAlertsFactory({ supertest, log });
   const riskEngineRoutes = riskEngineRouteHelpersFactory(supertest);
 
-  describe('@ess @serverless telemetry', () => {
+  describe('@ess @serverless @skipInServerlessMKI telemetry', () => {
     const { indexListOfDocuments } = dataGeneratorFactory({
       es,
       index: 'ecs_compliant',

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/entity_analytics/anomalies.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/entity_analytics/anomalies.cy.ts
@@ -26,7 +26,7 @@ import {
 describe(
   'Entity Analytics Dashboard',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout.cy.ts
@@ -35,7 +35,7 @@ const SIEM_KIBANA_HOST_NAME = 'Host-fwarau82er';
 describe(
   'Entity Flyout',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/host_details/risk_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/host_details/risk_tab.cy.ts
@@ -17,7 +17,7 @@ import { deleteAlertsAndRules } from '../../../tasks/api_calls/common';
 describe(
   'risk tab',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/hosts/host_risk_tab.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/hosts/host_risk_tab.cy.ts
@@ -25,7 +25,7 @@ import { mockRiskEngineEnabled } from '../../../tasks/entity_analytics';
 describe(
   'risk tab',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/hosts/hosts_risk_column.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/hosts/hosts_risk_column.cy.ts
@@ -15,7 +15,7 @@ import { mockRiskEngineEnabled } from '../../../tasks/entity_analytics';
 describe(
   'All hosts table',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/priv_mon/integration_onboarding.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/priv_mon/integration_onboarding.cy.ts
@@ -20,7 +20,7 @@ const OKTA_PACKAGE_NAME = 'entityanalytics_okta';
 describe(
   'Privileged User Monitoring - Integrations onboarding',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/pagination/pagination.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/pagination/pagination.cy.ts
@@ -24,7 +24,7 @@ import { goToTablePage, sortFirstTableColumn } from '../../../tasks/table_pagina
 describe(
   'Pagination',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/users/users_tabs.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/users/users_tabs.cy.ts
@@ -24,7 +24,7 @@ import { ENABLE_RISK_SCORE_BUTTON } from '../../../screens/entity_analytics';
 describe(
   'Users stats and tables',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [


### PR DESCRIPTION
## Summary

With https://github.com/elastic/kibana/pull/269976, we modified the environment for some tests to switch back to V1 because we haven't updated all the tests yet. These tests fail on serverless MKI because the MKI environment is already running so we can't change any feature flags at that point. This adds the `@skipInServerlessMKI` tag just to these tests so that they still run in CI but won't run in MKI.