### PR TITLE
[9.4] [One Workflow][Scout] Fix live progress flush racing concurrency cancellation

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts
@@ -88,10 +88,10 @@ describe('handleExecutionDelay', () => {
     });
   });
 
-  describe('long wait (>= 5s) schedules TM resume task', () => {
-    it('flushes state before scheduling resume task', async () => {
+  describe('short wait (< 5s) in-process delay', () => {
+    it('flushes state during short waits for live progress', async () => {
       const params = makeParams();
-      const resumeAt = new Date(Date.now() + 8000).toISOString();
+      const resumeAt = new Date(Date.now() + 2000).toISOString();
       const stepRuntime = makeStepRuntime({
         stepExecution: {
           status: ExecutionStatus.WAITING,
@@ -99,13 +99,33 @@ describe('handleExecutionDelay', () => {
         } as any,
       });
 
-      await handleExecutionDelay(params, stepRuntime);
+      const delayPromise = handleExecutionDelay(params, stepRuntime);
+      await Promise.resolve();
+      stepRuntime.abortController.abort();
+      await delayPromise;
 
       expect(params.workflowExecutionState.flush).toHaveBeenCalled();
       expect(params.workflowLogger.flushEvents).toHaveBeenCalled();
-      expect(params.workflowTaskManager.scheduleResumeTask).toHaveBeenCalledTimes(1);
-      expect(params.workflowExecutionState.updateWorkflowExecution).toHaveBeenCalledWith({
-        status: ExecutionStatus.WAITING,
+      expect(params.workflowTaskManager.scheduleResumeTask).not.toHaveBeenCalled();
+    });
+
+    it('does not reset workflow status to RUNNING when delay is aborted', async () => {
+      const params = makeParams();
+      const resumeAt = new Date(Date.now() + 2000).toISOString();
+      const stepRuntime = makeStepRuntime({
+        stepExecution: {
+          status: ExecutionStatus.WAITING,
+          state: { resumeAt },
+        } as any,
+      });
+
+      const delayPromise = handleExecutionDelay(params, stepRuntime);
+      await Promise.resolve();
+      stepRuntime.abortController.abort();
+      await delayPromise;
+
+      expect(params.workflowExecutionState.updateWorkflowExecution).not.toHaveBeenCalledWith({
+        status: ExecutionStatus.RUNNING,
       });
     });
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.ts
@@ -45,20 +45,24 @@ export async function handleExecutionDelay(
   const resumeAt = new Date(resumeAtFromState);
   const now = new Date();
   const diff = resumeAt.getTime() - now.getTime();
-  await flushState(params);
-  params.workflowExecutionState.updateWorkflowExecution({
-    status: ExecutionStatus.WAITING,
-  });
   if (diff < SHORT_DURATION_THRESHOLD) {
+    // Flush while workflow is still RUNNING so the persistence loop stays active and
+    // cancellation is not racing a freshly-persisted WAITING workflow status.
+    await flushState(params);
+    params.workflowExecutionState.updateWorkflowExecution({
+      status: ExecutionStatus.WAITING,
+    });
     const timeout = diff > 0 ? diff : 0;
 
     try {
       await abortableTimeout(timeout, stepExecutionRuntime.abortController.signal);
     } catch (error) {
       if (error instanceof TimeoutAbortedError) {
-        // Delay was interrupted (e.g. by a timeout or cancellation).
-        // Reset status to RUNNING so the execution loop can continue
-        // after error handling (e.g. on-failure continue).
+        if (stepExecutionRuntime.abortController.signal.aborted) {
+          return;
+        }
+        // Delay was interrupted for other reasons (e.g. on-failure continue).
+        // Reset status to RUNNING so the execution loop can continue.
         params.workflowExecutionState.updateWorkflowExecution({
           status: ExecutionStatus.RUNNING,
         });
@@ -71,6 +75,9 @@ export async function handleExecutionDelay(
       status: ExecutionStatus.RUNNING,
     });
   } else {
+    params.workflowExecutionState.updateWorkflowExecution({
+      status: ExecutionStatus.WAITING,
+    });
     await params.workflowTaskManager.scheduleResumeTask({
       workflowExecution,
       resumeAt,


### PR DESCRIPTION
## Summary

Follow-up to [#270968](https://github.com/elastic/kibana/pull/270968) (backport of #270900). That change flushed workflow state before every timer wait, which made concurrency cancellation during `wait` steps reliably fail Scout (`cancelled`/`skipped` vs `failed`).

UX Regression as a result of the conflict: Workflow executions marked as failed instead of cancelled

This PR keeps live progress for short in-process waits while avoiding the race:

- Call `flushState()` only on the short wait path (`diff < 5s`), not before long waits that schedule a Task Manager resume task.
- Flush while the workflow is still `RUNNING`, then set `WAITING`, so the persistence loop is not stopped before cancellation can propagate.
- On `TimeoutAbortedError`, do not reset workflow status to `RUNNING` when the step abort signal was triggered by cancellation.

Fixes #257103

## Test plan

- [x] `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/handle_execution_delay.test.ts`
- [x] `node scripts/scout run-tests --arch stateful --domain classic --serverConfigSet workflows_ui --testFiles src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/api/tests/workflow_execution/concurrency_control.spec.ts`


Made with Cursor