### PR TITLE
[CI] Allow infra-vault-gh-plugin-prod[bot] to trigger failed-test alert workflow

### DIFF
--- a/.github/workflows/alert-failed-test.yml
+++ b/.github/workflows/alert-failed-test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Alert on failed test
     if: |
       !github.event.issue.pull_request
-      && (github.event.comment.user.login == 'kibanamachine' || github.event.comment.user.login == 'elasticmachine')
+      && (github.event.comment.user.login == 'kibanamachine' || github.event.comment.user.login == 'elasticmachine' || github.event.comment.user.login == 'infra-vault-gh-plugin-prod[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout kibana-operations


### PR DESCRIPTION
## Summary

Around 2026-05-01, the team-pinging comment on new failing-test issues switched from `elasticmachine` to `infra-vault-gh-plugin-prod[bot]` (ephemeral tokens minted via Vault). The trigger filter in `alert-failed-test.yml` only matched the old identities, so the `failed-test-alert` script has not run on issue creation since then — no team has received a "new failure" Slack notification org-wide.

This adds the new bot identity to the allowlist. `failed-test-auto.js` (skip notifications) is unaffected and has been working throughout.

## Test plan

- [x] Local DEBUG run of `failed-test-alert.js` against a fresh failing-test issue (#271193) classifies as `new_failure` and would post to the correct team channel.
- [ ] After merge, observe a fresh failing-test issue and confirm the Slack ping fires.