### PR TITLE
[Operations] Add sparse checkout to VM build orchestrator pipeline

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-vm-build-orchestrator.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-vm-build-orchestrator.yml
@@ -24,6 +24,15 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/orchestrate_vm_builds.yml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite
+              - .node-version
+              - package.json
+              - tsconfig.base.json
+              - versions.json
+            cleanup_sparse_state: true
       provider_settings:
         trigger_mode: none
       teams:

--- a/.buildkite/pipelines/orchestrate_vm_builds.yml
+++ b/.buildkite/pipelines/orchestrate_vm_builds.yml
@@ -14,6 +14,7 @@ steps:
         required: true
 
   - name: 'Upload trigger steps'
+    checkout: none
     command: |
       VM_IMAGES_BRANCH="$$(buildkite-agent meta-data get "VM_IMAGES_BRANCH")"
       KIBANA_BRANCH="$$(buildkite-agent meta-data get "KIBANA_BRANCH")"


### PR DESCRIPTION
## Summary

Adds sparse checkout to the `kibana-vm-build-orchestrator` Buildkite pipeline. The initial upload-pipeline step only needs a small subset of the repository, so there is no reason to clone the full tree.

Paths checked out match what other operations pipelines (e.g. `kibana-version-bump`) already use:
- `.buildkite`
- `.node-version`
- `package.json`
- `tsconfig.base.json`
- `versions.json`