### PR TITLE
[One Workflow](fix): scope managed workflow template value types to templated IDs

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/index.ts
@@ -24,15 +24,27 @@ type ManagedWorkflowDefinitionById = {
 export type ManagedWorkflowId = keyof ManagedWorkflowDefinitionById;
 type ManagedWorkflowDefinitionEntry = ManagedWorkflowDefinitionById[ManagedWorkflowId];
 
+type ManagedWorkflowTemplateValuesForDefinition<TDefinition> = TDefinition extends {
+  yamlTemplate: (values: infer TValues) => string;
+}
+  ? TValues
+  : never;
+
+export type TemplatedManagedWorkflowId = {
+  [TId in ManagedWorkflowId]: ManagedWorkflowTemplateValuesForDefinition<
+    ManagedWorkflowDefinitionById[TId]
+  > extends never
+    ? never
+    : TId;
+}[ManagedWorkflowId];
+
 export type ManagedWorkflowTemplateValuesById = {
-  [TId in ManagedWorkflowId]: ManagedWorkflowDefinitionById[TId] extends {
-    yamlTemplate: (values: infer TValues) => string;
-  }
-    ? TValues
-    : never;
+  [TId in TemplatedManagedWorkflowId]: ManagedWorkflowTemplateValuesForDefinition<
+    ManagedWorkflowDefinitionById[TId]
+  >;
 };
 
-export type ManagedWorkflowTemplateValuesForId<TId extends ManagedWorkflowId> =
+export type ManagedWorkflowTemplateValuesForId<TId extends TemplatedManagedWorkflowId> =
   ManagedWorkflowTemplateValuesById[TId];
 
 export const getManagedWorkflowDefinition = (id: string): ManagedWorkflowDefinition | undefined => {

--- a/src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts
@@ -10,7 +10,7 @@
 import { parse } from 'yaml';
 import { z } from '@kbn/zod/v4';
 import { managedWorkflowDefinitions } from '.';
-import type { ManagedWorkflowTemplateValuesById } from '.';
+import type { ManagedWorkflowTemplateValuesById, TemplatedManagedWorkflowId } from '.';
 import { EXAMPLE_MANAGED_WORKFLOW_ID } from './definitions';
 import type { ManagedWorkflowDefinition, ManagedWorkflowTemplateValues } from './types';
 import { WorkflowSchemaBase } from '../spec/schema';
@@ -20,7 +20,12 @@ const ManagedWorkflowSchema = WorkflowSchemaBase.extend({
 });
 
 type RegistryManagedWorkflowDefinition = (typeof managedWorkflowDefinitions)[number];
-type TemplateManagedWorkflowDefinition = RegistryManagedWorkflowDefinition & {
+type TemplateManagedWorkflowDefinition = RegistryManagedWorkflowDefinition extends {
+  yamlTemplate: (values: infer _TValues) => string;
+}
+  ? RegistryManagedWorkflowDefinition
+  : never;
+type YamlTemplateManagedWorkflowDefinition = ManagedWorkflowDefinition & {
   yamlTemplate: (values: ManagedWorkflowTemplateValues) => string;
 };
 
@@ -45,7 +50,7 @@ const managedTemplateDefinitionsById: Array<[string, TemplateManagedWorkflowDefi
 
 function hasYamlTemplate(
   definition: ManagedWorkflowDefinition
-): definition is TemplateManagedWorkflowDefinition {
+): definition is YamlTemplateManagedWorkflowDefinition {
   return typeof definition.yamlTemplate === 'function';
 }
 
@@ -56,12 +61,14 @@ function hasYaml(
 }
 
 function renderWorkflowYaml(definition: ManagedWorkflowDefinition): string {
+  const { id } = definition;
+
   if (hasYaml(definition)) {
     return definition.yaml;
   }
 
   if (!hasYamlTemplate(definition)) {
-    throw new Error(`Managed workflow '${definition.id}' must define either yaml or yamlTemplate`);
+    throw new Error(`Managed workflow '${id}' must define either yaml or yamlTemplate`);
   }
 
   const representativeValues = templateValuesLookup[definition.id];
@@ -147,8 +154,9 @@ describe('managedWorkflowDefinitions', () => {
   it.each(managedTemplateDefinitionsById)(
     '%s yamlTemplate renders cleanly with representative values',
     (id, definition) => {
-      const representativeValues = templateValuesLookup[id];
-      const renderedYaml = definition.yamlTemplate(representativeValues!);
+      const representativeValues =
+        templateRepresentativeValuesById[id as TemplatedManagedWorkflowId];
+      const renderedYaml = definition.yamlTemplate(representativeValues);
 
       expect(typeof renderedYaml).toBe('string');
       expect(renderedYaml.trim()).not.toHaveLength(0);


### PR DESCRIPTION
## Summary

Fixes managed workflow template typing so it only applies to `yamlTemplate` definitions, not yaml-only managed workflows.

Previously, adding yaml-only managed workflows broke TypeScript while Jest still passed.

## What was broken

After introducing `ManagedWorkflowTemplateValuesById` in `@kbn/workflows`, the mapped type was built over **all** registry workflow IDs:

- Templated workflows resolved to their template value shape (e.g. `{ recipient: string }` for `system-example-greeting`).
- Yaml-only workflows resolved to `never`.

That caused two compile-time failures once yaml-only workflows joined the registry:

1. **`ManagedWorkflowTemplateValuesById` required every registry ID** — test/helper objects had to include keys for yaml-only workflows even though they never use template values.
2. **The test type guard used a registry union intersection** — intersecting yaml-only definitions with `{ yamlTemplate: ... }` produced invalid types and broke the `hasYamlTemplate()` type predicate.

Runtime validation was unaffected; only `tsc` failed.

## What changed

- Added `TemplatedManagedWorkflowId` and scoped `ManagedWorkflowTemplateValuesById` / `ManagedWorkflowTemplateValuesForId` to templated IDs only.
- Updated tests to use a distributive conditional for registry template definitions and a generic yamlTemplate type guard.
- Kept all existing runtime assertions unchanged (xor yaml/yamlTemplate, representative values coverage, YAML parse + schema validation).

## Test plan

- [x] `node scripts/jest src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts`
- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts`
- [x] `node scripts/type_check --project src/platform/packages/shared/kbn-workflows/tsconfig.type_check.json`
- [x] `node scripts/type_check --project src/platform/plugins/shared/workflows_management/tsconfig.type_check.json`