### PR TITLE
[One Workflow] fix: preserve step output after resume (clear evicted on setStepOutput)

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_io_service.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_io_service.ts
@@ -327,6 +327,11 @@ export class StepIoService implements StepIoWriter, StepIoLifecycle {
     output: JsonValue | null,
     sizeBytes?: number
   ): void {
+    // Fresh in-memory output is authoritative — do not let a subsequent
+    // prepareForRead rehydrate from ES and overwrite with a stale doc
+    // (common when a deferred step completes on resume before flush).
+    this.clearEvicted(stepExecutionId);
+
     if (this.state.getStepExecution(stepExecutionId)?.stepType === 'data.set') {
       this.recordDataSetOutput(stepExecutionId, output);
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_io_service.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_io_service.test.ts
@@ -252,6 +252,42 @@ describe('StepIoService', () => {
 
       expect(service.getOutputSizeStats()).toEqual({ totalBytes: 0, stepCount: 0 });
     });
+
+    it('clears the evicted flag so rehydration does not overwrite fresh output', async () => {
+      const { state, service, stepExecutionRepository } = buildHarness({
+        evictionMinBytes: 0,
+      });
+      seedCompletedStepWithSize(
+        state,
+        service,
+        'step-1',
+        'run_health_check',
+        { stale: true },
+        1,
+        'workflow.execute'
+      );
+      await service.flushStepChanges();
+      await service.flushStepChanges();
+      expect(service.hasEvictedOutputs()).toBe(true);
+
+      service.setStepOutput('step-1', { health: 'ok' });
+
+      expect(service.hasEvictedOutputs()).toBe(false);
+      expect(service.getStepOutput('step-1')).toEqual({ health: 'ok' });
+
+      stepExecutionRepository.getStepExecutionsByIds.mockResolvedValue([
+        {
+          id: 'step-1',
+          output: { stale: true },
+          workflowRunId: 'test-workflow-execution-id',
+        } as unknown as EsWorkflowStepExecution,
+      ]);
+
+      await service.rehydrateOutputs(['step-1']);
+
+      expect(service.getStepOutput('step-1')).toEqual({ health: 'ok' });
+      expect(stepExecutionRepository.getStepExecutionsByIds).not.toHaveBeenCalled();
+    });
   });
 
   describe('size threshold (driven through setStepOutput)', () => {
@@ -1296,6 +1332,74 @@ describe('StepIoService', () => {
         node: stepCNode,
         predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
       });
+      expect(stepExecutionRepository.getStepExecutionsByIds).not.toHaveBeenCalled();
+    });
+
+    it('preserves fresh output when a deferred step completes on resume before flush', async () => {
+      const { state, service, stepExecutionRepository } = buildHarness();
+      state.updateWorkflowExecution({ stepExecutionIds: ['exec-child'] });
+
+      stepExecutionRepository.getStepExecutionsByIds.mockResolvedValueOnce([
+        {
+          id: 'exec-child',
+          stepId: 'run_health_check',
+          stepType: 'workflow.execute',
+          status: ExecutionStatus.WAITING_FOR_CHILD,
+        } as EsWorkflowStepExecution,
+      ]);
+      await service.load();
+
+      expect(service.hasEvictedOutputs()).toBe(true);
+      expect(service.getStepOutput('exec-child')).toBeUndefined();
+
+      state.upsertStep({
+        id: 'exec-child',
+        stepId: 'run_health_check',
+        stepType: 'workflow.execute',
+        status: ExecutionStatus.COMPLETED,
+      });
+      const childOutput = { health: 'ok' };
+      service.setStepOutput('exec-child', childOutput);
+
+      const workflow = {
+        name: 'Parent',
+        version: '1',
+        description: 'test',
+        enabled: true,
+        triggers: [],
+        steps: [
+          {
+            name: 'run_health_check',
+            type: 'workflow.execute',
+            with: { 'workflow-id': 'child' },
+          } as ConnectorStep,
+          {
+            name: 'log_result',
+            type: 'console',
+            with: { message: '{{steps.run_health_check.output | json}}' },
+          } as ConnectorStep,
+        ],
+      } as unknown as WorkflowYaml;
+      const graph = WorkflowGraph.fromWorkflowDefinition(workflow);
+      const logResultNode = graph.topologicalOrder
+        .map((nodeId) => graph.getNode(nodeId))
+        .find((n) => n.stepId === 'log_result')!;
+
+      stepExecutionRepository.getStepExecutionsByIds.mockClear();
+      stepExecutionRepository.getStepExecutionsByIds.mockResolvedValue([
+        {
+          id: 'exec-child',
+          output: null,
+          workflowRunId: 'test-workflow-execution-id',
+        } as unknown as EsWorkflowStepExecution,
+      ]);
+
+      await service.prepareForRead({
+        node: logResultNode,
+        predecessorsResolver: (n) => graph.getAllPredecessors(n.id),
+      });
+
+      expect(service.getStepOutput('exec-child')).toEqual(childOutput);
       expect(stepExecutionRepository.getStepExecutionsByIds).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

Fixes parent workflows failing to read child output after a sync `workflow.execute` step resumes across Task Manager tasks.

On resume, `StepIoService.load()` marks non-pinned step outputs as evicted (deferred rehydration from ES). When a deferred step such as `workflow.execute` completes on the resume task, `finishStep` writes the fresh output to the in-memory map via `setStepOutput`, but the step remained flagged as evicted. The next step's `prepareForRead` then called `rehydrateOutputs`, fetched the last persisted ES doc (written while the step was still `WAITING_FOR_CHILD`, before output existed), and overwrote the correct in-memory value with `null`.

**Fix:** call `clearEvicted(stepExecutionId)` at the start of `setStepOutput`. This makes a fresh in-memory write authoritative: `rehydrateOutputs` only fetches IDs still in `evictedOutputIds`, so the just-completed step is read from memory instead of stale ES. This is the correct general rule — whenever output is written to memory, that write should win over deferred rehydration — and it applies per step ID only (earlier evicted predecessors are still rehydrated from ES as before).

## Test plan

- [x] Unit test: `setStepOutput` clears evicted flag and blocks stale rehydration
- [x] Unit test: resume path (`load` → `setStepOutput` → `prepareForRead`) preserves fresh output
- [x] All 72 tests in `step_io_service.test.ts` pass

## References

Closes elastic/security-team#17554

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->