### PR TITLE
[APM] Fix SLO overview flyout details crash and alerts tab navigation

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/slo_overview_flyout/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/slo_overview_flyout/index.tsx
@@ -198,14 +198,17 @@ export function SloOverviewFlyout({ serviceName, agentName, onClose }: Props) {
     [activeAlerts]
   );
 
-  const handleActiveAlertsClick = useCallback((sloItem: SLOWithSummaryResponse) => {
-    setSelectedSlo(null);
-    setSelectedSloTabId(undefined);
+  const isSloExpanded = useCallback(
+    (sloItem: SLOWithSummaryResponse) =>
+      !!selectedSlo &&
+      selectedSlo.id === sloItem.id &&
+      selectedSlo.instanceId === sloItem.instanceId,
+    [selectedSlo]
+  );
 
-    requestAnimationFrame(() => {
-      setSelectedSlo(sloItem);
-      setSelectedSloTabId(ALERTS_TAB_ID);
-    });
+  const handleActiveAlertsClick = useCallback((sloItem: SLOWithSummaryResponse) => {
+    setSelectedSlo(sloItem);
+    setSelectedSloTabId(ALERTS_TAB_ID);
   }, []);
 
   const statusCounts = useMemo(() => {
@@ -273,24 +276,15 @@ export function SloOverviewFlyout({ serviceName, agentName, onClose }: Props) {
     setSearchQuery(e.target.value);
   }, []);
 
-  const isSloExpanded = useCallback(
-    (sloItem: SLOWithSummaryResponse) =>
-      !!selectedSlo &&
-      selectedSlo.id === sloItem.id &&
-      selectedSlo.instanceId === sloItem.instanceId,
-    [selectedSlo]
-  );
-
   const handleSloToggle = useCallback(
     (sloItem: SLOWithSummaryResponse) => {
-      setSelectedSlo(null);
-      setSelectedSloTabId(undefined);
       if (isSloExpanded(sloItem)) {
+        setSelectedSlo(null);
+        setSelectedSloTabId(undefined);
         return;
       }
-      requestAnimationFrame(() => {
-        setSelectedSlo(sloItem);
-      });
+      setSelectedSlo(sloItem);
+      setSelectedSloTabId(undefined);
     },
     [isSloExpanded]
   );
@@ -413,7 +407,10 @@ export function SloOverviewFlyout({ serviceName, agentName, onClose }: Props) {
               <EuiBadge
                 iconType="warning"
                 color="danger"
-                onClick={() => handleActiveAlertsClick(sloItem)}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleActiveAlertsClick(sloItem);
+                }}
                 onClickAriaLabel={i18n.translate(
                   'xpack.apm.sloOverviewFlyout.activeAlertsBadge.ariaLabel',
                   { defaultMessage: 'active alerts badge' }
@@ -737,6 +734,7 @@ export function SloOverviewFlyout({ serviceName, agentName, onClose }: Props) {
       </EuiFlyoutBody>
       {selectedSlo && sloPlugin?.getSLODetailsFlyout && (
         <sloPlugin.getSLODetailsFlyout
+          key={`${selectedSlo.id}-${selectedSlo.instanceId ?? ''}`}
           sloId={selectedSlo.id}
           sloInstanceId={selectedSlo.instanceId}
           onClose={handleCloseSloDetails}

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/common/slo_overview_details.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/common/slo_overview_details.tsx
@@ -45,6 +45,10 @@ export function SloOverviewDetailsContent({
   const { telemetry } = usePluginContext();
   const [selectedTabId, setSelectedTabId] = useState<SloTabId>(initialTabId);
 
+  useEffect(() => {
+    setSelectedTabId(initialTabId);
+  }, [initialTabId, slo.id, slo.instanceId]);
+
   const handleTabChange = useCallback(
     (tabId: SloTabId) => {
       setSelectedTabId(tabId);

--- a/x-pack/solutions/observability/plugins/slo/public/utils/get_lazy_with_context_providers.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/utils/get_lazy_with_context_providers.tsx
@@ -57,6 +57,23 @@ export const getLazyWithContextProviders =
   ): React.FunctionComponent<React.ComponentProps<TElement>> => {
     const { spinnerSize = 'xl' } = options ?? {};
     const queryClient = new QueryClient();
+    const unwrappingSloClient: SLORepositoryClient = {
+      fetch: (endpoint, ...args) =>
+        sloClient.fetch(endpoint, ...args).then((response) => {
+          if (response && typeof response === 'object') {
+            const resp = response as Record<string, unknown>;
+            if ('_wrapped' in resp && '_inspect' in resp) {
+              return resp._wrapped as typeof response;
+            }
+            if ('_inspect' in resp) {
+              const { _inspect, ...rest } = resp;
+              return rest as typeof response;
+            }
+          }
+          return response;
+        }),
+      stream: sloClient.stream,
+    };
     return (props) => (
       <KibanaContextProvider
         services={{
@@ -75,7 +92,7 @@ export const getLazyWithContextProviders =
             observabilityRuleTypeRegistry,
             ObservabilityPageTemplate,
             experimentalFeatures,
-            sloClient,
+            sloClient: unwrappingSloClient,
             telemetry,
           }}
         >


### PR DESCRIPTION
## Summary

Fixes two regressions in the APM service inventory SLO overview flyout opened from a service row.

### 1. SLO details flyout crash on expand

Opening the SLO details flyout via the expand icon crashed inside `HistoricalDataCharts` with a runtime error (`historicalSummaries.find is not a function`) introduced by https://github.com/elastic/kibana/pull/267332.

**Root cause:** The server-side route wrapper introduced for ES query inspect support wraps array responses (e.g. historical summary) as `{ _wrapped: T[], _inspect: ... }`. The main SLO app already unwraps this in `InspectedSloClientProvider`, but the lazy/embedded flyout path used by APM in `getLazyWithContextProviders` passed the raw `sloClient` straight through, so consumers received the envelope and crashed.

**Fix:** Apply the same inline unwrap that `InspectedSloClientProvider` already performs, in `getLazyWithContextProviders`, so embedded consumers see the unwrapped payload.

#### Before

https://github.com/user-attachments/assets/2925db33-7076-4472-9307-0ad303282d95


#### After

https://github.com/user-attachments/assets/d198c3c7-83f0-4e3e-a799-00f543c9ceda


### 2. Alerts badge no longer opened details flyout on Alerts tab + visible flash

Clicking the active alerts badge:
- did not switch to the Alerts tab when the same SLO's details flyout was already open, and
- caused a visible flash (close → reopen) every time it (or the expand icon) was clicked, because the handler called `setSelectedSlo(null)` followed by a `requestAnimationFrame` reopen to force the inner flyout to re-read `initialTabId`.

**Fix:**
- The handlers now set state directly — no unmount + rAF dance, no flash.
- The details flyout is keyed by `sloId + instanceId` only, so it remounts only on a real SLO switch (not on every tab change).
- `SloOverviewDetailsContent` syncs `initialTabId` via `useEffect`, so an in-place tab change (e.g. clicking the alerts badge on the already-open SLO) updates the selected tab without remounting.
- Added `event.stopPropagation()` on the alerts badge `onClick` so the row click doesn't interfere.

#### Before

https://github.com/user-attachments/assets/fcef220f-4279-4ebb-8789-cb60e4d92ac2


#### After

https://github.com/user-attachments/assets/53798c5d-9fe2-4160-94ea-522b704df13c



## Test plan

- [x] APM → Service inventory → click SLO badge to open SLO overview flyout
- [x] Click expand on an SLO row → details flyout opens on Overview tab, no flash, no crash, historical charts render
- [x] Click expand again on the same row → details flyout closes
- [x] Click expand on a different SLO row → details flyout switches to that SLO (single remount, no flash)
- [x] Click the alerts badge on a row with active alerts → details flyout opens on Alerts tab
- [x] With details flyout open on Overview tab, click the alerts badge on the same row → switches to Alerts tab in place (no flash, no remount)
- [x] With details flyout open on one SLO, click the alerts badge on a different SLO → details flyout switches and lands on Alerts tab
