### PR TITLE
[content list] Custom filter and sort extensions

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/index.ts
@@ -13,7 +13,23 @@ export type { ContentListClientProviderProps } from './src/provider';
 
 // Strategy.
 export { createClientStrategy } from './src/strategy';
-export type { ClientStrategy } from './src/strategy';
+export type { ClientStrategy, ItemsSnapshotListener } from './src/strategy';
+
+// Client filters.
+export { defineContentListFilter } from './src/filters';
+export type {
+  ContentListFilterDefinition,
+  ContentListFilterMap,
+  ContentListFilterOption,
+  ResolvedContentListFilter,
+} from './src/filters';
+export { useClientFilterCounts } from './src/use_client_filter_counts';
+export { defineContentListSortField } from './src/sorting';
+export type {
+  ContentListSortField,
+  ContentListSortFieldConfig,
+  ContentListSortFieldMap,
+} from './src/sorting';
 
 // Content editor.
 export type { ContentEditorConfig } from './src/content_editor';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/client_strategy_context.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/client_strategy_context.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createContext, useContext } from 'react';
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+import type { ContentListFilterMap } from './filters';
+
+export interface ClientStrategyContextValue {
+  getItemsSnapshot: () => UserContentCommonSchema[];
+  subscribe: (listener: () => void) => () => void;
+  filters: ContentListFilterMap;
+}
+
+export const ClientStrategyContext = createContext<ClientStrategyContextValue | undefined>(
+  undefined
+);
+
+export const useClientStrategyContext = (consumerName: string): ClientStrategyContextValue => {
+  const value = useContext(ClientStrategyContext);
+  if (!value) {
+    throw new Error(`${consumerName} must be used inside <ContentListClientProvider>.`);
+  }
+  return value;
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/custom_filter_renderer.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { EuiText, type Query } from '@elastic/eui';
+import {
+  SelectableFilterPopover,
+  StandardFilterOption,
+  type SelectableFilterOption,
+} from '@kbn/content-list-toolbar';
+import type { ResolvedContentListFilter } from './filters';
+import { useClientFilterCounts } from './use_client_filter_counts';
+
+interface CustomFilterRendererProps {
+  query?: Query;
+  onChange?: (query: Query) => void;
+  filterDefinition: ResolvedContentListFilter;
+  'data-test-subj'?: string;
+}
+
+export const CustomFilterRenderer = ({
+  query,
+  onChange,
+  filterDefinition,
+  'data-test-subj': dataTestSubj,
+}: CustomFilterRendererProps) => {
+  const countByKey = useClientFilterCounts(filterDefinition.fieldName);
+
+  const idHead = filterDefinition.id.charAt(0).toUpperCase();
+  const idTail = filterDefinition.id.slice(1);
+  const fallbackDataTestSubj = `contentList${idHead}${idTail}Filter`;
+
+  const options = useMemo(
+    (): Array<SelectableFilterOption> =>
+      filterDefinition.getOptions().map((option) => ({
+        key: option.value,
+        label: option.label,
+        value: option.label,
+        count: countByKey.get(option.value) ?? 0,
+      })),
+    [countByKey, filterDefinition]
+  );
+
+  const renderOption = useCallback(
+    (option: SelectableFilterOption, state: { isActive: boolean }) => (
+      <StandardFilterOption count={option.count} isActive={state.isActive}>
+        <EuiText
+          size="s"
+          data-test-subj={`${filterDefinition.fieldName}-searchbar-option-${option.key}`}
+        >
+          {option.label}
+        </EuiText>
+      </StandardFilterOption>
+    ),
+    [filterDefinition.fieldName]
+  );
+
+  return (
+    <SelectableFilterPopover
+      fieldName={filterDefinition.fieldName}
+      title={filterDefinition.title}
+      query={query}
+      onChange={onChange}
+      options={options}
+      renderOption={renderOption}
+      emptyMessage={filterDefinition.emptyMessage ?? ''}
+      noMatchesMessage={filterDefinition.noMatchesMessage ?? ''}
+      panelMinWidth={filterDefinition.panelMinWidth}
+      data-test-subj={dataTestSubj ?? fallbackDataTestSubj}
+    />
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/filters.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+import type { FieldDefinition } from '@kbn/content-list-provider';
+
+type MaybeArray<T> = T | readonly T[] | null | undefined;
+
+/** A single selectable option in a {@link ContentListFilterDefinition}. */
+export interface ContentListFilterOption<TValue extends string = string> {
+  value: TValue;
+  label: string;
+}
+
+interface FilterOptionsFromItems<TOption, TValue extends string> {
+  items: readonly TOption[];
+  getOptionValue: (option: TOption) => TValue;
+  getOptionLabel: (option: TOption) => string;
+  unmatchedOption?: ContentListFilterOption<TValue>;
+}
+
+type ContentListFilterOptions<TOption, TValue extends string> =
+  | readonly ContentListFilterOption<TValue>[]
+  | FilterOptionsFromItems<TOption, TValue>;
+
+/**
+ * Declarative descriptor for a custom filter contributed by a content list provider.
+ * Pass to {@link defineContentListFilter} to obtain a {@link ResolvedContentListFilter}.
+ */
+export interface ContentListFilterDefinition<
+  TItem extends UserContentCommonSchema = UserContentCommonSchema,
+  TValue extends string = string,
+  TOption = unknown
+> {
+  /** Unique filter id; also used as the query field name when `queryField` is omitted. */
+  id: string;
+  /** Display label shown in the toolbar filter button. */
+  title: string;
+  /** KQL field name to use in queries. Defaults to `id`. */
+  queryField?: string;
+  /** Extracts the filterable value(s) from a single item. */
+  getItemValue: (item: TItem) => MaybeArray<TValue>;
+  /** Static option list or a descriptor for deriving options from a data array. */
+  options?: ContentListFilterOptions<TOption, TValue>;
+  /** Shown when the option list is empty. */
+  emptyMessage?: string;
+  /** Shown when the active search yields no matching options. */
+  noMatchesMessage?: string;
+  /** Minimum pixel width of the filter popover panel. */
+  panelMinWidth?: number;
+}
+
+/**
+ * Runtime form of a {@link ContentListFilterDefinition}, produced by {@link defineContentListFilter}.
+ * Consumed by the toolbar and by {@link useClientFilterCounts}.
+ */
+export interface ResolvedContentListFilter<TValue extends string = string> {
+  id: string;
+  title: string;
+  /** KQL field name used in queries. */
+  fieldName: string;
+  emptyMessage?: string;
+  noMatchesMessage?: string;
+  panelMinWidth?: number;
+  /** Returns the current option list. */
+  getOptions: () => Array<ContentListFilterOption<TValue>>;
+  /** Looks up the display label for a stored value; returns `undefined` for unknown values. */
+  getLabelForValue: (value: string | null | undefined) => string | undefined;
+  /** Extracts and normalizes filterable values from an item, mapping unknowns to `unmatchedOption` when configured. */
+  normalizeValues: (item: UserContentCommonSchema) => TValue[];
+  /** Produces a {@link FieldDefinition} for wiring this filter into the KQL query pipeline. */
+  toFieldDefinition: () => FieldDefinition;
+}
+
+/** All resolved custom filters registered on a provider, keyed by filter id. */
+export type ContentListFilterMap = Record<string, ResolvedContentListFilter>;
+
+const isOptionsFromItems = <TOption, TValue extends string>(
+  options: ContentListFilterOptions<TOption, TValue>
+): options is FilterOptionsFromItems<TOption, TValue> => !Array.isArray(options);
+
+const getOptions = <TOption, TValue extends string>(
+  options?: ContentListFilterOptions<TOption, TValue>
+): Array<ContentListFilterOption<TValue>> => {
+  if (!options) {
+    return [];
+  }
+  if (isOptionsFromItems(options)) {
+    const resolved = options.items.map((option) => ({
+      value: options.getOptionValue(option),
+      label: options.getOptionLabel(option),
+    }));
+    return options.unmatchedOption ? [options.unmatchedOption, ...resolved] : resolved;
+  }
+  return [...options];
+};
+
+const getUnmatchedOption = <TOption, TValue extends string>(
+  options?: ContentListFilterOptions<TOption, TValue>
+): ContentListFilterOption<TValue> | undefined =>
+  options && isOptionsFromItems(options) ? options.unmatchedOption : undefined;
+
+const isValueArray = <TValue extends string>(
+  value: MaybeArray<TValue>
+): value is readonly TValue[] => Array.isArray(value);
+
+const toArray = <TValue extends string>(value: MaybeArray<TValue>): TValue[] => {
+  if (isValueArray(value)) {
+    return value.filter((v): v is TValue => v != null);
+  }
+  return value == null ? [] : [value];
+};
+
+/**
+ * Converts a {@link ContentListFilterDefinition} into a {@link ResolvedContentListFilter}
+ * ready for registration on a content list provider.
+ */
+export const defineContentListFilter = <
+  TItem extends UserContentCommonSchema,
+  TValue extends string = string,
+  TOption = unknown
+>(
+  definition: ContentListFilterDefinition<TItem, TValue, TOption>
+): ResolvedContentListFilter<TValue> => {
+  const fieldName = definition.queryField ?? definition.id;
+
+  const getKnownOptions = () => getOptions(definition.options);
+
+  const getLabelForValue = (value: string | null | undefined) =>
+    value == null ? undefined : getKnownOptions().find((option) => option.value === value)?.label;
+
+  const normalizeValues = (item: UserContentCommonSchema): TValue[] => {
+    const options = getKnownOptions();
+    const rawValues = toArray(definition.getItemValue(item as TItem));
+    if (!definition.options) {
+      return Array.from(new Set(rawValues));
+    }
+    const knownValues = new Set(options.map(({ value }) => value));
+    const unmatchedOption = getUnmatchedOption(definition.options);
+    const normalized = new Set<TValue>();
+
+    for (const value of rawValues) {
+      if (knownValues.has(value)) {
+        normalized.add(value);
+      } else if (unmatchedOption) {
+        normalized.add(unmatchedOption.value);
+      }
+    }
+
+    if (normalized.size === 0 && unmatchedOption) {
+      normalized.add(unmatchedOption.value);
+    }
+
+    return Array.from(normalized);
+  };
+
+  const resolveDisplayToValue = (displayValue: string): string | undefined => {
+    const match = getKnownOptions().find(
+      (option) => option.label === displayValue || option.value === displayValue
+    );
+    return match?.value;
+  };
+
+  return {
+    id: definition.id,
+    title: definition.title,
+    fieldName,
+    emptyMessage: definition.emptyMessage,
+    noMatchesMessage: definition.noMatchesMessage,
+    panelMinWidth: definition.panelMinWidth,
+    getOptions: getKnownOptions,
+    getLabelForValue,
+    normalizeValues,
+    toFieldDefinition: () => ({
+      fieldName,
+      resolveIdToDisplay: (id) => getLabelForValue(id) ?? id,
+      resolveDisplayToId: resolveDisplayToValue,
+      resolveFuzzyDisplayToIds: (partial) => {
+        const lower = partial.toLowerCase();
+        return getKnownOptions()
+          .filter(
+            (option) =>
+              option.label.toLowerCase().includes(lower) ||
+              option.value.toLowerCase().includes(lower)
+          )
+          .map(({ value }) => value);
+      },
+    }),
+  };
+};
+
+export const matchesFilterValue = (
+  item: UserContentCommonSchema,
+  filter: ResolvedContentListFilter,
+  value: string
+): boolean => filter.normalizeValues(item).includes(value);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.test.tsx
@@ -15,9 +15,15 @@ import {
   useOpenContentEditor,
   type OpenContentEditorParams,
 } from '@kbn/content-management-content-editor';
-import { useContentListConfig } from '@kbn/content-list-provider';
+import {
+  CREATED_BY_FILTER_ID,
+  type FindItemsParams,
+  TAG_FILTER_ID,
+  useContentListConfig,
+} from '@kbn/content-list-provider';
 import { ContentListClientProvider } from './provider';
 import type { ContentListClientProviderProps } from './provider';
+import { defineContentListFilter } from './filters';
 import type {
   TableListViewFindItemsFn,
   ContentListClientServices,
@@ -62,6 +68,32 @@ describe('ContentListClientProvider', () => {
     } as unknown as ContentListKibanaCore);
 
   const createMockServices = (): ContentListClientServices => ({});
+
+  const createContentTypeFilter = (queryField?: string) =>
+    defineContentListFilter({
+      id: 'contentType',
+      ...(queryField ? { queryField } : {}),
+      title: 'Content type',
+      getItemValue: (item: UserContentCommonSchema) => item.type,
+      options: [
+        { value: 'dashboard', label: 'Dashboard' },
+        { value: 'visualization', label: 'Visualization' },
+      ],
+    });
+
+  const findIds = async (
+    dataSource: ReturnType<typeof useContentListConfig>['dataSource'],
+    params: Pick<FindItemsParams, 'filters'> & Partial<Pick<FindItemsParams, 'sort'>>
+  ) => {
+    const response = await dataSource.findItems({
+      searchQuery: '',
+      filters: params.filters,
+      sort: params.sort,
+      page: { index: 0, size: 20 },
+    });
+
+    return response.items.map(({ id }) => id);
+  };
 
   const createWrapper = (props?: Partial<ContentListClientProviderProps>) => {
     const defaultFindItems = createMockFindItems([createMockItem('1')]);
@@ -192,6 +224,169 @@ describe('ContentListClientProvider', () => {
 
       expect(result.current.features.pagination).toBe(false);
       expect(result.current.supports.pagination).toBe(false);
+    });
+
+    it('registers and applies updater-defined custom filters', async () => {
+      const findItems = createMockFindItems([
+        createMockItem('1'),
+        { ...createMockItem('2'), type: 'visualization' },
+      ]);
+      const typeFilter = createContentTypeFilter();
+
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          findItems,
+          features: {
+            filters: (defaults) => ({ ...defaults, contentType: typeFilter }),
+          },
+        }),
+      });
+
+      expect(result.current.features.fields).toEqual([
+        expect.objectContaining({ fieldName: 'contentType' }),
+      ]);
+      expect(result.current.features.toolbarFilters?.contentType).toMatchObject({
+        type: 'custom_component',
+      });
+      await expect(
+        findIds(result.current.dataSource, {
+          filters: { contentType: { include: ['visualization'] } },
+        })
+      ).resolves.toEqual(['2']);
+    });
+
+    it('applies custom filters by query field when it differs from the filter id', async () => {
+      const findItems = createMockFindItems([
+        createMockItem('1'),
+        { ...createMockItem('2'), type: 'visualization' },
+      ]);
+      const typeFilter = createContentTypeFilter('type');
+
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          findItems,
+          features: {
+            filters: {
+              contentType: typeFilter,
+            },
+          },
+        }),
+      });
+
+      expect(result.current.features.fields).toEqual([
+        expect.objectContaining({ fieldName: 'type' }),
+      ]);
+      await expect(
+        findIds(result.current.dataSource, {
+          filters: { type: { include: ['visualization'] } },
+        })
+      ).resolves.toEqual(['2']);
+    });
+
+    it('registers and applies updater-defined custom sort fields', async () => {
+      const findItems = createMockFindItems([createMockItem('1'), createMockItem('2')]);
+
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          findItems,
+          features: {
+            sorting: {
+              fields: (defaults) => ({
+                ...defaults,
+                priority: {
+                  id: 'priority',
+                  title: 'Priority',
+                  getValue: (item) => (item.id === '1' ? 2 : 1),
+                },
+              }),
+            },
+          },
+        }),
+      });
+
+      expect(result.current.features.sorting).toMatchObject({
+        fields: expect.arrayContaining([expect.objectContaining({ field: 'priority' })]),
+      });
+      await expect(
+        findIds(result.current.dataSource, {
+          filters: {},
+          sort: { field: 'priority', direction: 'asc' },
+        })
+      ).resolves.toEqual(['2', '1']);
+    });
+
+    it('preserves default sort fields when custom sort fields are keyed', () => {
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          features: {
+            sorting: {
+              fields: {
+                priority: { id: 'priority', title: 'Priority' },
+              },
+            },
+          },
+        }),
+      });
+
+      expect(result.current.features.sorting).toMatchObject({
+        fields: expect.arrayContaining([
+          expect.objectContaining({ field: 'title' }),
+          expect.objectContaining({ field: 'updatedAt' }),
+          expect.objectContaining({ field: 'priority' }),
+        ]),
+      });
+    });
+
+    it('applies built-in tag filters through shared filter dimensions', async () => {
+      const taggedItem = {
+        ...createMockItem('1'),
+        references: [{ type: 'tag', id: 'tag-1', name: 'tag-1' }],
+      };
+      const untaggedItem = {
+        ...createMockItem('2'),
+        references: [{ type: 'tag', id: 'tag-2', name: 'tag-2' }],
+      };
+      const tags = {
+        getTagList: () => [
+          { id: 'tag-1', name: 'Production' },
+          { id: 'tag-2', name: 'Development' },
+        ],
+      } as ContentListClientServices['tags'];
+
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          findItems: createMockFindItems([taggedItem, untaggedItem]),
+          services: { tags },
+        }),
+      });
+
+      await expect(
+        findIds(result.current.dataSource, {
+          filters: { [TAG_FILTER_ID]: { include: ['tag-1'] } },
+        })
+      ).resolves.toEqual(['1']);
+    });
+
+    it('applies built-in creator filters through shared filter dimensions', async () => {
+      const janeItem = { ...createMockItem('1'), createdBy: 'u_jane' };
+      const maxItem = { ...createMockItem('2'), createdBy: 'u_max' };
+
+      const { result } = renderHook(() => useContentListConfig(), {
+        wrapper: createWrapper({
+          findItems: createMockFindItems([janeItem, maxItem]),
+          services: {
+            userProfiles: {
+              bulkResolve: jest.fn().mockResolvedValue([]),
+            },
+          },
+        }),
+      });
+
+      await expect(
+        findIds(result.current.dataSource, {
+          filters: { [CREATED_BY_FILTER_ID]: { include: ['u_jane'] } },
+        })
+      ).resolves.toEqual(['1']);
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import type { SearchFilterConfig } from '@elastic/eui';
 import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
 import type {
   ContentEditorFeatureConfig,
@@ -27,6 +28,8 @@ import {
   MANAGED_USER_LABEL,
   NO_CREATOR_USER_LABEL,
   SENTINEL_KEYS,
+  TAG_FILTER_ID,
+  CREATED_BY_FILTER_ID,
 } from '@kbn/content-list-provider';
 import {
   SAVED_OBJECTS_PER_PAGE_ID,
@@ -49,20 +52,24 @@ import type { ItemDecorator } from './strategy';
 import { ProfilePrimeEffect } from './profile_prime_effect';
 import type { ContentEditorConfig } from './content_editor';
 import { useContentEditorOpen } from './content_editor';
+import { ClientStrategyContext } from './client_strategy_context';
+import type { ClientStrategyContextValue } from './client_strategy_context';
+import { defineContentListFilter, type ContentListFilterMap } from './filters';
+import type { ResolvedContentListFilter } from './filters';
+import { CustomFilterRenderer } from './custom_filter_renderer';
+import type { ContentListSortFieldMap } from './sorting';
+import { resolveSortFieldMap, toSortField } from './sorting';
 
 /**
- * Compute per-key item counts from the full item set.
- *
- * @param items - The item set to count.
- * @param keyFn - Extracts zero or more keys from a single item.
+ * Compute per-value item counts from the full item set.
  */
-const computeCounts = (
+const computeFilterCounts = (
   items: UserContentCommonSchema[],
-  keyFn: (item: UserContentCommonSchema) => string[]
+  filter: ResolvedContentListFilter
 ): Record<string, number> => {
   const counts: Record<string, number> = {};
   for (const item of items) {
-    for (const key of keyFn(item)) {
+    for (const key of filter.normalizeValues(item)) {
       counts[key] = (counts[key] ?? 0) + 1;
     }
   }
@@ -73,8 +80,21 @@ const computeCounts = (
 const tagKeys = (item: UserContentCommonSchema): string[] =>
   item.references?.filter((ref) => ref.type === 'tag').map((ref) => ref.id) ?? [];
 
-/** Extract the creator key for an item, aligned with {@link getCreatorKey} in `strategy.ts`. */
-const createdByKeys = (item: UserContentCommonSchema): string[] => [getCreatorKey(item)];
+const EMPTY_SORT_FIELDS: ContentListSortFieldMap = {};
+const BUILT_IN_FILTER_IDS = new Set<string>([TAG_FILTER_ID, CREATED_BY_FILTER_ID]);
+
+const resolveFilterDimensions = (
+  filters: ContentListClientFeatures['filters'],
+  defaults: ContentListFilterMap
+): ContentListFilterMap => {
+  const merged = !filters
+    ? defaults
+    : typeof filters === 'function'
+    ? filters(defaults)
+    : { ...defaults, ...filters };
+
+  return Object.fromEntries(Object.values(merged).map((filter) => [filter.fieldName, filter]));
+};
 
 /**
  * Bridges React Query's `useFavorites()` data into the strategy's decorator
@@ -243,21 +263,6 @@ const ContentListClientProviderInner = ({
     core.uiSettings.get<number>(SAVED_OBJECTS_LISTING_LIMIT_ID)
   );
 
-  const { findItems, onInvalidate, onRefresh, getItems } = useMemo(
-    () =>
-      createClientStrategy(
-        tableListViewFindItems,
-        starredEnabled ? decorate : undefined,
-        listingLimit
-      ),
-    [tableListViewFindItems, starredEnabled, decorate, listingLimit]
-  );
-
-  const dataSource: DataSourceConfig = useMemo(
-    () => ({ findItems, onInvalidate, onRefresh, onFetchSuccess }),
-    [findItems, onInvalidate, onRefresh, onFetchSuccess]
-  );
-
   const tagsService = services?.tags;
   const userProfilesService = services?.userProfiles;
 
@@ -268,6 +273,105 @@ const ContentListClientProviderInner = ({
   }
   const profileCache = profileCacheRef.current;
 
+  const builtInFilters = useMemo((): ContentListFilterMap => {
+    const filters: ContentListFilterMap = {};
+
+    if (featuresProp.tags !== false && tagsService?.getTagList) {
+      filters[TAG_FILTER_ID] = defineContentListFilter({
+        id: TAG_FILTER_ID,
+        title: 'Tags',
+        getItemValue: tagKeys,
+      });
+    }
+
+    if (featuresProp.userProfiles !== false && userProfilesService && profileCache) {
+      filters[CREATED_BY_FILTER_ID] = defineContentListFilter({
+        id: CREATED_BY_FILTER_ID,
+        title: 'Created by',
+        getItemValue: getCreatorKey,
+      });
+    }
+
+    return filters;
+  }, [
+    featuresProp.tags,
+    featuresProp.userProfiles,
+    tagsService,
+    userProfilesService,
+    profileCache,
+  ]);
+
+  const filterDimensions = useMemo(
+    () => resolveFilterDimensions(featuresProp.filters, builtInFilters),
+    [builtInFilters, featuresProp.filters]
+  );
+
+  const customFilters = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(filterDimensions).filter(([id]) => !BUILT_IN_FILTER_IDS.has(id))
+      ),
+    [filterDimensions]
+  );
+
+  const sortingConfig = featuresProp.sorting;
+  const { sortingFeature, customSortFields } = useMemo<{
+    sortingFeature: ContentListFeatures['sorting'];
+    customSortFields: ContentListSortFieldMap;
+  }>(() => {
+    const sorting = sortingConfig;
+    if (sorting === false || typeof sorting !== 'object') {
+      return { sortingFeature: sorting, customSortFields: EMPTY_SORT_FIELDS };
+    }
+    const { fields: sortFields, ...baseSorting } = sorting;
+    if (!sortFields) {
+      return { sortingFeature: baseSorting, customSortFields: EMPTY_SORT_FIELDS };
+    }
+    const resolvedFields = resolveSortFieldMap(sortFields);
+    return {
+      customSortFields: resolvedFields,
+      sortingFeature: {
+        ...baseSorting,
+        fields: Object.values(resolvedFields).map(toSortField),
+      },
+    };
+  }, [sortingConfig]);
+
+  const filterDimensionsRef = useRef(filterDimensions);
+  useEffect(() => {
+    filterDimensionsRef.current = filterDimensions;
+  }, [filterDimensions]);
+
+  const customSortFieldsRef = useRef(customSortFields);
+  useEffect(() => {
+    customSortFieldsRef.current = customSortFields;
+  }, [customSortFields]);
+
+  const { findItems, onInvalidate, onRefresh, getItems, subscribe } = useMemo(
+    () =>
+      createClientStrategy(
+        tableListViewFindItems,
+        starredEnabled ? decorate : undefined,
+        listingLimit,
+        () => filterDimensionsRef.current,
+        () => customSortFieldsRef.current
+      ),
+    [tableListViewFindItems, starredEnabled, decorate, listingLimit]
+  );
+
+  const dataSource: DataSourceConfig = useMemo(
+    () => ({ findItems, onInvalidate, onRefresh, onFetchSuccess }),
+    [findItems, onInvalidate, onRefresh, onFetchSuccess]
+  );
+
+  const clientStrategyContext = useMemo<ClientStrategyContextValue>(
+    () => ({ getItemsSnapshot: getItems, subscribe, filters: filterDimensions }),
+    [getItems, subscribe, filterDimensions]
+  );
+
+  const tagFilter = filterDimensions[TAG_FILTER_ID];
+  const createdByFilter = filterDimensions[CREATED_BY_FILTER_ID];
+
   // Build `FilterFacetConfig<Tag>` for tags when the tags service is available
   // and the feature isn't explicitly disabled or already configured.
   const tagsFeature = useMemo((): ContentListFeatures['tags'] => {
@@ -277,15 +381,15 @@ const ContentListClientProviderInner = ({
     if (typeof featuresProp.tags === 'object') {
       return featuresProp.tags;
     }
-    if (!tagsService?.getTagList) {
+    if (!tagsService?.getTagList || !tagFilter) {
       return featuresProp.tags;
     }
 
     const { getTagList } = tagsService;
     const config: FilterFacetConfig<Tag> = {
       getFacets: async ({ filters }) => {
-        const narrowed = filterItems(getItems(), filters);
-        const tagCounts = computeCounts(narrowed, tagKeys);
+        const narrowed = filterItems(getItems(), filters, filterDimensions);
+        const tagCounts = computeFilterCounts(narrowed, tagFilter);
         const tags = getTagList();
         return tags.map((tag) => ({
           key: tag.id ?? tag.name,
@@ -296,7 +400,7 @@ const ContentListClientProviderInner = ({
       },
     };
     return config;
-  }, [featuresProp.tags, tagsService, getItems]);
+  }, [featuresProp.tags, tagsService, tagFilter, getItems, filterDimensions]);
 
   // Build `FilterFacetConfig<UserProfileEntry>` for user profiles when the
   // service is available and the feature isn't explicitly disabled or already
@@ -311,15 +415,15 @@ const ContentListClientProviderInner = ({
     if (typeof featuresProp.userProfiles === 'object') {
       return featuresProp.userProfiles;
     }
-    if (!userProfilesService || !profileCache) {
+    if (!userProfilesService || !profileCache || !createdByFilter) {
       return featuresProp.userProfiles;
     }
 
     const cache = profileCache;
     const config: FilterFacetConfig<UserProfileEntry> = {
       getFacets: async ({ filters }) => {
-        const narrowed = filterItems(getItems(), filters);
-        const userCounts = computeCounts(narrowed, createdByKeys);
+        const narrowed = filterItems(getItems(), filters, filterDimensions);
+        const userCounts = computeFilterCounts(narrowed, createdByFilter);
         const allKeys = Object.keys(userCounts);
         if (allKeys.length === 0) {
           return [];
@@ -359,7 +463,14 @@ const ContentListClientProviderInner = ({
       },
     };
     return config;
-  }, [featuresProp.userProfiles, userProfilesService, profileCache, getItems]);
+  }, [
+    featuresProp.userProfiles,
+    userProfilesService,
+    profileCache,
+    createdByFilter,
+    getItems,
+    filterDimensions,
+  ]);
 
   // Read page size from uiSettings once at mount. Not reactive — page size
   // setting changes during a session are not expected to take effect until reload.
@@ -404,13 +515,29 @@ const ContentListClientProviderInner = ({
   // `{ open }` shape (or drop it). Every other field passes through unchanged.
   const features: ContentListFeatures = useMemo(() => {
     const baseContentEditor: ContentEditorFeatureConfig | undefined = open ? { open } : undefined;
+    const { filters: _filters, sorting: _sorting, ...baseFeatures } = featuresProp;
+    const toolbarFilters: Record<string, SearchFilterConfig> = Object.fromEntries(
+      Object.values(customFilters).map((filter) => [
+        filter.id,
+        {
+          type: 'custom_component' as const,
+          component: (props) => <CustomFilterRenderer {...props} filterDefinition={filter} />,
+        },
+      ])
+    );
     return {
-      ...featuresProp,
+      ...baseFeatures,
+      sorting: sortingFeature,
+      fields: [
+        ...(featuresProp.fields ?? []),
+        ...Object.values(customFilters).map((filter) => filter.toFieldDefinition()),
+      ],
+      toolbarFilters,
       tags: tagsFeature,
       userProfiles: userProfilesFeature,
       contentEditor: baseContentEditor,
     };
-  }, [featuresProp, tagsFeature, userProfilesFeature, open]);
+  }, [featuresProp, customFilters, sortingFeature, tagsFeature, userProfilesFeature, open]);
 
   // Merge: explicit pagination: false > explicit initialPageSize > uiSettings > base default.
   const resolvedFeatures = useMemo<ContentListFeatures>(() => {
@@ -436,18 +563,20 @@ const ContentListClientProviderInner = ({
   }, [features, uiSettingsPageSize]);
 
   return (
-    <ContentListProvider
-      dataSource={dataSource}
-      features={resolvedFeatures}
-      services={services}
-      profileCache={profileCache}
-      item={itemConfigProp}
-      {...rest}
-      queryKeyScope={queryKeyScope}
-    >
-      {starredEnabled && <FavoritesSyncEffect favoriteIdsRef={favoriteIdsRef} />}
-      {profileCache && <ProfilePrimeEffect getItems={getItems} />}
-      {children}
-    </ContentListProvider>
+    <ClientStrategyContext.Provider value={clientStrategyContext}>
+      <ContentListProvider
+        dataSource={dataSource}
+        features={resolvedFeatures}
+        services={services}
+        profileCache={profileCache}
+        item={itemConfigProp}
+        {...rest}
+        queryKeyScope={queryKeyScope}
+      >
+        {starredEnabled && <FavoritesSyncEffect favoriteIdsRef={favoriteIdsRef} />}
+        {profileCache && <ProfilePrimeEffect getItems={getItems} />}
+        {children}
+      </ContentListProvider>
+    </ClientStrategyContext.Provider>
   );
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/sorting.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/sorting.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+import { DEFAULT_SORT_FIELDS, type SortField } from '@kbn/content-list-provider';
+
+/**
+ * Descriptor for a custom sort field contributed by a content list provider.
+ * Pass to {@link defineContentListSortField} or include in {@link ContentListSortFieldConfig}.
+ */
+export interface ContentListSortField<
+  TItem extends UserContentCommonSchema = UserContentCommonSchema
+> {
+  /** Unique sort field id; maps to the KQL/query field name. */
+  id: string;
+  /** Display label shown in the sort dropdown. */
+  title: string;
+  /** Extracts the sortable value from an item for client-side sorting. When omitted, falls back to the built-in field resolver. */
+  getValue?: (item: TItem) => string | number | null | undefined;
+  /** Label for ascending direction (e.g. "A → Z"). */
+  ascLabel?: string;
+  /** Label for descending direction (e.g. "Z → A"). */
+  descLabel?: string;
+}
+
+/** All sort fields available on a provider, keyed by field id. */
+export type ContentListSortFieldMap = Record<string, ContentListSortField>;
+
+/**
+ * Accepted shapes for the `sorting` option on a content list provider:
+ * - `SortField[]` — replaces defaults entirely.
+ * - `ContentListSortFieldMap` — merged with defaults (own keys win).
+ * - `(defaults) => ContentListSortFieldMap` — full control; receives defaults for reference.
+ */
+export type ContentListSortFieldConfig =
+  | SortField[]
+  | ContentListSortFieldMap
+  | ((defaults: ContentListSortFieldMap) => ContentListSortFieldMap);
+
+/**
+ * Identity helper that infers `TItem` so callers get type-safe `getValue` without
+ * an explicit type parameter. Equivalent to passing the object directly.
+ */
+export const defineContentListSortField = <TItem extends UserContentCommonSchema>(
+  field: ContentListSortField<TItem>
+): ContentListSortField => field as ContentListSortField;
+
+export const toSortField = (field: ContentListSortField): SortField => ({
+  field: field.id,
+  name: field.title,
+  ...(field.ascLabel && { ascLabel: field.ascLabel }),
+  ...(field.descLabel && { descLabel: field.descLabel }),
+});
+
+export const DEFAULT_CLIENT_SORT_FIELDS: ContentListSortFieldMap = {
+  ...Object.fromEntries(
+    DEFAULT_SORT_FIELDS.map((field) => [
+      field.field,
+      {
+        id: field.field,
+        title: field.name,
+        ascLabel: field.ascLabel,
+        descLabel: field.descLabel,
+      },
+    ])
+  ),
+};
+
+export const resolveSortFieldMap = (
+  fields?: ContentListSortFieldConfig
+): ContentListSortFieldMap => {
+  if (!fields) {
+    return DEFAULT_CLIENT_SORT_FIELDS;
+  }
+  if (Array.isArray(fields)) {
+    return Object.fromEntries(
+      fields.map((field) => [
+        field.field,
+        {
+          id: field.field,
+          title: field.name,
+          ascLabel: field.ascLabel,
+          descLabel: field.descLabel,
+        },
+      ])
+    );
+  }
+  return typeof fields === 'function'
+    ? fields(DEFAULT_CLIENT_SORT_FIELDS)
+    : {
+        ...DEFAULT_CLIENT_SORT_FIELDS,
+        ...fields,
+      };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.test.ts
@@ -12,6 +12,7 @@ import type { FindItemsParams } from '@kbn/content-list-provider';
 import { createClientStrategy } from './strategy';
 import type { ItemDecorator } from './strategy';
 import type { TableListViewFindItemsFn } from './types';
+import { defineContentListFilter, type ContentListFilterMap } from './filters';
 
 const createParams = (overrides?: Partial<FindItemsParams>): FindItemsParams => ({
   searchQuery: '',
@@ -38,6 +39,19 @@ describe('createClientStrategy', () => {
   ): jest.Mock<ReturnType<TableListViewFindItemsFn>> => {
     return jest.fn().mockResolvedValue({ hits: items, total: items.length });
   };
+
+  const createdByFilter = defineContentListFilter({
+    id: 'createdBy',
+    title: 'Created by',
+    getItemValue: (item: UserContentCommonSchema) => item.createdBy,
+  });
+
+  const tagFilter = defineContentListFilter({
+    id: 'tag',
+    title: 'Tags',
+    getItemValue: (item: UserContentCommonSchema) =>
+      item.references?.filter((ref) => ref.type === 'tag').map((ref) => ref.id) ?? [],
+  });
 
   describe('findItems', () => {
     it('calls the consumer with searchQuery and signal', async () => {
@@ -167,7 +181,9 @@ describe('createClientStrategy', () => {
       const item1: UserContentCommonSchema = { ...createMockItem('1'), createdBy: 'u_jane' };
       const item2: UserContentCommonSchema = { ...createMockItem('2'), createdBy: 'u_diego' };
       const mockFindItems = createMockFindItems([item1, item2]);
-      const { findItems } = createClientStrategy(mockFindItems);
+      const { findItems } = createClientStrategy(mockFindItems, undefined, undefined, {
+        createdBy: createdByFilter,
+      });
 
       await findItems(createParams({ searchQuery: 'test' }));
       const result = await findItems(
@@ -180,6 +196,38 @@ describe('createClientStrategy', () => {
       expect(mockFindItems).toHaveBeenCalledTimes(1);
       expect(result.items).toHaveLength(1);
       expect(result.items[0].id).toBe('1');
+    });
+
+    it('keeps cached items when custom filter definitions change', async () => {
+      let customFilters: ContentListFilterMap = {};
+      const mockFindItems = createMockFindItems([
+        createMockItem('1'),
+        { ...createMockItem('2'), type: 'visualization' },
+      ]);
+      const { findItems } = createClientStrategy(
+        mockFindItems,
+        undefined,
+        undefined,
+        () => customFilters
+      );
+
+      await findItems(createParams({ searchQuery: 'ecommer' }));
+      customFilters = {
+        contentType: defineContentListFilter({
+          id: 'contentType',
+          title: 'Content type',
+          getItemValue: (item: UserContentCommonSchema) => item.type,
+        }),
+      };
+      const result = await findItems(
+        createParams({
+          searchQuery: 'ecommer',
+          filters: { contentType: { include: ['visualization'] } },
+        })
+      );
+
+      expect(mockFindItems).toHaveBeenCalledTimes(1);
+      expect(result.items.map(({ id }) => id)).toEqual(['2']);
     });
   });
 
@@ -225,7 +273,9 @@ describe('createClientStrategy', () => {
       const item1: UserContentCommonSchema = { ...createMockItem('1'), createdBy: 'u_jane' };
       const item2: UserContentCommonSchema = { ...createMockItem('2'), createdBy: 'u_diego' };
       const mockFindItems = createMockFindItems([item1, item2]);
-      const { findItems } = createClientStrategy(mockFindItems);
+      const { findItems } = createClientStrategy(mockFindItems, undefined, undefined, {
+        createdBy: createdByFilter,
+      });
 
       const result = await findItems(
         createParams({ filters: { createdBy: { include: ['u_jane'] } } })
@@ -245,7 +295,9 @@ describe('createClientStrategy', () => {
         references: [{ type: 'tag', id: 'tag-2', name: 'tag-2' }],
       };
       const mockFindItems = createMockFindItems([item1, item2]);
-      const { findItems } = createClientStrategy(mockFindItems);
+      const { findItems } = createClientStrategy(mockFindItems, undefined, undefined, {
+        tag: tagFilter,
+      });
 
       const result = await findItems(createParams({ filters: { tag: { include: ['tag-1'] } } }));
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.ts
@@ -17,13 +17,15 @@ import type {
   ContentListItem,
 } from '@kbn/content-list-provider';
 import {
-  TAG_FILTER_ID,
   getIncludeExcludeFlag,
   MANAGED_USER_FILTER,
   NO_CREATOR_USER_FILTER,
   getCreatorKey,
 } from '@kbn/content-list-provider';
 import type { TableListViewFindItemsFn } from './types';
+import type { ContentListFilterMap } from './filters';
+import { matchesFilterValue } from './filters';
+import type { ContentListSortFieldMap } from './sorting';
 
 // Re-export for consumers that import from strategy.
 export { MANAGED_USER_FILTER, NO_CREATOR_USER_FILTER, getCreatorKey };
@@ -44,6 +46,13 @@ type DecoratedItem = UserContentCommonSchema & Record<string, unknown>;
 export type ItemDecorator = (
   items: UserContentCommonSchema[]
 ) => Promise<UserContentCommonSchema[]>;
+
+/** Callback passed to {@link ClientStrategy.subscribe}; called whenever the items snapshot changes. */
+export type ItemsSnapshotListener = () => void;
+type DynamicConfig<T> = T | (() => T);
+
+const resolveConfig = <T>(config: DynamicConfig<T> | undefined): T | undefined =>
+  typeof config === 'function' ? (config as () => T)() : config;
 
 /**
  * Return type from {@link createClientStrategy}.
@@ -75,6 +84,8 @@ export interface ClientStrategy {
   onRefresh: () => Promise<void>;
   /** Returns the full (unfiltered, decorated) item set from the most recent fetch. */
   getItems: () => UserContentCommonSchema[];
+  /** Subscribe to full item snapshot changes. */
+  subscribe: (listener: ItemsSnapshotListener) => () => void;
 }
 
 /**
@@ -139,11 +150,13 @@ const getUserContentFieldValue = (
 const sortItems = (
   items: UserContentCommonSchema[],
   field: string,
-  direction: 'asc' | 'desc'
+  direction: 'asc' | 'desc',
+  customSorts: ContentListSortFieldMap = {}
 ): UserContentCommonSchema[] => {
   return [...items].sort((a, b) => {
-    const aValue = getUserContentFieldValue(a, field);
-    const bValue = getUserContentFieldValue(b, field);
+    const customSort = customSorts[field];
+    const aValue = customSort?.getValue?.(a) ?? getUserContentFieldValue(a, field);
+    const bValue = customSort?.getValue?.(b) ?? getUserContentFieldValue(b, field);
 
     if (aValue === null && bValue === null) {
       return 0;
@@ -189,11 +202,12 @@ const asIncludeExclude = (value: ActiveFilters[string]): IncludeExcludeFilter | 
     ? (value as IncludeExcludeFilter)
     : undefined;
 
+const RESERVED_FILTER_KEYS = new Set<string>(['search']);
+
 /**
  * Apply client-side filters to the item set.
  *
- * - Tag filters use `filters[TAG_FILTER_ID]` (include/exclude arrays of tag IDs).
- * - Creator filters use `filters.createdBy` (include/exclude arrays of UIDs + sentinels).
+ * - Field filters use registered dimensions.
  * - Boolean flag filters (e.g. `starred`) are detected generically via
  *   {@link getIncludeExcludeFlag} and matched against `item[key]`.
  *
@@ -202,49 +216,44 @@ const asIncludeExclude = (value: ActiveFilters[string]): IncludeExcludeFilter | 
  */
 export const filterItems = (
   items: UserContentCommonSchema[],
-  filters: ActiveFilters
+  filters: ActiveFilters,
+  customFilters: ContentListFilterMap = {}
 ): UserContentCommonSchema[] => {
   let result = items as DecoratedItem[];
-
-  const tagFilter = asIncludeExclude(filters[TAG_FILTER_ID]);
-  if (tagFilter) {
-    const { include, exclude } = tagFilter;
-    if (include?.length) {
-      const includeSet = new Set(include);
-      result = result.filter((item) =>
-        item.references?.some((ref) => ref.type === 'tag' && includeSet.has(ref.id))
-      );
-    }
-    if (exclude?.length) {
-      const excludeSet = new Set(exclude);
-      result = result.filter(
-        (item) => !item.references?.some((ref) => ref.type === 'tag' && excludeSet.has(ref.id))
-      );
-    }
-  }
-
-  const userFilter = asIncludeExclude(filters.createdBy);
-  if (userFilter) {
-    const { include, exclude } = userFilter;
-    if (include?.length) {
-      const includeSet = new Set(include);
-      result = result.filter((item) => includeSet.has(getCreatorKey(item)));
-    }
-    if (exclude?.length) {
-      const excludeSet = new Set(exclude);
-      result = result.filter((item) => !excludeSet.has(getCreatorKey(item)));
-    }
-  }
 
   // Flag keys must match the decorated property name set by the `ItemDecorator`
   // (e.g. `starred` in `ActiveFilters` corresponds to `item.starred`).
   for (const [key, value] of Object.entries(filters)) {
+    if (RESERVED_FILTER_KEYS.has(key)) {
+      continue;
+    }
+
     const flag = getIncludeExcludeFlag(value);
     if (flag) {
       result = result.filter((item) => {
         const v = item[key];
         return flag.state === 'include' ? v === true : v !== true;
       });
+      continue;
+    }
+
+    const customFilter = customFilters[key];
+    const fieldFilter = asIncludeExclude(value);
+    if (!customFilter || !fieldFilter) {
+      continue;
+    }
+
+    const { include, exclude } = fieldFilter;
+    if (include?.length) {
+      result = result.filter((item) =>
+        include.some((filterValue) => matchesFilterValue(item, customFilter, filterValue))
+      );
+    }
+    if (exclude?.length) {
+      result = result.filter(
+        (item) =>
+          !exclude.some((filterValue) => matchesFilterValue(item, customFilter, filterValue))
+      );
     }
   }
 
@@ -317,14 +326,24 @@ const transformItem = (item: UserContentCommonSchema): ContentListItem => {
 export const createClientStrategy = (
   tableListViewFindItems: TableListViewFindItemsFn,
   decorate?: ItemDecorator,
-  listingLimit?: number
+  listingLimit?: number,
+  customFilters?: DynamicConfig<ContentListFilterMap>,
+  customSorts?: DynamicConfig<ContentListSortFieldMap>
 ): ClientStrategy => {
   let rawItems: UserContentCommonSchema[] = [];
   let decoratedItems: UserContentCommonSchema[] = [];
   let lastSearchQuery: string | undefined;
+  const listeners = new Set<ItemsSnapshotListener>();
+
+  const notify = () => {
+    for (const listener of Array.from(listeners)) {
+      listener();
+    }
+  };
 
   const applyDecoration = async () => {
     decoratedItems = decorate ? await decorate(rawItems) : rawItems;
+    notify();
   };
 
   const findItemsFn: FindItemsFn = async (params: FindItemsParams): Promise<FindItemsResult> => {
@@ -344,10 +363,10 @@ export const createClientStrategy = (
       lastSearchQuery = searchQuery;
     }
 
-    let items = filterItems(decoratedItems, filters);
+    let items = filterItems(decoratedItems, filters, resolveConfig(customFilters));
 
     if (sort?.field) {
-      items = sortItems(items, sort.field, sort.direction ?? 'asc');
+      items = sortItems(items, sort.field, sort.direction ?? 'asc', resolveConfig(customSorts));
     }
 
     const start = page.index * page.size;
@@ -363,6 +382,7 @@ export const createClientStrategy = (
     lastSearchQuery = undefined;
     rawItems = [];
     decoratedItems = [];
+    notify();
   };
 
   const onRefresh = async () => {
@@ -374,5 +394,11 @@ export const createClientStrategy = (
     onInvalidate,
     onRefresh,
     getItems: () => decoratedItems,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/types.ts
@@ -8,9 +8,15 @@
  */
 
 import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
-import type { ContentListFeatures, ContentListServices } from '@kbn/content-list-provider';
+import type {
+  ContentListFeatures,
+  ContentListServices,
+  SortingConfig,
+} from '@kbn/content-list-provider';
 import type { ContentEditorKibanaDependencies } from '@kbn/content-management-content-editor';
 import type { ContentEditorConfig } from './content_editor';
+import type { ContentListFilterMap } from './filters';
+import type { ContentListSortFieldConfig } from './sorting';
 
 /**
  * Kibana `CoreStart` slice required by {@link ContentEditorKibanaProvider}.
@@ -43,11 +49,24 @@ export interface ContentListClientServices extends ContentListServices {
 /**
  * Feature configuration for {@link ContentListClientProvider}.
  */
-export interface ContentListClientFeatures extends Omit<ContentListFeatures, 'contentEditor'> {
+export type ContentListFilterConfig =
+  | ContentListFilterMap
+  | ((defaults: ContentListFilterMap) => ContentListFilterMap);
+
+export interface ContentListClientSortingConfig extends Omit<SortingConfig, 'fields'> {
+  fields?: SortingConfig['fields'] | ContentListSortFieldConfig;
+}
+
+export interface ContentListClientFeatures
+  extends Omit<ContentListFeatures, 'contentEditor' | 'sorting' | 'toolbarFilters'> {
   /**
    * Content editor (metadata editing flyout) feature configuration.
    */
   contentEditor?: ContentEditorConfig;
+  /** Client-side custom filters keyed by filter id. */
+  filters?: ContentListFilterConfig;
+  /** Sorting configuration with client-side custom sort field support. */
+  sorting?: boolean | ContentListClientSortingConfig;
 }
 
 /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/use_client_filter_counts.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/use_client_filter_counts.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo, useSyncExternalStore } from 'react';
+import { useActiveFilters, type ActiveFilters } from '@kbn/content-list-provider';
+import { useClientStrategyContext } from './client_strategy_context';
+import { filterItems } from './strategy';
+
+const EMPTY_COUNTS: ReadonlyMap<string, number> = new Map();
+
+const excludeOwnFilter = (active: ActiveFilters, filterId: string): ActiveFilters => {
+  if (!(filterId in active)) {
+    return active;
+  }
+  const { [filterId]: _own, ...rest } = active;
+  return rest;
+};
+
+/**
+ * Returns a map of option value → item count for the given filter, computed
+ * client-side from the current items snapshot with all other active filters
+ * applied (faceted counts). Returns an empty map when the filter id is not
+ * registered or no items are loaded.
+ *
+ * Must be called inside a {@link ContentListClientProvider} tree.
+ */
+export const useClientFilterCounts = (filterId: string): ReadonlyMap<string, number> => {
+  const { getItemsSnapshot, subscribe, filters } =
+    useClientStrategyContext('useClientFilterCounts');
+  const activeFilters = useActiveFilters();
+  const filter = filters[filterId];
+  const items = useSyncExternalStore(subscribe, getItemsSnapshot, getItemsSnapshot);
+
+  const facetFilters = useMemo(
+    () => excludeOwnFilter(activeFilters, filterId),
+    [activeFilters, filterId]
+  );
+
+  return useMemo(() => {
+    if (!filter) {
+      return EMPTY_COUNTS;
+    }
+    const narrowed = filterItems(items, facetFilters, filters);
+    const counts = new Map<string, number>();
+    for (const item of narrowed) {
+      for (const value of filter.normalizeValues(item)) {
+        counts.set(value, (counts.get(value) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [facetFilters, filter, filters, items]);
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
@@ -123,7 +123,12 @@ export type {
   FieldDefinition,
   FlagDefinition,
 } from './src/query_model';
-export { EMPTY_MODEL, toFindItemsFilters, useQueryModel } from './src/query_model';
+export {
+  EMPTY_MODEL,
+  toFindItemsFilters,
+  useActiveFilters,
+  useQueryModel,
+} from './src/query_model';
 
 // Services.
 export {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
@@ -163,6 +163,15 @@ export interface ContentListFeatures {
   flags?: FlagDefinition[];
 
   /**
+   * Toolbar filter configs compiled by a provider variant.
+   *
+   * Internal pass-through from a provider to {@link `@kbn/content-list-toolbar`};
+   * the toolbar narrows each value to `SearchFilterConfig` at the consumption
+   * site, keeping the EUI dependency out of this base package's public types.
+   */
+  toolbarFilters?: Record<string, unknown>;
+
+  /**
    * Content editor configuration. See {@link ContentEditorFeatureConfig}.
    * Populated automatically by the client provider.
    */


### PR DESCRIPTION
## Summary

Extends `@kbn/content-list-provider-client` with a typed API for defining custom filters and sort orders that content list providers can contribute at registration time. This gives plugin-level providers first-class control over the toolbar filters their listing exposes, without having to reach into content list internals.

**New public API surface (`kbn-content-list-provider-client`)**
- `ContentListFilterDefinition<TItem, TValue, TOption>` — declarative filter descriptor: title, the field it targets, how to extract values from items, and the available options (either a static array or derived from a data array via `getOptionValue`/`getOptionLabel`).
- `ResolvedContentListFilter` — runtime form of a filter definition with methods: `getOptions()`, `getLabelForValue()`, `normalizeValues()`, `toFieldDefinition()`.
- `ContentListFilterMap` — record of resolved filters keyed by id.
- `ContentListSortDefinition` / `sorting.ts` — analogous API for custom sort fields.
- `CustomFilterRenderer` — React component that renders a resolved filter as an EUI `FilterGroup` button.
- `useClientFilterCounts` — hook that counts how many items match each option's value against the current item set, used to populate filter option counts without a server round-trip.
- `ClientStrategyContext` — context type threading filter/sort definitions into the client strategy.
- Updated `provider.tsx` and `strategy.ts` to wire custom filter and sort definitions through the provider lifecycle.

**Part of the `@kbn/content-list` stacked PR series:**
- #271117 — performance foundations
- **This PR** — custom filter/sort extension API
- #271119 — render custom filters in toolbar
- #271120 — migrate annotation library listing
- #271121 — data view filter for annotation listing

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] [Backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) reviewed and applicable `backport:*` labels applied

### Identify risks

New API surface on a shared package. No existing callers are modified; the new types are purely additive. The resolved filter/sort objects are computed inside the provider, so a misconfigured definition fails loudly at provider setup rather than silently at query time.
