### PR TITLE
[One Workflow] managed workflows: scope workflow.execute targets by managed context

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -770,6 +770,7 @@ export interface WorkflowsSearchParams {
   createdBy?: string[];
   enabled?: boolean[];
   tags?: string[];
+  managed?: 'all' | 'managed' | 'unmanaged';
 }
 
 export interface RequestOptions {

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/model/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/model/types.ts
@@ -17,6 +17,7 @@ export interface WorkflowsMap {
   [workflowId: string]: {
     id: string;
     name: string;
+    managed?: boolean;
     inputsSchema?: JsonModelSchemaType;
   };
 }

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_workflow_thunk.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_workflow_thunk.ts
@@ -11,6 +11,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { i18n } from '@kbn/i18n';
 import type { WorkflowDetailDto } from '@kbn/workflows';
 import { WorkflowApi } from '@kbn/workflows-ui';
+import { loadWorkflowsThunk } from './load_workflows_thunk';
 import type { WorkflowsServices } from '../../../../../types';
 import type { RootState } from '../../types';
 import { setWorkflow, setYamlString } from '../slice';
@@ -34,6 +35,7 @@ export const loadWorkflowThunk = createAsyncThunk<
       const response = await api.getWorkflow(id);
       dispatch(setWorkflow(response));
       dispatch(setYamlString(response.yaml));
+      dispatch(loadWorkflowsThunk());
 
       return response;
     } catch (error) {

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_workflows_thunk.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_workflows_thunk.test.ts
@@ -10,7 +10,7 @@
 import { loadWorkflowsThunk } from './load_workflows_thunk';
 import { createMockStore, getMockServices } from '../../__mocks__/store.mock';
 import type { MockServices, MockStore } from '../../__mocks__/store.mock';
-import { initialWorkflowsState } from '../slice';
+import { initialWorkflowsState, setWorkflow } from '../slice';
 
 const mockGetWorkflows = jest.fn();
 
@@ -64,6 +64,7 @@ describe('loadWorkflowsThunk', () => {
     expect(mockGetWorkflows).toHaveBeenCalledWith({
       size: 1000,
       page: 1,
+      managed: 'unmanaged',
     });
     expect(result.type).toBe('detail/loadWorkflowsThunk/fulfilled');
     expect(result.payload).toEqual({
@@ -126,6 +127,44 @@ describe('loadWorkflowsThunk', () => {
     expect(result.payload).toEqual({
       workflows: {},
       totalWorkflows: 0,
+    });
+  });
+
+  it('should request all workflows when the current workflow is managed', async () => {
+    store.dispatch(
+      setWorkflow({
+        id: 'managed-wf',
+        name: 'Managed Workflow',
+        enabled: true,
+        managed: true,
+        yaml: '',
+        valid: true,
+        createdAt: '',
+        createdBy: '',
+        lastUpdatedAt: '',
+        lastUpdatedBy: '',
+        definition: null,
+      })
+    );
+
+    mockGetWorkflows.mockResolvedValue({
+      results: [
+        {
+          id: 'managed-child',
+          name: 'Managed Child',
+          managed: true,
+          definition: null,
+        },
+      ],
+      total: 1,
+    });
+
+    await store.dispatch(loadWorkflowsThunk());
+
+    expect(mockGetWorkflows).toHaveBeenCalledWith({
+      size: 1000,
+      page: 1,
+      managed: 'all',
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_workflows_thunk.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_workflows_thunk.ts
@@ -28,47 +28,56 @@ export const loadWorkflowsThunk = createAsyncThunk<
   LoadWorkflowsResponse,
   LoadWorkflowsParams,
   { state: RootState; extra: { services: WorkflowsServices } }
->('detail/loadWorkflowsThunk', async (_, { dispatch, rejectWithValue, extra: { services } }) => {
-  const { http, notifications } = services;
-  try {
-    const api = new WorkflowApi(http);
-    const response = await api.getWorkflows({ size: MAX_WORKFLOWS_LOOKUP_SIZE, page: 1 });
+>(
+  'detail/loadWorkflowsThunk',
+  async (_, { dispatch, getState, rejectWithValue, extra: { services } }) => {
+    const { http, notifications } = services;
+    try {
+      const isCurrentWorkflowManaged = getState().detail.workflow?.managed === true;
+      const api = new WorkflowApi(http);
+      const response = await api.getWorkflows({
+        size: MAX_WORKFLOWS_LOOKUP_SIZE,
+        page: 1,
+        managed: isCurrentWorkflowManaged ? 'all' : 'unmanaged',
+      });
 
-    const workflowsMap: WorkflowsResponse['workflows'] = {};
-    response.results.forEach((workflow) => {
-      const inputsSchema = getInputsFromDefinition(workflow.definition);
+      const workflowsMap: WorkflowsResponse['workflows'] = {};
+      response.results.forEach((workflow) => {
+        const inputsSchema = getInputsFromDefinition(workflow.definition);
 
-      workflowsMap[workflow.id] = {
-        id: workflow.id,
-        name: workflow.name,
-        inputsSchema,
+        workflowsMap[workflow.id] = {
+          id: workflow.id,
+          name: workflow.name,
+          managed: workflow.managed,
+          inputsSchema,
+        };
+      });
+
+      const workflowsResponse: WorkflowsResponse = {
+        workflows: workflowsMap,
+        totalWorkflows: response.total || 0,
       };
-    });
 
-    const workflowsResponse: WorkflowsResponse = {
-      workflows: workflowsMap,
-      totalWorkflows: response.total || 0,
-    };
+      dispatch(setWorkflows(workflowsResponse));
 
-    dispatch(setWorkflows(workflowsResponse));
+      return workflowsResponse;
+    } catch (error) {
+      const errorMessage =
+        error && typeof error === 'object' && 'body' in error
+          ? (error as { body?: { message?: string } }).body?.message
+          : undefined;
+      const message =
+        typeof errorMessage === 'string'
+          ? errorMessage
+          : error instanceof Error
+          ? error.message
+          : 'Failed to load workflows';
 
-    return workflowsResponse;
-  } catch (error) {
-    const errorMessage =
-      error && typeof error === 'object' && 'body' in error
-        ? (error as { body?: { message?: string } }).body?.message
-        : undefined;
-    const message =
-      typeof errorMessage === 'string'
-        ? errorMessage
-        : error instanceof Error
-        ? error.message
-        : 'Failed to load workflows';
-
-    notifications.toasts.addError(new Error(message), {
-      title: 'Failed to load workflows',
-    });
-    dispatch(setWorkflows(initialWorkflowsState));
-    return rejectWithValue(message);
+      notifications.toasts.addError(new Error(message), {
+        title: 'Failed to load workflows',
+      });
+      dispatch(setWorkflows(initialWorkflowsState));
+      return rejectWithValue(message);
+    }
   }
-});
+);

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/autocomplete.types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/autocomplete.types.ts
@@ -62,6 +62,7 @@ export interface AutocompleteContext {
   dynamicConnectorTypes: Record<string, ConnectorTypeInfo> | null;
   workflows: WorkflowsResponse;
   currentWorkflowId: string | null;
+  isCurrentWorkflowManaged: boolean;
   workflowDefinition: WorkflowYaml | null;
 }
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/build_autocomplete_context.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/build_autocomplete_context.ts
@@ -208,6 +208,7 @@ export function buildAutocompleteContext({
       totalWorkflows: 0,
     },
     currentWorkflowId: editorState?.workflow?.id ?? null,
+    isCurrentWorkflowManaged: editorState?.workflow?.managed === true,
     workflowDefinition: workflowDefinition ?? null,
   };
 }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/get_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/get_suggestions.test.ts
@@ -84,6 +84,7 @@ function createMockContext(
     dynamicConnectorTypes: null,
     workflows: { workflows: {}, totalWorkflows: 0 },
     currentWorkflowId: null,
+    isCurrentWorkflowManaged: false,
     workflowDefinition: null,
     model: {} as monaco.editor.ITextModel,
     position: new monaco.Position(1, 1),

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/json_schema/get_json_schema_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/json_schema/get_json_schema_suggestions.test.ts
@@ -53,6 +53,7 @@ describe('getJsonSchemaSuggestions', () => {
       },
       workflowDefinition: null,
       currentWorkflowId: null,
+      isCurrentWorkflowManaged: false,
       model: {} as any,
       position: {
         lineNumber: 1,

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.test.ts
@@ -70,6 +70,7 @@ describe('getVariableSuggestions', () => {
     isInWorkflowInputsContext: false,
     workflowDefinition: null,
     currentWorkflowId: null,
+    isCurrentWorkflowManaged: false,
     ...overrides,
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/workflow/get_workflow_outputs_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/workflow/get_workflow_outputs_suggestions.test.ts
@@ -88,6 +88,7 @@ const createMockAutocompleteContext = (
     dynamicConnectorTypes: null,
     workflows: { workflows: {}, totalWorkflows: 0 },
     currentWorkflowId: null,
+    isCurrentWorkflowManaged: false,
     workflowDefinition: null,
     isInLiquidBlock: false,
     isInTriggerConditionField: false,

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/workflow/get_workflow_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/workflow/get_workflow_suggestions.test.ts
@@ -54,6 +54,7 @@ function makeContext(
     },
     range,
     workflows,
+    isCurrentWorkflowManaged: false,
     focusedStepInfo: createStepInfo({
       stepId: 'step1',
       stepType: 'workflow.execute',
@@ -157,5 +158,36 @@ describe('getWorkflowSuggestions', () => {
   it('returns all workflows when currentWorkflowId is null', async () => {
     const result = await getWorkflowSuggestions(makeContext({ currentWorkflowId: null }));
     expect(result).toHaveLength(2);
+  });
+
+  it('excludes managed workflows unless the current workflow is managed', async () => {
+    const managedWorkflows: WorkflowsResponse = {
+      workflows: {
+        'wf-user': {
+          id: 'wf-user',
+          name: 'User Workflow',
+        },
+        'wf-managed': {
+          id: 'wf-managed',
+          name: 'Managed Workflow',
+          managed: true,
+        },
+      },
+      totalWorkflows: 2,
+    };
+
+    const userWorkflowResult = await getWorkflowSuggestions(
+      makeContext({ workflows: managedWorkflows })
+    );
+    expect(userWorkflowResult).toHaveLength(1);
+    expect(userWorkflowResult[0].label).toBe('User Workflow (id: wf-user)');
+
+    const managedWorkflowResult = await getWorkflowSuggestions(
+      makeContext({
+        workflows: managedWorkflows,
+        isCurrentWorkflowManaged: true,
+      })
+    );
+    expect(managedWorkflowResult).toHaveLength(2);
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/workflow/get_workflow_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/workflow/get_workflow_suggestions.ts
@@ -28,6 +28,7 @@ type WorkflowSuggestionsContext = ExtendedAutocompleteContext & {
 function getWorkflowsFromStore(
   workflows: WorkflowsResponse,
   currentWorkflowId: string | null,
+  isCurrentWorkflowManaged: boolean,
   searchPrefix?: string
 ): Array<{ id: string; name: string; inputsSchema?: JsonModelSchemaType }> {
   if (!workflows.workflows) {
@@ -39,6 +40,9 @@ function getWorkflowsFromStore(
 
   const filtered = allWorkflows.filter((workflow) => {
     if (workflow.id === currentWorkflowId) {
+      return false;
+    }
+    if (workflow.managed === true && !isCurrentWorkflowManaged) {
       return false;
     }
     if (!lowerSearchPrefix) {
@@ -84,8 +88,16 @@ function buildDocumentation(
 export async function getWorkflowSuggestions(
   autocompleteContext: WorkflowSuggestionsContext
 ): Promise<monaco.languages.CompletionItem[]> {
-  const { focusedStepInfo, line, lineParseResult, range, workflows, currentWorkflowId, model } =
-    autocompleteContext;
+  const {
+    focusedStepInfo,
+    line,
+    lineParseResult,
+    range,
+    workflows,
+    currentWorkflowId,
+    isCurrentWorkflowManaged,
+    model,
+  } = autocompleteContext;
 
   if (lineParseResult?.matchType !== 'workflow-id') {
     return [];
@@ -101,7 +113,12 @@ export async function getWorkflowSuggestions(
 
   const searchPrefix = lineParseResult.fullKey ?? '';
 
-  const workflowSuggestions = getWorkflowsFromStore(workflows, currentWorkflowId, searchPrefix);
+  const workflowSuggestions = getWorkflowsFromStore(
+    workflows,
+    currentWorkflowId,
+    isCurrentWorkflowManaged,
+    searchPrefix
+  );
 
   const valueStartIndex = lineParseResult.valueStartIndex;
   const adjustedRange =


### PR DESCRIPTION
## Summary

Managed workflows should not appear as `workflow.execute` / `workflow.executeAsync` targets in the YAML editor unless the workflow being edited is itself managed. Runtime execution already enforced this via `managedFilter` in `workflow_execute_step_impl.ts`; the editor workflow lookup did not.

- **`loadWorkflowsThunk`** now requests `managed: 'unmanaged'` by default and `managed: 'all'` when the loaded workflow is managed, and stores the `managed` flag on lookup entries.
- **`loadWorkflowThunk`** reloads the workflow lookup after the current workflow loads, so opening a managed workflow refreshes autocomplete/validation targets after Redux knows the managed context.
- **`getWorkflowSuggestions`** filters out managed targets unless `isCurrentWorkflowManaged` is true (defense in depth during the initial page load race).

## Behavior

| Editor context | `workflow-id` autocomplete targets |
|---|---|
| User workflow | Unmanaged workflows only |
| Managed workflow | Unmanaged + managed workflows |

## Test plan

- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_workflows_thunk.test.ts`
- [x] `node scripts/jest src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/workflow/get_workflow_suggestions.test.ts`
- [x] `node scripts/check_changes.ts`

## References

Closes elastic/security-team#17551