### PR TITLE
[9.4] [ES|QL] Handles dom exceptions (#270603)

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -96,6 +96,18 @@ describe('helpers', function () {
         },
       ]);
     });
+
+    it('should return a string message when error.message is a non-string (e.g. DOMException from aborted fetch)', function () {
+      const domException = new DOMException('signal is aborted without reason', 'AbortError');
+      const error = new Error('placeholder');
+      (error as unknown as { message: unknown }).message = domException;
+
+      const result = parseErrors([error], 'FROM logs-*');
+
+      expect(result).toHaveLength(1);
+      expect(typeof result[0].message).toBe('string');
+      expect(result[0].code).toBe('unknownError');
+    });
   });
 
   describe('parseWarning', function () {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -125,57 +125,65 @@ export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
         !errorMessage.includes('esql_illegal_argument_exception') &&
         errorMessage.includes('line')
       ) {
-        const text = error.message.split('line')[1];
-        const [lineNumber, startPosition, errorMessage] = text.split(':');
+        const text = errorMessage.split('line')[1];
+        const [lineNumber, startPosition, lineErrorMessage] = text.split(':');
         // initialize the length to 10 in case no error word found
         let errorLength = 10;
-        const [_, wordWithError] = errorMessage.split('[');
+        const [_, wordWithError] = lineErrorMessage.split('[');
         if (wordWithError) {
           errorLength = wordWithError.length - 1;
         }
-        return {
-          message: errorMessage,
-          startColumn: Number(startPosition),
-          startLineNumber: Number(lineNumber),
-          endColumn: Number(startPosition) + errorLength + 1,
-          endLineNumber: Number(lineNumber),
-          severity: monaco.MarkerSeverity.Error,
-          code: 'errorFromES',
-        };
-      } else if (error.message.includes('expression was aborted')) {
-        return {
-          message: i18n.translate('esqlEditor.query.aborted', {
-            defaultMessage: 'Request was aborted',
-          }),
-          startColumn: 1,
-          startLineNumber: 1,
-          endColumn: 10,
-          endLineNumber: 1,
-          severity: monaco.MarkerSeverity.Warning,
-          code: 'abortedRequest',
-        };
+        return [
+          {
+            message: lineErrorMessage,
+            startColumn: Number(startPosition),
+            startLineNumber: Number(lineNumber),
+            endColumn: Number(startPosition) + errorLength + 1,
+            endLineNumber: Number(lineNumber),
+            severity: monaco.MarkerSeverity.Error,
+            code: 'errorFromES',
+          },
+        ];
+      } else if (errorMessage.includes('expression was aborted')) {
+        return [
+          {
+            message: i18n.translate('esqlEditor.query.aborted', {
+              defaultMessage: 'Request was aborted',
+            }),
+            startColumn: 1,
+            startLineNumber: 1,
+            endColumn: 10,
+            endLineNumber: 1,
+            severity: monaco.MarkerSeverity.Warning,
+            code: 'abortedRequest',
+          },
+        ];
       } else {
         // unknown error message
-        return {
-          message: error.message,
+        return [
+          {
+            message: errorMessage,
+            startColumn: 1,
+            startLineNumber: 1,
+            endColumn: 10,
+            endLineNumber: 1,
+            severity: monaco.MarkerSeverity.Error,
+            code: 'unknownError',
+          },
+        ];
+      }
+    } catch (e) {
+      return [
+        {
+          message: errorMessage,
           startColumn: 1,
           startLineNumber: 1,
           endColumn: 10,
           endLineNumber: 1,
           severity: monaco.MarkerSeverity.Error,
           code: 'unknownError',
-        };
-      }
-    } catch (e) {
-      return {
-        message: error.message,
-        startColumn: 1,
-        startLineNumber: 1,
-        endColumn: 10,
-        endLineNumber: 1,
-        severity: monaco.MarkerSeverity.Error,
-        code: 'unknownError',
-      };
+        },
+      ];
     }
   });
 };

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -117,12 +117,13 @@ export const parseWarning = (warning: string): MonacoMessage[] => {
 };
 
 export const parseErrors = (errors: Error[], code: string): MonacoMessage[] => {
-  return errors.map((error) => {
+  return errors.flatMap((error): MonacoMessage[] => {
+    const errorMessage = typeof error.message === 'string' ? error.message : String(error.message);
     try {
       if (
         // Found while testing random commands (as inlinestats)
-        !error.message.includes('esql_illegal_argument_exception') &&
-        error.message.includes('line')
+        !errorMessage.includes('esql_illegal_argument_exception') &&
+        errorMessage.includes('line')
       ) {
         const text = error.message.split('line')[1];
         const [lineNumber, startPosition, errorMessage] = text.split(':');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ES|QL] Handles dom exceptions (#270603)](https://github.com/elastic/kibana/pull/270603)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratou","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2026-05-22T14:21:08Z","message":"[ES|QL] Handles dom exceptions (#270603)\n\n## Summary\n\nThis is a regression caused by\nhttps://github.com/elastic/kibana/pull/242346. It changed the error:\nfrom the original throwError(() => new AbortError()) to throwError(() =>\nnew AbortError((e.target as AbortSignal)?.reason)), intending to\npreserve the abort reason in the error.\n\nThe editor though was not handling this kind of errors correctly causing\nthe following bug:\n\n- I am in Lens ES|QL\n- I cancel the query\n- I see an error at the footer of my editor\n- I click the error\n- 💥 \n\nThis PR handles this kind of errors gracefully\n\n<img width=\"722\" height=\"493\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/374eadfd-93e0-47d8-8e2f-a2e2c1e3caaf\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"55690be1086a3f9316b0a0c150b41eca7de1af6e","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:ES|QL","Team:ESQL","backport:version","v9.5.0","v9.4.2"],"title":"[ES|QL] Handles dom exceptions","number":270603,"url":"https://github.com/elastic/kibana/pull/270603","mergeCommit":{"message":"[ES|QL] Handles dom exceptions (#270603)\n\n## Summary\n\nThis is a regression caused by\nhttps://github.com/elastic/kibana/pull/242346. It changed the error:\nfrom the original throwError(() => new AbortError()) to throwError(() =>\nnew AbortError((e.target as AbortSignal)?.reason)), intending to\npreserve the abort reason in the error.\n\nThe editor though was not handling this kind of errors correctly causing\nthe following bug:\n\n- I am in Lens ES|QL\n- I cancel the query\n- I see an error at the footer of my editor\n- I click the error\n- 💥 \n\nThis PR handles this kind of errors gracefully\n\n<img width=\"722\" height=\"493\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/374eadfd-93e0-47d8-8e2f-a2e2c1e3caaf\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"55690be1086a3f9316b0a0c150b41eca7de1af6e"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270603","number":270603,"mergeCommit":{"message":"[ES|QL] Handles dom exceptions (#270603)\n\n## Summary\n\nThis is a regression caused by\nhttps://github.com/elastic/kibana/pull/242346. It changed the error:\nfrom the original throwError(() => new AbortError()) to throwError(() =>\nnew AbortError((e.target as AbortSignal)?.reason)), intending to\npreserve the abort reason in the error.\n\nThe editor though was not handling this kind of errors correctly causing\nthe following bug:\n\n- I am in Lens ES|QL\n- I cancel the query\n- I see an error at the footer of my editor\n- I click the error\n- 💥 \n\nThis PR handles this kind of errors gracefully\n\n<img width=\"722\" height=\"493\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/374eadfd-93e0-47d8-8e2f-a2e2c1e3caaf\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"55690be1086a3f9316b0a0c150b41eca7de1af6e"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->