### PR TITLE
[content list] Render custom filters in toolbar

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/dashboard_listing.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/dashboard_listing.stories.tsx
@@ -9,7 +9,7 @@
 
 import React, { useMemo } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { EuiButton, EuiSpacer } from '@elastic/eui';
+import { EuiBadge, EuiButton, EuiSpacer } from '@elastic/eui';
 import type { ContentListItem } from '@kbn/content-list-provider';
 import {
   ContentList,
@@ -18,8 +18,16 @@ import {
   ContentListFooter,
   ContentListToolbar,
 } from '@kbn/content-list';
+import {
+  ContentListClientProvider,
+  defineContentListFilter,
+  defineContentListSortField,
+  type ContentListClientProviderProps,
+  type TableListViewFindItemsFn,
+} from '@kbn/content-list-provider-client';
 import { KibanaContentListPage } from '@kbn/content-list-page';
 import {
+  type DashboardMockItem,
   MOCK_DASHBOARDS,
   createMockFavoritesClient,
   mockContentListUserProfilesServices,
@@ -52,6 +60,93 @@ const labels = {
   entity: 'dashboard',
   entityPlural: 'dashboards',
 } as const;
+
+type TimeRestoreFilterValue = 'restoresTime' | 'usesGlobalTime';
+
+const getTimeRestoreValue = (item: DashboardMockItem): TimeRestoreFilterValue =>
+  item.attributes.timeRestore ? 'restoresTime' : 'usesGlobalTime';
+
+const timeRestoreFilter = defineContentListFilter<DashboardMockItem, TimeRestoreFilterValue>({
+  id: 'timeRestore',
+  title: 'Time behavior',
+  getItemValue: getTimeRestoreValue,
+  options: [
+    { value: 'restoresTime', label: 'Restores time range' },
+    { value: 'usesGlobalTime', label: 'Uses global time' },
+  ],
+});
+
+const timeRestoreSort = defineContentListSortField<DashboardMockItem>({
+  id: 'timeRestore',
+  title: 'Time behavior',
+  getValue: getTimeRestoreValue,
+});
+
+const clientProviderFeatures = {
+  sorting: {
+    initialSort: { field: 'updatedAt', direction: 'desc' },
+    fields: (defaults) => ({
+      ...defaults,
+      timeRestore: timeRestoreSort,
+    }),
+  },
+  pagination: { initialPageSize: 20 },
+  filters: (defaults) => ({
+    ...defaults,
+    timeRestore: timeRestoreFilter,
+  }),
+} satisfies ContentListClientProviderProps['features'];
+
+const clientStoryCore = {
+  analytics: { reportEvent: () => undefined },
+  i18n: {},
+  theme: { theme$: {} },
+  userProfile: { bulkGet: async () => [] },
+  overlays: {
+    openSystemFlyout: () => ({
+      onClose: Promise.resolve(),
+      close: async () => undefined,
+    }),
+  },
+  notifications: {
+    toasts: {
+      addDanger: () => undefined,
+    },
+  },
+  rendering: {
+    addContext: (element: React.ReactNode) => <>{element}</>,
+  },
+  uiSettings: {
+    get: <T,>(key: string): T => (key === 'savedObjects:listingLimit' ? 1000 : 20) as T,
+  },
+} as unknown as ContentListClientProviderProps['core'];
+
+const findDashboardItems: TableListViewFindItemsFn = async (searchQuery, options, signal) => {
+  if (signal?.aborted) {
+    throw new DOMException('The operation was aborted.', 'AbortError');
+  }
+
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+  const matchingItems = normalizedSearch
+    ? MOCK_DASHBOARDS.filter((dashboard) =>
+        [dashboard.attributes.title, dashboard.attributes.description]
+          .filter((text): text is string => Boolean(text))
+          .some((text) => text.toLowerCase().includes(normalizedSearch))
+      )
+    : MOCK_DASHBOARDS;
+  const limitedItems = matchingItems.slice(0, options?.listingLimit ?? matchingItems.length);
+
+  return {
+    hits: limitedItems,
+    total: matchingItems.length,
+  };
+};
+
+const TimeBehaviorBadge = ({ restoresTime }: { restoresTime: boolean }) => (
+  <EuiBadge color={restoresTime ? 'primary' : 'hollow'}>
+    {restoresTime ? 'Restores time range' : 'Uses global time'}
+  </EuiBadge>
+);
 
 const useDashboardProviderProps = ({
   openContentEditor,
@@ -229,6 +324,56 @@ const ProposalStory = () => {
   );
 };
 
+const ClientProviderExtensionsStory = () => {
+  const pageElement = useMemo(
+    () => (
+      <KibanaContentListPage>
+        <KibanaContentListPage.Header
+          title="Dashboards"
+          tabs={[{ label: 'Dashboards', isSelected: true, onClick: () => undefined }]}
+        />
+        <Section>
+          <ContentList emptyState={<DashboardListingEmptyPromptMock />}>
+            <ContentListToolbar />
+            <ContentListTable title="Dashboards">
+              <Column.Name showDescription showTags />
+              <Column
+                id="timeRestore"
+                name="Time behavior"
+                sortable
+                width="180px"
+                render={(item) => <TimeBehaviorBadge restoresTime={Boolean(item.timeRestore)} />}
+              />
+              <Column.CreatedBy />
+              <Column.UpdatedAt />
+            </ContentListTable>
+            <ContentListFooter />
+          </ContentList>
+        </Section>
+      </KibanaContentListPage>
+    ),
+    []
+  );
+
+  return (
+    <ContentListClientProvider
+      id="dashboard-listing-client-provider-extensions"
+      labels={labels}
+      core={clientStoryCore}
+      services={{
+        tags: mockTagsService,
+        userProfiles: mockContentListUserProfilesServices,
+      }}
+      features={clientProviderFeatures}
+      findItems={findDashboardItems}
+    >
+      {pageElement}
+      <EuiSpacer size="m" />
+      <StateDiagnosticPanel element={pageElement} />
+    </ContentListClientProvider>
+  );
+};
+
 // =============================================================================
 // Bulk-delete partition and selection gating
 // =============================================================================
@@ -362,6 +507,10 @@ export const Original: StoryObj = {
 
 export const Proposal: StoryObj = {
   render: () => <ProposalStory />,
+};
+
+export const ClientProviderExtensions: StoryObj = {
+  render: () => <ClientProviderExtensionsStory />,
 };
 
 /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/tsconfig.json
@@ -19,6 +19,7 @@
   ],
   "kbn_references": [
     "@kbn/content-list",
+    "@kbn/content-list-provider-client",
     "@kbn/content-list-provider",
     "@kbn/content-list-mock-data",
     "@kbn/content-management-favorites-public",

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.test.tsx
@@ -37,6 +37,31 @@ describe('SelectableFilterPopover', () => {
     expect(screen.queryByText('2')).not.toBeInTheDocument();
   });
 
+  it('treats option keys as active query aliases', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <SelectableFilterPopover
+        fieldName="tag"
+        title="Tags"
+        query={Query.parse('').addOrFieldValue('tag', 'prod', true, 'eq')}
+        onChange={onChange}
+        options={options}
+        renderOption={(option) => <span>{option.label}</span>}
+      />
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Tags'));
+    fireEvent.click(await screen.findByText('Production'));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+    expect(onChange.mock.calls[0][0].text).not.toContain('prod');
+  });
+
   it('shows the raw active-clause count before options load (URL hydration)', () => {
     // Facets are typically fetched lazily on first popover open, so `options`
     // can be empty when the page hydrates from a URL with filter clauses. The

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
@@ -203,7 +203,10 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
   // active clauses so URL-hydrated filters render immediately on page load.
   // Once `options` is non-empty, drop unresolved or stale clauses (e.g.
   // `tag:NonExistent`) so the badge matches what the popover actually shows.
-  const validOptionValues = useMemo(() => new Set(options.map((o) => o.value ?? o.key)), [options]);
+  const validOptionValues = useMemo(
+    () => new Set(options.flatMap((option) => [option.key, option.value ?? option.key])),
+    [options]
+  );
   const activeCount = useMemo(() => {
     const selectedKeys = Object.keys(selection);
     if (options.length === 0) {
@@ -215,8 +218,9 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
   // Build selectable options with view rendering.
   const selectableOptions = useMemo((): Array<InternalSelectableOption<T>> => {
     return options.map((option) => {
-      const value = option.value ?? option.key;
-      const state: FilterType | undefined = selection[value];
+      const queryValue = option.value ?? option.key;
+      const selectedValue = selection[queryValue] ? queryValue : option.key;
+      const state: FilterType | undefined = selection[queryValue] ?? selection[option.key];
       const checked = getCheckedState(state);
       const isActive = checked !== undefined;
       const count = option.count ?? 0;
@@ -224,7 +228,7 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
       return {
         key: option.key,
         label: option.label,
-        value,
+        value: isActive ? selectedValue : queryValue,
         checked,
         data: option.data,
         count,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.ts
@@ -83,8 +83,9 @@ const parseFilterParts = (children: ReactNode): ParsedPart[] => {
  */
 export const useFilters = (children: ReactNode): SearchFilterConfig[] => {
   const { isSupported: hasSorting } = useContentListSort();
-  const { supports } = useContentListConfig();
+  const { features, supports } = useContentListConfig();
   const { tags: hasTags, starred: hasStarred, userProfiles: hasCreatedBy } = supports;
+  const toolbarFilters = features.toolbarFilters;
 
   // Note: `children` is used as a memo dependency. React children are often
   // unstable references (new JSX objects each render), so this memo may
@@ -94,8 +95,27 @@ export const useFilters = (children: ReactNode): SearchFilterConfig[] => {
     const parts = parseFilterParts(children);
     const context: FilterContext = { hasSorting, hasTags, hasStarred, hasCreatedBy };
 
-    return parts
-      .map((part) => filter.resolve(part, context))
-      .filter((f): f is SearchFilterConfig => f !== undefined);
-  }, [children, hasSorting, hasTags, hasStarred, hasCreatedBy]);
+    const resolvedParts = parts
+      .map((part) => ({ part, filterConfig: filter.resolve(part, context) }))
+      .filter(
+        (entry): entry is { part: ParsedPart; filterConfig: SearchFilterConfig } =>
+          entry.filterConfig !== undefined
+      );
+    // `toolbarFilters` is typed `Record<string, unknown>` in the base provider
+    // package to keep `@elastic/eui` out of its public types; the client
+    // provider always populates entries as {@link SearchFilterConfig}, so we
+    // narrow them at the consumption site.
+    const customFilters = Object.values(toolbarFilters ?? {}) as SearchFilterConfig[];
+    if (parts === DEFAULT_PARTS) {
+      const sortIndex = resolvedParts.findIndex((entry) => entry.part.preset === 'sort');
+      if (sortIndex >= 0) {
+        return [
+          ...resolvedParts.slice(0, sortIndex).map(({ filterConfig }) => filterConfig),
+          ...customFilters,
+          ...resolvedParts.slice(sortIndex).map(({ filterConfig }) => filterConfig),
+        ];
+      }
+    }
+    return [...resolvedParts.map(({ filterConfig }) => filterConfig), ...customFilters];
+  }, [children, hasSorting, hasTags, hasStarred, hasCreatedBy, toolbarFilters]);
 };


### PR DESCRIPTION
## Summary

Wires the custom filter/sort definitions introduced in #271118 into the content list toolbar so they render alongside the built-in filters (tags, starred, created-by, sort).

**Changes**
- `use_filters.ts` — reads `customFilters` from the provider client context and merges them into the resolved filter list handed to the toolbar's `FilterGroup`.
- `dashboard_listing.stories.tsx` — adds a Storybook story demonstrating a dashboard listing with a custom provider filter (data view picker), serving as a live integration example and a visual regression target.
- `kbn-content-list-docs` `tsconfig.json` — adds the `kbn-content-list-provider-client` reference needed by the new story.

**Part of the `@kbn/content-list` stacked PR series:**
- #271117 — performance foundations
- #271118 — custom filter/sort extension API
- **This PR** — render custom filters in toolbar
- #271120 — migrate annotation library listing
- #271121 — data view filter for annotation listing

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] [Backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) reviewed and applicable `backport:*` labels applied

### Identify risks

Small surface change to `use_filters.ts`. Custom filters only appear when the provider registers them; listings with no custom filters are unaffected.
