### PR TITLE
[Entity Store] Lag Cutoff Circuit Breaker for Entity Store Logs Extraction

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/PAGINATION.md
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/PAGINATION.md
@@ -130,6 +130,39 @@ If the process is aborted between sub-windows, recovery resumes from the last pe
 
 ---
 
+## Lag cutoff circuit breaker
+
+When queries are consistently slow (e.g., large index, high ingest rate, under-sized ES cluster), each run may process less wall-clock data than real-time advances. The engine falls progressively further behind `now - delay`. Sub-window capping bounds per-query cost but does not help catchup — it just slices an ever-growing backlog into fixed-size pieces.
+
+The lag cutoff is a circuit breaker applied **before** the sub-window loop begins. If the computed `fromDateISO` is more than `1.5 × lookbackPeriod` before `effectiveWindowEnd`, the engine is so far behind that it cannot catch up. Rather than continuing to work through stale data, the window start is reset to `effectiveWindowEnd - frequency` — a single, frequency-sized slice of recent data.
+
+| Condition | Action |
+|-----------|--------|
+| `lag ≤ 1.5 × lookbackPeriod` | Normal operation; window unchanged. |
+| `lag > 1.5 × lookbackPeriod` | `fromDateISO` reset to `effectiveWindowEnd - frequency`; skipped range dropped; WARN logged. |
+
+After the cycle, the checkpoint is persisted at or near the frequency-sized window's end. The next run starts from there, naturally within the real-time window.
+
+The WARN log includes: original `from`, new `from`, `effectiveEnd`, `lagMs`, and `droppedMs` for observability.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant ES as Elasticsearch
+    Note over C: fromDateISO=T0 (far in the past), effectiveEnd=T_end
+    Note over C: lag = T_end - T0 > 1.5 × lookbackPeriod
+    Note over C: WARN logged — resetting fromDateISO to T_end - frequency
+    Note over C: fromDateISO = T_end - frequency (recent slice)
+    C->>ES: probe(from=T_end-freq, to=T_end) → slice end, then extract + ingest
+    Note over C: checkpoint persisted near T_end — next run is current
+```
+
+**What is dropped**: all data between the original `fromDateISO` and `effectiveWindowEnd - frequency`. This is an explicit trade-off: maintaining real-time coverage is preferred over eventually processing old backlog data that would never catch up anyway.
+
+**Manual override runs are exempt**: `specificWindow` / `windowOverride` calls supply explicit bounds and bypass the cutoff entirely (same as the sub-window cap).
+
+---
+
 ## Recovery
 
 A crash mid-entity-page leaves the following state on disk:

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.test.ts
@@ -75,6 +75,7 @@ describe('CcsLogsExtractionClient', () => {
     maxLogsPerPage: DEFAULT_MAX_LOGS_PER_PAGE,
     lookbackPeriod: '3h',
     delay: '1m',
+    frequency: '1m',
     entityDefinition: getEntityDefinition('host', 'default'),
     // Use a very large cap so existing tests remain a single sub-window. The sub-window cap
     // behavior is exercised by the dedicated tests at the end of this describe block.
@@ -345,7 +346,8 @@ describe('CcsLogsExtractionClient', () => {
   });
 
   it('should resume from mid entity-page recovery state (paginationRecoveryId set)', async () => {
-    const recoveryTimestamp = '2024-06-15T10:00:00.000Z';
+    // Use a recent checkpoint (within 4.5h of FIXED_NOW) so the lag cutoff does not fire.
+    const recoveryTimestamp = '2026-01-01T08:00:00.000Z';
     const recoveryId = 'host:h2';
     mockCcsStateClient.findOrInit.mockResolvedValue({
       checkpointTimestamp: recoveryTimestamp,
@@ -358,11 +360,11 @@ describe('CcsLogsExtractionClient', () => {
         { name: ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD, type: 'date' },
         { name: 'entity.id', type: 'keyword' },
       ],
-      values: [['2024-06-15T11:00:00.000Z', '2024-06-15T10:00:00.000Z', 'host:h3']],
+      values: [['2026-01-01T09:00:00.000Z', '2026-01-01T08:00:00.000Z', 'host:h3']],
     };
 
     mockExecuteEsqlQuery
-      .mockResolvedValueOnce(makeProbeResponse('2024-06-15T11:00:00.000Z', 1))
+      .mockResolvedValueOnce(makeProbeResponse('2026-01-01T09:00:00.000Z', 1))
       .mockResolvedValueOnce(entityPageResponse);
 
     const result = await client.extractToUpdates(defaultExtractParams);
@@ -378,7 +380,8 @@ describe('CcsLogsExtractionClient', () => {
   });
 
   it('should resume from slice-boundary recovery state (checkpointTimestamp set, paginationRecoveryId null)', async () => {
-    const sliceBoundaryTimestamp = '2024-06-15T10:00:00.000Z';
+    // Use a recent checkpoint (within 4.5h of FIXED_NOW) so the lag cutoff does not fire.
+    const sliceBoundaryTimestamp = '2026-01-01T08:00:00.000Z';
     mockCcsStateClient.findOrInit.mockResolvedValue({
       checkpointTimestamp: sliceBoundaryTimestamp,
       paginationRecoveryId: null,
@@ -390,11 +393,11 @@ describe('CcsLogsExtractionClient', () => {
         { name: ENGINE_METADATA_PAGINATION_FIRST_SEEN_LOG_FIELD, type: 'date' },
         { name: 'entity.id', type: 'keyword' },
       ],
-      values: [['2024-06-15T11:00:00.000Z', '2024-06-15T10:30:00.000Z', 'host:h4']],
+      values: [['2026-01-01T09:00:00.000Z', '2026-01-01T08:30:00.000Z', 'host:h4']],
     };
 
     mockExecuteEsqlQuery
-      .mockResolvedValueOnce(makeProbeResponse('2024-06-15T11:00:00.000Z', 1))
+      .mockResolvedValueOnce(makeProbeResponse('2026-01-01T09:00:00.000Z', 1))
       .mockResolvedValueOnce(entityPageResponse);
 
     const result = await client.extractToUpdates(defaultExtractParams);
@@ -420,7 +423,8 @@ describe('CcsLogsExtractionClient', () => {
   });
 
   it('should use checkpointTimestamp as fromDateISO on normal continuation', async () => {
-    const checkpoint = '2025-12-01T06:00:00.000Z';
+    // Use a recent checkpoint (within 4.5h of FIXED_NOW) so the lag cutoff does not fire.
+    const checkpoint = '2026-01-01T08:00:00.000Z';
     mockCcsStateClient.findOrInit.mockResolvedValue({
       checkpointTimestamp: checkpoint,
       paginationRecoveryId: null,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/ccs_logs_extraction_client.ts
@@ -35,7 +35,11 @@ import { executeEsqlQuery } from '../../infra/elasticsearch/esql';
 import { ingestEntities } from '../../infra/elasticsearch/ingest';
 import { getUpdatesEntitiesDataStreamName } from '../asset_manager/updates_data_stream';
 import type { CcsLogExtractionStateClient } from '../saved_objects/ccs_log_extraction_state';
-import { capExtractionWindowEnd, resolveCcsExtractionWindow } from './extraction_window';
+import {
+  applyMaxLagCutoff,
+  capExtractionWindowEnd,
+  resolveCcsExtractionWindow,
+} from './extraction_window';
 import { capAtMaxLogsPerWindow } from './effective_page_limits';
 
 interface CcsExtractToUpdatesParams {
@@ -45,6 +49,7 @@ interface CcsExtractToUpdatesParams {
   maxLogsPerPage: number;
   lookbackPeriod: string;
   delay: string;
+  frequency: string;
   entityDefinition: ManagedEntityDefinition;
   abortController?: AbortController;
   /** Explicit time window override (API calls). When set, the internal checkpoint is not updated. */
@@ -94,6 +99,7 @@ export class CcsLogsExtractionClient {
     maxLogsPerPage,
     lookbackPeriod,
     delay,
+    frequency,
     entityDefinition,
     abortController,
     windowOverride,
@@ -106,13 +112,27 @@ export class CcsLogsExtractionClient {
         ? { checkpointTimestamp: null, paginationRecoveryId: null }
         : await this.ccsStateClient.findOrInit(type);
 
-    const { effectiveFromDateISO, effectiveWindowEnd, recoveryId, isWindowOverride } =
-      resolveCcsExtractionWindow({
-        config: { lookbackPeriod, delay },
-        ccsState,
-        windowOverride,
-        logger: this.logger,
-      });
+    const {
+      effectiveFromDateISO: resolvedFromDateISO,
+      effectiveWindowEnd,
+      recoveryId,
+      isWindowOverride,
+    } = resolveCcsExtractionWindow({
+      config: { lookbackPeriod, delay },
+      ccsState,
+      windowOverride,
+      logger: this.logger,
+    });
+
+    const effectiveFromDateISO = isWindowOverride
+      ? resolvedFromDateISO
+      : applyMaxLagCutoff({
+          fromDateISO: resolvedFromDateISO,
+          effectiveWindowEnd,
+          lookbackPeriod,
+          frequency,
+          logger: this.logger,
+        });
 
     if (effectiveFromDateISO >= effectiveWindowEnd) {
       this.logger.error(

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/extraction_window.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/extraction_window.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import { applyMaxLagCutoff } from './extraction_window';
+
+describe('applyMaxLagCutoff', () => {
+  const frequency = '1m';
+  const lookbackPeriod = '3h';
+  // threshold = 1.5 * 3h = 4.5h = 16_200_000 ms
+  // frequency = 1m = 60_000 ms
+
+  const effectiveWindowEnd = '2024-01-01T12:00:00.000Z'; // "now - delay"
+
+  let logger: ReturnType<typeof loggerMock.create>;
+
+  beforeEach(() => {
+    logger = loggerMock.create();
+  });
+
+  it('returns unchanged window when lag is below the threshold', () => {
+    // lag = 2h < 4.5h threshold
+    const fromDateISO = '2024-01-01T10:00:00.000Z';
+
+    const result = applyMaxLagCutoff({
+      fromDateISO,
+      effectiveWindowEnd,
+      lookbackPeriod,
+      frequency,
+      logger,
+    });
+
+    expect(result).toEqual(fromDateISO);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns unchanged window when lag is exactly at the threshold (strict >)', () => {
+    // lag = exactly 4.5h = threshold; should NOT trigger
+    const fromDateISO = '2024-01-01T07:30:00.000Z';
+
+    const result = applyMaxLagCutoff({
+      fromDateISO,
+      effectiveWindowEnd,
+      lookbackPeriod,
+      frequency,
+      logger,
+    });
+
+    expect(result).toEqual(fromDateISO);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('applies cutoff and resets to effectiveWindowEnd - frequency when lag just exceeds threshold', () => {
+    // lag = 4.5h + 1ms > threshold
+    const fromDateISO = '2024-01-01T07:29:59.999Z';
+    // expected newFrom = 2024-01-01T12:00:00.000Z - 1m = 2024-01-01T11:59:00.000Z
+    const expectedNewFrom = '2024-01-01T11:59:00.000Z';
+
+    const result = applyMaxLagCutoff({
+      fromDateISO,
+      effectiveWindowEnd,
+      lookbackPeriod,
+      frequency,
+      logger,
+    });
+
+    expect(result).toEqual(expectedNewFrom);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('skipping backlog'));
+  });
+
+  it('applies cutoff for a far-behind scenario and the new window width equals frequency', () => {
+    // lag = 24h >> 4.5h threshold
+    const fromDateISO = '2023-12-31T12:00:00.000Z';
+    const expectedNewFrom = '2024-01-01T11:59:00.000Z';
+
+    const result = applyMaxLagCutoff({
+      fromDateISO,
+      effectiveWindowEnd,
+      lookbackPeriod,
+      frequency,
+      logger,
+    });
+
+    expect(result).toEqual(expectedNewFrom);
+    // verify the resulting window width is exactly frequency (1m = 60_000 ms)
+    const widthMs = new Date(effectiveWindowEnd).getTime() - new Date(result).getTime();
+    expect(widthMs).toBe(60_000);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes original fromDateISO, newFrom, and effectiveWindowEnd in the warn log', () => {
+    const fromDateISO = '2023-12-31T12:00:00.000Z';
+
+    applyMaxLagCutoff({ fromDateISO, effectiveWindowEnd, lookbackPeriod, frequency, logger });
+
+    const warnArg = (logger.warn as jest.Mock).mock.calls[0][0] as string;
+    expect(warnArg).toContain(`from=${fromDateISO}`);
+    expect(warnArg).toContain(`effectiveEnd=${effectiveWindowEnd}`);
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/extraction_window.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/extraction_window.ts
@@ -15,6 +15,7 @@ import type {
 } from '../saved_objects';
 
 export const WINDOW_CAP_GRACE_PERIOD_MS = 30_000;
+const MAX_LAG_LOOKBACK_FACTOR = 1.5;
 
 /** `now - delay`. Upper bound of all data eligible to be processed in this cycle. */
 export const computeEffectiveWindowEnd = (delay: string): string =>
@@ -128,6 +129,51 @@ export const resolveCcsExtractionWindow = ({
     recoveryId: undefined,
     isWindowOverride: false,
   };
+};
+
+/**
+ * Skip-ahead circuit breaker for stalled extractions.
+ *
+ * When the gap between `fromDateISO` and `effectiveWindowEnd` exceeds MAX_LAG_LOOKBACK_FACTOR × `lookbackPeriod`,
+ * continuing to chip away at the backlog won't let the engine catch up. Reset the window start
+ * to `effectiveWindowEnd - frequency` so this cycle still processes a real, frequency-sized
+ * slice of recent data, re-anchoring the persisted checkpoint near real-time. The skipped range
+ * is intentionally dropped.
+ */
+export const applyMaxLagCutoff = ({
+  fromDateISO,
+  effectiveWindowEnd,
+  lookbackPeriod,
+  frequency,
+  logger,
+}: {
+  fromDateISO: string;
+  effectiveWindowEnd: string;
+  lookbackPeriod: string;
+  frequency: string;
+  logger: Logger;
+}): string => {
+  const fromMs = moment(fromDateISO).valueOf();
+  const effectiveEndMs = moment(effectiveWindowEnd).valueOf();
+  const lagMs = effectiveEndMs - fromMs;
+  const lookbackMs = parseDurationToMs(lookbackPeriod);
+  const thresholdMs = MAX_LAG_LOOKBACK_FACTOR * lookbackMs;
+
+  if (lagMs <= thresholdMs) {
+    return fromDateISO;
+  }
+
+  const frequencyMs = parseDurationToMs(frequency);
+  const newFromDateISO = moment(effectiveEndMs - frequencyMs)
+    .utc()
+    .toISOString();
+
+  const droppedMs = lagMs - frequencyMs;
+  logger.warn(
+    `Extraction lag exceeded ${thresholdMs} — skipping backlog: from=${fromDateISO}, newFrom=${newFromDateISO}, effectiveEnd=${effectiveWindowEnd}, lagMs=${lagMs}, droppedMs=${droppedMs}`
+  );
+
+  return newFromDateISO;
 };
 
 export interface CappedExtractionWindow {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -33,6 +33,7 @@ import {
   HASHED_ID_FIELD,
 } from './logs_extraction_query_builder';
 import {
+  applyMaxLagCutoff,
   capExtractionWindowEnd,
   resolveMainExtractionWindow,
   validateExtractionWindow,
@@ -295,6 +296,7 @@ export class LogsExtractionClient {
         maxLogsPerPage: config.maxLogsPerPage,
         lookbackPeriod: config.lookbackPeriod,
         delay: config.delay,
+        frequency: config.frequency,
         entityDefinition,
         abortController: opts?.abortController,
         windowOverride: opts?.specificWindow,
@@ -385,12 +387,20 @@ export class LogsExtractionClient {
       };
     }
 
-    const { fromDateISO: initialFromDateISO, effectiveWindowEnd } = resolveMainExtractionWindow({
+    const { fromDateISO: resolvedFromDateISO, effectiveWindowEnd } = resolveMainExtractionWindow({
       config,
       engineState,
     });
     // Surface clock skew / corrupted state loudly if the persisted resume point is in the future.
-    validateExtractionWindow(initialFromDateISO, effectiveWindowEnd);
+    validateExtractionWindow(resolvedFromDateISO, effectiveWindowEnd);
+
+    const initialFromDateISO = applyMaxLagCutoff({
+      fromDateISO: resolvedFromDateISO,
+      effectiveWindowEnd,
+      lookbackPeriod: config.lookbackPeriod,
+      frequency: config.frequency,
+      logger: this.logger,
+    });
 
     let currentFromDateISO = initialFromDateISO;
     // Recovery cursors on the engine state apply only to the first sub-window of this run; once

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/force_ccs_extract_to_updates.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/force_ccs_extract_to_updates.ts
@@ -17,6 +17,7 @@ import { getEntityDefinition } from '../../../common/domain/definitions/registry
 import {
   LOG_EXTRACTION_CAP_BEHAVIOR_DEFAULT,
   LOG_EXTRACTION_DELAY_DEFAULT,
+  LOG_EXTRACTION_FREQUENCY_DEFAULT,
   LOG_EXTRACTION_LOOKBACK_PERIOD_DEFAULT,
   LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT,
   LOG_EXTRACTION_MAX_LOGS_PER_WINDOW_DEFAULT,
@@ -93,6 +94,7 @@ export function registerForceCcsExtractToUpdates(router: EntityStorePluginRouter
           maxLogsPerPage: maxLogsPerPage ?? LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT,
           lookbackPeriod: LOG_EXTRACTION_LOOKBACK_PERIOD_DEFAULT,
           delay: LOG_EXTRACTION_DELAY_DEFAULT,
+          frequency: LOG_EXTRACTION_FREQUENCY_DEFAULT,
           entityDefinition,
           windowOverride: { fromDateISO, toDateISO },
           maxTimeWindowSize: LOG_EXTRACTION_MAX_TIME_WINDOW_SIZE_DEFAULT,


### PR DESCRIPTION
 ### Problem
 When ES|QL queries are consistently slow (high ingest rate, large indices, under-provisioned cluster), each extraction cycle processes less wall-clock data than real time advances. The persisted checkpoint inches forward while the engine falls progressively further behind `now - delay`. The existing sub-window cap (`maxTimeWindowSize`) bounds per-query cost but doesn't solve the underlying problem — it just slices an ever-growing backlog into fixed-size chunks that can never catch up.
 
 
 ### Solution
 Add a skip-ahead circuit breaker (`applyMaxLagCutoff`) applied before the sub-window loop begins. If the gap between the persisted resume point and `effectiveWindowEnd` exceeds **1.5 × `lookbackPeriod`**, abandon the backlog for this cycle and reset the window start to `effectiveWindowEnd - frequency` — a small, frequency-sized slice of recent data. This re-anchors the checkpoint near real-time in a single cycle.
 
 The skipped range is intentionally dropped. A `WARN` log with `from`, `newFrom`, `effectiveEnd`, `lagMs`, and `droppedMs` is emitted so the skip is observable in operations.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->