### PR TITLE
[9.4] [Fleet] Add .otel suffix to named OTel inputs (#269074)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/index.ts
@@ -16,6 +16,7 @@ export {
   varsReducer,
   getInputEffectiveName,
   buildInputKey,
+  dataStreamUsesOtelInput,
 } from './package_to_package_policy';
 export type {
   DocumentationPageInput,

--- a/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.test.ts
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import type { NewPackagePolicyInput, PackageInfo } from '../types';
+import type { NewPackagePolicyInput, PackageInfo, RegistryDataStream } from '../types';
 
 import {
   packageToPackagePolicy,
   packageToPackagePolicyInputs,
   getInputEffectiveName,
+  dataStreamUsesOtelInput,
 } from './package_to_package_policy';
 import { AWS_PACKAGE } from './fixtures/aws_package';
 
@@ -673,5 +674,65 @@ describe('Fleet - packageToPackagePolicy', () => {
         )
       ).toMatchSnapshot();
     });
+  });
+});
+
+describe('dataStreamUsesOtelInput', () => {
+  const makePackageInfo = (
+    inputs: Array<{ name?: string; type: string }>
+  ): Pick<PackageInfo, 'policy_templates'> => ({
+    policy_templates: [
+      {
+        name: 'otel',
+        title: 'OTel template',
+        description: '',
+        inputs,
+      } as any,
+    ],
+  });
+
+  const makeDataStream = (inputRef: string): Pick<RegistryDataStream, 'streams'> => ({
+    streams: [{ input: inputRef, title: 'stream' } as any],
+  });
+
+  it('returns true when stream.input is "otelcol" directly (regression)', () => {
+    const pkgInfo = makePackageInfo([{ type: 'otelcol' }]);
+    expect(dataStreamUsesOtelInput(pkgInfo, makeDataStream('otelcol'))).toBe(true);
+  });
+
+  it('returns true when stream.input matches the name of an otelcol input (named input case)', () => {
+    const pkgInfo = makePackageInfo([
+      { name: 'otel_logs', type: 'otelcol' },
+      { name: 'otel_metrics', type: 'otelcol' },
+    ]);
+    expect(dataStreamUsesOtelInput(pkgInfo, makeDataStream('otel_logs'))).toBe(true);
+    expect(dataStreamUsesOtelInput(pkgInfo, makeDataStream('otel_metrics'))).toBe(true);
+  });
+
+  it('returns false when stream.input is a named input of a non-otelcol type (regression)', () => {
+    const pkgInfo = makePackageInfo([{ name: 'my_logfile', type: 'logfile' }]);
+    expect(dataStreamUsesOtelInput(pkgInfo, makeDataStream('my_logfile'))).toBe(false);
+  });
+
+  it('returns false when stream.input matches a name that exists but on a non-otelcol input', () => {
+    const pkgInfo = makePackageInfo([{ name: 'otel_logs', type: 'logfile' }]);
+    expect(dataStreamUsesOtelInput(pkgInfo, makeDataStream('otel_logs'))).toBe(false);
+  });
+
+  it('returns false when there are no streams', () => {
+    const pkgInfo = makePackageInfo([{ name: 'otel_logs', type: 'otelcol' }]);
+    expect(dataStreamUsesOtelInput(pkgInfo, { streams: [] })).toBe(false);
+    expect(dataStreamUsesOtelInput(pkgInfo, {})).toBe(false);
+  });
+
+  it('does not crash when policy_templates is absent and returns false for non-otelcol streams', () => {
+    // policy_templates absent/empty — no named inputs to resolve; direct 'otelcol' still matches
+    expect(dataStreamUsesOtelInput({}, makeDataStream('otelcol'))).toBe(true);
+    expect(dataStreamUsesOtelInput({ policy_templates: [] }, makeDataStream('otelcol'))).toBe(true);
+    // A named reference that can't be resolved (no policy_templates) → false
+    expect(dataStreamUsesOtelInput({}, makeDataStream('some_named_input'))).toBe(false);
+    expect(
+      dataStreamUsesOtelInput({ policy_templates: [] }, makeDataStream('some_named_input'))
+    ).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
@@ -16,7 +16,10 @@ import type {
   NewPackagePolicy,
   PackagePolicyConfigRecordEntry,
   RegistryStreamWithDataStream,
+  RegistryDataStream,
 } from '../types';
+
+import { OTEL_COLLECTOR_INPUT_TYPE } from '../constants';
 
 import { doesPackageHaveIntegrations } from '.';
 import {
@@ -39,6 +42,34 @@ type PackagePolicyStream = RegistryStream & {
  */
 export const getInputEffectiveName = (input: { name?: string; type: string }): string =>
   input.name ?? input.type;
+
+/**
+ * Returns true if the given data stream effectively uses the OTel collector input type.
+ *
+ * A data stream is considered OTel when any of its `streams[].input` values is either:
+ * - the literal type `'otelcol'`, or
+ * - the `name` of an input within `pkgInfo.policy_templates[*].inputs` whose `type` is `'otelcol'`.
+ *
+ * The second case handles the named-input feature (package-spec 3.6.1+) where multiple inputs
+ * of the same type coexist in one policy template and data streams reference them by name instead
+ * of by type.
+ */
+export const dataStreamUsesOtelInput = (
+  pkgInfo: Pick<PackageInfo, 'policy_templates'>,
+  dataStream: Pick<RegistryDataStream, 'streams'>
+): boolean => {
+  const namedOtelInputs = new Set<string>();
+  for (const tpl of pkgInfo.policy_templates ?? []) {
+    for (const input of getNormalizedInputs(tpl)) {
+      if (input.type === OTEL_COLLECTOR_INPUT_TYPE && input.name) {
+        namedOtelInputs.add(input.name);
+      }
+    }
+  }
+  return (dataStream.streams ?? []).some(
+    (stream) => stream.input === OTEL_COLLECTOR_INPUT_TYPE || namedOtelInputs.has(stream.input)
+  );
+};
 
 /**
  * Builds the composite key used to index input validation results and var definitions.

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/install.test.ts
@@ -871,6 +871,119 @@ describe('EPM index template install', () => {
         },
       });
     });
+
+    it('should apply .otel index pattern suffix for integration package with named otelcol input (named input case)', () => {
+      // This test covers the bug: when a data stream's stream.input references the *name*
+      // of an otelcol input (rather than the literal type "otelcol"), Fleet must still
+      // recognise it as an OTel data stream and apply the .otel suffix to the index pattern.
+      const integrationOtelPackageInstallContext = {
+        packageInfo: {
+          name: 'good_integration_otel',
+          version: '0.0.1',
+          type: 'integration',
+          policy_templates: [
+            {
+              name: 'otel',
+              title: 'OTel template',
+              inputs: [
+                { name: 'otel_logs', type: 'otelcol', title: 'OTel Logs', description: '' },
+                { name: 'otel_metrics', type: 'otelcol', title: 'OTel Metrics', description: '' },
+              ],
+            },
+          ],
+        },
+        paths: [],
+        archiveIterator: {},
+      } as any as PackageInstallContext;
+
+      appContextService.start(
+        createAppContextStartContractMock(
+          { internal: { disableILMPolicies: false } } as any,
+          undefined,
+          undefined,
+          { enableOtelIntegrations: true } as ExperimentalFeatures
+        )
+      );
+
+      const dataStream = {
+        type: 'logs',
+        dataset: 'good_integration_otel.otel_logs',
+        title: 'OTel Logs',
+        release: 'experimental',
+        package: 'good_integration_otel',
+        path: 'otel_logs',
+        ingest_pipeline: 'default',
+        streams: [
+          {
+            // Named input reference — NOT the literal type 'otelcol'
+            input: 'otel_logs',
+            title: 'OTel log stream',
+          },
+        ],
+      } as RegistryDataStream;
+
+      const { indexTemplate } = prepareTemplate({
+        packageInstallContext: integrationOtelPackageInstallContext,
+        fieldAssetsMap: new Map(),
+        dataStream,
+        ilmMigrationStatusMap: new Map(),
+      });
+
+      // The index pattern MUST include the .otel suffix
+      expect(indexTemplate.indexTemplate.index_patterns).toEqual([
+        'logs-good_integration_otel.otel_logs.otel-*',
+      ]);
+    });
+
+    it('should NOT apply .otel suffix when enableOtelIntegrations is false, even for named otelcol input', () => {
+      const integrationOtelPackageInstallContext = {
+        packageInfo: {
+          name: 'good_integration_otel',
+          version: '0.0.1',
+          type: 'integration',
+          policy_templates: [
+            {
+              name: 'otel',
+              title: 'OTel template',
+              inputs: [{ name: 'otel_logs', type: 'otelcol', title: 'OTel Logs', description: '' }],
+            },
+          ],
+        },
+        paths: [],
+        archiveIterator: {},
+      } as any as PackageInstallContext;
+
+      appContextService.start(
+        createAppContextStartContractMock(
+          { internal: { disableILMPolicies: false } } as any,
+          undefined,
+          undefined,
+          { enableOtelIntegrations: false } as ExperimentalFeatures
+        )
+      );
+
+      const dataStream = {
+        type: 'logs',
+        dataset: 'good_integration_otel.otel_logs',
+        title: 'OTel Logs',
+        release: 'experimental',
+        package: 'good_integration_otel',
+        path: 'otel_logs',
+        ingest_pipeline: 'default',
+        streams: [{ input: 'otel_logs', title: 'OTel log stream' }],
+      } as RegistryDataStream;
+
+      const { indexTemplate } = prepareTemplate({
+        packageInstallContext: integrationOtelPackageInstallContext,
+        fieldAssetsMap: new Map(),
+        dataStream,
+        ilmMigrationStatusMap: new Map(),
+      });
+
+      expect(indexTemplate.indexTemplate.index_patterns).toEqual([
+        'logs-good_integration_otel.otel_logs-*',
+      ]);
+    });
   });
 
   describe('prepareToInstallTemplates', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -48,7 +48,8 @@ import {
 import { appContextService } from '../../../app_context';
 import type { AssetsMap, PackageInstallContext } from '../../../../../common/types';
 
-import { OTEL_COLLECTOR_INPUT_TYPE, OTEL_TEMPLATE_SUFFIX } from '../../../../../common/constants';
+import { OTEL_TEMPLATE_SUFFIX } from '../../../../../common/constants';
+import { dataStreamUsesOtelInput } from '../../../../../common/services';
 
 import {
   generateMappings,
@@ -636,7 +637,7 @@ export function prepareTemplate({
   const experimentalFeature = appContextService.getExperimentalFeatures();
   const isOtelInputType =
     experimentalFeature.enableOtelIntegrations &&
-    (dataStream?.streams || []).some((stream) => stream.input === OTEL_COLLECTOR_INPUT_TYPE);
+    dataStreamUsesOtelInput(packageInstallContext.packageInfo, dataStream);
   const isIndexModeTimeSeries =
     dataStream.elasticsearch?.index_mode === 'time_series' ||
     !!experimentalDataStreamFeature?.features.tsdb;


### PR DESCRIPTION
# Backport

This will backport the following change to 9.4:
* #269074