### PR TITLE
[9.3] [Profiling] Fix profiling tests failing on polluted test lanes (#270623)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/playwright.config.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/playwright.config.ts
@@ -9,4 +9,5 @@ import { createPlaywrightConfig } from '@kbn/scout-oblt';
 
 export default createPlaywrightConfig({
   testDir: './tests',
+  runGlobalSetup: true,
 });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.setup.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mergeTests, globalSetupHook as obltGlobalSetupHook, tags } from '@kbn/scout-oblt';
+import { synthtraceFixture } from '@kbn/scout-synthtrace';
+
+const globalSetupHook = mergeTests(obltGlobalSetupHook, synthtraceFixture);
+
+globalSetupHook(
+  'Ingest data to Elasticsearch',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  async ({ log, apiServices }) => {
+    log.info('Running profiling API global setup...');
+    await apiServices.fleet.internal.setup();
+    log.info('Fleet infrastructure setup completed');
+  }
+);

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.teardown.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/global.teardown.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mergeTests, globalTeardownHook as obltGlobalTeardownHook, tags } from '@kbn/scout-oblt';
+import { apiTest as profilingFixtures } from '../../common/fixtures';
+
+const globalTeardownHook = mergeTests(obltGlobalTeardownHook, profilingFixtures);
+
+globalTeardownHook(
+  'Reset profiling state after API tests',
+  { tag: tags.stateful.classic },
+  async ({ profilingSetup, log, profilingHelper }) => {
+    log.info('Running profiling API global teardown...');
+
+    // Cleanup policies
+    await profilingHelper.cleanupPolicies({ includeAgentPolicy: true });
+
+    // Reset profiling ES resources (data streams + indices)
+    await profilingSetup.cleanup();
+
+    log.info('Profiling API global teardown complete');
+  }
+);

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
@@ -11,8 +11,7 @@ import { tags } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
-// Failing: See https://github.com/elastic/kibana/issues/253221
-apiTest.describe.skip(
+apiTest.describe(
   'APM integration not installed but setup completed',
   { tag: tags.stateful.classic },
   () => {

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts
@@ -11,85 +11,77 @@ import { tags } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
 
-// Failing: See https://github.com/elastic/kibana/issues/268025
-apiTest.describe.skip(
-  'Collector integration is not installed',
-  { tag: tags.stateful.classic },
-  () => {
-    let viewerApiCreditials: RoleApiCredentials;
-    apiTest.beforeAll(async ({ requestAuth, profilingSetup }) => {
-      await profilingSetup.cleanup();
-      viewerApiCreditials = await requestAuth.getApiKey('viewer');
+apiTest.describe('Collector integration is not installed', { tag: tags.stateful.classic }, () => {
+  let viewerApiCreditials: RoleApiCredentials;
+  apiTest.beforeAll(async ({ requestAuth, profilingSetup }) => {
+    await profilingSetup.cleanup();
+    viewerApiCreditials = await requestAuth.getApiKey('viewer');
+  });
+  apiTest.afterAll(async ({ profilingHelper }) => {
+    profilingHelper.cleanupPolicies();
+  });
+
+  apiTest('collector integration missing', async ({ profilingHelper, apiServices, apiClient }) => {
+    const ids = await profilingHelper.getPolicyIds();
+    const collectorId = ids.collectorId;
+
+    await apiServices.fleet.package_policies.delete(collectorId!);
+
+    expect(collectorId).toBeDefined();
+
+    const adminRes = await apiClient.get(esResourcesEndpoint);
+    const adminStatus = adminRes.body;
+    expect(adminStatus.has_setup).toBeUndefined();
+    expect(adminStatus.has_data).toBeUndefined();
+    expect(adminStatus.pre_8_9_1_data).toBeUndefined();
+
+    const readRes = await apiClient.get(esResourcesEndpoint, {
+      headers: {
+        ...viewerApiCreditials.apiKeyHeader,
+        'content-type': 'application/json',
+        'kbn-xsrf': 'reporting',
+      },
     });
-    apiTest.afterAll(async ({ profilingHelper }) => {
-      profilingHelper.cleanupPolicies();
-    });
+    const readStatus = readRes.body;
+    expect(readStatus.has_setup).toBe(false);
+    expect(readStatus.has_data).toBe(false);
+    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.has_required_role).toBe(false);
+  });
 
-    apiTest(
-      'collector integration missing',
-      async ({ profilingHelper, apiServices, apiClient }) => {
-        const ids = await profilingHelper.getPoliciyIds();
-        const collectorId = ids.collectorId;
+  apiTest(
+    'Symbolizer integration is not installed',
+    async ({ profilingHelper, apiClient, apiServices }) => {
+      const ids = await profilingHelper.getPolicyIds();
 
-        await apiServices.fleet.package_policies.delete(collectorId!);
+      const symbolizerId = ids.symbolizerId;
 
-        expect(collectorId).toBeDefined();
+      await apiServices.fleet.package_policies.delete(symbolizerId!);
 
-        const adminRes = await apiClient.get(esResourcesEndpoint);
-        const adminStatus = adminRes.body;
-        expect(adminStatus.has_setup).toBeUndefined();
-        expect(adminStatus.has_data).toBeUndefined();
-        expect(adminStatus.pre_8_9_1_data).toBeUndefined();
+      expect(symbolizerId).toBeDefined();
 
-        const readRes = await apiClient.get(esResourcesEndpoint, {
-          headers: {
-            ...viewerApiCreditials.apiKeyHeader,
-            'content-type': 'application/json',
-            'kbn-xsrf': 'reporting',
-          },
-        });
-        const readStatus = readRes.body;
-        expect(readStatus.has_setup).toBe(false);
-        expect(readStatus.has_data).toBe(false);
-        expect(readStatus.pre_8_9_1_data).toBe(false);
-        expect(readStatus.has_required_role).toBe(false);
-      }
-    );
+      const adminRes = await apiClient.get(esResourcesEndpoint, {
+        headers: {
+          ...viewerApiCreditials.apiKeyHeader,
+          'content-type': 'application/json',
+          'kbn-xsrf': 'reporting',
+        },
+      });
+      const adminStatus = adminRes.body;
+      expect(adminStatus.has_setup).toBe(false);
+      expect(adminStatus.has_data).toBe(false);
+      expect(adminStatus.pre_8_9_1_data).toBe(false);
 
-    apiTest(
-      'Symbolizer integration is not installed',
-      async ({ profilingHelper, apiClient, apiServices }) => {
-        const ids = await profilingHelper.getPoliciyIds();
-
-        const symbolizerId = ids.symbolizerId;
-
-        await apiServices.fleet.package_policies.delete(symbolizerId!);
-
-        expect(symbolizerId).toBeDefined();
-
-        const adminRes = await apiClient.get(esResourcesEndpoint, {
-          headers: {
-            ...viewerApiCreditials.apiKeyHeader,
-            'content-type': 'application/json',
-            'kbn-xsrf': 'reporting',
-          },
-        });
-        const adminStatus = adminRes.body;
-        expect(adminStatus.has_setup).toBe(false);
-        expect(adminStatus.has_data).toBe(false);
-        expect(adminStatus.pre_8_9_1_data).toBe(false);
-
-        const readRes = await apiClient.get(esResourcesEndpoint, {
-          headers: {
-            ...viewerApiCreditials.apiKeyHeader,
-          },
-        });
-        const readStatus = readRes.body;
-        expect(readStatus.has_setup).toBe(false);
-        expect(readStatus.has_data).toBe(false);
-        expect(readStatus.pre_8_9_1_data).toBe(false);
-        expect(readStatus.has_required_role).toBe(false);
-      }
-    );
-  }
-);
+      const readRes = await apiClient.get(esResourcesEndpoint, {
+        headers: {
+          ...viewerApiCreditials.apiKeyHeader,
+        },
+      });
+      const readStatus = readRes.body;
+      expect(readStatus.has_setup).toBe(false);
+      expect(readStatus.has_data).toBe(false);
+      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_required_role).toBe(false);
+    }
+  );
+});

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/common/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/common/fixtures/index.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import type { AgentPolicy, PackagePolicy } from '@kbn/fleet-plugin/common';
 import { apiTest as base } from '@kbn/scout-oblt';
 import { COLLECTOR_PACKAGE_POLICY_NAME, SYMBOLIZER_PACKAGE_POLICY_NAME } from './constants';
 
 export interface ProfilingHelper {
   installPolicies: () => Promise<void>;
-  cleanupPolicies: () => Promise<void>;
-  getPoliciyIds: () => Promise<{ collectorId?: string; symbolizerId?: string }>;
+  cleanupPolicies: (opts?: { includeAgentPolicy?: boolean }) => Promise<void>;
+  getPolicyIds: () => Promise<{ collectorId?: string; symbolizerId?: string }>;
 }
 
 const APM_AGENT_POLICY_ID = 'policy-elastic-agent-on-cloud';
@@ -24,10 +24,10 @@ export const apiTest = base.extend<{}, { profilingHelper: ProfilingHelper }>({
         log.info('Checking if APM agent policy exists, creating if needed...');
         const getPolicyResponse = await apiServices.fleet.agent_policies.get({
           page: 1,
-          perPage: 10,
+          perPage: 1000,
         });
         const apmPolicyData = getPolicyResponse.data.items.find(
-          (policy: { id: string }) => policy.id === 'policy-elastic-agent-on-cloud'
+          (policy: { id: string }) => policy.id === APM_AGENT_POLICY_ID
         );
 
         if (!apmPolicyData) {
@@ -45,28 +45,51 @@ export const apiTest = base.extend<{}, { profilingHelper: ProfilingHelper }>({
           log.info(`APM agent policy '${APM_AGENT_POLICY_ID}' already exists`);
         }
       };
-      const cleanupPolicies = async (): Promise<void> => {
+
+      const cleanupPolicies = async (
+        opts: { includeAgentPolicy?: boolean } = {}
+      ): Promise<void> => {
+        const { includeAgentPolicy = false } = opts;
         log.info('Cleaning up profiling resources...');
 
-        const res = await apiServices.fleet.package_policies.get();
-        const policies: PackagePolicy[] = res.data.items;
+        const res = await apiServices.fleet.package_policies.get({ perPage: 1000 });
+        const packagePolicies: PackagePolicy[] = res.data.items;
 
-        const collectorId = policies.find(
-          (item) => item.name === 'elastic-universal-profiling-collector'
+        const collectorId = packagePolicies.find(
+          (item) => item.name === COLLECTOR_PACKAGE_POLICY_NAME
         )?.id;
-        const symbolizerId = policies.find(
-          (item) => item.name === 'elastic-universal-profiling-symbolizer'
+        const symbolizerId = packagePolicies.find(
+          (item) => item.name === SYMBOLIZER_PACKAGE_POLICY_NAME
         )?.id;
+
+        let apmPolicyPromise = Promise.resolve();
+        if (includeAgentPolicy) {
+          const getPolicyResponse = await apiServices.fleet.agent_policies.get({
+            page: 1,
+            perPage: 1000,
+          });
+          const agentPolicies: AgentPolicy[] = getPolicyResponse.data.items;
+          const apmId = agentPolicies.find(
+            (policy: { id: string }) => policy.id === APM_AGENT_POLICY_ID
+          )?.id;
+
+          if (apmId) {
+            apmPolicyPromise = apiServices.fleet.agent_policies.delete(apmId);
+          }
+        }
 
         await Promise.all([
           collectorId ? apiServices.fleet.package_policies.delete(collectorId) : Promise.resolve(),
           symbolizerId
             ? apiServices.fleet.package_policies.delete(symbolizerId)
             : Promise.resolve(),
+          apmPolicyPromise,
         ]);
+
+        log.info('Profiling resources cleaned up');
       };
 
-      const getPoliciyIds = async (): Promise<{ collectorId?: string; symbolizerId?: string }> => {
+      const getPolicyIds = async (): Promise<{ collectorId?: string; symbolizerId?: string }> => {
         const res = await apiServices.fleet.package_policies.get();
         const policies: PackagePolicy[] = res.data.items;
 
@@ -81,7 +104,7 @@ export const apiTest = base.extend<{}, { profilingHelper: ProfilingHelper }>({
       await use({
         installPolicies,
         cleanupPolicies,
-        getPoliciyIds,
+        getPolicyIds,
       });
     },
     { scope: 'worker' },

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/tsconfig.json
@@ -10,6 +10,7 @@
     "@kbn/scout-oblt",
     "@kbn/fleet-plugin",
     "@kbn/observability-plugin",
+    "@kbn/scout-synthtrace",
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Profiling] Fix profiling tests failing on polluted test lanes (#270623)](https://github.com/elastic/kibana/pull/270623)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-05-25T11:04:02Z","message":"[Profiling] Fix profiling tests failing on polluted test lanes (#270623)\n\n## Summary\n\n### The Problem\n\nThe profiling API tests fail with `Saved object\n[fleet-agent-policies/policy-elastic-agent-on-cloud] not found` when run\nin a lane where earlier test suites have deleted Fleet's global settings\nobject from Elasticsearch.\n\nThe root cause is a Fleet internal mechanism called\n`isSpaceAwarenessEnabled()`. Every Fleet API call (creating an agent\npolicy, listing package policies) invokes this function to decide which\nsaved object type to use: either `fleet-agent-policies` (the modern,\nspace-aware type) or the legacy `ingest-agent-policies`. The decision\nreads the `ingest_manager_settings` saved object, which has namespace\ntype `agnostic` — meaning it lives in a single shared ES document\nvisible from any Kibana space.\n\nWhen `ingest_manager_settings` does not exist,\n`isSpaceAwarenessEnabled()` returns `false`, causing Fleet to use the\nlegacy `ingest-agent-policies` SO type. When `ingest_manager_settings`\nexists and carries `use_space_awareness_migration_status: 'success'`,\nFleet uses `fleet-agent-policies`. These two types are distinct\nElasticsearch documents — there is no fallback lookup, no aliasing, and\nno migration between them at query time.\n\nThe profiling `beforeAll` hook calls `installPolicies()` followed by\n`setupResources()`. If `ingest_manager_settings` is absent when\n`installPolicies()` runs, it creates the agent policy as\n`ingest-agent-policies:policy-elastic-agent-on-cloud`. Then, deep inside\nthe `setupResources()` call chain, `packagePolicyClient.create()`\ntriggers Fleet's `settingsSetup`, which catches the 404 for\n`ingest_manager_settings` and recreates it with\n`use_space_awareness_migration_status: 'success'`. From this point\nforward, `isSpaceAwarenessEnabled()` returns `true` — but the agent\npolicy already exists under the wrong type. When `setupResources()`\nsubsequently calls `agentPolicyService.get(soClient,\n'policy-elastic-agent-on-cloud')`, Fleet looks for a\n`fleet-agent-policies` document that was never created, and throws the\nnot-found error.\n\n### How It Is Triggered in Polluted Lanes\n\nAny test suite that calls `kbnClient.savedObjects.cleanStandardList()`\nagainst the default Kibana space will delete `ingest_manager_settings`\nfrom Elasticsearch. Because `ingest_manager_settings` is an `agnostic`\ntype, it is stored without a namespace prefix in `.kibana` and is\naccessible from every space — which means deleting it from the default\nspace removes the only copy. The deletion takes effect immediately;\nthere is no cross-request cache for `isSpaceAwarenessEnabled()` (it uses\n`AsyncLocalStorage`, which scopes to a single HTTP request lifetime and\nis empty at the start of every new request).\n\nIn CI lanes, multiple test configs run sequentially against the same\nKibana instance. If the profiling suite follows any suite that performs\nthis cleanup, the `ingest_manager_settings` object is gone by the time\n`installPolicies()` executes.\n\n### The Fix: Calling `fleet.internal.setup()` Before `installPolicies()`\n\n`apiServices.fleet.internal.setup()` issues `POST /api/fleet/setup`,\nwhich calls Fleet's `settingsSetup` server-side. That function checks\nwhether `ingest_manager_settings` exists and, if it does not (404),\ncreates it from `createDefaultSettings()` — which, when the\n`useSpaceAwareness` experimental feature is enabled, sets\n`use_space_awareness_migration_status: 'success'`. After this call\nreturns, `ingest_manager_settings` is guaranteed to be present with the\ncorrect migration status.\n\nPlacing `await apiServices.fleet.internal.setup()` in the profiling\nglobal setup hook (`global.setup.ts`) will ensure fleet is properly\nconfigured before running any `installPolicies()` calls within the\nsuite. This makes sure there is no window where the SO type can flip\nbetween the two calls. Both `installPolicies()` and `setupResources()`\nthen agree on the same type.\n\nThis is also safe to call repeatedly: if `ingest_manager_settings`\nalready exists (the happy path in isolation), `settingsSetup` is a no-op\nand returns immediately. The call adds no observable overhead or issues\nin clean environments.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n### References\n\nCloses https://github.com/elastic/kibana/issues/268025\nCloses https://github.com/elastic/kibana/issues/253221\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2486bdf91a9d2571cec1a4c54e316495e87ddcf5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","v9.4.0","Team:obs-presentation","v9.5.0"],"title":"[Profiling] Fix profiling tests failing on polluted test lanes","number":270623,"url":"https://github.com/elastic/kibana/pull/270623","mergeCommit":{"message":"[Profiling] Fix profiling tests failing on polluted test lanes (#270623)\n\n## Summary\n\n### The Problem\n\nThe profiling API tests fail with `Saved object\n[fleet-agent-policies/policy-elastic-agent-on-cloud] not found` when run\nin a lane where earlier test suites have deleted Fleet's global settings\nobject from Elasticsearch.\n\nThe root cause is a Fleet internal mechanism called\n`isSpaceAwarenessEnabled()`. Every Fleet API call (creating an agent\npolicy, listing package policies) invokes this function to decide which\nsaved object type to use: either `fleet-agent-policies` (the modern,\nspace-aware type) or the legacy `ingest-agent-policies`. The decision\nreads the `ingest_manager_settings` saved object, which has namespace\ntype `agnostic` — meaning it lives in a single shared ES document\nvisible from any Kibana space.\n\nWhen `ingest_manager_settings` does not exist,\n`isSpaceAwarenessEnabled()` returns `false`, causing Fleet to use the\nlegacy `ingest-agent-policies` SO type. When `ingest_manager_settings`\nexists and carries `use_space_awareness_migration_status: 'success'`,\nFleet uses `fleet-agent-policies`. These two types are distinct\nElasticsearch documents — there is no fallback lookup, no aliasing, and\nno migration between them at query time.\n\nThe profiling `beforeAll` hook calls `installPolicies()` followed by\n`setupResources()`. If `ingest_manager_settings` is absent when\n`installPolicies()` runs, it creates the agent policy as\n`ingest-agent-policies:policy-elastic-agent-on-cloud`. Then, deep inside\nthe `setupResources()` call chain, `packagePolicyClient.create()`\ntriggers Fleet's `settingsSetup`, which catches the 404 for\n`ingest_manager_settings` and recreates it with\n`use_space_awareness_migration_status: 'success'`. From this point\nforward, `isSpaceAwarenessEnabled()` returns `true` — but the agent\npolicy already exists under the wrong type. When `setupResources()`\nsubsequently calls `agentPolicyService.get(soClient,\n'policy-elastic-agent-on-cloud')`, Fleet looks for a\n`fleet-agent-policies` document that was never created, and throws the\nnot-found error.\n\n### How It Is Triggered in Polluted Lanes\n\nAny test suite that calls `kbnClient.savedObjects.cleanStandardList()`\nagainst the default Kibana space will delete `ingest_manager_settings`\nfrom Elasticsearch. Because `ingest_manager_settings` is an `agnostic`\ntype, it is stored without a namespace prefix in `.kibana` and is\naccessible from every space — which means deleting it from the default\nspace removes the only copy. The deletion takes effect immediately;\nthere is no cross-request cache for `isSpaceAwarenessEnabled()` (it uses\n`AsyncLocalStorage`, which scopes to a single HTTP request lifetime and\nis empty at the start of every new request).\n\nIn CI lanes, multiple test configs run sequentially against the same\nKibana instance. If the profiling suite follows any suite that performs\nthis cleanup, the `ingest_manager_settings` object is gone by the time\n`installPolicies()` executes.\n\n### The Fix: Calling `fleet.internal.setup()` Before `installPolicies()`\n\n`apiServices.fleet.internal.setup()` issues `POST /api/fleet/setup`,\nwhich calls Fleet's `settingsSetup` server-side. That function checks\nwhether `ingest_manager_settings` exists and, if it does not (404),\ncreates it from `createDefaultSettings()` — which, when the\n`useSpaceAwareness` experimental feature is enabled, sets\n`use_space_awareness_migration_status: 'success'`. After this call\nreturns, `ingest_manager_settings` is guaranteed to be present with the\ncorrect migration status.\n\nPlacing `await apiServices.fleet.internal.setup()` in the profiling\nglobal setup hook (`global.setup.ts`) will ensure fleet is properly\nconfigured before running any `installPolicies()` calls within the\nsuite. This makes sure there is no window where the SO type can flip\nbetween the two calls. Both `installPolicies()` and `setupResources()`\nthen agree on the same type.\n\nThis is also safe to call repeatedly: if `ingest_manager_settings`\nalready exists (the happy path in isolation), `settingsSetup` is a no-op\nand returns immediately. The call adds no observable overhead or issues\nin clean environments.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n### References\n\nCloses https://github.com/elastic/kibana/issues/268025\nCloses https://github.com/elastic/kibana/issues/253221\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2486bdf91a9d2571cec1a4c54e316495e87ddcf5"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270623","number":270623,"mergeCommit":{"message":"[Profiling] Fix profiling tests failing on polluted test lanes (#270623)\n\n## Summary\n\n### The Problem\n\nThe profiling API tests fail with `Saved object\n[fleet-agent-policies/policy-elastic-agent-on-cloud] not found` when run\nin a lane where earlier test suites have deleted Fleet's global settings\nobject from Elasticsearch.\n\nThe root cause is a Fleet internal mechanism called\n`isSpaceAwarenessEnabled()`. Every Fleet API call (creating an agent\npolicy, listing package policies) invokes this function to decide which\nsaved object type to use: either `fleet-agent-policies` (the modern,\nspace-aware type) or the legacy `ingest-agent-policies`. The decision\nreads the `ingest_manager_settings` saved object, which has namespace\ntype `agnostic` — meaning it lives in a single shared ES document\nvisible from any Kibana space.\n\nWhen `ingest_manager_settings` does not exist,\n`isSpaceAwarenessEnabled()` returns `false`, causing Fleet to use the\nlegacy `ingest-agent-policies` SO type. When `ingest_manager_settings`\nexists and carries `use_space_awareness_migration_status: 'success'`,\nFleet uses `fleet-agent-policies`. These two types are distinct\nElasticsearch documents — there is no fallback lookup, no aliasing, and\nno migration between them at query time.\n\nThe profiling `beforeAll` hook calls `installPolicies()` followed by\n`setupResources()`. If `ingest_manager_settings` is absent when\n`installPolicies()` runs, it creates the agent policy as\n`ingest-agent-policies:policy-elastic-agent-on-cloud`. Then, deep inside\nthe `setupResources()` call chain, `packagePolicyClient.create()`\ntriggers Fleet's `settingsSetup`, which catches the 404 for\n`ingest_manager_settings` and recreates it with\n`use_space_awareness_migration_status: 'success'`. From this point\nforward, `isSpaceAwarenessEnabled()` returns `true` — but the agent\npolicy already exists under the wrong type. When `setupResources()`\nsubsequently calls `agentPolicyService.get(soClient,\n'policy-elastic-agent-on-cloud')`, Fleet looks for a\n`fleet-agent-policies` document that was never created, and throws the\nnot-found error.\n\n### How It Is Triggered in Polluted Lanes\n\nAny test suite that calls `kbnClient.savedObjects.cleanStandardList()`\nagainst the default Kibana space will delete `ingest_manager_settings`\nfrom Elasticsearch. Because `ingest_manager_settings` is an `agnostic`\ntype, it is stored without a namespace prefix in `.kibana` and is\naccessible from every space — which means deleting it from the default\nspace removes the only copy. The deletion takes effect immediately;\nthere is no cross-request cache for `isSpaceAwarenessEnabled()` (it uses\n`AsyncLocalStorage`, which scopes to a single HTTP request lifetime and\nis empty at the start of every new request).\n\nIn CI lanes, multiple test configs run sequentially against the same\nKibana instance. If the profiling suite follows any suite that performs\nthis cleanup, the `ingest_manager_settings` object is gone by the time\n`installPolicies()` executes.\n\n### The Fix: Calling `fleet.internal.setup()` Before `installPolicies()`\n\n`apiServices.fleet.internal.setup()` issues `POST /api/fleet/setup`,\nwhich calls Fleet's `settingsSetup` server-side. That function checks\nwhether `ingest_manager_settings` exists and, if it does not (404),\ncreates it from `createDefaultSettings()` — which, when the\n`useSpaceAwareness` experimental feature is enabled, sets\n`use_space_awareness_migration_status: 'success'`. After this call\nreturns, `ingest_manager_settings` is guaranteed to be present with the\ncorrect migration status.\n\nPlacing `await apiServices.fleet.internal.setup()` in the profiling\nglobal setup hook (`global.setup.ts`) will ensure fleet is properly\nconfigured before running any `installPolicies()` calls within the\nsuite. This makes sure there is no window where the SO type can flip\nbetween the two calls. Both `installPolicies()` and `setupResources()`\nthen agree on the same type.\n\nThis is also safe to call repeatedly: if `ingest_manager_settings`\nalready exists (the happy path in isolation), `settingsSetup` is a no-op\nand returns immediately. The call adds no observable overhead or issues\nin clean environments.\n\n### Checklist\n\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n### References\n\nCloses https://github.com/elastic/kibana/issues/268025\nCloses https://github.com/elastic/kibana/issues/253221\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"2486bdf91a9d2571cec1a4c54e316495e87ddcf5"}}]}] BACKPORT-->