### PR TITLE
[Operations] Fix checkout in VM build orchestrator upload step

### DIFF
--- a/.buildkite/pipelines/orchestrate_vm_builds.yml
+++ b/.buildkite/pipelines/orchestrate_vm_builds.yml
@@ -14,7 +14,15 @@ steps:
         required: true
 
   - name: 'Upload trigger steps'
-    checkout: none
+    plugins:
+      - sparse-checkout#v1.6.0:
+          paths:
+            - .buildkite
+            - .node-version
+            - package.json
+            - tsconfig.base.json
+            - versions.json
+          cleanup_sparse_state: true
     command: |
       VM_IMAGES_BRANCH="$$(buildkite-agent meta-data get "VM_IMAGES_BRANCH")"
       KIBANA_BRANCH="$$(buildkite-agent meta-data get "KIBANA_BRANCH")"


### PR DESCRIPTION
## Summary

Fixes the `checkout: none` set in #270989 — Buildkite requires `checkout` to be a hash, not a string, so that caused a pipeline upload rejection.

Replaces it with the `sparse-checkout#v1.6.0` plugin (same pattern used by other operations pipelines) limiting the clone to just `.buildkite`. The step only calls `buildkite-agent meta-data get` and uploads inline YAML, so it needs no other files.