### PR TITLE
[Saved Objects] Fix KQL filter to support root fields when type has matching field

### DIFF
--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/utils/filter_utils.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/utils/filter_utils.test.ts
@@ -33,6 +33,9 @@ const mockMappings = {
         bytes: {
           type: 'integer',
         },
+        updated_at: {
+          type: 'date',
+        },
       },
     },
     bar: {
@@ -279,6 +282,26 @@ describe('Filter Utils', () => {
         validateConvertFilterToKueryNode([], 'hiddentype.title: "title"', mockMappings);
       }).toThrowErrorMatchingInlineSnapshot(`"This type hiddentype is not allowed: Bad Request"`);
     });
+
+    test('Verify that foo.updated_at targets root field and foo.attributes.updated_at targets type field', () => {
+      // Test foo.updated_at (should target root updated_at field)
+      const rootFieldResult = validateConvertFilterToKueryNode(
+        ['foo'],
+        'foo.updated_at: 5678654567',
+        mockMappings
+      );
+      expect(rootFieldResult).toEqual(
+        esKuery.fromKueryExpression('(type: foo and updated_at: 5678654567)')
+      );
+
+      // Test foo.attributes.updated_at (should target type-specific updated_at field)
+      const typeFieldResult = validateConvertFilterToKueryNode(
+        ['foo'],
+        'foo.attributes.updated_at: 5678654567',
+        mockMappings
+      );
+      expect(typeFieldResult).toEqual(esKuery.fromKueryExpression('foo.updated_at: 5678654567'));
+    });
   });
 
   describe('#validateFilterKueryNode', () => {
@@ -295,42 +318,42 @@ describe('Filter Utils', () => {
         {
           astPath: 'arguments.0',
           error: null,
-          isSavedObjectAttr: true,
+          isRootField: true,
           key: 'foo.updated_at',
           type: 'foo',
         },
         {
           astPath: 'arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
         {
           astPath: 'arguments.2',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
         {
           astPath: 'arguments.3',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.title',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.0',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
@@ -350,7 +373,7 @@ describe('Filter Utils', () => {
         {
           astPath: 'arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'alert.attributes.actions.actionTypeId',
           type: 'alert',
         },
@@ -370,42 +393,42 @@ describe('Filter Utils', () => {
         {
           astPath: 'arguments.0',
           error: "This key 'updated_at' need to be wrapped by a saved object type like foo",
-          isSavedObjectAttr: true,
+          isRootField: true,
           key: 'updated_at',
           type: null,
         },
         {
           astPath: 'arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
         {
           astPath: 'arguments.2',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
         {
           astPath: 'arguments.3',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.title',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.0',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
@@ -425,14 +448,14 @@ describe('Filter Utils', () => {
         {
           astPath: 'arguments.0',
           error: null,
-          isSavedObjectAttr: true,
+          isRootField: true,
           key: 'foo.updated_at',
           type: 'foo',
         },
         {
           astPath: 'arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
@@ -440,21 +463,21 @@ describe('Filter Utils', () => {
           astPath: 'arguments.2',
           error:
             "This key 'foo.bytes' does NOT match the filter proposition SavedObjectType.attributes.key",
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.bytes',
           type: 'foo',
         },
         {
           astPath: 'arguments.3',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.title',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.0',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
@@ -462,7 +485,7 @@ describe('Filter Utils', () => {
           astPath: 'arguments.4.arguments.1',
           error:
             "This key 'foo.description' does NOT match the filter proposition SavedObjectType.attributes.key",
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.description',
           type: 'foo',
         },
@@ -482,42 +505,42 @@ describe('Filter Utils', () => {
         {
           astPath: 'arguments.0',
           error: 'This type bar is not allowed',
-          isSavedObjectAttr: true,
+          isRootField: true,
           key: 'bar.updated_at',
           type: 'bar',
         },
         {
           astPath: 'arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
         {
           astPath: 'arguments.2',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
         {
           astPath: 'arguments.3',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.title',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.0',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
@@ -537,21 +560,21 @@ describe('Filter Utils', () => {
         {
           astPath: 'arguments.0',
           error: "This key 'foo.updated_at33' does NOT exist in foo saved object index patterns",
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.updated_at33',
           type: 'foo',
         },
         {
           astPath: 'arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
         {
           astPath: 'arguments.2',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.bytes',
           type: 'foo',
         },
@@ -559,21 +582,21 @@ describe('Filter Utils', () => {
           astPath: 'arguments.3',
           error:
             "This key 'foo.attributes.header' does NOT exist in foo saved object index patterns",
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.header',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.0',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
         {
           astPath: 'arguments.4.arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
@@ -591,14 +614,14 @@ describe('Filter Utils', () => {
         {
           astPath: 'arguments.0',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'foo.attributes.description',
           type: 'foo',
         },
         {
           astPath: 'arguments.1',
           error: 'The key is empty and needs to be wrapped by a saved object type like foo',
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: null,
           type: null,
         },
@@ -618,14 +641,14 @@ describe('Filter Utils', () => {
         {
           astPath: 'arguments.1.arguments.0',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'alert.attributes.actions.actionTypeId',
           type: 'alert',
         },
         {
           astPath: 'arguments.1.arguments.1',
           error: null,
-          isSavedObjectAttr: false,
+          isRootField: false,
           key: 'alert.attributes.actions.actionRef',
           type: 'alert',
         },

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/utils/filter_utils.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/utils/filter_utils.ts
@@ -54,7 +54,7 @@ export const validateConvertFilterToKueryNode = (
       const path: string[] = item.astPath.length === 0 ? [] : item.astPath.split('.');
       const existingKueryNode: KueryNode =
         path.length === 0 ? filterKueryNode : get(filterKueryNode, path);
-      if (item.isSavedObjectAttr) {
+      if (item.isRootField) {
         const keySavedObjectAttr = existingKueryNode.arguments[0].value.split('.')[1];
         existingKueryNode.arguments[0].value =
           keySavedObjectAttr === 'id' ? '_id' : keySavedObjectAttr;
@@ -85,7 +85,7 @@ export const validateConvertFilterToKueryNode = (
 interface ValidateFilterKueryNode {
   astPath: string;
   error: string;
-  isSavedObjectAttr: boolean;
+  isRootField: boolean;
   key: string;
   type: string | null;
 }
@@ -148,7 +148,7 @@ export const validateFilterKueryNode = ({
             types,
             indexMapping
           ),
-          isSavedObjectAttr: isSavedObjectAttr(
+          isRootField: isRootField(
             nestedKeys != null ? `${nestedKeys}.${ast.value}` : ast.value,
             indexMapping
           ),
@@ -171,7 +171,7 @@ const getType = (key: string | undefined | null) =>
  * @param key
  * @param indexMapping
  */
-export const isSavedObjectAttr = (key: string | null | undefined, indexMapping: IndexMapping) => {
+export const isRootField = (key: string | null | undefined, indexMapping: IndexMapping) => {
   const keySplit = key != null ? key.split('.') : [];
   if (keySplit.length === 1 && fieldDefined(indexMapping, keySplit[0])) {
     return true;
@@ -200,7 +200,9 @@ export const hasFilterKeyError = (
       return `This type ${keySplit[0]} is not allowed`;
     }
     if (
-      (keySplit.length === 2 && fieldDefined(indexMapping, key)) ||
+      (keySplit.length === 2 &&
+        fieldDefined(indexMapping, key) &&
+        !isRootField(key, indexMapping)) ||
       (keySplit.length > 2 && keySplit[1] !== 'attributes')
     ) {
       return `This key '${key}' does NOT match the filter proposition SavedObjectType.attributes.key`;

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/utils/index.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/utils/index.ts
@@ -10,7 +10,7 @@
 export {
   fieldDefined,
   hasFilterKeyError,
-  isSavedObjectAttr,
+  isRootField,
   validateConvertFilterToKueryNode,
   validateFilterKueryNode,
 } from './filter_utils';


### PR DESCRIPTION
## Summary

Fixes #239704

When a saved object type defines a field with the same name as a root-level field (e.g. both root and type `foo` have `updated_at`), filtering on the root field via `foo.updated_at` is incorrectly rejected with:

> "This key 'foo.updated_at' does NOT match the filter proposition SavedObjectType.attributes.key"

### Root cause

`hasFilterKeyError` checks `fieldDefined(indexMapping, key)` where `key = "foo.updated_at"`. This resolves to `properties.foo.properties.updated_at`, which exists as a *type* attribute. The function assumes the user forgot `.attributes`, but the user is legitimately targeting the root field.

### Fix

When `keySplit.length === 2`, before rejecting, check whether the field is also a valid root field via `isRootField()`. If it is, allow it through — root fields take priority over type attributes in the `type.field` syntax.

Users who want the type attribute can still access it explicitly via `foo.attributes.updated_at`.

Also renames `isSavedObjectAttr` → `isRootField` for clarity, as suggested in the issue.

### Changes

- **`filter_utils.ts`**: Added `&& !isRootField(key, indexMapping)` guard to `hasFilterKeyError`; renamed `isSavedObjectAttr` → `isRootField` (function, interface field, all internal references)
- **`index.ts`**: Updated barrel export to reflect the rename
- **`filter_utils.test.ts`**: Added `updated_at` to `foo` type in `mockMappings` to create the collision scenario; added test verifying both root field access (`foo.updated_at`) and type attribute access (`foo.attributes.updated_at`) work correctly; renamed all assertion references

### Risk Matrix

Low risk. The change is narrowly scoped to filter validation logic. Root field access is only allowed when the field is confirmed to exist at the root level via `isRootField()`, so no new security surface is exposed. All existing tests continue to pass.

### Release note

Fixes KQL filter validation for saved objects to correctly support root-level fields (like `updated_at`) when a type attribute with the same name also exists.
