### PR TITLE
[Discover] Don't hide fields button for mobile if sidebar is collapsed

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar_container.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar_container.tsx
@@ -467,7 +467,7 @@ function ButtonVariant({
       {isFieldListFlyoutVisible && (
         <EuiPortal>
           <EuiFlyout
-            size="s"
+            size="fill"
             onClose={() => setIsFieldListFlyoutVisible(false)}
             aria-labelledby="flyoutTitle"
             ownFocus

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar_container.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar_container.tsx
@@ -467,7 +467,8 @@ function ButtonVariant({
       {isFieldListFlyoutVisible && (
         <EuiPortal>
           <EuiFlyout
-            size="fill"
+            size="s"
+            container={null}
             onClose={() => setIsFieldListFlyoutVisible(false)}
             aria-labelledby="flyoutTitle"
             ownFocus

--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -11,7 +11,13 @@ import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } 
 import type { UiCounterMetricType } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
-import { EuiFlexGroup, EuiFlexItem, EuiHideFor, useEuiTheme } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHideFor,
+  useEuiTheme,
+  useIsWithinBreakpoints,
+} from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
 import type { BehaviorSubject } from 'rxjs';
 import { of } from 'rxjs';
@@ -362,6 +368,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
     [onRemoveField]
   );
 
+  const isMobile = useIsWithinBreakpoints(['xs', 's']);
   const isSidebarCollapsed = useObservable(
     unifiedFieldListSidebarContainerApi?.sidebarVisibility.isCollapsed$ ?? of(false),
     false
@@ -410,7 +417,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
       gutterSize="none"
       css={css`
         height: 100%;
-        display: ${isSidebarCollapsed ? 'none' : 'flex'};
+        display: ${isSidebarCollapsed && !isMobile ? 'none' : 'flex'};
         // Make Discover's field list background distinguished for the "new chrome"
         background-color: ${chromeStyle === 'project'
           ? euiTheme.colors.backgroundBasePlain


### PR DESCRIPTION
## Summary

Fixes: #270461

After layout toggle refactor mobile-purpose button for fields was not being rendered if the `isSidebarCollapsed=true`.

It should be visible always on mobile, regardless the `isSidebarCollapsed` value.


https://github.com/user-attachments/assets/6473e2cc-4525-4859-aaaf-b46ec487cb98


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->