### PR TITLE
[kbn-code-owners] Add `elastic/security-detection-platform` team under Security area

### DIFF
--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -80,6 +80,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/security-defend-workflows',
     'elastic/security-design',
     'elastic/security-detection-engine',
+    'elastic/security-detection-platform',
     'elastic/security-detection-rule-management',
     'elastic/security-engineering-productivity',
     'elastic/security-entity-analytics',


### PR DESCRIPTION
This PR adds the `elastic/security-detection-platform` to the `security` code owner <> area mapping. Adding the team here ensures their tests are correctly attributed to the security area by our Scout Reporter.