### PR TITLE
[9.3] Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-management files (#269652)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/components/console_menu.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/console_menu.tsx
@@ -172,6 +172,9 @@ export class ConsoleMenu extends Component<Props, State> {
           closePopover={this.closePopover}
           panelPaddingSize="none"
           anchorPosition="downLeft"
+          aria-label={i18n.translate('console.consoleMenu.popoverAriaLabel', {
+            defaultMessage: 'Request options',
+          })}
         >
           <EuiContextMenuPanel items={items} data-test-subj="consoleMenu" />
         </EuiPopover>

--- a/src/platform/plugins/shared/console/public/application/components/help_popover.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/help_popover.tsx
@@ -9,7 +9,15 @@
 
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiPopover, EuiTitle, EuiText, EuiPanel, EuiSpacer, EuiListGroup } from '@elastic/eui';
+import {
+  EuiPopover,
+  EuiTitle,
+  EuiText,
+  EuiPanel,
+  EuiSpacer,
+  EuiListGroup,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useServicesContext } from '../contexts';
 
@@ -41,6 +49,7 @@ const styles = {
 };
 
 export const HelpPopover = ({ button, isOpen, closePopover, resetTour }: HelpPopoverProps) => {
+  const popoverTitleId = useGeneratedHtmlId();
   const { docLinks } = useServicesContext();
 
   const listItems = useMemo(
@@ -109,10 +118,11 @@ export const HelpPopover = ({ button, isOpen, closePopover, resetTour }: HelpPop
       ownFocus={false}
       panelPaddingSize="none"
       data-test-subj="consoleHelpPopover"
+      aria-labelledby={popoverTitleId}
     >
       <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false}>
         <EuiTitle size="xs">
-          <h4>
+          <h4 id={popoverTitleId}>
             {i18n.translate('console.helpPopover.title', {
               defaultMessage: 'Elastic Console',
             })}

--- a/src/platform/plugins/shared/console/public/application/components/shortcuts_popover/shortcuts_popover.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/shortcuts_popover/shortcuts_popover.tsx
@@ -27,6 +27,9 @@ export const ShortcutsPopover = ({ button, isOpen, closePopover }: ShortcutsPopo
       closePopover={closePopover}
       anchorPosition="downRight"
       data-test-subj="consoleShortcutsPopover"
+      aria-label={i18n.translate('console.shortcutsPopover.ariaLabel', {
+        defaultMessage: 'Keyboard shortcuts',
+      })}
     >
       <EuiTitle size="xxs">
         <h5>

--- a/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.tsx
@@ -343,6 +343,9 @@ export const ContextMenu = ({
         closePopover={closePopover}
         panelPaddingSize="none"
         anchorPosition="downLeft"
+        aria-label={i18n.translate('console.contextMenu.popoverAriaLabel', {
+          defaultMessage: 'Request options',
+        })}
       >
         <EuiContextMenuPanel items={items} data-test-subj="consoleMenu" />
       </EuiPopover>

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/retention_period_field/retention_period_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/retention_period_field/retention_period_field.tsx
@@ -8,6 +8,7 @@
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { EuiButton, EuiPopover, EuiSelectable } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 
@@ -41,6 +42,10 @@ export const RetentionPeriodField: FunctionComponent<{ disabled: boolean }> = ({
 
                 return (
                   <EuiPopover
+                    aria-label={i18n.translate(
+                      'xpack.failureStoreModal.retentionPeriodField.popoverAriaLabel',
+                      { defaultMessage: 'Select time unit' }
+                    )}
                     isOpen={open}
                     panelPaddingSize="none"
                     closePopover={() => setOpen(false)}

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/components/auto_follow_pattern_action_menu/auto_follow_pattern_action_menu.tsx
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/components/auto_follow_pattern_action_menu/auto_follow_pattern_action_menu.tsx
@@ -141,6 +141,10 @@ const AutoFollowPatternActionMenuUI: FunctionComponent<Props> = ({
 
   return (
     <EuiPopover
+      aria-label={i18n.translate(
+        'xpack.crossClusterReplication.autoFollowPatternActionMenu.popoverAriaLabel',
+        { defaultMessage: 'Auto-follow pattern options' }
+      )}
       isOpen={showPopover}
       closePopover={() => setShowPopover(false)}
       button={button}

--- a/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/context_menu/context_menu.js
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/public/app/sections/home/follower_indices_list/components/context_menu/context_menu.js
@@ -14,6 +14,7 @@ import {
   EuiContextMenuItem,
   EuiPopover,
   EuiPopoverTitle,
+  htmlIdGenerator,
 } from '@elastic/eui';
 
 import { routing } from '../../../../../services/routing';
@@ -36,6 +37,8 @@ export class ContextMenu extends PureComponent {
   state = {
     isPopoverOpen: false,
   };
+
+  popoverTitleId = htmlIdGenerator()();
 
   onButtonClick = () => {
     this.setState((prevState) => ({
@@ -91,6 +94,7 @@ export class ContextMenu extends PureComponent {
 
     return (
       <EuiPopover
+        aria-labelledby={this.popoverTitleId}
         button={button}
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover}
@@ -98,7 +102,7 @@ export class ContextMenu extends PureComponent {
         anchorPosition={anchorPosition}
         repositionOnScroll
       >
-        <EuiPopoverTitle paddingSize="s">
+        <EuiPopoverTitle paddingSize="s" id={this.popoverTitleId}>
           <FormattedMessage
             id="xpack.crossClusterReplication.followerIndex.contextMenu.title"
             defaultMessage="Follower {followerIndicesLength, plural, one {index} other {indices}} options"

--- a/x-pack/platform/plugins/private/data_usage/public/app/components/filters/charts_filter_popover.tsx
+++ b/x-pack/platform/plugins/private/data_usage/public/app/components/filters/charts_filter_popover.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useMemo } from 'react';
 import { EuiFilterButton, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useTestIdGenerator } from '../../../hooks/use_test_id_generator';
 import { type FilterName } from '../../hooks/use_charts_filter';
 import { FILTER_NAMES } from '../../../translations';
@@ -66,6 +67,10 @@ export const ChartsFilterPopover = memo(
 
     return (
       <EuiPopover
+        aria-label={i18n.translate('xpack.dataUsage.chartsFilterPopover.ariaLabel', {
+          defaultMessage: 'Filter by {filterName}',
+          values: { filterName: FILTER_NAMES[filterName] },
+        })}
         button={button}
         closePopover={closePopover}
         id={filterGroupPopoverId}

--- a/x-pack/platform/plugins/private/data_usage/public/app/components/legend_action.tsx
+++ b/x-pack/platform/plugins/private/data_usage/public/app/components/legend_action.tsx
@@ -6,6 +6,7 @@
  */
 import React, { useCallback } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiButtonIcon, EuiPopover, EuiListGroup } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { IndexManagementLocatorParams } from '@kbn/index-management-shared-types';
 import { DatasetQualityLink } from './dataset_quality_link';
 import { useKibanaContextForPlugin } from '../../utils/use_kibana';
@@ -52,6 +53,9 @@ export const LegendAction: React.FC<LegendActionProps> = React.memo(
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiPopover
+          aria-label={i18n.translate('xpack.dataUsage.legendAction.popoverAriaLabel', {
+            defaultMessage: 'Data stream actions',
+          })}
           data-test-subj="legendActionPopover"
           button={
             <EuiFlexGroup gutterSize="s" alignItems="center">

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/policy_list/policy_flyout/view_policy_flyout.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/policy_list/policy_flyout/view_policy_flyout.tsx
@@ -175,6 +175,10 @@ export const ViewPolicyFlyout = ({ policy }: { policy: PolicyFromES }) => {
             <EuiFlexGroup gutterSize="none" alignItems="center" justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
                 <EuiPopover
+                  aria-label={i18n.translate(
+                    'xpack.indexLifecycleMgmt.policyFlyout.managePolicyPopoverAriaLabel',
+                    { defaultMessage: 'Manage policy options' }
+                  )}
                   isOpen={showPopover}
                   closePopover={() => setShowPopover(false)}
                   button={managePolicyButton}

--- a/x-pack/platform/plugins/private/painless_lab/public/application/components/main_controls.tsx
+++ b/x-pack/platform/plugins/private/painless_lab/public/application/components/main_controls.tsx
@@ -87,6 +87,9 @@ export function MainControls({ toggleRequestFlyout, isRequestFlyoutOpen, reset, 
           <EuiFlexGroup gutterSize="s" justifyContent="flexStart">
             <EuiFlexItem grow={false}>
               <EuiPopover
+                aria-label={i18n.translate('xpack.painlessLab.helpPopoverAriaLabel', {
+                  defaultMessage: 'Help menu',
+                })}
                 id="painlessLabHelpContextMenu"
                 button={
                   <EuiButtonEmpty

--- a/x-pack/platform/plugins/private/rollup/public/crud_app/sections/components/job_action_menu/job_action_menu.js
+++ b/x-pack/platform/plugins/private/rollup/public/crud_app/sections/components/job_action_menu/job_action_menu.js
@@ -261,6 +261,7 @@ export class JobActionMenuUi extends Component {
       <div>
         {this.confirmDeleteModal()}
         <EuiPopover
+          aria-label={actionsAriaLabel}
           button={button}
           isOpen={this.state.isPopoverOpen}
           closePopover={this.closePopover}

--- a/x-pack/platform/plugins/private/rollup/public/crud_app/sections/job_create/steps/step_metrics.js
+++ b/x-pack/platform/plugins/private/rollup/public/crud_app/sections/job_create/steps/step_metrics.js
@@ -193,6 +193,12 @@ export class StepMetrics extends Component {
     return (
       <Fragment>
         <EuiPopover
+          aria-label={i18n.translate(
+            'xpack.rollupJobs.create.stepMetrics.selectMetricsPopoverAriaLabel',
+            {
+              defaultMessage: 'Select metrics',
+            }
+          )}
           ownFocus
           isOpen={this.state.metricsPopoverOpen}
           closePopover={this.closeMetricsPopover}

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/policy_list/policy_details/policy_details.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/policy_list/policy_details/policy_details.tsx
@@ -201,6 +201,10 @@ export const PolicyDetails: React.FunctionComponent<Props> = ({
                       return (
                         <EuiPopover
                           id="policyActionMenu"
+                          aria-label={i18n.translate(
+                            'xpack.snapshotRestore.policyDetails.policyActionMenuAriaLabel',
+                            { defaultMessage: 'Policy options' }
+                          )}
                           button={
                             <EuiButton
                               data-test-subj="policyActionMenuButton"

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/policy_list/policy_retention_schedule/policy_retention_schedule.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/policy_list/policy_retention_schedule/policy_retention_schedule.tsx
@@ -161,6 +161,10 @@ export const PolicyRetentionSchedule: React.FunctionComponent<Props> = ({
                   return (
                     <EuiPopover
                       id="retentionActionMenu"
+                      aria-label={i18n.translate(
+                        'xpack.snapshotRestore.policyRetentionSchedulePanel.retentionActionMenuAriaLabel',
+                        { defaultMessage: 'Retention options' }
+                      )}
                       button={
                         <EuiButton
                           data-test-subj="retentionActionMenuButton"

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/restore_list/restore_list.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/restore_list/restore_list.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useEffect, useState, Fragment } from 'react';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
   EuiPopover,
@@ -145,6 +146,10 @@ export const RestoreList: React.FunctionComponent = () => {
             <EuiFlexItem grow={false}>
               <EuiPopover
                 id="srRestoreListIntervalMenu"
+                aria-label={i18n.translate(
+                  'xpack.snapshotRestore.restoreList.intervalMenuAriaLabel',
+                  { defaultMessage: 'Refresh interval options' }
+                )}
                 button={
                   <EuiButtonEmpty
                     size="xs"

--- a/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/aggregation_list/agg_label_form.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/aggregation_list/agg_label_form.tsx
@@ -87,6 +87,9 @@ export const AggLabelForm: React.FC<Props> = ({
           <EuiPopover
             id="transformFormPopover"
             ownFocus
+            aria-label={i18n.translate('xpack.transform.aggLabelForm.editAggPopoverAriaLabel', {
+              defaultMessage: 'Edit aggregation',
+            })}
             button={
               <EuiButtonIcon
                 aria-label={i18n.translate('xpack.transform.aggLabelForm.editAggAriaLabel', {

--- a/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/group_by_list/group_by_label_form.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/group_by_list/group_by_label_form.tsx
@@ -73,6 +73,10 @@ export const GroupByLabelForm: React.FC<Props> = ({
         <EuiPopover
           id="transformIntervalFormPopover"
           ownFocus
+          aria-label={i18n.translate(
+            'xpack.transform.groupByLabelForm.editIntervalPopoverAriaLabel',
+            { defaultMessage: 'Edit interval' }
+          )}
           button={
             <EuiButtonIcon
               aria-label={i18n.translate('xpack.transform.groupByLabelForm.editIntervalAriaLabel', {

--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/transform_list/transform_list.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/components/transform_list/transform_list.tsx
@@ -298,6 +298,10 @@ export const TransformList: FC<TransformListProps> = ({
       <EuiPopover
         key="bulkActionIcon"
         id="transformBulkActionsMenu"
+        aria-label={i18n.translate(
+          'xpack.transform.multiTransformActionsMenu.bulkActionsPopoverAriaLabel',
+          { defaultMessage: 'Bulk actions' }
+        )}
         button={buttonIcon}
         isOpen={isActionsMenuOpen}
         closePopover={() => setIsActionsMenuOpen(false)}

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/deprecation_logging_toggle/deprecation_logging_toggle.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/deprecation_logging_toggle/deprecation_logging_toggle.tsx
@@ -73,7 +73,15 @@ const ErrorDetailsLink = ({ error }: { error: ResponseError }) => {
   );
 
   return (
-    <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      aria-label={i18n.translate(
+        'xpack.upgradeAssistant.overview.deprecationLogs.errorDetailsPopoverAriaLabel',
+        { defaultMessage: 'Error details' }
+      )}
+    >
       <EuiText style={{ width: 300 }}>
         <p>{error.message as string}</p>
       </EuiText>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/modal_container.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/modal_container.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { EuiModal } from '@elastic/eui';
 import { METRIC_TYPE } from '@kbn/analytics';
+import { i18n } from '@kbn/i18n';
 
 import moment from 'moment';
 import type { EnrichedDeprecationInfo } from '../../../../../../../common/types';
@@ -153,6 +154,10 @@ export const DataStreamReadonlyModal: React.FunctionComponent<Props> = ({
       data-test-subj="updateIndexModal"
       maxWidth={true}
       css={{ minWidth: 750 }}
+      aria-label={i18n.translate(
+        'xpack.upgradeAssistant.esDeprecations.dataStreams.flyout.modalAriaLabel',
+        { defaultMessage: 'Data stream migration' }
+      )}
     >
       {modalContent}
     </EuiModal>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/modal_container.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/modal_container.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { METRIC_TYPE } from '@kbn/analytics';
+import { i18n } from '@kbn/i18n';
 
 import { EuiModal } from '@elastic/eui';
 import type { IndicesResolutionType } from '../../../../../../../common/types';
@@ -166,6 +167,10 @@ export const IndexModal: React.FunctionComponent<IndexModalProps> = ({
       data-test-subj="updateIndexModal"
       maxWidth={true}
       css={{ minWidth: 750 }}
+      aria-label={i18n.translate(
+        'xpack.upgradeAssistant.esDeprecations.indices.flyout.modalAriaLabel',
+        { defaultMessage: 'Index migration' }
+      )}
     >
       {modalContent}
     </EuiModal>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/warning/warning_step_checkbox.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/warning/warning_step_checkbox.tsx
@@ -80,6 +80,10 @@ const InfoPopover: React.FunctionComponent<{
 
   return (
     <EuiPopover
+      aria-label={i18n.translate(
+        'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.warningsStep.infoPopoverAriaLabel',
+        { defaultMessage: 'More information' }
+      )}
       button={
         <EuiButtonIcon
           display="empty"

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_action_dropdown.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_action_dropdown.tsx
@@ -97,6 +97,12 @@ export const WatchActionsDropdown: React.FunctionComponent<Props> = ({ settings,
       closePopover={() => setIsPopOverOpen(false)}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={i18n.translate(
+        'xpack.watcher.sections.watchEdit.actions.addActionPopoverAriaLabel',
+        {
+          defaultMessage: 'Add action',
+        }
+      )}
     >
       <EuiContextMenuPanel
         items={actions.map((action, index) => {

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_edit.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_edit.tsx
@@ -26,6 +26,7 @@ import {
   EuiTitle,
   EuiPageHeader,
   EuiPageSection,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -188,6 +189,12 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [isIndiciesLoading, setIsIndiciesLoading] = useState<boolean>(false);
   const [isRequestVisible, setIsRequestVisible] = useState<boolean>(false);
+
+  const aggTypePopoverTitleId = useGeneratedHtmlId({ prefix: 'aggTypePopoverTitle' });
+  const aggFieldPopoverTitleId = useGeneratedHtmlId({ prefix: 'aggFieldPopoverTitle' });
+  const groupByPopoverTitleId = useGeneratedHtmlId({ prefix: 'groupByPopoverTitle' });
+  const watchThresholdPopoverTitleId = useGeneratedHtmlId({ prefix: 'watchThresholdPopoverTitle' });
+  const watchDurationPopoverTitleId = useGeneratedHtmlId({ prefix: 'watchDurationPopoverTitle' });
 
   const { watch, setWatchProperty } = useContext(WatchContext);
 
@@ -491,9 +498,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                   }}
                   ownFocus
                   anchorPosition="downLeft"
+                  aria-labelledby={aggTypePopoverTitleId}
                 >
                   <div>
-                    <EuiPopoverTitle>
+                    <EuiPopoverTitle id={aggTypePopoverTitleId}>
                       {i18n.translate(
                         'xpack.watcher.sections.watchEdit.threshold.whenButtonLabel',
                         {
@@ -548,9 +556,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                       setAggFieldPopoverOpen(false);
                     }}
                     anchorPosition="downLeft"
+                    aria-labelledby={aggFieldPopoverTitleId}
                   >
                     <div>
-                      <EuiPopoverTitle>
+                      <EuiPopoverTitle id={aggFieldPopoverTitleId}>
                         {i18n.translate(
                           'xpack.watcher.sections.watchEdit.threshold.ofButtonLabel',
                           {
@@ -645,9 +654,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                   }}
                   ownFocus
                   anchorPosition="downLeft"
+                  aria-labelledby={groupByPopoverTitleId}
                 >
                   <div>
-                    <EuiPopoverTitle>
+                    <EuiPopoverTitle id={groupByPopoverTitleId}>
                       {i18n.translate(
                         'xpack.watcher.sections.watchEdit.threshold.overButtonLabel',
                         {
@@ -763,9 +773,12 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                   }}
                   ownFocus
                   anchorPosition="downLeft"
+                  aria-labelledby={watchThresholdPopoverTitleId}
                 >
                   <div>
-                    <EuiPopoverTitle>{comparators[watch.thresholdComparator].text}</EuiPopoverTitle>
+                    <EuiPopoverTitle id={watchThresholdPopoverTitleId}>
+                      {comparators[watch.thresholdComparator].text}
+                    </EuiPopoverTitle>
                     <EuiFlexGroup>
                       <EuiFlexItem grow={false}>
                         <EuiSelect
@@ -854,9 +867,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                   }}
                   ownFocus
                   anchorPosition="downLeft"
+                  aria-labelledby={watchDurationPopoverTitleId}
                 >
                   <div>
-                    <EuiPopoverTitle>
+                    <EuiPopoverTitle id={watchDurationPopoverTitleId}>
                       <FormattedMessage
                         id="xpack.watcher.sections.watchEdit.threshold.forTheLastButtonLabel"
                         defaultMessage="For the last"

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_list_page/watch_list_page.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_list_page/watch_list_page.tsx
@@ -210,6 +210,9 @@ export const WatchListPage = () => {
       closePopover={() => setIsPopOverOpen(false)}
       panelPaddingSize="none"
       anchorPosition="downCenter"
+      aria-label={i18n.translate('xpack.watcher.sections.watchList.createWatchPopoverAriaLabel', {
+        defaultMessage: 'Create watch',
+      })}
     >
       <EuiContextMenuPanel
         items={[WATCH_TYPES.THRESHOLD, WATCH_TYPES.JSON].map((watchType: string) => {

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/disconnect_cluster_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/disconnect_cluster_modal/index.tsx
@@ -22,6 +22,7 @@ import {
   EuiLink,
   EuiIcon,
   copyToClipboard,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -43,6 +44,7 @@ export const DisconnectClusterModal: React.FC<DisconnectClusterModalProps> = ({
   const { telemetryService } = useCloudConnectedAppContext();
   const [confirmationText, setConfirmationText] = useState('');
   const isConfirmationValid = confirmationText === clusterName;
+  const modalTitleId = useGeneratedHtmlId({ prefix: 'disconnectClusterModalTitle' });
 
   const handleConfirm = async () => {
     if (isConfirmationValid) {
@@ -52,9 +54,9 @@ export const DisconnectClusterModal: React.FC<DisconnectClusterModalProps> = ({
   };
 
   return (
-    <EuiModal onClose={onClose} maxWidth={650}>
+    <EuiModal onClose={onClose} maxWidth={650} aria-labelledby={modalTitleId}>
       <EuiModalHeader>
-        <EuiModalHeaderTitle data-test-subj="disconnectClusterModalTitle">
+        <EuiModalHeaderTitle id={modalTitleId} data-test-subj="disconnectClusterModalTitle">
           <FormattedMessage
             id="xpack.cloudConnect.connectedServices.disconnect.modalTitle"
             defaultMessage="Disconnect cluster"

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/index.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/index.tsx
@@ -227,6 +227,12 @@ export const ConnectedServicesPage: React.FC<ConnectedServicesPageProps> = ({
                   closePopover={closeActionsPopover}
                   panelPaddingSize="none"
                   anchorPosition="downRight"
+                  aria-label={i18n.translate(
+                    'xpack.cloudConnect.connectedServices.actionsPopoverAriaLabel',
+                    {
+                      defaultMessage: 'Actions',
+                    }
+                  )}
                 >
                   <EuiContextMenuPanel items={actionsMenuItems} />
                 </EuiPopover>,

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/services_section/details_card.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/services_section/details_card.tsx
@@ -222,6 +222,12 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
               closePopover={closeLicensePopover}
               panelPaddingSize="s"
               anchorPosition="upCenter"
+              aria-label={i18n.translate(
+                'xpack.cloudConnect.connectedServices.service.licensePopoverAriaLabel',
+                {
+                  defaultMessage: 'License information',
+                }
+              )}
             >
               <div style={{ maxWidth: '300px' }}>
                 <EuiText size="s">
@@ -416,6 +422,12 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
               panelPaddingSize="none"
               anchorPosition="downRight"
               data-test-subj="serviceCardMoreActionsPopover"
+              aria-label={i18n.translate(
+                'xpack.cloudConnect.connectedServices.service.moreActionsPopoverAriaLabel',
+                {
+                  defaultMessage: 'More actions',
+                }
+              )}
             >
               <EuiContextMenuPanel items={menuItems} />
             </EuiPopover>

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/services_section/disable_service_modal.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/services_section/disable_service_modal.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiConfirmModal } from '@elastic/eui';
+import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 interface DisableServiceModalProps {
@@ -22,8 +22,11 @@ export const DisableServiceModal: React.FC<DisableServiceModalProps> = ({
   onConfirm,
   isLoading,
 }) => {
+  const confirmModalTitleId = useGeneratedHtmlId({ prefix: 'disableServiceModalTitle' });
+
   return (
     <EuiConfirmModal
+      aria-labelledby={confirmModalTitleId}
       title={
         <FormattedMessage
           id="xpack.cloudConnect.services.disable.modalTitle"
@@ -50,6 +53,7 @@ export const DisableServiceModal: React.FC<DisableServiceModalProps> = ({
       confirmButtonDisabled={isLoading}
       isLoading={isLoading}
       data-test-subj="disableServiceModal"
+      titleProps={{ id: confirmModalTitleId }}
     >
       <p data-test-subj="disableServiceModalDescription">
         <FormattedMessage

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/common/insufficient_privileges.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/common/insufficient_privileges.tsx
@@ -76,6 +76,7 @@ export const PrivilegesWarningIconWrapper = ({
       }
       isOpen={isPopoverOpen}
       closePopover={togglePopover}
+      aria-label={insufficientPrivilegesText}
     >
       {insufficientPrivilegesText} {/* <LearnMoreLink /> TODO: Add docs link when available */}
     </EuiPopover>

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/filters/integrations_selector.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/filters/integrations_selector.tsx
@@ -13,6 +13,7 @@ import {
   EuiPopoverTitle,
   EuiSelectable,
   EuiText,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import type { EuiSelectableOptionCheckedType } from '@elastic/eui/src/components/selectable/selectable_option';
@@ -69,6 +70,7 @@ export function IntegrationsSelector({
   onIntegrationsChange,
 }: IntegrationsSelectorProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId({ prefix: 'integrationsSelectorPopoverTitle' });
 
   const onButtonClick = () => {
     setIsPopoverOpen(!isPopoverOpen);
@@ -108,6 +110,7 @@ export function IntegrationsSelector({
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       panelPaddingSize="none"
+      aria-labelledby={popoverTitleId}
     >
       <EuiSelectable
         data-test-subj="datasetQualityIntegrationsSelectable"
@@ -127,7 +130,9 @@ export function IntegrationsSelector({
       >
         {(list, search) => (
           <div style={{ width: 300 }}>
-            <EuiPopoverTitle paddingSize="s">{search}</EuiPopoverTitle>
+            <EuiPopoverTitle paddingSize="s" id={popoverTitleId}>
+              {search}
+            </EuiPopoverTitle>
             {list}
           </div>
         )}

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/filters/namespaces_selector.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/filters/namespaces_selector.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import { EuiFilterButton, EuiPopover, EuiPopoverTitle, EuiSelectable, EuiText } from '@elastic/eui';
+import {
+  EuiFilterButton,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSelectable,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import React, { useState } from 'react';
 import type { EuiSelectableOptionCheckedType } from '@elastic/eui/src/components/selectable/selectable_option';
 import { i18n } from '@kbn/i18n';
@@ -56,6 +63,7 @@ export function NamespacesSelector({
   onNamespacesChange,
 }: NamespacesSelectorProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId({ prefix: 'namespacesSelectorPopoverTitle' });
 
   const onButtonClick = () => {
     setIsPopoverOpen(!isPopoverOpen);
@@ -88,6 +96,7 @@ export function NamespacesSelector({
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       panelPaddingSize="none"
+      aria-labelledby={popoverTitleId}
     >
       <EuiSelectable
         data-test-subj="datasetQualityNamespacesSelectable"
@@ -107,7 +116,9 @@ export function NamespacesSelector({
       >
         {(list, search) => (
           <div style={{ width: 300 }}>
-            <EuiPopoverTitle paddingSize="s">{search}</EuiPopoverTitle>
+            <EuiPopoverTitle paddingSize="s" id={popoverTitleId}>
+              {search}
+            </EuiPopoverTitle>
             {list}
           </div>
         )}

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/filters/qualities_selector.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/filters/qualities_selector.tsx
@@ -88,6 +88,7 @@ export function QualitiesSelector({
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       panelPaddingSize="none"
+      aria-label={qualitiesSelectorLabel}
     >
       <EuiSelectable
         data-test-subj="datasetQualityQualitiesSelectable"

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/filters/selector.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/filters/selector.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import { EuiFilterButton, EuiPopover, EuiPopoverTitle, EuiSelectable, EuiText } from '@elastic/eui';
+import {
+  EuiFilterButton,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSelectable,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import React, { useState } from 'react';
 import type { EuiSelectableOptionCheckedType } from '@elastic/eui/src/components/selectable/selectable_option';
 import { i18n } from '@kbn/i18n';
@@ -43,6 +50,7 @@ export function Selector({
   onOptionsChange,
 }: SelectorProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId({ prefix: 'selectorPopoverTitle' });
 
   const onButtonClick = () => {
     setIsPopoverOpen(!isPopoverOpen);
@@ -79,6 +87,7 @@ export function Selector({
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       panelPaddingSize="none"
+      aria-labelledby={popoverTitleId}
     >
       <EuiSelectable
         data-test-subj={`${dataTestSubj}Options`}
@@ -98,7 +107,9 @@ export function Selector({
       >
         {(list, search) => (
           <div style={{ width: 300 }}>
-            <EuiPopoverTitle paddingSize="s">{search}</EuiPopoverTitle>
+            <EuiPopoverTitle paddingSize="s" id={popoverTitleId}>
+              {search}
+            </EuiPopoverTitle>
             {list}
           </div>
         )}

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/details/integration_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/details/integration_actions_menu.tsx
@@ -201,6 +201,7 @@ export function IntegrationActionsMenu({
       button={actionButton}
       isOpen={isOpen}
       closePopover={handleCloseMenu}
+      aria-label={integrationActionsText}
     >
       <EuiContextMenu size="s" panels={panelItems} initialPanelId={0} />
     </EuiPopover>

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_details/manage_button.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_details/manage_button.tsx
@@ -60,6 +60,9 @@ export const ManageButton: React.FunctionComponent<Props> = ({
   return (
     <EuiPopover
       id="manageComponentTemplatePanel"
+      aria-label={i18n.translate('xpack.idxMgmt.componentTemplateDetails.managePopoverAriaLabel', {
+        defaultMessage: 'Manage component template',
+      })}
       button={
         <EuiButton
           fill

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_list/table.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_list/table.tsx
@@ -222,6 +222,10 @@ export const ComponentTable: FunctionComponent<Props> = ({
                   isOpen={isPopoverOpen}
                   closePopover={closePopover}
                   panelPaddingSize="none"
+                  aria-label={i18n.translate(
+                    'xpack.idxMgmt.componentTemplatesList.table.filtersPopoverAriaLabel',
+                    { defaultMessage: 'Component templates filters' }
+                  )}
                 >
                   <EuiSelectable
                     allowExclusions

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_selector/components/create_button_popover.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_selector/components/create_button_popover.tsx
@@ -21,6 +21,9 @@ export const CreateButtonPopOver = ({ anchorPosition = 'upCenter' }: Props) => {
   return (
     <EuiPopover
       id="createComponentTemplatePanel"
+      aria-label={i18n.translate('xpack.idxMgmt.componentTemplatesFlyout.createPopoverAriaLabel', {
+        defaultMessage: 'Create component template',
+      })}
       button={
         <EuiButton
           fill

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -173,6 +173,10 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
       <EuiFlexGroup data-test-subj="selectInferenceId" alignItems="flexEnd">
         <EuiFlexItem grow={false}>
           <EuiPopover
+            aria-label={i18n.translate(
+              'xpack.idxMgmt.mappingsEditor.parameters.inferenceId.popover.ariaLabel',
+              { defaultMessage: 'Select inference endpoint' }
+            )}
             button={
               <>
                 <EuiText size="xs">

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/enrich_policy_create/steps/configuration.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/enrich_policy_create/steps/configuration.tsx
@@ -191,6 +191,10 @@ export const ConfigurationStep = ({ onNext }: Props) => {
         component={SelectField}
         labelAppend={
           <EuiPopover
+            aria-label={i18n.translate(
+              'xpack.idxMgmt.enrichPolicyCreate.configurationStep.typePopoverAriaLabel',
+              { defaultMessage: 'Policy type information' }
+            )}
             button={
               <EuiLink
                 data-test-subj="typePopoverIcon"

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/components/filter_list_button.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/components/filter_list_button.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFilterButton, EuiFilterGroup, EuiPopover, EuiSelectable } from '@elastic/eui';
 
@@ -82,6 +83,9 @@ export function FilterListButton<T extends string>({ onChange, filters }: Props<
         closePopover={closePopover}
         panelPaddingSize="none"
         data-test-subj="filterList"
+        aria-label={i18n.translate('xpack.idxMgmt.indexTemplatesList.filterPopoverAriaLabel', {
+          defaultMessage: 'View filters',
+        })}
       >
         <EuiSelectable
           allowExclusions

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_actions_menu/data_stream_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_actions_menu/data_stream_actions_menu.tsx
@@ -38,6 +38,10 @@ export const DataStreamActionsMenu = ({ dataStreamActions, selectedDataStreamsCo
   return (
     <EuiPopover
       id="dataStreamActionsPopover"
+      aria-label={i18n.translate(
+        'xpack.idxMgmt.dataStreamList.table.dataStreamActionsPopoverAriaLabel',
+        { defaultMessage: 'Data stream actions' }
+      )}
       button={popoverButton}
       isOpen={isPopoverOpen}
       closePopover={() => setIsPopoverOpen(false)}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/data_stream_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/data_stream_detail_panel.tsx
@@ -718,6 +718,10 @@ export const DataStreamDetailPanel: React.FunctionComponent<Props> = ({
                   closePopover={closePopover}
                   panelPaddingSize="none"
                   anchorPosition="downLeft"
+                  aria-label={i18n.translate(
+                    'xpack.idxMgmt.dataStreamDetailPanel.managePopoverAriaLabel',
+                    { defaultMessage: 'Manage data stream' }
+                  )}
                 >
                   <EuiContextMenu initialPanelId={0} panels={panels} />
                 </EuiPopover>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_filter_fields.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_filter_fields.tsx
@@ -14,6 +14,7 @@ import {
   EuiPopoverFooter,
   EuiPopoverTitle,
   EuiSelectable,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -40,6 +41,7 @@ export const MappingsFilter: React.FC<Props> = ({
   state,
 }) => {
   const [isFilterByPopoverVisible, setIsFilterPopoverVisible] = useState<boolean>(false);
+  const popoverTitleId = useGeneratedHtmlId();
   const dispatch = useDispatch();
 
   const isClearAllFilterDisabled = !isAddingFields
@@ -142,6 +144,7 @@ export const MappingsFilter: React.FC<Props> = ({
         anchorPosition="downCenter"
         data-test-subj="indexDetailsMappingsFilter"
         panelPaddingSize="none"
+        aria-labelledby={popoverTitleId}
       >
         <EuiSelectable
           searchable
@@ -169,6 +172,7 @@ export const MappingsFilter: React.FC<Props> = ({
             <div style={{ width: 200 }}>
               <EuiPopoverTitle
                 paddingSize="s"
+                id={popoverTitleId}
                 data-test-subj="indexDetailsMappingsFilterByFieldTypeSearch"
               >
                 {search}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/template_list/template_details/template_details_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/template_list/template_details/template_details_content.tsx
@@ -259,6 +259,9 @@ export const TemplateDetailsContent = ({
               {/* Manage templates context menu */}
               <EuiPopover
                 id="manageTemplatePanel"
+                aria-label={i18n.translate('xpack.idxMgmt.templateDetails.managePopoverAriaLabel', {
+                  defaultMessage: 'Manage template',
+                })}
                 button={
                   <EuiButton
                     fill

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/pipeline_processors_editor_item/context_menu.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/pipeline_processors_editor_item/context_menu.tsx
@@ -9,6 +9,7 @@ import React, { useState, forwardRef } from 'react';
 import { css } from '@emotion/react';
 
 import { EuiContextMenuItem, EuiContextMenuPanel, EuiPopover, EuiButtonIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { i18nTexts } from './i18n_texts';
 
@@ -78,6 +79,10 @@ export const ContextMenu = forwardRef<HTMLButtonElement, Props>((props, ref) => 
     <div css={styles.container}>
       <EuiPopover
         data-test-subj={props['data-test-subj']}
+        aria-label={i18n.translate(
+          'xpack.ingestPipelines.pipelineEditor.item.contextMenuAriaLabel',
+          { defaultMessage: 'Processor actions' }
+        )}
         anchorPosition="leftCenter"
         panelPaddingSize="none"
         isOpen={isOpen}

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/documents_dropdown/documents_dropdown.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/documents_dropdown/documents_dropdown.tsx
@@ -15,6 +15,7 @@ import {
   EuiButtonEmpty,
   EuiPopoverTitle,
   EuiSelectable,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import type { Document } from '../../../types';
@@ -58,6 +59,7 @@ export const DocumentsDropdown: FunctionComponent<Props> = ({
   openFlyout,
 }) => {
   const [showPopover, setShowPopover] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
 
   const managePipelineButton = (
     <EuiButtonEmpty
@@ -84,6 +86,7 @@ export const DocumentsDropdown: FunctionComponent<Props> = ({
       repositionOnScroll
       data-test-subj="documentsDropdown"
       panelStyle={panelStyle}
+      aria-labelledby={popoverTitleId}
     >
       <EuiSelectable
         singleSelection
@@ -110,7 +113,9 @@ export const DocumentsDropdown: FunctionComponent<Props> = ({
       >
         {(list) => (
           <>
-            <EuiPopoverTitle paddingSize="s">{i18nTexts.popoverTitle}</EuiPopoverTitle>
+            <EuiPopoverTitle paddingSize="s" id={popoverTitleId}>
+              {i18nTexts.popoverTitle}
+            </EuiPopoverTitle>
             {list}
           </>
         )}

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/empty_list.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/empty_list.tsx
@@ -70,6 +70,10 @@ export const EmptyList: FunctionComponent = () => {
         <EuiPopover
           isOpen={showPopover}
           closePopover={() => setShowPopover(false)}
+          aria-label={i18n.translate(
+            'xpack.ingestPipelines.list.table.emptyPrompt.createPipelinePopoverAriaLabel',
+            { defaultMessage: 'Create pipeline options' }
+          )}
           button={
             <EuiButton
               fill

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/flyout_content/details_panel.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/flyout_content/details_panel.tsx
@@ -93,7 +93,7 @@ export const DetailsPanel: FunctionComponent<Props> = ({
       name: i18n.translate('xpack.ingestPipelines.list.pipelineDetails.duplicateActionLabel', {
         defaultMessage: 'Duplicate',
       }),
-      icon: <EuiIcon type="copy" />,
+      icon: <EuiIcon type="copy" aria-hidden={true} />,
       onClick: () => onCloneClick(pipeline.name),
     },
     /**
@@ -103,7 +103,7 @@ export const DetailsPanel: FunctionComponent<Props> = ({
       name: i18n.translate('xpack.ingestPipelines.list.pipelineDetails.deleteActionLabel', {
         defaultMessage: 'Delete',
       }),
-      icon: <EuiIcon type="trash" />,
+      icon: <EuiIcon type="trash" aria-hidden={true} />,
       'data-test-subj': 'deletePipelineButton',
       onClick: () => {
         setShowPopover(false);
@@ -307,6 +307,10 @@ export const DetailsPanel: FunctionComponent<Props> = ({
                       button={actionsPopoverButton}
                       panelPaddingSize="none"
                       repositionOnScroll
+                      aria-label={i18n.translate(
+                        'xpack.ingestPipelines.list.pipelineDetails.actionsPopoverAriaLabel',
+                        { defaultMessage: 'Pipeline actions' }
+                      )}
                     >
                       <EuiContextMenu
                         initialPanelId={0}

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.tsx
@@ -167,6 +167,10 @@ export const PipelinesList: React.FunctionComponent<RouteComponentProps> = ({ hi
       key="createPipelinePopover"
       isOpen={showPopover}
       closePopover={() => setShowPopover(false)}
+      aria-label={i18n.translate(
+        'xpack.ingestPipelines.list.table.createPipelinePopoverAriaLabel',
+        { defaultMessage: 'Create pipeline options' }
+      )}
       button={
         <EuiButton
           fill

--- a/x-pack/platform/plugins/shared/license_management/public/application/components/telemetry_opt_in/telemetry_opt_in.tsx
+++ b/x-pack/platform/plugins/shared/license_management/public/application/components/telemetry_opt_in/telemetry_opt_in.tsx
@@ -16,6 +16,7 @@ import {
   EuiLoadingSpinner,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { LazyOptInExampleFlyout } from '@kbn/telemetry-management-section-plugin/public';
 import type { TelemetryPluginStart } from '../../lib/telemetry';
@@ -110,6 +111,9 @@ export class TelemetryOptIn extends React.Component<Props, State> {
       <EuiPopover
         ownFocus
         id="readMorePopover"
+        aria-label={i18n.translate('xpack.licenseMgmt.telemetryOptIn.readMorePopoverAriaLabel', {
+          defaultMessage: 'Telemetry information',
+        })}
         button={readMoreButton}
         isOpen={showMoreTelemetryInfo}
         closePopover={this.closeReadMorePopover}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-management files (#269652)](https://github.com/elastic/kibana/pull/269652)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-19T11:45:54Z","message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-management files (#269652)\n\nFixes 58 ESLint violations for\n`@elastic/eui/require-aria-label-for-modals` across 53 files owned by\n@elastic/kibana-management.\n\n## Approach\n\nFollowing `.agents/skills/accessibility/SKILL.md` canonical patterns:\n\n- **EuiPopover with visible title** → `aria-labelledby` +\n`useGeneratedHtmlId()` wiring the title's `id`\n- **EuiPopover without visible title** → `aria-label` with\n`i18n.translate()`\n- **EuiConfirmModal** → `aria-labelledby` + `titleProps={{ id }}`\n- **EuiModal** → `aria-labelledby` + `id` on modal title element\n- Class components use `htmlIdGenerator()` instead of\n`useGeneratedHtmlId()`\n\n## Example\n\n```tsx\n// Popover with visible title (preferred: aria-labelledby)\nconst popoverTitleId = useGeneratedHtmlId();\n\n<EuiPopover aria-labelledby={popoverTitleId} ...>\n  <EuiPopoverTitle id={popoverTitleId}>Documents</EuiPopoverTitle>\n  ...\n</EuiPopover>\n\n// Popover without visible title (fallback: aria-label)\n<EuiPopover\n  aria-label={i18n.translate('myPlugin.popoverAriaLabel', {\n    defaultMessage: 'Request options',\n  })}\n  ...\n>\n```\n\n## Checklist\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] All 53 files fixed\n- [x] `node scripts/check_changes.ts` passes\n- [x] Zero `@elastic/eui/require-aria-label-for-modals` violations\nremain\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2 /snap/bin/git git\ne_modules/npm/bin/node-gyp-bin/ldd platform/pluginsldd git h .2 b/li\u0004\u0018\nche/ms-playwright/firefox-1511/firefox/libplds4.so /steps/configura-e\nn/node-gyp-bin/ldd a4d6d074:x-pack/ldd\nt/data_stream_de/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ndd ldd` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node scripts/kbn\nbootstrap git show\u0004\u0018\nplatform/plugins/shared/dataset_quality/public/components/dataset_quality_details/details/integrdirname\ngit e_modules/.bin/sh rvices/index.tsxawk pplication/sectiBEGIN {\n    if (ARGV[1] == &#34;&#34; || ARGV[2] == &#34;&#34;) exit(1)\nsplit(AR\u0004\u0018 &gt; b[i]) exit(0) git show\u0004\u0018\nplatform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/componenthead\ngit nfig/composer/vendor/bin/sh R) &#43; 1)\nif (grep on/components/co-q\non/components/co/home/REDACTED/.nvm/[^/]*/bin bash` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node install.js\nyp-bin/ldd ldd b/li\u0004\u0018 /usr/local/sbin/git e}}\nx-pack/platform/plugins/shared/index_management/public/appli--noEmit\n/ldd a4d6d074:x-pack/ldd git rgo/bin/git ldd s/li\u0004\u0018 nt/parser\n=ecmaVersion:2020,sourceType:modHEAD\nm/versions/node/v24.14.1/lib/node_modules/npm/bin/node-gyp-bin/ldd\n]*/bin\nplugins/shared/i/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libsoup-3.0.so.0.7.4\ns/npm/bin/node-gyp-bin/git ldd` (dns block)\n> - `iojs.org`\n> - Triggering command: `/usr/bin/curl curl -q --fail --compressed -L -s\nREDACTED -o - components/conne--norc git\norm/plugins/shared/index_management/public/appli--noEmit 8d00\u0004\u0018\nplatform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecatr\nbash k/node_modules/.bin/sh s/test_pipeline/git git\nmponent_template--name-only 0,sourceType:modHEAD` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"16f2e488703e0651433abb1cecdf802fd7e95e23","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Project:Accessibility","backport missing","💝community","backport:version","a11y:agent-pr","v9.5.0","v9.3.5","v9.4.2"],"title":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-management files","number":269652,"url":"https://github.com/elastic/kibana/pull/269652","mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-management files (#269652)\n\nFixes 58 ESLint violations for\n`@elastic/eui/require-aria-label-for-modals` across 53 files owned by\n@elastic/kibana-management.\n\n## Approach\n\nFollowing `.agents/skills/accessibility/SKILL.md` canonical patterns:\n\n- **EuiPopover with visible title** → `aria-labelledby` +\n`useGeneratedHtmlId()` wiring the title's `id`\n- **EuiPopover without visible title** → `aria-label` with\n`i18n.translate()`\n- **EuiConfirmModal** → `aria-labelledby` + `titleProps={{ id }}`\n- **EuiModal** → `aria-labelledby` + `id` on modal title element\n- Class components use `htmlIdGenerator()` instead of\n`useGeneratedHtmlId()`\n\n## Example\n\n```tsx\n// Popover with visible title (preferred: aria-labelledby)\nconst popoverTitleId = useGeneratedHtmlId();\n\n<EuiPopover aria-labelledby={popoverTitleId} ...>\n  <EuiPopoverTitle id={popoverTitleId}>Documents</EuiPopoverTitle>\n  ...\n</EuiPopover>\n\n// Popover without visible title (fallback: aria-label)\n<EuiPopover\n  aria-label={i18n.translate('myPlugin.popoverAriaLabel', {\n    defaultMessage: 'Request options',\n  })}\n  ...\n>\n```\n\n## Checklist\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] All 53 files fixed\n- [x] `node scripts/check_changes.ts` passes\n- [x] Zero `@elastic/eui/require-aria-label-for-modals` violations\nremain\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2 /snap/bin/git git\ne_modules/npm/bin/node-gyp-bin/ldd platform/pluginsldd git h .2 b/li\u0004\u0018\nche/ms-playwright/firefox-1511/firefox/libplds4.so /steps/configura-e\nn/node-gyp-bin/ldd a4d6d074:x-pack/ldd\nt/data_stream_de/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ndd ldd` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node scripts/kbn\nbootstrap git show\u0004\u0018\nplatform/plugins/shared/dataset_quality/public/components/dataset_quality_details/details/integrdirname\ngit e_modules/.bin/sh rvices/index.tsxawk pplication/sectiBEGIN {\n    if (ARGV[1] == &#34;&#34; || ARGV[2] == &#34;&#34;) exit(1)\nsplit(AR\u0004\u0018 &gt; b[i]) exit(0) git show\u0004\u0018\nplatform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/componenthead\ngit nfig/composer/vendor/bin/sh R) &#43; 1)\nif (grep on/components/co-q\non/components/co/home/REDACTED/.nvm/[^/]*/bin bash` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node install.js\nyp-bin/ldd ldd b/li\u0004\u0018 /usr/local/sbin/git e}}\nx-pack/platform/plugins/shared/index_management/public/appli--noEmit\n/ldd a4d6d074:x-pack/ldd git rgo/bin/git ldd s/li\u0004\u0018 nt/parser\n=ecmaVersion:2020,sourceType:modHEAD\nm/versions/node/v24.14.1/lib/node_modules/npm/bin/node-gyp-bin/ldd\n]*/bin\nplugins/shared/i/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libsoup-3.0.so.0.7.4\ns/npm/bin/node-gyp-bin/git ldd` (dns block)\n> - `iojs.org`\n> - Triggering command: `/usr/bin/curl curl -q --fail --compressed -L -s\nREDACTED -o - components/conne--norc git\norm/plugins/shared/index_management/public/appli--noEmit 8d00\u0004\u0018\nplatform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecatr\nbash k/node_modules/.bin/sh s/test_pipeline/git git\nmponent_template--name-only 0,sourceType:modHEAD` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"16f2e488703e0651433abb1cecdf802fd7e95e23"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269652","number":269652,"mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` lint violations across @elastic/kibana-management files (#269652)\n\nFixes 58 ESLint violations for\n`@elastic/eui/require-aria-label-for-modals` across 53 files owned by\n@elastic/kibana-management.\n\n## Approach\n\nFollowing `.agents/skills/accessibility/SKILL.md` canonical patterns:\n\n- **EuiPopover with visible title** → `aria-labelledby` +\n`useGeneratedHtmlId()` wiring the title's `id`\n- **EuiPopover without visible title** → `aria-label` with\n`i18n.translate()`\n- **EuiConfirmModal** → `aria-labelledby` + `titleProps={{ id }}`\n- **EuiModal** → `aria-labelledby` + `id` on modal title element\n- Class components use `htmlIdGenerator()` instead of\n`useGeneratedHtmlId()`\n\n## Example\n\n```tsx\n// Popover with visible title (preferred: aria-labelledby)\nconst popoverTitleId = useGeneratedHtmlId();\n\n<EuiPopover aria-labelledby={popoverTitleId} ...>\n  <EuiPopoverTitle id={popoverTitleId}>Documents</EuiPopoverTitle>\n  ...\n</EuiPopover>\n\n// Popover without visible title (fallback: aria-label)\n<EuiPopover\n  aria-label={i18n.translate('myPlugin.popoverAriaLabel', {\n    defaultMessage: 'Request options',\n  })}\n  ...\n>\n```\n\n## Checklist\n- [x] Read and applied `.agents/skills/accessibility/SKILL.md`\n- [x] Added label `a11y:agent-pr`\n- [x] All 53 files fixed\n- [x] `node scripts/check_changes.ts` passes\n- [x] Zero `@elastic/eui/require-aria-label-for-modals` violations\nremain\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\nscripts/yarn_install_scripts.js run ldd 0.8.2 /snap/bin/git git\ne_modules/npm/bin/node-gyp-bin/ldd platform/pluginsldd git h .2 b/li\u0004\u0018\nche/ms-playwright/firefox-1511/firefox/libplds4.so /steps/configura-e\nn/node-gyp-bin/ldd a4d6d074:x-pack/ldd\nt/data_stream_de/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ndd ldd` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node scripts/kbn\nbootstrap git show\u0004\u0018\nplatform/plugins/shared/dataset_quality/public/components/dataset_quality_details/details/integrdirname\ngit e_modules/.bin/sh rvices/index.tsxawk pplication/sectiBEGIN {\n    if (ARGV[1] == &#34;&#34; || ARGV[2] == &#34;&#34;) exit(1)\nsplit(AR\u0004\u0018 &gt; b[i]) exit(0) git show\u0004\u0018\nplatform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/componenthead\ngit nfig/composer/vendor/bin/sh R) &#43; 1)\nif (grep on/components/co-q\non/components/co/home/REDACTED/.nvm/[^/]*/bin bash` (dns block)\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node node\nscripts/check_changes.ts` (dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :build-webpack x86-64.so.2 b/li\u0004\u0018\npeline/documents_dropdown/docume--noprofile git ndor/bin/ldd\nplatform/plugins/lib/ld-linux.so.2 n.tsx yp-bin/ldd ldd nibr\u0004\u0018\ns/component_template_selector/co--name-only\nmponents/document_fields/field_pHEAD n/ldd a4d6d074:x-pack/ldd\nt/data_stream_ac/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libjxl.so.0.8\ncal/bin/git ldd` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command:\n`/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node\n/home/REDACTED/.nvm/versions/node/v24.14.1/bin/node install.js\nyp-bin/ldd ldd b/li\u0004\u0018 /usr/local/sbin/git e}}\nx-pack/platform/plugins/shared/index_management/public/appli--noEmit\n/ldd a4d6d074:x-pack/ldd git rgo/bin/git ldd s/li\u0004\u0018 nt/parser\n=ecmaVersion:2020,sourceType:modHEAD\nm/versions/node/v24.14.1/lib/node_modules/npm/bin/node-gyp-bin/ldd\n]*/bin\nplugins/shared/i/home/REDACTED/.cache/ms-playwright/webkit-2272/minibrowser-wpe/sys/lib/libsoup-3.0.so.0.7.4\ns/npm/bin/node-gyp-bin/git ldd` (dns block)\n> - `iojs.org`\n> - Triggering command: `/usr/bin/curl curl -q --fail --compressed -L -s\nREDACTED -o - components/conne--norc git\norm/plugins/shared/index_management/public/appli--noEmit 8d00\u0004\u0018\nplatform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecatr\nbash k/node_modules/.bin/sh s/test_pipeline/git git\nmponent_template--name-only 0,sourceType:modHEAD` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"16f2e488703e0651433abb1cecdf802fd7e95e23"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->