### PR TITLE
[ftr] remove isFatalErrorScreen check in url navigation

### DIFF
--- a/src/platform/test/functional/page_objects/common_page.ts
+++ b/src/platform/test/functional/page_objects/common_page.ts
@@ -270,7 +270,6 @@ export class CommonPageObject extends FtrService {
       search = '',
       disableWelcomePrompt = true,
       insertTimestamp = true,
-      retryOnFatalError = true,
       skipUrlValidation = false,
     } = {}
   ) {
@@ -349,12 +348,6 @@ export class CommonPageObject extends FtrService {
 
         if (!navSuccessful) {
           const msg = `App failed to load: ${appName} in ${this.defaultFindTimeout}ms appUrl=${decodedAppUrl} currentUrl=${decodedCurrentUrl}`;
-          this.log.debug(msg);
-          throw new Error(msg);
-        }
-
-        if (retryOnFatalError && (await this.isFatalErrorScreen())) {
-          const msg = `Fatal error screen shown. Let's try refreshing the page once more.`;
           this.log.debug(msg);
           throw new Error(msg);
         }
@@ -476,10 +469,6 @@ export class CommonPageObject extends FtrService {
 
   async isChromeHidden() {
     return await this.testSubjects.exists('kbnAppWrapper hiddenChrome');
-  }
-
-  async isFatalErrorScreen() {
-    return await this.testSubjects.exists('fatalErrorScreen');
   }
 
   async waitForTopNavToBeVisible() {


### PR DESCRIPTION
## Summary

Added in [PR #163696](https://github.com/elastic/kibana/pull/163696) (Aug 2023, commit ba843882a7bb) to unskip a single flaky test: the "table listing" describe block in `x-pack/test/saved_object_tagging/functional/tests/listing.ts` (issue [#90578](https://github.com/elastic/kibana/issues/90578)).

That commit also tweaked the fatal error screen rendering itself. The FTR check was added as a "safety net" to retry navigation when the screen happened to render.

`isFatalErrorScreen()` calls `testSubjects.exists('fatalErrorScreen')`. That delegates to `find.existsByDisplayedByCssSelector(...)`, which uses `retry.tryForTime(timeout, …)` with `timeouts.waitForExists` default **2.5s** (https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts#L142  also **2.5s** in serverless config). Because the element almost never exists, the call polls for the full **2.5s** before returning false on the happy path.

`fatalErrorScreen` is rendered by core when an unhandled bootstrap/runtime error fires ([src/core/packages/fatal-errors/browser-internal/src/generic_error.tsx](https://github.com/elastic/kibana/blob/main/src/core/packages/fatal-errors/browser-internal/src/generic_error.tsx)). In FTR runs against a healthy local stack this is exceedingly rare; the original flake (#90578) was a one-off race fixed long ago, and there's been no further public usage that depends on this retry.

Delete the check + retryOnFatalError arg entirely as it brings biggest CI saving; also aligns with Tyler's recent changes.
pected impact: removes a ~2.5s polling penalty (testSubjects.exists('fatalErrorScreen') with the default timeouts.waitForExists) from every navigateToApp call.

According to PR #270081 there are ~4,281 such calls per CI run, so this should free up on the order of ~3 hours of FTR CPU time per full run

