### PR TITLE
[One Workflow] fix: HTTP connector fetchOptions rename regression

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.test.ts
@@ -490,7 +490,7 @@ describe('ConnectorStepImpl', () => {
       expect.objectContaining({
         connectorType: '.http-system',
         input: expect.objectContaining({
-          fetchOptions: expect.objectContaining({
+          fetcher: expect.objectContaining({
             max_content_length: expect.any(Number),
           }),
         }),
@@ -529,7 +529,7 @@ describe('ConnectorStepImpl', () => {
 
     await (impl as any)._run({ url: 'https://example.com' });
     const callInput = connectorExecutor.execute.mock.calls[0][0].input;
-    expect(callInput.fetchOptions).toBeDefined();
-    expect(callInput.fetchOptions.max_content_length).toBeGreaterThan(0);
+    expect(callInput.fetcher).toBeDefined();
+    expect(callInput.fetcher.max_content_length).toBeGreaterThan(0);
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
@@ -131,8 +131,9 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
           }
         : withInputs;
 
-      // For connector types with Layer 1 support, inject max_content_length into fetchOptions
+      // For connector types with Layer 1 support, inject max_content_length
       // so axios can abort mid-stream (Layer 1 OOM prevention).
+      // The HTTP system connector uses "fetcher"; spec-based connectors use "fetchOptions".
       const rawType = step.type;
       const isSpecConnector = isSpecConnectorType(stepType);
       const hasStepMaxSize = Boolean(step['max-step-size']);
@@ -144,10 +145,11 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
       if (usesWorkflowTransportLimit) {
         const maxBytes = this.getMaxResponseBytes();
         if (maxBytes > 0) {
+          const fetchKey = CONNECTOR_TYPES_WITH_LAYER_1.has(rawType) ? 'fetcher' : 'fetchOptions';
           renderedInputs = {
             ...renderedInputs,
-            fetchOptions: {
-              ...(renderedInputs?.fetchOptions || {}),
+            [fetchKey]: {
+              ...(renderedInputs?.[fetchKey] || {}),
               max_content_length: maxBytes,
             },
           };


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #268591 where all HTTP workflow steps fail with `Unrecognized key: "fetchOptions"`.

- PR #268591 renamed `fetcher` to `fetchOptions` for spec-based connectors, but mistakenly applied the rename to the HTTP system connector injection path in `connector_step.ts`
- The HTTP system connector schema expects `fetcher`, not `fetchOptions`
- Fix: use the correct field name based on connector type — `fetcher` for `CONNECTOR_TYPES_WITH_LAYER_1` (HTTP system connector) and `fetchOptions` for spec-based connectors

## Test Plan

- [x] Unit tests updated and passing (14/14)
- [ ] Manual: run a workflow with `type: http` step and verify it succeeds
- [ ] Manual: run a workflow with a spec connector step (e.g. `google_drive.downloadFile`) with `max-step-size` and verify `fetchOptions` is injected correctly

## References

Closes elastic/security-team#17553

Made with [Cursor](https://cursor.com)