### PR TITLE
Add Cases / Agent Builder convergence POC (Option B).

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/index.ts
@@ -29,6 +29,7 @@ export type { ConversationInputShellProps } from './conversation_input_shell';
 export type {
   AgentBuilderPluginSetup,
   AgentBuilderPluginStart,
+  CaseAiWorkspaceProps,
   EmbeddableConversationProps,
   PublicEmbeddableConversationProps,
   OpenConversationSidebarOptions,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ComponentType } from 'react';
+import type { ComponentType, FC } from 'react';
 import type { AttachmentInput, UpdateOriginResponse } from '@kbn/agent-builder-common/attachments';
 import type { BrowserApiToolDefinition } from './tools/browser_api_tool';
 import type {
@@ -113,6 +113,19 @@ export interface EmbeddableConversationProps {
    * ```
    */
   browserApiTools?: Array<BrowserApiToolDefinition<any>>;
+}
+
+/**
+ * Props for the case detail "AI Workspace" tab (Option B: case is the entry point).
+ */
+export interface CaseAiWorkspaceProps {
+  caseId: string;
+  caseTitle: string;
+  caseOwner: string;
+  caseDescription?: string;
+  totalAlerts?: number;
+  totalComments?: number;
+  fileCount?: number;
 }
 
 /**
@@ -234,4 +247,8 @@ export interface AgentBuilderPluginStart {
    * functional agent_builder chat without the sidebar chrome.
    */
   EmbeddableConversation: ComponentType<PublicEmbeddableConversationProps>;
+  /**
+   * Inline AI Workspace for a case detail tab. Undefined when Agent Builder is unavailable.
+   */
+  CaseAiWorkspace?: FC<CaseAiWorkspaceProps>;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
@@ -75,6 +75,16 @@ export interface EmbeddableConversationProps {
   attachments?: AttachmentInput[];
 
   /**
+   * Cases case ID when opening chat from a case (persisted on new conversations).
+   */
+  caseId?: string;
+
+  /**
+   * Agent Builder project ID when chat belongs to a project workspace.
+   */
+  projectId?: string;
+
+  /**
    * Browser API tools that the agent can use to interact with the page.
    * Tools are executed browser-side when the LLM requests them.
    *

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/plugin_contract.ts
@@ -80,6 +80,16 @@ export interface EmbeddableConversationProps {
   caseId?: string;
 
   /**
+   * Cases owner for `caseId` (e.g. `securitySolution`). Used to get-or-create a case-typed project.
+   */
+  caseOwner?: string;
+
+  /**
+   * Optional case title when auto-creating a case-typed project for `caseId` + `caseOwner`.
+   */
+  caseTitle?: string;
+
+  /**
    * Agent Builder project ID when chat belongs to a project workspace.
    */
   projectId?: string;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -345,6 +345,14 @@ export interface Conversation {
    * Keeps track of which prompts have been answered and the response.
    */
   state?: ConversationInternalState;
+  /**
+   * Optional link to a Cases case when the conversation was opened from case context.
+   */
+  case_id?: string;
+  /**
+   * Optional link to an Agent Builder project workspace.
+   */
+  project_id?: string;
 }
 
 export type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
@@ -133,6 +133,14 @@ export {
   type AgentDeleteRequest,
 } from './agents';
 export {
+  ProjectType,
+  type CaseRef,
+  type Project,
+  type ProjectCreateRequest,
+  type ProjectUpdateRequest,
+  type CreateProjectFromCaseRequest,
+} from './project/project';
+export {
   type RoundInput,
   type ConverseInput,
   type AssistantResponse,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/project/project.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/project/project.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UserIdAndName } from '../base/users';
+
+/**
+ * Project types drive UI lens, default knowledge sources, and connector surfacing.
+ */
+export enum ProjectType {
+  case = 'case',
+  hunt = 'hunt',
+  investigation = 'investigation',
+  general = 'general',
+}
+
+/**
+ * Reference to a Cases plugin case when `type` is `case`.
+ */
+export interface CaseRef {
+  case_id: string;
+  owner: string;
+}
+
+/**
+ * Agent Builder workspace: persistent context container with conversations and knowledge.
+ */
+export interface Project {
+  id: string;
+  title: string;
+  type: ProjectType;
+  case_ref?: CaseRef;
+  /** Profile UIDs or usernames with access; mirrors case assignees for case projects. */
+  members: string[];
+  conversation_ids: string[];
+  created_at: string;
+  updated_at: string;
+  created_by: UserIdAndName;
+  space: string;
+}
+
+export interface ProjectCreateRequest {
+  id?: string;
+  title: string;
+  type: ProjectType;
+  case_ref?: CaseRef;
+  members?: string[];
+  conversation_ids?: string[];
+}
+
+export interface ProjectUpdateRequest {
+  id: string;
+  title?: string;
+  members?: string[];
+  conversation_ids?: string[];
+}
+
+export interface CreateProjectFromCaseRequest {
+  case_id: string;
+  owner: string;
+  title?: string;
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/execution/types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/execution/types.ts
@@ -55,6 +55,10 @@ export interface ConversationExecutionParams extends BaseExecutionParams {
   browserApiTools?: BrowserApiToolMetadata[];
   /** The action to perform: "regenerate" re-executes the last round with original input (requires conversationId). */
   action?: ConversationAction;
+  /** Cases case ID to persist on conversation create. */
+  caseId?: string;
+  /** Project ID to persist on conversation create. */
+  projectId?: string;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/common/case_project_owners.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/case_project_owners.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+/** Cases `owner` values supported when linking a case-typed Agent Builder project. */
+export const CASE_PROJECT_OWNER_OPTIONS = [
+  {
+    value: 'securitySolution',
+    label: i18n.translate('xpack.agentBuilder.projects.caseOwner.security', {
+      defaultMessage: 'Security',
+    }),
+  },
+  {
+    value: 'observability',
+    label: i18n.translate('xpack.agentBuilder.projects.caseOwner.observability', {
+      defaultMessage: 'Observability',
+    }),
+  },
+  {
+    value: 'cases',
+    label: i18n.translate('xpack.agentBuilder.projects.caseOwner.stack', {
+      defaultMessage: 'Stack (Management)',
+    }),
+  },
+] as const;
+
+export type CaseProjectOwner = (typeof CASE_PROJECT_OWNER_OPTIONS)[number]['value'];

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/chat.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/chat.ts
@@ -24,6 +24,10 @@ export interface ChatRequestBodyPayload {
   connector_id?: string | null;
   inference_id?: string | null;
   conversation_id?: string;
+  /** Cases case ID to associate with a new or updated conversation. */
+  case_id?: string;
+  /** Agent Builder project ID to associate with the conversation. */
+  project_id?: string;
   capabilities?: AgentCapabilities;
   attachments?: AttachmentInput[];
   input?: string;

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/projects.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/projects.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Project } from '@kbn/agent-builder-common';
+
+export interface ListProjectsResponse {
+  results: Project[];
+}
+
+export interface GetProjectResponse {
+  project: Project;
+}
+
+export interface CreateProjectFromCaseBody {
+  case_id: string;
+  owner: string;
+  title?: string;
+}

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/projects.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/projects.ts
@@ -7,12 +7,29 @@
 
 import type { Project } from '@kbn/agent-builder-common';
 
+export interface ProjectKnowledgeSummary {
+  case_id: string;
+  owner: string;
+  title?: string;
+  description?: string;
+  status?: string;
+  severity?: string;
+  total_alerts?: number;
+  total_comments?: number;
+}
+
 export interface ListProjectsResponse {
   results: Project[];
 }
 
 export interface GetProjectResponse {
   project: Project;
+  knowledge?: ProjectKnowledgeSummary;
+}
+
+export interface ListProjectsQuery {
+  type?: string;
+  case_id?: string;
 }
 
 export interface CreateProjectFromCaseBody {

--- a/x-pack/platform/plugins/shared/agent_builder/docs/cases_ab_chat_org_issue_comment_draft.md
+++ b/x-pack/platform/plugins/shared/agent_builder/docs/cases_ab_chat_org_issue_comment_draft.md
@@ -1,0 +1,52 @@
+# Draft comment for [search-team#14200](https://github.com/elastic/search-team/issues/14200) (Chat organisation)
+
+Copy/paste into the GitHub issue (edit names/links as needed).
+
+---
+
+## Cases / Agent Builder convergence — alignment with program doc + Chat organisation
+
+We are exploring **Cases + Agent Builder convergence** (case-centric AI workspace). A POC branch introduces an AB **`Project`** with `type: 'case'`, `case_ref`, projected case knowledge, and linked `conversation_ids`.
+
+After reading the **Agent Builder program doc**, this POC targets the same primitive the doc describes under **Experience Principles (Jan 2026)**:
+
+> **“Chat” as a project-like container** — interactions include the conversation plus metadata and **relations to other artifacts (e.g. connected cases, alerts, workflows)**. A “Chat” represents an **investigation project**.
+
+That is the same bucket as this epic’s **“projects”** (P2; doc notes *“labels and pinning are v1; projects build on labels”*), not a separate Cases-only workspace.
+
+### Terminology we are *not* duplicating
+
+| Program doc term | Meaning | Cases POC |
+|----------------|---------|-----------|
+| **Agent Workspace** | Few, largely independent top-level workspaces | **Not** our `Project` SO |
+| **Context Plugin/Package/Project** | Skills + Sources bundle for a use case | **Not** our `Project` SO (see `cases/SKILL.md` instead) |
+| **Multi-user chat** (P0) | Shared conversation, attribution, group UX | [#14201](https://github.com/elastic/search-team/issues/14201) / [#259692](https://github.com/elastic/kibana/pull/259692) — **inside** a project, not instead of it |
+
+### Proposed split
+
+| Layer | Owner | What it is |
+|-------|--------|------------|
+| **Investigation container** (“Chat” / project) | #14200 + program doc | Persistent container: `type`, members, conversation list, persisted vs ephemeral attachments, relations (`case_ref`, alerts, workflows). |
+| **Group thread** | #14201 / #259692 | Multi-user **conversation** (timeline, `@agent`, shared ACL). |
+| **`ProjectType.case`** | Cases + AB | `case_ref { case_id, owner }`, knowledge projected from Case; case UI entry. **Does not** replace Case SO, connectors, or UserAction audit. |
+
+### Illustrative shape
+
+```
+Investigation container (type=case, case_ref → Case)
+├── Shared context (projected case knowledge — not re-attached every chat)
+├── Group conversation(s)          ← P0 multi-user
+└── Private / forked conversation(s) ← #14221
+```
+
+Human + AI activity that must appear on the **case audit trail** stays in the **Cases activity log**. AB threads are for agent collaboration grounded in the case.
+
+### Asks
+
+1. Confirm the canonical name going forward: **“Chat” (project-like)** vs **“Project”** in APIs/storage — we can rename the POC to match.
+2. Is **`ProjectType.case` / `connected cases`** the right extension for Security/O11y case views, or should case linking live only as attachments until generic projects ship?
+3. Treat `.chat-projects` POC index as **throwaway** until #14200 lands?
+
+**Internal spec:** `x-pack/platform/plugins/shared/agent_builder/docs/cases_ab_convergence_spec.md` (Agent Builder roadmap alignment).
+
+cc @chrisbmar @pgayvallet @deeptidheer-dotcom

--- a/x-pack/platform/plugins/shared/agent_builder/docs/cases_ab_convergence_spec.md
+++ b/x-pack/platform/plugins/shared/agent_builder/docs/cases_ab_convergence_spec.md
@@ -1,0 +1,57 @@
+# Cases / Agent Builder convergence specification
+
+## Target state
+
+- **Now (Option B):** Agent Builder **Project** wraps an existing Case (`type: 'case'`, `case_ref`, projected knowledge).
+- **Later (Option A):** Case UI becomes a view on a `type=case` Project if product fit is proven.
+- **Not in scope:** `ProjectCollection` hierarchy; sidebar grouping is `filter by type` only.
+
+## Team ownership
+
+| Area | Owner |
+|------|--------|
+| Case SO, user actions, connectors, push-to-service | `@elastic/kibana-cases` |
+| Project SO, conversations, agent execution | `@elastic/workchat-eng` |
+| Security case attachment + Add to Chat entry | Security Solution + Cases UI |
+| Platform case attachment | `agent_builder_platform` |
+
+## AI persistence (default until changed)
+
+- **Phase 1–2:** AI replies are **chat-only** (Agent Builder conversation rounds).
+- **Phase 3:** Opt-in **persisted** AI comments via `cases.ai_response` unified attachment + UserAction (audit on case).
+
+## Trigger policy (Phase 3)
+
+1. **Manual:** Add to Chat / user sends message in case-linked conversation.
+2. **Mention (future):** `@agent` in case comment text triggers agent run.
+3. **Event-driven (future):** New alert attached to case → optional auto-summary (feature-flagged).
+
+## RBAC
+
+- Case access: existing Cases `owner` + feature privileges.
+- Project/conversation access: `agentBuilder:read` / `agentBuilder:write` + conversation owner (shared ACL when [PR #259692](https://github.com/elastic/kibana/pull/259692) lands).
+- Project `members` mirror case assignees at create time; membership sync is best-effort on project get.
+
+## Citation model
+
+- Neither Cases comments nor AB `AssistantResponse` use Elastic Assistant `contentReferences` today.
+- Rich citations: **versioned AB attachments** + Cases unified attachment `metadata` on `ai_response` (Phase 3).
+
+## Elastic Assistant
+
+- Security case flows should **not** assume EA `PRIVATE|RESTRICTED|SHARED` or anonymization; those are EA-only.
+- Deprecation of EA for case-centric flows is a separate program decision.
+
+## API surfaces (implemented)
+
+| API | Purpose |
+|-----|---------|
+| `security.case` / `platform.core.cases.case` attachment | Case context in chat |
+| `POST /api/agent_builder/projects` | Create project (incl. from case) |
+| `GET/PATCH /api/agent_builder/projects/{id}` | Project CRUD |
+| `conversation.case_id` / `project_id` | Link chat to case/project |
+| Cases UI Add to Chat | Opens AB with case attachment |
+
+## Multi-user dependency
+
+See [pr_259692_multi_user_dependency.md](./pr_259692_multi_user_dependency.md).

--- a/x-pack/platform/plugins/shared/agent_builder/docs/cases_ab_convergence_spec.md
+++ b/x-pack/platform/plugins/shared/agent_builder/docs/cases_ab_convergence_spec.md
@@ -6,6 +6,48 @@
 - **Later (Option A):** Case UI becomes a view on a `type=case` Project if product fit is proven.
 - **Not in scope:** `ProjectCollection` hierarchy; sidebar grouping is `filter by type` only.
 
+## Agent Builder roadmap alignment
+
+Source: **Agent Builder program doc** (Google Doc / `Agent Builder.docx`) + GitHub epics under [search-team#14069](https://github.com/elastic/search-team/issues/14069).
+
+Cases/AB convergence **must not introduce a parallel container model**. The program doc already defines a **chat-as-investigation-project** primitive with explicit **connected cases**; the POC `Project` type should converge to that, not to unrelated “project” names in the stack.
+
+### Terminology map (avoid duplicate concepts)
+
+| Program doc concept | Priority (doc) | POC / Cases term | Relationship |
+|---------------------|----------------|------------------|--------------|
+| **Chat as a project-like container** — conversation + metadata + relations to **connected cases, alerts, workflows**; investigation handoff / reuse | Experience principles (Jan 2026) | `Project` / `type=case` + `case_ref` | **Primary alignment.** Cases integration is a first-class relation on the container, not a separate product. |
+| **Chat organization — projects** (after labels & pinning) | P2 — “labels and pinning are v1; **projects build on labels**” | `ProjectType` + sidebar `filter by type` | Same intent as [search-team#14200](https://github.com/elastic/search-team/issues/14200). Case-typed projects are one flavour. |
+| **Chat based container** — history, context, metadata; shareable | Core components | One or more **conversations** listed on a project | Conversations are threads; the container holds many + persisted attachments policy. |
+| **Collaboration: Multi-user chat** | **P0** | Group conversations inside a project | [search-team#14201](https://github.com/elastic/search-team/issues/14201), [#259692](https://github.com/elastic/kibana/pull/259692) — see [pr_259692_multi_user_dependency.md](./pr_259692_multi_user_dependency.md) |
+| **Agent Workspace** | Core components (few, independent) | **Not** the POC `Project` SO | Higher-level scope (e.g. space/deployment grouping). Do not overload case linking into “workspace”. |
+| **Context Plugin/Package/Project** | Core components | **Not** the POC `Project` SO | Means **Skills + Sources** bundle for a use case (`kibana-best-practices/cases/SKILL.md`, etc.). |
+| **Non-collaborative sharing (read-only)** | Backlog | Fork / duplicate conversation | [search-team#14221](https://github.com/elastic/search-team/issues/14221) — handoff, not the same as group chat. |
+| Cross **Project** Search | Separate initiative | N/A | [search-team#14234](https://github.com/elastic/search-team/issues/14234) — Elasticsearch CPS only. |
+
+### Duplication verdict
+
+| Question | Answer |
+|----------|--------|
+| Is “AB Project” duplicative of the program roadmap? | **Yes — it is the same planned capability**, named “Chat” / “projects” in the doc and #14200, not a Cases-only invention. |
+| Is Cases `case_ref` duplicative? | **No — it is called out** (“connected cases”) as a relation on the investigation container. |
+| Is multi-user chat duplicative of Projects? | **No — complementary.** P0 multi-user is at **conversation** level; the container groups threads and shared knowledge. |
+| Is Option A (`case.project` on Case SO) in the doc? | **Not as canonical storage.** Doc centres the **chat container** with case **relations**. Prefer container + `case_ref` unless Cases team requires SO co-location for connectors/audit. |
+
+### Division of responsibility
+
+- **AB Chat organisation (#14200):** labels → pins → **projects**; generic container (title, `type`, members, `conversation_ids`). `ProjectType`: `case`, `hunt`, `investigation`, `general` in `@kbn/agent-builder-common`.
+- **AB Multi-user (#14201 / #259692):** timeline, group ACL, `@agent` trigger, attribution / audit questions in doc UC2.
+- **Cases/AB convergence:** `ProjectType.case`, `case_ref`, knowledge projection, case UI entry (Add to Chat → AI Workspace), persisted AI via Cases UserAction when required for audit.
+
+### Sequencing note (from program doc)
+
+Multi-user chat is **P0**; chat organisation projects are **P2** (after labels/pins). The case-linking POC may run **ahead of generic project UX** — treat `.chat-projects` as spike-only until #14200 schema/UX is agreed.
+
+**Coordination:** `#ws-chat-experience-ux` (Chris Martin, Pierre Gayvallet, Deepti).
+
+Draft GitHub comment for #14200: [cases_ab_chat_org_issue_comment_draft.md](./cases_ab_chat_org_issue_comment_draft.md).
+
 ## Team ownership
 
 | Area | Owner |

--- a/x-pack/platform/plugins/shared/agent_builder/docs/pr_259692_multi_user_dependency.md
+++ b/x-pack/platform/plugins/shared/agent_builder/docs/pr_259692_multi_user_dependency.md
@@ -1,0 +1,32 @@
+# PR #259692 — multi-user conversation dependency
+
+**PR:** [elastic/kibana#259692](https://github.com/elastic/kibana/pull/259692)  
+**Author:** Pierre Gayvallet (`pgayvallet`)  
+**Status:** Open (not on `main` as of implementation)
+
+## What the PR targets
+
+- Timeline model: `UserMessageEvent` + `AgentExecutionEvent` alongside legacy `conversation_rounds`
+- `AgentTriggerHook`: single-user (always run) vs group (`@agent` mention)
+- Planned persistence: `events`, `conversation_mode`, `execution_state`
+- Planned ACL: group conversations visible to all participants
+
+## What shipped in the scoped PR diff (verify on merge)
+
+- Execution-layer refactor (`AgentExecution`, timeline converters)
+- **May not include:** full persistence schema, `queued_trigger`, shared list/get ACL
+
+## Impact on Cases/AB convergence
+
+| Feature | Blocked on #259692? |
+|---------|---------------------|
+| Phase 1: Add to Chat + case attachment | No |
+| Phase 2: case-typed Project (owner-scoped conversations) | No |
+| Shared conversations inside a Project | **Yes** — needs group ACL + timeline persistence |
+| AI as case participant (Cases UserAction) | No |
+
+## Action items
+
+1. Re-read PR diff on merge; update this doc with actual fields and hooks.
+2. Wire Project `conversation_ids` to shared conversations when `conversation_mode=group` is available.
+3. Align `@agent` trigger with Cases `@mention` on comments if both land.

--- a/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
@@ -44,6 +44,7 @@
     ],
     "optionalPlugins": [
       "cloud",
+      "cases",
       "evals",
       "licenseManagement",
       "security",

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/agent_builder_view_ids.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/agent_builder_view_ids.ts
@@ -32,4 +32,5 @@ export const agentBuilderViewIds = {
   manageToolDetails: 'agent_builder_manage_tools_detail',
   manageMcpClients: 'agent_builder_manage_mcp_clients',
   manageMcpClientCreate: 'agent_builder_manage_mcp_clients_create',
+  manageProjects: 'agent_builder_manage_projects',
 } as const;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/projects/link_case_modal.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/projects/link_case_modal.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiForm,
+  EuiFormRow,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSelect,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  CASE_PROJECT_OWNER_OPTIONS,
+  type CaseProjectOwner,
+} from '../../../../common/case_project_owners';
+import { useCreateProjectFromCase } from '../../hooks/projects/use_create_project_from_case';
+
+export interface LinkCaseModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onLinked?: (projectId: string) => void;
+}
+
+export const LinkCaseModal = ({ isOpen, onClose, onLinked }: LinkCaseModalProps) => {
+  const { linkCaseToProject, isLinking } = useCreateProjectFromCase();
+  const [caseId, setCaseId] = useState('');
+  const [owner, setOwner] = useState<CaseProjectOwner>('securitySolution');
+  const [title, setTitle] = useState('');
+
+  const resetForm = useCallback(() => {
+    setCaseId('');
+    setOwner('securitySolution');
+    setTitle('');
+  }, []);
+
+  const handleClose = useCallback(() => {
+    resetForm();
+    onClose();
+  }, [onClose, resetForm]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault();
+      const trimmedCaseId = caseId.trim();
+      if (!trimmedCaseId) {
+        return;
+      }
+
+      const project = await linkCaseToProject({
+        case_id: trimmedCaseId,
+        owner,
+        ...(title.trim() ? { title: title.trim() } : {}),
+      });
+      onLinked?.(project.id);
+      handleClose();
+    },
+    [caseId, owner, title, linkCaseToProject, onLinked, handleClose]
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <EuiModal onClose={handleClose} data-test-subj="agentBuilderLinkCaseModal">
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          {i18n.translate('xpack.agentBuilder.projects.linkCaseModal.title', {
+            defaultMessage: 'Link case to project',
+          })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiForm component="form" onSubmit={handleSubmit}>
+        <EuiModalBody>
+          <EuiFormRow
+            label={i18n.translate('xpack.agentBuilder.projects.linkCaseModal.caseIdLabel', {
+              defaultMessage: 'Case ID',
+            })}
+            helpText={i18n.translate('xpack.agentBuilder.projects.linkCaseModal.caseIdHelp', {
+              defaultMessage: 'The Cases plugin ID for the case you want to link.',
+            })}
+            fullWidth
+          >
+            <EuiFieldText
+              value={caseId}
+              onChange={(e) => setCaseId(e.target.value)}
+              fullWidth
+              required
+              data-test-subj="agentBuilderLinkCaseModalCaseId"
+            />
+          </EuiFormRow>
+          <EuiFormRow
+            label={i18n.translate('xpack.agentBuilder.projects.linkCaseModal.ownerLabel', {
+              defaultMessage: 'Case owner',
+            })}
+            fullWidth
+          >
+            <EuiSelect
+              options={CASE_PROJECT_OWNER_OPTIONS.map((option) => ({
+                value: option.value,
+                text: option.label,
+              }))}
+              value={owner}
+              onChange={(e) => setOwner(e.target.value as CaseProjectOwner)}
+              fullWidth
+              data-test-subj="agentBuilderLinkCaseModalOwner"
+            />
+          </EuiFormRow>
+          <EuiFormRow
+            label={i18n.translate('xpack.agentBuilder.projects.linkCaseModal.titleLabel', {
+              defaultMessage: 'Project title (optional)',
+            })}
+            fullWidth
+          >
+            <EuiFieldText
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              fullWidth
+              data-test-subj="agentBuilderLinkCaseModalTitle"
+            />
+          </EuiFormRow>
+        </EuiModalBody>
+        <EuiModalFooter>
+          <EuiButtonEmpty onClick={handleClose} data-test-subj="agentBuilderLinkCaseModalCancel">
+            {i18n.translate('xpack.agentBuilder.projects.linkCaseModal.cancel', {
+              defaultMessage: 'Cancel',
+            })}
+          </EuiButtonEmpty>
+          <EuiButton
+            type="submit"
+            fill
+            isLoading={isLinking}
+            disabled={!caseId.trim()}
+            data-test-subj="agentBuilderLinkCaseModalSubmit"
+          >
+            {i18n.translate('xpack.agentBuilder.projects.linkCaseModal.submit', {
+              defaultMessage: 'Link case',
+            })}
+          </EuiButton>
+        </EuiModalFooter>
+      </EuiForm>
+    </EuiModal>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/projects/project_details_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/projects/project_details_flyout.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiCodeBlock,
+  EuiDescriptionList,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiLink,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { ProjectType } from '@kbn/agent-builder-common';
+import { useProject } from '../../hooks/projects/use_project';
+import { useKibana } from '../../hooks/use_kibana';
+import { getCaseViewUrl } from '../../utils/get_case_view_url';
+
+export interface ProjectDetailsFlyoutProps {
+  projectId: string | null;
+  onClose: () => void;
+}
+
+export const ProjectDetailsFlyout = ({ projectId, onClose }: ProjectDetailsFlyoutProps) => {
+  const {
+    services: { application },
+  } = useKibana();
+  const { project, knowledge, isLoading } = useProject(projectId ?? undefined);
+
+  if (!projectId) {
+    return null;
+  }
+
+  const caseRef = project?.case_ref;
+  const caseUrl =
+    caseRef &&
+    getCaseViewUrl({
+      application,
+      caseId: caseRef.case_id,
+      owner: caseRef.owner,
+    });
+
+  return (
+    <EuiFlyout onClose={onClose} size="m" data-test-subj="agentBuilderProjectDetailsFlyout">
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 data-test-subj="agentBuilderProjectDetailsFlyoutTitle">
+            {project?.title ??
+              i18n.translate('xpack.agentBuilder.projects.detailsFlyout.loadingTitle', {
+                defaultMessage: 'Project details',
+              })}
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        {isLoading ? (
+          <EuiLoadingSpinner size="l" />
+        ) : (
+          <>
+            <EuiDescriptionList
+              compressed
+              listItems={[
+                {
+                  title: i18n.translate('xpack.agentBuilder.projects.detailsFlyout.id', {
+                    defaultMessage: 'ID',
+                  }),
+                  description: project?.id,
+                },
+                {
+                  title: i18n.translate('xpack.agentBuilder.projects.detailsFlyout.type', {
+                    defaultMessage: 'Type',
+                  }),
+                  description: project?.type,
+                },
+                {
+                  title: i18n.translate('xpack.agentBuilder.projects.detailsFlyout.space', {
+                    defaultMessage: 'Space',
+                  }),
+                  description: project?.space,
+                },
+                {
+                  title: i18n.translate('xpack.agentBuilder.projects.detailsFlyout.updated', {
+                    defaultMessage: 'Updated',
+                  }),
+                  description: project?.updated_at
+                    ? new Date(project.updated_at).toLocaleString()
+                    : undefined,
+                },
+                {
+                  title: i18n.translate('xpack.agentBuilder.projects.detailsFlyout.conversations', {
+                    defaultMessage: 'Conversations',
+                  }),
+                  description: String(project?.conversation_ids.length ?? 0),
+                },
+              ]}
+            />
+            {project?.type === ProjectType.case && caseRef && (
+              <>
+                <EuiSpacer size="l" />
+                <EuiTitle size="xs">
+                  <h3>
+                    {i18n.translate('xpack.agentBuilder.projects.detailsFlyout.linkedCase', {
+                      defaultMessage: 'Linked case',
+                    })}
+                  </h3>
+                </EuiTitle>
+                <EuiSpacer size="s" />
+                <EuiDescriptionList
+                  compressed
+                  listItems={[
+                    {
+                      title: i18n.translate('xpack.agentBuilder.projects.detailsFlyout.caseId', {
+                        defaultMessage: 'Case ID',
+                      }),
+                      description: caseUrl ? (
+                        <EuiLink href={caseUrl} data-test-subj="agentBuilderProjectCaseLink">
+                          {caseRef.case_id}
+                        </EuiLink>
+                      ) : (
+                        caseRef.case_id
+                      ),
+                    },
+                    {
+                      title: i18n.translate('xpack.agentBuilder.projects.detailsFlyout.caseOwner', {
+                        defaultMessage: 'Owner',
+                      }),
+                      description: caseRef.owner,
+                    },
+                  ]}
+                />
+                {knowledge && (
+                  <>
+                    <EuiSpacer size="m" />
+                    <EuiDescriptionList
+                      compressed
+                      listItems={[
+                        {
+                          title: i18n.translate(
+                            'xpack.agentBuilder.projects.detailsFlyout.caseTitle',
+                            { defaultMessage: 'Case title' }
+                          ),
+                          description: knowledge.title,
+                        },
+                        {
+                          title: i18n.translate(
+                            'xpack.agentBuilder.projects.detailsFlyout.caseStatus',
+                            { defaultMessage: 'Status' }
+                          ),
+                          description: knowledge.status,
+                        },
+                        {
+                          title: i18n.translate(
+                            'xpack.agentBuilder.projects.detailsFlyout.caseSeverity',
+                            { defaultMessage: 'Severity' }
+                          ),
+                          description: knowledge.severity,
+                        },
+                        {
+                          title: i18n.translate(
+                            'xpack.agentBuilder.projects.detailsFlyout.caseAlerts',
+                            { defaultMessage: 'Alerts' }
+                          ),
+                          description: knowledge.total_alerts,
+                        },
+                        {
+                          title: i18n.translate(
+                            'xpack.agentBuilder.projects.detailsFlyout.caseComments',
+                            { defaultMessage: 'Comments' }
+                          ),
+                          description: knowledge.total_comments,
+                        },
+                      ]}
+                    />
+                  </>
+                )}
+              </>
+            )}
+            {project && project.conversation_ids.length > 0 && (
+              <>
+                <EuiSpacer size="l" />
+                <EuiTitle size="xs">
+                  <h3>
+                    {i18n.translate('xpack.agentBuilder.projects.detailsFlyout.conversationIds', {
+                      defaultMessage: 'Conversation IDs',
+                    })}
+                  </h3>
+                </EuiTitle>
+                <EuiSpacer size="s" />
+                <EuiCodeBlock language="json" isCopyable>
+                  {JSON.stringify(project.conversation_ids, null, 2)}
+                </EuiCodeBlock>
+              </>
+            )}
+          </>
+        )}
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/projects/projects.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/projects/projects.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+import { EuiButton, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { useUiPrivileges } from '../../hooks/use_ui_privileges';
+import { ProjectsTable } from './projects_table';
+import { LinkCaseModal } from './link_case_modal';
+
+export const AgentBuilderProjects = () => {
+  const { euiTheme } = useEuiTheme();
+  const { write: canWrite } = useUiPrivileges();
+  const [isLinkCaseModalOpen, setIsLinkCaseModalOpen] = useState(false);
+  const [focusProjectId, setFocusProjectId] = useState<string | null>(null);
+
+  return (
+    <KibanaPageTemplate data-test-subj="agentBuilderProjectsPage">
+      <KibanaPageTemplate.Header
+        pageTitle={i18n.translate('xpack.agentBuilder.projects.pageTitle', {
+          defaultMessage: 'Projects',
+        })}
+        description={i18n.translate('xpack.agentBuilder.projects.pageDescription', {
+          defaultMessage:
+            'Workspaces that group Agent Builder conversations. Case-typed projects link to Cases and surface projected case knowledge for chat context.',
+        })}
+        css={css`
+          background-color: ${euiTheme.colors.backgroundBasePlain};
+          border-block-end: none;
+        `}
+        rightSideItems={[
+          canWrite && (
+            <EuiButton
+              key="link-case"
+              fill
+              iconType="link"
+              onClick={() => setIsLinkCaseModalOpen(true)}
+              data-test-subj="agentBuilderLinkCaseButton"
+            >
+              {i18n.translate('xpack.agentBuilder.projects.linkCaseButton', {
+                defaultMessage: 'Link case',
+              })}
+            </EuiButton>
+          ),
+        ]}
+      />
+      <KibanaPageTemplate.Section>
+        <ProjectsTable
+          focusProjectId={focusProjectId}
+          onFocusProjectHandled={() => setFocusProjectId(null)}
+        />
+      </KibanaPageTemplate.Section>
+      <LinkCaseModal
+        isOpen={isLinkCaseModalOpen}
+        onClose={() => setIsLinkCaseModalOpen(false)}
+        onLinked={(projectId) => setFocusProjectId(projectId)}
+      />
+    </KibanaPageTemplate>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/projects/projects_table.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/projects/projects_table.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiBasicTableColumn, SearchFilterConfig } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiButtonEmpty,
+  EuiInMemoryTable,
+  EuiLink,
+  EuiSkeletonText,
+  EuiText,
+} from '@elastic/eui';
+import type { Project } from '@kbn/agent-builder-common';
+import { ProjectType } from '@kbn/agent-builder-common';
+import { i18n } from '@kbn/i18n';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useProjects } from '../../hooks/projects/use_projects';
+import { useKibana } from '../../hooks/use_kibana';
+import { getCaseViewUrl } from '../../utils/get_case_view_url';
+import { ProjectDetailsFlyout } from './project_details_flyout';
+
+const formatDate = (value: string) => new Date(value).toLocaleString();
+
+type ProjectTableItem = Project & { conversation_count: number };
+
+export interface ProjectsTableProps {
+  focusProjectId?: string | null;
+  onFocusProjectHandled?: () => void;
+}
+
+export const ProjectsTable = ({
+  focusProjectId,
+  onFocusProjectHandled,
+}: ProjectsTableProps) => {
+  const {
+    services: { application },
+  } = useKibana();
+  const { projects, isLoading } = useProjects();
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (focusProjectId) {
+      setSelectedProjectId(focusProjectId);
+      onFocusProjectHandled?.();
+    }
+  }, [focusProjectId, onFocusProjectHandled]);
+
+  const tableItems = useMemo(
+    (): ProjectTableItem[] =>
+      projects.map((project) => ({
+        ...project,
+        conversation_count: project.conversation_ids.length,
+      })),
+    [projects]
+  );
+
+  const columns = useMemo((): Array<EuiBasicTableColumn<ProjectTableItem>> => {
+    return [
+      {
+        field: 'title',
+        name: i18n.translate('xpack.agentBuilder.projects.table.title', {
+          defaultMessage: 'Title',
+        }),
+        render: (title: string, project: ProjectTableItem) => (
+          <EuiButtonEmpty
+            flush="left"
+            size="s"
+            onClick={() => setSelectedProjectId(project.id)}
+            data-test-subj={`agentBuilderProjectTitle-${project.id}`}
+          >
+            {title}
+          </EuiButtonEmpty>
+        ),
+        sortable: true,
+      },
+      {
+        field: 'type',
+        name: i18n.translate('xpack.agentBuilder.projects.table.type', {
+          defaultMessage: 'Type',
+        }),
+        render: (type: ProjectType) => <EuiBadge>{type}</EuiBadge>,
+        sortable: true,
+      },
+      {
+        name: i18n.translate('xpack.agentBuilder.projects.table.case', {
+          defaultMessage: 'Case',
+        }),
+        render: (project: ProjectTableItem) => {
+          const caseRef = project.case_ref;
+          if (!caseRef) {
+            return <EuiText size="s" color="subdued">—</EuiText>;
+          }
+          const caseUrl = getCaseViewUrl({
+            application,
+            caseId: caseRef.case_id,
+            owner: caseRef.owner,
+          });
+          if (caseUrl) {
+            return (
+              <EuiLink href={caseUrl} data-test-subj={`agentBuilderProjectCaseLink-${project.id}`}>
+                {caseRef.case_id}
+              </EuiLink>
+            );
+          }
+          return <EuiText size="s">{caseRef.case_id}</EuiText>;
+        },
+      },
+      {
+        field: 'conversation_count',
+        name: i18n.translate('xpack.agentBuilder.projects.table.conversations', {
+          defaultMessage: 'Conversations',
+        }),
+        sortable: true,
+      },
+      {
+        field: 'updated_at',
+        name: i18n.translate('xpack.agentBuilder.projects.table.updated', {
+          defaultMessage: 'Updated',
+        }),
+        render: formatDate,
+        sortable: true,
+      },
+    ];
+  }, [application]);
+
+  const search = useMemo(() => {
+    const filters: SearchFilterConfig[] = [
+      {
+        type: 'field_value_selection',
+        field: 'type',
+        name: i18n.translate('xpack.agentBuilder.projects.table.typeFilter', {
+          defaultMessage: 'Type',
+        }),
+        multiSelect: false,
+        options: Object.values(ProjectType).map((type) => ({
+          value: type,
+          name: type,
+        })),
+      },
+    ];
+    return {
+      box: {
+        incremental: true,
+        placeholder: i18n.translate('xpack.agentBuilder.projects.table.searchPlaceholder', {
+          defaultMessage: 'Search projects',
+        }),
+        'data-test-subj': 'agentBuilderProjectsTableSearch',
+      },
+      filters,
+    };
+  }, []);
+
+  if (isLoading) {
+    return <EuiSkeletonText lines={6} />;
+  }
+
+  return (
+    <>
+      <EuiInMemoryTable
+        items={tableItems}
+        columns={columns}
+        itemId="id"
+        search={search}
+        sorting={{ sort: { field: 'updated_at', direction: 'desc' } }}
+        data-test-subj="agentBuilderProjectsTable"
+      />
+      <ProjectDetailsFlyout
+        projectId={selectedProjectId}
+        onClose={() => setSelectedProjectId(null)}
+      />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/conversation_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/conversation_context.tsx
@@ -16,6 +16,8 @@ interface ConversationContextValue {
   isEmbeddedContext: boolean;
   sessionTag?: string;
   agentId?: string;
+  caseId?: string;
+  projectId?: string;
   initialMessage?: string;
   autoSendInitialMessage?: boolean;
   resetInitialMessage?: () => void;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -219,6 +219,8 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
       isEmbeddedContext: true,
       sessionTag: currentProps.sessionTag,
       agentId: currentProps.agentId ?? agentBuilderDefaultAgentId,
+      caseId: currentProps.caseId,
+      projectId: currentProps.projectId,
       initialMessage: currentProps.initialMessage,
       autoSendInitialMessage: currentProps.autoSendInitialMessage ?? false,
       resetInitialMessage,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -22,6 +22,7 @@ import { StreamingProvider } from '../streaming/streaming_context';
 import { useConversationActions } from './use_conversation_actions';
 import { ConversationChangeNotifier } from './conversation_change_notifier';
 import { usePersistedConversationId } from '../../hooks/use_persisted_conversation_id';
+import { useResolveCaseProject } from '../../hooks/projects/use_resolve_case_project';
 import { AppLeaveContext } from '../app_leave_context';
 
 const noopOnAppLeave = () => {};
@@ -212,6 +213,14 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
     setCurrentProps((prev) => ({ ...prev, agentId: id, newConversation: true }));
   }, []);
 
+  const resolvedProjectId = useResolveCaseProject({
+    projectsService: services.projectsService,
+    caseId: currentProps.caseId,
+    caseOwner: currentProps.caseOwner,
+    caseTitle: currentProps.caseTitle,
+    projectId: currentProps.projectId,
+  });
+
   const conversationContextValue = useMemo(
     () => ({
       conversationId,
@@ -220,7 +229,7 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
       sessionTag: currentProps.sessionTag,
       agentId: currentProps.agentId ?? agentBuilderDefaultAgentId,
       caseId: currentProps.caseId,
-      projectId: currentProps.projectId,
+      projectId: resolvedProjectId,
       initialMessage: currentProps.initialMessage,
       autoSendInitialMessage: currentProps.autoSendInitialMessage ?? false,
       resetInitialMessage,
@@ -237,6 +246,9 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
       conversationId,
       currentProps.sessionTag,
       currentProps.agentId,
+      currentProps.caseId,
+      currentProps.caseOwner,
+      resolvedProjectId,
       currentProps.initialMessage,
       currentProps.autoSendInitialMessage,
       currentProps.browserApiTools,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_send_message_mutation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/streaming/use_send_message_mutation.ts
@@ -40,6 +40,12 @@ import {
 
 const SCREEN_CONTEXT_ATTACHMENT_ID = 'screen-context';
 
+/** Extracts case ID from Kibana case detail URLs (`.../cases/{caseId}`). */
+const extractCaseIdFromUrl = (url: string): string | undefined => {
+  const match = url.match(/\/cases\/([0-9a-f-]{36})(?:\?|#|$|\/)/i);
+  return match?.[1];
+};
+
 const optimisticConversationListTitle = i18n.translate(
   'xpack.agentBuilder.conversationList.optimisticNewConversationTitle',
   { defaultMessage: 'New conversation' }
@@ -51,6 +57,8 @@ export interface SendMessageVars {
   conversationId: string;
   agentId: string;
   connectorId?: string;
+  caseId?: string;
+  projectId?: string;
   attachments?: AttachmentInput[];
   conversationAttachments?: VersionedAttachment[];
   lastRoundSteps?: ConversationRoundStep[];
@@ -81,10 +89,13 @@ const buildScreenContextData = async ({
   const timeRange =
     time?.from && time?.to ? { from: String(time.from), to: String(time.to) } : undefined;
 
+  const caseIdFromUrl = url ? extractCaseIdFromUrl(url) : undefined;
+
   const data: ScreenContextAttachmentData = {
     ...(url ? { url } : {}),
     ...(app ? { app } : {}),
     ...(timeRange ? { time_range: timeRange } : {}),
+    ...(caseIdFromUrl ? { additional_data: { case_id: caseIdFromUrl } } : {}),
   };
 
   if (!data.url && !data.app && !data.time_range) {
@@ -217,6 +228,8 @@ export const useSendMessageMutation = ({
               conversationId: vars.conversationId,
               agentId: vars.agentId,
               connectorId: vars.connectorId,
+              caseId: vars.caseId,
+              projectId: vars.projectId,
               attachments: [
                 ...(vars.attachments ?? []),
                 ...(await withScreenContextAttachment({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/projects/use_create_project_from_case.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/projects/use_create_project_from_case.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { formatAgentBuilderErrorMessage } from '@kbn/agent-builder-browser';
+import type { Project } from '@kbn/agent-builder-common';
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import { i18n } from '@kbn/i18n';
+import type { CreateProjectFromCaseBody } from '../../../../common/http_api/projects';
+import { queryKeys } from '../../query_keys';
+import { useAgentBuilderServices } from '../use_agent_builder_service';
+import { useToasts } from '../use_toasts';
+
+export const useCreateProjectFromCase = () => {
+  const queryClient = useQueryClient();
+  const { projectsService } = useAgentBuilderServices();
+  const { addSuccessToast, addErrorToast } = useToasts();
+
+  const { mutateAsync, isLoading } = useMutation<Project, Error, CreateProjectFromCaseBody>({
+    mutationFn: (body) => projectsService.getOrCreateForCase(body),
+    onSuccess: (project) => {
+      addSuccessToast({
+        title: i18n.translate('xpack.agentBuilder.projects.linkCaseSuccessToast', {
+          defaultMessage: 'Case linked to project',
+        }),
+        text: project.title,
+      });
+    },
+    onError: (error) => {
+      addErrorToast({
+        title: i18n.translate('xpack.agentBuilder.projects.linkCaseErrorToast', {
+          defaultMessage: 'Unable to link case to project',
+        }),
+        text: formatAgentBuilderErrorMessage(error),
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all });
+    },
+  });
+
+  return { linkCaseToProject: mutateAsync, isLinking: isLoading };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/projects/use_project.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/projects/use_project.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { formatAgentBuilderErrorMessage } from '@kbn/agent-builder-browser';
+import { useQuery } from '@kbn/react-query';
+import { useEffect } from 'react';
+import { i18n } from '@kbn/i18n';
+import { queryKeys } from '../../query_keys';
+import { useAgentBuilderServices } from '../use_agent_builder_service';
+import { useToasts } from '../use_toasts';
+
+export const useProject = (projectId?: string) => {
+  const { projectsService } = useAgentBuilderServices();
+  const { addErrorToast } = useToasts();
+
+  const { data, isLoading, error, isError } = useQuery({
+    enabled: Boolean(projectId),
+    queryKey: queryKeys.projects.byId(projectId),
+    queryFn: () => projectsService.get(projectId!),
+  });
+
+  useEffect(() => {
+    if (projectId && isError) {
+      addErrorToast({
+        title: i18n.translate('xpack.agentBuilder.projects.loadProjectErrorToast', {
+          defaultMessage: 'Unable to load project',
+        }),
+        text: formatAgentBuilderErrorMessage(error),
+      });
+    }
+  }, [isError, error, projectId, addErrorToast]);
+
+  return {
+    project: data?.project,
+    knowledge: data?.knowledge,
+    isLoading,
+    error,
+    isError,
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/projects/use_projects.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/projects/use_projects.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { formatAgentBuilderErrorMessage } from '@kbn/agent-builder-browser';
+import type { ProjectType } from '@kbn/agent-builder-common';
+import { useQuery } from '@kbn/react-query';
+import { useEffect } from 'react';
+import { i18n } from '@kbn/i18n';
+import { queryKeys } from '../../query_keys';
+import { useAgentBuilderServices } from '../use_agent_builder_service';
+import { useToasts } from '../use_toasts';
+
+export interface UseProjectsOptions {
+  type?: ProjectType;
+  caseId?: string;
+}
+
+export const useProjects = ({ type, caseId }: UseProjectsOptions = {}) => {
+  const { projectsService } = useAgentBuilderServices();
+  const { addErrorToast } = useToasts();
+
+  const filters = { type, caseId };
+  const { data, isLoading, error, isError, refetch } = useQuery({
+    queryKey: queryKeys.projects.list(filters),
+    queryFn: () => projectsService.list({ type, case_id: caseId }),
+  });
+
+  useEffect(() => {
+    if (isError) {
+      addErrorToast({
+        title: i18n.translate('xpack.agentBuilder.projects.loadProjectsErrorToast', {
+          defaultMessage: 'Unable to load projects',
+        }),
+        text: formatAgentBuilderErrorMessage(error),
+      });
+    }
+  }, [isError, error, addErrorToast]);
+
+  return {
+    projects: data ?? [],
+    isLoading,
+    error,
+    isError,
+    refetch,
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/projects/use_resolve_case_project.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/projects/use_resolve_case_project.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+import type { ProjectsService } from '../../../services/projects';
+
+export interface UseResolveCaseProjectOptions {
+  projectsService: ProjectsService;
+  caseId?: string;
+  caseOwner?: string;
+  projectId?: string;
+  caseTitle?: string;
+}
+
+/**
+ * Resolves (get-or-create) a case-typed project when chat is opened with case context.
+ */
+export const useResolveCaseProject = ({
+  projectsService,
+  caseId,
+  caseOwner,
+  projectId: projectIdProp,
+  caseTitle,
+}: UseResolveCaseProjectOptions): string | undefined => {
+  const [resolvedProjectId, setResolvedProjectId] = useState<string | undefined>(projectIdProp);
+
+  useEffect(() => {
+    setResolvedProjectId(projectIdProp);
+  }, [projectIdProp]);
+
+  useEffect(() => {
+    if (projectIdProp || !caseId || !caseOwner) {
+      return;
+    }
+
+    let isCancelled = false;
+
+    projectsService
+      .getOrCreateForCase({
+        case_id: caseId,
+        owner: caseOwner,
+        ...(caseTitle ? { title: caseTitle } : {}),
+      })
+      .then((project) => {
+        if (!isCancelled) {
+          setResolvedProjectId(project.id);
+        }
+      })
+      .catch(() => {
+        // Conversation still receives case_id; project association is best-effort.
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [caseId, caseOwner, caseTitle, projectIdProp, projectsService]);
+
+  return projectIdProp ?? resolvedProjectId;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_conversation_stream.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_conversation_stream.ts
@@ -32,7 +32,8 @@ export const useConversationStream = () => {
   const conversationId = useConversationId();
   const agentId = useAgentId();
   const { conversation } = useConversation();
-  const { attachments, resetAttachments, browserApiTools } = useConversationContext();
+  const { attachments, resetAttachments, browserApiTools, caseId, projectId } =
+    useConversationContext();
   const { selectedConnector: connectorId } = useConnectorSelection();
 
   const {
@@ -72,6 +73,8 @@ export const useConversationStream = () => {
         conversationId: targetConversationId,
         agentId,
         connectorId,
+        caseId,
+        projectId,
         attachments,
         conversationAttachments: conversation?.attachments,
         lastRoundSteps: lastRound?.steps,
@@ -114,8 +117,10 @@ export const useConversationStream = () => {
     connectorId,
     conversation?.attachments,
     lastRound?.steps,
-    browserApiTools,
-  ]);
+      browserApiTools,
+      caseId,
+      projectId,
+    ]);
 
   const resumeRound = useCallback(
     ({ prompts }: { prompts: Record<string, { allow: boolean }> }) => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/projects.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/projects.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { AgentBuilderProjects } from '../components/projects/projects';
+import { useBreadcrumb } from '../hooks/use_breadcrumbs';
+import { appPaths } from '../utils/app_paths';
+
+export const AgentBuilderProjectsPage = () => {
+  useBreadcrumb([
+    {
+      text: i18n.translate('xpack.agentBuilder.projects.breadcrumb', {
+        defaultMessage: 'Projects',
+      }),
+      path: appPaths.manage.projects,
+    },
+  ]);
+
+  return <AgentBuilderProjects />;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
@@ -67,4 +67,10 @@ export const queryKeys = {
     all: ['oauthClients', 'list'] as const,
     byId: (clientId: string) => ['oauthClients', clientId] as const,
   },
+  projects: {
+    all: ['projects', 'list'] as const,
+    list: (filters?: { type?: string; caseId?: string }) =>
+      ['projects', 'list', filters ?? {}] as const,
+    byId: (projectId?: string) => ['projects', projectId] as const,
+  },
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -30,6 +30,7 @@ import { AgentBuilderPluginsPage } from './pages/plugins';
 import { AgentBuilderPluginDetailsPage } from './pages/plugin_details';
 import { AgentBuilderMcpClientsPage } from './pages/mcp_clients';
 import { AgentBuilderMcpClientCreatePage } from './pages/mcp_client_create';
+import { AgentBuilderProjectsPage } from './pages/projects';
 import { agentBuilderViewIds } from './agent_builder_view_ids';
 import { appPaths } from './utils/app_paths';
 
@@ -79,6 +80,9 @@ const navLabels = {
   }),
   agents: i18n.translate('xpack.agentBuilder.routeConfig.agents', {
     defaultMessage: 'Agents',
+  }),
+  projects: i18n.translate('xpack.agentBuilder.routeConfig.projects', {
+    defaultMessage: 'Projects',
   }),
 };
 
@@ -238,6 +242,14 @@ export const manageRoutes: RouteDefinition[] = [
     viewId: agentBuilderViewIds.manageToolDetails,
     sidebarView: 'manage',
     element: <AgentBuilderToolDetailsPage />,
+  },
+  {
+    path: '/manage/projects',
+    viewId: agentBuilderViewIds.manageProjects,
+    sidebarView: 'manage',
+    isExperimental: true,
+    navLabel: navLabels.projects,
+    element: <AgentBuilderProjectsPage />,
   },
 ];
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -248,7 +248,6 @@ export const manageRoutes: RouteDefinition[] = [
     viewId: agentBuilderViewIds.manageProjects,
     sidebarView: 'manage',
     isExperimental: true,
-    navLabel: navLabels.projects,
     element: <AgentBuilderProjectsPage />,
   },
 ];

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
@@ -40,6 +40,7 @@ export const appPaths = {
     connectors: '/manage/connectors',
     mcpClients: '/manage/tools/mcp_clients',
     mcpClientCreate: '/manage/tools/mcp_clients/new',
+    projects: '/manage/projects',
   },
 
   // Legacy paths - redirect to new structure via LegacyConversationRedirect

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/get_case_view_url.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/get_case_view_url.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ApplicationStart } from '@kbn/core-application-browser';
+
+const OWNER_TO_APP_ID: Record<string, string> = {
+  securitySolution: 'securitySolutionUI',
+  observability: 'observability-overview',
+  cases: 'management',
+};
+
+/**
+ * Builds a case view URL for the Cases owner app. Returns undefined when the owner is unknown.
+ */
+export const getCaseViewUrl = ({
+  application,
+  caseId,
+  owner,
+}: {
+  application: ApplicationStart;
+  caseId: string;
+  owner: string;
+}): string | undefined => {
+  const appId = OWNER_TO_APP_ID[owner];
+  if (!appId) {
+    return undefined;
+  }
+
+  const casesPath =
+    owner === 'cases' ? `/insightsAndAlerting/cases/${caseId}` : `/cases/${caseId}`;
+
+  try {
+    return application.getUrlForApp(appId, { path: casesPath });
+  } catch {
+    return undefined;
+  }
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/case_ai_workspace_internal.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/case_ai_workspace_internal.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import type { CoreStart } from '@kbn/core/public';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import type { CaseAiWorkspaceProps } from '@kbn/agent-builder-browser';
+import type { AgentBuilderInternalService } from '../services';
+import type { AgentBuilderStartDependencies } from '../types';
+import { AgentBuilderServicesContext } from '../application/context/agent_builder_services_context';
+import { CaseAiWorkspaceView } from './components/case_ai_workspace_view';
+
+export interface CaseAiWorkspaceInternalProps extends CaseAiWorkspaceProps {
+  services: AgentBuilderInternalService;
+  coreStart: CoreStart;
+}
+
+export const CaseAiWorkspaceInternal: React.FC<CaseAiWorkspaceInternalProps> = ({
+  services,
+  coreStart,
+  ...caseProps
+}) => {
+  const queryClient = useMemo(() => new QueryClient(), []);
+
+  const kibanaServices = useMemo(
+    () => ({
+      ...coreStart,
+      plugins: services.startDependencies as AgentBuilderStartDependencies,
+    }),
+    [coreStart, services.startDependencies]
+  );
+
+  return (
+    <KibanaContextProvider services={kibanaServices}>
+      <I18nProvider>
+        <QueryClientProvider client={queryClient}>
+          <AgentBuilderServicesContext.Provider value={services}>
+            <CaseAiWorkspaceView {...caseProps} services={services} coreStart={coreStart} />
+          </AgentBuilderServicesContext.Provider>
+        </QueryClientProvider>
+      </I18nProvider>
+    </KibanaContextProvider>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/components/case_ai_workspace_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/components/case_ai_workspace_view.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { CoreStart } from '@kbn/core/public';
+import {
+  EuiButton,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiSpacer,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { useQuery } from '@kbn/react-query';
+import type { CaseAiWorkspaceProps } from '@kbn/agent-builder-browser';
+import { ProjectType } from '@kbn/agent-builder-common';
+import { queryKeys } from '../../application/query_keys';
+import { useAgentBuilderServices } from '../../application/hooks/use_agent_builder_service';
+import { useCreateProjectFromCase } from '../../application/hooks/projects/use_create_project_from_case';
+import { KnowledgePanel } from './knowledge_panel';
+import { ConversationsPanel } from './conversations_panel';
+import type { AgentBuilderInternalService } from '../../services';
+import { CaseConversationPanel } from './case_conversation_panel';
+
+export interface CaseAiWorkspaceViewProps extends CaseAiWorkspaceProps {
+  services: AgentBuilderInternalService;
+  coreStart: CoreStart;
+}
+
+export const CaseAiWorkspaceView: React.FC<CaseAiWorkspaceViewProps> = ({
+  services,
+  coreStart,
+  caseId,
+  caseTitle,
+  caseOwner,
+  caseDescription,
+  totalAlerts,
+  totalComments,
+  fileCount,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const { projectsService } = useAgentBuilderServices();
+  const { linkCaseToProject, isLinking } = useCreateProjectFromCase();
+  const [selectedConversationId, setSelectedConversationId] = useState<string | undefined>();
+  const [conversationEpoch, setConversationEpoch] = useState(0);
+
+  const { data: projects, isLoading: isLoadingProjects, refetch } = useQuery({
+    queryKey: queryKeys.projects.list({ caseId }),
+    queryFn: () => projectsService.list({ type: ProjectType.case, case_id: caseId }),
+  });
+
+  const project = projects?.[0];
+
+  const enableWorkspace = useCallback(async () => {
+    await linkCaseToProject({
+      case_id: caseId,
+      owner: caseOwner,
+      title: caseTitle,
+    });
+    await refetch();
+  }, [caseId, caseOwner, caseTitle, linkCaseToProject, refetch]);
+
+  const handleNewConversation = useCallback(() => {
+    setSelectedConversationId(undefined);
+    setConversationEpoch((epoch) => epoch + 1);
+  }, []);
+
+  const handleSelectConversation = useCallback((conversationId: string) => {
+    setSelectedConversationId(conversationId);
+    setConversationEpoch((epoch) => epoch + 1);
+  }, []);
+
+  const sessionTag = useMemo(() => `case-ai-workspace-${caseId}`, [caseId]);
+
+  const layoutStyles = css`
+    min-height: 520px;
+    border: 1px solid ${euiTheme.border.color};
+    border-radius: ${euiTheme.border.radius.medium};
+    overflow: hidden;
+  `;
+
+  if (isLoadingProjects) {
+    return (
+      <EuiPanel hasBorder data-test-subj="caseAiWorkspaceLoading">
+        <EuiLoadingSpinner size="l" />
+      </EuiPanel>
+    );
+  }
+
+  if (!project) {
+    return (
+      <EuiPanel hasBorder data-test-subj="caseAiWorkspaceEnable">
+        <EuiEmptyPrompt
+          iconType="sparkles"
+          title={
+            <h2>
+              {i18n.translate('xpack.agentBuilder.caseAiWorkspace.enableTitle', {
+                defaultMessage: 'No AI Workspace yet for this case',
+              })}
+            </h2>
+          }
+          body={
+            <p>
+              {i18n.translate('xpack.agentBuilder.caseAiWorkspace.enableDescription', {
+                defaultMessage:
+                  'Enable AI Workspace to investigate this case with AI. Case context, alerts, and description are loaded automatically.',
+              })}
+            </p>
+          }
+          actions={
+            <EuiButton
+              fill
+              iconType="sparkles"
+              onClick={() => void enableWorkspace()}
+              isLoading={isLinking}
+              data-test-subj="caseAiWorkspaceEnableButton"
+            >
+              {i18n.translate('xpack.agentBuilder.caseAiWorkspace.enableButton', {
+                defaultMessage: 'Enable AI Workspace',
+              })}
+            </EuiButton>
+          }
+        />
+      </EuiPanel>
+    );
+  }
+
+  return (
+    <div css={layoutStyles} data-test-subj="caseAiWorkspace">
+      <EuiFlexGroup gutterSize="none" responsive={false}>
+        <EuiFlexItem
+          grow={false}
+          css={css`
+            width: 300px;
+            border-right: 1px solid ${euiTheme.border.color};
+            background: ${euiTheme.colors.backgroundBaseSubdued};
+            padding: ${euiTheme.size.m};
+          `}
+        >
+          <KnowledgePanel
+            caseTitle={caseTitle}
+            caseDescription={caseDescription}
+            totalAlerts={totalAlerts}
+            totalComments={totalComments}
+            fileCount={fileCount}
+            projectId={project.id}
+            updatedAt={project.updated_at}
+            onRefresh={() => void refetch()}
+          />
+          <EuiSpacer size="m" />
+          <ConversationsPanel
+            conversationIds={project.conversation_ids}
+            selectedConversationId={selectedConversationId}
+            onSelectConversation={handleSelectConversation}
+            onNewConversation={handleNewConversation}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <CaseConversationPanel
+            key={`${conversationEpoch}-${selectedConversationId ?? 'new'}`}
+            services={services}
+            coreStart={coreStart}
+            caseId={caseId}
+            caseOwner={caseOwner}
+            caseTitle={caseTitle}
+            caseDescription={caseDescription}
+            projectId={project.id}
+            sessionTag={sessionTag}
+            conversationId={selectedConversationId}
+            isNewConversation={selectedConversationId === undefined}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/components/case_conversation_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/components/case_conversation_panel.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useMemo } from 'react';
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import { EmbeddableConversationsProvider } from '../../application/context/conversation/embeddable_conversations_provider';
+import { EmbeddableAccessBoundary } from '../../embeddable/embeddable_access_boundary';
+import { Conversation } from '../../application/components/conversations/conversation';
+import { conversationBackgroundStyles } from '../../application/components/conversations/conversation.styles';
+import { storageKeys } from '../../application/storage_keys';
+import type { AgentBuilderInternalService } from '../../services';
+import type { CoreStart } from '@kbn/core/public';
+
+const PLATFORM_CASE_ATTACHMENT_TYPE = 'platform.core.cases.case';
+
+const CASE_ATTACHMENT_PROMPT = i18n.translate(
+  'xpack.agentBuilder.caseAiWorkspace.caseAttachmentPrompt',
+  {
+    defaultMessage:
+      'Help me investigate this case. Review linked alerts, observables, and comments. Summarize the current status and suggest next steps.',
+  }
+);
+
+export interface CaseConversationPanelProps {
+  services: AgentBuilderInternalService;
+  coreStart: CoreStart;
+  caseId: string;
+  caseOwner: string;
+  caseTitle: string;
+  caseDescription?: string;
+  projectId: string;
+  sessionTag: string;
+  conversationId?: string;
+  isNewConversation: boolean;
+}
+
+export const CaseConversationPanel: React.FC<CaseConversationPanelProps> = ({
+  services,
+  coreStart,
+  caseId,
+  caseOwner,
+  caseTitle,
+  caseDescription,
+  projectId,
+  sessionTag,
+  conversationId,
+  isNewConversation,
+}) => {
+  const { euiTheme } = useEuiTheme();
+
+  const attachments = useMemo((): AttachmentInput[] => {
+    return [
+      {
+        id: `case-${caseId}`,
+        type: PLATFORM_CASE_ATTACHMENT_TYPE,
+        data: {
+          case_id: caseId,
+          owner: caseOwner,
+          title: caseTitle,
+          description: caseDescription,
+          attachmentLabel: caseTitle,
+        },
+      },
+    ];
+  }, [caseId, caseOwner, caseTitle, caseDescription]);
+
+  useEffect(() => {
+    const storageKey = storageKeys.getLastConversationKey(sessionTag, agentBuilderDefaultAgentId);
+    if (conversationId) {
+      window.localStorage.setItem(storageKey, JSON.stringify(conversationId));
+    } else if (isNewConversation) {
+      window.localStorage.removeItem(storageKey);
+    }
+  }, [conversationId, isNewConversation, sessionTag]);
+
+  const panelStyles = css`
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 480px;
+    ${conversationBackgroundStyles(euiTheme)}
+  `;
+
+  const bodyStyles = css`
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  `;
+
+  return (
+    <div css={panelStyles} data-test-subj="caseAiWorkspaceConversation">
+      <EmbeddableConversationsProvider
+        coreStart={coreStart}
+        services={services}
+        sessionTag={sessionTag}
+        agentId={agentBuilderDefaultAgentId}
+        caseId={caseId}
+        caseOwner={caseOwner}
+        caseTitle={caseTitle}
+        projectId={projectId}
+        newConversation={isNewConversation}
+        initialMessage={isNewConversation ? CASE_ATTACHMENT_PROMPT : undefined}
+        autoSendInitialMessage={false}
+        attachments={attachments}
+        ariaLabelledBy="case-ai-workspace-conversation"
+      >
+        <EmbeddableAccessBoundary>
+          <div css={bodyStyles}>
+            <Conversation />
+          </div>
+        </EmbeddableAccessBoundary>
+      </EmbeddableConversationsProvider>
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/components/conversations_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/components/conversations_panel.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiCollapsibleNavGroup,
+  EuiFlexGroup,
+  EuiListGroup,
+  EuiListGroupItem,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export interface ConversationsPanelProps {
+  conversationIds: string[];
+  selectedConversationId?: string;
+  onSelectConversation: (conversationId: string) => void;
+  onNewConversation: () => void;
+}
+
+export const ConversationsPanel: React.FC<ConversationsPanelProps> = ({
+  conversationIds,
+  selectedConversationId,
+  onSelectConversation,
+  onNewConversation,
+}) => {
+  const [isListOpen, setIsListOpen] = useState(conversationIds.length > 1);
+
+  const listItems = useMemo(
+    () =>
+      conversationIds.map((id, index) => ({
+        id,
+        label:
+          conversationIds.length === 1
+            ? i18n.translate('xpack.agentBuilder.caseAiWorkspace.defaultThread', {
+                defaultMessage: 'Triage thread',
+              })
+            : i18n.translate('xpack.agentBuilder.caseAiWorkspace.threadLabel', {
+                defaultMessage: 'Thread {number}',
+                values: { number: index + 1 },
+              }),
+      })),
+    [conversationIds]
+  );
+
+  const conversationSummary =
+    conversationIds.length === 0
+      ? i18n.translate('xpack.agentBuilder.caseAiWorkspace.noConversations', {
+          defaultMessage: 'No conversations yet',
+        })
+      : i18n.translate('xpack.agentBuilder.caseAiWorkspace.conversationCount', {
+          defaultMessage: '{count, plural, one {# conversation} other {# conversations}}',
+          values: { count: conversationIds.length },
+        });
+
+  return (
+    <div data-test-subj="caseAiWorkspaceConversations">
+      <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
+        <EuiTitle size="xxs">
+          <h3>
+            {i18n.translate('xpack.agentBuilder.caseAiWorkspace.conversationsTitle', {
+              defaultMessage: 'Conversations',
+            })}
+          </h3>
+        </EuiTitle>
+        <EuiButtonEmpty
+          size="s"
+          iconType="plus"
+          onClick={onNewConversation}
+          data-test-subj="caseAiWorkspaceNewConversation"
+        >
+          {i18n.translate('xpack.agentBuilder.caseAiWorkspace.newConversation', {
+            defaultMessage: 'New conversation',
+          })}
+        </EuiButtonEmpty>
+        {conversationIds.length <= 1 ? (
+          <EuiText size="xs" color="subdued">
+            {conversationSummary}
+          </EuiText>
+        ) : (
+          <EuiCollapsibleNavGroup
+            title={conversationSummary}
+            isCollapsible
+            initialIsOpen={isListOpen}
+            onToggle={(isOpen) => setIsListOpen(isOpen)}
+          >
+            <EuiListGroup flush gutterSize="none" maxWidth={false}>
+              {listItems.map((item) => (
+                <EuiListGroupItem
+                  key={item.id}
+                  label={item.label}
+                  size="s"
+                  isActive={selectedConversationId === item.id}
+                  onClick={() => onSelectConversation(item.id)}
+                  data-test-subj={`caseAiWorkspaceConversation-${item.id}`}
+                />
+              ))}
+            </EuiListGroup>
+          </EuiCollapsibleNavGroup>
+        )}
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/components/knowledge_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/components/knowledge_panel.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useProject } from '../../application/hooks/projects/use_project';
+
+export interface KnowledgePanelProps {
+  caseTitle: string;
+  caseDescription?: string;
+  totalAlerts?: number;
+  totalComments?: number;
+  fileCount?: number;
+  projectId: string;
+  updatedAt: string;
+  onRefresh: () => void;
+}
+
+export const KnowledgePanel: React.FC<KnowledgePanelProps> = ({
+  caseTitle,
+  caseDescription,
+  totalAlerts = 0,
+  totalComments = 0,
+  fileCount = 0,
+  projectId,
+  updatedAt,
+  onRefresh,
+}) => {
+  const { knowledge } = useProject(projectId);
+
+  const displayTitle = knowledge?.title ?? caseTitle;
+  const alertCount = knowledge?.total_alerts ?? totalAlerts;
+  const commentCount = knowledge?.total_comments ?? totalComments;
+
+  return (
+    <div data-test-subj="caseAiWorkspaceKnowledge">
+      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xxs">
+            <h3>
+              {i18n.translate('xpack.agentBuilder.caseAiWorkspace.knowledgeTitle', {
+                defaultMessage: 'Knowledge',
+              })}
+            </h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty size="xs" iconType="refresh" onClick={onRefresh}>
+            {i18n.translate('xpack.agentBuilder.caseAiWorkspace.refresh', {
+              defaultMessage: 'Refresh',
+            })}
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiText size="xs" color="subdued">
+        {i18n.translate('xpack.agentBuilder.caseAiWorkspace.knowledgeFreshness', {
+          defaultMessage:
+            '{alertCount, plural, one {# alert} other {# alerts}} loaded · Updated {updated}',
+          values: {
+            alertCount,
+            updated: new Date(updatedAt).toLocaleString(),
+          },
+        })}
+      </EuiText>
+      <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="bell" />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="s">
+                {i18n.translate('xpack.agentBuilder.caseAiWorkspace.alertsLoaded', {
+                  defaultMessage: '{count, plural, one {# alert loaded} other {# alerts loaded}}',
+                  values: { count: alertCount },
+                })}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        {caseDescription ? (
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiIcon type="document" />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="s" className="eui-textTruncate">
+                  {displayTitle}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        ) : null}
+        {fileCount > 0 ? (
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiIcon type="paperClip" />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="s">
+                  {i18n.translate('xpack.agentBuilder.caseAiWorkspace.filesLoaded', {
+                    defaultMessage:
+                      '{count, plural, one {# file} other {# files}}',
+                    values: { count: fileCount },
+                  })}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        ) : null}
+        {commentCount > 0 ? (
+          <EuiFlexItem>
+            <EuiText size="xs" color="subdued">
+              {i18n.translate('xpack.agentBuilder.caseAiWorkspace.commentsSummary', {
+                defaultMessage: '{count, plural, one {# comment} other {# comments}} on case',
+                values: { count: commentCount },
+              })}
+            </EuiText>
+          </EuiFlexItem>
+        ) : null}
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/create_case_ai_workspace.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/case_ai_workspace/create_case_ai_workspace.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { CaseAiWorkspaceProps } from '@kbn/agent-builder-browser';
+import type { EmbeddableConversationDependencies } from '../embeddable/types';
+import { CaseAiWorkspaceInternal } from './case_ai_workspace_internal';
+
+export const createCaseAiWorkspace = ({
+  services,
+  coreStart,
+}: EmbeddableConversationDependencies): React.FC<CaseAiWorkspaceProps> => {
+  return (props: CaseAiWorkspaceProps) => (
+    <CaseAiWorkspaceInternal {...props} services={services} coreStart={coreStart} />
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/mocks.ts
@@ -80,6 +80,7 @@ const createStartContractMock = (): AgentBuilderPluginStartMock => {
     addAttachment: jest.fn(),
     updateAttachmentOrigin: jest.fn(),
     EmbeddableConversation: () => null,
+    CaseAiWorkspace: () => null,
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -42,6 +42,7 @@ import {
   SmlService,
   OAuthClientsService,
   PluginsService,
+  ProjectsService,
   EventsService,
   type AgentBuilderInternalService,
 } from './services';
@@ -161,6 +162,7 @@ export class AgentBuilderPlugin
     const skillsService = new SkillsService({ http });
     const smlService = new SmlService({ http });
     const pluginsService = new PluginsService({ http });
+    const projectsService = new ProjectsService({ http });
     const oauthClientsService = new OAuthClientsService({ http });
     const accessChecker = new AgentBuilderAccessChecker({ licensing, inference });
 
@@ -228,6 +230,7 @@ export class AgentBuilderPlugin
       skillsService,
       smlService,
       pluginsService,
+      projectsService,
       oauthClientsService,
       startDependencies,
       usageCollection,

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -61,6 +61,7 @@ import type {
 } from './types';
 import type { EmbeddableConversationProps } from './embeddable/types';
 import type { PublicEmbeddableConversationProps } from './types';
+import { createCaseAiWorkspace } from './case_ai_workspace/create_case_ai_workspace';
 import type { OpenConversationSidebarOptions, OpenSidebarInternalOptions } from './sidebar/types';
 import {
   setSidebarServices,
@@ -273,6 +274,11 @@ export class AgentBuilderPlugin
       </React.Suspense>
     );
 
+    const CaseAiWorkspace = createCaseAiWorkspace({
+      services: internalServices,
+      coreStart: core,
+    });
+
     this.experimentalDeepLinksSubscription = core.uiSettings
       .get$<boolean>(AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID)
       .pipe(distinctUntilChanged())
@@ -328,6 +334,7 @@ export class AgentBuilderPlugin
         return attachmentsService.updateOrigin(conversationId, attachmentId, origin);
       },
       EmbeddableConversation: PublicEmbeddableConversation,
+      CaseAiWorkspace,
     };
 
     if (hasAgentBuilder) {

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/chat/chat_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/chat/chat_service.ts
@@ -27,6 +27,8 @@ interface BaseConverseParams {
   agentId?: string;
   connectorId?: string;
   conversationId: string;
+  caseId?: string;
+  projectId?: string;
   browserApiTools?: BrowserApiToolMetadata[];
   capabilities?: AgentCapabilities;
 }
@@ -62,6 +64,8 @@ export class ChatService {
       input: params.input,
       agent_id: params.agentId,
       conversation_id: params.conversationId,
+      case_id: params.caseId,
+      project_id: params.projectId,
       connector_id: params.connectorId,
       capabilities: params.capabilities ?? getKibanaDefaultAgentCapabilities(),
       attachments: params.attachments,

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/index.ts
@@ -16,6 +16,7 @@ export { ToolsService } from './tools';
 export { SkillsService } from './skills/skills_service';
 export { SmlService } from './sml/sml_service';
 export { PluginsService } from './plugins/plugins_service';
+export { ProjectsService } from './projects';
 export { OAuthClientsService } from './oauth_clients';
 export { EventsService } from './events';
 export type { AgentBuilderInternalService } from './types';

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/projects/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/projects/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { ProjectsService } from './projects_service';

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/projects/projects_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/projects/projects_service.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpSetup } from '@kbn/core-http-browser';
+import type { Project, ProjectType } from '@kbn/agent-builder-common';
+import type {
+  CreateProjectFromCaseBody,
+  GetProjectResponse,
+  ListProjectsQuery,
+  ListProjectsResponse,
+} from '../../../common/http_api/projects';
+import { publicApiPath } from '../../../common/constants';
+
+export class ProjectsService {
+  private readonly http: HttpSetup;
+
+  constructor({ http }: { http: HttpSetup }) {
+    this.http = http;
+  }
+
+  async list(query?: ListProjectsQuery): Promise<Project[]> {
+    const res = await this.http.get<ListProjectsResponse>(`${publicApiPath}/projects`, {
+      query,
+    });
+    return res.results;
+  }
+
+  async get(projectId: string): Promise<GetProjectResponse> {
+    return await this.http.get<GetProjectResponse>(`${publicApiPath}/projects/${projectId}`);
+  }
+
+  async getOrCreateForCase(body: CreateProjectFromCaseBody): Promise<Project> {
+    const res = await this.http.post<GetProjectResponse>(`${publicApiPath}/projects/from_case`, {
+      body: JSON.stringify(body),
+    });
+    return res.project;
+  }
+
+  async listByType(type: ProjectType): Promise<Project[]> {
+    return this.list({ type });
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/types.ts
@@ -18,6 +18,7 @@ import type { ToolsService } from './tools';
 import type { SkillsService } from './skills/skills_service';
 import type { SmlService } from './sml/sml_service';
 import type { PluginsService } from './plugins/plugins_service';
+import type { ProjectsService } from './projects';
 import type { OAuthClientsService } from './oauth_clients';
 import type { NavigationService } from './navigation';
 import type { EventsService } from './events';
@@ -33,6 +34,7 @@ export interface AgentBuilderInternalService {
   skillsService: SkillsService;
   smlService: SmlService;
   pluginsService: PluginsService;
+  projectsService: ProjectsService;
   oauthClientsService: OAuthClientsService;
   startDependencies: AgentBuilderStartDependencies;
   usageCollection?: UsageCollectionSetup;

--- a/x-pack/platform/plugins/shared/agent_builder/public/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/types.ts
@@ -32,6 +32,7 @@ import type { EvalsPublicStart } from '@kbn/evals-plugin/public';
 export type {
   AgentBuilderPluginSetup,
   AgentBuilderPluginStart,
+  CaseAiWorkspaceProps,
   ConversationSidebarRef,
   OpenConversationSidebarReturn,
   PublicEmbeddableConversationProps,

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -239,6 +239,7 @@ export class AgentBuilderPlugin
       trackingService: this.trackingService,
       analyticsService: this.analyticsService,
       searchInferenceEndpoints,
+      getCasesClientWithRequest: startDeps.cases?.getCasesClientWithRequest,
     });
 
     const { tools, agents, skills, runnerFactory, execution, plugins, conversations } =

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
@@ -80,6 +80,22 @@ export function registerChatRoutes({
         },
       })
     ),
+    case_id: schema.maybe(
+      schema.string({
+        meta: {
+          description:
+            'Optional Cases case ID to associate with the conversation when it is first persisted.',
+        },
+      })
+    ),
+    project_id: schema.maybe(
+      schema.string({
+        validate: (v) => (uuidValidate(v) ? undefined : 'project_id must be a valid UUID'),
+        meta: {
+          description: 'Optional Agent Builder project ID to associate with the conversation.',
+        },
+      })
+    ),
     input: schema.maybe(
       schema.string({
         meta: { description: 'The user input message to send to the agent.' },
@@ -279,6 +295,8 @@ export function registerChatRoutes({
     const {
       agent_id: agentId,
       conversation_id: conversationId,
+      case_id: caseId,
+      project_id: projectId,
       input,
       prompts,
       attachments,
@@ -313,6 +331,8 @@ export function registerChatRoutes({
           prompts,
           attachments,
         },
+        caseId,
+        projectId,
       },
     });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/index.ts
@@ -17,6 +17,7 @@ import { registerInternalInferenceEndpointsRoute } from './internal/inference_en
 import { registerAgentRoutes } from './agents';
 import { registerChatRoutes } from './chat';
 import { registerConversationRoutes } from './conversations';
+import { registerProjectRoutes } from './projects';
 import { registerAttachmentRoutes } from './attachments';
 import { registerMCPRoutes } from './mcp';
 import { registerA2ARoutes } from './a2a';
@@ -36,6 +37,7 @@ export const registerRoutes = (dependencies: RouteDependencies) => {
   registerAgentRoutes(dependencies);
   registerChatRoutes(dependencies);
   registerConversationRoutes(dependencies);
+  registerProjectRoutes(dependencies);
   registerAttachmentRoutes(dependencies);
   registerMCPRoutes(dependencies);
   registerA2ARoutes(dependencies);

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/projects.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/projects.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { ProjectType } from '@kbn/agent-builder-common';
+import type { RouteDependencies } from './types';
+import { getHandlerWrapper } from './wrap_handler';
+import type {
+  CreateProjectFromCaseBody,
+  GetProjectResponse,
+  ListProjectsResponse,
+} from '../../common/http_api/projects';
+import { apiPrivileges } from '../../common/features';
+import { publicApiPath } from '../../common/constants';
+
+export function registerProjectRoutes({
+  router,
+  getInternalServices,
+  logger,
+}: RouteDependencies) {
+  const wrapHandler = getHandlerWrapper({ logger });
+
+  router.versioned
+    .get({
+      path: `${publicApiPath}/projects`,
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.readAgentBuilder] },
+      },
+      access: 'public',
+      summary: 'List Agent Builder projects',
+      options: {
+        tags: ['project', 'oas-tag:agent builder'],
+        availability: { since: '9.3.0' },
+      },
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            query: schema.object({
+              type: schema.maybe(schema.string()),
+              case_id: schema.maybe(schema.string()),
+            }),
+          },
+        },
+      },
+      wrapHandler(async (ctx, request, response) => {
+        const { projects: projectsService } = getInternalServices();
+        const client = await projectsService.getScopedClient({ request });
+        const { type, case_id: caseId } = request.query;
+        const results = await client.list({
+          type: type as ProjectType | undefined,
+          caseId,
+        });
+        return response.ok<ListProjectsResponse>({ body: { results } });
+      })
+    );
+
+  router.versioned
+    .get({
+      path: `${publicApiPath}/projects/{projectId}`,
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.readAgentBuilder] },
+      },
+      access: 'public',
+      summary: 'Get Agent Builder project',
+      options: {
+        tags: ['project', 'oas-tag:agent builder'],
+        availability: { since: '9.3.0' },
+      },
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            params: schema.object({
+              projectId: schema.string(),
+            }),
+          },
+        },
+      },
+      wrapHandler(async (ctx, request, response) => {
+        const { projects: projectsService } = getInternalServices();
+        const client = await projectsService.getScopedClient({ request });
+        const project = await client.get(request.params.projectId);
+        const knowledge = await projectsService.getKnowledgeSummary({ request, project });
+        return response.ok<GetProjectResponse & { knowledge?: unknown }>({
+          body: { project, ...(knowledge ? { knowledge } : {}) },
+        });
+      })
+    );
+
+  router.versioned
+    .post({
+      path: `${publicApiPath}/projects/from_case`,
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.writeAgentBuilder] },
+      },
+      access: 'public',
+      summary: 'Get or create a case-typed project for a case',
+      options: {
+        tags: ['project', 'oas-tag:agent builder'],
+        availability: { since: '9.3.0' },
+      },
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: schema.object({
+              case_id: schema.string(),
+              owner: schema.string(),
+              title: schema.maybe(schema.string()),
+            }),
+          },
+        },
+      },
+      wrapHandler(async (ctx, request, response) => {
+        const { projects: projectsService } = getInternalServices();
+        const body = request.body as CreateProjectFromCaseBody;
+        const project = await projectsService.getOrCreateForCase({
+          request,
+          caseId: body.case_id,
+          owner: body.owner,
+          title: body.title,
+        });
+        return response.ok<GetProjectResponse>({ body: { project } });
+      })
+    );
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -59,6 +59,8 @@ const convertBaseFromEs = (document: Document) => {
     title: document._source.title,
     created_at: document._source.created_at,
     updated_at: document._source.updated_at,
+    ...(document._source.case_id && { case_id: document._source.case_id }),
+    ...(document._source.project_id && { project_id: document._source.project_id }),
   };
 };
 
@@ -188,12 +190,18 @@ export const fromEs = (document: Document): Conversation => {
 
   const roundsWithRefs = applyAttachmentRefsToRounds(deserializedRounds, refsByRound);
 
+  const contextLinks = {
+    ...(document._source!.case_id && { case_id: document._source!.case_id }),
+    ...(document._source!.project_id && { project_id: document._source!.project_id }),
+  };
+
   if (existingAttachments && existingAttachments.length > 0) {
     return {
       ...base,
       rounds: roundsWithRefs,
       attachments: existingAttachments,
       ...(document._source!.state && { state: document._source!.state }),
+      ...contextLinks,
     };
   }
 
@@ -203,6 +211,7 @@ export const fromEs = (document: Document): Conversation => {
       rounds: roundsWithRefs,
       ...(attachmentsForRefs.length > 0 && { attachments: attachmentsForRefs }),
       ...(document._source!.state && { state: document._source!.state }),
+      ...contextLinks,
     };
   }
 
@@ -210,6 +219,7 @@ export const fromEs = (document: Document): Conversation => {
     ...base,
     rounds: roundsWithRefs,
     ...(document._source!.state && { state: document._source!.state }),
+    ...contextLinks,
   };
 };
 
@@ -231,6 +241,8 @@ export const toEs = (conversation: Conversation, space: string): ConversationPro
     conversation_rounds: serializeStepResults(conversation.rounds),
     attachments: conversation.attachments ?? [],
     state: conversation.state,
+    ...(conversation.case_id && { case_id: conversation.case_id }),
+    ...(conversation.project_id && { project_id: conversation.project_id }),
   };
 };
 
@@ -277,5 +289,21 @@ export const createRequestToEs = ({
     conversation_rounds: serializeStepResults(conversation.rounds),
     attachments: conversation.attachments ?? [],
     state: conversation.state,
+    ...(conversation.case_id && { case_id: conversation.case_id }),
+    ...(conversation.project_id && { project_id: conversation.project_id }),
   };
 };
+
+export const mergeConversationContextLinks = ({
+  conversation,
+  caseId,
+  projectId,
+}: {
+  conversation: Conversation;
+  caseId?: string;
+  projectId?: string;
+}): Conversation => ({
+  ...conversation,
+  ...(caseId && !conversation.case_id ? { case_id: caseId } : {}),
+  ...(projectId && !conversation.project_id ? { project_id: projectId } : {}),
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
@@ -29,6 +29,8 @@ const storageSettings = {
       conversation_rounds: types.object({ dynamic: false, properties: {} }),
       attachments: types.object({ dynamic: false, properties: {} }),
       state: types.object({ dynamic: false, properties: {} }),
+      case_id: types.keyword({}),
+      project_id: types.keyword({}),
     },
   },
 } satisfies IndexStorageSettings;
@@ -44,6 +46,8 @@ export interface ConversationProperties {
   conversation_rounds: PersistentConversationRound[];
   attachments?: VersionedAttachment[];
   state?: ConversationInternalState;
+  case_id?: string;
+  project_id?: string;
   // legacy field
   rounds?: PersistentConversationRound[];
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -18,6 +18,7 @@ import { ToolsService } from './tools';
 import { AgentsService } from './agents';
 import { RunnerFactoryImpl } from './execution/runner';
 import { ConversationServiceImpl } from './conversation';
+import { ProjectServiceImpl } from './project';
 import { type AttachmentService, createAttachmentService } from './attachments';
 import { HooksService } from './hooks';
 import { type SkillService, createSkillService } from './skills';
@@ -199,6 +200,14 @@ export class ServiceManager {
       spaces,
     });
 
+    const projects = new ProjectServiceImpl({
+      logger: logger.get('projects'),
+      security,
+      elasticsearch,
+      spaces,
+      getCasesClientWithRequest: startDeps.getCasesClientWithRequest,
+    });
+
     const auditLogService = new AuditLogService({
       security,
       logger: logger.get('audit'),
@@ -246,6 +255,7 @@ export class ServiceManager {
       attachments,
       skills: skillsServiceStart,
       conversations,
+      projects,
       runnerFactory,
       auditLogService,
       execution: executionService,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -104,6 +104,7 @@ export class ServiceManager {
     trackingService,
     analyticsService,
     searchInferenceEndpoints,
+    getCasesClientWithRequest,
   }: ServicesStartDeps): InternalStartServices {
     if (!this.services) {
       throw new Error('#startServices called before #setupServices');
@@ -205,7 +206,7 @@ export class ServiceManager {
       security,
       elasticsearch,
       spaces,
-      getCasesClientWithRequest: startDeps.getCasesClientWithRequest,
+      getCasesClientWithRequest,
     });
 
     const auditLogService = new AuditLogService({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_runner.ts
@@ -120,6 +120,8 @@ const handleConversationExecution = async ({
     browserApiTools,
     configurationOverrides,
     action,
+    caseId,
+    projectId,
   } = execution.agentParams;
 
   const { logger, runAgent, trackingService, analyticsService, meteringService } = deps;
@@ -184,6 +186,8 @@ const handleConversationExecution = async ({
         title$,
         agentEvents$,
         action,
+        caseId,
+        projectId,
       })
     : EMPTY;
 
@@ -376,6 +380,8 @@ const buildPersistenceEvents = ({
   title$,
   agentEvents$,
   action,
+  caseId,
+  projectId,
 }: {
   agentId: string;
   conversation: ConversationWithOperation;
@@ -384,6 +390,8 @@ const buildPersistenceEvents = ({
   title$: Observable<string>;
   agentEvents$: Observable<ChatEvent>;
   action?: ConversationAction;
+  caseId?: string;
+  projectId?: string;
 }): Observable<ChatEvent> => {
   const roundCompletedEvents$ = agentEvents$.pipe(filter(isRoundCompleteEvent));
 
@@ -394,6 +402,8 @@ const buildPersistenceEvents = ({
       conversationId: conversationId || conversation.id,
       title$,
       roundCompletedEvents$,
+      caseId,
+      projectId,
     });
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
@@ -25,12 +25,16 @@ export const createConversation$ = ({
   conversationId,
   title$,
   roundCompletedEvents$,
+  caseId,
+  projectId,
 }: {
   agentId: string;
   conversationClient: ConversationClient;
   conversationId?: string;
   title$: Observable<string>;
   roundCompletedEvents$: Observable<RoundCompleteEvent>;
+  caseId?: string;
+  projectId?: string;
 }) => {
   return forkJoin({
     title: title$,
@@ -46,6 +50,8 @@ export const createConversation$ = ({
         ...(roundCompletedEvent.data.attachments
           ? { attachments: roundCompletedEvent.data.attachments }
           : {}),
+        ...(caseId ? { case_id: caseId } : {}),
+        ...(projectId ? { project_id: projectId } : {}),
       });
     }),
     switchMap((createdConversation) => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/project/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/project/client.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { Logger, ElasticsearchClient } from '@kbn/core/server';
+import type {
+  Project,
+  ProjectCreateRequest,
+  ProjectUpdateRequest,
+  ProjectType,
+  UserIdAndName,
+} from '@kbn/agent-builder-common';
+import { createSpaceDslFilter } from '../../utils/spaces';
+import type { ProjectProperties, ProjectStorage } from './storage';
+import { createProjectStorage } from './storage';
+
+export type ProjectDocument = {
+  _id: string;
+  _source: ProjectProperties;
+  _seq_no?: number;
+  _primary_term?: number;
+};
+
+export interface ProjectClient {
+  get(projectId: string): Promise<Project>;
+  list(options?: { type?: ProjectType; caseId?: string }): Promise<Project[]>;
+  create(request: ProjectCreateRequest): Promise<Project>;
+  update(request: ProjectUpdateRequest): Promise<Project>;
+  findByCaseRef(caseId: string, owner: string): Promise<Project | undefined>;
+}
+
+const fromEs = (document: ProjectDocument): Project => {
+  const source = document._source;
+  return {
+    id: document._id,
+    title: source.title,
+    type: source.type,
+    ...(source.case_id && source.case_owner
+      ? { case_ref: { case_id: source.case_id, owner: source.case_owner } }
+      : {}),
+    members: source.members ?? [],
+    conversation_ids: source.conversation_ids ?? [],
+    created_at: source.created_at,
+    updated_at: source.updated_at,
+    created_by: {
+      id: source.user_id,
+      username: source.user_name,
+    },
+    space: source.space,
+  };
+};
+
+const toEs = ({
+  request,
+  user,
+  space,
+  now,
+}: {
+  request: ProjectCreateRequest;
+  user: UserIdAndName;
+  space: string;
+  now: Date;
+}): ProjectProperties => ({
+  title: request.title,
+  type: request.type,
+  ...(request.case_ref
+    ? { case_id: request.case_ref.case_id, case_owner: request.case_ref.owner }
+    : {}),
+  members: request.members ?? [],
+  conversation_ids: request.conversation_ids ?? [],
+  user_id: user.id,
+  user_name: user.username,
+  space,
+  created_at: now.toISOString(),
+  updated_at: now.toISOString(),
+});
+
+export const createProjectClient = ({
+  space,
+  logger,
+  esClient,
+  user,
+}: {
+  space: string;
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  user: UserIdAndName;
+}): ProjectClient => {
+  const storage = createProjectStorage({ logger, esClient });
+
+  const hasAccess = (document: ProjectDocument) => {
+    if (user.id && document._source.user_id === user.id) {
+      return true;
+    }
+    return document._source.user_name === user.username;
+  };
+
+  const getDocument = async (projectId: string): Promise<ProjectDocument | undefined> => {
+    const response = await storage.getClient().search({
+      track_total_hits: false,
+      size: 1,
+      terminate_after: 1,
+      query: {
+        bool: {
+          filter: [createSpaceDslFilter(space), { term: { _id: projectId } }],
+        },
+      },
+    });
+    const hit = response.hits.hits[0];
+    if (!hit?._source) {
+      return undefined;
+    }
+    return hit as ProjectDocument;
+  };
+
+  return {
+    async get(projectId) {
+      const document = await getDocument(projectId);
+      if (!document || !hasAccess(document)) {
+        throw new Error(`Project not found: ${projectId}`);
+      }
+      return fromEs(document);
+    },
+
+    async list(options = {}) {
+      const filters = [createSpaceDslFilter(space), { term: { user_name: user.username } }];
+      if (options.type) {
+        filters.push({ term: { type: options.type } });
+      }
+      if (options.caseId) {
+        filters.push({ term: { case_id: options.caseId } });
+      }
+
+      const response = await storage.getClient().search({
+        track_total_hits: false,
+        size: 1000,
+        query: { bool: { filter: filters } },
+      });
+
+      return response.hits.hits
+        .filter((hit): hit is ProjectDocument => Boolean(hit._source))
+        .filter(hasAccess)
+        .map(fromEs);
+    },
+
+    async create(request) {
+      const now = new Date();
+      const id = request.id ?? uuidv4();
+      const document = toEs({ request, user, space, now });
+
+      await storage.getClient().index({ id, document });
+
+      return this.get(id);
+    },
+
+    async update(request) {
+      const document = await getDocument(request.id);
+      if (!document || !hasAccess(document)) {
+        throw new Error(`Project not found: ${request.id}`);
+      }
+
+      const now = new Date();
+      const updated: ProjectProperties = {
+        ...document._source,
+        ...(request.title !== undefined ? { title: request.title } : {}),
+        ...(request.members !== undefined ? { members: request.members } : {}),
+        ...(request.conversation_ids !== undefined
+          ? { conversation_ids: request.conversation_ids }
+          : {}),
+        updated_at: now.toISOString(),
+      };
+
+      await storage.getClient().index({
+        id: request.id,
+        document: updated,
+        if_seq_no: document._seq_no,
+        if_primary_term: document._primary_term,
+      });
+
+      return this.get(request.id);
+    },
+
+    async findByCaseRef(caseId, owner) {
+      const response = await storage.getClient().search({
+        track_total_hits: false,
+        size: 1,
+        query: {
+          bool: {
+            filter: [
+              createSpaceDslFilter(space),
+              { term: { user_name: user.username } },
+              { term: { case_id: caseId } },
+              { term: { case_owner: owner } },
+            ],
+          },
+        },
+      });
+
+      const hit = response.hits.hits[0] as ProjectDocument | undefined;
+      if (!hit?._source || !hasAccess(hit)) {
+        return undefined;
+      }
+      return fromEs(hit);
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/project/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/project/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { ProjectServiceImpl, type ProjectService } from './project_service';
+export type { ProjectClient } from './client';

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/project/knowledge_projection.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/project/knowledge_projection.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { CasesClient } from '@kbn/cases-plugin/server';
+import type { Project } from '@kbn/agent-builder-common';
+
+export interface ProjectKnowledgeSummary {
+  case_id: string;
+  owner: string;
+  title?: string;
+  description?: string;
+  status?: string;
+  severity?: string;
+  total_alerts?: number;
+  total_comments?: number;
+}
+
+/**
+ * Projects case metadata into a lightweight knowledge summary for Agent Builder projects.
+ */
+export const projectCaseKnowledgeProjection = async ({
+  project,
+  casesClient,
+  logger,
+}: {
+  project: Project;
+  casesClient: CasesClient;
+  logger: Logger;
+}): Promise<ProjectKnowledgeSummary | undefined> => {
+  if (!project.case_ref) {
+    return undefined;
+  }
+
+  try {
+    const caseInfo = await casesClient.cases.get({
+      id: project.case_ref.case_id,
+    });
+
+    return {
+      case_id: project.case_ref.case_id,
+      owner: project.case_ref.owner,
+      title: caseInfo.title,
+      description: caseInfo.description,
+      status: caseInfo.status,
+      severity: caseInfo.severity,
+      total_alerts: caseInfo.totalAlerts,
+      total_comments: caseInfo.totalComment,
+    };
+  } catch (error) {
+    logger.warn(`Failed to project case knowledge for project ${project.id}: ${error}`);
+    return undefined;
+  }
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/project/project_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/project/project_service.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  KibanaRequest,
+  Logger,
+  SecurityServiceStart,
+  ElasticsearchServiceStart,
+} from '@kbn/core/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { CasesClient } from '@kbn/cases-plugin/server';
+import { ProjectType, type Project, type ProjectCreateRequest } from '@kbn/agent-builder-common';
+import { getUserFromRequest } from '../utils';
+import { getCurrentSpaceId } from '../../utils/spaces';
+import type { ProjectClient } from './client';
+import { createProjectClient } from './client';
+import { projectCaseKnowledgeProjection } from './knowledge_projection';
+
+export interface ProjectService {
+  getScopedClient(options: { request: KibanaRequest }): Promise<ProjectClient>;
+  getOrCreateForCase(options: {
+    request: KibanaRequest;
+    caseId: string;
+    owner: string;
+    title?: string;
+  }): Promise<Project>;
+  getKnowledgeSummary(options: {
+    request: KibanaRequest;
+    project: Project;
+  }): Promise<ReturnType<typeof projectCaseKnowledgeProjection>>;
+}
+
+interface ProjectServiceDeps {
+  logger: Logger;
+  security: SecurityServiceStart;
+  elasticsearch: ElasticsearchServiceStart;
+  spaces?: SpacesPluginStart;
+  getCasesClientWithRequest?: (request: KibanaRequest) => Promise<CasesClient>;
+}
+
+export class ProjectServiceImpl implements ProjectService {
+  private readonly logger: Logger;
+  private readonly security: SecurityServiceStart;
+  private readonly elasticsearch: ElasticsearchServiceStart;
+  private readonly spaces?: SpacesPluginStart;
+  private readonly getCasesClientWithRequest?: ProjectServiceDeps['getCasesClientWithRequest'];
+
+  constructor(deps: ProjectServiceDeps) {
+    this.logger = deps.logger;
+    this.security = deps.security;
+    this.elasticsearch = deps.elasticsearch;
+    this.spaces = deps.spaces;
+    this.getCasesClientWithRequest = deps.getCasesClientWithRequest;
+  }
+
+  async getScopedClient({ request }: { request: KibanaRequest }): Promise<ProjectClient> {
+    const scopedClient = this.elasticsearch.client.asScoped(request);
+    const user = await getUserFromRequest({
+      request,
+      security: this.security,
+      esClient: scopedClient.asCurrentUser,
+    });
+    const esClient = scopedClient.asInternalUser;
+    const space = getCurrentSpaceId({ request, spaces: this.spaces });
+
+    return createProjectClient({ user, esClient, logger: this.logger, space });
+  }
+
+  async getOrCreateForCase({
+    request,
+    caseId,
+    owner,
+    title,
+  }: {
+    request: KibanaRequest;
+    caseId: string;
+    owner: string;
+    title?: string;
+  }): Promise<Project> {
+    const client = await this.getScopedClient({ request });
+    const existing = await client.findByCaseRef(caseId, owner);
+    if (existing) {
+      return existing;
+    }
+
+    const members = await this.resolveCaseAssigneeMembers({ request, caseId, owner });
+
+    const createRequest: ProjectCreateRequest = {
+      title: title ?? `Case ${caseId}`,
+      type: ProjectType.case,
+      case_ref: { case_id: caseId, owner },
+      members,
+    };
+
+    return client.create(createRequest);
+  }
+
+  async getKnowledgeSummary({
+    request,
+    project,
+  }: {
+    request: KibanaRequest;
+    project: Project;
+  }) {
+    if (!this.getCasesClientWithRequest) {
+      return undefined;
+    }
+    const casesClient = await this.getCasesClientWithRequest(request);
+    return projectCaseKnowledgeProjection({
+      project,
+      casesClient,
+      logger: this.logger,
+    });
+  }
+
+  private async resolveCaseAssigneeMembers({
+    request,
+    caseId,
+    owner,
+  }: {
+    request: KibanaRequest;
+    caseId: string;
+    owner: string;
+  }): Promise<string[]> {
+    if (!this.getCasesClientWithRequest) {
+      return [];
+    }
+    try {
+      const casesClient = await this.getCasesClientWithRequest(request);
+      const caseInfo = await casesClient.cases.get({ id: caseId });
+      return (caseInfo.assignees ?? []).map((assignee) => assignee.uid);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/project/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/project/storage.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, ElasticsearchClient } from '@kbn/core/server';
+import type { IndexStorageSettings } from '@kbn/storage-adapter';
+import { StorageIndexAdapter, types } from '@kbn/storage-adapter';
+import { chatSystemIndex } from '@kbn/agent-builder-server';
+import type { ProjectType } from '@kbn/agent-builder-common';
+
+export const projectIndexName = chatSystemIndex('projects');
+
+const storageSettings = {
+  name: projectIndexName,
+  schema: {
+    properties: {
+      title: types.text({}),
+      type: types.keyword({}),
+      case_id: types.keyword({}),
+      case_owner: types.keyword({}),
+      members: types.keyword({}),
+      conversation_ids: types.keyword({}),
+      user_id: types.keyword({}),
+      user_name: types.keyword({}),
+      space: types.keyword({}),
+      created_at: types.date({}),
+      updated_at: types.date({}),
+    },
+  },
+} satisfies IndexStorageSettings;
+
+export interface ProjectProperties {
+  title: string;
+  type: ProjectType;
+  case_id?: string;
+  case_owner?: string;
+  members: string[];
+  conversation_ids: string[];
+  user_id?: string;
+  user_name: string;
+  space: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export type ProjectStorageSettings = typeof storageSettings;
+
+export type ProjectStorage = StorageIndexAdapter<ProjectStorageSettings, ProjectProperties>;
+
+export const createProjectStorage = ({
+  logger,
+  esClient,
+}: {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+}): ProjectStorage => {
+  return new StorageIndexAdapter<ProjectStorageSettings, ProjectProperties>(
+    esClient,
+    logger,
+    storageSettings
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
@@ -27,6 +27,7 @@ import type { ToolsServiceSetup, ToolsServiceStart } from './tools';
 import type { RunnerFactory } from './execution/runner';
 import type { AgentsServiceSetup, AgentsServiceStart } from './agents';
 import type { ConversationService } from './conversation';
+import type { ProjectService } from './project';
 import type { AttachmentServiceSetup, AttachmentServiceStart } from './attachments';
 import type { SkillServiceSetup, SkillServiceStart } from './skills';
 import type { TrackingService } from '../telemetry/tracking_service';
@@ -35,6 +36,8 @@ import type { AuditLogService } from '../audit';
 import type { TaskHandler } from './execution';
 import type { MeteringService, ConsumptionServiceStart } from './metering';
 import type { PluginsServiceSetup, PluginsServiceStart } from './plugins';
+import type { CasesClient } from '@kbn/cases-plugin/server';
+import type { KibanaRequest } from '@kbn/core-http-server';
 
 export interface InternalSetupServices {
   tools: ToolsServiceSetup;
@@ -52,6 +55,7 @@ export interface InternalStartServices {
   attachments: AttachmentServiceStart;
   skills: SkillServiceStart;
   conversations: ConversationService;
+  projects: ProjectService;
   runnerFactory: RunnerFactory;
   hooks: HooksServiceStart;
   auditLogService: AuditLogService;
@@ -91,4 +95,5 @@ export interface ServicesStartDeps {
   trackingService?: TrackingService;
   analyticsService?: AnalyticsService;
   searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
+  getCasesClientWithRequest?: (request: KibanaRequest) => Promise<CasesClient>;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -32,6 +32,7 @@ import type {
   AgentContextLayerPluginSetup,
   AgentContextLayerPluginStart,
 } from '@kbn/agent-context-layer-plugin/server';
+import type { CasesServerStart } from '@kbn/cases-plugin/server';
 
 export type {
   AgentBuilderPluginSetup,
@@ -79,4 +80,5 @@ export interface AgentBuilderStartDependencies {
   security?: SecurityPluginStart;
   searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
   agentContextLayer: AgentContextLayerPluginStart;
+  cases?: CasesServerStart;
 }

--- a/x-pack/platform/plugins/shared/agent_builder_platform/common/attachments/case.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/common/attachments/case.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const PLATFORM_CASE_ATTACHMENT_TYPE = 'platform.core.cases.case' as const;

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/case.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/case.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import { PLATFORM_CASE_ATTACHMENT_TYPE } from '../../common/attachments/case';
+
+export const caseAttachmentDataSchema = z.object({
+  case_id: z.string(),
+  owner: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  attachmentLabel: z.string().optional(),
+});
+
+export type CaseAttachmentData = z.infer<typeof caseAttachmentDataSchema>;
+
+const isCaseAttachmentData = (data: unknown): data is CaseAttachmentData => {
+  return caseAttachmentDataSchema.safeParse(data).success;
+};
+
+export const createCaseAttachmentType = (): AttachmentTypeDefinition => {
+  return {
+    id: PLATFORM_CASE_ATTACHMENT_TYPE,
+    validate: (input) => {
+      const parseResult = caseAttachmentDataSchema.safeParse(input);
+      if (parseResult.success) {
+        return { valid: true, data: parseResult.data };
+      }
+      return { valid: false, error: parseResult.error.message };
+    },
+    format: (attachment: Attachment<string, unknown>) => {
+      const data = attachment.data;
+      if (!isCaseAttachmentData(data)) {
+        throw new Error(`Invalid case attachment data for attachment ${attachment.id}`);
+      }
+      return {
+        getRepresentation: () => ({
+          type: 'text' as const,
+          value: formatCaseData(data),
+        }),
+      };
+    },
+    getTools: () => [platformCoreTools.cases],
+    getAgentDescription: () => {
+      return `You are assisting with a Kibana case. Use the cases tool to load full case details, comments, and linked alerts.
+
+CASE CONTEXT:
+{caseData}
+
+When responding:
+1. Use case_id and owner from the attachment when calling the cases tool.
+2. Summarize linked alerts and observables when relevant.
+3. Suggest creating or updating case comments when the user asks to document findings.`;
+    },
+  };
+};
+
+const formatCaseData = (data: CaseAttachmentData): string => {
+  const lines = [
+    `case_id: ${data.case_id}`,
+    `owner: ${data.owner}`,
+    ...(data.title ? [`title: ${data.title}`] : []),
+    ...(data.description ? [`description: ${data.description}`] : []),
+  ];
+  return lines.join('\n');
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/index.ts
@@ -13,6 +13,7 @@ import { createScreenContextAttachmentType } from './screen_context';
 import { createVisualizationAttachmentType } from './visualization';
 import { createGraphAttachmentType } from './graph';
 import { createConnectorAttachmentType } from './connector';
+import { createCaseAttachmentType } from './case';
 import type {
   AgentBuilderPlatformPluginStart,
   PluginSetupDependencies,
@@ -35,6 +36,7 @@ export const registerAttachmentTypes = ({
     createVisualizationAttachmentType(),
     createGraphAttachmentType(),
     createConnectorAttachmentType(),
+    createCaseAttachmentType(),
   ];
 
   attachmentTypes.forEach((attachmentType) => {

--- a/x-pack/platform/plugins/shared/cases/common/attachment_framework/define_attachment.ts
+++ b/x-pack/platform/plugins/shared/cases/common/attachment_framework/define_attachment.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { z } from '@kbn/zod/v4';
+
+/**
+ * Runtime helper for unified attachment registration. Kept in a leaf module under
+ * `common/` so other plugins can import it without pulling in the Cases plugin
+ * class and its attachment registration chain (circular dependency risk).
+ *
+ * Prop narrowing is provided by the typed overload in the Cases public API.
+ */
+export const defineAttachment = <S extends z.ZodType, T extends { schema: S }>(
+  attachmentType: T
+): T => attachmentType;

--- a/x-pack/platform/plugins/shared/cases/common/constants/agent_builder.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/agent_builder.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Agent Builder attachment type for case context (registered by agent_builder_platform). */
+export const PLATFORM_CASE_ATTACHMENT_TYPE = 'platform.core.cases.case' as const;

--- a/x-pack/platform/plugins/shared/cases/common/types.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types.ts
@@ -29,4 +29,5 @@ export enum CASE_VIEW_PAGE_TABS {
   OBSERVABLES = 'observables',
   SIMILAR_CASES = 'similar_cases',
   ATTACHMENTS = 'attachments',
+  AI_WORKSPACE = 'ai_workspace',
 }

--- a/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/ai_response/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain_zod/attachment/ai_response/v1.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { MAX_COMMENT_LENGTH } from '../../../../constants';
+
+export const AI_RESPONSE_ATTACHMENT_TYPE = 'cases.ai_response' as const;
+
+export const AiResponseAttachmentDataSchema = z
+  .object({
+    content: z
+      .string()
+      .max(MAX_COMMENT_LENGTH)
+      .refine((value) => value.trim().length > 0, {
+        message: 'AI response content must not be empty',
+      }),
+    agent_id: z.string().optional(),
+    skill_id: z.string().optional(),
+    conversation_id: z.string().optional(),
+    citations: z
+      .array(
+        z
+          .object({
+            label: z.string(),
+            url: z.string().optional(),
+            type: z.string().optional(),
+          })
+          .strict()
+      )
+      .optional(),
+  })
+  .strict();
+
+export const AiResponseAttachmentPayloadSchema = z
+  .object({
+    type: z.literal(AI_RESPONSE_ATTACHMENT_TYPE),
+    owner: z.string(),
+    data: AiResponseAttachmentDataSchema,
+  })
+  .strict();
+
+export type AiResponseAttachmentData = z.infer<typeof AiResponseAttachmentDataSchema>;
+export type AiResponseAttachmentPayload = z.infer<typeof AiResponseAttachmentPayloadSchema>;

--- a/x-pack/platform/plugins/shared/cases/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/cases/kibana.jsonc
@@ -29,8 +29,22 @@
       "uiActions",
       "workflowsExtensions"
     ],
-    "optionalPlugins": ["cloud", "home", "taskManager", "usageCollection", "spaces", "serverless"],
-    "requiredBundles": ["esUiShared", "kibanaReact", "kibanaUtils", "savedObjectsFinder"],
+    "optionalPlugins": [
+      "cloud",
+      "home",
+      "taskManager",
+      "usageCollection",
+      "spaces",
+      "serverless",
+      "agentBuilder"
+    ],
+    "requiredBundles": [
+      "esUiShared",
+      "kibanaReact",
+      "kibanaUtils",
+      "savedObjectsFinder",
+      "agentBuilder"
+    ],
     "extraPublicDirs": ["common"]
   }
 }

--- a/x-pack/platform/plugins/shared/cases/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/cases/kibana.jsonc
@@ -29,22 +29,9 @@
       "uiActions",
       "workflowsExtensions"
     ],
-    "optionalPlugins": [
-      "cloud",
-      "home",
-      "taskManager",
-      "usageCollection",
-      "spaces",
-      "serverless",
-      "agentBuilder"
-    ],
-    "requiredBundles": [
-      "esUiShared",
-      "kibanaReact",
-      "kibanaUtils",
-      "savedObjectsFinder",
-      "agentBuilder"
-    ],
+    "optionalPlugins": ["cloud", "home", "taskManager", "usageCollection", "spaces", "serverless"],
+    "runtimePluginDependencies": ["agentBuilder"],
+    "requiredBundles": ["esUiShared", "kibanaReact", "kibanaUtils", "savedObjectsFinder"],
     "extraPublicDirs": ["common"]
   }
 }

--- a/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/client/attachment_framework/types.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../../common/types/domain';
 import type { CaseUI, CaseUser } from '../../containers/types';
 import { AttachmentActionType } from '../../../common/utils/attachment_actions';
+import { defineAttachment as defineAttachmentRuntime } from '../../../common/attachment_framework/define_attachment';
 
 export { AttachmentActionType };
 
@@ -171,4 +172,4 @@ type UnifiedAttachmentTypeForRegistry<S extends z.ZodType> = IsReferenceSchema<S
 export const defineAttachment = <S extends z.ZodType>(
   attachmentType: UnifiedAttachmentTypeFromSchema<S> & { schema: S }
 ): UnifiedAttachmentTypeForRegistry<S> =>
-  attachmentType as unknown as UnifiedAttachmentTypeForRegistry<S>;
+  defineAttachmentRuntime(attachmentType) as unknown as UnifiedAttachmentTypeForRegistry<S>;

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_dependencies.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_dependencies.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
+import { useKibana } from './lib/kibana';
+
+export interface CasesDependencies {
+  agentBuilder?: AgentBuilderPluginStart;
+}
+
+export const useCasesDependencies = (): CasesDependencies => {
+  const { services } = useKibana();
+
+  return useMemo(
+    () => ({
+      agentBuilder: services.agentBuilder as AgentBuilderPluginStart | undefined,
+    }),
+    [services.agentBuilder]
+  );
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/agent_builder/add_case_to_chat_button.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/agent_builder/add_case_to_chat_button.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import { EuiButtonEmpty } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import { PLATFORM_CASE_ATTACHMENT_TYPE } from '../../../common/constants/agent_builder';
+import type { CaseUI } from '../../../common/ui/types';
+import { useCasesDependencies } from '../../common/use_cases_dependencies';
+
+const ADD_TO_CHAT = i18n.translate('xpack.cases.agentBuilder.addToChat', {
+  defaultMessage: 'Add to Chat',
+});
+
+const CASE_ATTACHMENT_PROMPT = i18n.translate('xpack.cases.agentBuilder.caseAttachmentPrompt', {
+  defaultMessage:
+    'Help me investigate this case. Review linked alerts, observables, and comments. Summarize the current status and suggest next steps.',
+});
+
+export interface AddCaseToChatButtonProps {
+  caseData: CaseUI;
+}
+
+export const AddCaseToChatButton: React.FC<AddCaseToChatButtonProps> = ({ caseData }) => {
+  const { agentBuilder } = useCasesDependencies();
+
+  const onClick = useCallback(() => {
+    if (!agentBuilder?.openChat) {
+      return;
+    }
+
+    const owner = Array.isArray(caseData.owner) ? caseData.owner[0] : caseData.owner;
+
+    const attachment: AttachmentInput = {
+      id: `case-${caseData.id}`,
+      type: PLATFORM_CASE_ATTACHMENT_TYPE,
+      data: {
+        case_id: caseData.id,
+        owner,
+        title: caseData.title,
+        description: caseData.description,
+        attachmentLabel: caseData.title,
+      },
+    };
+
+    agentBuilder.openChat({
+      autoSendInitialMessage: false,
+      newConversation: true,
+      initialMessage: CASE_ATTACHMENT_PROMPT,
+      attachments: [attachment],
+      caseId: caseData.id,
+      sessionTag: `cases-${owner}`,
+    });
+  }, [agentBuilder, caseData]);
+
+  if (!agentBuilder?.openChat) {
+    return null;
+  }
+
+  return (
+    <EuiButtonEmpty
+      data-test-subj="casesAddToChatButton"
+      iconType="sparkles"
+      onClick={onClick}
+      flush="left"
+    >
+      {ADD_TO_CHAT}
+    </EuiButtonEmpty>
+  );
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/agent_builder/add_case_to_chat_button.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/agent_builder/add_case_to_chat_button.tsx
@@ -54,6 +54,8 @@ export const AddCaseToChatButton: React.FC<AddCaseToChatButtonProps> = ({ caseDa
       initialMessage: CASE_ATTACHMENT_PROMPT,
       attachments: [attachment],
       caseId: caseData.id,
+      caseOwner: owner,
+      caseTitle: caseData.title,
       sessionTag: `cases-${owner}`,
     });
   }, [agentBuilder, caseData]);

--- a/x-pack/platform/plugins/shared/cases/public/components/agent_builder/add_case_to_chat_button.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/agent_builder/add_case_to_chat_button.tsx
@@ -8,18 +8,13 @@
 import React, { useCallback } from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
-import { PLATFORM_CASE_ATTACHMENT_TYPE } from '../../../common/constants/agent_builder';
+import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 import type { CaseUI } from '../../../common/ui/types';
+import { useCaseViewNavigation } from '../../common/navigation';
 import { useCasesDependencies } from '../../common/use_cases_dependencies';
 
-const ADD_TO_CHAT = i18n.translate('xpack.cases.agentBuilder.addToChat', {
-  defaultMessage: 'Add to Chat',
-});
-
-const CASE_ATTACHMENT_PROMPT = i18n.translate('xpack.cases.agentBuilder.caseAttachmentPrompt', {
-  defaultMessage:
-    'Help me investigate this case. Review linked alerts, observables, and comments. Summarize the current status and suggest next steps.',
+const OPEN_AI_WORKSPACE = i18n.translate('xpack.cases.agentBuilder.openAiWorkspace', {
+  defaultMessage: 'AI Workspace',
 });
 
 export interface AddCaseToChatButtonProps {
@@ -28,50 +23,45 @@ export interface AddCaseToChatButtonProps {
 
 export const AddCaseToChatButton: React.FC<AddCaseToChatButtonProps> = ({ caseData }) => {
   const { agentBuilder } = useCasesDependencies();
+  const { navigateToCaseView } = useCaseViewNavigation();
 
   const onClick = useCallback(() => {
+    if (agentBuilder?.CaseAiWorkspace) {
+      navigateToCaseView({
+        detailName: caseData.id,
+        tabId: CASE_VIEW_PAGE_TABS.AI_WORKSPACE,
+      });
+      return;
+    }
+
     if (!agentBuilder?.openChat) {
       return;
     }
 
     const owner = Array.isArray(caseData.owner) ? caseData.owner[0] : caseData.owner;
 
-    const attachment: AttachmentInput = {
-      id: `case-${caseData.id}`,
-      type: PLATFORM_CASE_ATTACHMENT_TYPE,
-      data: {
-        case_id: caseData.id,
-        owner,
-        title: caseData.title,
-        description: caseData.description,
-        attachmentLabel: caseData.title,
-      },
-    };
-
     agentBuilder.openChat({
       autoSendInitialMessage: false,
       newConversation: true,
-      initialMessage: CASE_ATTACHMENT_PROMPT,
-      attachments: [attachment],
       caseId: caseData.id,
       caseOwner: owner,
       caseTitle: caseData.title,
       sessionTag: `cases-${owner}`,
     });
-  }, [agentBuilder, caseData]);
+  }, [agentBuilder, caseData, navigateToCaseView]);
 
-  if (!agentBuilder?.openChat) {
+  if (!agentBuilder?.CaseAiWorkspace && !agentBuilder?.openChat) {
     return null;
   }
 
   return (
     <EuiButtonEmpty
-      data-test-subj="casesAddToChatButton"
+      data-test-subj="casesOpenAiWorkspaceButton"
       iconType="sparkles"
       onClick={onClick}
       flush="left"
     >
-      {ADD_TO_CHAT}
+      {OPEN_AI_WORKSPACE}
     </EuiButtonEmpty>
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/ai_response/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/ai_response/index.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiMarkdownFormat, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { AttachmentType } from '../../../client/attachment_framework/types';
+import { AI_RESPONSE_ATTACHMENT_TYPE } from '../../../../common/types/domain_zod/attachment/ai_response/v1';
+import type { AiResponseAttachmentData } from '../../../../common/types/domain_zod/attachment/ai_response/v1';
+
+const displayName = i18n.translate('xpack.cases.aiResponse.attachment.displayName', {
+  defaultMessage: 'AI assistant',
+});
+
+export const aiResponseAttachmentType: AttachmentType<{ attachment: { data: AiResponseAttachmentData } }> =
+  {
+    id: AI_RESPONSE_ATTACHMENT_TYPE,
+    icon: 'sparkles',
+    displayName,
+    getAttachmentViewObject: ({ attachment }) => ({
+      event: displayName,
+      children: (
+        <EuiText size="s">
+          <EuiMarkdownFormat>{attachment.data.content}</EuiMarkdownFormat>
+        </EuiText>
+      ),
+    }),
+  };

--- a/x-pack/platform/plugins/shared/cases/public/components/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/attachments/index.ts
@@ -10,10 +10,12 @@ import { getCommentAttachmentType } from './comment';
 import { getFileAttachmentType } from './file';
 import { getVisualizationAttachmentType } from './lens';
 import { getStackAlertAttachmentType } from './alert';
+import { aiResponseAttachmentType } from './ai_response';
 
 export const registerInternalAttachments = (unifiedRegistry: UnifiedAttachmentTypeRegistry) => {
   unifiedRegistry.register(getFileAttachmentType());
   unifiedRegistry.register(getVisualizationAttachmentType());
   unifiedRegistry.register(getCommentAttachmentType());
+  unifiedRegistry.register(aiResponseAttachmentType);
   unifiedRegistry.register(getStackAlertAttachmentType());
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_action_bar/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_action_bar/index.tsx
@@ -25,6 +25,7 @@ import { useCasesFeatures } from '../../common/use_cases_features';
 import { useGetCaseConnectors } from '../../containers/use_get_case_connectors';
 import { useShouldDisableStatus } from '../actions/status/use_should_disable_status';
 import { useStatusAction } from '../actions/status/use_status_action';
+import { AddCaseToChatButton } from '../agent_builder/add_case_to_chat_button';
 
 export interface CaseActionBarProps {
   caseData: CaseUI;
@@ -146,6 +147,10 @@ const CaseActionBarComponent: React.FC<CaseActionBarProps> = ({
             </ActionBarStatusItem>
           </EuiFlexItem>
         ) : null}
+
+        <EuiFlexItem grow={false}>
+          <AddCaseToChatButton caseData={caseData} />
+        </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
@@ -21,6 +21,7 @@ import type { CaseViewPageProps } from './types';
 import { useRefreshCaseViewPage } from './use_on_refresh_case_view_page';
 import { useOnUpdateField } from './use_on_update_field';
 import { CaseViewSimilarCases } from './components/case_view_similar_cases';
+import { CaseViewAiWorkspace } from './components/case_view_ai_workspace';
 import { CaseViewAttachments } from './components/case_view_attachments';
 import { filterCaseAttachmentsBySearchTerm } from './components/helpers';
 import { toUnifiedAttachmentType } from '../../../common/utils/attachments/migration_utils';
@@ -199,6 +200,9 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
           )}
           {activeTabId === CASE_VIEW_PAGE_TABS.SIMILAR_CASES && (
             <CaseViewSimilarCases caseData={caseWithFilteredAttachments} searchTerm={searchTerm} />
+          )}
+          {activeTabId === CASE_VIEW_PAGE_TABS.AI_WORKSPACE && (
+            <CaseViewAiWorkspace caseData={caseWithFilteredAttachments} />
           )}
         </EuiFlexGroup>
       </>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.tsx
@@ -10,7 +10,8 @@ import { EuiTab, EuiTabs, useEuiTheme } from '@elastic/eui';
 
 import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 import { useCaseViewNavigation } from '../../common/navigation';
-import { ACTIVITY_TAB, ATTACHMENTS_TAB, SIMILAR_CASES_TAB } from './translations';
+import { ACTIVITY_TAB, AI_WORKSPACE_TAB, ATTACHMENTS_TAB, SIMILAR_CASES_TAB } from './translations';
+import { useCasesDependencies } from '../../common/use_cases_dependencies';
 import { type CaseUI } from '../../../common';
 import type { CaseViewTab } from './use_case_attachment_tabs';
 import {
@@ -32,6 +33,7 @@ export interface CaseViewTabsProps {
 }
 
 export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab, searchTerm }) => {
+  const { agentBuilder } = useCasesDependencies();
   const { navigateToCaseView } = useCaseViewNavigation();
   const { tabs: attachmentTabs, totalAttachments } = useCaseAttachmentTabs({
     caseData,
@@ -58,8 +60,8 @@ export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab
 
   const defaultAttachmentsTabId = attachmentTabs[0].id;
 
-  const tabs: CaseViewTab[] = useMemo(
-    () => [
+  const tabs: CaseViewTab[] = useMemo(() => {
+    const baseTabs: CaseViewTab[] = [
       {
         id: CASE_VIEW_PAGE_TABS.ACTIVITY,
         name: ACTIVITY_TAB,
@@ -86,9 +88,24 @@ export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab
           />
         ),
       },
-    ],
-    [activeTab, euiTheme, isAttachmentsTabActive, similarCasesData?.total, totalAttachments]
-  );
+    ];
+
+    if (agentBuilder?.CaseAiWorkspace) {
+      baseTabs.splice(1, 0, {
+        id: CASE_VIEW_PAGE_TABS.AI_WORKSPACE,
+        name: AI_WORKSPACE_TAB,
+      });
+    }
+
+    return baseTabs;
+  }, [
+    activeTab,
+    agentBuilder?.CaseAiWorkspace,
+    euiTheme,
+    isAttachmentsTabActive,
+    similarCasesData?.total,
+    totalAttachments,
+  ]);
 
   const trackAttachmentsTabClick = useAttachmentsTabClickedEBT();
   const trackAttachmentsSubTabClick = useAttachmentsSubTabClickedEBT();

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_ai_workspace.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_ai_workspace.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import type { CaseUI } from '../../../../common';
+import { CASE_VIEW_PAGE_TABS } from '../../../../common/types';
+import { FILE_ATTACHMENT_TYPE } from '../../../../common/constants';
+import { useCasesDependencies } from '../../../common/use_cases_dependencies';
+import { CaseViewTabs } from '../case_view_tabs';
+
+export interface CaseViewAiWorkspaceProps {
+  caseData: CaseUI;
+}
+
+export const CaseViewAiWorkspace: React.FC<CaseViewAiWorkspaceProps> = ({ caseData }) => {
+  const { agentBuilder } = useCasesDependencies();
+
+  const owner = Array.isArray(caseData.owner) ? caseData.owner[0] : caseData.owner;
+
+  const fileCount = useMemo(
+    () => caseData.comments?.filter((comment) => comment.type === FILE_ATTACHMENT_TYPE).length ?? 0,
+    [caseData.comments]
+  );
+
+  const CaseAiWorkspace = agentBuilder?.CaseAiWorkspace;
+
+  if (!CaseAiWorkspace) {
+    return null;
+  }
+
+  return (
+    <EuiFlexItem data-test-subj="case-view-ai-workspace-tab">
+      <CaseViewTabs
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.AI_WORKSPACE}
+      />
+      <EuiSpacer size="l" />
+      <CaseAiWorkspace
+        caseId={caseData.id}
+        caseTitle={caseData.title}
+        caseOwner={owner}
+        caseDescription={caseData.description}
+        totalAlerts={caseData.totalAlerts}
+        totalComments={caseData.totalComment}
+        fileCount={fileCount}
+      />
+    </EuiFlexItem>
+  );
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
@@ -210,6 +210,10 @@ export const SIMILAR_CASES_TAB = i18n.translate('xpack.cases.caseView.tabs.simil
   defaultMessage: 'Similar cases',
 });
 
+export const AI_WORKSPACE_TAB = i18n.translate('xpack.cases.caseView.tabs.aiWorkspace', {
+  defaultMessage: 'AI Workspace',
+});
+
 export const SEND_EMAIL_ARIA = (user: string) =>
   i18n.translate('xpack.cases.caseView.sendEmalLinkAria', {
     values: { user },

--- a/x-pack/platform/plugins/shared/cases/public/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/index.tsx
@@ -34,6 +34,7 @@ export type {
   CommonAttachmentTabViewProps,
   UnifiedReferenceAttachmentViewProps,
 } from './client/attachment_framework/types';
-export { AttachmentActionType, defineAttachment } from './client/attachment_framework/types';
+export { AttachmentActionType } from './client/attachment_framework/types';
+export { defineAttachment } from '../common/attachment_framework/define_attachment';
 export { useCasesContext } from './components/cases_context/use_cases_context';
 export { ShowTableButton } from './components/attachments/common/show_table_button';

--- a/x-pack/platform/plugins/shared/cases/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/public/plugin.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type { ManagementAppMountParams } from '@kbn/management-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { createBrowserHistory } from 'history';
@@ -61,6 +62,7 @@ export class CasesUiPlugin
   private externalReferenceAttachmentTypeRegistry: ExternalReferenceAttachmentTypeRegistry;
   private persistableStateAttachmentTypeRegistry: PersistableStateAttachmentTypeRegistry;
   private unifiedAttachmentTypeRegistry: UnifiedAttachmentTypeRegistry;
+  private agentBuilderPromise?: Promise<AgentBuilderPluginStart | undefined>;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.kibanaVersion = initializerContext.env.packageInfo.version;
@@ -69,12 +71,18 @@ export class CasesUiPlugin
     this.unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
   }
 
-  public setup(core: CoreSetup, plugins: CasesPublicSetupDependencies): CasesPublicSetup {
+  public setup(
+    core: CoreSetup<CasesPublicStartDependencies, CasesPublicStart>,
+    plugins: CasesPublicSetupDependencies
+  ): CasesPublicSetup {
+    this.setupAgentBuilderStart(core);
+
     const kibanaVersion = this.kibanaVersion;
     const storage = this.storage;
     const externalReferenceAttachmentTypeRegistry = this.externalReferenceAttachmentTypeRegistry;
     const persistableStateAttachmentTypeRegistry = this.persistableStateAttachmentTypeRegistry;
     const unifiedAttachmentTypeRegistry = this.unifiedAttachmentTypeRegistry;
+    const agentBuilderPromise = this.agentBuilderPromise;
 
     registerInternalAttachments(unifiedAttachmentTypeRegistry);
 
@@ -103,13 +111,18 @@ export class CasesUiPlugin
             CasesPublicStartDependencies,
             unknown
           ];
+          const agentBuilder = await agentBuilderPromise;
+          const pluginsStartWithAgentBuilder: CasesPublicStartDependencies = {
+            ...pluginsStart,
+            agentBuilder: pluginsStart.agentBuilder ?? agentBuilder,
+          };
 
           const { renderApp } = await import('./application');
 
           return renderApp({
             mountParams: params,
             coreStart,
-            pluginsStart,
+            pluginsStart: pluginsStartWithAgentBuilder,
             storage,
             kibanaVersion,
             externalReferenceAttachmentTypeRegistry,
@@ -232,4 +245,21 @@ export class CasesUiPlugin
   }
 
   public stop() {}
+
+  /**
+   * Resolves Agent Builder at runtime without an optional plugin dependency, which would
+   * create a circular dependency with agentBuilder's optional cases dependency.
+   */
+  private setupAgentBuilderStart(
+    core: CoreSetup<CasesPublicStartDependencies, CasesPublicStart>
+  ): void {
+    try {
+      this.agentBuilderPromise = core.plugins
+        .onStart<{ agentBuilder: AgentBuilderPluginStart }>('agentBuilder')
+        .then(({ agentBuilder }) => (agentBuilder.found ? agentBuilder.contract : undefined))
+        .catch(() => undefined);
+    } catch {
+      this.agentBuilderPromise = Promise.resolve(undefined);
+    }
+  }
 }

--- a/x-pack/platform/plugins/shared/cases/public/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/types.ts
@@ -29,6 +29,7 @@ import type { FilesSetup, FilesStart } from '@kbn/files-plugin/public';
 import type { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
@@ -80,6 +81,7 @@ export interface CasesPublicSetupDependencies {
 
 export interface CasesPublicStartDependencies {
   apm?: ApmBase;
+  agentBuilder?: AgentBuilderPluginStart;
   cloud?: CloudStart;
   data: DataPublicPluginStart;
   embeddable: EmbeddableStart;

--- a/x-pack/platform/plugins/shared/cases/server/attachment_framework/attachments/ai_response.ts
+++ b/x-pack/platform/plugins/shared/cases/server/attachment_framework/attachments/ai_response.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  AiResponseAttachmentPayloadSchema,
+  AI_RESPONSE_ATTACHMENT_TYPE,
+} from '../../../common/types/domain_zod/attachment/ai_response/v1';
+import type { UnifiedAttachmentTypeSetup } from '../types';
+
+export const aiResponseAttachmentType: UnifiedAttachmentTypeSetup = {
+  id: AI_RESPONSE_ATTACHMENT_TYPE,
+  schema: AiResponseAttachmentPayloadSchema,
+};

--- a/x-pack/platform/plugins/shared/cases/server/internal_attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/internal_attachments/index.ts
@@ -12,10 +12,12 @@ import {
   stackAlertAttachmentType,
   fileAttachmentType,
 } from '../attachment_framework/attachments';
+import { aiResponseAttachmentType } from '../attachment_framework/attachments/ai_response';
 
 export const registerInternalAttachments = (unifiedRegistry: UnifiedAttachmentTypeRegistry) => {
   unifiedRegistry.register(fileAttachmentType);
   unifiedRegistry.register(lensAttachmentType);
   unifiedRegistry.register(commentAttachmentType);
+  unifiedRegistry.register(aiResponseAttachmentType);
   unifiedRegistry.register(stackAlertAttachmentType);
 };

--- a/x-pack/platform/plugins/shared/cases/server/services/ai_assistant/case_ai_trigger_service.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/ai_assistant/case_ai_trigger_service.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { CasesClient } from '../../client';
+
+const AGENT_MENTION_PATTERN = /@agent\b/i;
+
+export interface CaseAiTriggerInput {
+  caseId: string;
+  owner: string;
+  commentText?: string;
+  eventType?: 'comment_created' | 'alert_attached';
+}
+
+export interface CaseAiTriggerResult {
+  shouldTrigger: boolean;
+  reason: 'mention' | 'assignee_bot' | 'event' | 'none';
+}
+
+/**
+ * Determines whether an Agent Builder run should be triggered for a case event.
+ * Phase 3 default: @agent mention in comment text only.
+ */
+export const evaluateCaseAiTrigger = ({
+  input,
+  logger,
+}: {
+  input: CaseAiTriggerInput;
+  logger: Logger;
+}): CaseAiTriggerResult => {
+  if (input.commentText && AGENT_MENTION_PATTERN.test(input.commentText)) {
+    return { shouldTrigger: true, reason: 'mention' };
+  }
+
+  if (input.eventType === 'alert_attached') {
+    logger.debug(`Case AI auto-trigger disabled for alert_attached on case ${input.caseId}`);
+  }
+
+  return { shouldTrigger: false, reason: 'none' };
+};
+
+export interface PostAiResponseToCaseParams {
+  casesClient: CasesClient;
+  caseId: string;
+  owner: string;
+  content: string;
+  agentId?: string;
+  skillId?: string;
+  conversationId?: string;
+  citations?: Array<{ label: string; url?: string; type?: string }>;
+}
+
+/**
+ * Persists an AI-authored response on the case activity log as a unified attachment.
+ */
+export const postAiResponseToCase = async ({
+  casesClient,
+  caseId,
+  owner,
+  content,
+  agentId,
+  skillId,
+  conversationId,
+  citations,
+}: PostAiResponseToCaseParams): Promise<{ commentId: string }> => {
+  const updatedCase = await casesClient.attachments.add({
+    caseId,
+    comment: {
+      type: 'cases.ai_response',
+      owner,
+      data: {
+        content,
+        ...(agentId ? { agent_id: agentId } : {}),
+        ...(skillId ? { skill_id: skillId } : {}),
+        ...(conversationId ? { conversation_id: conversationId } : {}),
+        ...(citations?.length ? { citations } : {}),
+      },
+    },
+    mode: 'unified',
+  });
+
+  const aiComment = updatedCase.comments
+    ?.filter((attachment) => attachment.type === 'cases.ai_response')
+    .at(-1);
+
+  const commentId = aiComment?.id;
+  if (!commentId) {
+    throw new Error('Failed to create AI response attachment on case');
+  }
+
+  return { commentId };
+};

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -712,6 +712,7 @@ export const ESSENTIAL_ALERT_FIELDS: string[] = [
 
 export enum SecurityAgentBuilderAttachments {
   alert = 'security.alert',
+  case = 'security.case',
   entity = 'security.entity',
   entityAnalyticsDashboard = 'security.entity_analytics_dashboard',
   rule = 'security.rule',

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.ts
@@ -41,6 +41,14 @@ const ALERT_ATTACHMENT_CONFIG: AttachmentTypeConfig = {
   icon: 'bell',
 };
 
+const CASE_ATTACHMENT_CONFIG: AttachmentTypeConfig = {
+  type: SecurityAgentBuilderAttachments.case,
+  label: i18n.translate('xpack.securitySolution.agentBuilder.attachments.case.label', {
+    defaultMessage: 'Security Case',
+  }),
+  icon: 'folderOpen',
+};
+
 const createAttachmentTypeConfig = (defaultLabel: string, icon: string) => ({
   getLabel: (attachment: UnknownAttachmentWithLabel) => {
     const attachmentLabel = attachment?.data?.attachmentLabel;
@@ -62,6 +70,10 @@ export const registerAttachmentUiDefinitions = (attachments: AttachmentServiceSt
   attachments.addAttachmentType<UnknownAttachmentWithLabel>(
     ALERT_ATTACHMENT_CONFIG.type,
     createAttachmentTypeConfig(ALERT_ATTACHMENT_CONFIG.label, ALERT_ATTACHMENT_CONFIG.icon)
+  );
+  attachments.addAttachmentType<UnknownAttachmentWithLabel>(
+    CASE_ATTACHMENT_CONFIG.type,
+    createAttachmentTypeConfig(CASE_ATTACHMENT_CONFIG.label, CASE_ATTACHMENT_CONFIG.icon)
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/indicator/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/indicator/index.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public';
-import { defineAttachment } from '@kbn/cases-plugin/public';
+import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public/types';
+import { defineAttachment } from '@kbn/cases-plugin/common/attachment_framework/define_attachment';
 import { INDICATOR_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
 import type { JsonValue } from '@kbn/utility-types';
 import React from 'react';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/case.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/case.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createCaseAttachmentType } from './case';
+
+describe('createCaseAttachmentType', () => {
+  const attachmentType = createCaseAttachmentType();
+
+  it('registers security.case type', () => {
+    expect(attachmentType.id).toBe('security.case');
+  });
+
+  it('validates case attachment data', () => {
+    const result = attachmentType.validate({
+      case_id: 'case-1',
+      owner: 'securitySolution',
+      title: 'Test case',
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/case.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/case.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import { SecurityAgentBuilderAttachments } from '../../../common/constants';
+import {
+  SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+  SECURITY_ATTACK_DISCOVERY_SEARCH_TOOL_ID,
+  SECURITY_LABS_SEARCH_TOOL_ID,
+  SECURITY_ALERTS_TOOL_ID,
+} from '../tools';
+import { securityAttachmentDataSchema } from './security_attachment_data_schema';
+
+export const caseAttachmentDataSchema = securityAttachmentDataSchema.extend({
+  case_id: z.string(),
+  owner: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+});
+
+export type CaseAttachmentData = z.infer<typeof caseAttachmentDataSchema>;
+
+const isCaseAttachmentData = (data: unknown): data is CaseAttachmentData => {
+  return caseAttachmentDataSchema.safeParse(data).success;
+};
+
+export const createCaseAttachmentType = (): AttachmentTypeDefinition => {
+  return {
+    id: SecurityAgentBuilderAttachments.case,
+    validate: (input) => {
+      const parseResult = caseAttachmentDataSchema.safeParse(input);
+      if (parseResult.success) {
+        return { valid: true, data: parseResult.data };
+      }
+      return { valid: false, error: parseResult.error.message };
+    },
+    format: (attachment: Attachment<string, unknown>) => {
+      const data = attachment.data;
+      if (!isCaseAttachmentData(data)) {
+        throw new Error(`Invalid security case attachment data for attachment ${attachment.id}`);
+      }
+      return {
+        getRepresentation: () => ({
+          type: 'text' as const,
+          value: formatCaseData(data),
+        }),
+      };
+    },
+    getTools: () => [
+      SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+      SECURITY_ATTACK_DISCOVERY_SEARCH_TOOL_ID,
+      SECURITY_LABS_SEARCH_TOOL_ID,
+      SECURITY_ALERTS_TOOL_ID,
+      platformCoreTools.cases,
+      platformCoreTools.generateEsql,
+      platformCoreTools.productDocumentation,
+    ],
+    getAgentDescription: () => {
+      return `You are assisting with a Security case. Use security and cases tools for full context.
+
+SECURITY CASE:
+{caseData}
+
+1. Load the case by case_id via the cases tool.
+2. Review linked alerts and entities.
+3. Provide actionable investigation guidance.`;
+    },
+  };
+};
+
+const formatCaseData = (data: CaseAttachmentData): string => {
+  const lines = [
+    `case_id: ${data.case_id}`,
+    `owner: ${data.owner}`,
+    ...(data.title ? [`title: ${data.title}`] : []),
+    ...(data.description ? [`description: ${data.description}`] : []),
+  ];
+  return lines.join('\n');
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/register_attachments.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/register_attachments.ts
@@ -8,6 +8,7 @@
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-server';
 import { createRuleAttachmentType } from './rule';
 import { createAlertAttachmentType } from './alert';
+import { createCaseAttachmentType } from './case';
 import { createEntityAttachmentType } from './entity';
 import { createEntityAnalyticsDashboardAttachmentType } from './entity_analytics_dashboard';
 import { createSiemReadinessAttachmentType } from './siem_readiness';
@@ -17,6 +18,7 @@ import { createSiemReadinessAttachmentType } from './siem_readiness';
  */
 export const registerAttachments = async (agentBuilder: AgentBuilderPluginSetup) => {
   agentBuilder.attachments.registerType(createAlertAttachmentType());
+  agentBuilder.attachments.registerType(createCaseAttachmentType());
   agentBuilder.attachments.registerType(createEntityAttachmentType());
   agentBuilder.attachments.registerType(createEntityAnalyticsDashboardAttachmentType());
   agentBuilder.attachments.registerType(createRuleAttachmentType());


### PR DESCRIPTION
## Summary

Spike for **Cases + Agent Builder convergence** using **Option B**: an Agent Builder **Project** wraps an existing Case (`type: 'case'`, `case_ref`, projected knowledge) instead of making the Case SO the primary container.

**Latest:** embeddable **Case AI Workspace** on the case detail page — a dedicated **AI Workspace** tab with case-scoped knowledge, conversation list, and inline agent chat (replaces opening the global sidebar as the primary entry).

- **Project** container: server storage, REST APIs, standalone **Projects** UI (table, flyout, link-case modal).
- **Case AI Workspace** (in-case): `CaseAiWorkspace` public API, enable flow, three-panel layout (knowledge · conversations · chat).
- **Case entry points:** **AI Workspace** tab on case view; action bar button navigates to the tab (falls back to `openChat` when workspace is unavailable).
- **Integrations:** case attachments (Security + platform), `conversation.case_id` / `project_id`, scaffolding for persisted AI (`ai_response`, `CaseAiTriggerService`).
- **Docs:** alignment with Agent Builder program doc and [search-team#14200](https://github.com/elastic/search-team/issues/14200).

**Not production-ready.** Treat storage/indexing as throwaway until generic chat projects (#14200) and multi-user chat (#14201 / [#259692](https://github.com/elastic/kibana/pull/259692)) are agreed.

## Motivation

Cases need a durable **investigation workspace** (shared context, multiple conversations, relations to cases/alerts/workflows) without duplicating Case SO responsibilities (connectors, push-to-service, audit UserActions). The program doc’s **“Chat as a project-like container”** with **connected cases** matches this model; see `x-pack/platform/plugins/shared/agent_builder/docs/cases_ab_convergence_spec.md`.

## What changed

### Case AI Workspace (latest commit)

| Area | Details |
|------|---------|
| **Public API** | `CaseAiWorkspace` + `CaseAiWorkspaceProps` on `@kbn/agent-builder-browser` / `AgentBuilderPluginStart` |
| **Layout** | Left rail: **Knowledge** panel (case summary, projected project knowledge) + **Conversations** list; main pane: embedded **CaseConversationPanel** (reuses `EmbeddableConversationsProvider` + `Conversation`) |
| **Enable flow** | Empty state → **Enable AI Workspace** creates/links `ProjectType.case` project via `useCreateProjectFromCase` |
| **Session** | Per-case `sessionTag` (`case-ai-workspace-{caseId}`); new/select conversation within the project |
| **Cases UI** | New `CASE_VIEW_PAGE_TABS.AI_WORKSPACE` tab (between Activity and Attachments when AB is available); `CaseViewAiWorkspace` host component |
| **Add to Chat → AI Workspace** | Button label **AI Workspace**; navigates to the in-case tab when `CaseAiWorkspace` is registered, else legacy `openChat` sidebar |

### Agent Builder (foundation)

| Area | Details |
|------|---------|
| **Types** | `Project`, `CaseRef`, `ProjectType` in `@kbn/agent-builder-common` |
| **Server** | Project SO/client/service, knowledge projection, `POST/GET/PATCH /api/agent_builder/projects` |
| **Conversations** | `case_id` / `project_id` on create/stream paths |
| **UI** | `/projects` page (table, details flyout, link-case modal) |

### Cases & Security Solution

| Area | Details |
|------|---------|
| **Attachments** | Platform + Security `case` chat attachments; `ai_response` schema (Phase 3) |
| **Server** | `CaseAiTriggerService` stub |
| **Security** | Security case attachment type for Agent Builder chat |

### Docs (in-repo)

- `cases_ab_convergence_spec.md` — target state, ownership, RBAC, roadmap alignment
- `cases_ab_chat_org_issue_comment_draft.md` — draft for #14200
- `pr_259692_multi_user_dependency.md` — multi-user dependency notes

## Out of scope (this POC)

- Option A (Case UI as a view on a `type=case` Project only — partial step: in-case workspace tab, not full Case UI replacement)
- `ProjectCollection` / sidebar hierarchy
- Persisted AI on case activity log (schema stub only)
- `@agent` mention triggers, event-driven auto-summary
- Elastic Assistant migration / deprecation

## Test plan

- [ ] Open a Security case with Agent Builder enabled.
- [ ] **AI Workspace** action bar button → lands on **AI Workspace** tab (not global sidebar).
- [ ] **Enable AI Workspace** creates a case-typed project; knowledge panel shows case context.
- [ ] Start a **new conversation** and switch between conversations in the left rail; chat retains case attachment context.
- [ ] **Projects** page: list/link case projects independently.
- [ ] Fallback: without `CaseAiWorkspace`, button still opens `openChat` with `caseId` / `caseOwner`.
- [ ] RBAC: users without case access cannot use another user’s case workspace.
- [ ] Smoke-test platform vs Security case owners.

## Follow-ups

1. Align naming (**Chat** vs **Project** vs **AI Workspace**) with #14200 before hardening APIs/storage.
2. Coordinate with [#259692](https://github.com/elastic/kibana/pull/259692) for shared conversation ACL / group chat inside projects.
3. Post alignment comment to [search-team#14200](https://github.com/elastic/search-team/issues/14200).
4. Product decision on Phase 3: persist AI via `ai_response` UserAction vs chat-only.
5. Improve commit message for workspace UI commit; add test coverage for tab navigation and enable flow.

## Labels / metadata

- **Type:** POC / spike
- **Teams:** `@elastic/workchat-eng`, `@elastic/kibana-cases`, Security Solution
- **Related:** [search-team#14200](https://github.com/elastic/search-team/issues/14200), [search-team#14201](https://github.com/elastic/search-team/issues/14201), [#259692](https://github.com/elastic/kibana/pull/259692)