### PR TITLE
[9.4] [Profiling] Fix profiling tests failing on polluted test lanes (#270623)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.setup.ts
@@ -13,8 +13,9 @@ const globalSetupHook = mergeTests(obltGlobalSetupHook, synthtraceFixture);
 globalSetupHook(
   'Ingest data to Elasticsearch',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
-  async ({ log }) => {
-    // It's required for globalteardown to work
-    log.info(`Global setup for profiling API tests`);
+  async ({ log, apiServices }) => {
+    log.info('Running profiling API global setup...');
+    await apiServices.fleet.internal.setup();
+    log.info('Fleet infrastructure setup completed');
   }
 );

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.teardown.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.teardown.ts
@@ -5,41 +5,19 @@
  * 2.0.
  */
 
-import { globalTeardownHook, tags } from '@kbn/scout-oblt';
-import {
-  COLLECTOR_PACKAGE_POLICY_NAME,
-  SYMBOLIZER_PACKAGE_POLICY_NAME,
-} from '../../common/fixtures/constants';
+import { mergeTests, globalTeardownHook as obltGlobalTeardownHook, tags } from '@kbn/scout-oblt';
+import { apiTest as profilingFixtures } from '../../common/fixtures';
+
+const globalTeardownHook = mergeTests(obltGlobalTeardownHook, profilingFixtures);
 
 globalTeardownHook(
   'Reset profiling state after API tests',
   { tag: tags.stateful.classic },
-  async ({ profilingSetup, apiServices, log }) => {
+  async ({ profilingSetup, log, profilingHelper }) => {
     log.info('Running profiling API global teardown...');
 
-    // Clean up Fleet package policies left by integration tests
-    try {
-      const res = await apiServices.fleet.package_policies.get({ perPage: 1000 });
-      const policies = res.data.items;
-
-      const collectorId = policies.find(
-        (item: { name: string }) => item.name === COLLECTOR_PACKAGE_POLICY_NAME
-      )?.id;
-      const symbolizerId = policies.find(
-        (item: { name: string }) => item.name === SYMBOLIZER_PACKAGE_POLICY_NAME
-      )?.id;
-
-      await Promise.all([
-        collectorId ? apiServices.fleet.package_policies.delete(collectorId) : Promise.resolve(),
-        symbolizerId ? apiServices.fleet.package_policies.delete(symbolizerId) : Promise.resolve(),
-      ]);
-
-      if (collectorId || symbolizerId) {
-        log.info('Cleaned up profiling Fleet package policies');
-      }
-    } catch (error) {
-      log.warning(`Fleet policy cleanup (non-fatal): ${error}`);
-    }
+    // Cleanup policies
+    await profilingHelper.cleanupPolicies({ includeAgentPolicy: true });
 
     // Reset profiling ES resources (data streams + indices)
     await profilingSetup.cleanup();

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
@@ -11,8 +11,7 @@ import type { RoleApiCredentials } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
-// Failing: See https://github.com/elastic/kibana/issues/253221
-apiTest.describe.skip(
+apiTest.describe(
   'APM integration not installed but setup completed',
   { tag: tags.stateful.classic },
   () => {

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts
@@ -11,119 +11,111 @@ import type { ApiClientFixture, RoleApiCredentials } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esArchiversPath, esResourcesEndpoint } from '../../common/fixtures/constants';
 
-// Failing: See https://github.com/elastic/kibana/issues/268023
-apiTest.describe.skip(
-  'Collector integration is not installed',
-  { tag: tags.stateful.classic },
-  () => {
-    // Profiling POST /setup can wait on ES plugin resources after Fleet policy creation — allow a longer hook budget than the default project timeout (60s).
-    // eslint-disable-next-line @kbn/eslint/scout_no_describe_configure -- extended timeout applies to hooks (beforeAll); see https://playwright.dev/docs/test-timeouts
-    apiTest.describe.configure({ timeout: 180_000 });
+apiTest.describe('Collector integration is not installed', { tag: tags.stateful.classic }, () => {
+  // Profiling POST /setup can wait on ES plugin resources after Fleet policy creation — allow a longer hook budget than the default project timeout (60s).
+  // eslint-disable-next-line @kbn/eslint/scout_no_describe_configure -- extended timeout applies to hooks (beforeAll); see https://playwright.dev/docs/test-timeouts
+  apiTest.describe.configure({ timeout: 180_000 });
 
-    let viewerApiCreditials: RoleApiCredentials;
+  let viewerApiCreditials: RoleApiCredentials;
 
-    apiTest.beforeAll(async ({ requestAuth, profilingSetup, profilingHelper }) => {
-      await profilingHelper.installPolicies();
+  apiTest.beforeAll(async ({ requestAuth, profilingSetup, profilingHelper }) => {
+    await profilingHelper.installPolicies();
 
-      let ids = await profilingHelper.getPolicyIds();
-      if (!ids.collectorId || !ids.symbolizerId) {
-        await profilingSetup.setupResources();
-        ids = await profilingHelper.getPolicyIds();
-      }
+    let ids = await profilingHelper.getPolicyIds();
+    if (!ids.collectorId || !ids.symbolizerId) {
+      await profilingSetup.setupResources();
+      ids = await profilingHelper.getPolicyIds();
+    }
 
-      expect(ids.collectorId).toBeDefined();
-      expect(ids.symbolizerId).toBeDefined();
+    expect(ids.collectorId).toBeDefined();
+    expect(ids.symbolizerId).toBeDefined();
 
-      // Same fixture as has_setup_with_data: ensure profiling* has documents so we assert has_data like has_setup — indexed data remains after Fleet policy deletion.
-      let status = await profilingSetup.checkStatus();
-      if (!status.has_data) {
-        await profilingSetup.loadData(esArchiversPath);
-        status = await profilingSetup.checkStatus();
-      }
-      expect(status.has_data).toBe(true);
+    // Same fixture as has_setup_with_data: ensure profiling* has documents so we assert has_data like has_setup — indexed data remains after Fleet policy deletion.
+    let status = await profilingSetup.checkStatus();
+    if (!status.has_data) {
+      await profilingSetup.loadData(esArchiversPath);
+      status = await profilingSetup.checkStatus();
+    }
+    expect(status.has_data).toBe(true);
 
-      viewerApiCreditials = await requestAuth.getApiKey('viewer');
+    viewerApiCreditials = await requestAuth.getApiKey('viewer');
+  });
+
+  apiTest.afterAll(async ({ profilingHelper, profilingSetup }) => {
+    await profilingHelper.cleanupPolicies();
+    await profilingSetup.cleanup();
+  });
+
+  // Fleet package_policies.delete is eventually consistent — a subsequent /api/profiling/setup/es_resources call may still see the policy as installed for a brief window. Polling until `has_setup` reflects the deletion (cloud: false; self-managed: unchanged true) keeps the test deterministic.
+  const getViewerStatus = async (apiClient: ApiClientFixture) => {
+    const res = await apiClient.get(esResourcesEndpoint, {
+      headers: {
+        ...viewerApiCreditials.apiKeyHeader,
+        'content-type': 'application/json',
+        'kbn-xsrf': 'reporting',
+      },
     });
+    return res.body;
+  };
 
-    apiTest.afterAll(async ({ profilingHelper, profilingSetup }) => {
-      await profilingHelper.cleanupPolicies();
-      await profilingSetup.cleanup();
-    });
-
-    // Fleet package_policies.delete is eventually consistent — a subsequent /api/profiling/setup/es_resources call may still see the policy as installed for a brief window. Polling until `has_setup` reflects the deletion (cloud: false; self-managed: unchanged true) keeps the test deterministic.
-    const getViewerStatus = async (apiClient: ApiClientFixture) => {
-      const res = await apiClient.get(esResourcesEndpoint, {
-        headers: {
-          ...viewerApiCreditials.apiKeyHeader,
-          'content-type': 'application/json',
-          'kbn-xsrf': 'reporting',
+  const waitForExpectedHasSetup = async (apiClient: ApiClientFixture) => {
+    // In cloud, has_setup requires collector + symbolizer Fleet policies — deleting either flips it to false. In self-managed/serverless, has_setup is ES-only and unaffected by Fleet policy deletion.
+    await expect
+      .poll(
+        async () => {
+          const status = await getViewerStatus(apiClient);
+          return status.has_setup === (status.type !== 'cloud');
         },
-      });
-      return res.body;
-    };
+        {
+          timeout: 30_000,
+          intervals: [500, 1000, 2000, 4000],
+          message:
+            'has_setup did not converge to expected value after Fleet package policy deletion',
+        }
+      )
+      .toBe(true);
+  };
 
-    const waitForExpectedHasSetup = async (apiClient: ApiClientFixture) => {
-      // In cloud, has_setup requires collector + symbolizer Fleet policies — deleting either flips it to false. In self-managed/serverless, has_setup is ES-only and unaffected by Fleet policy deletion.
-      await expect
-        .poll(
-          async () => {
-            const status = await getViewerStatus(apiClient);
-            return status.has_setup === (status.type !== 'cloud');
-          },
-          {
-            timeout: 30_000,
-            intervals: [500, 1000, 2000, 4000],
-            message:
-              'has_setup did not converge to expected value after Fleet package policy deletion',
-          }
-        )
-        .toBe(true);
-    };
+  apiTest('collector integration missing', async ({ profilingHelper, apiServices, apiClient }) => {
+    const ids = await profilingHelper.getPolicyIds();
+    const collectorId = ids.collectorId;
 
-    apiTest(
-      'collector integration missing',
-      async ({ profilingHelper, apiServices, apiClient }) => {
-        const ids = await profilingHelper.getPolicyIds();
-        const collectorId = ids.collectorId;
+    expect(collectorId).toBeDefined();
 
-        expect(collectorId).toBeDefined();
+    await apiServices.fleet.package_policies.delete(collectorId!);
 
-        await apiServices.fleet.package_policies.delete(collectorId!);
+    const adminRes = await apiClient.get(esResourcesEndpoint);
+    const adminStatus = adminRes.body;
+    expect(adminStatus.has_setup).toBeUndefined();
+    expect(adminStatus.has_data).toBeUndefined();
+    expect(adminStatus.pre_8_9_1_data).toBeUndefined();
 
-        const adminRes = await apiClient.get(esResourcesEndpoint);
-        const adminStatus = adminRes.body;
-        expect(adminStatus.has_setup).toBeUndefined();
-        expect(adminStatus.has_data).toBeUndefined();
-        expect(adminStatus.pre_8_9_1_data).toBeUndefined();
+    await waitForExpectedHasSetup(apiClient);
 
-        await waitForExpectedHasSetup(apiClient);
+    const readStatus = await getViewerStatus(apiClient);
+    expect(readStatus.has_setup).toBe(readStatus.type !== 'cloud');
+    expect(readStatus.has_data).toBe(true);
+    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.has_required_role).toBe(false);
+  });
 
-        const readStatus = await getViewerStatus(apiClient);
-        expect(readStatus.has_setup).toBe(readStatus.type !== 'cloud');
-        expect(readStatus.has_data).toBe(true);
-        expect(readStatus.pre_8_9_1_data).toBe(false);
-        expect(readStatus.has_required_role).toBe(false);
-      }
-    );
+  apiTest(
+    'Symbolizer integration is not installed',
+    async ({ profilingHelper, apiClient, apiServices }) => {
+      const ids = await profilingHelper.getPolicyIds();
+      const symbolizerId = ids.symbolizerId;
 
-    apiTest(
-      'Symbolizer integration is not installed',
-      async ({ profilingHelper, apiClient, apiServices }) => {
-        const ids = await profilingHelper.getPolicyIds();
-        const symbolizerId = ids.symbolizerId;
+      expect(symbolizerId).toBeDefined();
 
-        expect(symbolizerId).toBeDefined();
+      await apiServices.fleet.package_policies.delete(symbolizerId!);
 
-        await apiServices.fleet.package_policies.delete(symbolizerId!);
+      await waitForExpectedHasSetup(apiClient);
 
-        await waitForExpectedHasSetup(apiClient);
-
-        const readStatus = await getViewerStatus(apiClient);
-        expect(readStatus.has_setup).toBe(readStatus.type !== 'cloud');
-        expect(readStatus.has_data).toBe(true);
-        expect(readStatus.pre_8_9_1_data).toBe(false);
-        expect(readStatus.has_required_role).toBe(false);
-      }
-    );
-  }
-);
+      const readStatus = await getViewerStatus(apiClient);
+      expect(readStatus.has_setup).toBe(readStatus.type !== 'cloud');
+      expect(readStatus.has_data).toBe(true);
+      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_required_role).toBe(false);
+    }
+  );
+});

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/common/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/common/fixtures/index.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import type { AgentPolicy, PackagePolicy } from '@kbn/fleet-plugin/common';
 import { apiTest as base } from '@kbn/scout-oblt';
 import { COLLECTOR_PACKAGE_POLICY_NAME, SYMBOLIZER_PACKAGE_POLICY_NAME } from './constants';
 
 export interface ProfilingHelper {
   installPolicies: () => Promise<void>;
-  cleanupPolicies: () => Promise<void>;
+  cleanupPolicies: (opts?: { includeAgentPolicy?: boolean }) => Promise<void>;
   getPolicyIds: () => Promise<{ collectorId?: string; symbolizerId?: string }>;
 }
 
@@ -24,10 +24,10 @@ export const apiTest = base.extend<{}, { profilingHelper: ProfilingHelper }>({
         log.info('Checking if APM agent policy exists, creating if needed...');
         const getPolicyResponse = await apiServices.fleet.agent_policies.get({
           page: 1,
-          perPage: 10,
+          perPage: 1000,
         });
         const apmPolicyData = getPolicyResponse.data.items.find(
-          (policy: { id: string }) => policy.id === 'policy-elastic-agent-on-cloud'
+          (policy: { id: string }) => policy.id === APM_AGENT_POLICY_ID
         );
 
         if (!apmPolicyData) {
@@ -45,25 +45,48 @@ export const apiTest = base.extend<{}, { profilingHelper: ProfilingHelper }>({
           log.info(`APM agent policy '${APM_AGENT_POLICY_ID}' already exists`);
         }
       };
-      const cleanupPolicies = async (): Promise<void> => {
+
+      const cleanupPolicies = async (
+        opts: { includeAgentPolicy?: boolean } = {}
+      ): Promise<void> => {
+        const { includeAgentPolicy = false } = opts;
         log.info('Cleaning up profiling resources...');
 
         const res = await apiServices.fleet.package_policies.get({ perPage: 1000 });
-        const policies: PackagePolicy[] = res.data.items;
+        const packagePolicies: PackagePolicy[] = res.data.items;
 
-        const collectorId = policies.find(
+        const collectorId = packagePolicies.find(
           (item) => item.name === COLLECTOR_PACKAGE_POLICY_NAME
         )?.id;
-        const symbolizerId = policies.find(
+        const symbolizerId = packagePolicies.find(
           (item) => item.name === SYMBOLIZER_PACKAGE_POLICY_NAME
         )?.id;
+
+        let apmPolicyPromise = Promise.resolve();
+        if (includeAgentPolicy) {
+          const getPolicyResponse = await apiServices.fleet.agent_policies.get({
+            page: 1,
+            perPage: 1000,
+          });
+          const agentPolicies: AgentPolicy[] = getPolicyResponse.data.items;
+          const apmId = agentPolicies.find(
+            (policy: { id: string }) => policy.id === APM_AGENT_POLICY_ID
+          )?.id;
+
+          if (apmId) {
+            apmPolicyPromise = apiServices.fleet.agent_policies.delete(apmId);
+          }
+        }
 
         await Promise.all([
           collectorId ? apiServices.fleet.package_policies.delete(collectorId) : Promise.resolve(),
           symbolizerId
             ? apiServices.fleet.package_policies.delete(symbolizerId)
             : Promise.resolve(),
+          apmPolicyPromise,
         ]);
+
+        log.info('Profiling resources cleaned up');
       };
 
       const getPolicyIds = async (): Promise<{ collectorId?: string; symbolizerId?: string }> => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Profiling] Fix profiling tests failing on polluted test lanes (#270623)](https://github.com/elastic/kibana/pull/270623)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-25T11:04:02Z","message":"[Profiling] Fix profiling tests failing on polluted test lanes (#270623)\n\n## Summary\n\n### The Problem\n\nThe profiling API tests fail with `Saved object\n[fleet-agent-policies/policy-elastic-agent-on-cloud] not found` when run\nin a lane where earlier test suites have deleted Fleet's global settings\nobject from Elasticsearch.\n\nThe root cause is a Fleet internal mechanism called\n`isSpaceAwarenessEnabled()`. Every Fleet API call (creating an agent\npolicy, listing package policies) invokes this function to decide which\nsaved object type to use: either `fleet-agent-policies` (the modern,\nspace-aware type) or the legacy `ingest-agent-policies`. The decision\nreads the `ingest_manager_settings` saved object, which has namespace\ntype `agnostic` — meaning it lives in a single shared ES document\nvisible from any Kibana space.\n\nWhen `ingest_manager_settings` does not exist,\n`isSpaceAwarenessEnabled()` returns `false`, causing Fleet to use the\nlegacy `ingest-agent-policies` SO type. When `ingest_manager_settings`\nexists and carries `use_space_awareness_migration_status: 'success'`,\nFleet uses `fleet-agent-policies`. These two types are distinct\nElasticsearch documents — there is no fallback lookup, no aliasing, and\nno migration between them at query time.\n\nThe profiling `beforeAll` hook calls `installPolicies()` followed by\n`setupResources()`. If `ingest_manager_settings` is absent when\n`installPolicies()` runs, it creates the agent policy as\n`ingest-agent-policies:policy-elastic-agent-on-cloud`. Then, deep inside\nthe `setupResources()` call chain, `packagePolicyClient.create()`\ntriggers Fleet's `settingsSetup`, which catches the 404 for\n`ingest_manager_settings` and recreates it with\n`use_space_awareness_migration_status: 'success'`. From this point\nforward, `isSpaceAwarenessEnabled()` returns `true` — but the agent\npolicy already exists under the wrong type. When `setupResources()`\nsubsequently calls `agentPolicyService.get(soClient,\n'policy-elastic-agent-on-cloud')`, Fleet looks for a\n`fleet-agent-policies` document that was never created, and throws the\nnot-found error.\n\n### How It Is Triggered in Polluted Lanes\n\nAny test suite that calls `kbnClient.savedObjects.cleanStandardList()`\nagainst the default Kibana space will delete `ingest_manager_settings`\nfrom Elasticsearch. Because `ingest_manager_settings` is an `agnostic`\ntype, it is stored without a namespace prefix in `.kibana` and is\naccessible from every space — which means deleting it from the default\nspace removes the only copy. The deletion takes effect immediately;\nthere is no cross-request cache for `isSpaceAwarenessEnabled()` (it uses\n`AsyncLocalStorage`, which scopes to a single HTTP request lifetime and\nis empty at the start of every new request).\n\nIn CI lanes, multiple test configs run sequentially against the same\nKibana instance. If the profiling suite follows any suite that performs\nthis cleanup, the `ingest_manager_settings` object is gone by the time\n`installPolicies()` executes.\n\n### The Fix: Calling `fleet.internal.setup()` Before `installPolicies()`\n\n`apiServices.fleet.internal.setup()` issues `POST /api/fleet/setup`,\nwhich calls Fleet's `settingsSetup` server-side. That function checks\nwhether `ingest_manager_settings` exists and, if it does not (404),\ncreates it from `createDefaultSettings()` — which, when the\n`useSpaceAwareness` experimental feature is enabled, sets\n`use_space_awareness_migration_status: 'success'`. After this call\nreturns, `ingest_manager_settings` is guaranteed to be present with the\ncorrect migration status.\n\nPlacing `await apiServices.fleet.internal.setup()` in the profiling\nglobal setup hook (`global.setup.ts`) will ensure fleet is properly\nconfigured before running any `installPolicies()` calls within the\nsuite. This makes sure there is no window where the SO type can flip\nbetween the two calls. Both `installPolicies()` and `setupResources()`\nthen agree on the same type.\n\nThis is also safe to call repeatedly: if `ingest_manager_settings`\nalready exists (the happy path in isolation), `settingsSetup` is a no-op\nand returns immediately. The call adds no observable overhead or issues\nin clean environments.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n### References\n\nCloses https://github.com/elastic/kibana/issues/268025\nCloses https://github.com/elastic/kibana/issues/253221\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2486bdf91a9d2571cec1a4c54e316495e87ddcf5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","v9.4.0","Team:obs-presentation","v9.5.0"],"title":"[Profiling] Fix profiling tests failing on polluted test lanes","number":270623,"url":"https://github.com/elastic/kibana/pull/270623","mergeCommit":{"message":"[Profiling] Fix profiling tests failing on polluted test lanes (#270623)\n\n## Summary\n\n### The Problem\n\nThe profiling API tests fail with `Saved object\n[fleet-agent-policies/policy-elastic-agent-on-cloud] not found` when run\nin a lane where earlier test suites have deleted Fleet's global settings\nobject from Elasticsearch.\n\nThe root cause is a Fleet internal mechanism called\n`isSpaceAwarenessEnabled()`. Every Fleet API call (creating an agent\npolicy, listing package policies) invokes this function to decide which\nsaved object type to use: either `fleet-agent-policies` (the modern,\nspace-aware type) or the legacy `ingest-agent-policies`. The decision\nreads the `ingest_manager_settings` saved object, which has namespace\ntype `agnostic` — meaning it lives in a single shared ES document\nvisible from any Kibana space.\n\nWhen `ingest_manager_settings` does not exist,\n`isSpaceAwarenessEnabled()` returns `false`, causing Fleet to use the\nlegacy `ingest-agent-policies` SO type. When `ingest_manager_settings`\nexists and carries `use_space_awareness_migration_status: 'success'`,\nFleet uses `fleet-agent-policies`. These two types are distinct\nElasticsearch documents — there is no fallback lookup, no aliasing, and\nno migration between them at query time.\n\nThe profiling `beforeAll` hook calls `installPolicies()` followed by\n`setupResources()`. If `ingest_manager_settings` is absent when\n`installPolicies()` runs, it creates the agent policy as\n`ingest-agent-policies:policy-elastic-agent-on-cloud`. Then, deep inside\nthe `setupResources()` call chain, `packagePolicyClient.create()`\ntriggers Fleet's `settingsSetup`, which catches the 404 for\n`ingest_manager_settings` and recreates it with\n`use_space_awareness_migration_status: 'success'`. From this point\nforward, `isSpaceAwarenessEnabled()` returns `true` — but the agent\npolicy already exists under the wrong type. When `setupResources()`\nsubsequently calls `agentPolicyService.get(soClient,\n'policy-elastic-agent-on-cloud')`, Fleet looks for a\n`fleet-agent-policies` document that was never created, and throws the\nnot-found error.\n\n### How It Is Triggered in Polluted Lanes\n\nAny test suite that calls `kbnClient.savedObjects.cleanStandardList()`\nagainst the default Kibana space will delete `ingest_manager_settings`\nfrom Elasticsearch. Because `ingest_manager_settings` is an `agnostic`\ntype, it is stored without a namespace prefix in `.kibana` and is\naccessible from every space — which means deleting it from the default\nspace removes the only copy. The deletion takes effect immediately;\nthere is no cross-request cache for `isSpaceAwarenessEnabled()` (it uses\n`AsyncLocalStorage`, which scopes to a single HTTP request lifetime and\nis empty at the start of every new request).\n\nIn CI lanes, multiple test configs run sequentially against the same\nKibana instance. If the profiling suite follows any suite that performs\nthis cleanup, the `ingest_manager_settings` object is gone by the time\n`installPolicies()` executes.\n\n### The Fix: Calling `fleet.internal.setup()` Before `installPolicies()`\n\n`apiServices.fleet.internal.setup()` issues `POST /api/fleet/setup`,\nwhich calls Fleet's `settingsSetup` server-side. That function checks\nwhether `ingest_manager_settings` exists and, if it does not (404),\ncreates it from `createDefaultSettings()` — which, when the\n`useSpaceAwareness` experimental feature is enabled, sets\n`use_space_awareness_migration_status: 'success'`. After this call\nreturns, `ingest_manager_settings` is guaranteed to be present with the\ncorrect migration status.\n\nPlacing `await apiServices.fleet.internal.setup()` in the profiling\nglobal setup hook (`global.setup.ts`) will ensure fleet is properly\nconfigured before running any `installPolicies()` calls within the\nsuite. This makes sure there is no window where the SO type can flip\nbetween the two calls. Both `installPolicies()` and `setupResources()`\nthen agree on the same type.\n\nThis is also safe to call repeatedly: if `ingest_manager_settings`\nalready exists (the happy path in isolation), `settingsSetup` is a no-op\nand returns immediately. The call adds no observable overhead or issues\nin clean environments.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n### References\n\nCloses https://github.com/elastic/kibana/issues/268025\nCloses https://github.com/elastic/kibana/issues/253221\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2486bdf91a9d2571cec1a4c54e316495e87ddcf5"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270623","number":270623,"mergeCommit":{"message":"[Profiling] Fix profiling tests failing on polluted test lanes (#270623)\n\n## Summary\n\n### The Problem\n\nThe profiling API tests fail with `Saved object\n[fleet-agent-policies/policy-elastic-agent-on-cloud] not found` when run\nin a lane where earlier test suites have deleted Fleet's global settings\nobject from Elasticsearch.\n\nThe root cause is a Fleet internal mechanism called\n`isSpaceAwarenessEnabled()`. Every Fleet API call (creating an agent\npolicy, listing package policies) invokes this function to decide which\nsaved object type to use: either `fleet-agent-policies` (the modern,\nspace-aware type) or the legacy `ingest-agent-policies`. The decision\nreads the `ingest_manager_settings` saved object, which has namespace\ntype `agnostic` — meaning it lives in a single shared ES document\nvisible from any Kibana space.\n\nWhen `ingest_manager_settings` does not exist,\n`isSpaceAwarenessEnabled()` returns `false`, causing Fleet to use the\nlegacy `ingest-agent-policies` SO type. When `ingest_manager_settings`\nexists and carries `use_space_awareness_migration_status: 'success'`,\nFleet uses `fleet-agent-policies`. These two types are distinct\nElasticsearch documents — there is no fallback lookup, no aliasing, and\nno migration between them at query time.\n\nThe profiling `beforeAll` hook calls `installPolicies()` followed by\n`setupResources()`. If `ingest_manager_settings` is absent when\n`installPolicies()` runs, it creates the agent policy as\n`ingest-agent-policies:policy-elastic-agent-on-cloud`. Then, deep inside\nthe `setupResources()` call chain, `packagePolicyClient.create()`\ntriggers Fleet's `settingsSetup`, which catches the 404 for\n`ingest_manager_settings` and recreates it with\n`use_space_awareness_migration_status: 'success'`. From this point\nforward, `isSpaceAwarenessEnabled()` returns `true` — but the agent\npolicy already exists under the wrong type. When `setupResources()`\nsubsequently calls `agentPolicyService.get(soClient,\n'policy-elastic-agent-on-cloud')`, Fleet looks for a\n`fleet-agent-policies` document that was never created, and throws the\nnot-found error.\n\n### How It Is Triggered in Polluted Lanes\n\nAny test suite that calls `kbnClient.savedObjects.cleanStandardList()`\nagainst the default Kibana space will delete `ingest_manager_settings`\nfrom Elasticsearch. Because `ingest_manager_settings` is an `agnostic`\ntype, it is stored without a namespace prefix in `.kibana` and is\naccessible from every space — which means deleting it from the default\nspace removes the only copy. The deletion takes effect immediately;\nthere is no cross-request cache for `isSpaceAwarenessEnabled()` (it uses\n`AsyncLocalStorage`, which scopes to a single HTTP request lifetime and\nis empty at the start of every new request).\n\nIn CI lanes, multiple test configs run sequentially against the same\nKibana instance. If the profiling suite follows any suite that performs\nthis cleanup, the `ingest_manager_settings` object is gone by the time\n`installPolicies()` executes.\n\n### The Fix: Calling `fleet.internal.setup()` Before `installPolicies()`\n\n`apiServices.fleet.internal.setup()` issues `POST /api/fleet/setup`,\nwhich calls Fleet's `settingsSetup` server-side. That function checks\nwhether `ingest_manager_settings` exists and, if it does not (404),\ncreates it from `createDefaultSettings()` — which, when the\n`useSpaceAwareness` experimental feature is enabled, sets\n`use_space_awareness_migration_status: 'success'`. After this call\nreturns, `ingest_manager_settings` is guaranteed to be present with the\ncorrect migration status.\n\nPlacing `await apiServices.fleet.internal.setup()` in the profiling\nglobal setup hook (`global.setup.ts`) will ensure fleet is properly\nconfigured before running any `installPolicies()` calls within the\nsuite. This makes sure there is no window where the SO type can flip\nbetween the two calls. Both `installPolicies()` and `setupResources()`\nthen agree on the same type.\n\nThis is also safe to call repeatedly: if `ingest_manager_settings`\nalready exists (the happy path in isolation), `settingsSetup` is a no-op\nand returns immediately. The call adds no observable overhead or issues\nin clean environments.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n### References\n\nCloses https://github.com/elastic/kibana/issues/268025\nCloses https://github.com/elastic/kibana/issues/253221\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2486bdf91a9d2571cec1a4c54e316495e87ddcf5"}}]}] BACKPORT-->