### PR TITLE
[One Workflow](fix): avoid reserved generated workflow ids

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/lib/import/index.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/import/index.ts
@@ -38,6 +38,7 @@ export const WORKFLOW_REFERENCE_KEY = 'workflow-id';
 export const isDynamicWorkflowReference = (value: string): boolean => value.includes('{{');
 
 const RESERVED_ID_PREFIXES = ['system', 'internal', 'system--'];
+const WORKFLOW_ID_FALLBACK_PREFIX = 'workflow';
 
 export const isUnsafeWorkflowId = isUnsafeId;
 
@@ -47,8 +48,13 @@ export const isReservedWorkflowId = (id: string): boolean =>
 export const isValidWorkflowId = (id: string): boolean =>
   isValidId(id) && !isReservedWorkflowId(id);
 
-export const generateWorkflowId = (name?: string | null): string =>
-  generateHumanReadableId(name, { fallbackPrefix: 'workflow' });
+const prefixReservedWorkflowId = (id: string): string =>
+  `${WORKFLOW_ID_FALLBACK_PREFIX}-${id}`.slice(0, HUMAN_READABLE_ID_MAX_LENGTH).replace(/-+$/, '');
+
+export const generateWorkflowId = (name?: string | null): string => {
+  const id = generateHumanReadableId(name, { fallbackPrefix: WORKFLOW_ID_FALLBACK_PREFIX });
+  return isReservedWorkflowId(id) ? prefixReservedWorkflowId(id) : id;
+};
 
 // ZIP magic bytes: PK (0x50 0x4B)
 const ZIP_MAGIC_BYTE_0 = 0x50;

--- a/src/platform/plugins/shared/workflows_management/common/lib/import/workflow_import_constants.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/import/workflow_import_constants.test.ts
@@ -7,7 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { detectFileFormat, isDynamicWorkflowReference, isValidWorkflowId } from '.';
+import {
+  detectFileFormat,
+  generateWorkflowId,
+  isDynamicWorkflowReference,
+  isValidWorkflowId,
+} from '.';
 
 describe('isValidWorkflowId', () => {
   it('should reject IDs with reserved prefixes', () => {
@@ -17,6 +22,13 @@ describe('isValidWorkflowId', () => {
 
   it('should accept valid non-reserved IDs', () => {
     expect(isValidWorkflowId('my-workflow')).toBe(true);
+  });
+});
+
+describe('generateWorkflowId', () => {
+  it('should not generate IDs with reserved workflow prefixes', () => {
+    expect(generateWorkflowId('system-foo')).toBe('workflow-system-foo');
+    expect(generateWorkflowId('internal-bar')).toBe('workflow-internal-bar');
   });
 });
 

--- a/src/platform/plugins/shared/workflows_management/server/lib/workflow_id_resolver.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/lib/workflow_id_resolver.test.ts
@@ -31,6 +31,13 @@ describe('generateWorkflowId', () => {
   it('should strip diacritics and produce a valid slug', () => {
     expect(generateWorkflowId('Alerte Sécurité')).toBe('alerte-securite');
   });
+
+  it('should avoid reserved workflow prefixes when deriving an ID from the name', () => {
+    expect(generateWorkflowId('system-example-greeting Copy')).toBe(
+      'workflow-system-example-greeting-copy'
+    );
+    expect(generateWorkflowId('internal-workflow Copy')).toBe('workflow-internal-workflow-copy');
+  });
 });
 
 describe('validateWorkflowId', () => {

--- a/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/services/workflow_crud_service.test.ts
@@ -340,6 +340,26 @@ describe('WorkflowCrudService', () => {
       );
     });
 
+    it('does not generate a reserved workflow ID from the YAML name', async () => {
+      const { deps, client } = makeDeps();
+      client.search.mockResolvedValue({ hits: { hits: [] } });
+      const reservedNameYaml = validYaml.replace('name: My Workflow', 'name: system-workflow Copy');
+
+      const service = new WorkflowCrudService(deps);
+      const result = await service.createWorkflow({ yaml: reservedNameYaml }, 'default', request);
+
+      expect(result.id).toBe('workflow-system-workflow-copy');
+      expect(client.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'workflow-system-workflow-copy',
+          op_type: 'create',
+          document: expect.objectContaining({
+            name: 'system-workflow Copy',
+          }),
+        })
+      );
+    });
+
     it('throws WorkflowConflictError when a user-supplied id matches an existing workflow (including tombstones)', async () => {
       const { deps, client } = makeDeps();
       // checkExistingIds uses an ids query (no bool/must_not) and is index-wide


### PR DESCRIPTION
## Summary

Fixes a workflow ID reservation bypass where create and clone flows could generate an ID with a reserved prefix when no explicit ID was provided.

## Context / STR

1. Create or clone a workflow whose YAML name starts with a reserved prefix, for example `system-example-greeting`.
2. Do not provide an explicit workflow ID.
3. The create path derives the ID from the workflow name, allowing a generated ID such as `system-example-greeting` or `system-example-greeting-copy`.

```yaml
name: system-example-greeting
enabled: false
triggers:
  - type: manual
steps:
  - name: log-message
    type: console
    with:
      message: hello
```

## Proposed Fix

Prefix generated workflow IDs that would otherwise start with a reserved prefix using the normal `workflow-` fallback prefix, and add regression coverage for generated IDs in create/clone-relevant paths.

## Before
(Name "system-New workflow" -> ID "system-new-workflow", reserved "system" prefix)
<img width="1299" height="325" alt="image" src="https://github.com/user-attachments/assets/8989e699-b68e-4613-b4e3-dea19ae95ef2" />

## After
(Name "system-New workflow" -> ID "workflow-system-new-workflow", "workflow-" is added as prefix)
<img width="1299" height="325" alt="Screenshot 2026-05-26 at 10 42 38" src="https://github.com/user-attachments/assets/15f42182-29a9-4caa-8138-7306d4447fc6" />

## References

Closes elastic/security-team#17557