### PR TITLE
[Graph] update graph api and ftr test entities fixtures alias

### DIFF
--- a/x-pack/solutions/security/test/cloud_security_posture_api/es_archives/entity_store_v2/mappings.json
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/es_archives/entity_store_v2/mappings.json
@@ -2,7 +2,7 @@
   "type": "index",
   "value": {
     "aliases": {
-      "entities-generic-latest": {}
+      "entities-latest-default": {}
     },
     "index": ".entities.v2.latest.security_entities-space-00001",
     "settings": {

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/entity_store_v2/mappings.json
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/entity_store_v2/mappings.json
@@ -2,7 +2,7 @@
   "type": "index",
   "value": {
     "aliases": {
-      "entities-generic-latest": {}
+      "entities-latest-default": {}
     },
     "index": ".entities.v2.latest.security_default-00001",
     "settings": {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/271205

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Screenshots

before fix:

<img width="1551" height="926" alt="image" src="https://github.com/user-attachments/assets/b48164c4-9020-45aa-afc1-efcac2b98b77" />

after fix:

<img width="1557" height="928" alt="image" src="https://github.com/user-attachments/assets/633d7f4b-938b-4e71-bf3f-f0785229f1cd" />




