### PR TITLE
[APM] Add click tracking to "Explore traces" row action in top traces table

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/ebt_constants.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/ebt_constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TOP_TRACES_TABLE_EBT_ELEMENTS = {
+  ROW_ACTIONS: 'topTracesTableRowActions',
+} as const;

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/use_trace_actions.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/use_trace_actions.ts
@@ -13,6 +13,8 @@ import { getESQLQuery } from '../../shared/links/discover_links/get_esql_query';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 import type { TableActions } from '../../shared/managed_table';
 import type { APIReturnType } from '../../../services/rest/create_call_apm_api';
+import { APM_EBT_ACTIONS } from '../ebt_constants';
+import { TOP_TRACES_TABLE_EBT_ELEMENTS } from './ebt_constants';
 
 export type TraceGroup = APIReturnType<'GET /internal/apm/traces'>['items'][number];
 
@@ -46,6 +48,10 @@ export function useTraceActions({
               defaultMessage: 'Explore traces',
             }),
             icon: 'discoverApp',
+            ebt: {
+              action: APM_EBT_ACTIONS.EXPLORE_TRACES,
+              element: TOP_TRACES_TABLE_EBT_ELEMENTS.ROW_ACTIONS,
+            },
             href: (item) => {
               if (!discoverLocator) return undefined;
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/269979

The "Explore traces" row action added to the top traces table in #269283 was missing EBT click instrumentation. The page-header entry point was already instrumented in #269979; this PR adds the equivalent tracking to the table row action.

<img width="1107" height="400" alt="Screenshot 2026-05-26 at 12 59 06" src="https://github.com/user-attachments/assets/95214294-1ef4-45c2-9be2-46ef21b9bed8" />

_Note: the purple highlight and the tooltip containing the EBT attribute values are added via a browser extension used to inspect EBT click enrichment. Let me know if you’re interested in it._

