### PR TITLE
[9.3] [scout] Add Scout "tests-only" CI mode to only run affected playwright configs (#267533)

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/const.ts
+++ b/.buildkite/pipeline-utils/affected-packages/const.ts
@@ -47,20 +47,3 @@ export const CRITICAL_FILES_JEST_INTEGRATION_TESTS = [
   '.buildkite/pipeline-utils/affected-packages/**/*.{ts,js,sh}',
   '.buildkite/pipeline-utils/ci-stats/**/*.{ts,js}',
 ];
-
-export const CRITICAL_FILES_SCOUT = [
-  'package.json',
-  'yarn.lock',
-  'tsconfig.json',
-  '.node-version',
-  '.nvmrc',
-  'src/setup_node_env/**/*',
-  'packages/kbn-babel-preset/**/*',
-  'src/platform/packages/shared/kbn-repo-info/**/*',
-  'src/platform/packages/shared/kbn-scout/**/*',
-  'src/platform/packages/private/kbn-scout-reporting/**/*',
-  'scripts/scout.js',
-  '.buildkite/scripts/steps/test/scout/**/*',
-  '.buildkite/pipeline-utils/affected-packages/**/*.{ts,js,sh}',
-  '.buildkite/pipeline-utils/ci-stats/**/*.{ts,js}',
-];

--- a/.buildkite/pipeline-utils/affected-packages/utils.ts
+++ b/.buildkite/pipeline-utils/affected-packages/utils.ts
@@ -7,7 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import minimatch from 'minimatch';
+import { Minimatch } from 'minimatch';
+
+// Don't annotate the return type as `Minimatch[]`: the installed
+// @types/minimatch exports `Minimatch` as a value (not a type), and ts-node
+// will reject it. Inference + `ReturnType` keeps the file ts-node-clean.
+const compileMatchers = (patterns: readonly string[]) =>
+  patterns.map((p) => new Minimatch(p, { dot: true }));
+
+const matchesAny = (file: string, matchers: ReturnType<typeof compileMatchers>): boolean =>
+  matchers.some((m) => m.match(file));
 
 /**
  * Returns file paths that don't match any of the given glob patterns.
@@ -17,14 +26,35 @@ export function filterIgnoredFiles(files: string[], patterns: string[]): string[
   if (patterns.length === 0) {
     return files;
   }
-  return files.filter((file) => !patterns.some((p) => minimatch(file, p, { dot: true })));
+  const matchers = compileMatchers(patterns);
+  return files.filter((file) => !matchesAny(file, matchers));
 }
 
 /**
  * Returns true when any pattern matches any file in the list
  */
 export function touchedCriticalFiles(files: string[], criticalFiles: string[]): boolean {
-  return files.some((file) =>
-    criticalFiles.some((criticalFile) => minimatch(file, criticalFile, { dot: true }))
-  );
+  const matchers = compileMatchers(criticalFiles);
+  return files.some((file) => matchesAny(file, matchers));
+}
+
+/**
+ * Returns true when every file matches a `scope` pattern, treating files
+ * that match an `ignore` pattern as irrelevant. Returns false on an empty
+ * list or as soon as a file matches neither.
+ */
+export function allChangedFilesInScope(
+  files: readonly string[],
+  scope: readonly string[],
+  ignore: readonly string[] = []
+): boolean {
+  const ignoreMatchers = compileMatchers(ignore);
+  const scopeMatchers = compileMatchers(scope);
+  let hasScopedChange = false;
+  for (const file of files) {
+    if (matchesAny(file, ignoreMatchers)) continue;
+    if (!matchesAny(file, scopeMatchers)) return false;
+    hasScopedChange = true;
+  }
+  return hasScopedChange;
 }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/pick_test_group_run_order.ts
@@ -9,6 +9,7 @@
 
 import * as Fs from 'fs';
 
+import { listChangedFiles } from '../../affected-packages';
 import type { BuildkiteStep } from '../../buildkite';
 import { BuildkiteClient } from '../../buildkite';
 import { getTrackedBranch } from '../../utils';
@@ -20,6 +21,7 @@ import { loadRunOrderConfig } from './env_config';
 import { getEnabledFtrConfigs } from './ftr_manifests';
 import { discoverJestIntegrationConfigs, discoverJestUnitConfigs } from './jest_configs';
 import { getRunGroup, getRunGroups, labelJestSubgroups } from './run_groups';
+import { isScoutTestsOnlyDiff } from './selective_scout';
 import {
   filterJestIntegrationConfigsByAffected,
   filterJestUnitConfigsByAffected,
@@ -41,6 +43,26 @@ export async function pickTestGroupRunOrder() {
   const ciStats = new CiStatsClient();
   const config = loadRunOrderConfig();
 
+  // Holds the merge base only when selective testing is enabled; the two
+  // `if` blocks below both use it (Scout skip check, then Jest filter).
+  const selectiveTestingMergeBase = config.useSelectiveTesting ? config.prMergeBase : undefined;
+
+  // Fast path: a PR whose diff is exclusively Scout test files cannot affect
+  // any Jest unit/integration or FTR config — skip emitting them entirely.
+  // The Scout pipeline still runs its own selective testing in parallel.
+  if (selectiveTestingMergeBase) {
+    const changedFiles = listChangedFiles({ mergeBase: selectiveTestingMergeBase, commit: 'HEAD' });
+    if (isScoutTestsOnlyDiff(changedFiles)) {
+      console.log('Scout-tests-only diff detected — skipping Jest/FTR test steps');
+      bk.setAnnotation(
+        'selective-testing-scout-tests-only',
+        'info',
+        'Selective testing: Scout-tests-only diff — Jest/FTR test steps were skipped.'
+      );
+      return;
+    }
+  }
+
   const unitIncluded = config.limitConfigType.includes('unit');
   const integrationIncluded = config.limitConfigType.includes('integration');
   const ftrConfigsIncluded = config.limitConfigType.includes('functional');
@@ -55,8 +77,8 @@ export async function pickTestGroupRunOrder() {
   );
   if (!ftrConfigsIncluded) ftrConfigsByQueue.clear();
 
-  if (config.useSelectiveTesting && config.prMergeBase) {
-    const selectiveCtx = await resolveSelectiveTestingContext(config.prMergeBase);
+  if (selectiveTestingMergeBase) {
+    const selectiveCtx = await resolveSelectiveTestingContext(selectiveTestingMergeBase);
     if (selectiveCtx !== null) {
       jestUnitConfigs = filterJestUnitConfigsByAffected(jestUnitConfigs, selectiveCtx);
       jestIntegrationConfigs = filterJestIntegrationConfigsByAffected(

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isScoutTestsOnlyDiff } from './selective_scout';
+
+describe('isScoutTestsOnlyDiff', () => {
+  it('returns false for an empty diff (no signal)', () => {
+    expect(isScoutTestsOnlyDiff([])).toBe(false);
+  });
+
+  it('returns true for a single Scout UI spec', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/foo.spec.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for a single Scout API spec', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'x-pack/platform/plugins/shared/maps/test/scout/api/tests/health.spec.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for shared test code (fixtures, page objects) inside a scope', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
+        'src/platform/plugins/shared/discover/test/scout/ui/helpers/build_query.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for custom Scout server directories (scout_*)', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'x-pack/solutions/security/plugins/cloud_security_posture/test/scout_with_setup/ui/tests/findings.spec.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for generated manifests under .meta', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/.meta/ui/configs.json',
+      ])
+    ).toBe(true);
+  });
+
+  it('treats README / *.md / CHANGELOG as noise (still true if every other file is Scout)', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'README.md',
+        'src/platform/plugins/shared/discover/test/scout/ui/README',
+        'CHANGELOG.asciidoc.md',
+        'src/platform/plugins/shared/discover/test/scout/ui/tests/foo.spec.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false when the diff is noise-only (no Scout signal)', () => {
+    expect(isScoutTestsOnlyDiff(['README.md', 'docs/extend/scout/best-practices.md'])).toBe(false);
+  });
+
+  it('returns false when any non-Scout, non-noise file is present', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/tests/foo.spec.ts',
+        'src/platform/plugins/shared/discover/public/application/main.tsx',
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false for plugin source changes that are not under a Scout scope', () => {
+    expect(
+      isScoutTestsOnlyDiff(['src/platform/plugins/shared/discover/public/application/main.tsx'])
+    ).toBe(false);
+  });
+
+  it('does not confuse `test/scout_<custom>/<not-api-or-ui>` with a Scout scope', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'src/platform/plugins/shared/discover/test/scout_setup/playwright.config.ts',
+      ])
+    ).toBe(false);
+  });
+});

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { allChangedFilesInScope } from '../../affected-packages';
+
+/**
+ * Scout-tests-only fast path for the Jest/FTR orchestrator.
+ *
+ * When a PR's diff contains only Scout test files (Playwright configs, specs,
+ * page objects, fixtures, generated `.meta` manifests), no Jest unit/integration
+ * or FTR config can be affected, so the orchestrator skips emitting them entirely.
+ * The Scout pipeline still runs its own selective testing in parallel.
+ *
+ * The two arrays below duplicate constants in `@kbn/scout-info`'s `paths.ts`
+ * (the source of truth) — `pipeline-utils/` may not import `@kbn/*`. A unit test
+ * in `kbn-scout-info` fails CI if the two copies drift.
+ */
+
+const SCOUT_TESTS_ONLY_IGNORE_PATTERNS: readonly string[] = [
+  '**/README*',
+  '**/*.md',
+  '**/CHANGELOG*',
+];
+
+const SCOUT_TESTS_ONLY_SCOPE_GLOBS: readonly string[] = [
+  '**/test/scout{_*,}/{api,ui}/**',
+  '**/test/scout{_*,}/.meta/{api,ui}/**',
+];
+
+/**
+ * Returns `true` only when every changed file is either documentation noise
+ * (README, *.md, CHANGELOG*) or sits inside a Scout test scope. Falls back
+ * to `false` on an empty diff or anything unrecognised, so unrelated changes
+ * keep using the default test discovery.
+ */
+export function isScoutTestsOnlyDiff(changedFiles: readonly string[]): boolean {
+  return allChangedFilesInScope(
+    changedFiles,
+    SCOUT_TESTS_ONLY_SCOPE_GLOBS,
+    SCOUT_TESTS_ONLY_IGNORE_PATTERNS
+  );
+}

--- a/.buildkite/scripts/steps/test/scout/resolve_selective_testing.ts
+++ b/.buildkite/scripts/steps/test/scout/resolve_selective_testing.ts
@@ -7,29 +7,42 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+/**
+ * Produces the code-changes file consumed by the Scout selective-testing CLI.
+ *
+ * This script is intentionally thin: its only job is to bridge between
+ * `pipeline-utils` (Buildkite-side helpers that compute git diffs and the
+ * @kbn/ module graph) and `node scripts/scout discover-playwright-configs
+ * --code-changes`, which owns all Scout selective-testing decisions
+ * (critical-files check, tests-only fast path, dependency-tree fallback).
+ *
+ * Usage:
+ *   ts-node resolve_selective_testing.ts <mergeBase> <outPath>
+ *
+ * Args:
+ *   mergeBase  — git ref to diff against (required)
+ *   outPath    — output JSON path (required)
+ *
+ * Output (file):
+ *   {
+ *     "mergeBase": "<sha>",
+ *     "changedFiles": ["src/...", ...],
+ *     "affectedModules": ["@kbn/foo", ...]
+ *   }
+ */
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { ToolingLog } from '@kbn/tooling-log';
 import { expandWithImplicitConsumers } from './scout_implicit_consumers';
-import {
-  getAffectedPackages,
-  listChangedFiles,
-  touchedCriticalFiles,
-  CRITICAL_FILES_SCOUT,
-} from '#pipeline-utils';
+import { getAffectedPackages, listChangedFiles } from '#pipeline-utils';
 
 const log = new ToolingLog({ level: 'info', writeTo: process.stderr });
 
-const mergeBase = process.env.AFFECTED_MERGE_BASE;
-const outPath = process.env.AFFECTED_MODULES_FILE;
+const [mergeBase, outPath] = process.argv.slice(2);
 
-if (!mergeBase) {
-  console.error('AFFECTED_MERGE_BASE environment variable is required');
-  process.exit(1);
-}
-
-if (!outPath) {
-  console.error('AFFECTED_MODULES_FILE environment variable is required');
+if (!mergeBase || !outPath) {
+  console.error('Usage: resolve_selective_testing.ts <mergeBase> <outPath>');
   process.exit(1);
 }
 
@@ -37,8 +50,8 @@ if (!outPath) {
   // List changed files once; reuse for both affected-packages and critical-files check.
   const changedFiles = listChangedFiles({ mergeBase, commit: 'HEAD' });
 
-  // Write affected modules JSON (replaces the list_affected binary call).
-  // TEMP: overlay implicit runtime-registry consumers — see scout_implicit_consumers.ts.
+  // Compute affected @kbn/ modules (replaces the legacy `list_affected` binary).
+  // Overlay implicit runtime-registry consumers — see scout_implicit_consumers.ts.
   const affectedPackages = expandWithImplicitConsumers(
     await getAffectedPackages(mergeBase, {
       strategy: 'git',
@@ -49,18 +62,14 @@ if (!outPath) {
     log
   );
 
+  const codeChanges = {
+    mergeBase,
+    changedFiles: [...changedFiles].sort(),
+    affectedModules: [...affectedPackages].sort(),
+  };
+
+  // Write the code-changes JSON consumed by `scout resolve-testing-scope`.
   const resolvedOutPath = path.resolve(outPath);
   fs.mkdirSync(path.dirname(resolvedOutPath), { recursive: true });
-  fs.writeFileSync(resolvedOutPath, JSON.stringify(Array.from(affectedPackages).sort(), null, 2));
-
-  // Top-level check: if critical Scout files were touched, the all Scout tests should run.
-  const criticalTouched = touchedCriticalFiles(changedFiles, CRITICAL_FILES_SCOUT);
-  if (criticalTouched) {
-    console.warn(
-      'Critical Scout files changed — selective testing will be skipped (full suite run)'
-    );
-  }
-
-  // Output true/false to stdout for the shell script to capture.
-  process.stdout.write(criticalTouched ? 'true' : 'false');
+  fs.writeFileSync(resolvedOutPath, JSON.stringify(codeChanges, null, 2));
 })();

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -13,7 +13,11 @@ echo '--- Update Scout Test Config Manifests'
 # so they do not cause extra modules to be considered "changed" in the next step.
 node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
 
-echo '--- Evaluate selective testing scope'
+# Resolve Scout's selective-testing scope once, before either distribution
+# strategy runs. Both artifacts produced below (code_changes.json and
+# testing_scope.json) are consumed by the configs/lanes branches further down
+# and by other pipeline steps (e.g. FTR/Jest run-order pick).
+
 # PR builds: GITHUB_PR_MERGE_BASE is computed by set_git_merge_base() in util.sh.
 # On-merge builds: falls back to HEAD~1 (parent of the merge commit).
 if [[ -n "${GITHUB_PR_MERGE_BASE:-}" ]]; then
@@ -21,40 +25,48 @@ if [[ -n "${GITHUB_PR_MERGE_BASE:-}" ]]; then
 else
   echo "GITHUB_PR_MERGE_BASE not set — using HEAD~1 as merge base (on-merge build)"
 fi
-export AFFECTED_MERGE_BASE="${GITHUB_PR_MERGE_BASE:-HEAD~1}"
+AFFECTED_MERGE_BASE="${GITHUB_PR_MERGE_BASE:-HEAD~1}"
 
 mkdir -p .scout
-export AFFECTED_MODULES_FILE=".scout/affected_modules.json"
+CODE_CHANGES_FILE=".scout/code_changes.json"
+export TESTING_SCOPE_FILE=".scout/testing_scope.json"
 
-# Computes affected modules (writes AFFECTED_MODULES_FILE) and checks whether
-# any critical Scout files were touched.
-SCOUT_CRITICAL_FILES_TOUCHED=$(ts-node "$(dirname "${0}")/resolve_selective_testing.ts")
-echo "Critical Scout files touched: ${SCOUT_CRITICAL_FILES_TOUCHED}"
+echo '--- Resolve Scout selective-testing scope'
 
+# Build the generic code-changes file (changed files + affected @kbn/ modules)
+# consumed by `scout resolve-testing-scope` below.
+ts-node "$(dirname "${0}")/resolve_selective_testing.ts" \
+  "$AFFECTED_MERGE_BASE" \
+  "$CODE_CHANGES_FILE"
+
+# Decide the scope once (full / tests-only / dependency-tree) so every
+# downstream step uses the same decision.
+SELECTIVE_SCOUT_FLAG=()
 if [[ "${SELECTIVE_TESTING_ENABLED:-}" == "true" ]] \
-  && ! is_pr_with_label "scout:run-all-tests" \
-  && [[ "$SCOUT_CRITICAL_FILES_TOUCHED" != "true" ]]; then
-  echo '--- Selective testing: ON'
-  RUN_WITH_SELECTIVE_TESTING="true"
+  && ! is_pr_with_label "scout:run-all-tests"; then
+  SELECTIVE_SCOUT_FLAG=(--selective-testing)
+  echo "Selective testing: enabled (Scout CLI will auto-select tests-only / dependency-tree mode based on the diff)"
 else
-  echo '--- Selective testing: OFF'
-  RUN_WITH_SELECTIVE_TESTING="false"
+  echo "Selective testing: disabled"
+  echo "Reason: SELECTIVE_TESTING_ENABLED=${SELECTIVE_TESTING_ENABLED:-false}, 'scout:run-all-tests' label=$(is_pr_with_label "scout:run-all-tests" && echo yes || echo no)"
 fi
-echo "Decision made based on the following signals:
-  • SELECTIVE_TESTING_ENABLED=${SELECTIVE_TESTING_ENABLED:-false}
-  • 'scout:run-all-tests' GitHub label present: $(is_pr_with_label "scout:run-all-tests" && echo yes || echo no)
-  • Critical Scout files touched: ${SCOUT_CRITICAL_FILES_TOUCHED}"
+
+node scripts/scout resolve-testing-scope \
+  --code-changes "$CODE_CHANGES_FILE" \
+  --scope-output "$TESTING_SCOPE_FILE" \
+  "${SELECTIVE_SCOUT_FLAG[@]}"
+
+buildkite-agent artifact upload "$CODE_CHANGES_FILE"
+# Consumed by the configs/lanes branches below. The Jest/FTR "Pick Test Group
+# Run Order" step computes its own scope independently, so it does not need
+# this artifact.
+buildkite-agent artifact upload "$TESTING_SCOPE_FILE"
 
 SCOUT_TEST_DISTRIBUTION_STRATEGY="${SCOUT_TEST_DISTRIBUTION_STRATEGY:-configs}"
 
 if [[ "$SCOUT_TEST_DISTRIBUTION_STRATEGY" == "lanes" ]]; then
   echo '--- Update Scout Test Config Stats'
   node scripts/scout update-test-config-stats
-
-  SELECTIVE_TESTING_FLAGS=()
-  if [[ "${RUN_WITH_SELECTIVE_TESTING}" == "true" ]]; then
-    SELECTIVE_TESTING_FLAGS=(--moduleFilterPath "$AFFECTED_MODULES_FILE")
-  fi
 
   echo '--- Create Test Tracks'
   SERVERLESS_TARGETS=(
@@ -81,8 +93,8 @@ if [[ "$SCOUT_TEST_DISTRIBUTION_STRATEGY" == "lanes" ]]; then
   node scripts/scout create-test-tracks \
     --estimatedLaneSetupMinutes "${SCOUT_TEST_LANE_ESTIMATED_SETUP_MINUTES:-5}" \
     --targetRuntimeMinutes "${SCOUT_TEST_LANE_TARGET_RUNTIME_MINUTES:-15}" \
+    --testing-scope "$TESTING_SCOPE_FILE" \
     "${TEST_TARGET_FLAGS[@]}" \
-    "${SELECTIVE_TESTING_FLAGS[@]}" \
     --showMultiTrackSummary
 else
   if [[ "${BUILDKITE_BRANCH:-}" == "main" || "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" == "main" ]]; then
@@ -91,18 +103,11 @@ else
     SCOUT_DISCOVERY_TARGET="local-stateful-only"
   fi
 
-  echo "--- Discover Playwright Configs and upload to Buildkite artifacts (affected modules detected)"
-  SELECTIVE_SCOUT_DISCOVERY_FLAG=()
-  if [[ "${RUN_WITH_SELECTIVE_TESTING}" == "true" ]]; then
-    SELECTIVE_SCOUT_DISCOVERY_FLAG=(--selective-testing)
-    echo "The '--selective-testing' flag will be passed to discover-playwright-configs" \
-         " because selective testing is enabled."
-  fi
+  echo "--- Discover Playwright Configs and upload to Buildkite artifacts"
   node scripts/scout discover-playwright-configs \
     --include-custom-servers \
     --target "$SCOUT_DISCOVERY_TARGET" \
-    --affected-modules "$AFFECTED_MODULES_FILE" \
-    "${SELECTIVE_SCOUT_DISCOVERY_FLAG[@]}" \
+    --testing-scope "$TESTING_SCOPE_FILE" \
     --save
   cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
   buildkite-agent artifact upload "scout_playwright_configs.json"

--- a/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
@@ -7,7 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
 import mm from 'micromatch';
+import { REPO_ROOT } from '@kbn/repo-info';
 import {
   TESTABLE_COMPONENT_SCOUT_ROOT_PATH_GLOB,
   SCOUT_CONFIG_PATH_GLOB,
@@ -16,6 +19,8 @@ import {
   SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX,
   SCOUT_UNIFIED_CONFIG_PATH_REGEX,
   TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX,
+  SCOUT_TESTS_ONLY_IGNORE_PATTERNS,
+  SCOUT_TESTS_ONLY_SCOPE_GLOBS,
 } from './paths';
 
 describe('Scout path globs', () => {
@@ -404,4 +409,37 @@ describe('Scout path regexes', () => {
       ).toBe(false);
     });
   });
+});
+
+/**
+ * `selective_scout.ts` (under `.buildkite/pipeline-utils/`) can't import from
+ * `@kbn/*` packages, so it keeps its own copy of these patterns. This test
+ * reads that file and checks each pattern is still present, so the two
+ * copies stay in sync.
+ */
+describe('Scout tests-only patterns duplicated in pipeline-utils/selective_scout', () => {
+  const duplicatePath = path.resolve(
+    REPO_ROOT,
+    '.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts'
+  );
+  const duplicateSource = fs.readFileSync(duplicatePath, 'utf-8');
+
+  // Match the pattern whether it's written with single or double quotes,
+  // so reformatting selective_scout.ts can't accidentally break this test.
+  const containsPatternLiteral = (source: string, pattern: string): boolean =>
+    source.includes(`'${pattern}'`) || source.includes(`"${pattern}"`);
+
+  it.each(SCOUT_TESTS_ONLY_IGNORE_PATTERNS)(
+    'selective_scout.ts contains ignore pattern verbatim: %s',
+    (pattern) => {
+      expect(containsPatternLiteral(duplicateSource, pattern)).toBe(true);
+    }
+  );
+
+  it.each(SCOUT_TESTS_ONLY_SCOPE_GLOBS)(
+    'selective_scout.ts contains scope glob verbatim: %s',
+    (pattern) => {
+      expect(containsPatternLiteral(duplicateSource, pattern)).toBe(true);
+    }
+  );
 });

--- a/src/platform/packages/private/kbn-scout-info/src/paths.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.ts
@@ -101,3 +101,72 @@ export const SCOUT_UNIFIED_CONFIG_PATH_REGEX = new RegExp(
 
 // Scout CI
 export const SCOUT_CI_CONFIG_PATH = path.resolve(REPO_ROOT, '.buildkite', 'scout_ci_config.yml');
+
+// Selective testing — patterns used by the Scout selective-testing resolver.
+
+/**
+ * Documentation-only files inside Scout test scopes that should be ignored when
+ * deciding whether a PR's diff is "Scout tests only". A README or markdown change
+ * next to a Playwright config is noise — it must not block the fast path nor
+ * schedule any Playwright config to run.
+ */
+export const SCOUT_TESTS_ONLY_IGNORE_PATTERNS: readonly string[] = [
+  '**/README*',
+  '**/*.md',
+  '**/CHANGELOG*',
+];
+
+/**
+ * Path globs that uniquely identify a Scout test scope — i.e. a directory
+ * containing a Playwright config and its co-located tests/fixtures/helpers.
+ *
+ * A "scope" is `<package-root>/test/(scout|scout_<custom>)/(api|ui)`, owning at
+ * most two configs:
+ *   - <scope>/playwright.config.ts          (single-thread, tests under tests/)
+ *   - <scope>/parallel.playwright.config.ts (parallel, tests under parallel_tests/)
+ *
+ * The `.meta/(api|ui)` variant covers auto-generated manifests that belong to
+ * the matching scope. Both patterns derive their `(api|ui)` and `scout(_*,)`
+ * segments from `SCOUT_TEST_CATEGORIES` and the same brace-expansion idiom used
+ * by `SCOUT_CONFIG_MANIFEST_PATH_GLOB` so they all stay in sync.
+ */
+export const SCOUT_TESTS_ONLY_SCOPE_GLOBS: readonly string[] = [
+  `**/test/scout{_*,}/{${SCOUT_TEST_CATEGORIES.join(',')}}/**`,
+  `**/test/scout{_*,}/.meta/{${SCOUT_TEST_CATEGORIES.join(',')}}/**`,
+];
+
+/**
+ * Captures `<prefix>/test/(scout|scout_<custom>)/(api|ui)/<rest?>` and the
+ * `.meta/` variant `<prefix>/test/(scout|scout_<custom>)/.meta/(api|ui)/<rest?>`.
+ *
+ * Capture groups: 1=prefix, 2=scoutDir, 3=category (api|ui), 4=rest (optional).
+ * The category alternation is derived from `SCOUT_TEST_CATEGORIES` for parity
+ * with the rest of this file.
+ */
+export const SCOUT_TEST_SCOPE_PATTERN = new RegExp(
+  `^(.+?)\\/test\\/(scout(?:_[^/]+)?)\\/(?:\\.meta\\/)?(${SCOUT_TEST_CATEGORIES.join(
+    '|'
+  )})(?:\\/(.*))?$`
+);
+
+/**
+ * Files whose modification invalidates Scout selective testing entirely:
+ * any change here forces a full Scout suite run regardless of the diff's
+ * other contents.
+ */
+export const CRITICAL_FILES_SCOUT: readonly string[] = [
+  'package.json',
+  'yarn.lock',
+  'tsconfig.json',
+  '.node-version',
+  '.nvmrc',
+  'src/setup_node_env/**/*',
+  'packages/kbn-babel-preset/**/*',
+  'src/platform/packages/shared/kbn-repo-info/**/*',
+  'src/platform/packages/shared/kbn-scout/**/*',
+  'src/platform/packages/private/kbn-scout-reporting/**/*',
+  'scripts/scout.js',
+  '.buildkite/scripts/steps/test/scout/**/*',
+  '.buildkite/pipeline-utils/affected-packages/**/*.{ts,js,sh}',
+  '.buildkite/pipeline-utils/ci-stats/**/*.{ts,js}',
+];

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -120,6 +120,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
       info: jest.fn(),
       error: jest.fn(),
       warn: jest.fn(),
+      warning: jest.fn(),
     } as any;
   });
 
@@ -319,97 +320,6 @@ describe('runDiscoverPlaywrightConfigs', () => {
     expect(foundMessage).toBeDefined();
     expect(foundMessage![0]).toContain('1 plugin(s)'); // pluginA only (pluginB filtered out)
     expect(foundMessage![0]).toContain('1 package(s)'); // packageA
-  });
-
-  it('fails when --selective-testing is set without --affected-modules', () => {
-    flagsReader.boolean.mockImplementation((flag: string) => flag === 'selective-testing');
-    flagsReader.string.mockReturnValue('');
-
-    expect(() => runDiscoverPlaywrightConfigs(flagsReader, log)).toThrow(
-      '--selective-testing requires --affected-modules'
-    );
-  });
-
-  it('with --selective-testing and --affected-modules, limits discovery to affected modules only', () => {
-    flagsReader.enum.mockReturnValue('mki');
-    flagsReader.boolean.mockImplementation((flag: string) => flag === 'selective-testing');
-    flagsReader.string.mockImplementation((name: string) =>
-      name === 'affected-modules' ? '/mock/affected_modules.json' : ''
-    );
-
-    (findPackageForPath as jest.Mock).mockImplementation((_root: string, absPath: string) => {
-      if (absPath.includes('/pluginA/')) return { id: '@kbn/pluginA' };
-      if (absPath.includes('/pluginB/')) return { id: '@kbn/pluginB' };
-      if (absPath.includes('/packageA/')) return { id: '@kbn/packageA' };
-      return undefined;
-    });
-
-    (fs.readFileSync as jest.Mock).mockImplementation((readPath: string) => {
-      if (readPath === '/mock/affected_modules.json') {
-        return JSON.stringify(['@kbn/pluginA']);
-      }
-      if (typeof readPath === 'string' && readPath.endsWith('package.json')) {
-        return JSON.stringify({ name: 'kibana', version: '1.0.0' });
-      }
-      if (typeof readPath === 'string' && readPath.endsWith('.yml')) {
-        return 'mock yaml content';
-      }
-      return '';
-    });
-
-    runDiscoverPlaywrightConfigs(flagsReader, log);
-
-    const infoCalls = log.info.mock.calls;
-    const foundMessage = infoCalls.find((call) =>
-      call[0].includes('Found Playwright config files')
-    );
-    expect(foundMessage).toBeDefined();
-    expect(foundMessage![0]).toContain('1 plugin(s)');
-    expect(foundMessage![0]).toContain('0 package(s)');
-
-    expect(
-      infoCalls.some((call) =>
-        String(call[0]).includes('Selective testing: Scout discovery limited')
-      )
-    ).toBe(true);
-  });
-
-  it('with --affected-modules but without --selective-testing, still discovers all modules matching the target', () => {
-    flagsReader.enum.mockReturnValue('mki');
-    flagsReader.boolean.mockReturnValue(false);
-    flagsReader.string.mockImplementation((name: string) =>
-      name === 'affected-modules' ? '/mock/affected_modules_non_draft.json' : ''
-    );
-
-    (findPackageForPath as jest.Mock).mockImplementation((_root: string, absPath: string) => {
-      if (absPath.includes('/pluginA/')) return { id: '@kbn/pluginA' };
-      if (absPath.includes('/pluginB/')) return { id: '@kbn/pluginB' };
-      if (absPath.includes('/packageA/')) return { id: '@kbn/packageA' };
-      return undefined;
-    });
-
-    (fs.readFileSync as jest.Mock).mockImplementation((readPath: string) => {
-      if (readPath === '/mock/affected_modules_non_draft.json') {
-        return JSON.stringify(['@kbn/pluginA']);
-      }
-      if (typeof readPath === 'string' && readPath.endsWith('package.json')) {
-        return JSON.stringify({ name: 'kibana', version: '1.0.0' });
-      }
-      if (typeof readPath === 'string' && readPath.endsWith('.yml')) {
-        return 'mock yaml content';
-      }
-      return '';
-    });
-
-    runDiscoverPlaywrightConfigs(flagsReader, log);
-
-    const infoCalls = log.info.mock.calls;
-    const foundMessage = infoCalls.find((call) =>
-      call[0].includes('Found Playwright config files')
-    );
-    expect(foundMessage).toBeDefined();
-    expect(foundMessage![0]).toContain('2 plugin(s)');
-    expect(foundMessage![0]).toContain('1 package(s)');
   });
 
   it('filters configs based on target tags for "mki" target (@cloud-serverless-*)', () => {
@@ -1487,6 +1397,147 @@ describe('runDiscoverPlaywrightConfigs', () => {
       expect(serverlessObltGroup.configs).toContain(
         'x-pack/platform/plugins/private/pluginMultiMode/test/scout/ui/playwright.config.ts'
       );
+    });
+  });
+
+  describe('"--testing-scope" flag', () => {
+    const TESTING_SCOPE_PATH = '/mock/testing_scope.json';
+
+    const setupTestingScope = (scope: Record<string, unknown>) => {
+      (fs.readFileSync as jest.Mock).mockImplementation((readPath: string) => {
+        if (readPath === TESTING_SCOPE_PATH) {
+          return JSON.stringify(scope);
+        }
+        if (typeof readPath === 'string' && readPath.endsWith('package.json')) {
+          return JSON.stringify({ name: 'kibana', version: '1.0.0' });
+        }
+        if (typeof readPath === 'string' && readPath.endsWith('.yml')) {
+          return 'mock yaml content';
+        }
+        return '';
+      });
+    };
+
+    beforeEach(() => {
+      (findPackageForPath as jest.Mock).mockImplementation((_root: string, absPath: string) => {
+        if (absPath.includes('/pluginA/')) return { id: '@kbn/pluginA' };
+        if (absPath.includes('/pluginB/')) return { id: '@kbn/pluginB' };
+        if (absPath.includes('/packageA/')) return { id: '@kbn/packageA' };
+        return undefined;
+      });
+    });
+
+    it('routes kind=full/critical-files to a full suite run (warning preserved upstream, no "limited to" message here)', () => {
+      flagsReader.enum.mockReturnValue('mki');
+      flagsReader.boolean.mockReturnValue(false);
+      flagsReader.string.mockImplementation((name: string) =>
+        name === 'testing-scope' ? TESTING_SCOPE_PATH : ''
+      );
+      setupTestingScope({
+        kind: 'full',
+        reason: 'critical-files',
+        affectedModules: ['@kbn/scout'],
+      });
+
+      runDiscoverPlaywrightConfigs(flagsReader, log);
+
+      const infoCalls = log.info.mock.calls;
+      // No filtering applied: every module passes through to the target-tag step.
+      expect(infoCalls.some((call) => String(call[0]).includes('limited to'))).toBe(false);
+    });
+
+    it('routes kind=tests-only to the configs fast path using affectedConfigs', () => {
+      flagsReader.enum.mockReturnValue('all');
+      flagsReader.boolean.mockReturnValue(false);
+      flagsReader.string.mockImplementation((name: string) =>
+        name === 'testing-scope' ? TESTING_SCOPE_PATH : ''
+      );
+      setupTestingScope({
+        kind: 'tests-only',
+        affectedModules: ['@kbn/pluginA'],
+        affectedConfigs: [
+          'x-pack/platform/plugins/private/pluginA/test/scout/ui/playwright.config.ts',
+        ],
+      });
+
+      runDiscoverPlaywrightConfigs(flagsReader, log);
+
+      const infoCalls = log.info.mock.calls;
+      expect(
+        infoCalls.some((call) => String(call[0]).includes('limited to affected configs'))
+      ).toBe(true);
+    });
+
+    it('routes kind=dependency-tree to the affected-modules filter', () => {
+      flagsReader.enum.mockReturnValue('mki');
+      flagsReader.boolean.mockReturnValue(false);
+      flagsReader.string.mockImplementation((name: string) =>
+        name === 'testing-scope' ? TESTING_SCOPE_PATH : ''
+      );
+      setupTestingScope({
+        kind: 'dependency-tree',
+        affectedModules: ['@kbn/pluginA'],
+      });
+
+      runDiscoverPlaywrightConfigs(flagsReader, log);
+
+      const infoCalls = log.info.mock.calls;
+      expect(
+        infoCalls.some((call) => String(call[0]).includes('limited to affected modules'))
+      ).toBe(true);
+    });
+
+    it('marks isAffected on every module from scope.affectedModules even when kind=full', () => {
+      flagsReader.enum.mockReturnValue('mki');
+      flagsReader.boolean.mockReturnValue(false);
+      flagsReader.string.mockImplementation((name: string) =>
+        name === 'testing-scope' ? TESTING_SCOPE_PATH : ''
+      );
+      setupTestingScope({
+        kind: 'full',
+        reason: 'selective-disabled',
+        affectedModules: ['@kbn/pluginA'],
+      });
+
+      runDiscoverPlaywrightConfigs(flagsReader, log);
+
+      const infoCalls = log.info.mock.calls;
+      // Full-suite run: pluginA, pluginB, and packageA all included.
+      const foundMessage = infoCalls.find((call) =>
+        String(call[0]).includes('Found Playwright config files')
+      );
+      expect(foundMessage).toBeDefined();
+      expect(foundMessage![0]).toContain('2 plugin(s)');
+      expect(foundMessage![0]).toContain('1 package(s)');
+      // Marking ran: the "Affected modules: ..." line appears.
+      expect(infoCalls.some((call) => String(call[0]).includes('Affected modules:'))).toBe(true);
+    });
+
+    it('runs the full suite without marking when --testing-scope is omitted', () => {
+      flagsReader.enum.mockReturnValue('mki');
+      flagsReader.boolean.mockReturnValue(false);
+      flagsReader.string.mockImplementation(() => '');
+
+      runDiscoverPlaywrightConfigs(flagsReader, log);
+
+      const infoCalls = log.info.mock.calls;
+      // Marking did NOT run.
+      expect(infoCalls.some((call) => String(call[0]).includes('Affected modules:'))).toBe(false);
+      // Full-suite log is emitted.
+      expect(infoCalls.some((call) => String(call[0]).includes('no testing-scope provided'))).toBe(
+        true
+      );
+    });
+
+    it('throws when the testing-scope file is missing required fields', () => {
+      flagsReader.enum.mockReturnValue('all');
+      flagsReader.boolean.mockReturnValue(false);
+      flagsReader.string.mockImplementation((name: string) =>
+        name === 'testing-scope' ? TESTING_SCOPE_PATH : ''
+      );
+      setupTestingScope({ kind: 'full' }); // missing affectedModules
+
+      expect(() => runDiscoverPlaywrightConfigs(flagsReader, log)).toThrow(/testing-scope file/i);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
@@ -7,13 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createFailError } from '@kbn/dev-cli-errors';
 import type { Command, FlagsReader } from '@kbn/dev-cli-runner';
 import { SCOUT_PLAYWRIGHT_CONFIGS_PATH } from '@kbn/scout-info';
 import { testableModules } from '@kbn/scout-reporting/src/registry';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { saveFlattenedConfigGroups, saveModuleDiscoveryInfo } from '../tests_discovery/file_utils';
-import { markModulesAffectedStatus } from '../tests_discovery/affected_modules';
+import {
+  filterModulesByAffectedConfigs,
+  markModulesAffectedStatusFromSet,
+} from '../tests_discovery/affected_modules';
+import { readScoutTestingScope } from '../tests_discovery/testing_scope';
 import {
   filterModulesByScoutCiConfig,
   getScoutCiExcludedConfigs,
@@ -180,7 +183,7 @@ const handleNonFlattenedOutput = (
   filteredModules: ModuleDiscoveryInfo[],
   flagsReader: FlagsReader,
   log: ToolingLog,
-  selectiveTesting: boolean
+  isSelective: boolean
 ): void => {
   if (flagsReader.boolean('save')) {
     const filteredForCiModules = filterModulesByScoutCiConfig(log, filteredModules);
@@ -189,7 +192,7 @@ const handleNonFlattenedOutput = (
     const { plugins: savedPluginCount, packages: savedPackageCount } =
       countModulesByType(filteredForCiModules);
 
-    const runScope = selectiveTesting ? 'selective' : 'full suite';
+    const runScope = isSelective ? 'selective' : 'full suite';
     log.info(
       `Scout configs saved for CI (${runScope}): ${savedPluginCount} plugin(s) and ${savedPackageCount} package(s) written to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'`
     );
@@ -210,38 +213,46 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
   const targetTags = getTestTagsForTarget(target);
   const flatten = flagsReader.boolean('flatten');
   const includeCustomServers = flagsReader.boolean('include-custom-servers');
-  const selectiveTesting = flagsReader.boolean('selective-testing');
-  const affectedModulesPath = flagsReader.string('affected-modules');
+  const testingScopePath = flagsReader.string('testing-scope');
 
-  if (selectiveTesting && !affectedModulesPath) {
-    throw createFailError(
-      '--selective-testing requires --affected-modules (JSON array of @kbn/ IDs from list_affected).'
-    );
-  }
+  // Read the resolved scope produced upstream by `scout resolve-testing-scope`.
+  // The CLI is intentionally a pure consumer: it never re-derives the scope
+  // from raw code-changes, so the decision is computed exactly once per build.
+  const scope = testingScopePath ? readScoutTestingScope(testingScopePath) : null;
+  const isSelective = scope ? scope.kind !== 'full' : false;
 
-  // Build initial module discovery info
+  // Build initial module discovery info.
   const modulesWithTests = buildModuleDiscoveryInfo();
 
-  // --affected-modules: keep every Scout module that passes target/CI filters; set isAffected
-  // per module so CI step labels can use an "affected " prefix where the PR touched that @kbn/ ID.
-  const modulesAfterAffectedMark = affectedModulesPath
-    ? markModulesAffectedStatus(modulesWithTests, affectedModulesPath, log)
+  // Annotate every module with isAffected so CI step labels can carry an
+  // "affected " prefix even on full-suite runs that have a scope artifact.
+  // Marking is independent of the testing scope's `kind`.
+  const modulesAfterMark = scope
+    ? markModulesAffectedStatusFromSet(modulesWithTests, new Set(scope.affectedModules), log)
     : modulesWithTests;
 
-  // --selective-testing: narrow to affected module groups only.
-  const limitDiscoveryToAffectedModules = selectiveTesting;
-
-  const modulesForTargetTags = limitDiscoveryToAffectedModules
-    ? modulesAfterAffectedMark.filter((m) => m.isAffected === true)
-    : modulesAfterAffectedMark;
-
-  if (limitDiscoveryToAffectedModules) {
+  // Translate the scope into a concrete module list for the target-tag step.
+  let modulesForTargetTags: ModuleDiscoveryInfo[];
+  if (!scope || scope.kind === 'full') {
+    modulesForTargetTags = modulesAfterMark;
+    if (!scope) {
+      log.info(
+        `Full suite run: all ${modulesAfterMark.length} discovered module(s) will be included (no testing-scope provided)`
+      );
+    }
+  } else if (scope.kind === 'tests-only') {
+    modulesForTargetTags = filterModulesByAffectedConfigs(
+      modulesAfterMark,
+      new Set(scope.affectedConfigs ?? [])
+    );
     log.info(
-      `Selective testing: Scout discovery limited to affected modules (${modulesForTargetTags.length} of ${modulesAfterAffectedMark.length})`
+      `Selective testing: Scout discovery limited to affected configs (${modulesForTargetTags.length} module(s))`
     );
   } else {
+    // 'dependency-tree'
+    modulesForTargetTags = modulesAfterMark.filter((m) => m.isAffected === true);
     log.info(
-      `Full suite run: all ${modulesAfterAffectedMark.length} discovered module(s) will be included (selective testing is disabled)`
+      `Selective testing: Scout discovery limited to affected modules (${modulesForTargetTags.length} of ${modulesAfterMark.length})`
     );
   }
 
@@ -258,12 +269,7 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
   if (flatten) {
     handleFlattenedOutput(filteredModulesWithExcludedConfigs, flagsReader, log);
   } else {
-    handleNonFlattenedOutput(
-      filteredModulesWithExcludedConfigs,
-      flagsReader,
-      log,
-      selectiveTesting
-    );
+    handleNonFlattenedOutput(filteredModulesWithExcludedConfigs, flagsReader, log, isSelective);
   }
 };
 
@@ -285,10 +291,15 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
  * - Standard: Lists modules grouped by plugin/package with their configs and tags
  * - Flattened: Groups configs by deployment mode (stateful/serverless), group, and run mode
  *
- * Affected modules:
- * - With --affected-modules, all modules are still considered; isAffected flags drive the
- *   "affected " Buildkite step prefix. With --selective-testing, only affected module groups
- *   are emitted; those steps keep the same prefix.
+ * Selective testing (PR pipelines):
+ * - The selective-testing decision (full / tests-only / dependency-tree) is made
+ *   upstream by `scout resolve-testing-scope`, which writes a `testing_scope.json`
+ *   hand-off artifact. Pass it via --testing-scope <file>.
+ *   - kind: 'full'             -> no filtering, run every module
+ *   - kind: 'tests-only'       -> filter to the Playwright configs owning the diff
+ *   - kind: 'dependency-tree'  -> filter to modules in scope.affectedModules
+ *   In all cases, scope.affectedModules is used to mark each module's `isAffected`
+ *   flag so CI step labels can carry an "affected " prefix.
  */
 export const discoverPlaywrightConfigsCmd: Command<void> = {
   name: 'discover-playwright-configs',
@@ -306,13 +317,12 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
                               - 'local-stateful-only': @local-stateful-* tags only
                               - 'mki': @cloud-serverless-* tags
                               - 'ech': @cloud-stateful-* tags
-    --affected-modules <file>  Path to a JSON file of affected @kbn/ module IDs (list_affected).
-                              All Scout modules still go through discovery; each module is marked
-                              isAffected so CI can prefix steps with "affected " when the PR
-                              touches that module. Combine with --selective-testing to emit only
-                              affected module groups.
-    --selective-testing       Requires --affected-modules.
-                              Limits output / Scout CI steps to affected modules; labels unchanged.
+    --testing-scope <file>    Path to a 'testing_scope.json' file produced upstream
+                              by 'scout resolve-testing-scope'. Drives both filtering
+                              (per kind: full / tests-only / dependency-tree) and
+                              isAffected marking (from scope.affectedModules).
+                              When omitted, the command runs in full-suite mode
+                              with no isAffected marking.
     --include-custom-servers  Include configs under 'test/scout_*' paths for custom server setups
     --validate                Validate that all discovered modules are registered in Scout CI config
     --save                    Validate and save enabled modules to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'
@@ -326,43 +336,25 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
     # Discover configs for local targets (@local-*)
     node scripts/scout discover-playwright-configs --target local
 
-    # Discover only local stateful configs (@local-stateful-*)
-    node scripts/scout discover-playwright-configs --target local-stateful-only
-
-    # Discover cloud serverless configs (@cloud-serverless-*)
-    node scripts/scout discover-playwright-configs --target mki
-
-    # Discover cloud stateful configs (@cloud-stateful-*)
-    node scripts/scout discover-playwright-configs --target ech
-
-    # Discover local custom-server configs only
-    node scripts/scout discover-playwright-configs --include-custom-servers
-
-    # Validate discovered configs against CI configuration
-    node scripts/scout discover-playwright-configs --validate
-
     # Save filtered configs for CI use
     node scripts/scout discover-playwright-configs --save
 
+    # PR pipeline: selective testing driven by the upstream scope artifact
+    node scripts/scout discover-playwright-configs \\
+      --testing-scope .scout/testing_scope.json --save
+
     # Save flattened configs for Cloud test execution
     node scripts/scout discover-playwright-configs --flatten --save
-
-    # Affected-module labels on every Scout group (full CI matrix)
-    node scripts/scout discover-playwright-configs --affected-modules .scout/affected_modules.json --save
-
-    # Only affected module groups (selective testing for PRs)
-    node scripts/scout discover-playwright-configs --affected-modules .scout/affected_modules.json --selective-testing --save
   `,
   flags: {
-    string: ['target', 'affected-modules'],
-    boolean: ['save', 'validate', 'flatten', 'include-custom-servers', 'selective-testing'],
+    string: ['target', 'testing-scope'],
+    boolean: ['save', 'validate', 'flatten', 'include-custom-servers'],
     default: {
       target: 'all',
       save: false,
       validate: false,
       flatten: false,
       'include-custom-servers': false,
-      'selective-testing': false,
     },
   },
   run: ({ flagsReader, log }) => {

--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.test.ts
@@ -162,7 +162,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
     expect(loads).toHaveLength(0);
   });
 
@@ -218,7 +218,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
     expect(loads).toHaveLength(1);
     expect(loads[0].config.path).toBe('matching/config.ts');
   });
@@ -248,7 +248,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
     expect(loads).toHaveLength(1);
     expect(loads[0].enabled).toBe(false);
   });
@@ -270,7 +270,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
     expect(loads).toHaveLength(1);
     expect(loads[0].enabled).toBe(true);
   });
@@ -300,7 +300,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
     expect(loads).toHaveLength(1);
     expect(loads[0].enabled).toBe(false);
   });
@@ -324,7 +324,7 @@ describe('identifyTestLoads', () => {
       configs: [statsEntry],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
     expect(loads).toHaveLength(1);
     expect(loads[0].stats).toBeDefined();
     expect(loads[0].stats!.path).toBe('plugin/config.ts');
@@ -347,12 +347,12 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
     expect(loads).toHaveLength(1);
     expect(loads[0].stats).toBeUndefined();
   });
 
-  describe('moduleIds filter', () => {
+  describe('testing-scope filter', () => {
     const ciConfig: ScoutCIConfig = {
       plugins: { enabled: [], disabled: [] },
       packages: { enabled: [], disabled: [] },
@@ -369,58 +369,109 @@ describe('identifyTestLoads', () => {
       mockFindPackageForPath.mockReset();
     });
 
-    it('includes configs whose resolved module ID is in the filter set', () => {
-      const config = createMockConfig({ path: 'plugin/config.ts' });
-      mockTestConfigs = [config];
-      mockFindPackageForPath.mockReturnValue({ id: '@kbn/test-plugin' });
+    describe('null filter (full scope)', () => {
+      it('includes all configs and never resolves module IDs', () => {
+        const config = createMockConfig({ path: 'plugin/config.ts' });
+        mockTestConfigs = [config];
 
-      const loads = identifyTestLoads(
-        ciConfig,
-        stats,
-        testTarget,
-        new Set(['@kbn/test-plugin']),
-        log
-      );
-      expect(loads).toHaveLength(1);
+        const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
+        expect(loads).toHaveLength(1);
+        expect(mockFindPackageForPath).not.toHaveBeenCalled();
+      });
     });
 
-    it('excludes configs whose resolved module ID is not in the filter set', () => {
-      const config = createMockConfig({ path: 'plugin/config.ts' });
-      mockTestConfigs = [config];
-      mockFindPackageForPath.mockReturnValue({ id: '@kbn/other-plugin' });
+    describe('kind: "modules" (dependency-tree scope)', () => {
+      it('includes configs whose resolved module ID is in the filter set', () => {
+        const config = createMockConfig({ path: 'plugin/config.ts' });
+        mockTestConfigs = [config];
+        mockFindPackageForPath.mockReturnValue({ id: '@kbn/test-plugin' });
 
-      const loads = identifyTestLoads(
-        ciConfig,
-        stats,
-        testTarget,
-        new Set(['@kbn/test-plugin']),
-        log
-      );
-      expect(loads).toHaveLength(0);
+        const loads = identifyTestLoads(
+          ciConfig,
+          stats,
+          testTarget,
+          { kind: 'modules', ids: new Set(['@kbn/test-plugin']) },
+          log
+        );
+        expect(loads).toHaveLength(1);
+      });
+
+      it('excludes configs whose resolved module ID is not in the filter set', () => {
+        const config = createMockConfig({ path: 'plugin/config.ts' });
+        mockTestConfigs = [config];
+        mockFindPackageForPath.mockReturnValue({ id: '@kbn/other-plugin' });
+
+        const loads = identifyTestLoads(
+          ciConfig,
+          stats,
+          testTarget,
+          { kind: 'modules', ids: new Set(['@kbn/test-plugin']) },
+          log
+        );
+        expect(loads).toHaveLength(0);
+      });
+
+      it('excludes configs that cannot be resolved to a module ID', () => {
+        const config = createMockConfig({ path: 'plugin/config.ts' });
+        mockTestConfigs = [config];
+        mockFindPackageForPath.mockReturnValue(undefined);
+
+        const loads = identifyTestLoads(
+          ciConfig,
+          stats,
+          testTarget,
+          { kind: 'modules', ids: new Set(['@kbn/test-plugin']) },
+          log
+        );
+        expect(loads).toHaveLength(0);
+      });
+
+      it('includes all configs when ids set is empty', () => {
+        const config = createMockConfig({ path: 'plugin/config.ts' });
+        mockTestConfigs = [config];
+
+        const loads = identifyTestLoads(
+          ciConfig,
+          stats,
+          testTarget,
+          { kind: 'modules', ids: new Set() },
+          log
+        );
+        expect(loads).toHaveLength(1);
+        expect(mockFindPackageForPath).not.toHaveBeenCalled();
+      });
     });
 
-    it('excludes configs that cannot be resolved to a module ID', () => {
-      const config = createMockConfig({ path: 'plugin/config.ts' });
-      mockTestConfigs = [config];
-      mockFindPackageForPath.mockReturnValue(undefined);
+    describe('kind: "configs" (tests-only scope)', () => {
+      it('includes only configs whose path is in the affected paths set', () => {
+        const affected = createMockConfig({ path: 'plugin-a/test/scout/ui/playwright.config.ts' });
+        const other = createMockConfig({ path: 'plugin-b/test/scout/ui/playwright.config.ts' });
+        mockTestConfigs = [affected, other];
 
-      const loads = identifyTestLoads(
-        ciConfig,
-        stats,
-        testTarget,
-        new Set(['@kbn/test-plugin']),
-        log
-      );
-      expect(loads).toHaveLength(0);
-    });
+        const loads = identifyTestLoads(
+          ciConfig,
+          stats,
+          testTarget,
+          { kind: 'configs', paths: new Set([affected.path]) },
+          log
+        );
+        expect(loads).toHaveLength(1);
+        expect(loads[0].config.path).toBe(affected.path);
+        expect(mockFindPackageForPath).not.toHaveBeenCalled();
+      });
 
-    it('includes all configs when no module filter is provided', () => {
-      const config = createMockConfig({ path: 'plugin/config.ts' });
-      mockTestConfigs = [config];
+      it('excludes everything when affected paths set is empty', () => {
+        mockTestConfigs = [createMockConfig({ path: 'plugin/config.ts' })];
 
-      const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
-      expect(loads).toHaveLength(1);
-      expect(mockFindPackageForPath).not.toHaveBeenCalled();
+        const loads = identifyTestLoads(
+          ciConfig,
+          stats,
+          testTarget,
+          { kind: 'configs', paths: new Set() },
+          log
+        );
+        expect(loads).toHaveLength(0);
+      });
     });
   });
 
@@ -440,7 +491,7 @@ describe('identifyTestLoads', () => {
       configs: [],
     });
 
-    const loads = identifyTestLoads(ciConfig, stats, testTarget, new Set(), log);
+    const loads = identifyTestLoads(ciConfig, stats, testTarget, null, log);
     expect(loads).toHaveLength(0);
     expect(log.warning).toHaveBeenCalledWith(expect.stringContaining('No test loads discovered'));
   });

--- a/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/create_test_tracks.ts
@@ -25,6 +25,20 @@ import { findPackageForPath } from '@kbn/repo-packages';
 import { REPO_ROOT } from '@kbn/repo-info';
 import type { TestTrackLoad } from '../execution/test_track';
 import { TestTrack } from '../execution/test_track';
+import type { SerializedScoutTestingScope } from '../tests_discovery/testing_scope';
+import { readScoutTestingScope } from '../tests_discovery/testing_scope';
+
+/**
+ * Selects which Scout test configs are eligible for distribution into lanes.
+ *
+ * - `null`            → no filter (full suite)
+ * - `kind: 'modules'` → keep configs whose owning @kbn/ module ID is in `ids`
+ * - `kind: 'configs'` → keep configs whose repo-relative path is in `paths`
+ */
+export type TestLoadFilter =
+  | { kind: 'modules'; ids: ReadonlySet<string> }
+  | { kind: 'configs'; paths: ReadonlySet<string> }
+  | null;
 
 export interface ScoutCIConfig {
   plugins: {
@@ -66,7 +80,7 @@ export function identifyTestLoads(
   scoutCIConfig: ScoutCIConfig,
   testConfigStats: ScoutTestConfigStats,
   testTarget: ScoutTestTarget,
-  moduleIDs: Set<string>,
+  filter: TestLoadFilter,
   log: ToolingLog
 ): ScoutCITestLoad[] {
   const testLoads = testConfigs.all
@@ -77,9 +91,14 @@ export function identifyTestLoads(
       })
     )
     .filter((config) => {
-      if (moduleIDs.size === 0) return true;
+      if (!filter) return true;
+      if (filter.kind === 'configs') {
+        return filter.paths.has(config.path);
+      }
+      // kind === 'modules'
+      if (filter.ids.size === 0) return true;
       const resolvedModuleID = findPackageForPath(REPO_ROOT, config.path)?.id;
-      return resolvedModuleID ? moduleIDs.has(resolvedModuleID) : false;
+      return resolvedModuleID ? filter.ids.has(resolvedModuleID) : false;
     })
     .map((config) => {
       let enabled: boolean;
@@ -422,7 +441,7 @@ export const createTestTracks: Command<void> = {
       'targetRuntimeMinutes',
       'minRuntimeMinutes',
       'estimatedLaneSetupMinutes',
-      'moduleFilterPath',
+      'testing-scope',
     ],
     boolean: ['showIndividualTrackSummaries', 'showMultiTrackSummary'],
     default: {
@@ -436,33 +455,34 @@ export const createTestTracks: Command<void> = {
     --estimatedLaneSetupMinutes     (optional)  How long a lane setup is expected to take
     --showIndividualTrackSummaries  (optional)  Display individual test track summaries
     --showMultiTrackSummary         (optional)  Display multi-track summary
-    --moduleFilterPath              (optional)  Path to a JSON file of @kbn/ module IDs; only configs belonging to those modules will be distributed
+    --testing-scope                 (optional)  Path to a 'testing_scope.json' produced by 'scout resolve-testing-scope'.
+                                                Distribution is restricted to:
+                                                  - tests-only      → only Playwright configs touched by the diff
+                                                  - dependency-tree → only configs whose @kbn/ module is affected
+                                                  - full            → no filter (all configs are distributed)
     `,
   },
   run: async ({ flagsReader, log }) => {
-    const moduleIds: Set<string> = new Set();
-    const moduleFilterPath = flagsReader.string('moduleFilterPath');
+    const testingScopePath = flagsReader.string('testing-scope');
+    const scope: SerializedScoutTestingScope = testingScopePath
+      ? readScoutTestingScope(testingScopePath)
+      : { kind: 'full', affectedModules: [] };
 
-    if (moduleFilterPath) {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(readFileSync(moduleFilterPath, 'utf-8'));
-      } catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
-        throw createFlagError(
-          `Failed to read '${moduleFilterPath}': ${message}. ` +
-            `Ensure the file exists and is a valid JSON array of @kbn/ module IDs.`
-        );
-      }
-
-      if (!Array.isArray(parsed)) {
-        throw createFlagError(`Expected '${moduleFilterPath}' to contain a JSON array.`);
-      }
-
-      parsed.forEach((id) => moduleIds.add(id));
+    let filter: TestLoadFilter = null;
+    if (scope.kind === 'tests-only') {
+      const paths = new Set(scope.affectedConfigs ?? []);
+      filter = { kind: 'configs', paths };
       log.info(
-        `Limiting test load selection to the following modules: ${Array.from(moduleIds).join(', ')}`
+        `Selective testing (tests-only): limiting distribution to ${paths.size} affected config(s)`
       );
+    } else if (scope.kind === 'dependency-tree') {
+      const ids = new Set(scope.affectedModules);
+      filter = { kind: 'modules', ids };
+      log.info(
+        `Selective testing (dependency-tree): limiting distribution to ${ids.size} affected module(s)`
+      );
+    } else {
+      log.info('Distributing all eligible configs (full scope)');
     }
 
     const selectedTestTargets: ScoutTestTarget[] = flagsReader
@@ -490,7 +510,7 @@ export const createTestTracks: Command<void> = {
     const testLoadsByTarget = selectedTestTargets.reduce((loadsByTarget, target) => {
       loadsByTarget.set(
         target,
-        identifyTestLoads(scoutCIConfig, testConfigStats, target, moduleIds, log)
+        identifyTestLoads(scoutCIConfig, testConfigStats, target, filter, log)
       );
       return loadsByTarget;
     }, new Map<ScoutTestTarget, ScoutCITestLoad[]>());

--- a/src/platform/packages/shared/kbn-scout/src/cli/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/index.ts
@@ -13,6 +13,7 @@ import { startServerCmd } from './start_server';
 import { runTestsCmd } from './run_tests';
 import { runPlaywrightTestCheckCmd } from './run_playwright_test_check';
 import { discoverPlaywrightConfigsCmd } from './config_discovery';
+import { resolveTestingScopeCmd } from './resolve_testing_scope';
 import { createTestTracks } from './create_test_tracks';
 import { generateCmd } from './generate';
 
@@ -26,6 +27,7 @@ export async function run() {
       runTestsCmd,
       runPlaywrightTestCheckCmd,
       discoverPlaywrightConfigsCmd,
+      resolveTestingScopeCmd,
       reportingCLI.initializeReportDatastream,
       reportingCLI.uploadEvents,
       reportingCLI.updateTestConfigStats,

--- a/src/platform/packages/shared/kbn-scout/src/cli/resolve_testing_scope.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/resolve_testing_scope.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { FlagsReader } from '@kbn/dev-cli-runner';
+import type { ToolingLog } from '@kbn/tooling-log';
+
+import { runResolveTestingScope } from './resolve_testing_scope';
+import { readScoutTestingScope } from '../tests_discovery/testing_scope';
+
+describe('runResolveTestingScope', () => {
+  let tmpRoot: string;
+  let flagsReader: jest.Mocked<FlagsReader>;
+  let log: jest.Mocked<ToolingLog>;
+  let codeChangesPath: string;
+  let scopeOutputPath: string;
+
+  const writeCodeChanges = (changedFiles: string[], affectedModules: string[]): void => {
+    fs.writeFileSync(
+      codeChangesPath,
+      JSON.stringify({ mergeBase: 'abc123', changedFiles, affectedModules })
+    );
+  };
+
+  const setFlags = (overrides: {
+    codeChanges?: string;
+    scopeOutput?: string;
+    selectiveTesting?: boolean;
+  }) => {
+    flagsReader.string.mockImplementation((name: string) => {
+      if (name === 'code-changes') return overrides.codeChanges ?? '';
+      if (name === 'scope-output') return overrides.scopeOutput ?? '';
+      return '';
+    });
+    flagsReader.requiredString.mockImplementation((name: string) => {
+      if (name === 'scope-output') return overrides.scopeOutput ?? scopeOutputPath;
+      throw new Error(`unexpected requiredString flag: ${name}`);
+    });
+    flagsReader.boolean.mockImplementation((name: string) => {
+      if (name === 'selective-testing') return overrides.selectiveTesting ?? false;
+      return false;
+    });
+  };
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-resolve-testing-scope-'));
+    codeChangesPath = path.join(tmpRoot, 'code_changes.json');
+    scopeOutputPath = path.join(tmpRoot, 'testing_scope.json');
+
+    flagsReader = {
+      string: jest.fn(),
+      requiredString: jest.fn(),
+      boolean: jest.fn(),
+    } as any;
+
+    log = {
+      info: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+    } as any;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes a full/selective-disabled scope when --selective-testing is off', () => {
+    writeCodeChanges(['some/file.ts'], ['@kbn/foo', '@kbn/bar']);
+    setFlags({ codeChanges: codeChangesPath, scopeOutput: scopeOutputPath });
+
+    runResolveTestingScope(flagsReader, log);
+
+    expect(readScoutTestingScope(scopeOutputPath)).toEqual({
+      kind: 'full',
+      reason: 'selective-disabled',
+      affectedModules: ['@kbn/bar', '@kbn/foo'],
+    });
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining(scopeOutputPath));
+  });
+
+  it('writes a full/selective-disabled scope (no modules) when --code-changes is omitted', () => {
+    setFlags({ scopeOutput: scopeOutputPath });
+
+    runResolveTestingScope(flagsReader, log);
+
+    expect(readScoutTestingScope(scopeOutputPath)).toEqual({
+      kind: 'full',
+      reason: 'selective-disabled',
+      affectedModules: [],
+    });
+  });
+
+  it('writes a full/critical-files scope when a critical Scout file is touched', () => {
+    writeCodeChanges(
+      ['src/platform/packages/shared/kbn-scout/src/runner/index.ts'],
+      ['@kbn/scout']
+    );
+    setFlags({
+      codeChanges: codeChangesPath,
+      scopeOutput: scopeOutputPath,
+      selectiveTesting: true,
+    });
+
+    runResolveTestingScope(flagsReader, log);
+
+    expect(readScoutTestingScope(scopeOutputPath)).toEqual({
+      kind: 'full',
+      reason: 'critical-files',
+      affectedModules: ['@kbn/scout'],
+    });
+  });
+
+  it('writes a tests-only scope for a Scout-tests-only diff', () => {
+    // `affectedConfigs` is discovered on disk relative to REPO_ROOT, which
+    // we can't redirect at this tmp path, so we only assert on `kind` and
+    // `affectedModules` here.
+    writeCodeChanges(['pkg/test/scout/ui/tests/foo.spec.ts'], ['@kbn/pkg']);
+    setFlags({
+      codeChanges: codeChangesPath,
+      scopeOutput: scopeOutputPath,
+      selectiveTesting: true,
+    });
+
+    runResolveTestingScope(flagsReader, log);
+    const written = readScoutTestingScope(scopeOutputPath);
+
+    expect(written.kind).toBe('tests-only');
+    expect(written.affectedModules).toEqual(['@kbn/pkg']);
+  });
+
+  it('writes a dependency-tree scope for a mixed source+test diff', () => {
+    writeCodeChanges(
+      ['pkg/test/scout/ui/tests/foo.spec.ts', 'pkg/public/foo.ts'],
+      ['@kbn/foo', '@kbn/bar']
+    );
+    setFlags({
+      codeChanges: codeChangesPath,
+      scopeOutput: scopeOutputPath,
+      selectiveTesting: true,
+    });
+
+    runResolveTestingScope(flagsReader, log);
+
+    expect(readScoutTestingScope(scopeOutputPath)).toEqual({
+      kind: 'dependency-tree',
+      affectedModules: ['@kbn/bar', '@kbn/foo'],
+    });
+  });
+
+  it('throws when the code-changes file is missing required fields', () => {
+    fs.writeFileSync(codeChangesPath, JSON.stringify({ mergeBase: 'abc' })); // invalid
+    setFlags({
+      codeChanges: codeChangesPath,
+      scopeOutput: scopeOutputPath,
+      selectiveTesting: true,
+    });
+
+    expect(() => runResolveTestingScope(flagsReader, log)).toThrow(/code-changes file/i);
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/cli/resolve_testing_scope.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/resolve_testing_scope.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Command, FlagsReader } from '@kbn/dev-cli-runner';
+import type { ToolingLog } from '@kbn/tooling-log';
+import { readCodeChanges } from '../tests_discovery/code_changes';
+import { resolveScoutTestingScope, writeScoutTestingScope } from '../tests_discovery/testing_scope';
+
+/**
+ * Decides which Scout tests to run for a PR diff and writes the result to
+ * `testing_scope.json`. The same file is then read by
+ * `discover-playwright-configs` (configs strategy) and `create-test-tracks`
+ * (lanes strategy), so the decision is made once per build.
+ */
+export const runResolveTestingScope = (flagsReader: FlagsReader, log: ToolingLog): void => {
+  const codeChangesPath = flagsReader.string('code-changes');
+  const outputPath = flagsReader.requiredString('scope-output');
+  const selectiveTesting = flagsReader.boolean('selective-testing');
+
+  const codeChanges = codeChangesPath ? readCodeChanges(codeChangesPath) : null;
+  const scope = resolveScoutTestingScope(codeChanges, selectiveTesting, log);
+  const affectedModules = new Set(codeChanges?.affectedModules ?? []);
+
+  writeScoutTestingScope(scope, affectedModules, outputPath);
+  log.info(`Scout testing scope written to '${outputPath}' (kind: ${scope.kind})`);
+};
+
+export const resolveTestingScopeCmd: Command<void> = {
+  name: 'resolve-testing-scope',
+  description: `
+  Resolve the Scout selective-testing scope for a PR diff and write it to disk
+  as a hand-off artifact. The output is consumed by:
+    - 'discover-playwright-configs' (configs strategy filter)
+    - 'create-test-tracks'          (lanes strategy filter)
+
+  Options:
+    --code-changes <file>     Path to a JSON file describing the PR's diff:
+                                { "mergeBase": string, "changedFiles": string[],
+                                  "affectedModules": string[] }
+                              When omitted, the scope is { kind: 'full',
+                              reason: 'selective-disabled' }.
+    --scope-output <file>     (required) Output path for the resolved scope JSON.
+    --selective-testing       Enable selective testing. Without it, the scope is
+                              always { kind: 'full', reason: 'selective-disabled' }
+                              regardless of --code-changes. With it, the scope is
+                              auto-selected:
+                                1. Critical Scout files touched -> kind: 'full'
+                                2. Diff is exclusively Scout tests -> 'tests-only'
+                                3. Otherwise -> 'dependency-tree'
+
+  Example:
+    node scripts/scout resolve-testing-scope \\
+      --code-changes .scout/code_changes.json \\
+      --scope-output .scout/testing_scope.json \\
+      --selective-testing
+  `,
+  flags: {
+    string: ['code-changes', 'scope-output'],
+    boolean: ['selective-testing'],
+    default: {
+      'selective-testing': false,
+    },
+  },
+  run: ({ flagsReader, log }) => {
+    runResolveTestingScope(flagsReader, log);
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_modules.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_modules.test.ts
@@ -8,7 +8,6 @@
  */
 
 import { ToolingLog } from '@kbn/tooling-log';
-import fs from 'fs';
 import path from 'path';
 import type { ModuleDiscoveryInfo } from './types';
 
@@ -16,14 +15,15 @@ jest.mock('@kbn/repo-info', () => ({
   REPO_ROOT: '/mock/repo/root',
 }));
 
-jest.mock('fs');
-
 const mockFindPackageForPath = jest.fn();
 jest.mock('@kbn/repo-packages', () => ({
   findPackageForPath: (...args: unknown[]) => mockFindPackageForPath(...args),
 }));
 
-import { markModulesAffectedStatus, readAffectedModules } from './affected_modules';
+import {
+  filterModulesByAffectedConfigs,
+  markModulesAffectedStatusFromSet,
+} from './affected_modules';
 
 /** Path -> @kbn/ module ID mapping used by the findPackageForPath mock */
 const CONFIG_PATH_TO_MODULE_ID: Record<string, string> = {
@@ -36,20 +36,19 @@ const CONFIG_PATH_TO_MODULE_ID: Record<string, string> = {
 const createModule = (
   name: string,
   type: 'plugin' | 'package',
-  configPath: string
+  configPath: string,
+  extraConfigs: string[] = []
 ): ModuleDiscoveryInfo => ({
   name,
   group: 'test-group',
   type,
-  configs: [
-    {
-      path: configPath,
-      hasTests: true,
-      tags: ['@local-stateful-classic'],
-      serverRunFlags: ['--arch stateful --domain classic'],
-      usesParallelWorkers: false,
-    },
-  ],
+  configs: [configPath, ...extraConfigs].map((p) => ({
+    path: p,
+    hasTests: true,
+    tags: ['@local-stateful-classic'],
+    serverRunFlags: ['--arch stateful --domain classic'],
+    usesParallelWorkers: false,
+  })),
 });
 
 const setupFindPackageMock = () => {
@@ -74,50 +73,7 @@ describe('affected_modules', () => {
     jest.clearAllMocks();
   });
 
-  describe('readAffectedModules', () => {
-    it('should read and parse a valid JSON array file', () => {
-      const modules = ['@kbn/scout', '@kbn/discover-plugin'];
-      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(modules));
-
-      const result = readAffectedModules('/some/path.json', mockLog);
-
-      expect(result).toEqual(new Set(modules));
-    });
-
-    it('should return null for non-array JSON', () => {
-      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ not: 'an array' }));
-
-      const result = readAffectedModules('/some/path.json', mockLog);
-
-      expect(result).toBeNull();
-      expect(mockLog.warning).toHaveBeenCalledWith(
-        expect.stringContaining('does not contain a JSON array')
-      );
-    });
-
-    it('should return null when file does not exist', () => {
-      (fs.readFileSync as jest.Mock).mockImplementation(() => {
-        throw new Error('ENOENT: no such file or directory');
-      });
-
-      const result = readAffectedModules('/missing/file.json', mockLog);
-
-      expect(result).toBeNull();
-      expect(mockLog.warning).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to read affected modules file')
-      );
-    });
-
-    it('should return null for invalid JSON', () => {
-      (fs.readFileSync as jest.Mock).mockReturnValue('not valid json');
-
-      const result = readAffectedModules('/some/path.json', mockLog);
-
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('markModulesAffectedStatus', () => {
+  describe('markModulesAffectedStatusFromSet', () => {
     const modules: ModuleDiscoveryInfo[] = [
       createModule(
         'security_solution',
@@ -136,12 +92,12 @@ describe('affected_modules', () => {
       ),
     ];
 
-    it('should mark affected modules with isAffected: true', () => {
-      (fs.readFileSync as jest.Mock).mockReturnValue(
-        JSON.stringify(['@kbn/security-solution-plugin', '@kbn/scout'])
+    it('marks affected modules with isAffected: true', () => {
+      const result = markModulesAffectedStatusFromSet(
+        modules,
+        new Set(['@kbn/security-solution-plugin', '@kbn/scout']),
+        mockLog
       );
-
-      const result = markModulesAffectedStatus(modules, '/affected.json', mockLog);
 
       expect(result).toHaveLength(3);
       expect(result.find((m) => m.name === 'security_solution')?.isAffected).toBe(true);
@@ -149,18 +105,7 @@ describe('affected_modules', () => {
       expect(result.find((m) => m.name === 'kbn-scout')?.isAffected).toBe(true);
     });
 
-    it('should mark non-affected modules with isAffected: false', () => {
-      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(['@kbn/scout']));
-
-      const result = markModulesAffectedStatus(modules, '/affected.json', mockLog);
-
-      expect(result).toHaveLength(3);
-      expect(result.find((m) => m.name === 'security_solution')?.isAffected).toBe(false);
-      expect(result.find((m) => m.name === 'discover')?.isAffected).toBe(false);
-      expect(result.find((m) => m.name === 'kbn-scout')?.isAffected).toBe(true);
-    });
-
-    it('should mark unmapped modules with isAffected: false and warn', () => {
+    it('marks unmapped modules with isAffected: false and warns', () => {
       const modulesWithUnmapped: ModuleDiscoveryInfo[] = [
         ...modules,
         createModule(
@@ -170,9 +115,11 @@ describe('affected_modules', () => {
         ),
       ];
 
-      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(['@kbn/scout']));
-
-      const result = markModulesAffectedStatus(modulesWithUnmapped, '/affected.json', mockLog);
+      const result = markModulesAffectedStatusFromSet(
+        modulesWithUnmapped,
+        new Set(['@kbn/scout']),
+        mockLog
+      );
 
       expect(result).toHaveLength(4);
       expect(result.find((m) => m.name === 'unknown_module')?.isAffected).toBe(false);
@@ -184,35 +131,65 @@ describe('affected_modules', () => {
       );
     });
 
-    it('should throw when the affected modules file cannot be read', () => {
-      (fs.readFileSync as jest.Mock).mockImplementation(() => {
-        throw new Error('ENOENT');
-      });
-
-      expect(() => markModulesAffectedStatus(modules, '/missing.json', mockLog)).toThrow(
-        'Selective testing: could not load affected modules file'
-      );
-    });
-
-    it('should mark all as isAffected: false when affected set is empty', () => {
-      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify([]));
-
-      const result = markModulesAffectedStatus(modules, '/affected.json', mockLog);
+    it('marks all as isAffected: false when affected set is empty', () => {
+      const result = markModulesAffectedStatusFromSet(modules, new Set(), mockLog);
 
       expect(result).toHaveLength(3);
       expect(result.every((m) => m.isAffected === false)).toBe(true);
     });
 
-    it('should log affected and unaffected counts', () => {
-      (fs.readFileSync as jest.Mock).mockReturnValue(
-        JSON.stringify(['@kbn/security-solution-plugin'])
+    it('logs affected and unaffected counts', () => {
+      markModulesAffectedStatusFromSet(
+        modules,
+        new Set(['@kbn/security-solution-plugin']),
+        mockLog
       );
-
-      markModulesAffectedStatus(modules, '/affected.json', mockLog);
 
       expect(mockLog.info).toHaveBeenCalledWith(
         expect.stringContaining('1 affected, 2 unaffected')
       );
+    });
+  });
+
+  describe('filterModulesByAffectedConfigs', () => {
+    const modules: ModuleDiscoveryInfo[] = [
+      createModule('a', 'plugin', 'a/test/scout/ui/playwright.config.ts', [
+        'a/test/scout/ui/parallel.playwright.config.ts',
+      ]),
+      createModule('b', 'plugin', 'b/test/scout/api/playwright.config.ts'),
+    ];
+
+    it('keeps only configs in the affected set and forces isAffected: true on survivors', () => {
+      const result = filterModulesByAffectedConfigs(
+        modules,
+        new Set(['a/test/scout/ui/playwright.config.ts', 'b/test/scout/api/playwright.config.ts'])
+      );
+
+      expect(result).toHaveLength(2);
+      const a = result.find((m) => m.name === 'a')!;
+      expect(a.configs).toHaveLength(1);
+      expect(a.configs[0].path).toBe('a/test/scout/ui/playwright.config.ts');
+      expect(a.isAffected).toBe(true);
+
+      const b = result.find((m) => m.name === 'b')!;
+      expect(b.configs).toHaveLength(1);
+      expect(b.isAffected).toBe(true);
+    });
+
+    it('drops modules whose configs are entirely filtered out', () => {
+      const result = filterModulesByAffectedConfigs(
+        modules,
+        new Set(['a/test/scout/ui/parallel.playwright.config.ts'])
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('a');
+      expect(result[0].configs[0].path).toBe('a/test/scout/ui/parallel.playwright.config.ts');
+    });
+
+    it('returns an empty array when no config is affected', () => {
+      const result = filterModulesByAffectedConfigs(modules, new Set(['unrelated/config.ts']));
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_modules.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_modules.ts
@@ -7,9 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import fs from 'fs';
 import path from 'path';
-import { createFailError } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { findPackageForPath } from '@kbn/repo-packages';
 import type { ToolingLog } from '@kbn/tooling-log';
@@ -25,51 +23,20 @@ const getModuleIdForConfigPath = (configPath: string): string | undefined => {
 };
 
 /**
- * Read the affected modules JSON file produced by the `list_affected` CLI.
- * Returns null on any error (missing file, invalid JSON) to allow graceful fallback.
- */
-export const readAffectedModules = (filePath: string, log: ToolingLog): Set<string> | null => {
-  try {
-    const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(REPO_ROOT, filePath);
-    const content = fs.readFileSync(absolutePath, 'utf-8');
-    const parsed = JSON.parse(content);
-
-    if (!Array.isArray(parsed)) {
-      log.warning(`Affected modules file does not contain a JSON array: ${filePath}`);
-      return null;
-    }
-
-    return new Set<string>(parsed);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    log.warning(`Failed to read affected modules file '${filePath}': ${message}`);
-    return null;
-  }
-};
-
-/**
- * Mark modules with isAffected based on the affected modules set (see --affected-modules).
- * All modules are returned; use --selective-testing in discover-playwright-configs to drop non-affected.
+ * Mark each module with `isAffected` against an in-memory set of @kbn/ IDs.
+ * All modules are returned; downstream callers can drop non-affected ones to
+ * implement selective testing.
  *
  * Behavior:
  * - Module maps to an affected @kbn/ ID -> isAffected: true
  * - Module does not map to any @kbn/ ID -> isAffected: false (warn)
  * - Module maps to a @kbn/ ID NOT in affected set -> isAffected: false
- * - If the file cannot be read or is invalid -> throw (fail fast)
  */
-export const markModulesAffectedStatus = (
+export const markModulesAffectedStatusFromSet = (
   modules: ModuleDiscoveryInfo[],
-  affectedModulesPath: string,
+  affectedModules: ReadonlySet<string>,
   log: ToolingLog
 ): ModuleDiscoveryInfo[] => {
-  const affectedModules = readAffectedModules(affectedModulesPath, log);
-
-  if (affectedModules === null) {
-    throw createFailError(
-      'Selective testing: could not load affected modules file. Check that list_affected produced a valid JSON array.'
-    );
-  }
-
   let affectedCount = 0;
   let unmappedCount = 0;
 
@@ -98,3 +65,20 @@ export const markModulesAffectedStatus = (
 
   return marked;
 };
+
+/**
+ * Drop configs whose path is not in the `affectedConfigs` allowlist; drop modules
+ * left without configs. Surviving configs are by definition affected, so the
+ * module's isAffected flag is set to `true`.
+ */
+export const filterModulesByAffectedConfigs = (
+  modules: ModuleDiscoveryInfo[],
+  affectedConfigs: ReadonlySet<string>
+): ModuleDiscoveryInfo[] =>
+  modules
+    .map((module) => ({
+      ...module,
+      isAffected: true,
+      configs: module.configs.filter((config) => affectedConfigs.has(config.path)),
+    }))
+    .filter((module) => module.configs.length > 0);

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/code_changes.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/code_changes.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createFailError } from '@kbn/dev-cli-errors';
+import { REPO_ROOT } from '@kbn/repo-info';
+
+/**
+ * Generic input artifact handed to Scout selective-testing logic by the
+ * Buildkite layer. Contains everything Scout needs to make a selective-testing
+ * decision without having to call git/repo tooling itself.
+ */
+export interface CodeChanges {
+  /** Git ref the diff was computed against. */
+  mergeBase: string;
+  /** Repo-relative paths of files changed since `mergeBase`. */
+  changedFiles: string[];
+  /** @kbn/ module IDs identified as affected by the changed files (downstream-included). */
+  affectedModules: string[];
+}
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+
+const isCodeChanges = (value: unknown): value is CodeChanges => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.mergeBase === 'string' &&
+    isStringArray(candidate.changedFiles) &&
+    isStringArray(candidate.affectedModules)
+  );
+};
+
+/**
+ * Read and validate a code-changes JSON file produced by the Buildkite Scout
+ * resolver. Throws (via createFailError) on missing/invalid input — selective
+ * testing must not silently fall back to a wrong mode.
+ */
+export const readCodeChanges = (filePath: string): CodeChanges => {
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(REPO_ROOT, filePath);
+  let content: string;
+  try {
+    content = fs.readFileSync(absolutePath, 'utf-8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw createFailError(`Failed to read code-changes file '${filePath}': ${message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw createFailError(`Code-changes file is not valid JSON ('${filePath}'): ${message}`);
+  }
+
+  if (!isCodeChanges(parsed)) {
+    throw createFailError(
+      `Code-changes file '${filePath}' must contain { mergeBase: string, changedFiles: string[], affectedModules: string[] }`
+    );
+  }
+
+  return parsed;
+};

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/index.ts
@@ -13,3 +13,5 @@ export * from './transform_utils';
 export * from './file_utils';
 export * from './search_configs';
 export * from './affected_modules';
+export * from './code_changes';
+export * from './testing_scope';

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/testing_scope.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/testing_scope.test.ts
@@ -1,0 +1,513 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ToolingLog } from '@kbn/tooling-log';
+
+import {
+  criticalScoutFilesTouched,
+  deriveScoutConfigsForFile,
+  deriveScoutConfigsForFiles,
+  isScoutTestsOnlyDiff,
+  readScoutTestingScope,
+  resolveScoutTestingScope,
+  serializeScoutTestingScope,
+  writeScoutTestingScope,
+} from './testing_scope';
+import type { ScoutTestingScope } from './testing_scope';
+import type { CodeChanges } from './code_changes';
+
+describe('isScoutTestsOnlyDiff', () => {
+  it('returns false for an empty diff', () => {
+    expect(isScoutTestsOnlyDiff([])).toBe(false);
+  });
+
+  it('returns false when the diff contains only noise files (no real signal)', () => {
+    expect(isScoutTestsOnlyDiff(['README.md', 'docs/CHANGELOG.md'])).toBe(false);
+  });
+
+  it('returns true when every non-noise file is in a Scout test scope', () => {
+    const files = [
+      'pkg/test/scout/ui/tests/a.spec.ts',
+      'pkg/test/scout/ui/fixtures/page_objects/foo.ts',
+      'pkg/README.md', // noise — ignored
+    ];
+    expect(isScoutTestsOnlyDiff(files)).toBe(true);
+  });
+
+  it('returns false when at least one non-noise file is outside Scout scope', () => {
+    const files = ['pkg/test/scout/ui/tests/a.spec.ts', 'pkg/public/foo.ts'];
+    expect(isScoutTestsOnlyDiff(files)).toBe(false);
+  });
+
+  it('matches custom scout_<server> scopes', () => {
+    expect(isScoutTestsOnlyDiff(['pkg/test/scout_search_sessions/api/tests/a.spec.ts'])).toBe(true);
+  });
+
+  it('matches .meta/ paths under both default and custom scopes', () => {
+    expect(
+      isScoutTestsOnlyDiff([
+        'pkg/test/scout/.meta/ui/standard.json',
+        'pkg/test/scout_examples/.meta/api/standard.json',
+      ])
+    ).toBe(true);
+  });
+});
+
+describe('criticalScoutFilesTouched', () => {
+  it('returns false for empty input', () => {
+    expect(criticalScoutFilesTouched([])).toBe(false);
+  });
+
+  it('returns true for changes in @kbn/scout package', () => {
+    expect(
+      criticalScoutFilesTouched(['src/platform/packages/shared/kbn-scout/src/runner/index.ts'])
+    ).toBe(true);
+  });
+
+  it('returns true for top-level dependency files', () => {
+    expect(criticalScoutFilesTouched(['package.json'])).toBe(true);
+    expect(criticalScoutFilesTouched(['yarn.lock'])).toBe(true);
+  });
+
+  it('returns true for buildkite Scout step changes', () => {
+    expect(
+      criticalScoutFilesTouched(['.buildkite/scripts/steps/test/scout/test_run_builder.sh'])
+    ).toBe(true);
+  });
+
+  it('returns false for changes outside the critical list', () => {
+    expect(
+      criticalScoutFilesTouched([
+        'src/platform/plugins/shared/foo/public/index.ts',
+        'README.md',
+        'pkg/test/scout/ui/tests/a.spec.ts',
+      ])
+    ).toBe(false);
+  });
+});
+
+describe('deriveScoutConfigsForFile', () => {
+  let tmpRoot: string;
+
+  const touch = (rel: string) => {
+    const abs = path.join(tmpRoot, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '');
+  };
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-affected-resolver-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns [] for paths outside any Scout scope', () => {
+    expect(deriveScoutConfigsForFile('src/core/server/foo.ts', tmpRoot)).toEqual([]);
+    expect(deriveScoutConfigsForFile('test/scout/foo.ts', tmpRoot)).toEqual([]);
+  });
+
+  it('maps a single-thread spec to playwright.config.ts', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    expect(deriveScoutConfigsForFile('pkg/test/scout/ui/tests/a.spec.ts', tmpRoot)).toEqual([
+      'pkg/test/scout/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('maps a parallel spec to parallel.playwright.config.ts', () => {
+    touch('pkg/test/scout/ui/parallel.playwright.config.ts');
+    expect(
+      deriveScoutConfigsForFile('pkg/test/scout/ui/parallel_tests/a.spec.ts', tmpRoot)
+    ).toEqual(['pkg/test/scout/ui/parallel.playwright.config.ts']);
+  });
+
+  it('maps shared scope files (fixtures/page_objects/helpers) to both configs when both exist', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    touch('pkg/test/scout/ui/parallel.playwright.config.ts');
+
+    const configs = deriveScoutConfigsForFile(
+      'pkg/test/scout/ui/fixtures/page_objects/foo.ts',
+      tmpRoot
+    );
+    expect(configs.sort()).toEqual([
+      'pkg/test/scout/ui/parallel.playwright.config.ts',
+      'pkg/test/scout/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('drops configs that do not exist on disk', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    // No parallel config exists.
+    const configs = deriveScoutConfigsForFile('pkg/test/scout/ui/helpers.ts', tmpRoot);
+    expect(configs).toEqual(['pkg/test/scout/ui/playwright.config.ts']);
+  });
+
+  it('never crosses ui ↔ api scopes', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    touch('pkg/test/scout/api/playwright.config.ts');
+
+    const uiChange = deriveScoutConfigsForFile('pkg/test/scout/ui/fixtures/foo.ts', tmpRoot);
+    expect(uiChange.every((c) => c.includes('/ui/'))).toBe(true);
+
+    const apiChange = deriveScoutConfigsForFile('pkg/test/scout/api/helpers.ts', tmpRoot);
+    expect(apiChange.every((c) => c.includes('/api/'))).toBe(true);
+  });
+
+  it('never crosses scout ↔ scout_<custom> scopes', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    touch('pkg/test/scout_custom/ui/playwright.config.ts');
+
+    expect(deriveScoutConfigsForFile('pkg/test/scout/ui/tests/a.spec.ts', tmpRoot)).toEqual([
+      'pkg/test/scout/ui/playwright.config.ts',
+    ]);
+    expect(deriveScoutConfigsForFile('pkg/test/scout_custom/ui/tests/a.spec.ts', tmpRoot)).toEqual([
+      'pkg/test/scout_custom/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('handles custom-server scopes (test/scout_<custom>) symmetrically', () => {
+    touch('pkg/test/scout_oas_schema/ui/playwright.config.ts');
+    expect(
+      deriveScoutConfigsForFile('pkg/test/scout_oas_schema/ui/tests/a.spec.ts', tmpRoot)
+    ).toEqual(['pkg/test/scout_oas_schema/ui/playwright.config.ts']);
+  });
+
+  it('maps .meta/(ui|api) manifests to the matching scope', () => {
+    touch('pkg/test/scout/api/playwright.config.ts');
+    touch('pkg/test/scout/api/parallel.playwright.config.ts');
+
+    const configs = deriveScoutConfigsForFile('pkg/test/scout/.meta/api/standard.json', tmpRoot);
+    expect(configs.sort()).toEqual([
+      'pkg/test/scout/api/parallel.playwright.config.ts',
+      'pkg/test/scout/api/playwright.config.ts',
+    ]);
+  });
+
+  it('maps .meta under custom-server scopes too', () => {
+    touch('pkg/test/scout_examples/ui/playwright.config.ts');
+    const configs = deriveScoutConfigsForFile(
+      'pkg/test/scout_examples/.meta/ui/standard.json',
+      tmpRoot
+    );
+    expect(configs).toEqual(['pkg/test/scout_examples/ui/playwright.config.ts']);
+  });
+
+  it('maps an edit to the playwright config itself to that single config', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    touch('pkg/test/scout/ui/parallel.playwright.config.ts');
+
+    const configs = deriveScoutConfigsForFile('pkg/test/scout/ui/playwright.config.ts', tmpRoot);
+    expect(configs.sort()).toEqual([
+      'pkg/test/scout/ui/parallel.playwright.config.ts',
+      'pkg/test/scout/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('handles deeply-nested package roots', () => {
+    touch('x-pack/solutions/observability/plugins/foo/test/scout/ui/playwright.config.ts');
+    expect(
+      deriveScoutConfigsForFile(
+        'x-pack/solutions/observability/plugins/foo/test/scout/ui/tests/a.spec.ts',
+        tmpRoot
+      )
+    ).toEqual(['x-pack/solutions/observability/plugins/foo/test/scout/ui/playwright.config.ts']);
+  });
+});
+
+describe('deriveScoutConfigsForFiles', () => {
+  let tmpRoot: string;
+
+  const touch = (rel: string) => {
+    const abs = path.join(tmpRoot, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '');
+  };
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-affected-resolver-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('unions configs across multiple files and dedupes', () => {
+    touch('a/test/scout/ui/playwright.config.ts');
+    touch('a/test/scout/api/playwright.config.ts');
+    touch('b/test/scout_custom/ui/playwright.config.ts');
+
+    const result = deriveScoutConfigsForFiles(
+      [
+        'a/test/scout/ui/tests/x.spec.ts',
+        'a/test/scout/ui/tests/y.spec.ts', // dedupes with previous
+        'a/test/scout/api/helpers.ts',
+        'b/test/scout_custom/ui/parallel_tests/z.spec.ts', // no parallel config -> dropped
+      ],
+      tmpRoot
+    );
+
+    expect([...result].sort()).toEqual([
+      'a/test/scout/api/playwright.config.ts',
+      'a/test/scout/ui/playwright.config.ts',
+    ]);
+  });
+
+  it('returns an empty set when no file maps to a Scout scope', () => {
+    expect(deriveScoutConfigsForFiles(['src/foo.ts', 'README.md'], tmpRoot).size).toBe(0);
+  });
+});
+
+describe('resolveScoutTestingScope', () => {
+  let tmpRoot: string;
+  let log: ToolingLog;
+  let infoSpy: jest.SpyInstance;
+  let warningSpy: jest.SpyInstance;
+
+  const touch = (rel: string) => {
+    const abs = path.join(tmpRoot, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '');
+  };
+
+  const codeChanges = (changedFiles: string[], affectedModules: string[] = []): CodeChanges => ({
+    mergeBase: 'abc123',
+    changedFiles,
+    affectedModules,
+  });
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-testing-scope-'));
+    log = new ToolingLog({ level: 'verbose', writeTo: process.stdout });
+    infoSpy = jest.spyOn(log, 'info').mockImplementation(jest.fn());
+    warningSpy = jest.spyOn(log, 'warning').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('returns full/selective-disabled when selectiveTesting is false', () => {
+    const scope = resolveScoutTestingScope(codeChanges(['some/file.ts']), false, log, tmpRoot);
+    expect(scope).toEqual({ kind: 'full', reason: 'selective-disabled' });
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns full/selective-disabled when codeChanges is null', () => {
+    const scope = resolveScoutTestingScope(null, true, log, tmpRoot);
+    expect(scope).toEqual({ kind: 'full', reason: 'selective-disabled' });
+  });
+
+  it('returns full/critical-files when a critical Scout file is touched', () => {
+    const scope = resolveScoutTestingScope(
+      codeChanges(['src/platform/packages/shared/kbn-scout/src/runner/index.ts']),
+      true,
+      log,
+      tmpRoot
+    );
+    expect(scope).toEqual({ kind: 'full', reason: 'critical-files' });
+    expect(warningSpy).toHaveBeenCalledWith(
+      expect.stringContaining('critical Scout files touched')
+    );
+  });
+
+  it('returns tests-only with the affected configs when the diff is purely Scout tests', () => {
+    touch('pkg/test/scout/ui/playwright.config.ts');
+    const scope = resolveScoutTestingScope(
+      codeChanges(['pkg/test/scout/ui/tests/foo.spec.ts']),
+      true,
+      log,
+      tmpRoot
+    );
+    expect(scope.kind).toBe('tests-only');
+    if (scope.kind === 'tests-only') {
+      expect([...scope.affectedConfigPaths]).toEqual(['pkg/test/scout/ui/playwright.config.ts']);
+    }
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('tests-only fast path'));
+  });
+
+  it('returns dependency-tree when the diff mixes Scout tests and source files', () => {
+    const scope = resolveScoutTestingScope(
+      codeChanges(
+        ['pkg/test/scout/ui/tests/foo.spec.ts', 'pkg/public/foo.ts'],
+        ['@kbn/foo', '@kbn/bar']
+      ),
+      true,
+      log,
+      tmpRoot
+    );
+    expect(scope.kind).toBe('dependency-tree');
+    if (scope.kind === 'dependency-tree') {
+      expect([...scope.affectedModuleIds].sort()).toEqual(['@kbn/bar', '@kbn/foo']);
+    }
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('dependency-tree mode'));
+  });
+
+  it('priorities critical-files over tests-only', () => {
+    // A diff that is BOTH a Scout-tests-only diff AND touches a critical file
+    // should fall through to critical-files (full suite).
+    const scope = resolveScoutTestingScope(
+      codeChanges([
+        'pkg/test/scout/ui/tests/foo.spec.ts',
+        'src/platform/packages/shared/kbn-scout/src/runner/index.ts',
+      ]),
+      true,
+      log,
+      tmpRoot
+    );
+    expect(scope).toEqual({ kind: 'full', reason: 'critical-files' });
+  });
+});
+
+describe('serializeScoutTestingScope', () => {
+  it('serialises a full/selective-disabled scope with sorted affectedModules', () => {
+    const scope: ScoutTestingScope = { kind: 'full', reason: 'selective-disabled' };
+    expect(serializeScoutTestingScope(scope, new Set(['@kbn/b', '@kbn/a']))).toEqual({
+      kind: 'full',
+      reason: 'selective-disabled',
+      affectedModules: ['@kbn/a', '@kbn/b'],
+    });
+  });
+
+  it('serialises a full/critical-files scope including affectedModules', () => {
+    const scope: ScoutTestingScope = { kind: 'full', reason: 'critical-files' };
+    expect(serializeScoutTestingScope(scope, new Set(['@kbn/scout']))).toEqual({
+      kind: 'full',
+      reason: 'critical-files',
+      affectedModules: ['@kbn/scout'],
+    });
+  });
+
+  it('serialises a tests-only scope with sorted affectedConfigs', () => {
+    const scope: ScoutTestingScope = {
+      kind: 'tests-only',
+      affectedConfigPaths: new Set(['b/playwright.config.ts', 'a/playwright.config.ts']),
+    };
+    expect(serializeScoutTestingScope(scope, new Set(['@kbn/foo']))).toEqual({
+      kind: 'tests-only',
+      affectedModules: ['@kbn/foo'],
+      affectedConfigs: ['a/playwright.config.ts', 'b/playwright.config.ts'],
+    });
+  });
+
+  it('serialises a dependency-tree scope with sorted modules', () => {
+    const scope: ScoutTestingScope = {
+      kind: 'dependency-tree',
+      affectedModuleIds: new Set(['@kbn/foo', '@kbn/bar']),
+    };
+    // By contract `resolveScoutTestingScope` builds `scope.affectedModuleIds`
+    // from the same data as the `affectedModules` arg — the serializer just
+    // reuses the explicit arg.
+    expect(serializeScoutTestingScope(scope, new Set(['@kbn/foo', '@kbn/bar']))).toEqual({
+      kind: 'dependency-tree',
+      affectedModules: ['@kbn/bar', '@kbn/foo'],
+    });
+  });
+
+  it('produces an empty affectedModules array when no modules are affected', () => {
+    const scope: ScoutTestingScope = { kind: 'full', reason: 'selective-disabled' };
+    expect(serializeScoutTestingScope(scope, new Set())).toEqual({
+      kind: 'full',
+      reason: 'selective-disabled',
+      affectedModules: [],
+    });
+  });
+});
+
+describe('writeScoutTestingScope', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-write-scope-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes the serialised scope as pretty-printed JSON, creating parent dirs', () => {
+    const outputPath = path.join(tmpRoot, 'nested/dir/testing_scope.json');
+    const scope: ScoutTestingScope = {
+      kind: 'tests-only',
+      affectedConfigPaths: new Set(['x/playwright.config.ts']),
+    };
+
+    writeScoutTestingScope(scope, new Set(['@kbn/x']), outputPath);
+
+    expect(fs.existsSync(outputPath)).toBe(true);
+    const written = JSON.parse(fs.readFileSync(outputPath, 'utf-8'));
+    expect(written).toEqual({
+      kind: 'tests-only',
+      affectedModules: ['@kbn/x'],
+      affectedConfigs: ['x/playwright.config.ts'],
+    });
+  });
+});
+
+describe('readScoutTestingScope', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-read-scope-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  const writeFixture = (content: string, name = 'testing_scope.json'): string => {
+    const filePath = path.join(tmpRoot, name);
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  };
+
+  it('reads back a tests-only scope written by writeScoutTestingScope (round-trip)', () => {
+    const outputPath = path.join(tmpRoot, 'rt.json');
+    writeScoutTestingScope(
+      {
+        kind: 'tests-only',
+        affectedConfigPaths: new Set(['a/playwright.config.ts']),
+      },
+      new Set(['@kbn/a']),
+      outputPath
+    );
+    expect(readScoutTestingScope(outputPath)).toEqual({
+      kind: 'tests-only',
+      affectedModules: ['@kbn/a'],
+      affectedConfigs: ['a/playwright.config.ts'],
+    });
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => readScoutTestingScope(path.join(tmpRoot, 'missing.json'))).toThrow(
+      /Failed to read testing-scope file/
+    );
+  });
+
+  it('throws when the file is not valid JSON', () => {
+    const filePath = writeFixture('{not json');
+    expect(() => readScoutTestingScope(filePath)).toThrow(/not valid JSON/);
+  });
+
+  it('throws when the JSON shape is missing required fields', () => {
+    const filePath = writeFixture(JSON.stringify({ kind: 'full' })); // missing affectedModules
+    expect(() => readScoutTestingScope(filePath)).toThrow(/must contain/);
+  });
+
+  it('throws when kind is unknown', () => {
+    const filePath = writeFixture(JSON.stringify({ kind: 'something', affectedModules: [] }));
+    expect(() => readScoutTestingScope(filePath)).toThrow(/must contain/);
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/testing_scope.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/testing_scope.ts
@@ -1,0 +1,319 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { Minimatch } from 'minimatch';
+import { createFailError } from '@kbn/dev-cli-errors';
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { ToolingLog } from '@kbn/tooling-log';
+import {
+  CRITICAL_FILES_SCOUT,
+  SCOUT_TESTS_ONLY_IGNORE_PATTERNS,
+  SCOUT_TESTS_ONLY_SCOPE_GLOBS,
+  SCOUT_TEST_SCOPE_PATTERN,
+} from '@kbn/scout-info';
+import type { CodeChanges } from './code_changes';
+
+const PLAYWRIGHT_CONFIG = 'playwright.config.ts';
+const PARALLEL_PLAYWRIGHT_CONFIG = 'parallel.playwright.config.ts';
+
+// Pre-compile glob patterns once at module load; `minimatch(file, pattern, ...)`
+// compiles the pattern on every call, which dominates the per-file cost when
+// matching N changed files against M patterns.
+const compileMatchers = (patterns: readonly string[]): readonly Minimatch[] =>
+  patterns.map((p) => new Minimatch(p, { dot: true }));
+
+const CRITICAL_FILES_MATCHERS = compileMatchers(CRITICAL_FILES_SCOUT);
+const IGNORE_MATCHERS = compileMatchers(SCOUT_TESTS_ONLY_IGNORE_PATTERNS);
+const SCOPE_MATCHERS = compileMatchers(SCOUT_TESTS_ONLY_SCOPE_GLOBS);
+
+const matchesAny = (file: string, matchers: readonly Minimatch[]): boolean =>
+  matchers.some((m) => m.match(file));
+
+const filterExisting = (
+  configs: readonly string[],
+  repoRoot: string,
+  existsCache?: Map<string, boolean>
+): string[] =>
+  configs.filter((rel) => {
+    const cached = existsCache?.get(rel);
+    if (cached !== undefined) return cached;
+    const exists = fs.existsSync(path.join(repoRoot, rel));
+    existsCache?.set(rel, exists);
+    return exists;
+  });
+
+/**
+ * Returns true when at least one changed file matches the Scout critical-files list.
+ * A critical-files hit forces a full Scout suite run (selective testing skipped).
+ */
+export const criticalScoutFilesTouched = (changedFiles: readonly string[]): boolean =>
+  changedFiles.some((file) => matchesAny(file, CRITICAL_FILES_MATCHERS));
+
+/**
+ * Returns true when, after dropping noise files (READMEs, markdown, changelogs),
+ * every remaining changed file lives inside a Scout test scope. Empty diffs
+ * (or noise-only diffs) return false — there is nothing to fast-path.
+ */
+export const isScoutTestsOnlyDiff = (changedFiles: readonly string[]): boolean => {
+  let sawMeaningful = false;
+  for (const file of changedFiles) {
+    if (matchesAny(file, IGNORE_MATCHERS)) continue;
+    sawMeaningful = true;
+    if (!matchesAny(file, SCOPE_MATCHERS)) return false;
+  }
+  return sawMeaningful;
+};
+
+/**
+ * Map a single changed file path to the Playwright config(s) that own it.
+ *
+ * Returns 0–2 repo-relative config paths:
+ *   - 0 when the file is outside any Scout scope
+ *   - 1 when the file is under `tests/` or `parallel_tests/` (single owning config)
+ *   - 1–2 for shared scope files (fixtures, helpers, page objects, .meta/, the
+ *     config file itself) filtered against `repoRoot` to drop configs that
+ *     don't exist on disk.
+ *
+ * The resolver never crosses ui ↔ api or scout ↔ scout_<custom> scopes.
+ */
+export const deriveScoutConfigsForFile = (
+  file: string,
+  repoRoot: string,
+  existsCache?: Map<string, boolean>
+): string[] => {
+  const match = file.match(SCOUT_TEST_SCOPE_PATTERN);
+  if (!match) {
+    return [];
+  }
+
+  const [, prefix, scoutDir, type, rest = ''] = match;
+  const scope = `${prefix}/test/${scoutDir}/${type}`;
+
+  if (rest.startsWith('tests/')) {
+    return filterExisting([`${scope}/${PLAYWRIGHT_CONFIG}`], repoRoot, existsCache);
+  }
+
+  if (rest.startsWith('parallel_tests/')) {
+    return filterExisting([`${scope}/${PARALLEL_PLAYWRIGHT_CONFIG}`], repoRoot, existsCache);
+  }
+
+  // Shared scope file (fixtures/, helpers, constants, page_objects/, .meta/, ...)
+  // or the playwright config itself: map to whichever configs exist in the scope.
+  return filterExisting(
+    [`${scope}/${PLAYWRIGHT_CONFIG}`, `${scope}/${PARALLEL_PLAYWRIGHT_CONFIG}`],
+    repoRoot,
+    existsCache
+  );
+};
+
+/**
+ * Map a list of changed files to the union of owning Playwright configs.
+ * Used as the affected-configs filter in `discover-playwright-configs` and
+ * `create-test-tracks`.
+ */
+export const deriveScoutConfigsForFiles = (
+  files: readonly string[],
+  repoRoot: string
+): Set<string> => {
+  // Many changed files typically share the same scope (e.g. multiple spec
+  // edits in one plugin). Memoise existence checks across the whole batch so
+  // we don't re-stat the same playwright.config.ts once per file.
+  const existsCache = new Map<string, boolean>();
+  const configs = new Set<string>();
+  for (const file of files) {
+    for (const config of deriveScoutConfigsForFile(file, repoRoot, existsCache)) {
+      configs.add(config);
+    }
+  }
+  return configs;
+};
+
+/**
+ * Outcome of the Scout selective-testing decision. Consumers
+ * (`discover-playwright-configs`, `create-test-tracks`) dispatch on `kind` to
+ * apply the matching filter to their own test items.
+ *
+ *   - 'full'             : run everything (selective testing disabled, or the
+ *                          diff touches a critical Scout file).
+ *   - 'tests-only'       : run only the Playwright configs whose owning scope
+ *                          contains a changed file. `affectedConfigPaths` is
+ *                          repo-relative.
+ *   - 'dependency-tree'  : run configs whose owning @kbn/ module appears in
+ *                          `affectedModuleIds` (graph-traversal mode).
+ */
+export type ScoutTestingScope =
+  | { kind: 'full'; reason: 'selective-disabled' | 'critical-files' }
+  | { kind: 'tests-only'; affectedConfigPaths: ReadonlySet<string> }
+  | { kind: 'dependency-tree'; affectedModuleIds: ReadonlySet<string> };
+
+/**
+ * Decide which Scout testing scope to apply for a given diff.
+ *
+ * Decision tree (only when `selectiveTesting` is true and `codeChanges` is set):
+ *   1. Critical Scout files touched      -> { kind: 'full', reason: 'critical-files' }
+ *   2. Diff is exclusively Scout tests   -> { kind: 'tests-only', affectedConfigPaths }
+ *   3. Otherwise                         -> { kind: 'dependency-tree', affectedModuleIds }
+ *
+ * When selective testing is disabled OR no code-changes file was provided, the
+ * scope is `{ kind: 'full', reason: 'selective-disabled' }`. Per-item `isAffected`
+ * marking is NOT part of the scope — consumers derive it from
+ * `codeChanges.affectedModules` independently.
+ */
+export const resolveScoutTestingScope = (
+  codeChanges: CodeChanges | null,
+  selectiveTesting: boolean,
+  log: ToolingLog,
+  repoRoot: string = REPO_ROOT
+): ScoutTestingScope => {
+  if (!selectiveTesting || !codeChanges) {
+    return { kind: 'full', reason: 'selective-disabled' };
+  }
+
+  if (criticalScoutFilesTouched(codeChanges.changedFiles)) {
+    log.warning('Selective testing: critical Scout files touched — running full Scout suite');
+    return { kind: 'full', reason: 'critical-files' };
+  }
+
+  if (isScoutTestsOnlyDiff(codeChanges.changedFiles)) {
+    const affectedConfigPaths = deriveScoutConfigsForFiles(codeChanges.changedFiles, repoRoot);
+    log.info(
+      `Selective testing: tests-only fast path — ${affectedConfigPaths.size} affected Playwright config(s)`
+    );
+    return { kind: 'tests-only', affectedConfigPaths };
+  }
+
+  const affectedModuleIds: ReadonlySet<string> = new Set(codeChanges.affectedModules);
+  log.info(
+    `Selective testing: dependency-tree mode — ${affectedModuleIds.size} affected module(s)`
+  );
+  return { kind: 'dependency-tree', affectedModuleIds };
+};
+
+/**
+ * JSON shape produced by `scout resolve-testing-scope` and read by every
+ * downstream step (configs CLI, lanes CLI).
+ *
+ * Field semantics:
+ *   - `kind` / `reason` : the decision (mirrors ScoutTestingScope).
+ *   - `affectedModules` : ALWAYS present (sorted, possibly empty). Used both as
+ *                         the dependency-tree filter set AND for generic
+ *                         "isAffected" labeling regardless of kind.
+ *   - `affectedConfigs` : present only when `kind === 'tests-only'`; the exact
+ *                         set of Playwright configs to run.
+ */
+export interface SerializedScoutTestingScope {
+  kind: ScoutTestingScope['kind'];
+  reason?: 'selective-disabled' | 'critical-files';
+  affectedModules: readonly string[];
+  affectedConfigs?: readonly string[];
+}
+
+/**
+ * Convert a `ScoutTestingScope` into the JSON shape shared across pipeline
+ * steps. `affectedModules` is always included (even for `full` / `tests-only`
+ * scopes) so consumers can label items as "affected" regardless of kind.
+ */
+export const serializeScoutTestingScope = (
+  scope: ScoutTestingScope,
+  affectedModules: ReadonlySet<string>
+): SerializedScoutTestingScope => {
+  const sortedModules = Array.from(affectedModules).sort();
+  switch (scope.kind) {
+    case 'full':
+      return {
+        kind: 'full',
+        reason: scope.reason,
+        affectedModules: sortedModules,
+      };
+    case 'tests-only':
+      return {
+        kind: 'tests-only',
+        affectedModules: sortedModules,
+        affectedConfigs: Array.from(scope.affectedConfigPaths).sort(),
+      };
+    case 'dependency-tree':
+      // By contract `scope.affectedModuleIds === affectedModules` in this
+      // branch (set by `resolveScoutTestingScope`), so reuse the pre-sorted
+      // array instead of allocating + sorting a fresh copy.
+      return {
+        kind: 'dependency-tree',
+        affectedModules: sortedModules,
+      };
+  }
+};
+
+/**
+ * Write the serialised scope to `outputPath`, creating the parent directory
+ * if needed. Called by `scout resolve-testing-scope`.
+ */
+export const writeScoutTestingScope = (
+  scope: ScoutTestingScope,
+  affectedModules: ReadonlySet<string>,
+  outputPath: string
+): void => {
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(
+    outputPath,
+    `${JSON.stringify(serializeScoutTestingScope(scope, affectedModules), null, 2)}\n`
+  );
+};
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+
+const isSerializedScoutTestingScope = (value: unknown): value is SerializedScoutTestingScope => {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  if (
+    candidate.kind !== 'full' &&
+    candidate.kind !== 'tests-only' &&
+    candidate.kind !== 'dependency-tree'
+  ) {
+    return false;
+  }
+  if (!isStringArray(candidate.affectedModules)) return false;
+  if (candidate.affectedConfigs !== undefined && !isStringArray(candidate.affectedConfigs)) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Read and validate a testing-scope JSON file produced by `scout
+ * resolve-testing-scope`. Throws on missing/invalid input — downstream
+ * consumers must not silently fall back to a wrong mode.
+ */
+export const readScoutTestingScope = (filePath: string): SerializedScoutTestingScope => {
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(REPO_ROOT, filePath);
+  let content: string;
+  try {
+    content = fs.readFileSync(absolutePath, 'utf-8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw createFailError(`Failed to read testing-scope file '${filePath}': ${message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw createFailError(`Testing-scope file is not valid JSON ('${filePath}'): ${message}`);
+  }
+
+  if (!isSerializedScoutTestingScope(parsed)) {
+    throw createFailError(
+      `Testing-scope file '${filePath}' must contain { kind: 'full'|'tests-only'|'dependency-tree', affectedModules: string[], affectedConfigs?: string[] }`
+    );
+  }
+
+  return parsed;
+};

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/types.ts
@@ -20,7 +20,11 @@ export interface ModuleDiscoveryInfo {
   name: string;
   group: string;
   type: 'plugin' | 'package';
-  /** Set when using --affected-modules: true if this module's @kbn/ ID is in the affected set */
+  /**
+   * Set when --code-changes is provided: true if this module's @kbn/ ID is in
+   * the affected set (or if it owns an affected config in the tests-only fast
+   * path). Used to drive the "affected " prefix on Buildkite step labels.
+   */
   isAffected?: boolean;
   configs: {
     path: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[scout] Add Scout "tests-only" CI mode to only run affected playwright configs (#267533)](https://github.com/elastic/kibana/pull/267533)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-05-20T14:20:21Z","message":"[scout] Add Scout \"tests-only\" CI mode to only run affected playwright configs (#267533)\n\n## Summary\n\nfollow-up to https://github.com/elastic/kibana/pull/266379\n\nBuild skipping FTR/Jest and running a single affect Scout config:\nhttps://buildkite.com/elastic/kibana-pull-request/builds/443098#_\n**Passed in 28m 5s**\n\nAdds a `tests-only` fast path for Scout CI: when a PR's diff is\nexclusively Scout test files, only the directly-affected Playwright\nconfigs run — no dependency-tree analysis. Otherwise we fall back to the\nexisting dependency-tree mode, or to a full suite when critical Scout\nfiles are touched.\n\nThe decision tree (**full** / **tests-only** / **dependency-tree**) is\nencapsulated in a reusable resolver (`resolveScoutTestingScope`) and\nsurfaced as a new scout `resolve-testing-scope` CLI command. Both Scout\ndistribution strategies — configs (`discover-playwright-configs`) and\nlanes (`create-test-tracks`) — consume the same `testing_scope.json`\nartifact via a unified `--testing-scope` flag, so the decision is made\nonce per build.\n\nAs a free side-effect, the Jest/FTR \"Pick Test Group Run Order\" step now\nskips emitting any Jest unit/integration/FTR steps when the diff is\nexclusively Scout tests — no label, no opt-in required. The check is\nlocal to the picker and produces a Buildkite annotation explaining the\nskip.\n\n- Buildkite produces a generic `code_changes.json` artifact (changed\nfiles + affected @kbn/ modules).\n- Scout `resolve-testing-scope` consumes it and writes\n`testing_scope.json` (kind + reason + affected modules + affected\nconfigs).\n- The configs and lanes CLIs consume `testing_scope.json` and apply the\nmatching filter (config paths for tests-only, module IDs for\ndependency-tree, no filter for full).\n- The Jest/FTR picker independently runs the same \"is the diff\nexclusively Scout tests?\" predicate against the git diff it already\nneeds, via a new `selective_scout.ts` sibling of the existing\n`selective_testing.ts`. The Scout-side patterns live in\n`@kbn/scout-info` and are mirrored into `selective_scout.ts` with a\nlockstep Jest test that fails CI on drift (pipeline-utils is hermetic\nand cannot import `@kbn/*`).\n- Scout-specific patterns and the critical-files list are consolidated\nin `@kbn/scout-info`.\n\n<img width=\"1024\" height=\"559\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/16cc8576-0fd8-4c2a-983a-57371a2b4fda\"\n/>\n\n\n### How to test locally\n\n```bash\ncat > /tmp/cc.json <<'EOF'\n{\n  \"mergeBase\": \"manual-test\",\n  \"changedFiles\": [\n    \"src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts\"\n  ],\n  \"affectedModules\": [\"@kbn/discover-plugin\"]\n}\nEOF\n\nnode scripts/scout resolve-testing-scope \\\n  --code-changes /tmp/cc.json \\\n  --scope-output /tmp/testing_scope.json \\\n  --selective-testing\n\nnode scripts/scout discover-playwright-configs \\\n  --include-custom-servers \\\n  --target local-stateful-only \\\n  --testing-scope /tmp/testing_scope.json\n```\n\nExpect only a single Playwright config to be listed:\n\n```\ninfo Selective testing: tests-only fast path — 1 affected Playwright config(s)\ninfo Found Playwright config files in 1 plugin(s) and 0 package(s)\ninfo platform / [discover] plugin:\ninfo - src/platform/plugins/shared/discover/test/scout/ui/parallel.playwright.config.ts\n```\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a1870bc57296022938c4e0e25c946d5810d23f4c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.5.0"],"title":"[scout] Add Scout \"tests-only\" CI mode to only run affected playwright configs","number":267533,"url":"https://github.com/elastic/kibana/pull/267533","mergeCommit":{"message":"[scout] Add Scout \"tests-only\" CI mode to only run affected playwright configs (#267533)\n\n## Summary\n\nfollow-up to https://github.com/elastic/kibana/pull/266379\n\nBuild skipping FTR/Jest and running a single affect Scout config:\nhttps://buildkite.com/elastic/kibana-pull-request/builds/443098#_\n**Passed in 28m 5s**\n\nAdds a `tests-only` fast path for Scout CI: when a PR's diff is\nexclusively Scout test files, only the directly-affected Playwright\nconfigs run — no dependency-tree analysis. Otherwise we fall back to the\nexisting dependency-tree mode, or to a full suite when critical Scout\nfiles are touched.\n\nThe decision tree (**full** / **tests-only** / **dependency-tree**) is\nencapsulated in a reusable resolver (`resolveScoutTestingScope`) and\nsurfaced as a new scout `resolve-testing-scope` CLI command. Both Scout\ndistribution strategies — configs (`discover-playwright-configs`) and\nlanes (`create-test-tracks`) — consume the same `testing_scope.json`\nartifact via a unified `--testing-scope` flag, so the decision is made\nonce per build.\n\nAs a free side-effect, the Jest/FTR \"Pick Test Group Run Order\" step now\nskips emitting any Jest unit/integration/FTR steps when the diff is\nexclusively Scout tests — no label, no opt-in required. The check is\nlocal to the picker and produces a Buildkite annotation explaining the\nskip.\n\n- Buildkite produces a generic `code_changes.json` artifact (changed\nfiles + affected @kbn/ modules).\n- Scout `resolve-testing-scope` consumes it and writes\n`testing_scope.json` (kind + reason + affected modules + affected\nconfigs).\n- The configs and lanes CLIs consume `testing_scope.json` and apply the\nmatching filter (config paths for tests-only, module IDs for\ndependency-tree, no filter for full).\n- The Jest/FTR picker independently runs the same \"is the diff\nexclusively Scout tests?\" predicate against the git diff it already\nneeds, via a new `selective_scout.ts` sibling of the existing\n`selective_testing.ts`. The Scout-side patterns live in\n`@kbn/scout-info` and are mirrored into `selective_scout.ts` with a\nlockstep Jest test that fails CI on drift (pipeline-utils is hermetic\nand cannot import `@kbn/*`).\n- Scout-specific patterns and the critical-files list are consolidated\nin `@kbn/scout-info`.\n\n<img width=\"1024\" height=\"559\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/16cc8576-0fd8-4c2a-983a-57371a2b4fda\"\n/>\n\n\n### How to test locally\n\n```bash\ncat > /tmp/cc.json <<'EOF'\n{\n  \"mergeBase\": \"manual-test\",\n  \"changedFiles\": [\n    \"src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts\"\n  ],\n  \"affectedModules\": [\"@kbn/discover-plugin\"]\n}\nEOF\n\nnode scripts/scout resolve-testing-scope \\\n  --code-changes /tmp/cc.json \\\n  --scope-output /tmp/testing_scope.json \\\n  --selective-testing\n\nnode scripts/scout discover-playwright-configs \\\n  --include-custom-servers \\\n  --target local-stateful-only \\\n  --testing-scope /tmp/testing_scope.json\n```\n\nExpect only a single Playwright config to be listed:\n\n```\ninfo Selective testing: tests-only fast path — 1 affected Playwright config(s)\ninfo Found Playwright config files in 1 plugin(s) and 0 package(s)\ninfo platform / [discover] plugin:\ninfo - src/platform/plugins/shared/discover/test/scout/ui/parallel.playwright.config.ts\n```\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a1870bc57296022938c4e0e25c946d5810d23f4c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/267533","number":267533,"mergeCommit":{"message":"[scout] Add Scout \"tests-only\" CI mode to only run affected playwright configs (#267533)\n\n## Summary\n\nfollow-up to https://github.com/elastic/kibana/pull/266379\n\nBuild skipping FTR/Jest and running a single affect Scout config:\nhttps://buildkite.com/elastic/kibana-pull-request/builds/443098#_\n**Passed in 28m 5s**\n\nAdds a `tests-only` fast path for Scout CI: when a PR's diff is\nexclusively Scout test files, only the directly-affected Playwright\nconfigs run — no dependency-tree analysis. Otherwise we fall back to the\nexisting dependency-tree mode, or to a full suite when critical Scout\nfiles are touched.\n\nThe decision tree (**full** / **tests-only** / **dependency-tree**) is\nencapsulated in a reusable resolver (`resolveScoutTestingScope`) and\nsurfaced as a new scout `resolve-testing-scope` CLI command. Both Scout\ndistribution strategies — configs (`discover-playwright-configs`) and\nlanes (`create-test-tracks`) — consume the same `testing_scope.json`\nartifact via a unified `--testing-scope` flag, so the decision is made\nonce per build.\n\nAs a free side-effect, the Jest/FTR \"Pick Test Group Run Order\" step now\nskips emitting any Jest unit/integration/FTR steps when the diff is\nexclusively Scout tests — no label, no opt-in required. The check is\nlocal to the picker and produces a Buildkite annotation explaining the\nskip.\n\n- Buildkite produces a generic `code_changes.json` artifact (changed\nfiles + affected @kbn/ modules).\n- Scout `resolve-testing-scope` consumes it and writes\n`testing_scope.json` (kind + reason + affected modules + affected\nconfigs).\n- The configs and lanes CLIs consume `testing_scope.json` and apply the\nmatching filter (config paths for tests-only, module IDs for\ndependency-tree, no filter for full).\n- The Jest/FTR picker independently runs the same \"is the diff\nexclusively Scout tests?\" predicate against the git diff it already\nneeds, via a new `selective_scout.ts` sibling of the existing\n`selective_testing.ts`. The Scout-side patterns live in\n`@kbn/scout-info` and are mirrored into `selective_scout.ts` with a\nlockstep Jest test that fails CI on drift (pipeline-utils is hermetic\nand cannot import `@kbn/*`).\n- Scout-specific patterns and the critical-files list are consolidated\nin `@kbn/scout-info`.\n\n<img width=\"1024\" height=\"559\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/16cc8576-0fd8-4c2a-983a-57371a2b4fda\"\n/>\n\n\n### How to test locally\n\n```bash\ncat > /tmp/cc.json <<'EOF'\n{\n  \"mergeBase\": \"manual-test\",\n  \"changedFiles\": [\n    \"src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts\"\n  ],\n  \"affectedModules\": [\"@kbn/discover-plugin\"]\n}\nEOF\n\nnode scripts/scout resolve-testing-scope \\\n  --code-changes /tmp/cc.json \\\n  --scope-output /tmp/testing_scope.json \\\n  --selective-testing\n\nnode scripts/scout discover-playwright-configs \\\n  --include-custom-servers \\\n  --target local-stateful-only \\\n  --testing-scope /tmp/testing_scope.json\n```\n\nExpect only a single Playwright config to be listed:\n\n```\ninfo Selective testing: tests-only fast path — 1 affected Playwright config(s)\ninfo Found Playwright config files in 1 plugin(s) and 0 package(s)\ninfo platform / [discover] plugin:\ninfo - src/platform/plugins/shared/discover/test/scout/ui/parallel.playwright.config.ts\n```\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a1870bc57296022938c4e0e25c946d5810d23f4c"}},{"url":"https://github.com/elastic/kibana/pull/271242","number":271242,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->