### PR TITLE
[PoC] Discover profile state

### DIFF
--- a/src/platform/plugins/shared/discover/common/app_locator.ts
+++ b/src/platform/plugins/shared/discover/common/app_locator.ts
@@ -19,6 +19,8 @@ import type { VIEW_MODE, NEW_TAB_ID } from './constants';
 
 export const DISCOVER_APP_LOCATOR = 'DISCOVER_APP_LOCATOR';
 
+export type DiscoverProfileUrlState = Record<string, SerializableRecord>;
+
 export interface DiscoverAppLocatorParams extends SerializableRecord {
   /**
    * Optionally set saved search ID.
@@ -74,6 +76,11 @@ export interface DiscoverAppLocatorParams extends SerializableRecord {
    * Use `label` to set a fallback tab label if it was not defined before yet.
    */
   tab?: { id: typeof NEW_TAB_ID | string; label?: string };
+
+  /**
+   * Optionally set URL-synced profile state.
+   */
+  profileUrlState?: DiscoverProfileUrlState;
 
   /**
    * Columns displayed in the table

--- a/src/platform/plugins/shared/discover/common/app_locator_get_location.ts
+++ b/src/platform/plugins/shared/discover/common/app_locator_get_location.ts
@@ -11,13 +11,19 @@ import type { GlobalQueryStateFromUrl } from '@kbn/data-plugin/public';
 import { isFilterPinned, isOfAggregateQueryType } from '@kbn/es-query';
 import type { setStateToKbnUrl as setStateToKbnUrlCommon } from '@kbn/kibana-utils-plugin/common';
 import type {
+  DiscoverProfileUrlState,
   DiscoverAppLocatorGetLocation,
   DiscoverAppLocatorParams,
   MainHistoryLocationState,
 } from './app_locator';
 import type { DiscoverAppState } from '../public';
 import { createDataViewDataSource, createEsqlDataSource } from './data_sources';
-import { APP_STATE_URL_KEY, GLOBAL_STATE_URL_KEY, TAB_STATE_URL_KEY } from './constants';
+import {
+  APP_STATE_URL_KEY,
+  GLOBAL_STATE_URL_KEY,
+  PROFILE_STATE_URL_KEY,
+  TAB_STATE_URL_KEY,
+} from './constants';
 
 export const appLocatorGetLocationCommon = async (
   {
@@ -38,7 +44,7 @@ export const appLocatorGetLocationCommon = async (
     path = `${path}?searchSessionId=${searchSessionId}`;
   }
 
-  const { appState, globalState, state } = parseAppLocatorParams(params);
+  const { appState, globalState, profileUrlState, state } = parseAppLocatorParams(params);
 
   if (Object.keys(globalState).length) {
     path = setStateToKbnUrl<GlobalQueryStateFromUrl>(
@@ -51,6 +57,10 @@ export const appLocatorGetLocationCommon = async (
 
   if (Object.keys(appState).length) {
     path = setStateToKbnUrl(APP_STATE_URL_KEY, appState, { useHash }, path);
+  }
+
+  if (profileUrlState && Object.keys(profileUrlState).length) {
+    path = setStateToKbnUrl(PROFILE_STATE_URL_KEY, profileUrlState, { useHash }, path);
   }
 
   if (tab?.id) {
@@ -91,10 +101,13 @@ export const parseAppLocatorParams = (params: DiscoverAppLocatorParams) => {
     sampleSize,
     isAlertResults,
     esqlControls,
+    profileUrlState,
   } = params;
 
   const appState: Partial<DiscoverAppState> = {};
   const globalState: GlobalQueryStateFromUrl = {};
+  const parsedProfileUrlState: DiscoverProfileUrlState | undefined =
+    profileUrlState && Object.keys(profileUrlState).length > 0 ? profileUrlState : undefined;
 
   if (query) appState.query = query;
   if (filters && filters.length) appState.filters = filters?.filter((f) => !isFilterPinned(f));
@@ -123,5 +136,5 @@ export const parseAppLocatorParams = (params: DiscoverAppLocatorParams) => {
   if (isAlertResults) state.isAlertResults = isAlertResults;
   if (esqlControls) state.esqlControls = esqlControls;
 
-  return { appState, globalState, state };
+  return { appState, globalState, profileUrlState: parsedProfileUrlState, state };
 };

--- a/src/platform/plugins/shared/discover/common/constants.ts
+++ b/src/platform/plugins/shared/discover/common/constants.ts
@@ -41,6 +41,7 @@ export const NEW_TAB_ID = 'new' as const;
  */
 export const APP_STATE_URL_KEY = '_a';
 export const GLOBAL_STATE_URL_KEY = '_g';
+export const PROFILE_STATE_URL_KEY = '_p';
 export const TAB_STATE_URL_KEY = '_tab'; // `_t` is already used by Kibana for time, so we use `_tab` here
 
 /**

--- a/src/platform/plugins/shared/discover/common/index.ts
+++ b/src/platform/plugins/shared/discover/common/index.ts
@@ -10,11 +10,16 @@
 export const PLUGIN_ID = 'discover';
 export const APP_ICON = 'discoverApp';
 
-export { APP_STATE_URL_KEY, EMBEDDABLE_TRANSFORMS_FEATURE_FLAG_KEY } from './constants';
+export {
+  APP_STATE_URL_KEY,
+  EMBEDDABLE_TRANSFORMS_FEATURE_FLAG_KEY,
+  PROFILE_STATE_URL_KEY,
+} from './constants';
 export { DISCOVER_APP_LOCATOR } from './app_locator';
 export type {
   DiscoverAppLocator,
   DiscoverAppLocatorParams,
+  DiscoverProfileUrlState,
   MainHistoryLocationState,
 } from './app_locator';
 

--- a/src/platform/plugins/shared/discover/public/__mocks__/discover_state.mock.ts
+++ b/src/platform/plugins/shared/discover/public/__mocks__/discover_state.mock.ts
@@ -94,6 +94,7 @@ function createInternalStateStoreMock({
   const tabsStorageManager = createTabsStorageManager({
     urlStateStorage: stateStorageContainer,
     storage: services.storage,
+    profileStateRegistry: services.profileStateRegistry,
   });
   const searchSessionManager = new DiscoverSearchSessionManager({
     history: services.history,

--- a/src/platform/plugins/shared/discover/public/__mocks__/services.ts
+++ b/src/platform/plugins/shared/discover/public/__mocks__/services.ts
@@ -47,6 +47,7 @@ import type { SearchSourceDependencies } from '@kbn/data-plugin/common';
 import type { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
 import { createElement } from 'react';
 import { createContextAwarenessMocks } from '../context_awareness/__mocks__';
+import { ProfileStateRegistry } from '../context_awareness';
 import { DiscoverEBTManager } from '../ebt_manager';
 import { discoverSharedPluginMock } from '@kbn/discover-shared-plugin/public/mocks';
 import { createUrlTrackerMock } from './url_tracker.mock';
@@ -307,6 +308,7 @@ export function createDiscoverServicesMock(): DiscoverServices {
     singleDocLocator: { getRedirectUrl: jest.fn(() => '') },
     urlTracker: createUrlTrackerMock(),
     profilesManager: profilesManagerMock,
+    profileStateRegistry: new ProfileStateRegistry(),
     ebtManager: new DiscoverEBTManager(),
     cps: cpsPluginMock.createStartContract(),
     setHeaderActionMenu: jest.fn(),

--- a/src/platform/plugins/shared/discover/public/application/context/context_app_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/context/context_app_route.tsx
@@ -22,7 +22,7 @@ import { LoadingIndicator } from '../../components/common/loading_indicator';
 import { useDataView } from '../../hooks/use_data_view';
 import type { ContextHistoryLocationState } from './services/locator';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
-import { useRootProfile } from '../../context_awareness';
+import { EMPTY_CONTEXT_AWARENESS_TOOLKIT, useRootProfile } from '../../context_awareness';
 import { ScopedServicesProvider } from '../../components/scoped_services_provider';
 
 export interface ContextUrlParams {
@@ -104,7 +104,9 @@ export function ContextAppRoute() {
     profilesManager.createScopedProfilesManager({
       scopedEbtManager,
       toolkit: {
+        ...EMPTY_CONTEXT_AWARENESS_TOOLKIT,
         actions: {
+          ...EMPTY_CONTEXT_AWARENESS_TOOLKIT.actions,
           addFilter,
           setExpandedDoc,
         },

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
@@ -33,6 +33,7 @@ interface BuildShareOptionsParams {
   discoverParams: AppMenuDiscoverParams;
   services: DiscoverServices;
   currentTab: TabState;
+  profileUrlState?: DiscoverAppLocatorParams['profileUrlState'];
   persistedDiscoverSession: DiscoverSession | undefined;
   totalHitsState: DataTotalHitsMsg;
   hasUnsavedChanges: boolean;
@@ -50,6 +51,7 @@ export const buildShareOptions = async ({
   discoverParams,
   services,
   currentTab,
+  profileUrlState,
   persistedDiscoverSession,
   totalHitsState,
   hasUnsavedChanges,
@@ -84,6 +86,7 @@ export const buildShareOptions = async ({
     ...(dataView?.isPersisted()
       ? { dataViewId: dataView?.id }
       : { dataViewSpec: dataView?.toMinimalSpec() }),
+    ...(profileUrlState ? { profileUrlState } : {}),
     filters,
     timeRange,
     refreshInterval,
@@ -256,6 +259,7 @@ export const getShareAppMenuItem = ({
   hasIntegrations,
   hasUnsavedChanges,
   currentTab,
+  profileUrlState,
   persistedDiscoverSession,
   totalHitsState,
   intl,
@@ -265,6 +269,7 @@ export const getShareAppMenuItem = ({
   hasIntegrations: boolean;
   hasUnsavedChanges: boolean;
   currentTab: TabState;
+  profileUrlState?: DiscoverAppLocatorParams['profileUrlState'];
   persistedDiscoverSession: DiscoverSession | undefined;
   totalHitsState: DataTotalHitsMsg;
   intl: IntlShape;
@@ -278,6 +283,7 @@ export const getShareAppMenuItem = ({
       discoverParams,
       services,
       currentTab,
+      profileUrlState,
       persistedDiscoverSession,
       totalHitsState,
       hasUnsavedChanges,
@@ -306,6 +312,7 @@ export const getShareAppMenuItem = ({
         discoverParams,
         services,
         currentTab,
+        profileUrlState,
         persistedDiscoverSession,
         totalHitsState,
         hasUnsavedChanges,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -42,6 +42,7 @@ import {
 import { useProfileAccessor } from '../../../../context_awareness';
 import {
   internalStateActions,
+  selectTabRuntimeState,
   selectTabSavedSearchByValueAttributes,
   useCurrentDataView,
   useCurrentTabSelector,
@@ -52,6 +53,7 @@ import {
   useRuntimeStateManager,
 } from '../../state_management/redux';
 import type { DiscoverAppState } from '../../state_management/redux';
+import { getProfileUrlState } from '../../state_management/utils/get_profile_url_state';
 import { useCurrentTabMenuActions } from '../../hooks/use_current_tab_menu_actions';
 import { useDataState } from '../../hooks/use_data_state';
 import { TransferAction } from '../../../../plugin_imports/embeddable_editor_service';
@@ -146,6 +148,16 @@ export const useTopNavLinks = ({
 
   const canCreateESQLRule = !!services.capabilities.alertingVTwo;
   const showCreateRuleV2 = isEsqlMode && canCreateESQLRule;
+  const activeProfileStateDefinition = selectTabRuntimeState(runtimeStateManager, currentTab.id)
+    .scopedProfilesManager$.getValue()
+    .getContexts().dataSourceContext.profileState;
+  const profileUrlState = activeProfileStateDefinition
+    ? getProfileUrlState({
+        definition: activeProfileStateDefinition,
+        profileState: currentTab.profileState,
+        profileStateRegistry: services.profileStateRegistry,
+      })
+    : undefined;
 
   const appMenuItems: DiscoverAppMenuItemType[] = useMemo(() => {
     const items: DiscoverAppMenuItemType[] = [];
@@ -227,6 +239,7 @@ export const useTopNavLinks = ({
       hasIntegrations: hasShareIntegration,
       hasUnsavedChanges,
       currentTab,
+      profileUrlState,
       persistedDiscoverSession,
       totalHitsState,
       intl,
@@ -288,6 +301,7 @@ export const useTopNavLinks = ({
     currentDataView,
     currentTab,
     isDataViewMode,
+    profileUrlState,
     openInspector,
     persistedDiscoverSession,
     hasShareIntegration,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -45,6 +45,7 @@ import { fetchAll, type CommonFetchParams, fetchMoreDocuments } from '../data_fe
 import { sendResetMsg } from '../hooks/use_saved_search_messages';
 import { getFetch$ } from '../data_fetching/get_fetch_observable';
 import { getDefaultProfileState, getProfileStateSnapshot } from './utils/default_profile_state';
+import { getRestoredProfileUrlState } from './utils/get_profile_url_state';
 import type { InternalStateStore, RuntimeStateManager, TabActionInjector, TabState } from './redux';
 import { internalStateActions, selectTabRuntimeState } from './redux';
 import { buildEsqlFetchSubscribe } from './utils/build_esql_fetch_subscribe';
@@ -383,7 +384,39 @@ export function getDataStateContainer({
 
           // If the data source profile changed, we may need to restore previous profile state
           if (didProfileChange) {
-            const profileId = scopedProfilesManager.getContexts().dataSourceContext.profileId;
+            const { dataSourceContext } = scopedProfilesManager.getContexts();
+            const profileId = dataSourceContext.profileId;
+            const activeProfileStateDefinition = dataSourceContext.profileState;
+            const initialProfileUrlState = getCurrentTab().initialProfileUrlState;
+
+            if (isFirstResolution && initialProfileUrlState) {
+              if (activeProfileStateDefinition) {
+                const restoredProfileUrlState = getRestoredProfileUrlState({
+                  definition: activeProfileStateDefinition,
+                  profileStateRegistry: services.profileStateRegistry,
+                  profileUrlState: initialProfileUrlState,
+                });
+
+                if (restoredProfileUrlState) {
+                  internalState.dispatch(
+                    injectCurrentTab(internalStateActions.setProfileState)({
+                      key: activeProfileStateDefinition.key,
+                      profileState: {
+                        ...(getCurrentTab().profileState[activeProfileStateDefinition.key] ?? {}),
+                        ...restoredProfileUrlState,
+                      },
+                    })
+                  );
+                }
+              }
+
+              internalState.dispatch(
+                injectCurrentTab(internalStateActions.setInitialProfileUrlState)({
+                  initialProfileUrlState: undefined,
+                })
+              );
+            }
+
             const profileStateSnapshot =
               getCurrentTab().defaultProfileState.snapshotsByProfileId[profileId];
             const profileStateUpdate = getProfileStateSnapshot(
@@ -428,6 +461,10 @@ export function getDataStateContainer({
                 injectCurrentTab(internalStateActions.syncProfileStateSnapshot)({})
               );
             }
+
+            await internalState.dispatch(
+              injectCurrentTab(internalStateActions.updateProfileUrlStateAndReplaceUrl)()
+            );
           }
 
           const dataView = currentDataView$.getValue();

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/hooks/use_state_managers.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/hooks/use_state_managers.ts
@@ -45,6 +45,7 @@ export const useStateManagers = ({
     createTabsStorageManager({
       urlStateStorage,
       storage: services.storage,
+      profileStateRegistry: services.profileStateRegistry,
       enabled: tabsEnabled,
     })
   );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
@@ -25,12 +25,12 @@ import { loadAndResolveDataView } from '../../utils/resolve_data_view';
 import { isDataViewSource } from '../../../../../../common/data_sources';
 import { isRefreshIntervalValid, isTimeRangeValid } from '../../../../../utils/validate_time';
 import { getValidFilters } from '../../../../../utils/get_valid_filters';
-import { APP_STATE_URL_KEY } from '../../../../../../common';
+import { APP_STATE_URL_KEY, type DiscoverProfileUrlState } from '../../../../../../common';
 import { selectTabRuntimeState } from '../runtime_state';
 import type { ConnectedCustomizationService } from '../../../../../customizations';
 import { selectTab } from '../selectors';
 import type { TabState, TabStateGlobalState } from '../types';
-import { GLOBAL_STATE_URL_KEY } from '../../../../../../common/constants';
+import { GLOBAL_STATE_URL_KEY, PROFILE_STATE_URL_KEY } from '../../../../../../common/constants';
 import { fromSavedObjectTabToSearchSource } from '../tab_mapping_utils';
 import { createInternalStateAsyncThunk, extractEsqlVariables } from '../utils';
 import { fetchData, updateAttributes } from './tab_state';
@@ -111,11 +111,20 @@ export const initializeSingleTab = createInternalStateAsyncThunk(
     // to avoid race conditions if the URL changes during tab initialization,
     // e.g. if the user quickly switches tabs
     const urlGlobalState = urlStateStorage.get<GlobalQueryStateFromUrl>(GLOBAL_STATE_URL_KEY);
+    const urlProfileState =
+      urlStateStorage.get<DiscoverProfileUrlState>(PROFILE_STATE_URL_KEY) ?? undefined;
     const urlAppState = {
       ...tabInitialAppState,
       ...(defaultUrlState ??
         cleanupUrlState(urlStateStorage.get<AppStateUrl>(APP_STATE_URL_KEY), services.uiSettings)),
     };
+
+    dispatch(
+      internalStateSlice.actions.setInitialProfileUrlState({
+        tabId,
+        initialProfileUrlState: urlProfileState,
+      })
+    );
 
     const discoverTabLoadTracker = scopedEbtManager$
       .getValue()

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_state.ts
@@ -18,10 +18,11 @@ import {
   isOfQueryType,
 } from '@kbn/es-query';
 import { getInitialESQLQuery } from '@kbn/esql-utils';
-import { GLOBAL_STATE_URL_KEY } from '../../../../../../common/constants';
+import { GLOBAL_STATE_URL_KEY, PROFILE_STATE_URL_KEY } from '../../../../../../common/constants';
 import { APP_STATE_URL_KEY } from '../../../../../../common';
 import { DataSourceType } from '../../../../../../common/data_sources';
 import { isEqualState } from '../../utils/state_comparators';
+import { getCurrentTabProfileUrlState } from '../../utils/get_profile_url_state';
 import {
   internalStateSlice,
   type InternalStateThunkActionCreator,
@@ -213,7 +214,34 @@ export const pushCurrentTabStateToUrl: InternalStateThunkActionCreator<
     await Promise.all([
       dispatch(updateGlobalStateAndReplaceUrl({ tabId, globalState: {} })),
       dispatch(updateAppStateAndReplaceUrl({ tabId, appState: {} })),
+      dispatch(updateProfileUrlStateAndReplaceUrl({ tabId })),
     ]);
+  };
+
+export const updateProfileUrlStateAndReplaceUrl: InternalStateThunkActionCreator<
+  [TabActionPayload],
+  Promise<void>
+> = ({ tabId }) =>
+  async function updateProfileUrlStateAndReplaceUrlThunkFn(
+    _dispatch,
+    getState,
+    { runtimeStateManager, services, urlStateStorage }
+  ) {
+    const currentState = getState();
+
+    if (currentState.tabs.unsafeCurrentId !== tabId) {
+      return;
+    }
+
+    const profileUrlState =
+      getCurrentTabProfileUrlState({
+        getState,
+        runtimeStateManager,
+        profileStateRegistry: services.profileStateRegistry,
+        tabId,
+      }) ?? null;
+
+    await urlStateStorage.set(PROFILE_STATE_URL_KEY, profileUrlState, { replace: true });
   };
 
 /**

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_sync.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_sync.test.ts
@@ -221,7 +221,7 @@ describe('tab_sync actions', () => {
 
     it('should subscribe to createTabPersistableStateObservable for syncing locally persisted tab state', async () => {
       const mockTabState$ = new Subject<
-        Pick<TabState, 'appState' | 'globalState' | 'attributes'>
+        Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
       >();
       const createTabPersistableStateObservableSpy = jest
         .spyOn(createTabPersistableStateObservableModule, 'createTabPersistableStateObservable')
@@ -236,6 +236,7 @@ describe('tab_sync actions', () => {
           tabId,
           internalState$: expect.any(Object),
           getState: expect.any(Function),
+          profileStateRegistry: expect.any(Object),
         })
       );
 
@@ -245,7 +246,7 @@ describe('tab_sync actions', () => {
 
     it('should dispatch syncLocallyPersistedTabState when tabState observable emits', async () => {
       const mockTabState$ = new Subject<
-        Pick<TabState, 'appState' | 'globalState' | 'attributes'>
+        Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
       >();
       jest
         .spyOn(createTabPersistableStateObservableModule, 'createTabPersistableStateObservable')
@@ -264,8 +265,8 @@ describe('tab_sync actions', () => {
       // Clear any calls that happened during initialization
       syncLocallyPersistedTabStateSpy.mockClear();
 
-      const { appState, globalState, attributes } = getCurrentTab();
-      const nextState = { appState, globalState, attributes };
+      const { appState, globalState, attributes, profileState } = getCurrentTab();
+      const nextState = { appState, globalState, attributes, profileState };
 
       // Emit a state change
       mockTabState$.next(nextState);
@@ -276,7 +277,7 @@ describe('tab_sync actions', () => {
 
     it('should unsubscribe from tabStateSubscription when stopSyncing is called', async () => {
       const mockTabState$ = new Subject<
-        Pick<TabState, 'appState' | 'globalState' | 'attributes'>
+        Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
       >();
       jest
         .spyOn(createTabPersistableStateObservableModule, 'createTabPersistableStateObservable')

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_sync.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_sync.ts
@@ -225,6 +225,7 @@ export const initializeAndSync: InternalStateThunkActionCreator<[TabActionPayloa
       tabId,
       internalState$: getInternalState$(),
       getState,
+      profileStateRegistry: services.profileStateRegistry,
     }).subscribe(() => {
       dispatch(
         internalStateActions.syncLocallyPersistedTabState({

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_sync.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tab_sync.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { combineLatest, merge, skip, startWith } from 'rxjs';
+import { combineLatest, distinctUntilChanged, merge, skip, startWith } from 'rxjs';
+import { isEqual } from 'lodash';
 import {
   connectToQueryState,
   noSearchSessionStorageCapabilityMessage,
@@ -20,12 +21,17 @@ import { selectTabRuntimeState } from '../runtime_state';
 import { addLog } from '../../../../../utils/add_log';
 import { internalStateActions } from '..';
 import { type DiscoverAppState } from '../types';
-import { APP_STATE_URL_KEY, GLOBAL_STATE_URL_KEY } from '../../../../../../common/constants';
+import {
+  APP_STATE_URL_KEY,
+  GLOBAL_STATE_URL_KEY,
+  PROFILE_STATE_URL_KEY,
+} from '../../../../../../common/constants';
 import { getCurrentUrlState } from '../../utils/cleanup_url_state';
 import { buildStateSubscribe } from '../../utils/build_state_subscribe';
 import { createUrlSyncObservables } from '../../utils/create_url_sync_observables';
 import { createTabPersistableStateObservable } from '../../utils/create_tab_persistable_state_observable';
 import { createSearchSessionRestorationDataProvider } from '../../utils/create_search_session_restoration_data_provider';
+import type { DiscoverProfileUrlState } from '../../../../../../common';
 import { getFieldsToReset } from '../../utils/default_profile_state';
 import {
   createDataViewDataSource,
@@ -50,11 +56,19 @@ export const initializeAndSync: InternalStateThunkActionCreator<[TabActionPayloa
     }
 
     dispatch(stopSyncing({ tabId }));
-    const { appState$, createAppStateContainer, globalStateContainer } = createUrlSyncObservables({
+    const {
+      appState$,
+      createAppStateContainer,
+      globalStateContainer,
+      profileUrlState$,
+      setProfileUrlStateFromUrl,
+    } = createUrlSyncObservables({
       tabId,
       dispatch,
       getState,
       internalState$: getInternalState$(),
+      runtimeStateManager,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
     const getCurrentTab = () => selectTab(getState(), tabId);
@@ -188,6 +202,22 @@ export const initializeAndSync: InternalStateThunkActionCreator<[TabActionPayloa
           stateStorage: urlStateStorage,
         });
 
+      const profileUrlStateSubscription = profileUrlState$.subscribe((profileUrlState) => {
+        const currentProfileUrlState =
+          urlStateStorage.get<DiscoverProfileUrlState>(PROFILE_STATE_URL_KEY);
+
+        if (!isEqual(profileUrlState, currentProfileUrlState)) {
+          void urlStateStorage.set(PROFILE_STATE_URL_KEY, profileUrlState, { replace: true });
+        }
+      });
+
+      const urlProfileStateSubscription = urlStateStorage
+        .change$<DiscoverProfileUrlState>(PROFILE_STATE_URL_KEY)
+        .pipe(distinctUntilChanged((a, b) => isEqual(a, b)))
+        .subscribe((profileUrlState) => {
+          setProfileUrlStateFromUrl(profileUrlState);
+        });
+
       // current state needs to be pushed to url
       dispatch(internalStateActions.pushCurrentTabStateToUrl({ tabId })).then(() => {
         startSyncingAppStateWithUrl();
@@ -199,6 +229,8 @@ export const initializeAndSync: InternalStateThunkActionCreator<[TabActionPayloa
         stopSyncingQueryGlobalStateWithStateContainer();
         stopSyncingAppStateWithUrl();
         stopSyncingGlobalStateWithUrl();
+        profileUrlStateSubscription.unsubscribe();
+        urlProfileStateSubscription.unsubscribe();
         cpsProjectRoutingSubscription?.unsubscribe();
       };
     };
@@ -250,6 +282,7 @@ export const initializeAndSync: InternalStateThunkActionCreator<[TabActionPayloa
     services.data.search.session.enableStorage(
       createSearchSessionRestorationDataProvider({
         data: services.data,
+        profileStateRegistry: services.profileStateRegistry,
         getPersistedDiscoverSession: () => getState().persistedDiscoverSession,
         getCurrentTab,
         getCurrentTabRuntimeState: () => selectTabRuntimeState(runtimeStateManager, tabId),

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -36,12 +36,14 @@ import {
   APP_STATE_URL_KEY,
   GLOBAL_STATE_URL_KEY,
   NEW_TAB_ID,
+  PROFILE_STATE_URL_KEY,
 } from '../../../../../../common/constants';
 import { createInternalStateAsyncThunk, createTabItem } from '../utils';
 import { setBreadcrumbs } from '../../../../../utils/breadcrumbs';
 import { DEFAULT_TAB_STATE } from '../constants';
 import type { DiscoverAppLocatorParams } from '../../../../../../common';
 import { parseAppLocatorParams } from '../../../../../../common/app_locator_get_location';
+import { getProfileUrlState } from '../../utils/get_profile_url_state';
 import { fetchData } from './tab_state';
 import { fromSavedObjectTabToTabState } from '../tab_mapping_utils';
 import { initializeAndSync, stopSyncing } from './tab_sync';
@@ -254,6 +256,16 @@ export const updateTabs: InternalStateThunkActionCreator<
       if (nextTab && nextTabDataStateContainer) {
         const { timeRange, refreshInterval, filters: globalFilters } = nextTab.globalState;
         const { filters: appFilters, query } = nextTab.appState;
+        const profileStateDefinition = nextTabRuntimeState?.scopedProfilesManager$
+          .getValue()
+          .getContexts().dataSourceContext.profileState;
+        const profileUrlState = profileStateDefinition
+          ? getProfileUrlState({
+              definition: profileStateDefinition,
+              profileState: nextTab.profileState,
+              profileStateRegistry: services.profileStateRegistry,
+            }) ?? null
+          : null;
 
         await Promise.all([
           urlStateStorage.set<QueryState>(
@@ -268,6 +280,7 @@ export const updateTabs: InternalStateThunkActionCreator<
           urlStateStorage.set<DiscoverAppState>(APP_STATE_URL_KEY, nextTab.appState, {
             replace: true,
           }),
+          urlStateStorage.set(PROFILE_STATE_URL_KEY, profileUrlState, { replace: true }),
         ]);
 
         services.timefilter.setTime(timeRange ?? services.timefilter.getTimeDefaults());
@@ -305,6 +318,7 @@ export const updateTabs: InternalStateThunkActionCreator<
         await Promise.all([
           urlStateStorage.set(GLOBAL_STATE_URL_KEY, null, { replace: true }),
           urlStateStorage.set(APP_STATE_URL_KEY, null, { replace: true }),
+          urlStateStorage.set(PROFILE_STATE_URL_KEY, null, { replace: true }),
         ]);
         searchSessionManager.removeSearchSessionIdFromURL({ replace: true });
         services.data.search.session.reset();

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -43,6 +43,7 @@ export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
     fieldsToReset: 'none',
     snapshotsByProfileId: {},
   },
+  profileState: {},
   expandedDoc: undefined,
   expandedDocOwner: undefined,
   renderDocumentViewMeta: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -14,6 +14,7 @@ export const DEFAULT_EXPANDED_DOC_OWNER = 'discover_main_grid';
 
 export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
   initializationState: { initializationStatus: TabInitializationStatus.NotStarted },
+  initialProfileUrlState: undefined,
   globalState: {},
   appState: {},
   previousAppState: {},

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/context_awareness_toolkit.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/context_awareness_toolkit.test.ts
@@ -40,7 +40,11 @@ describe('createContextAwarenessToolkit', () => {
       }),
     });
 
-    return { internalState: toolkit.internalState, tabId: persistedTab.id };
+    return {
+      internalState: toolkit.internalState,
+      stateRegistry: services.profileStateRegistry,
+      tabId: persistedTab.id,
+    };
   };
 
   beforeEach(() => {
@@ -48,22 +52,28 @@ describe('createContextAwarenessToolkit', () => {
   });
 
   it('wires updateESQLQuery to updateESQLQuery action with tab id', async () => {
-    const { internalState, tabId } = await setup();
+    const { internalState, stateRegistry, tabId } = await setup();
     const updateEsqlQuerySpy = jest.spyOn(internalStateActions, 'updateESQLQuery');
     const queryOrUpdater = 'FROM logs-*';
 
-    createContextAwarenessToolkit({ internalState, tabId }).actions.updateESQLQuery?.(
-      queryOrUpdater
-    );
+    createContextAwarenessToolkit({
+      internalState,
+      stateRegistry,
+      tabId,
+    }).actions.updateESQLQuery?.(queryOrUpdater);
 
     expect(updateEsqlQuerySpy).toHaveBeenCalledWith({ tabId, queryOrUpdater });
   });
 
   it('wires addFilter to addFilter action with tab id', async () => {
-    const { internalState, tabId } = await setup();
+    const { internalState, stateRegistry, tabId } = await setup();
     const addFilterSpy = jest.spyOn(internalStateActions, 'addFilter');
 
-    createContextAwarenessToolkit({ internalState, tabId }).actions.addFilter?.('status', 200, '+');
+    createContextAwarenessToolkit({ internalState, stateRegistry, tabId }).actions.addFilter?.(
+      'status',
+      200,
+      '+'
+    );
 
     expect(addFilterSpy).toHaveBeenCalledWith({
       tabId,
@@ -74,12 +84,15 @@ describe('createContextAwarenessToolkit', () => {
   });
 
   it('maps setExpandedDoc options.initialTabId to initialDocViewerTabId', async () => {
-    const { internalState, tabId } = await setup();
+    const { internalState, stateRegistry, tabId } = await setup();
     const setExpandedDocSpy = jest.spyOn(internalStateActions, 'setExpandedDoc');
 
-    createContextAwarenessToolkit({ internalState, tabId }).actions.setExpandedDoc?.(undefined, {
-      initialTabId: 'overview',
-    });
+    createContextAwarenessToolkit({ internalState, stateRegistry, tabId }).actions.setExpandedDoc?.(
+      undefined,
+      {
+        initialTabId: 'overview',
+      }
+    );
 
     expect(setExpandedDocSpy).toHaveBeenCalledWith({
       tabId,
@@ -89,7 +102,7 @@ describe('createContextAwarenessToolkit', () => {
   });
 
   it('dispatches openInNewTab through openInNewTabExtPointAction', async () => {
-    const { internalState, tabId } = await setup();
+    const { internalState, stateRegistry, tabId } = await setup();
     const openInNewTabSpy = jest.spyOn(internalStateActions, 'openInNewTabExtPointAction');
     const params = {
       query: { esql: 'FROM logs-*' },
@@ -97,28 +110,32 @@ describe('createContextAwarenessToolkit', () => {
       tabLabel: 'Logs',
     };
 
-    createContextAwarenessToolkit({ internalState, tabId }).actions.openInNewTab?.(params);
+    createContextAwarenessToolkit({ internalState, stateRegistry, tabId }).actions.openInNewTab?.(
+      params
+    );
 
     expect(openInNewTabSpy).toHaveBeenCalledWith(params);
   });
 
   it('dispatches refreshData through fetchData with tab id', async () => {
-    const { internalState, tabId } = await setup();
+    const { internalState, stateRegistry, tabId } = await setup();
     const fetchDataSpy = jest.spyOn(internalStateActions, 'fetchData');
 
-    createContextAwarenessToolkit({ internalState, tabId }).actions.refreshData?.();
+    createContextAwarenessToolkit({ internalState, stateRegistry, tabId }).actions.refreshData?.();
 
     expect(fetchDataSpy).toHaveBeenCalledWith({ tabId });
   });
 
   it('awaits updateAdHocDataViews dispatch', async () => {
-    const { internalState, tabId } = await setup();
+    const { internalState, stateRegistry, tabId } = await setup();
     const updateAdHocDataViewsSpy = jest.spyOn(internalStateActions, 'updateAdHocDataViews');
     const adHocDataViews = [dataViewMockWithTimeField];
 
-    await createContextAwarenessToolkit({ internalState, tabId }).actions.updateAdHocDataViews?.(
-      adHocDataViews
-    );
+    await createContextAwarenessToolkit({
+      internalState,
+      stateRegistry,
+      tabId,
+    }).actions.updateAdHocDataViews?.(adHocDataViews);
 
     expect(updateAdHocDataViewsSpy).toHaveBeenCalledWith(adHocDataViews);
   });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/context_awareness_toolkit.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/context_awareness_toolkit.ts
@@ -14,7 +14,7 @@ import { internalStateActions } from '.';
 import { selectTab } from './selectors';
 import type {
   ProfileStateAdapter,
-  ProfileStateKey,
+  ProfileStateDefinition,
   ProfileStateRegistry,
 } from '../../../../context_awareness';
 
@@ -56,16 +56,18 @@ export const createContextAwarenessToolkit = ({
         );
       },
     },
-    getStateAdapter: <TState extends object>(key: ProfileStateKey<TState>) => {
-      if (stateAdapters.has(key.rawKey)) {
-        return stateAdapters.get(key.rawKey) as unknown as ProfileStateAdapter<TState>;
+    getStateAdapter: <TState extends object>(definition: ProfileStateDefinition<TState>) => {
+      if (!stateRegistry.hasDefinition(definition)) {
+        throw new Error(`State with key ${definition.key} is not registered.`);
       }
 
-      stateRegistry.getDefinition(key);
+      if (stateAdapters.has(definition.key)) {
+        return stateAdapters.get(definition.key) as unknown as ProfileStateAdapter<TState>;
+      }
 
       const getState = () => {
         const tabState = selectTab(internalState.getState(), tabId);
-        return (tabState?.profileState[key.rawKey] ?? {}) as TState;
+        return (tabState?.profileState[definition.key] ?? {}) as TState;
       };
 
       const state$ = from(internalState).pipe(map(getState), distinctUntilChanged());
@@ -75,21 +77,21 @@ export const createContextAwarenessToolkit = ({
         getState$: () => state$,
         setState: (profileState, _options) => {
           internalState.dispatch(
-            internalStateActions.setProfileState({ tabId, key: key.rawKey, profileState })
+            internalStateActions.setProfileState({ tabId, key: definition.key, profileState })
           );
         },
         updateState: (stateUpdate, _options) => {
           internalState.dispatch(
             internalStateActions.setProfileState({
               tabId,
-              key: key.rawKey,
+              key: definition.key,
               profileState: { ...getState(), ...stateUpdate },
             })
           );
         },
       };
 
-      stateAdapters.set(key.rawKey, adapter as unknown as ProfileStateAdapter<object>);
+      stateAdapters.set(definition.key, adapter as unknown as ProfileStateAdapter<object>);
 
       return adapter;
     },

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/context_awareness_toolkit.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/context_awareness_toolkit.ts
@@ -7,17 +7,28 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { distinctUntilChanged, from, map } from 'rxjs';
 import type { ContextAwarenessToolkit } from '../../../../context_awareness/toolkit';
 import type { InternalStateStore } from './internal_state';
 import { internalStateActions } from '.';
+import { selectTab } from './selectors';
+import type {
+  ProfileStateAdapter,
+  ProfileStateKey,
+  ProfileStateRegistry,
+} from '../../../../context_awareness';
 
 export const createContextAwarenessToolkit = ({
   internalState,
+  stateRegistry,
   tabId,
 }: {
   internalState: InternalStateStore;
+  stateRegistry: ProfileStateRegistry;
   tabId: string;
 }): ContextAwarenessToolkit => {
+  const stateAdapters = new Map<string, ProfileStateAdapter<object>>();
+
   return {
     actions: {
       openInNewTab: async (params) => {
@@ -44,6 +55,43 @@ export const createContextAwarenessToolkit = ({
           })
         );
       },
+    },
+    getStateAdapter: <TState extends object>(key: ProfileStateKey<TState>) => {
+      if (stateAdapters.has(key.rawKey)) {
+        return stateAdapters.get(key.rawKey) as unknown as ProfileStateAdapter<TState>;
+      }
+
+      stateRegistry.getDefinition(key);
+
+      const getState = () => {
+        const tabState = selectTab(internalState.getState(), tabId);
+        return (tabState?.profileState[key.rawKey] ?? {}) as TState;
+      };
+
+      const state$ = from(internalState).pipe(map(getState), distinctUntilChanged());
+
+      const adapter: ProfileStateAdapter<TState> = {
+        getState,
+        getState$: () => state$,
+        setState: (profileState, _options) => {
+          internalState.dispatch(
+            internalStateActions.setProfileState({ tabId, key: key.rawKey, profileState })
+          );
+        },
+        updateState: (stateUpdate, _options) => {
+          internalState.dispatch(
+            internalStateActions.setProfileState({
+              tabId,
+              key: key.rawKey,
+              profileState: { ...getState(), ...stateUpdate },
+            })
+          );
+        },
+      };
+
+      stateAdapters.set(key.rawKey, adapter as unknown as ProfileStateAdapter<object>);
+
+      return adapter;
     },
   };
 };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.test.ts
@@ -36,6 +36,7 @@ describe('InternalStateStore', () => {
     const tabsStorageManager = createTabsStorageManager({
       urlStateStorage,
       storage: services.storage,
+      profileStateRegistry: services.profileStateRegistry,
     });
     const store = createInternalStateStore({
       services,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -669,6 +669,7 @@ const createMiddleware = (options: InternalStateDependencies) => {
             attributes: tab.attributes,
             appState: tab.appState,
             globalState: tab.globalState,
+            profileState: tab.profileState,
           });
         });
       },

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -429,6 +429,11 @@ export const internalStateSlice = createSlice({
         };
       }),
 
+    setProfileState: (state, action: TabAction<{ key: string; profileState: object }>) =>
+      withTab(state, { tabId: state.tabs.unsafeCurrentId }, (tab) => {
+        tab.profileState[action.payload.key] = action.payload.profileState;
+      }),
+
     resetOnSavedSearchChange: (state, action: TabAction) =>
       withTab(state, action.payload, (tab) => {
         tab.overriddenVisContextAfterInvalidation = undefined;
@@ -758,6 +763,7 @@ export const createInternalStateStore = (
     getContextAwarenessToolkit: (tabId: string) => {
       return createContextAwarenessToolkit({
         internalState,
+        stateRegistry: options.services.profileStateRegistry,
         tabId,
       });
     },

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -429,6 +429,14 @@ export const internalStateSlice = createSlice({
         };
       }),
 
+    setInitialProfileUrlState: (
+      state,
+      action: TabAction<Pick<TabState, 'initialProfileUrlState'>>
+    ) =>
+      withTab(state, action.payload, (tab) => {
+        tab.initialProfileUrlState = action.payload.initialProfileUrlState;
+      }),
+
     setProfileState: (state, action: TabAction<{ key: string; profileState: object }>) =>
       withTab(state, { tabId: state.tabs.unsafeCurrentId }, (tab) => {
         tab.profileState[action.payload.key] = action.payload.profileState;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -204,6 +204,7 @@ export interface TabState extends TabItem {
   dataRequestParams: InternalStateDataRequestParams;
   overriddenVisContextAfterInvalidation: UnifiedHistogramVisContext | {} | undefined; // it will be used during saving of the Discover Session
   defaultProfileState: DefaultProfileState;
+  profileState: Record<string, object | undefined>;
   uiState: {
     esqlEditor?: Partial<ESQLEditorRestorableState>;
     dataGrid?: Partial<UnifiedDataTableRestorableState>;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -33,6 +33,7 @@ import type { DocViewerRestorableState } from '@kbn/unified-doc-viewer';
 import type { SerializedError } from '@reduxjs/toolkit';
 import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
 import type { DataCascadeRestorableState } from '@kbn/shared-ux-document-data-cascade';
+import type { DiscoverProfileUrlState } from '../../../../../common';
 import type { DiscoverDataSource } from '../../../../../common/data_sources';
 import type { DiscoverLayoutRestorableState } from '../../components/layout/discover_layout_restorable_state';
 import type { DefaultEsqlQueryConfig } from '../../../../context_awareness';
@@ -185,6 +186,7 @@ export interface TabState extends TabItem {
     serializedSearchSource?: SerializedSearchSourceFields;
     searchSessionId?: string;
   };
+  initialProfileUrlState?: DiscoverProfileUrlState;
 
   // Persistable attributes of the tab (stored in Discover Session and in local storage).
   attributes: {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.test.tsx
@@ -102,6 +102,7 @@ describe('TabsStorageManager', () => {
       tabsStorageManager: createTabsStorageManager({
         urlStateStorage,
         storage: services.storage,
+        profileStateRegistry: services.profileStateRegistry,
         enabled: true,
       }),
     };
@@ -116,6 +117,7 @@ describe('TabsStorageManager', () => {
     attributes: tab.attributes,
     appState: tab.appState,
     globalState: tab.globalState,
+    profileState: tab.profileState,
     ...('closedAt' in tab ? { closedAt: tab.closedAt } : {}),
   });
 
@@ -625,6 +627,7 @@ describe('TabsStorageManager', () => {
       globalState: {
         refreshInterval: { pause: false, value: 300 },
       },
+      profileState: mockTab1.profileState,
     };
 
     tabsStorageManager.updateTabStateLocally(mockTab1.id, updatedTabState);

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.ts
@@ -16,6 +16,8 @@ import {
 } from '@kbn/kibana-utils-plugin/public';
 import type { TabItem } from '@kbn/unified-tabs';
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
+import type { ProfileStateRegistry } from '../../../context_awareness';
+import { ProfileStateType } from '../../../context_awareness';
 import { NEW_TAB_ID, TAB_STATE_URL_KEY } from '../../../../common/constants';
 import {
   createTabItem,
@@ -36,6 +38,7 @@ export type TabStateInLocalStorage = Pick<TabState, 'id' | 'label'> & {
   attributes: TabState['attributes'] | undefined;
   appState: DiscoverAppState | undefined;
   globalState: TabState['globalState'] | undefined;
+  profileState: TabState['profileState'] | undefined;
 };
 
 type RecentlyClosedTabStateInLocalStorage = TabStateInLocalStorage &
@@ -78,7 +81,7 @@ export interface TabsStorageManager {
     tabId: string,
     tabState: Pick<
       TabStateInLocalStorage,
-      'internalState' | 'attributes' | 'appState' | 'globalState'
+      'internalState' | 'attributes' | 'appState' | 'globalState' | 'profileState'
     >
   ) => void;
   loadLocally: (props: {
@@ -99,10 +102,12 @@ export interface TabsStorageManager {
 export const createTabsStorageManager = ({
   urlStateStorage,
   storage,
+  profileStateRegistry,
   enabled,
 }: {
   urlStateStorage: IKbnUrlStateStorage;
   storage: Storage;
+  profileStateRegistry: ProfileStateRegistry;
   enabled?: boolean;
 }): TabsStorageManager => {
   const urlStateContainer = createStateContainer<TabsUrlState>({});
@@ -191,6 +196,7 @@ export const createTabsStorageManager = ({
       attributes: tabState.attributes,
       appState: tabState.appState,
       globalState: tabState.globalState,
+      profileState: getPersistentProfileState(tabState.profileState),
     };
   };
 
@@ -211,6 +217,17 @@ export const createTabsStorageManager = ({
     return state;
   };
 
+  const getPersistentProfileState = (
+    profileState: TabState['profileState'] | undefined
+  ): TabState['profileState'] | undefined => {
+    return getDefinedStateOnly(
+      profileStateRegistry.pickStateByType({
+        profileState: profileState ?? {},
+        stateType: ProfileStateType.Persistent,
+      })
+    );
+  };
+
   const toTabState = (
     tabStateInStorage: TabStateInLocalStorage,
     defaultTabState: Omit<TabState, keyof TabItem>
@@ -221,6 +238,7 @@ export const createTabsStorageManager = ({
     const globalState = getDefinedStateOnly(
       tabStateInStorage.globalState || defaultTabState.globalState
     );
+    const profileState = getPersistentProfileState(tabStateInStorage.profileState);
 
     let controlGroupState = attributes?.controlGroupState
       ? parseControlGroupJson(JSON.stringify(attributes.controlGroupState))
@@ -251,6 +269,10 @@ export const createTabsStorageManager = ({
       },
       appState: appState || {},
       globalState: globalState || {},
+      profileState: {
+        ...defaultTabState.profileState,
+        ...profileState,
+      },
       esqlVariables,
     };
 
@@ -375,6 +397,7 @@ export const createTabsStorageManager = ({
             attributes: tabStatePartial.attributes,
             appState: tabStatePartial.appState,
             globalState: tabStatePartial.globalState,
+            profileState: getPersistentProfileState(tabStatePartial.profileState),
           };
         }
         return tab;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_search_session_restoration_data_provider.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_search_session_restoration_data_provider.ts
@@ -10,11 +10,14 @@
 import { i18n } from '@kbn/i18n';
 import type { DataPublicPluginStart, SearchSessionInfoProvider } from '@kbn/data-plugin/public';
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
+import type { ProfileStateRegistry } from '../../../../context_awareness';
 import type { ReactiveTabRuntimeState, TabState } from '../redux';
 import { DISCOVER_APP_LOCATOR, type DiscoverAppLocatorParams } from '../../../../../common';
+import { getProfileUrlState } from './get_profile_url_state';
 
 export function createSearchSessionRestorationDataProvider(deps: {
   data: DataPublicPluginStart;
+  profileStateRegistry?: ProfileStateRegistry;
   getPersistedDiscoverSession: () => DiscoverSession | undefined;
   getCurrentTab: () => TabState;
   getCurrentTabRuntimeState: () => ReactiveTabRuntimeState;
@@ -49,16 +52,32 @@ function createUrlGeneratorState({
   getPersistedDiscoverSession,
   getCurrentTab,
   getCurrentTabRuntimeState,
+  profileStateRegistry,
   shouldRestoreSearchSession,
 }: {
   data: DataPublicPluginStart;
+  profileStateRegistry?: ProfileStateRegistry;
   getPersistedDiscoverSession: () => DiscoverSession | undefined;
   getCurrentTab: () => TabState;
   getCurrentTabRuntimeState: () => ReactiveTabRuntimeState;
   shouldRestoreSearchSession: boolean;
 }): DiscoverAppLocatorParams {
-  const appState = getCurrentTab().appState;
-  const dataView = getCurrentTabRuntimeState().currentDataView$.getValue();
+  const currentTab = getCurrentTab();
+  const appState = currentTab.appState;
+  const currentTabRuntimeState = getCurrentTabRuntimeState();
+  const dataView = currentTabRuntimeState.currentDataView$.getValue();
+  const activeProfileStateDefinition = currentTabRuntimeState.scopedProfilesManager$
+    .getValue()
+    .getContexts().dataSourceContext.profileState;
+  const profileUrlState =
+    activeProfileStateDefinition && profileStateRegistry
+      ? getProfileUrlState({
+          definition: activeProfileStateDefinition,
+          profileState: currentTab.profileState,
+          profileStateRegistry,
+        })
+      : undefined;
+
   return {
     filters: data.query.filterManager.getFilters(),
     dataViewId: dataView?.id,
@@ -83,6 +102,7 @@ function createUrlGeneratorState({
     viewMode: appState.viewMode,
     hideAggregatedPreview: appState.hideAggregatedPreview,
     breakdownField: appState.breakdownField,
+    profileUrlState,
     dataViewSpec: !dataView?.isPersisted() ? dataView?.toMinimalSpec() : undefined,
     ...(shouldRestoreSearchSession
       ? {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_tab_persistable_state_observable.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_tab_persistable_state_observable.test.ts
@@ -69,27 +69,31 @@ describe('createTabPersistableStateObservable', () => {
   };
 
   it('should create an observable that emits tab persistable state', async () => {
-    const { internalState, internalState$, tabId } = await setup();
+    const { internalState, internalState$, tabId, services } = await setup();
 
     const observable$ = createTabPersistableStateObservable({
       tabId,
       internalState$,
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
     expect(observable$).toBeDefined();
   });
 
   it('should skip the first emission due to skip(1)', async () => {
-    const { internalState, internalState$, tabId } = await setup();
+    const { internalState, internalState$, tabId, services } = await setup();
 
     const observable$ = createTabPersistableStateObservable({
       tabId,
       internalState$,
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
-    const emittedValues: Array<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> = [];
+    const emittedValues: Array<
+      Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
+    > = [];
     const subscription = observable$.subscribe((value) => {
       emittedValues.push(value);
     });
@@ -101,15 +105,18 @@ describe('createTabPersistableStateObservable', () => {
   });
 
   it('should emit when appState changes', async () => {
-    const { internalState, internalState$, tabId } = await setup();
+    const { internalState, internalState$, tabId, services } = await setup();
 
     const observable$ = createTabPersistableStateObservable({
       tabId,
       internalState$,
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
-    const emittedValues: Array<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> = [];
+    const emittedValues: Array<
+      Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
+    > = [];
     const subscription = observable$.subscribe((value) => {
       emittedValues.push(value);
     });
@@ -129,15 +136,18 @@ describe('createTabPersistableStateObservable', () => {
   });
 
   it('should emit when globalState changes', async () => {
-    const { internalState, internalState$, tabId } = await setup();
+    const { internalState, internalState$, tabId, services } = await setup();
 
     const observable$ = createTabPersistableStateObservable({
       tabId,
       internalState$,
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
-    const emittedValues: Array<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> = [];
+    const emittedValues: Array<
+      Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
+    > = [];
     const subscription = observable$.subscribe((value) => {
       emittedValues.push(value);
     });
@@ -159,15 +169,18 @@ describe('createTabPersistableStateObservable', () => {
   });
 
   it('should emit when attributes change', async () => {
-    const { internalState, internalState$, tabId } = await setup();
+    const { internalState, internalState$, tabId, services } = await setup();
 
     const observable$ = createTabPersistableStateObservable({
       tabId,
       internalState$,
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
-    const emittedValues: Array<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> = [];
+    const emittedValues: Array<
+      Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
+    > = [];
     const subscription = observable$.subscribe((value) => {
       emittedValues.push(value);
     });
@@ -187,15 +200,18 @@ describe('createTabPersistableStateObservable', () => {
   });
 
   it('should not emit when state has not changed (distinctUntilChanged)', async () => {
-    const { internalState, internalState$, tabId } = await setup();
+    const { internalState, internalState$, tabId, services } = await setup();
 
     const observable$ = createTabPersistableStateObservable({
       tabId,
       internalState$,
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
-    const emittedValues: Array<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> = [];
+    const emittedValues: Array<
+      Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
+    > = [];
     const subscription = observable$.subscribe((value) => {
       emittedValues.push(value);
     });
@@ -216,16 +232,19 @@ describe('createTabPersistableStateObservable', () => {
     subscription.unsubscribe();
   });
 
-  it('should emit only the picked properties (appState, globalState, attributes)', async () => {
-    const { internalState, internalState$, tabId } = await setup();
+  it('should emit only the picked properties (appState, globalState, attributes, profileState)', async () => {
+    const { internalState, internalState$, tabId, services } = await setup();
 
     const observable$ = createTabPersistableStateObservable({
       tabId,
       internalState$,
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
-    const emittedValues: Array<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> = [];
+    const emittedValues: Array<
+      Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
+    > = [];
     const subscription = observable$.subscribe((value) => {
       emittedValues.push(value);
     });
@@ -244,6 +263,7 @@ describe('createTabPersistableStateObservable', () => {
     expect(emittedState).toHaveProperty('appState');
     expect(emittedState).toHaveProperty('globalState');
     expect(emittedState).toHaveProperty('attributes');
+    expect(emittedState).toHaveProperty('profileState');
 
     // Should not have other TabState properties
     expect(emittedState).not.toHaveProperty('id');
@@ -254,15 +274,18 @@ describe('createTabPersistableStateObservable', () => {
   });
 
   it('should emit multiple times for multiple distinct changes', async () => {
-    const { internalState, internalState$, tabId } = await setup();
+    const { internalState, internalState$, tabId, services } = await setup();
 
     const observable$ = createTabPersistableStateObservable({
       tabId,
       internalState$,
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     });
 
-    const emittedValues: Array<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> = [];
+    const emittedValues: Array<
+      Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>
+    > = [];
     const subscription = observable$.subscribe((value) => {
       emittedValues.push(value);
     });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_tab_persistable_state_observable.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_tab_persistable_state_observable.ts
@@ -9,6 +9,8 @@
 
 import { isEqual } from 'lodash';
 import { distinctUntilChanged, map, type Observable, skip } from 'rxjs';
+import type { ProfileStateRegistry } from '../../../../context_awareness';
+import { ProfileStateType } from '../../../../context_awareness';
 import { type DiscoverInternalState, selectTab, type TabState } from '../redux';
 import { isEqualState } from './state_comparators';
 
@@ -16,18 +18,27 @@ export const createTabPersistableStateObservable = ({
   tabId,
   internalState$,
   getState,
+  profileStateRegistry,
 }: {
   tabId: string;
   internalState$: Observable<DiscoverInternalState>;
   getState: () => DiscoverInternalState;
-}): Observable<Pick<TabState, 'appState' | 'globalState' | 'attributes'>> => {
-  const getTabState = (): Pick<TabState, 'appState' | 'globalState' | 'attributes'> => {
+  profileStateRegistry: ProfileStateRegistry;
+}): Observable<Pick<TabState, 'appState' | 'globalState' | 'attributes' | 'profileState'>> => {
+  const getTabState = (): Pick<
+    TabState,
+    'appState' | 'globalState' | 'attributes' | 'profileState'
+  > => {
     const tabState = selectTab(getState(), tabId);
 
     return {
       appState: tabState.appState,
       globalState: tabState.globalState,
       attributes: tabState.attributes,
+      profileState: profileStateRegistry.pickStateByType({
+        profileState: tabState.profileState,
+        stateType: ProfileStateType.Persistent,
+      }),
     };
   };
 
@@ -37,7 +48,8 @@ export const createTabPersistableStateObservable = ({
       (a, b) =>
         isEqualState(a.appState, b.appState) &&
         isEqualState(a.globalState, b.globalState) &&
-        isEqual(a.attributes, b.attributes)
+        isEqual(a.attributes, b.attributes) &&
+        isEqual(a.profileState, b.profileState)
     ),
     skip(1)
   );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_url_sync_observables.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_url_sync_observables.test.ts
@@ -42,6 +42,8 @@ describe('createUrlSyncObservables', () => {
         dispatch: toolkit.internalState.dispatch,
         getState: toolkit.internalState.getState,
         internalState$: from(toolkit.internalState),
+        runtimeStateManager: toolkit.runtimeStateManager,
+        profileStateRegistry: services.profileStateRegistry,
       }),
       internalState: toolkit.internalState,
       runtimeStateManager: toolkit.runtimeStateManager,
@@ -56,6 +58,8 @@ describe('createUrlSyncObservables', () => {
     expect(result.appState$).toBeDefined();
     expect(result.createAppStateContainer).toBeDefined();
     expect(result.globalStateContainer).toBeDefined();
+    expect(result.profileUrlState$).toBeDefined();
+    expect(result.setProfileUrlStateFromUrl).toBeDefined();
   });
 
   it('should allow appStateContainer to get and set app state', async () => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_url_sync_observables.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/create_url_sync_observables.ts
@@ -12,15 +12,24 @@ import { isEqual } from 'lodash';
 import { type GlobalQueryStateFromUrl } from '@kbn/data-plugin/public';
 import { type INullableBaseStateContainer } from '@kbn/kibana-utils-plugin/public';
 import type { AnyAction, ThunkDispatch } from '@reduxjs/toolkit';
+import type { DiscoverProfileUrlState } from '../../../../../common';
+import type { ProfileStateRegistry } from '../../../../context_awareness';
 import {
   internalStateActions,
   selectTab,
   selectTabAppState,
+  selectTabRuntimeState,
   type DiscoverAppState,
   type DiscoverInternalState,
   type InternalStateDependencies,
+  type RuntimeStateManager,
 } from '../redux';
 import { createTabAppStateObservable } from './create_tab_app_state_observable';
+import {
+  getCurrentTabProfileUrlState,
+  getProfileStateWithoutUrlFields,
+  getRestoredProfileUrlState,
+} from './get_profile_url_state';
 
 /**
  * Create observables and state containers for 2-directional syncing of appState and globalState with the URL
@@ -30,11 +39,15 @@ export const createUrlSyncObservables = ({
   dispatch,
   getState,
   internalState$,
+  runtimeStateManager,
+  profileStateRegistry,
 }: {
   tabId: string;
   dispatch: ThunkDispatch<DiscoverInternalState, InternalStateDependencies, AnyAction>;
   getState: () => DiscoverInternalState;
   internalState$: Observable<DiscoverInternalState>;
+  runtimeStateManager: RuntimeStateManager;
+  profileStateRegistry: ProfileStateRegistry;
 }) => {
   const getAppState = (): DiscoverAppState => {
     return selectTabAppState(getState(), tabId);
@@ -96,9 +109,67 @@ export const createUrlSyncObservables = ({
     state$: globalState$,
   };
 
+  const getProfileUrlState = (): DiscoverProfileUrlState | null => {
+    return (
+      getCurrentTabProfileUrlState({
+        getState,
+        runtimeStateManager,
+        profileStateRegistry,
+        tabId,
+      }) ?? null
+    );
+  };
+
+  const profileUrlState$ = internalState$.pipe(
+    map(getProfileUrlState),
+    distinctUntilChanged((a, b) => isEqual(a, b)),
+    skip(1)
+  );
+
+  const setProfileUrlStateFromUrl = (profileUrlState: DiscoverProfileUrlState | null) => {
+    const currentTab = selectTab(getState(), tabId);
+    const definition = selectTabRuntimeState(runtimeStateManager, tabId)
+      ?.scopedProfilesManager$.getValue()
+      .getContexts().dataSourceContext.profileState;
+
+    if (!currentTab || !definition) {
+      return;
+    }
+
+    const restoredProfileState = profileUrlState
+      ? getRestoredProfileUrlState({
+          definition,
+          profileStateRegistry,
+          profileUrlState,
+        })
+      : undefined;
+
+    const nextProfileState = {
+      ...getProfileStateWithoutUrlFields({
+        definition,
+        profileState: currentTab.profileState[definition.key],
+      }),
+      ...restoredProfileState,
+    };
+
+    if (isEqual(currentTab.profileState[definition.key], nextProfileState)) {
+      return;
+    }
+
+    dispatch(
+      internalStateActions.setProfileState({
+        tabId,
+        key: definition.key,
+        profileState: nextProfileState,
+      })
+    );
+  };
+
   return {
     appState$,
     createAppStateContainer,
     globalStateContainer,
+    profileUrlState$,
+    setProfileUrlStateFromUrl,
   };
 };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_profile_url_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_profile_url_state.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Serializable, SerializableRecord } from '@kbn/utility-types';
+import type { DiscoverProfileUrlState } from '../../../../../common';
+import {
+  ProfileStateType,
+  type ProfileStateDefinition,
+  type ProfileStateRegistry,
+} from '../../../../context_awareness';
+import type { DiscoverInternalState, RuntimeStateManager, TabState } from '../redux';
+import { selectTab, selectTabRuntimeState } from '../redux';
+
+const isSerializable = (value: unknown): value is Serializable => {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(isSerializable);
+  }
+
+  if (typeof value !== 'object') {
+    return false;
+  }
+
+  return Object.values(value).every(isSerializable);
+};
+
+const isSerializableRecord = (value: unknown): value is SerializableRecord => {
+  return (
+    Boolean(value) && !Array.isArray(value) && typeof value === 'object' && isSerializable(value)
+  );
+};
+
+const getFilteredUrlProfileState = ({
+  definition,
+  profileState,
+  profileStateRegistry,
+}: {
+  definition: ProfileStateDefinition<object>;
+  profileState: TabState['profileState'];
+  profileStateRegistry: ProfileStateRegistry;
+}) => {
+  const filteredProfileState = profileStateRegistry.pickStateByType({
+    profileState,
+    stateType: ProfileStateType.Url,
+  });
+
+  const filteredUrlProfileState = filteredProfileState[definition.key];
+
+  if (!filteredUrlProfileState || Object.keys(filteredUrlProfileState).length === 0) {
+    return undefined;
+  }
+
+  if (!isSerializableRecord(filteredUrlProfileState)) {
+    return undefined;
+  }
+
+  return filteredUrlProfileState;
+};
+
+export const getProfileUrlState = ({
+  definition,
+  profileState,
+  profileStateRegistry,
+}: {
+  definition: ProfileStateDefinition<object>;
+  profileState: TabState['profileState'];
+  profileStateRegistry: ProfileStateRegistry;
+}): DiscoverProfileUrlState | undefined => {
+  const filteredUrlProfileState = getFilteredUrlProfileState({
+    definition,
+    profileState,
+    profileStateRegistry,
+  });
+
+  if (!filteredUrlProfileState) {
+    return undefined;
+  }
+
+  return {
+    [definition.key]: filteredUrlProfileState,
+  };
+};
+
+export const getProfileStateWithoutUrlFields = ({
+  definition,
+  profileState,
+}: {
+  definition: ProfileStateDefinition<object>;
+  profileState: object | undefined;
+}) => {
+  if (!profileState) {
+    return {};
+  }
+
+  const profileStateWithoutUrlFields = { ...profileState } as Record<string, unknown>;
+
+  for (const [field, fieldDefinition] of Object.entries(definition.descriptor)) {
+    if (fieldDefinition.type === ProfileStateType.Url) {
+      delete profileStateWithoutUrlFields[field];
+    }
+  }
+
+  return profileStateWithoutUrlFields;
+};
+
+export const getCurrentTabProfileUrlState = ({
+  getState,
+  runtimeStateManager,
+  profileStateRegistry,
+  tabId,
+}: {
+  getState: () => DiscoverInternalState;
+  runtimeStateManager: RuntimeStateManager;
+  profileStateRegistry: ProfileStateRegistry;
+  tabId: string;
+}): DiscoverProfileUrlState | undefined => {
+  const tab = selectTab(getState(), tabId);
+  const tabRuntimeState = selectTabRuntimeState(runtimeStateManager, tabId);
+  const definition = tabRuntimeState?.scopedProfilesManager$.getValue().getContexts()
+    .dataSourceContext.profileState;
+
+  if (!tab || !definition) {
+    return undefined;
+  }
+
+  return getProfileUrlState({
+    definition,
+    profileState: tab.profileState,
+    profileStateRegistry,
+  });
+};
+
+export const getRestoredProfileUrlState = ({
+  definition,
+  profileStateRegistry,
+  profileUrlState,
+}: {
+  definition: ProfileStateDefinition<object>;
+  profileStateRegistry: ProfileStateRegistry;
+  profileUrlState: DiscoverProfileUrlState;
+}) => {
+  const restoredProfileState = profileUrlState[definition.key];
+
+  if (!restoredProfileState) {
+    return undefined;
+  }
+
+  return getFilteredUrlProfileState({
+    definition,
+    profileState: {
+      [definition.key]: restoredProfileState,
+    },
+    profileStateRegistry,
+  });
+};

--- a/src/platform/plugins/shared/discover/public/build_services.ts
+++ b/src/platform/plugins/shared/discover/public/build_services.ts
@@ -71,7 +71,7 @@ import type { DiscoverStartPlugins } from './types';
 import type { DiscoverContextAppLocator } from './application/context/services/locator';
 import type { DiscoverSingleDocLocator } from './application/doc/locator';
 import type { DiscoverAppLocator } from '../common';
-import type { ProfilesManager } from './context_awareness';
+import { type ProfilesManager, ProfileStateRegistry } from './context_awareness';
 import type { DiscoverEBTManager } from './ebt_manager';
 import {
   CASCADE_LAYOUT_ENABLED_FEATURE_FLAG_KEY,
@@ -158,6 +158,7 @@ export interface DiscoverServices {
   noDataPage?: NoDataPagePluginStart;
   observabilityAIAssistant?: ObservabilityAIAssistantPublicStart;
   profilesManager: ProfilesManager;
+  profileStateRegistry: ProfileStateRegistry;
   ebtManager: DiscoverEBTManager;
   fieldsMetadata?: FieldsMetadataPublicStart;
   logsDataAccess?: LogsDataAccessPluginStart;
@@ -265,6 +266,7 @@ export const buildServices = ({
     noDataPage: plugins.noDataPage,
     observabilityAIAssistant: plugins.observabilityAIAssistant,
     profilesManager,
+    profileStateRegistry: new ProfileStateRegistry(),
     ebtManager,
     fieldsMetadata: plugins.fieldsMetadata,
     logsDataAccess: plugins.logsDataAccess,

--- a/src/platform/plugins/shared/discover/public/components/data_types/logs/service_name_cell.test.tsx
+++ b/src/platform/plugins/shared/discover/public/components/data_types/logs/service_name_cell.test.tsx
@@ -15,7 +15,10 @@ import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 import { render, screen } from '@testing-library/react';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { getServiceNameCell } from './service_name_cell';
-import type { ContextAwarenessToolkit } from '../../../context_awareness';
+import {
+  EMPTY_CONTEXT_AWARENESS_TOOLKIT,
+  type ContextAwarenessToolkit,
+} from '../../../context_awareness';
 
 const core = {
   application: {
@@ -44,7 +47,9 @@ const renderCell = (
   fieldFormats: FieldFormatsStart = fieldFormatsMock
 ) => {
   const toolkit: ContextAwarenessToolkit = {
+    ...EMPTY_CONTEXT_AWARENESS_TOOLKIT,
     actions: {
+      ...EMPTY_CONTEXT_AWARENESS_TOOLKIT.actions,
       addFilter: jest.fn(),
     },
   };

--- a/src/platform/plugins/shared/discover/public/context_awareness/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/index.ts
@@ -20,6 +20,14 @@ export {
 } from './profiles_manager';
 export { type ProfileProviderSharedServices } from './profile_providers';
 export {
+  type ProfileStateAdapter,
+  type ProfileStateDefinition,
+  type ProfileStateDescriptor,
+  ProfileStateKey,
+  ProfileStateType,
+  ProfileStateRegistry,
+} from './profile_state';
+export {
   useProfileAccessor,
   useRootProfile,
   useAdditionalCellActions,

--- a/src/platform/plugins/shared/discover/public/context_awareness/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/index.ts
@@ -23,7 +23,6 @@ export {
   type ProfileStateAdapter,
   type ProfileStateDefinition,
   type ProfileStateDescriptor,
-  ProfileStateKey,
   ProfileStateType,
   ProfileStateRegistry,
 } from './profile_state';

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -35,9 +35,12 @@ import { CustomDocView } from './components/custom_doc_view';
 import { RestorableStateDocView } from './components/restorable_state_doc_view';
 import { COLOR_STATE_KEY, type ColorState } from '../../../profile_state';
 
-export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvider<{
-  formatRecord: (flattenedRecord: Record<string, unknown>) => string;
-}> => ({
+export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvider<
+  {
+    formatRecord: (flattenedRecord: Record<string, unknown>) => string;
+  },
+  ColorState
+> => ({
   profileId: 'example-data-source-profile',
   isExperimental: true,
   profile: {
@@ -390,6 +393,7 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
       isMatch: true,
       context: {
         category: DataSourceCategory.Logs,
+        profileStateKey: COLOR_STATE_KEY,
         formatRecord: (record) => JSON.stringify(record, null, 2),
       },
     };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -13,8 +13,10 @@ import {
   EuiFlexItem,
   EuiFlyout,
   EuiFormRow,
+  EuiPanel,
   EuiSelect,
   EuiSpacer,
+  EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import type { DataViewField } from '@kbn/data-views-plugin/common';
@@ -121,16 +123,22 @@ export const createExampleDataSourceProfileProvider = (): ExampleDataSourceProfi
               order: 2,
               render: function Render() {
                 const colorState = useObservable(colorState$, stateAdapter.getState());
-                const favoriteColorOptions = [
-                  { value: 'default', text: 'None' },
+                const timestampColorOptions = [
+                  { value: 'neutral', text: 'None' },
                   { value: 'blue', text: 'Blue' },
                   { value: 'pink', text: 'Pink' },
                   { value: 'green', text: 'Green' },
                 ];
                 const rowControlColorOptions = [
-                  { value: 'default', text: 'None' },
+                  { value: 'neutral', text: 'None' },
                   { value: 'primary', text: 'Primary' },
                   { value: 'success', text: 'Success' },
+                  { value: 'danger', text: 'Danger' },
+                ];
+                const boxColorOptions = [
+                  { value: 'transparent', text: 'None' },
+                  { value: 'success', text: 'Success' },
+                  { value: 'warning', text: 'Warning' },
                   { value: 'danger', text: 'Danger' },
                 ];
 
@@ -142,14 +150,14 @@ export const createExampleDataSourceProfileProvider = (): ExampleDataSourceProfi
                         <h3>Extensible State Example</h3>
                       </EuiTitle>
                       <EuiFlexItem grow={false}>
-                        <EuiFormRow label="Favorite color (UI state)">
+                        <EuiFormRow label="Timestamp color (UI state)">
                           <EuiSelect
-                            options={favoriteColorOptions}
-                            value={colorState.favoriteColor}
+                            options={timestampColorOptions}
+                            value={colorState.timestampColor}
                             onChange={(e) => {
-                              stateAdapter.updateState({ favoriteColor: e.target.value });
+                              stateAdapter.updateState({ timestampColor: e.target.value });
                             }}
-                            aria-label="Select favorite color"
+                            aria-label="Select timestamp color"
                           />
                         </EuiFormRow>
                       </EuiFlexItem>
@@ -166,6 +174,34 @@ export const createExampleDataSourceProfileProvider = (): ExampleDataSourceProfi
                             aria-label="Select row control color"
                           />
                         </EuiFormRow>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiFormRow label="Box color (URL state)">
+                          <EuiSelect
+                            options={boxColorOptions}
+                            value={colorState.boxColor}
+                            onChange={(e) => {
+                              stateAdapter.updateState({
+                                boxColor: e.target.value as ColorState['boxColor'],
+                              });
+                            }}
+                            aria-label="Select box color"
+                          />
+                        </EuiFormRow>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiPanel
+                          color={colorState.boxColor}
+                          css={{
+                            height: '100px',
+                            width: '100px',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <EuiText color={colorState.boxColor}>{colorState.boxColor}</EuiText>
+                        </EuiPanel>
                       </EuiFlexItem>
                     </EuiFlexGroup>
                   </>

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -18,7 +18,11 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import type { DataViewField } from '@kbn/data-views-plugin/common';
-import type { RowControlColumn } from '@kbn/discover-utils';
+import type {
+  RowControlColumn,
+  RowControlComponent,
+  RowControlRowProps,
+} from '@kbn/discover-utils';
 import { AppMenuActionId, getFieldValue } from '@kbn/discover-utils';
 import { capitalize } from 'lodash';
 import React from 'react';
@@ -29,7 +33,7 @@ import { extractIndexPatternFrom } from '../../extract_index_pattern_from';
 import { ChartWithCustomButtons, CustomDocViewerFooter, CustomDocViewerHeader } from './components';
 import { CustomDocView } from './components/custom_doc_view';
 import { RestorableStateDocView } from './components/restorable_state_doc_view';
-import { COLOR_STATE_KEY } from '../../../profile_state';
+import { COLOR_STATE_KEY, type ColorState } from '../../../profile_state';
 
 export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvider<{
   formatRecord: (flattenedRecord: Record<string, unknown>) => string;
@@ -110,11 +114,17 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
               order: 2,
               render: function Render() {
                 const colorState = useObservable(colorState$, stateAdapter.getState());
-                const options = [
+                const favoriteColorOptions = [
                   { value: 'default', text: 'None' },
                   { value: 'blue', text: 'Blue' },
                   { value: 'pink', text: 'Pink' },
                   { value: 'green', text: 'Green' },
+                ];
+                const rowControlColorOptions = [
+                  { value: 'default', text: 'None' },
+                  { value: 'primary', text: 'Primary' },
+                  { value: 'success', text: 'Success' },
+                  { value: 'danger', text: 'Danger' },
                 ];
 
                 return (
@@ -125,14 +135,28 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
                         <h3>Extensible State Example</h3>
                       </EuiTitle>
                       <EuiFlexItem grow={false}>
-                        <EuiFormRow label="Favourite color">
+                        <EuiFormRow label="Favorite color (UI state)">
                           <EuiSelect
-                            options={options}
-                            value={colorState.favouriteColor}
+                            options={favoriteColorOptions}
+                            value={colorState.favoriteColor}
                             onChange={(e) => {
-                              stateAdapter.updateState({ favouriteColor: e.target.value });
+                              stateAdapter.updateState({ favoriteColor: e.target.value });
                             }}
-                            aria-label="Select favourite color"
+                            aria-label="Select favorite color"
+                          />
+                        </EuiFormRow>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiFormRow label="Row control color (Persistent state)">
+                          <EuiSelect
+                            options={rowControlColorOptions}
+                            value={colorState.rowControlColor}
+                            onChange={(e) => {
+                              stateAdapter.updateState({
+                                rowControlColor: e.target.value as ColorState['rowControlColor'],
+                              });
+                            }}
+                            aria-label="Select row control color"
                           />
                         </EuiFormRow>
                       </EuiFlexItem>
@@ -236,30 +260,49 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
         },
       };
     },
-    getRowAdditionalLeadingControls: (prev) => (params) => {
-      const additionalControls = prev(params) || [];
+    getRowAdditionalLeadingControls: (prev, { toolkit }) => {
+      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_KEY);
+      const colorState$ = stateAdapter.getState$();
+      const RowControl = ({
+        Control,
+        rowProps,
+        iconType,
+      }: {
+        Control: RowControlComponent;
+        rowProps: RowControlRowProps;
+        iconType: string;
+      }) => {
+        const colorState = useObservable(colorState$, stateAdapter.getState());
 
-      return [
-        ...additionalControls,
-        ...['chartBarVerticalStack', 'heart', 'inspect'].map(
-          (iconType): RowControlColumn => ({
-            id: `exampleControl_${iconType}`,
-            render: (Control, rowProps) => {
-              return (
-                <Control
-                  data-test-subj={`exampleLogsControl_${iconType}`}
-                  label={`Example ${iconType}`}
-                  tooltipContent={`Example ${iconType}`}
-                  iconType={iconType}
-                  onClick={() => {
-                    alert(`Example "${iconType}" control clicked. Row index: ${rowProps.rowIndex}`);
-                  }}
-                />
-              );
-            },
-          })
-        ),
-      ];
+        return (
+          <Control
+            data-test-subj={`exampleLogsControl_${iconType}`}
+            label={`Example ${iconType}`}
+            tooltipContent={`Example ${iconType}`}
+            iconType={iconType}
+            onClick={() => {
+              alert(`Example "${iconType}" control clicked. Row index: ${rowProps.rowIndex}`);
+            }}
+            color={colorState.rowControlColor}
+          />
+        );
+      };
+
+      return (params) => {
+        const additionalControls = prev(params) || [];
+
+        return [
+          ...additionalControls,
+          ...['chartBarVerticalStack', 'heart', 'inspect'].map(
+            (iconType): RowControlColumn => ({
+              id: `exampleControl_${iconType}`,
+              render: (Control, rowProps) => {
+                return <RowControl Control={Control} rowProps={rowProps} iconType={iconType} />;
+              },
+            })
+          ),
+        ];
+      };
     },
     getDefaultAppState: () => () => ({
       breakdownField: 'log.level',

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -33,14 +33,18 @@ import { extractIndexPatternFrom } from '../../extract_index_pattern_from';
 import { ChartWithCustomButtons, CustomDocViewerFooter, CustomDocViewerHeader } from './components';
 import { CustomDocView } from './components/custom_doc_view';
 import { RestorableStateDocView } from './components/restorable_state_doc_view';
-import { COLOR_STATE_KEY, type ColorState } from '../../../profile_state';
+import { COLOR_STATE_DEF, type ColorState } from '../../../profile_state';
 
-export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvider<
-  {
-    formatRecord: (flattenedRecord: Record<string, unknown>) => string;
-  },
+interface ExampleDataSourceContext {
+  formatRecord: (flattenedRecord: Record<string, unknown>) => string;
+}
+
+type ExampleDataSourceProfileProvider = DataSourceProfileProvider<
+  ExampleDataSourceContext,
   ColorState
-> => ({
+>;
+
+export const createExampleDataSourceProfileProvider = (): ExampleDataSourceProfileProvider => ({
   profileId: 'example-data-source-profile',
   isExperimental: true,
   profile: {
@@ -80,7 +84,7 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
       },
     }),
     getDocViewer: (prev, { context, toolkit }) => {
-      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_KEY);
+      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_DEF);
       const colorState$ = stateAdapter.getState$();
 
       return (params) => {
@@ -264,7 +268,7 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
       };
     },
     getRowAdditionalLeadingControls: (prev, { toolkit }) => {
-      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_KEY);
+      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_DEF);
       const colorState$ = stateAdapter.getState$();
       const RowControl = ({
         Control,
@@ -393,7 +397,7 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
       isMatch: true,
       context: {
         category: DataSourceCategory.Logs,
-        profileStateKey: COLOR_STATE_KEY,
+        profileState: COLOR_STATE_DEF,
         formatRecord: (record) => JSON.stringify(record, null, 2),
       },
     };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -7,18 +7,29 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiBadge, EuiFlyout } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFormRow,
+  EuiSelect,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
 import type { DataViewField } from '@kbn/data-views-plugin/common';
 import type { RowControlColumn } from '@kbn/discover-utils';
 import { AppMenuActionId, getFieldValue } from '@kbn/discover-utils';
 import { capitalize } from 'lodash';
 import React from 'react';
+import { useObservable } from '@kbn/use-observable';
 import type { DataSourceProfileProvider } from '../../../profiles';
 import { DataSourceCategory } from '../../../profiles';
 import { extractIndexPatternFrom } from '../../extract_index_pattern_from';
 import { ChartWithCustomButtons, CustomDocViewerFooter, CustomDocViewerHeader } from './components';
 import { CustomDocView } from './components/custom_doc_view';
 import { RestorableStateDocView } from './components/restorable_state_doc_view';
+import { COLOR_STATE_KEY } from '../../../profile_state';
 
 export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvider<{
   formatRecord: (flattenedRecord: Record<string, unknown>) => string;
@@ -61,9 +72,11 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
         );
       },
     }),
-    getDocViewer:
-      (prev, { context, toolkit }) =>
-      (params) => {
+    getDocViewer: (prev, { context, toolkit }) => {
+      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_KEY);
+      const colorState$ = stateAdapter.getState$();
+
+      return (params) => {
         const { openInNewTab, updateESQLQuery } = toolkit.actions;
         const recordId = params.record.id;
         const prevValue = prev(params);
@@ -91,12 +104,51 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
               render: (props) => <RestorableStateDocView {...props} />,
             });
 
+            registry.add({
+              id: 'doc_view_extensible_state_example',
+              title: 'Extensible State Example',
+              order: 2,
+              render: function Render() {
+                const colorState = useObservable(colorState$, stateAdapter.getState());
+                const options = [
+                  { value: 'default', text: 'None' },
+                  { value: 'blue', text: 'Blue' },
+                  { value: 'pink', text: 'Pink' },
+                  { value: 'green', text: 'Green' },
+                ];
+
+                return (
+                  <>
+                    <EuiSpacer size="s" />
+                    <EuiFlexGroup direction="column" gutterSize="m" responsive={false}>
+                      <EuiTitle size="xs">
+                        <h3>Extensible State Example</h3>
+                      </EuiTitle>
+                      <EuiFlexItem grow={false}>
+                        <EuiFormRow label="Favourite color">
+                          <EuiSelect
+                            options={options}
+                            value={colorState.favouriteColor}
+                            onChange={(e) => {
+                              stateAdapter.updateState({ favouriteColor: e.target.value });
+                            }}
+                            aria-label="Select favourite color"
+                          />
+                        </EuiFormRow>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </>
+                );
+              },
+            });
+
             return prevValue.docViewsRegistry(registry);
           },
           renderHeader: (props) => <CustomDocViewerHeader {...props} />,
           renderFooter: (props) => <CustomDocViewerFooter {...props} />,
         };
-      },
+      };
+    },
     /**
      * The `getAppMenu` extension point gives access to AppMenuRegistry with methods `registerCustomItem` and
      * `registerCustomPopoverItem`.

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_root_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_root_profile/profile.tsx
@@ -31,7 +31,7 @@ export const createExampleRootProfileProvider = (): RootProfileProvider => ({
 
         return (
           <EuiBadge
-            color={colorState.favoriteColor}
+            color={colorState.timestampColor}
             title={timestamp}
             data-test-subj="exampleRootProfileTimestamp"
           >

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_root_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_root_profile/profile.tsx
@@ -10,8 +10,10 @@
 import { EuiBadge, EuiFlyout } from '@elastic/eui';
 import { getFieldValue } from '@kbn/discover-utils';
 import React from 'react';
+import { useObservable } from '@kbn/use-observable';
 import type { RootProfileProvider } from '../../../profiles';
 import { SolutionType } from '../../../profiles';
+import { COLOR_STATE_KEY } from '../../../profile_state';
 
 export const createExampleRootProfileProvider = (): RootProfileProvider => ({
   profileId: 'example-root-profile',
@@ -19,18 +21,28 @@ export const createExampleRootProfileProvider = (): RootProfileProvider => ({
   profile: {
     getDefaultAdHocDataViews,
     getDefaultEsqlQuery,
-    getCellRenderers: (prev) => (params) => ({
-      ...prev(params),
-      '@timestamp': (props) => {
-        const timestamp = getFieldValue(props.row, '@timestamp') as string;
+    getCellRenderers: (prev, { toolkit }) => {
+      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_KEY);
+      const colorState$ = stateAdapter.getState$();
 
-        return (
-          <EuiBadge color="hollow" title={timestamp} data-test-subj="exampleRootProfileTimestamp">
-            {timestamp}
-          </EuiBadge>
-        );
-      },
-    }),
+      return (params) => ({
+        ...prev(params),
+        '@timestamp': function Timestamp(props) {
+          const timestamp = getFieldValue(props.row, '@timestamp') as string;
+          const colorState = useObservable(colorState$, stateAdapter.getState());
+
+          return (
+            <EuiBadge
+              color={colorState.favouriteColor}
+              title={timestamp}
+              data-test-subj="exampleRootProfileTimestamp"
+            >
+              {timestamp}
+            </EuiBadge>
+          );
+        },
+      });
+    },
     /**
      * The `getAppMenu` extension point gives access to AppMenuRegistry with methods `registerCustomItem` and
      * `registerCustomPopoverItem`.

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_root_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_root_profile/profile.tsx
@@ -14,7 +14,7 @@ import { useObservable } from '@kbn/use-observable';
 import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
 import type { RootProfileProvider } from '../../../profiles';
 import { SolutionType } from '../../../profiles';
-import { COLOR_STATE_KEY } from '../../../profile_state';
+import { COLOR_STATE_DEF } from '../../../profile_state';
 
 export const createExampleRootProfileProvider = (): RootProfileProvider => ({
   profileId: 'example-root-profile',
@@ -23,7 +23,7 @@ export const createExampleRootProfileProvider = (): RootProfileProvider => ({
     getDefaultAdHocDataViews,
     getDefaultEsqlQuery,
     getCellRenderers: (prev, { toolkit }) => {
-      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_KEY);
+      const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_DEF);
       const colorState$ = stateAdapter.getState$();
       const Timestamp = (props: DataGridCellValueElementProps) => {
         const timestamp = getFieldValue(props.row, '@timestamp') as string;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_root_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_root_profile/profile.tsx
@@ -11,6 +11,7 @@ import { EuiBadge, EuiFlyout } from '@elastic/eui';
 import { getFieldValue } from '@kbn/discover-utils';
 import React from 'react';
 import { useObservable } from '@kbn/use-observable';
+import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
 import type { RootProfileProvider } from '../../../profiles';
 import { SolutionType } from '../../../profiles';
 import { COLOR_STATE_KEY } from '../../../profile_state';
@@ -24,23 +25,24 @@ export const createExampleRootProfileProvider = (): RootProfileProvider => ({
     getCellRenderers: (prev, { toolkit }) => {
       const stateAdapter = toolkit.getStateAdapter(COLOR_STATE_KEY);
       const colorState$ = stateAdapter.getState$();
+      const Timestamp = (props: DataGridCellValueElementProps) => {
+        const timestamp = getFieldValue(props.row, '@timestamp') as string;
+        const colorState = useObservable(colorState$, stateAdapter.getState());
+
+        return (
+          <EuiBadge
+            color={colorState.favoriteColor}
+            title={timestamp}
+            data-test-subj="exampleRootProfileTimestamp"
+          >
+            {timestamp}
+          </EuiBadge>
+        );
+      };
 
       return (params) => ({
         ...prev(params),
-        '@timestamp': function Timestamp(props) {
-          const timestamp = getFieldValue(props.row, '@timestamp') as string;
-          const colorState = useObservable(colorState$, stateAdapter.getState());
-
-          return (
-            <EuiBadge
-              color={colorState.favouriteColor}
-              title={timestamp}
-              data-test-subj="exampleRootProfileTimestamp"
-            >
-              {timestamp}
-            </EuiBadge>
-          );
-        },
+        '@timestamp': (props) => <Timestamp {...props} />,
       });
     },
     /**

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.test.ts
@@ -203,7 +203,9 @@ describe('logsDataSourceProfileProvider', () => {
   describe('getCellRenderers', () => {
     it('should return cell renderers for log level fields', () => {
       const toolkit = {
+        ...EMPTY_CONTEXT_AWARENESS_TOOLKIT,
         actions: {
+          ...EMPTY_CONTEXT_AWARENESS_TOOLKIT.actions,
           addFilter: jest.fn(),
         },
       };
@@ -229,7 +231,9 @@ describe('logsDataSourceProfileProvider', () => {
   describe('getRowAdditionalLeadingControls', () => {
     it('should return the passed additional controls', () => {
       const toolkit = {
+        ...EMPTY_CONTEXT_AWARENESS_TOOLKIT,
         actions: {
+          ...EMPTY_CONTEXT_AWARENESS_TOOLKIT.actions,
           setExpandedDoc: jest.fn(),
         },
       };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
@@ -11,6 +11,7 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import { ALERT_RULE_TYPE_ID, ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID } from '@kbn/rule-data-utils';
 import type { ProfileProviderServices } from '../profile_provider_services';
+import { EMPTY_CONTEXT_AWARENESS_TOOLKIT } from '../../toolkit';
 import { DocumentType } from '../../profiles';
 import { createSecurityDocumentProfileProviders } from './security_profile_providers';
 
@@ -40,7 +41,13 @@ const getDocViewerResult = (
   const prev = jest.fn().mockReturnValue(prevDocViewer);
   const getDocViewer = enhancedProvider.profile.getDocViewer!(prev, {
     context: { type: DocumentType.Default },
-    toolkit: { actions: toolkitActions },
+    toolkit: {
+      ...EMPTY_CONTEXT_AWARENESS_TOOLKIT,
+      actions: {
+        ...EMPTY_CONTEXT_AWARENESS_TOOLKIT.actions,
+        ...toolkitActions,
+      },
+    },
   });
   const result = getDocViewer({ record } as Parameters<typeof getDocViewer>[0]);
   return { result, prevRenderHeader, prevRenderFooter };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
@@ -7,19 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/* eslint-disable max-classes-per-file */
-
+import { isEqual } from 'lodash';
 import type { Observable } from 'rxjs';
-
-export class ProfileStateKey<TState extends object> {
-  private declare readonly __stateBrand: (_state: TState) => TState;
-
-  private constructor(public readonly rawKey: string) {}
-
-  static create<TState extends object>(rawKey: string): ProfileStateKey<TState> {
-    return new ProfileStateKey<TState>(rawKey);
-  }
-}
 
 export enum ProfileStateHistoryMethod {
   Push = 'push',
@@ -50,7 +39,7 @@ export type ProfileStateDescriptor<TState extends object> = {
 };
 
 export interface ProfileStateDefinition<TState extends object> {
-  key: ProfileStateKey<TState>;
+  key: string;
   descriptor: ProfileStateDescriptor<TState>;
 }
 
@@ -61,23 +50,21 @@ export class ProfileStateRegistry {
   >();
 
   public registerDefinition<TState extends object>(definition: ProfileStateDefinition<TState>) {
-    if (this.stateDefinitions.has(definition.key.rawKey)) {
-      throw new Error(`State with key ${definition.key.rawKey} is already registered.`);
+    if (this.stateDefinitions.has(definition.key)) {
+      throw new Error(`State with key ${definition.key} is already registered.`);
     }
-    this.stateDefinitions.set(
-      definition.key.rawKey,
-      definition as ProfileStateDefinition<Record<string, unknown>>
-    );
+
+    this.stateDefinitions.set(definition.key, definition);
   }
 
-  public getDefinition<TState extends object>(
-    key: ProfileStateKey<TState>
-  ): ProfileStateDefinition<TState> {
-    const definition = this.stateDefinitions.get(key.rawKey);
-    if (!definition) {
-      throw new Error(`State with key ${key.rawKey} is not registered.`);
+  public hasDefinition<TState extends object>(definition: ProfileStateDefinition<TState>): boolean {
+    const registeredDefinition = this.stateDefinitions.get(definition.key);
+
+    if (!registeredDefinition) {
+      return false;
     }
-    return definition as ProfileStateDefinition<TState>;
+
+    return isEqual(registeredDefinition.descriptor, definition.descriptor);
   }
 
   public pickStateByType({
@@ -118,7 +105,7 @@ export class ProfileStateRegistry {
 }
 
 export const registerProfileStateDefinitions = (registry: ProfileStateRegistry) => {
-  registry.registerDefinition(colorStateDefinition);
+  registry.registerDefinition(COLOR_STATE_DEF);
 };
 
 export interface ColorState {
@@ -126,10 +113,8 @@ export interface ColorState {
   rowControlColor: 'primary' | 'success' | 'danger';
 }
 
-export const COLOR_STATE_KEY = ProfileStateKey.create<ColorState>('color_state');
-
-const colorStateDefinition: ProfileStateDefinition<ColorState> = {
-  key: COLOR_STATE_KEY,
+export const COLOR_STATE_DEF: ProfileStateDefinition<ColorState> = {
+  key: 'colorState',
   descriptor: {
     favoriteColor: { type: ProfileStateType.Ui },
     rowControlColor: { type: ProfileStateType.Persistent },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
@@ -11,7 +11,9 @@
 
 import type { Observable } from 'rxjs';
 
-export class ProfileStateKey<_TState extends object> {
+export class ProfileStateKey<TState extends object> {
+  private declare readonly __stateBrand: (_state: TState) => TState;
+
   private constructor(public readonly rawKey: string) {}
 
   static create<TState extends object>(rawKey: string): ProfileStateKey<TState> {
@@ -62,7 +64,10 @@ export class ProfileStateRegistry {
     if (this.stateDefinitions.has(definition.key.rawKey)) {
       throw new Error(`State with key ${definition.key.rawKey} is already registered.`);
     }
-    this.stateDefinitions.set(definition.key.rawKey, definition);
+    this.stateDefinitions.set(
+      definition.key.rawKey,
+      definition as ProfileStateDefinition<Record<string, unknown>>
+    );
   }
 
   public getDefinition<TState extends object>(

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
@@ -53,7 +53,10 @@ export interface ProfileStateDefinition<TState extends object> {
 }
 
 export class ProfileStateRegistry {
-  private readonly stateDefinitions = new Map<string, ProfileStateDefinition<object>>();
+  private readonly stateDefinitions = new Map<
+    string,
+    ProfileStateDefinition<Record<string, unknown>>
+  >();
 
   public registerDefinition<TState extends object>(definition: ProfileStateDefinition<TState>) {
     if (this.stateDefinitions.has(definition.key.rawKey)) {
@@ -71,15 +74,51 @@ export class ProfileStateRegistry {
     }
     return definition as ProfileStateDefinition<TState>;
   }
+
+  public pickStateByType({
+    profileState,
+    stateType,
+  }: {
+    profileState: Record<string, object | undefined>;
+    stateType: ProfileStateType;
+  }): Record<string, object | undefined> {
+    const filteredProfileState: Record<string, object | undefined> = {};
+
+    for (const [rawKey, state] of Object.entries(profileState)) {
+      if (!state) {
+        continue;
+      }
+
+      const definition = this.stateDefinitions.get(rawKey);
+
+      if (!definition) {
+        continue;
+      }
+
+      const filteredState: Record<string, unknown> = {};
+
+      for (const [field, value] of Object.entries(state)) {
+        if (definition.descriptor[field]?.type === stateType) {
+          filteredState[field] = value;
+        }
+      }
+
+      if (Object.keys(filteredState).length > 0) {
+        filteredProfileState[rawKey] = filteredState;
+      }
+    }
+
+    return filteredProfileState;
+  }
 }
 
 export const registerProfileStateDefinitions = (registry: ProfileStateRegistry) => {
   registry.registerDefinition(colorStateDefinition);
 };
 
-interface ColorState {
-  favouriteColor: string;
-  leastFavouriteColor: string;
+export interface ColorState {
+  favoriteColor: string;
+  rowControlColor: 'primary' | 'success' | 'danger';
 }
 
 export const COLOR_STATE_KEY = ProfileStateKey.create<ColorState>('color_state');
@@ -87,7 +126,7 @@ export const COLOR_STATE_KEY = ProfileStateKey.create<ColorState>('color_state')
 const colorStateDefinition: ProfileStateDefinition<ColorState> = {
   key: COLOR_STATE_KEY,
   descriptor: {
-    favouriteColor: { type: ProfileStateType.Ui },
-    leastFavouriteColor: { type: ProfileStateType.Ui },
+    favoriteColor: { type: ProfileStateType.Ui },
+    rowControlColor: { type: ProfileStateType.Persistent },
   },
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
@@ -109,14 +109,16 @@ export const registerProfileStateDefinitions = (registry: ProfileStateRegistry) 
 };
 
 export interface ColorState {
-  favoriteColor: string;
-  rowControlColor: 'primary' | 'success' | 'danger';
+  timestampColor: string;
+  rowControlColor: 'neutral' | 'primary' | 'success' | 'danger';
+  boxColor: 'transparent' | 'success' | 'warning' | 'danger';
 }
 
 export const COLOR_STATE_DEF: ProfileStateDefinition<ColorState> = {
   key: 'colorState',
   descriptor: {
-    favoriteColor: { type: ProfileStateType.Ui },
+    timestampColor: { type: ProfileStateType.Ui },
     rowControlColor: { type: ProfileStateType.Persistent },
+    boxColor: { type: ProfileStateType.Url },
   },
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_state.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/* eslint-disable max-classes-per-file */
+
+import type { Observable } from 'rxjs';
+
+export class ProfileStateKey<_TState extends object> {
+  private constructor(public readonly rawKey: string) {}
+
+  static create<TState extends object>(rawKey: string): ProfileStateKey<TState> {
+    return new ProfileStateKey<TState>(rawKey);
+  }
+}
+
+export enum ProfileStateHistoryMethod {
+  Push = 'push',
+  Replace = 'replace',
+}
+
+export interface ProfileStateMutationOptions {
+  historyMethod?: ProfileStateHistoryMethod;
+}
+
+export interface ProfileStateAdapter<TState extends object> {
+  getState: () => TState;
+  getState$: () => Observable<TState>;
+  setState: (state: TState, options?: ProfileStateMutationOptions) => void;
+  updateState: (stateUpdate: Partial<TState>, options?: ProfileStateMutationOptions) => void;
+}
+
+export enum ProfileStateType {
+  Ui = 'ui',
+  Url = 'url',
+  Persistent = 'persistent',
+}
+
+export type ProfileStateDescriptor<TState extends object> = {
+  [key in keyof TState]: {
+    type: ProfileStateType;
+  };
+};
+
+export interface ProfileStateDefinition<TState extends object> {
+  key: ProfileStateKey<TState>;
+  descriptor: ProfileStateDescriptor<TState>;
+}
+
+export class ProfileStateRegistry {
+  private readonly stateDefinitions = new Map<string, ProfileStateDefinition<object>>();
+
+  public registerDefinition<TState extends object>(definition: ProfileStateDefinition<TState>) {
+    if (this.stateDefinitions.has(definition.key.rawKey)) {
+      throw new Error(`State with key ${definition.key.rawKey} is already registered.`);
+    }
+    this.stateDefinitions.set(definition.key.rawKey, definition);
+  }
+
+  public getDefinition<TState extends object>(
+    key: ProfileStateKey<TState>
+  ): ProfileStateDefinition<TState> {
+    const definition = this.stateDefinitions.get(key.rawKey);
+    if (!definition) {
+      throw new Error(`State with key ${key.rawKey} is not registered.`);
+    }
+    return definition as ProfileStateDefinition<TState>;
+  }
+}
+
+export const registerProfileStateDefinitions = (registry: ProfileStateRegistry) => {
+  registry.registerDefinition(colorStateDefinition);
+};
+
+interface ColorState {
+  favouriteColor: string;
+  leastFavouriteColor: string;
+}
+
+export const COLOR_STATE_KEY = ProfileStateKey.create<ColorState>('color_state');
+
+const colorStateDefinition: ProfileStateDefinition<ColorState> = {
+  key: COLOR_STATE_KEY,
+  descriptor: {
+    favouriteColor: { type: ProfileStateType.Ui },
+    leastFavouriteColor: { type: ProfileStateType.Ui },
+  },
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profiles/data_source_profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profiles/data_source_profile.ts
@@ -14,6 +14,7 @@ import type { AsyncProfileProvider, ContextWithProfileId } from '../profile_serv
 import { AsyncProfileService } from '../profile_service';
 import type { Profile } from '../types';
 import type { RootContext } from './root_profile';
+import type { ProfileStateKey } from '../profile_state';
 
 /**
  * Indicates the category of the data source (e.g. logs, alerts, etc.)
@@ -55,17 +56,24 @@ export interface DataSourceProfileProviderParams {
 /**
  * The resulting context object returned by the data source profile provider `resolve` method
  */
-export interface DataSourceContext {
+export interface DataSourceContext<TState extends object = object> {
   /**
    * The category of the current data source
    */
   category: DataSourceCategory;
+  /**
+   * Key of the profile state which should be synced to the URL when this profile is active
+   */
+  profileStateKey?: ProfileStateKey<TState>;
 }
 
-export type DataSourceProfileProvider<TProviderContext = {}> = AsyncProfileProvider<
+export type DataSourceProfileProvider<
+  TProviderContext = {},
+  TState extends object = object
+> = AsyncProfileProvider<
   DataSourceProfile,
   DataSourceProfileProviderParams,
-  DataSourceContext & TProviderContext
+  DataSourceContext<TState> & TProviderContext
 >;
 
 export class DataSourceProfileService extends AsyncProfileService<DataSourceProfileProvider> {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profiles/data_source_profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profiles/data_source_profile.ts
@@ -14,7 +14,7 @@ import type { AsyncProfileProvider, ContextWithProfileId } from '../profile_serv
 import { AsyncProfileService } from '../profile_service';
 import type { Profile } from '../types';
 import type { RootContext } from './root_profile';
-import type { ProfileStateKey } from '../profile_state';
+import type { ProfileStateDefinition } from '../profile_state';
 
 /**
  * Indicates the category of the data source (e.g. logs, alerts, etc.)
@@ -62,9 +62,9 @@ export interface DataSourceContext<TState extends object = object> {
    */
   category: DataSourceCategory;
   /**
-   * Key of the profile state which should be synced to the URL when this profile is active
+   * The profile state which should be synced to the URL when this profile is active
    */
-  profileStateKey?: ProfileStateKey<TState>;
+  profileState?: ProfileStateDefinition<TState>;
 }
 
 export type DataSourceProfileProvider<

--- a/src/platform/plugins/shared/discover/public/context_awareness/toolkit.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/toolkit.ts
@@ -11,7 +11,7 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { OpenInNewTabParams, UpdateESQLQueryFn } from './types';
-import type { ProfileStateAdapter, ProfileStateKey } from './profile_state';
+import type { ProfileStateAdapter, ProfileStateDefinition } from './profile_state';
 
 /**
  * Host-provided actions that profiles can use in extension point implementations.
@@ -55,7 +55,7 @@ export interface ContextAwarenessToolkit {
    */
   readonly actions: ContextAwarenessToolkitActions;
   readonly getStateAdapter: <TState extends object>(
-    key: ProfileStateKey<TState>
+    definition: ProfileStateDefinition<TState>
   ) => ProfileStateAdapter<TState>;
 }
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/toolkit.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/toolkit.ts
@@ -11,6 +11,7 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { OpenInNewTabParams, UpdateESQLQueryFn } from './types';
+import type { ProfileStateAdapter, ProfileStateKey } from './profile_state';
 
 /**
  * Host-provided actions that profiles can use in extension point implementations.
@@ -53,6 +54,9 @@ export interface ContextAwarenessToolkit {
    * Optional host actions made available to profile implementations.
    */
   readonly actions: ContextAwarenessToolkitActions;
+  readonly getStateAdapter: <TState extends object>(
+    key: ProfileStateKey<TState>
+  ) => ProfileStateAdapter<TState>;
 }
 
 /**
@@ -60,4 +64,7 @@ export interface ContextAwarenessToolkit {
  */
 export const EMPTY_CONTEXT_AWARENESS_TOOLKIT: ContextAwarenessToolkit = {
   actions: {},
+  getStateAdapter: () => {
+    throw new Error('No state adapter available in empty toolkit');
+  },
 };

--- a/src/platform/plugins/shared/discover/public/customizations/customization_provider.ts
+++ b/src/platform/plugins/shared/discover/public/customizations/customization_provider.ts
@@ -101,6 +101,7 @@ export const getExtendedDiscoverStateContainer = ({
       tabId: getCurrentTab().id,
       internalState$: from(internalState),
       getState: internalState.getState,
+      profileStateRegistry: services.profileStateRegistry,
     }),
   getAppStateFromSavedSearch: (newSavedSearch: SavedSearch) => {
     const persistedTab = fromSavedSearchToSavedObjectTab({

--- a/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -49,7 +49,10 @@ import { initializeInlineEditingApi } from './initialize_inline_editing_api';
 import { initializeSearchEmbeddableApi } from './initialize_search_embeddable_api';
 import type { SearchEmbeddableApi, SearchEmbeddablePanelApiState } from './types';
 import { deserializeState, serializeState } from './utils/serialization_utils';
-import { type ContextAwarenessToolkit } from '../context_awareness';
+import {
+  EMPTY_CONTEXT_AWARENESS_TOOLKIT,
+  type ContextAwarenessToolkit,
+} from '../context_awareness';
 import { ScopedServicesProvider } from '../components/scoped_services_provider';
 import { isFieldStatsMode } from './utils/is_field_stats_mode';
 import { isTabDeleted } from './utils/is_tab_deleted';
@@ -316,7 +319,9 @@ export const getSearchEmbeddableFactory = ({
       };
 
       const toolkit: ContextAwarenessToolkit = {
+        ...EMPTY_CONTEXT_AWARENESS_TOOLKIT,
         actions: {
+          ...EMPTY_CONTEXT_AWARENESS_TOOLKIT.actions,
           addFilter: enableFilters ? addFilter : undefined,
           refreshData: () => refreshTrigger$.next(undefined),
           setExpandedDoc: enableDocumentViewer ? setExpandedDoc : undefined,

--- a/src/platform/plugins/shared/discover/public/plugin.tsx
+++ b/src/platform/plugins/shared/discover/public/plugin.tsx
@@ -353,10 +353,14 @@ export class DiscoverPlugin
   }) {
     const [
       { rootProfileService, dataSourceProfileService, documentProfileService, profilesManager },
-      { createProfileProviderSharedServices, registerProfileProviders },
+      {
+        createProfileProviderSharedServices,
+        registerProfileProviders,
+        registerProfileStateDefinitions,
+      },
     ] = await Promise.all([
       this.createProfileServices(),
-      import('./context_awareness/profile_providers'),
+      import('./plugin_imports/context_awareness'),
     ]);
 
     const [sharedServices, services] = await Promise.all([
@@ -379,6 +383,8 @@ export class DiscoverPlugin
       sharedServices,
       services,
     });
+
+    registerProfileStateDefinitions(services.profileStateRegistry);
 
     return services;
   }

--- a/src/platform/plugins/shared/discover/public/plugin_imports/context_awareness.ts
+++ b/src/platform/plugins/shared/discover/public/plugin_imports/context_awareness.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export {
+  createProfileProviderSharedServices,
+  registerProfileProviders,
+} from '../context_awareness/profile_providers';
+export { registerProfileStateDefinitions } from '../context_awareness/profile_state';


### PR DESCRIPTION
## Summary

Introduces an extensible state-management layer that lets Discover profiles own state with different lifetimes — ephemeral UI, URL-synced, locally persisted, and locator-embedded — without each profile having to wire its own plumbing into the tab/Redux/URL stack.

Relates to https://github.com/elastic/kibana/issues/242987.

## Motivation

Profiles like Metrics need state that survives tab switches, page refreshes, shared URLs, and locator links (dimension breakdowns, chart configs, view-mode toggles, etc.). Today the only generic slots are `appState` / `globalState`, which don't fit ad-hoc profile shapes and don't expose lifetime distinctions. The goal is **one declarative contract a profile can describe once**, with a **single host-side registry** that routes each field to the right destination.

## Approach

A profile declares the shape of its state once, annotates each field with a lifetime ("type"), and reads/writes it through a per-tab adapter. The host inspects those descriptors to route state to Redux, the URL, local storage, and the locator. Profiles never touch any of those layers directly.

### Key building blocks

- **`ProfileStateDefinition<TState>`** — `{ key, descriptor }` where `descriptor` is `{ [field]: { type: 'ui' | 'url' | 'persistent' } }`. `key` namespaces this state across profiles in the tab's `profileState` record. (`profile_state.ts`)
- **`ProfileStateRegistry`** — Single registry on `services.profileStateRegistry`. Definitions register once at plugin start via `registerProfileStateDefinitions`. `pickStateByType` is what every destination uses to filter the right fields out.
- **`ProfileStateAdapter<TState>`** — The simplified interface profiles use to read and write their state. It deliberately hides Redux, observables wiring, URL syncing, and storage from profile code, which means:
  - Profiles can be hosted **outside Discover Main** — the host (an embeddable, the Surrounding Docs view, a future runtime, etc.) supplies its own adapter implementation, and the same profile code keeps working.
  - State is **strongly typed and customizable** — each definition declares its own `TState`, so there's no fixed schema profiles must conform to.
  - State **isn't tied to a specific profile** — a single definition can be consumed across context levels; a root, data source, and document profile can all call `toolkit.getStateAdapter(MY_DEF)` and read/write the same state.
- **`ContextAwarenessToolkit.getStateAdapter`** — The already-existing `toolkit` argument on extension points. Returns the adapter scoped to the current tab and definition.
- **`DataSourceContext.profileState`** — A data-source profile binds itself to a definition by returning `profileState: MY_DEF` from its `resolve` context. URL sync, locator emission, and restoration all key off this binding to know which definition is currently active for a tab.

### How each lifetime flows

| Type | Where it lives | Mechanism |
|---|---|---|
| `Ui` | Tab Redux state only | Never serialized. |
| `Url` | URL `_p` query param ⇄ Redux | Applied on init from `_p` and two-way synced with the URL while the bound profile is active. |
| `Persistent` | Local storage ⇄ Redux | Filtered via `getPersistentProfileState` on write and reload (`tabs_storage_manager.ts`). |
| Locator | `DiscoverAppLocatorParams.profileUrlState` | Produced by `getProfileUrlState`; consumed by the share menu, search-session restoration, and `appLocatorGetLocationCommon` (which writes it to `_p`). |

## Trying it out

1. Enable the example profiles in `kibana.dev.yml`:
   ```yaml
   discover.experimental.enabledProfiles:
     - example-root-profile
     - example-data-source-profile
     - example-document-profile
   ```
2. Install the **Sample web logs** dataset via *Add sample data*.
3. Add an alias so the example profile resolves against the sample data. In *Dev Tools*:
   ```
   POST _aliases
   {
     "actions": [
       { "add": { "index": "kibana_sample_data_logs", "alias": "my-example-logs" } }
     ]
   }
   ```
4. In Discover, switch to ES|QL and run `FROM my-example-logs`. Expand any row → **Extensible State Example** doc-viewer tab. The three selects exercise UI, Persistent, and URL state respectively.

## Examples

### 1. The adapter interface

```ts
interface ProfileStateAdapter<TState extends object> {
  getState: () => TState;
  getState$: () => Observable<TState>;
  setState: (state: TState, options?: ProfileStateMutationOptions) => void;
  updateState: (stateUpdate: Partial<TState>, options?: ProfileStateMutationOptions) => void;
}

interface ProfileStateMutationOptions {
  // Push a new URL history entry (default) or replace the current one.
  historyMethod?: 'push' | 'replace';
}
```

### 2. Declare state

```ts
export interface ColorState {
  timestampColor: string;                                           // UI
  rowControlColor: 'neutral' | 'primary' | 'success' | 'danger';    // Persistent
  boxColor: 'transparent' | 'success' | 'warning' | 'danger';       // URL
}

export const COLOR_STATE_DEF: ProfileStateDefinition<ColorState> = {
  key: 'colorState',
  descriptor: {
    timestampColor: { type: ProfileStateType.Ui },
    rowControlColor: { type: ProfileStateType.Persistent },
    boxColor: { type: ProfileStateType.Url },
  },
};

export const registerProfileStateDefinitions = (registry: ProfileStateRegistry) => {
  registry.registerDefinition(COLOR_STATE_DEF);
};
```

`registerProfileStateDefinitions` is called once during plugin start (`plugin.tsx`), so a new definition only has to be added there.

### 3. Bind state to a profile

Setting `profileState` on a data source profile's resolved context tells the URL sync layer which definition's `Url`-typed fields to two-way sync with `_p` while this profile is the active match for the tab. This is the only place a definition gets tied to a specific profile, and only for URL syncing — any state can still be consumed from any profile without a binding.

```ts
const provider: DataSourceProfileProvider<MyContext, ColorState> = {
  profileId: 'example-data-source-profile',
  profile: { /* extension points */ },
  resolve: (params) => ({
    isMatch: true,
    context: {
      category: DataSourceCategory.Logs,
      profileState: COLOR_STATE_DEF,
      // ...other context...
    },
  }),
};
```

### 4. Consume the same state across profile levels

Any profile — root, data source, or document — can pick up a definition through its toolkit and interact with it. This is useful when state needs to drive behavior across the whole hierarchy (e.g. a setting the chart, row controls, and cell renderers should all react to). The call site is identical regardless of the profile level:

```ts
getCellRenderers: (prev, { toolkit }) => {
  const adapter = toolkit.getStateAdapter(COLOR_STATE_DEF);
  const colorState$ = adapter.getState$();

  const Timestamp = (props) => {
    const { timestampColor } = useObservable(colorState$, adapter.getState());
    return <EuiBadge color={timestampColor}>{props.value}</EuiBadge>;
  };

  return (params) => ({ ...prev(params), '@timestamp': Timestamp });
},
```

### 5. Mutate state

```ts
adapter.updateState({ boxColor: 'warning' });                                  // shallow merge
adapter.updateState({ boxColor: 'warning' }, { historyMethod: 'replace' });    // skip a history entry

adapter.setState({                                                              // full replace
  timestampColor: 'neutral',
  rowControlColor: 'neutral',
  boxColor: 'transparent',
});
```

## Not yet covered

- **Saved-object persistence** — the issue's 5th lifetime is not in `ProfileStateType` yet; persisting profile state into the Discover Session saved object is TBD.
- **`historyMethod`** — accepted by the adapter API but not yet honored by the URL sync path.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.