### PR TITLE
[Security Solution][Entity Analytics] Show leads read-privileges callout on home page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_lead_generation_privileges.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_lead_generation_privileges.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SecurityAppError } from '@kbn/securitysolution-t-grid';
+import { useQuery } from '@kbn/react-query';
+import type { EntityAnalyticsPrivileges } from '../../../../common/api/entity_analytics';
+import { useEntityAnalyticsRoutes } from '../api';
+
+export const LEAD_GENERATION_PRIVILEGES_QUERY_KEY = 'lead-generation-privileges';
+
+export const useLeadGenerationPrivileges = (enabled = true) => {
+  const { fetchLeadGenerationPrivileges } = useEntityAnalyticsRoutes();
+  return useQuery<EntityAnalyticsPrivileges, SecurityAppError>({
+    queryKey: [LEAD_GENERATION_PRIVILEGES_QUERY_KEY],
+    queryFn: fetchLeadGenerationPrivileges,
+    enabled,
+    retry: 0,
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_read_privileges_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_read_privileges_callout.test.tsx
@@ -40,13 +40,15 @@ const makeEntityEnginePrivileges = (
 
 const renderCallout = (
   riskEngineReadPrivileges: RiskEngineMissingPrivilegesResponse,
-  entityEnginePrivileges: EntityAnalyticsPrivileges | undefined
+  entityEnginePrivileges: EntityAnalyticsPrivileges | undefined,
+  leadGenerationPrivileges?: EntityAnalyticsPrivileges
 ) =>
   render(
     <TestProviders>
       <EntityAnalyticsReadPrivilegesCallout
         riskEngineReadPrivileges={riskEngineReadPrivileges}
         entityEnginePrivileges={entityEnginePrivileges}
+        leadGenerationPrivileges={leadGenerationPrivileges}
       />
     </TestProviders>
   );
@@ -139,6 +141,49 @@ describe('EntityAnalyticsReadPrivilegesCallout', () => {
     };
 
     renderCallout(missingPrivileges, makeEntityEnginePrivileges({}));
+
+    expect(screen.queryByText(CALLOUT_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('shows callout when lead generation index is missing read privilege', () => {
+    const leadsIndex = '.entity_analytics.entity-leads-*';
+    const leadPrivileges = makeEntityEnginePrivileges({
+      [leadsIndex]: { read: false, view_index_metadata: true },
+    });
+
+    renderCallout(ALL_PRIVILEGES_GRANTED, makeEntityEnginePrivileges({}), leadPrivileges);
+
+    expect(screen.getByText(CALLOUT_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(leadsIndex)).toBeInTheDocument();
+  });
+
+  it('combines missing privileges from risk engine, entity store, and lead generation', () => {
+    const leadsIndex = '.entity_analytics.entity-leads-*';
+    const missingRiskPrivileges: RiskEngineMissingPrivilegesResponse = {
+      isLoading: false,
+      hasAllRequiredPrivileges: false,
+      missingPrivileges: {
+        indexPrivileges: [[RISK_ENGINE_PRIVILEGE, ['read']]],
+        clusterPrivileges: { enable: [], run: [] },
+      },
+    };
+    const entityPrivileges = makeEntityEnginePrivileges({
+      [ENTITY_ENGINE_PRIVILEGE]: { read: false, view_index_metadata: false },
+    });
+    const leadPrivileges = makeEntityEnginePrivileges({
+      [leadsIndex]: { read: false, view_index_metadata: true },
+    });
+
+    renderCallout(missingRiskPrivileges, entityPrivileges, leadPrivileges);
+
+    expect(screen.getByText(CALLOUT_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(RISK_ENGINE_PRIVILEGE)).toBeInTheDocument();
+    expect(screen.getByText(ENTITY_ENGINE_PRIVILEGE)).toBeInTheDocument();
+    expect(screen.getByText(leadsIndex)).toBeInTheDocument();
+  });
+
+  it('renders nothing when lead generation privileges are undefined', () => {
+    renderCallout(ALL_PRIVILEGES_GRANTED, makeEntityEnginePrivileges({}), undefined);
 
     expect(screen.queryByText(CALLOUT_TITLE)).not.toBeInTheDocument();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_read_privileges_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_read_privileges_callout.tsx
@@ -21,14 +21,17 @@ export const EntityAnalyticsReadPrivilegesCallout = React.memo(
   ({
     riskEngineReadPrivileges,
     entityEnginePrivileges,
+    leadGenerationPrivileges,
   }: {
     riskEngineReadPrivileges: RiskEngineMissingPrivilegesResponse;
     entityEnginePrivileges: EntityAnalyticsPrivileges | undefined;
+    leadGenerationPrivileges?: EntityAnalyticsPrivileges;
   }) => {
     const message = useMemo(() => {
       const indexPrivileges: MissingIndexPrivileges[] = [
         ...getRiskEngineMissingReadPrivileges(riskEngineReadPrivileges),
         ...getEntityStoreMissingReadPrivileges(entityEnginePrivileges),
+        ...getEntityStoreMissingReadPrivileges(leadGenerationPrivileges),
       ];
 
       if (indexPrivileges.length === 0) return null;
@@ -43,7 +46,7 @@ export const EntityAnalyticsReadPrivilegesCallout = React.memo(
           docs: [],
         }),
       };
-    }, [riskEngineReadPrivileges, entityEnginePrivileges]);
+    }, [riskEngineReadPrivileges, entityEnginePrivileges, leadGenerationPrivileges]);
 
     if (!message) return null;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.ts
@@ -11,12 +11,12 @@ import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useKibana } from '../../../../common/lib/kibana';
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
+import { useLeadGenerationPrivileges } from '../../../api/hooks/use_lead_generation_privileges';
 import { fromApiLead } from './types';
 import * as i18n from './translations';
 
 const HUNTING_LEADS_QUERY_KEY = 'hunting-leads';
 const LEAD_SCHEDULE_QUERY_KEY = 'lead-generation-status';
-const LEAD_GENERATION_PRIVILEGES_QUERY_KEY = 'lead-generation-privileges';
 
 const POLL_INTERVAL_MS = 2_000;
 const MAX_POLLS = 30;
@@ -43,7 +43,6 @@ export const useHuntingLeads = (connectorId: string, isEnabled: boolean = true) 
     fetchLeadGenerationStatus,
     enableLeadGeneration,
     disableLeadGeneration,
-    fetchLeadGenerationPrivileges,
   } = useEntityAnalyticsRoutes();
   const queryClient = useQueryClient();
   const { addSuccess, addError, addWarning } = useAppToasts();
@@ -53,11 +52,7 @@ export const useHuntingLeads = (connectorId: string, isEnabled: boolean = true) 
   const [readPermissionError, setReadPermissionError] = useState(false);
   const [writePermissionError, setWritePermissionError] = useState(false);
 
-  const { data: privileges } = useQuery({
-    queryKey: [LEAD_GENERATION_PRIVILEGES_QUERY_KEY],
-    queryFn: fetchLeadGenerationPrivileges,
-    enabled: isEnabled,
-  });
+  const { data: privileges } = useLeadGenerationPrivileges(isEnabled);
 
   const proactiveReadPermissionError =
     isEnabled && privileges != null && !privileges.has_read_permissions;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
@@ -16,6 +16,8 @@ import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { useEntityStoreStatus } from '../components/entity_store/hooks/use_entity_store';
 import { useMissingRiskEnginePrivileges } from '../hooks/use_missing_risk_engine_privileges';
 import { useEntityEnginePrivileges } from '../components/entity_store/hooks/use_entity_engine_privileges';
+import { useLeadGenerationPrivileges } from '../api/hooks/use_lead_generation_privileges';
+import { useHuntingLeads } from '../components/threat_hunting/top_threat_hunting_leads/use_hunting_leads';
 
 jest.mock('../../common/components/links/link_props', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -57,6 +59,8 @@ jest.mock('../../common/hooks/use_experimental_features', () => ({
     return false;
   }),
 }));
+
+jest.mock('../../common/hooks/use_license');
 
 jest.mock('../../data_view_manager/hooks/use_data_view', () => ({
   useDataView: jest.fn(() => ({
@@ -133,6 +137,48 @@ jest.mock('../components/entity_store/hooks/use_entity_engine_privileges', () =>
   })),
 }));
 
+jest.mock('../api/hooks/use_lead_generation_privileges', () => ({
+  useLeadGenerationPrivileges: jest.fn(() => ({
+    isLoading: false,
+    data: undefined,
+  })),
+}));
+
+jest.mock('../components/threat_hunting/top_threat_hunting_leads/use_hunting_leads', () => ({
+  useHuntingLeads: jest.fn(() => ({
+    leads: [],
+    totalCount: 0,
+    isLoading: false,
+    isGenerating: false,
+    hasGenerated: false,
+    lastRunTimestamp: null,
+    generate: jest.fn(),
+    refetch: jest.fn(),
+    isScheduled: false,
+    toggleSchedule: jest.fn(),
+    readPermissionError: false,
+    writePermissionError: false,
+  })),
+}));
+
+jest.mock('../components/threat_hunting/top_threat_hunting_leads/use_lead_attachment', () => ({
+  useLeadAttachment: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../components/threat_hunting/top_threat_hunting_leads', () => ({
+  TopThreatHuntingLeads: () => (
+    <div data-test-subj="top-threat-hunting-leads">{'Top Threat Hunting Leads'}</div>
+  ),
+}));
+
+jest.mock('../../onboarding/components/hooks/use_stored_state', () => ({
+  useStoredAssistantConnectorId: jest.fn(() => ['', jest.fn()]),
+}));
+
+jest.mock('../../agent_builder/hooks/use_agent_builder_availability', () => ({
+  useAgentBuilderAvailability: jest.fn(() => ({ isAgentChatExperienceEnabled: false })),
+}));
+
 // useEntityURLState is already mocked inside the entities_table mock above
 
 jest.mock('../../common/hooks/use_space_id', () => ({
@@ -151,6 +197,8 @@ const mockUseDataView = useDataView as jest.Mock;
 const mockUseEntityStoreStatus = useEntityStoreStatus as jest.Mock;
 const mockUseMissingRiskEnginePrivileges = useMissingRiskEnginePrivileges as jest.Mock;
 const mockUseEntityEnginePrivileges = useEntityEnginePrivileges as jest.Mock;
+const mockUseLeadGenerationPrivileges = useLeadGenerationPrivileges as jest.Mock;
+const mockUseHuntingLeads = useHuntingLeads as jest.Mock;
 
 describe('EntityAnalyticsHomePage', () => {
   beforeEach(() => {
@@ -187,6 +235,26 @@ describe('EntityAnalyticsHomePage', () => {
         has_read_permissions: true,
         privileges: { elasticsearch: { index: {} }, kibana: [] },
       },
+    });
+
+    mockUseLeadGenerationPrivileges.mockReturnValue({
+      isLoading: false,
+      data: undefined,
+    });
+
+    mockUseHuntingLeads.mockReturnValue({
+      leads: [],
+      totalCount: 0,
+      isLoading: false,
+      isGenerating: false,
+      hasGenerated: false,
+      lastRunTimestamp: null,
+      generate: jest.fn(),
+      refetch: jest.fn(),
+      isScheduled: false,
+      toggleSchedule: jest.fn(),
+      readPermissionError: false,
+      writePermissionError: false,
     });
   });
 
@@ -454,6 +522,52 @@ describe('EntityAnalyticsHomePage', () => {
     expect(screen.getByTestId('entityAnalyticsHomePage')).toBeInTheDocument();
   });
 
+  it('shows privileges callout and hides leads section when lead generation read access is missing', () => {
+    const leadsIndex = '.entity_analytics.entity-leads-*';
+    mockUseIsExperimentalFeatureEnabled.mockImplementation((flag: string) => {
+      if (flag === 'leadGenerationEnabled') return true;
+      if (flag === 'newDataViewPickerEnabled') return false;
+      return false;
+    });
+    mockUseLeadGenerationPrivileges.mockReturnValue({
+      isLoading: false,
+      data: {
+        has_all_required: false,
+        has_read_permissions: false,
+        privileges: {
+          elasticsearch: {
+            index: { [leadsIndex]: { read: false, view_index_metadata: true } },
+          },
+        },
+      },
+    });
+    mockUseHuntingLeads.mockReturnValue({
+      leads: [],
+      totalCount: 0,
+      isLoading: false,
+      isGenerating: false,
+      hasGenerated: false,
+      lastRunTimestamp: null,
+      generate: jest.fn(),
+      refetch: jest.fn(),
+      isScheduled: false,
+      toggleSchedule: jest.fn(),
+      readPermissionError: true,
+      writePermissionError: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
+    );
+
+    expect(screen.getByText('Insufficient privileges')).toBeInTheDocument();
+    expect(screen.getByText(leadsIndex)).toBeInTheDocument();
+    expect(screen.queryByTestId('top-threat-hunting-leads')).not.toBeInTheDocument();
+  });
+
   it('renders Privileges Callout when user lacks risk engine read permissions', () => {
     mockUseMissingRiskEnginePrivileges.mockReturnValue({
       isLoading: false,
@@ -501,5 +615,31 @@ describe('EntityAnalyticsHomePage', () => {
 
     expect(screen.queryByTestId('entityStoreDisabledEmptyPrompt')).not.toBeInTheDocument();
     expect(screen.queryByTestId('entity-analytics-home-entities-table')).not.toBeInTheDocument();
+  });
+
+  it('renders leads section without callout when lead generation privileges are present', () => {
+    mockUseIsExperimentalFeatureEnabled.mockImplementation((flag: string) => {
+      if (flag === 'leadGenerationEnabled') return true;
+      if (flag === 'newDataViewPickerEnabled') return false;
+      return false;
+    });
+    mockUseLeadGenerationPrivileges.mockReturnValue({
+      isLoading: false,
+      data: {
+        has_all_required: true,
+        has_read_permissions: true,
+        privileges: { elasticsearch: { index: {} } },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
+    );
+
+    expect(screen.queryByText('Insufficient privileges')).not.toBeInTheDocument();
+    expect(screen.getByTestId('top-threat-hunting-leads')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -63,6 +63,7 @@ import type { HuntingLead } from '../components/threat_hunting/top_threat_huntin
 import { useMissingRiskEnginePrivileges } from '../hooks/use_missing_risk_engine_privileges';
 import { useEntityEnginePrivileges } from '../components/entity_store/hooks/use_entity_engine_privileges';
 import { EntityAnalyticsReadPrivilegesCallout } from '../components/entity_analytics_read_privileges_callout';
+import { useLeadGenerationPrivileges } from '../api/hooks/use_lead_generation_privileges';
 import { NoPrivileges } from '../../common/components/no_privileges';
 
 const PAGE_TITLE = i18n.translate('xpack.securitySolution.entityAnalytics.homePage.pageTitle', {
@@ -88,6 +89,10 @@ const anomaliesPanelFlexItemStyle = css`
 export const EntityAnalyticsHomePage = () => {
   const riskEngineReadPrivileges = useMissingRiskEnginePrivileges({ readonly: true });
   const entityEnginePrivilegesQuery = useEntityEnginePrivileges();
+  const isEnterprise = useLicense().isEnterprise();
+  const leadGenerationEnabled =
+    useIsExperimentalFeatureEnabled('leadGenerationEnabled') && isEnterprise;
+  const leadGenerationPrivilegesQuery = useLeadGenerationPrivileges(leadGenerationEnabled);
 
   if (entityEnginePrivilegesQuery.isLoading || riskEngineReadPrivileges.isLoading) {
     return <PageLoader />;
@@ -101,6 +106,7 @@ export const EntityAnalyticsHomePage = () => {
       <EntityAnalyticsReadPrivilegesCallout
         riskEngineReadPrivileges={riskEngineReadPrivileges}
         entityEnginePrivileges={entityEnginePrivilegesQuery.data}
+        leadGenerationPrivileges={leadGenerationPrivilegesQuery.data}
       />
       <SecuritySolutionPageWrapper data-test-subj="entityAnalyticsHomePage">
         {noPrivileges ? (


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/security-team/issues/17408

When a user lacks \`read\` access to the leads index (\`.entity_analytics.entity-leads-*\`), the Top Threat Hunting Leads section was silently hidden with no user-facing explanation. This PR folds missing leads-index read privileges into the existing unified \`EntityAnalyticsReadPrivilegesCallout\` at the top of the Entity Analytics home page.

- Extracts a shared \`useLeadGenerationPrivileges\` hook from the inline \`useQuery\` in \`useHuntingLeads\` — the same React Query \`queryKey\` ensures both call sites share a single network request via deduplication
- Extends \`EntityAnalyticsReadPrivilegesCallout\` with an optional \`leadGenerationPrivileges\` prop, merging missing-read entries into the existing unified callout (no duplicate banners)
- Wires \`useLeadGenerationPrivileges\` in \`EntityAnalyticsHomePage\`, gated on \`leadGenerationEnabled\`, and passes data to the callout
- Section-hiding behavior is unchanged: Top Threat Hunting Leads stays hidden when \`leadsReadPermissionError=true\`

## Test plan

- [ ] With the \`leadGenerationEnabled\` feature flag enabled, as a user missing \`read\` on \`.entity_analytics.entity-leads-*\`: the unified "Insufficient privileges" callout lists the leads index; the Top Threat Hunting Leads section is hidden
- [ ] As a user with full privileges: no callout from the leads index; the section renders normally
- [ ] As a user missing both risk-engine and leads read privileges: a single combined callout (not two separate banners)

## Manual testing steps

**Prerequisites**
- Kibana running locally with \`leadGenerationEnabled: true\` in \`kibana.dev.yml\` (or xpack.securitySolution.enableExperimental: ['leadGenerationEnabled'])
- Entity Store initialized (Security -> Entity Analytics -> Manage Entity Store -> Start)
- An Enterprise license (dev license or trial)

**Scenario 1 — Full privileges (baseline)**
1. Log in as a user with full privileges (e.g. built-in \`elastic\` superuser)
2. Navigate to **Security → Entity Analytics**
3. ✅ Expected: No "Insufficient privileges" callout; **Top Threat Hunting Leads** section is visible at the top of the page

**Scenario 2 — Missing leads \`read\` privilege**
1. Create a role that grants access to Security but is missing \`read\` on the \`.entity_analytics.entity-leads-*\` index pattern
2. Log in as a user with that role
3. Navigate to **Security → Entity Analytics**
4. ✅ Expected:
   - "Insufficient privileges" callout appears at the top of the page
   - Callout body lists: _Missing \`read\` privileges for the \`.entity_analytics.entity-leads-*\` index_
   - **Top Threat Hunting Leads** section is **not** rendered

**Scenario 3 — Missing both risk-engine and leads \`read\` privileges**
1. Use a role that is also missing \`read\` on \`risk-score.risk-score-*\`
2. Navigate to **Security → Entity Analytics**
3. ✅ Expected:
   - A **single** "Insufficient privileges" callout (not two separate banners)
   - Callout body lists both missing indices: \`risk-score.risk-score-*\` **and** \`.entity_analytics.entity-leads-*\`
   - **Top Threat Hunting Leads** section is **not** rendered

Screenshots taken against a locally-running Kibana with the `leadGenerationEnabled` feature flag enabled:

**Scenario 1 — Full privileges** (`01_full_privileges.png`)
Top Threat Hunting Leads section visible, no callout rendered.

**Scenario 2 — Missing leads `read` privilege** (`02_missing_leads_read_privileges.png`)
"Insufficient privileges" callout shown at top of page listing `.entity_analytics.entity-leads-*` index. Top Threat Hunting Leads section hidden.

**Scenario 3 — Missing both risk-engine and leads `read` privileges** (`03_missing_both_privileges.png`)
Single combined callout listing both `risk-score.risk-score-*` and `.entity_analytics.entity-leads-*`. Top Threat Hunting Leads section hidden. No duplicate banners.

Full privileges : 
<img width="1440" height="900" alt="01_full_privileges" src="https://github.com/user-attachments/assets/d71e53c6-ded4-40f5-9456-c3ad02e0d85d" />

Missing leads read privileges :
<img width="1440" height="900" alt="02_missing_leads_read_privileges" src="https://github.com/user-attachments/assets/e5885a9b-ce7f-48c8-927f-29551644f039" />

Missing both privileges : 
<img width="1440" height="900" alt="03_missing_both_privileges" src="https://github.com/user-attachments/assets/ce694049-30b1-45c6-8b80-659091468180" />