### PR TITLE
[Entity Analytics] Skipping V1 tests in serverless MKI

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/indicator_match/trial_license_complete_tier/indicator_match_alert_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/indicator_match/trial_license_complete_tier/indicator_match_alert_suppression.ts
@@ -2497,7 +2497,7 @@ export default ({ getService }: FtrProviderContext) => {
           });
         });
 
-        describe('alerts should be enriched', () => {
+        describe('@skipInServerlessMKI alerts should be enriched', () => {
           before(async () => {
             await esArchiver.load(
               'x-pack/solutions/security/test/fixtures/es_archives/entity/risks'
@@ -2570,7 +2570,7 @@ export default ({ getService }: FtrProviderContext) => {
           });
         });
 
-        describe('with asset criticality', () => {
+        describe('@skipInServerlessMKI with asset criticality', () => {
           before(async () => {
             await esArchiver.load(
               'x-pack/solutions/security/test/fixtures/es_archives/asset_criticality'

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/machine_learning/trial_license_complete_tier/machine_learning_alert_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/machine_learning/trial_license_complete_tier/machine_learning_alert_suppression.ts
@@ -1100,7 +1100,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      describe('with enrichments', () => {
+      describe('@skipInServerlessMKI with enrichments', () => {
         before(async () => {
           await esArchiver.load('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
           await esArchiver.load(

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/new_terms/trial_license_complete_tier/new_terms_alert_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/new_terms/trial_license_complete_tier/new_terms_alert_suppression.ts
@@ -2248,7 +2248,7 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    describe('enrichment', () => {
+    describe('@skipInServerlessMKI enrichment', () => {
       const config = getService('config');
       const isServerless = config.get('serverless');
       const dataPathBuilder = new EsArchivePathBuilder(isServerless);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/threshold/trial_license_complete_tier/threshold_alert_suppression.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/threshold/trial_license_complete_tier/threshold_alert_suppression.ts
@@ -960,7 +960,7 @@ export default ({ getService }: FtrProviderContext) => {
       );
     });
 
-    describe('with host risk index', () => {
+    describe('@skipInServerlessMKI with host risk index', () => {
       before(async () => {
         await esArchiver.load('x-pack/solutions/security/test/fixtures/es_archives/entity/risks');
       });
@@ -993,7 +993,7 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    describe('with asset criticality', () => {
+    describe('@skipInServerlessMKI with asset criticality', () => {
       before(async () => {
         await esArchiver.load(
           'x-pack/solutions/security/test/fixtures/es_archives/asset_criticality'


### PR DESCRIPTION
## Summary

Adding `@skipInServerlessMKI` to some additional tests that were missed in https://github.com/elastic/kibana/pull/270974