### PR TITLE
[One Workflow] fix: require managed workflow template values on install

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/managed/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/index.ts
@@ -44,8 +44,8 @@ export type ManagedWorkflowTemplateValuesById = {
   >;
 };
 
-export type ManagedWorkflowTemplateValuesForId<TId extends TemplatedManagedWorkflowId> =
-  ManagedWorkflowTemplateValuesById[TId];
+export type ManagedWorkflowTemplateValuesForId<TId extends ManagedWorkflowId> =
+  TId extends TemplatedManagedWorkflowId ? ManagedWorkflowTemplateValuesById[TId] : never;
 
 export const getManagedWorkflowDefinition = (id: string): ManagedWorkflowDefinition | undefined => {
   return managedWorkflowDefinitions.find(

--- a/src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts
@@ -20,11 +20,13 @@ const ManagedWorkflowSchema = WorkflowSchemaBase.extend({
 });
 
 type RegistryManagedWorkflowDefinition = (typeof managedWorkflowDefinitions)[number];
-type TemplateManagedWorkflowDefinition = RegistryManagedWorkflowDefinition extends {
+type TemplateManagedWorkflowDefinition<TDefinition> = TDefinition extends {
   yamlTemplate: (values: infer _TValues) => string;
 }
-  ? RegistryManagedWorkflowDefinition
+  ? TDefinition
   : never;
+type RegistryTemplateManagedWorkflowDefinition =
+  TemplateManagedWorkflowDefinition<RegistryManagedWorkflowDefinition>;
 type YamlTemplateManagedWorkflowDefinition = ManagedWorkflowDefinition & {
   yamlTemplate: (values: ManagedWorkflowTemplateValues) => string;
 };
@@ -42,9 +44,9 @@ const templateValuesLookup = templateRepresentativeValuesById as Record<
 
 const managedDefinitionsById: Array<[string, RegistryManagedWorkflowDefinition]> =
   managedWorkflowDefinitions.map((definition) => [definition.id, definition]);
-const managedTemplateDefinitionsById: Array<[string, TemplateManagedWorkflowDefinition]> =
+const managedTemplateDefinitionsById: Array<[string, RegistryTemplateManagedWorkflowDefinition]> =
   managedDefinitionsById.filter(
-    (definitionEntry): definitionEntry is [string, TemplateManagedWorkflowDefinition] =>
+    (definitionEntry): definitionEntry is [string, RegistryTemplateManagedWorkflowDefinition] =>
       hasYamlTemplate(definitionEntry[1])
   );
 

--- a/src/platform/packages/shared/kbn-workflows/server/types.ts
+++ b/src/platform/packages/shared/kbn-workflows/server/types.ts
@@ -34,7 +34,8 @@ export type ManagedWorkflowOperationOptions = ManagedWorkflowOperationBaseOption
 export type ManagedWorkflowInstallOptions<TId extends ManagedWorkflowId> =
   ManagedWorkflowOperationBaseOptions & ManagedWorkflowInstallValuesOption<TId>;
 
-export type InternalManagedWorkflowInstallOptions = ManagedWorkflowOperationBaseOptions & {
+// Service installs can reuse persisted template values during reconciliation.
+export type ManagedWorkflowServiceInstallOptions = ManagedWorkflowOperationBaseOptions & {
   values?: ManagedWorkflowTemplateValues;
 };
 

--- a/src/platform/packages/shared/kbn-workflows/server/types.ts
+++ b/src/platform/packages/shared/kbn-workflows/server/types.ts
@@ -8,7 +8,11 @@
  */
 
 import type { CustomRequestHandlerContext, KibanaRequest } from '@kbn/core/server';
-import type { ManagedWorkflowId, ManagedWorkflowTemplateValuesForId } from '../managed';
+import type {
+  ManagedWorkflowId,
+  ManagedWorkflowTemplateValues,
+  ManagedWorkflowTemplateValuesForId,
+} from '../managed';
 
 interface ManagedWorkflowOperationBaseOptions {
   spaceId: string;
@@ -16,22 +20,25 @@ interface ManagedWorkflowOperationBaseOptions {
   workflowIdSuffix?: string;
 }
 
-type ManagedWorkflowValuesOption<TId extends ManagedWorkflowId> =
+type ManagedWorkflowInstallValuesOption<TId extends ManagedWorkflowId> =
   ManagedWorkflowTemplateValuesForId<TId> extends never
     ? {
         values?: never;
       }
     : {
-        values?: ManagedWorkflowTemplateValuesForId<TId>;
+        values: ManagedWorkflowTemplateValuesForId<TId>;
       };
 
-export type ManagedWorkflowOperationOptions<TId extends ManagedWorkflowId = ManagedWorkflowId> =
-  ManagedWorkflowOperationBaseOptions & ManagedWorkflowValuesOption<TId>;
+export type ManagedWorkflowOperationOptions = ManagedWorkflowOperationBaseOptions;
 
-export type ExecuteManagedWorkflowOptions<TId extends ManagedWorkflowId = ManagedWorkflowId> = Omit<
-  ManagedWorkflowOperationOptions<TId>,
-  'values'
-> & {
+export type ManagedWorkflowInstallOptions<TId extends ManagedWorkflowId> =
+  ManagedWorkflowOperationBaseOptions & ManagedWorkflowInstallValuesOption<TId>;
+
+export type InternalManagedWorkflowInstallOptions = ManagedWorkflowOperationBaseOptions & {
+  values?: ManagedWorkflowTemplateValues;
+};
+
+export type ExecuteManagedWorkflowOptions = ManagedWorkflowOperationOptions & {
   inputs?: Record<string, unknown>;
   triggeredBy?: string;
   metadata?: Record<string, unknown>;
@@ -43,11 +50,11 @@ export type ExecuteManagedWorkflowOptions<TId extends ManagedWorkflowId = Manage
 export interface RegisteredManagedWorkflowsLifecycleApi {
   install: <TId extends ManagedWorkflowId>(
     id: TId,
-    options: ManagedWorkflowOperationOptions<TId>
+    options: ManagedWorkflowInstallOptions<TId>
   ) => Promise<void>;
   uninstall: <TId extends ManagedWorkflowId>(
     id: TId,
-    options: ManagedWorkflowOperationOptions<TId>
+    options: ManagedWorkflowOperationOptions
   ) => Promise<void>;
   /**
    * Signal that the plugin has finished installing all its static managed workflows.
@@ -63,10 +70,7 @@ export interface RegisteredManagedWorkflowsLifecycleApi {
  * Plugin-bound API for managed workflow operations that do not require a Kibana request.
  */
 export interface RegisteredManagedWorkflowsApi extends RegisteredManagedWorkflowsLifecycleApi {
-  execute: <TId extends ManagedWorkflowId>(
-    id: TId,
-    options: ExecuteManagedWorkflowOptions<TId>
-  ) => Promise<string>;
+  execute: (id: ManagedWorkflowId, options: ExecuteManagedWorkflowOptions) => Promise<string>;
 }
 
 /**
@@ -76,17 +80,17 @@ export interface ManagedWorkflowsApi {
   install: <TId extends ManagedWorkflowId>(
     pluginId: string,
     id: TId,
-    options: ManagedWorkflowOperationOptions<TId>
+    options: ManagedWorkflowInstallOptions<TId>
   ) => Promise<void>;
   uninstall: <TId extends ManagedWorkflowId>(
     pluginId: string,
     id: TId,
-    options: ManagedWorkflowOperationOptions<TId>
+    options: ManagedWorkflowOperationOptions
   ) => Promise<void>;
-  execute: <TId extends ManagedWorkflowId>(
+  execute: (
     pluginId: string,
-    id: TId,
-    options: ExecuteManagedWorkflowOptions<TId>
+    id: ManagedWorkflowId,
+    options: ExecuteManagedWorkflowOptions
   ) => Promise<string>;
 }
 
@@ -94,10 +98,10 @@ export interface ManagedWorkflowsApi {
  * Consumer-facing managed workflows client returned by workflows_extensions.
  */
 export interface PluginScopedManagedWorkflowsApi extends RegisteredManagedWorkflowsLifecycleApi {
-  execute: <TId extends ManagedWorkflowId>(
+  execute: (
     request: KibanaRequest,
-    id: TId,
-    options: ExecuteManagedWorkflowOptions<TId>
+    id: ManagedWorkflowId,
+    options: ExecuteManagedWorkflowOptions
   ) => Promise<string>;
 }
 

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -37,8 +37,8 @@ import type {
 import type { ManagedWorkflowId } from '@kbn/workflows/managed';
 import type {
   ExecuteManagedWorkflowOptions,
-  InternalManagedWorkflowInstallOptions,
   ManagedWorkflowOperationOptions,
+  ManagedWorkflowServiceInstallOptions,
 } from '@kbn/workflows/server/types';
 import type {
   ChildWorkflowExecutionItem,
@@ -422,7 +422,7 @@ export class WorkflowsService {
 
   public async installManagedWorkflow(
     id: ManagedWorkflowId,
-    options: InternalManagedWorkflowInstallOptions,
+    options: ManagedWorkflowServiceInstallOptions,
     registeredPluginId: string
   ): Promise<void> {
     await this.ensureInitialized();

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -37,6 +37,7 @@ import type {
 import type { ManagedWorkflowId } from '@kbn/workflows/managed';
 import type {
   ExecuteManagedWorkflowOptions,
+  InternalManagedWorkflowInstallOptions,
   ManagedWorkflowOperationOptions,
 } from '@kbn/workflows/server/types';
 import type {
@@ -421,7 +422,7 @@ export class WorkflowsService {
 
   public async installManagedWorkflow(
     id: ManagedWorkflowId,
-    options: ManagedWorkflowOperationOptions,
+    options: InternalManagedWorkflowInstallOptions,
     registeredPluginId: string
   ): Promise<void> {
     await this.ensureInitialized();

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
@@ -20,8 +20,8 @@ import {
 import { GLOBAL_WORKFLOW_SPACE_ID } from '@kbn/workflows/server';
 import type {
   ExecuteManagedWorkflowOptions,
-  InternalManagedWorkflowInstallOptions,
   ManagedWorkflowOperationOptions,
+  ManagedWorkflowServiceInstallOptions,
 } from '@kbn/workflows/server/types';
 import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import { updateYamlField } from '@kbn/workflows-yaml';
@@ -128,7 +128,7 @@ export class ManagedWorkflowsService {
 
   public async installManagedWorkflow(
     id: ManagedWorkflowId,
-    options: InternalManagedWorkflowInstallOptions,
+    options: ManagedWorkflowServiceInstallOptions,
     registeredPluginId: string
   ): Promise<void> {
     for (let attempt = 0; attempt <= MAX_MANAGED_INSTALL_RETRIES; attempt++) {
@@ -149,7 +149,7 @@ export class ManagedWorkflowsService {
 
   private async installManagedWorkflowOnce(
     id: ManagedWorkflowId,
-    options: InternalManagedWorkflowInstallOptions,
+    options: ManagedWorkflowServiceInstallOptions,
     registeredPluginId: string
   ): Promise<void> {
     const definition = getManagedWorkflowDefinition(id);

--- a/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.ts
@@ -20,6 +20,7 @@ import {
 import { GLOBAL_WORKFLOW_SPACE_ID } from '@kbn/workflows/server';
 import type {
   ExecuteManagedWorkflowOptions,
+  InternalManagedWorkflowInstallOptions,
   ManagedWorkflowOperationOptions,
 } from '@kbn/workflows/server/types';
 import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
@@ -127,7 +128,7 @@ export class ManagedWorkflowsService {
 
   public async installManagedWorkflow(
     id: ManagedWorkflowId,
-    options: ManagedWorkflowOperationOptions,
+    options: InternalManagedWorkflowInstallOptions,
     registeredPluginId: string
   ): Promise<void> {
     for (let attempt = 0; attempt <= MAX_MANAGED_INSTALL_RETRIES; attempt++) {
@@ -148,7 +149,7 @@ export class ManagedWorkflowsService {
 
   private async installManagedWorkflowOnce(
     id: ManagedWorkflowId,
-    options: ManagedWorkflowOperationOptions,
+    options: InternalManagedWorkflowInstallOptions,
     registeredPluginId: string
   ): Promise<void> {
     const definition = getManagedWorkflowDefinition(id);


### PR DESCRIPTION
## Summary

- Require template values when installing managed workflows backed by `yamlTemplate`.
- Keep uninstall and execute options limited to workflow targeting fields, with a separate internal install option type for persisted template-value reuse.
- Make managed workflow registry test typing handle mixed `yaml` and `yamlTemplate` definitions.

## Test plan

- `node scripts/eslint --fix $(git diff --name-only)`
- `node scripts/type_check --project src/platform/packages/shared/kbn-workflows/tsconfig.json`
- `node scripts/type_check --project examples/workflows_extensions_example/tsconfig.json`
- `node scripts/jest src/platform/packages/shared/kbn-workflows/managed/managed_workflow_definitions.test.ts`
- `node scripts/jest src/platform/plugins/shared/workflows_management/server/services/managed_workflows_service.test.ts`
- `node scripts/check_changes.ts`