### PR TITLE
[Prototype] Alert episodes list KPI filters and toolbar

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_fetch_alerting_episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_fetch_alerting_episodes_query.ts
@@ -20,12 +20,14 @@ import {
   type EpisodesSortState,
 } from '../queries/episodes_query';
 import { normalizeTags } from '../utils/normalize_tags';
+import { resolveEpisodesFilterState } from '../utils/resolve_episodes_filter_state';
 
 export interface UseFetchAlertingEpisodesQueryOptions {
   pageSize: number;
   filterState?: EpisodesFilterState;
   sortState?: EpisodesSortState;
   timeRange?: TimeRange | null;
+  currentUserProfileUid?: string;
   services: UseAlertingEpisodesDataViewOptions['services'] & {
     expressions: ExpressionsStart;
   };
@@ -46,14 +48,16 @@ export const useFetchAlertingEpisodesQuery = ({
   filterState,
   sortState = DEFAULT_SORT,
   timeRange,
+  currentUserProfileUid,
 }: UseFetchAlertingEpisodesQueryOptions) => {
   const spaceId = useSpaceId(services.spaces);
   const dataView = useAlertingEpisodesDataView({ services });
+  const resolvedFilterState = resolveEpisodesFilterState(filterState, currentUserProfileUid);
 
   const queryKey = queryKeys.list(
     spaceId,
     pageSize,
-    filterState,
+    resolvedFilterState,
     sortState,
     timeRange ?? undefined
   );
@@ -67,7 +71,7 @@ export const useFetchAlertingEpisodesQuery = ({
         abortSignal,
         pageSize,
         services,
-        filterState,
+        filterState: resolvedFilterState,
         sortState,
         timeRange,
       }),

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.test.ts
@@ -240,6 +240,42 @@ describe('buildEpisodesQuery', () => {
     expect(queryString).not.toContain('QSTR');
   });
 
+  it('should apply action KPI filters for unassigned, acknowledged, and snoozed', () => {
+    const unassigned = buildEpisodesQuery(
+      SPACE_ID,
+      { sortField: '@timestamp', sortDirection: 'desc' },
+      { actionKpi: 'unassigned' }
+    ).print('basic');
+    expect(unassigned).toContain('WHERE last_assignee_uid IS NULL');
+
+    const acknowledged = buildEpisodesQuery(
+      SPACE_ID,
+      { sortField: '@timestamp', sortDirection: 'desc' },
+      { actionKpi: 'acknowledged' }
+    ).print('basic');
+    expect(acknowledged).toContain('WHERE last_ack_action == "ack"');
+
+    const snoozed = buildEpisodesQuery(
+      SPACE_ID,
+      { sortField: '@timestamp', sortDirection: 'desc' },
+      { actionKpi: 'snoozed' }
+    ).print('basic');
+    expect(snoozed).toContain('WHERE last_snooze_action == "snooze"');
+  });
+
+  it('should apply highSeverityOnly filter', () => {
+    const query = buildEpisodesQuery(
+      SPACE_ID,
+      { sortField: '@timestamp', sortDirection: 'desc' },
+      { highSeverityOnly: true }
+    );
+    const queryString = query.print('basic');
+
+    expect(queryString).toContain('EVAL alert_severity = TO_UPPER');
+    expect(queryString).toContain('alert_severity == "HIGH"');
+    expect(queryString).toContain('alert_severity == "CRITICAL"');
+  });
+
   it('should apply assigneeUid filter with per-episode INLINE STATS', () => {
     const query = buildEpisodesQuery(
       SPACE_ID,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/queries/episodes_query.ts
@@ -59,6 +59,14 @@ export const ALERT_EPISODE_FIELDS = [
   'episode_data',
 ] as const;
 
+export type EpisodesAlertsKpiFilter = 'active' | 'high_severity' | 'total';
+
+export type EpisodesActionKpiFilter =
+  | 'assigned_to_me'
+  | 'unassigned'
+  | 'acknowledged'
+  | 'snoozed';
+
 export interface EpisodesFilterState {
   /** Single episode status (inactive | pending | active | recovering) or null for All */
   status?: string | null;
@@ -70,7 +78,15 @@ export interface EpisodesFilterState {
   tags?: string[] | null;
   /** Assignee UID — episodes whose last assignee matches this user profile UID */
   assigneeUid?: string;
+  /** Selected Alerts KPI filter (maps to status / severity constraints). */
+  alertsKpi?: EpisodesAlertsKpiFilter;
+  /** Selected Alert actions KPI filter (maps to assignee / ack / snooze constraints). */
+  actionKpi?: EpisodesActionKpiFilter;
+  /** When true, only episodes whose alert data severity is high or critical. */
+  highSeverityOnly?: boolean;
 }
+
+const HIGH_SEVERITY_VALUES = ['HIGH', 'CRITICAL'] as const;
 
 export interface EpisodesSortState {
   sortField: string;
@@ -199,6 +215,26 @@ export const buildEpisodesQuery = (
 
   if (filterState?.assigneeUid) {
     query.where`last_assignee_uid == ${filterState.assigneeUid}`;
+  }
+
+  if (filterState?.actionKpi === 'unassigned') {
+    query.where`last_assignee_uid IS NULL`;
+  }
+
+  if (filterState?.actionKpi === 'acknowledged') {
+    query.where`last_ack_action == "ack"`;
+  }
+
+  if (filterState?.actionKpi === 'snoozed') {
+    query.where`last_snooze_action == "snooze"`;
+  }
+
+  if (filterState?.highSeverityOnly) {
+    query.pipe`EVAL alert_severity = TO_UPPER(COALESCE(JSON_EXTRACT(episode_data, "severity"), ""))`;
+    const severityClause = HIGH_SEVERITY_VALUES.map((s) => `alert_severity == "${s}"`).join(
+      ' OR '
+    );
+    query.pipe(`WHERE (${severityClause})`);
   }
 
   return query.sort([sortField, sortDir]).pipe`LIMIT ${pageSizeParam}`.keep(

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/utils/resolve_episodes_filter_state.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/utils/resolve_episodes_filter_state.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EpisodesFilterState } from '../queries/episodes_query';
+
+/**
+ * Maps KPI and UI filter state into the shape consumed by {@link buildEpisodesQuery}.
+ * Resolves "assigned to me" using the current user profile UID when available.
+ */
+export const resolveEpisodesFilterState = (
+  filterState: EpisodesFilterState | undefined,
+  currentUserProfileUid?: string
+): EpisodesFilterState | undefined => {
+  if (!filterState) {
+    return undefined;
+  }
+
+  const { alertsKpi, actionKpi, highSeverityOnly, ...rest } = filterState;
+
+  let status = rest.status;
+  let severityOnly = highSeverityOnly;
+
+  if (alertsKpi === 'active' && (status == null || status === 'active')) {
+    status = 'active';
+    severityOnly = undefined;
+  } else if (alertsKpi === 'high_severity') {
+    severityOnly = true;
+  } else if (alertsKpi === 'total' && status == null) {
+    status = undefined;
+    severityOnly = undefined;
+  }
+
+  let assigneeUid = rest.assigneeUid;
+  let actionKpiFilter = actionKpi;
+
+  if (rest.assigneeUid) {
+    assigneeUid = rest.assigneeUid;
+    if (actionKpi !== 'assigned_to_me') {
+      actionKpiFilter = undefined;
+    }
+  } else if (actionKpi === 'assigned_to_me') {
+    assigneeUid = currentUserProfileUid;
+    actionKpiFilter = undefined;
+  } else if (actionKpi === 'unassigned' || actionKpi === 'acknowledged' || actionKpi === 'snoozed') {
+    assigneeUid = undefined;
+  }
+
+  return {
+    ...rest,
+    status,
+    assigneeUid,
+    actionKpi: actionKpiFilter,
+    highSeverityOnly: severityOnly,
+  };
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/alert_episodes_list_page.tsx
@@ -15,12 +15,14 @@ import {
   EuiScreenReaderOnly,
   EuiSpacer,
   logicalCSS,
+  useEuiFontSize,
   useEuiTheme,
 } from '@elastic/eui';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import type { SortOrder } from '@kbn/unified-data-table';
 import {
   DataLoadingState,
+  getRenderCustomToolbarWithElements,
   ROWS_HEIGHT_OPTIONS,
   UnifiedDataTable,
   type CustomCellRenderer,
@@ -44,12 +46,17 @@ import type { AlertEpisodesKibanaServices } from '../../episodes_kibana_services
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import * as i18n from './translations';
 import { EpisodesFilterBar } from './components/episodes_filter_bar';
+import { EpisodesKpiBlocks } from './components/episodes_kpi_blocks';
+import { EpisodesTableToolbarStatus } from './components/episodes_table_toolbar_status';
+import { DEFAULT_EPISODES_LIST_FILTER } from './utils/episodes_list_url_state';
 import { alertEpisodeToDataTableRecord } from './utils';
 import { dataTableRecordToEpisode } from './utils/data_table_record_to_episode';
 import { getDiscoverHrefForRuleAndEpisodeTimestamp } from '../../utils/discover_href_for_episode';
 import { paths } from '../../constants';
 import { useEpisodesListUrlState } from './hooks/use_episodes_list_url_state';
 import { useEpisodesBulkActions } from './hooks/use_episodes_bulk_actions';
+import { useCurrentUserProfileUid } from './hooks/use_current_user_profile_uid';
+import { useEpisodesKpiCounts } from './hooks/use_episodes_kpi_counts';
 import { EpisodeAssigneeCell } from './components/episode_assignee_cell';
 
 const PAGE_SIZE = 1000;
@@ -77,9 +84,11 @@ const CUSTOM_GRID_COLUMNS_CONFIGURATION: CustomGridColumnsConfiguration = {
 
 const getTableCss = (euiTheme: EuiThemeComputed) => css`
   height: 100%;
-  border-radius: ${euiTheme.border.radius.medium};
-  border: ${euiTheme.border.thin};
   overflow: hidden;
+
+  & .euiDataGridHeaderCell {
+    background-color: ${euiTheme.colors.lightestShade};
+  }
 
   & .unifiedDataTable__cellValue {
     font-family: unset;
@@ -101,18 +110,30 @@ const getTableCss = (euiTheme: EuiThemeComputed) => css`
     > .euiFlexGroup {
     justify-content: center;
   }
+
+  & .unifiedDataTableToolbar {
+    padding-bottom: 4px;
+  }
 `;
 
 export const AlertEpisodesListPage = () => {
   const services = useKibana<AlertEpisodesKibanaServices>().services;
   const queryClient = useQueryClient();
   const { euiTheme } = useEuiTheme();
+  const pageTitleSizeM = useEuiFontSize('xl');
   const timefilter = services.data.query.timefilter.timefilter;
 
   useBreadcrumbs('episodes_list');
 
   const { filterState, setFilterState, timeRange, handleTimeChange } =
     useEpisodesListUrlState(timefilter);
+  const currentUserProfileUid = useCurrentUserProfileUid(services.userProfile);
+  const { counts: kpiCounts, isLoading: isLoadingKpiCounts } = useEpisodesKpiCounts({
+    filterState,
+    timeRange,
+    currentUserProfileUid,
+    services,
+  });
   const [sortState, setSortState] = useState<EpisodesSortState>(DEFAULT_SORT);
   const [columns, setColumns] = useState<string[]>([
     'episode.status',
@@ -135,6 +156,7 @@ export const AlertEpisodesListPage = () => {
     filterState,
     sortState,
     timeRange,
+    currentUserProfileUid,
   });
 
   const sort: SortOrder[] = useMemo(
@@ -249,6 +271,28 @@ export const AlertEpisodesListPage = () => {
     setColumns(cols);
   }, []);
 
+  const onClearFilters = useCallback(() => {
+    setFilterState({ ...DEFAULT_EPISODES_LIST_FILTER });
+  }, [setFilterState]);
+
+  const filteredCount = episodesData?.length ?? 0;
+  const viewAllCount = kpiCounts.totalAlerts;
+
+  const renderCustomToolbar = useMemo(
+    () =>
+      getRenderCustomToolbarWithElements({
+        leftSide: (
+          <EpisodesTableToolbarStatus
+            filterState={filterState}
+            filteredCount={filteredCount}
+            viewAllCount={viewAllCount}
+            onClearFilters={onClearFilters}
+          />
+        ),
+      }),
+    [filterState, filteredCount, viewAllCount, onClearFilters]
+  );
+
   const externalCustomRenderers = useMemo<CustomCellRenderer>(
     () => ({
       'episode.status': (props) => <EpisodeStatusCell {...props} />,
@@ -280,7 +324,16 @@ export const AlertEpisodesListPage = () => {
         min-width: 0;
       `}
     >
-      <EuiPageHeader bottomBorder pageTitle={i18n.EPISODES_LIST_PAGE_TITLE} />
+      <EuiPageHeader
+        bottomBorder
+        pageTitle={i18n.EPISODES_LIST_PAGE_TITLE}
+        css={css`
+          .euiPageHeaderContent .euiTitle {
+            font-size: ${pageTitleSizeM.fontSize};
+            line-height: ${pageTitleSizeM.lineHeight};
+          }
+        `}
+      />
       <EuiSpacer size="m" />
 
       <EuiFlexGroup
@@ -303,6 +356,12 @@ export const AlertEpisodesListPage = () => {
             services={services}
           />
           <EuiSpacer size="s" />
+          <EpisodesKpiBlocks
+            filterState={filterState}
+            onFilterChange={setFilterState}
+            counts={kpiCounts}
+            isLoading={isLoadingKpiCounts}
+          />
         </EuiFlexItem>
         <EuiFlexItem
           grow
@@ -324,6 +383,8 @@ export const AlertEpisodesListPage = () => {
                 settings={ALERT_EPISODES_TABLE_SETTINGS}
                 css={getTableCss(euiTheme)}
                 gridStyleOverride={{
+                  border: 'horizontal',
+                  header: 'shade',
                   stripes: false,
                   cellPadding: 'l',
                 }}
@@ -349,6 +410,7 @@ export const AlertEpisodesListPage = () => {
                 customBulkActions={customBulkActions}
                 rowAdditionalLeadingControls={rowAdditionalLeadingControls}
                 enableComparisonMode={false}
+                renderCustomToolbar={renderCustomToolbar}
                 services={services}
               />
             )}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_filter_bar.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_filter_bar.tsx
@@ -8,13 +8,11 @@
 import React, {
   useCallback,
   useEffect,
-  useMemo,
   useState,
   type ChangeEvent,
   type SetStateAction,
 } from 'react';
 import {
-  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFilterGroup,
@@ -31,8 +29,10 @@ import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import type { HttpStart } from '@kbn/core-http-browser';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import useDebounce from 'react-use/lib/useDebounce';
-import deepEqual from 'fast-deep-equal';
-import { DEFAULT_EPISODES_LIST_FILTER } from '../utils/episodes_list_url_state';
+import {
+  applyAssigneeFilterChange,
+  applyStatusFilterChange,
+} from '../utils/episodes_kpi_filter_utils';
 import * as i18n from '../translations';
 
 export interface EpisodesFilterBarProps {
@@ -77,7 +77,7 @@ export const EpisodesFilterBar = ({
 
   const onStatusChange = useCallback(
     (status: string | undefined) => {
-      onFilterChange((prev) => ({ ...prev, status }));
+      onFilterChange((prev) => applyStatusFilterChange(prev, status));
     },
     [onFilterChange]
   );
@@ -98,7 +98,7 @@ export const EpisodesFilterBar = ({
 
   const onAssigneeChange = useCallback(
     (assigneeUid: string | undefined) => {
-      onFilterChange((prev) => ({ ...prev, assigneeUid }));
+      onFilterChange((prev) => applyAssigneeFilterChange(prev, assigneeUid));
     },
     [onFilterChange]
   );
@@ -106,16 +106,6 @@ export const EpisodesFilterBar = ({
   const onKueryChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setQueryStringInput(e.target.value);
   }, []);
-
-  const hasActiveFilters = useMemo(
-    () => !deepEqual(filterState, DEFAULT_EPISODES_LIST_FILTER) || queryStringInput.trim() !== '',
-    [filterState, queryStringInput]
-  );
-
-  const onClearFilters = useCallback(() => {
-    setQueryStringInput('');
-    onFilterChange({ ...DEFAULT_EPISODES_LIST_FILTER });
-  }, [onFilterChange]);
 
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" wrap={false}>
@@ -165,17 +155,6 @@ export const EpisodesFilterBar = ({
             </EuiFilterGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty
-          size="xs"
-          iconType="cross"
-          disabled={!hasActiveFilters}
-          onClick={onClearFilters}
-          data-test-subj="episodesFilterBar-resetFilters"
-        >
-          {i18n.EPISODES_FILTER_BAR_RESET_FILTERS}
-        </EuiButtonEmpty>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiSuperDatePicker

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_kpi_blocks.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_kpi_blocks.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiTitle,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { EpisodesFilterState } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import type { EpisodesKpiCounts } from '../hooks/use_episodes_kpi_counts';
+import {
+  isActionKpiSelected,
+  isAlertsKpiSelected,
+  toggleActionKpiFilter,
+  toggleAlertsKpiFilter,
+} from '../utils/episodes_kpi_filter_utils';
+import * as i18n from '../translations';
+import { KpiMetricItem } from './kpi_metric_item';
+
+export interface EpisodesKpiBlocksProps {
+  filterState: EpisodesFilterState;
+  onFilterChange: (next: EpisodesFilterState) => void;
+  counts: EpisodesKpiCounts;
+  isLoading?: boolean;
+}
+
+interface KpiSectionProps {
+  title: string;
+  'data-test-subj': string;
+  children: React.ReactNode;
+}
+
+const KpiSection = ({ title, children, 'data-test-subj': dataTestSubj }: KpiSectionProps) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiFlexItem grow={1}>
+      <EuiPanel
+        paddingSize="s"
+        hasShadow={false}
+        data-test-subj={dataTestSubj}
+        css={css`
+          width: 100%;
+          height: 100%;
+          border: ${euiTheme.border.thin};
+          border-radius: ${euiTheme.border.radius.medium};
+        `}
+      >
+        <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="xxs">
+              <h3>{title}</h3>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup
+              gutterSize="s"
+              alignItems="flexStart"
+              responsive={false}
+              wrap={false}
+            >
+              {children}
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </EuiFlexItem>
+  );
+};
+
+export const EpisodesKpiBlocks = ({
+  filterState,
+  onFilterChange,
+  counts,
+}: EpisodesKpiBlocksProps) => {
+  const onAlertsKpiClick = useCallback(
+    (kpi: 'active' | 'high_severity' | 'total') => {
+      onFilterChange(toggleAlertsKpiFilter(filterState, kpi));
+    },
+    [filterState, onFilterChange]
+  );
+
+  const onActionKpiClick = useCallback(
+    (kpi: 'assigned_to_me' | 'unassigned' | 'acknowledged' | 'snoozed') => {
+      onFilterChange(toggleActionKpiFilter(filterState, kpi));
+    },
+    [filterState, onFilterChange]
+  );
+
+  return (
+    <EuiFlexGroup
+      gutterSize="m"
+      alignItems="stretch"
+      responsive={false}
+      data-test-subj="episodesKpiBlocks"
+      css={css`
+        width: 100%;
+      `}
+    >
+      <KpiSection title={i18n.EPISODES_KPI_ALERTS_TITLE} data-test-subj="episodesKpi-alerts">
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_ACTIVE_ALERTS}
+          value={counts.activeAlerts}
+          isSelected={isAlertsKpiSelected(filterState, 'active')}
+          emphasizeValue
+          onClick={() => onAlertsKpiClick('active')}
+          data-test-subj="episodesKpi-activeAlerts"
+        />
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_HIGH_SEVERITY}
+          value={counts.highSeverityAlerts}
+          isSelected={isAlertsKpiSelected(filterState, 'high_severity')}
+          emphasizeValue
+          onClick={() => onAlertsKpiClick('high_severity')}
+          data-test-subj="episodesKpi-highSeverity"
+        />
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_TOTAL_ALERTS}
+          value={counts.totalAlerts}
+          isSelected={isAlertsKpiSelected(filterState, 'total')}
+          onClick={() => onAlertsKpiClick('total')}
+          data-test-subj="episodesKpi-totalAlerts"
+        />
+      </KpiSection>
+
+      <KpiSection title={i18n.EPISODES_KPI_ACTIONS_TITLE} data-test-subj="episodesKpi-alertActions">
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_ASSIGNED_TO_ME}
+          value={counts.assignedToMe}
+          isSelected={isActionKpiSelected(filterState, 'assigned_to_me')}
+          onClick={() => onActionKpiClick('assigned_to_me')}
+          data-test-subj="episodesKpi-assignedToMe"
+        />
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_UNASSIGNED}
+          value={counts.unassigned}
+          isSelected={isActionKpiSelected(filterState, 'unassigned')}
+          onClick={() => onActionKpiClick('unassigned')}
+          data-test-subj="episodesKpi-unassigned"
+        />
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_ACKNOWLEDGED}
+          value={counts.acknowledged}
+          isSelected={isActionKpiSelected(filterState, 'acknowledged')}
+          onClick={() => onActionKpiClick('acknowledged')}
+          data-test-subj="episodesKpi-acknowledged"
+        />
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_SNOOZED}
+          value={counts.snoozed}
+          isSelected={isActionKpiSelected(filterState, 'snoozed')}
+          onClick={() => onActionKpiClick('snoozed')}
+          data-test-subj="episodesKpi-snoozed"
+        />
+      </KpiSection>
+
+      <KpiSection title={i18n.EPISODES_KPI_RULES_TITLE} data-test-subj="episodesKpi-rules">
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_TOTAL_RULES}
+          value={counts.totalRules}
+          isInteractive={false}
+          data-test-subj="episodesKpi-totalRules"
+        />
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_FIRING_RULES}
+          value={counts.firingRules}
+          isInteractive={false}
+          data-test-subj="episodesKpi-firingRules"
+        />
+        <KpiMetricItem
+          label={i18n.EPISODES_KPI_ENABLED_RULES}
+          value={counts.enabledRules}
+          isInteractive={false}
+          data-test-subj="episodesKpi-enabledRules"
+        />
+      </KpiSection>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_table_toolbar_status.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_table_toolbar_status.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { FormattedMessage, FormattedNumber } from '@kbn/i18n-react';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import type { EpisodesFilterState } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import * as i18n from '../translations';
+import {
+  getEpisodesToolbarStatusKind,
+  shouldShowToolbarReset,
+} from '../utils/episodes_filter_utils';
+
+export interface EpisodesTableToolbarStatusProps {
+  filterState: EpisodesFilterState;
+  filteredCount: number;
+  /** Total alerts in range (View all / Total KPI pool). */
+  viewAllCount: number;
+  onClearFilters: () => void;
+}
+
+export const EpisodesTableToolbarStatus = ({
+  filterState,
+  filteredCount,
+  viewAllCount,
+  onClearFilters,
+}: EpisodesTableToolbarStatusProps) => {
+  const showReset = shouldShowToolbarReset(filterState);
+  const statusKind = getEpisodesToolbarStatusKind(filterState);
+
+  const statusMessage = useMemo(() => {
+    const count = (
+      <strong>
+        <FormattedNumber value={filteredCount} />
+      </strong>
+    );
+    const total = (
+      <strong>
+        <FormattedNumber value={viewAllCount} />
+      </strong>
+    );
+
+    switch (statusKind) {
+      case 'active_alerts':
+      case 'filtered':
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.episodes.tableToolbar.showingFiltered"
+            defaultMessage="Showing {count} of {total} alerts"
+            values={{ count, total }}
+          />
+        );
+      case 'view_all':
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.episodes.tableToolbar.viewingAll"
+            defaultMessage="Viewing all {count} alerts"
+            values={{ count }}
+          />
+        );
+      case 'high_severity':
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.episodes.tableToolbar.viewingHighSeverity"
+            defaultMessage="Viewing {count} high severity alerts"
+            values={{ count }}
+          />
+        );
+      default:
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.episodes.tableToolbar.showingFiltered"
+            defaultMessage="Showing {count} of {total} alerts"
+            values={{ count, total }}
+          />
+        );
+    }
+  }, [statusKind, filteredCount, viewAllCount]);
+
+  return (
+    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center" wrap={false}>
+      <EuiFlexItem grow={false}>
+        <EuiText size="s" data-test-subj="episodesTableToolbar-status">
+          {statusMessage}
+        </EuiText>
+      </EuiFlexItem>
+      {showReset ? (
+        <>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s" color="subdued" aria-hidden>
+              |
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="xs"
+              color="text"
+              iconType="eraser"
+              onClick={onClearFilters}
+              data-test-subj="episodesTableToolbar-resetFilters"
+            >
+              {i18n.EPISODES_FILTER_BAR_RESET_FILTERS}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        </>
+      ) : null}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/kpi_metric_item.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/kpi_metric_item.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexItem, EuiStat, formatNumber, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export interface KpiMetricItemProps {
+  label: string;
+  value: number;
+  isSelected?: boolean;
+  isInteractive?: boolean;
+  emphasizeValue?: boolean;
+  onClick?: () => void;
+  'data-test-subj'?: string;
+}
+
+export const KpiMetricItem = ({
+  label,
+  value,
+  isSelected = false,
+  isInteractive = true,
+  emphasizeValue = false,
+  onClick,
+  'data-test-subj': dataTestSubj,
+}: KpiMetricItemProps) => {
+  const { euiTheme } = useEuiTheme();
+  const formattedValue = formatNumber(value, '0,0.[0]a');
+
+  const stat = (
+    <EuiStat
+      data-test-subj={dataTestSubj}
+      title={formattedValue}
+      description={label}
+      titleSize="s"
+      titleColor={emphasizeValue ? 'danger' : 'default'}
+      reverse
+      css={css`
+        width: 100%;
+      `}
+    />
+  );
+
+  const wrapperCss = css`
+    width: 100%;
+    padding: ${euiTheme.size.xs};
+    border-radius: ${euiTheme.border.radius.medium};
+    border: ${euiTheme.border.width.thin} solid
+      ${isSelected ? euiTheme.colors.borderBaseProminent : 'transparent'};
+    background: ${isSelected ? euiTheme.colors.backgroundBaseHighlighted : 'transparent'};
+    ${isInteractive
+      ? css`
+          cursor: pointer;
+          &:hover {
+            background: ${euiTheme.colors.backgroundBaseHighlighted};
+          }
+        `
+      : ''}
+  `;
+
+  if (!isInteractive || !onClick) {
+    return (
+      <EuiFlexItem grow={1}>
+        <div css={wrapperCss}>{stat}</div>
+      </EuiFlexItem>
+    );
+  }
+
+  return (
+    <EuiFlexItem grow={1}>
+      <button
+        type="button"
+        onClick={onClick}
+        css={css`
+          border: none;
+          background: transparent;
+          padding: 0;
+          text-align: left;
+          width: 100%;
+          ${wrapperCss}
+        `}
+        aria-pressed={isSelected}
+      >
+        {stat}
+      </button>
+    </EuiFlexItem>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/hooks/use_current_user_profile_uid.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/hooks/use_current_user_profile_uid.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+import type { UserProfileService } from '@kbn/core-user-profile-browser';
+
+export const useCurrentUserProfileUid = (userProfile: UserProfileService) => {
+  const [uid, setUid] = useState<string | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const profile = await userProfile.getCurrent();
+        if (!cancelled) {
+          setUid(profile?.uid);
+        }
+      } catch {
+        if (!cancelled) {
+          setUid(undefined);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userProfile]);
+
+  return uid;
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/hooks/use_episodes_kpi_counts.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/hooks/use_episodes_kpi_counts.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { TimeRange } from '@kbn/es-query';
+import type { AlertEpisode, EpisodesFilterState } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import { useFetchAlertingEpisodesQuery } from '@kbn/alerting-v2-episodes-ui/hooks/use_fetch_alerting_episodes_query';
+import type { UseFetchAlertingEpisodesQueryOptions } from '@kbn/alerting-v2-episodes-ui/hooks/use_fetch_alerting_episodes_query';
+import { useFetchRules } from '../../../hooks/use_fetch_rules';
+import { buildRulesListFilter } from '../../rules_list_page/utils';
+
+const KPI_COUNT_PAGE_SIZE = 1000;
+
+const HIGH_SEVERITY_VALUES = new Set(['HIGH', 'CRITICAL']);
+
+const getEpisodeSeverity = (episode: AlertEpisode): string | undefined => {
+  if (!episode.episode_data) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(episode.episode_data) as { severity?: string };
+    return parsed.severity?.toUpperCase();
+  } catch {
+    return undefined;
+  }
+};
+
+const buildCountFilterState = (filterState: EpisodesFilterState): EpisodesFilterState => ({
+  queryString: filterState.queryString,
+  ruleId: filterState.ruleId,
+  tags: filterState.tags,
+  status: undefined,
+  alertsKpi: undefined,
+  actionKpi: undefined,
+  highSeverityOnly: undefined,
+  assigneeUid: undefined,
+});
+
+export interface EpisodesKpiCounts {
+  activeAlerts: number;
+  highSeverityAlerts: number;
+  totalAlerts: number;
+  assignedToMe: number;
+  unassigned: number;
+  acknowledged: number;
+  snoozed: number;
+  totalRules: number;
+  firingRules: number;
+  enabledRules: number;
+}
+
+interface UseEpisodesKpiCountsParams {
+  filterState: EpisodesFilterState;
+  timeRange: TimeRange;
+  currentUserProfileUid?: string;
+  services: UseFetchAlertingEpisodesQueryOptions['services'];
+}
+
+export const useEpisodesKpiCounts = ({
+  filterState,
+  timeRange,
+  currentUserProfileUid,
+  services,
+}: UseEpisodesKpiCountsParams) => {
+  const countFilterState = useMemo(() => buildCountFilterState(filterState), [filterState]);
+
+  const { data: episodesForCounts, isLoading: isLoadingEpisodes } = useFetchAlertingEpisodesQuery({
+    pageSize: KPI_COUNT_PAGE_SIZE,
+    services,
+    filterState: countFilterState,
+    timeRange,
+    currentUserProfileUid,
+  });
+
+  const { data: allRulesData, isLoading: isLoadingAllRules } = useFetchRules({
+    page: 1,
+    perPage: 1,
+  });
+
+  const { data: enabledRulesData, isLoading: isLoadingEnabledRules } = useFetchRules({
+    page: 1,
+    perPage: 1,
+    filter: buildRulesListFilter({ enabled: 'true' }),
+  });
+
+  const episodeCounts = useMemo((): Omit<
+    EpisodesKpiCounts,
+    'totalRules' | 'firingRules' | 'enabledRules'
+  > => {
+    const episodes = episodesForCounts ?? [];
+
+    return {
+      activeAlerts: episodes.filter(
+        (ep) => ep['episode.status'] === 'active' && ep.last_deactivate_action !== 'deactivate'
+      ).length,
+      highSeverityAlerts: episodes.filter((ep) => {
+        const severity = getEpisodeSeverity(ep);
+        return severity != null && HIGH_SEVERITY_VALUES.has(severity);
+      }).length,
+      totalAlerts: episodes.length,
+      assignedToMe: currentUserProfileUid
+        ? episodes.filter((ep) => ep.last_assignee_uid === currentUserProfileUid).length
+        : 0,
+      unassigned: episodes.filter((ep) => ep.last_assignee_uid == null).length,
+      acknowledged: episodes.filter((ep) => ep.last_ack_action === 'ack').length,
+      snoozed: episodes.filter((ep) => ep.last_snooze_action === 'snooze').length,
+    };
+  }, [episodesForCounts, currentUserProfileUid]);
+
+  const firingRules = useMemo(() => {
+    const activeRuleIds = new Set(
+      (episodesForCounts ?? [])
+        .filter(
+          (ep) => ep['episode.status'] === 'active' && ep.last_deactivate_action !== 'deactivate'
+        )
+        .map((ep) => ep['rule.id'])
+    );
+    return activeRuleIds.size;
+  }, [episodesForCounts]);
+
+  return {
+    counts: {
+      ...episodeCounts,
+      totalRules: allRulesData?.total ?? 0,
+      enabledRules: enabledRulesData?.total ?? 0,
+      firingRules,
+    },
+    isLoading: isLoadingEpisodes || isLoadingAllRules || isLoadingEnabledRules,
+  };
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/translations.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/translations.ts
@@ -56,6 +56,76 @@ export const EPISODES_ASSIGNEE_UNKNOWN_USER = i18n.translate(
   }
 );
 
+export const EPISODES_KPI_ALERTS_TITLE = i18n.translate('xpack.alertingV2.episodes.kpi.alertsTitle', {
+  defaultMessage: 'Alerts',
+});
+
+export const EPISODES_KPI_ACTIVE_ALERTS = i18n.translate(
+  'xpack.alertingV2.episodes.kpi.activeAlerts',
+  {
+    defaultMessage: 'Active alerts',
+  }
+);
+
+export const EPISODES_KPI_HIGH_SEVERITY = i18n.translate(
+  'xpack.alertingV2.episodes.kpi.highSeverity',
+  {
+    defaultMessage: '> high severity',
+  }
+);
+
+export const EPISODES_KPI_TOTAL_ALERTS = i18n.translate('xpack.alertingV2.episodes.kpi.totalAlerts', {
+  defaultMessage: 'Total',
+});
+
+export const EPISODES_KPI_ACTIONS_TITLE = i18n.translate(
+  'xpack.alertingV2.episodes.kpi.actionsTitle',
+  {
+    defaultMessage: 'Alert actions',
+  }
+);
+
+export const EPISODES_KPI_ASSIGNED_TO_ME = i18n.translate(
+  'xpack.alertingV2.episodes.kpi.assignedToMe',
+  {
+    defaultMessage: 'Assign to me',
+  }
+);
+
+export const EPISODES_KPI_UNASSIGNED = i18n.translate('xpack.alertingV2.episodes.kpi.unassigned', {
+  defaultMessage: 'Unassigned',
+});
+
+export const EPISODES_KPI_ACKNOWLEDGED = i18n.translate(
+  'xpack.alertingV2.episodes.kpi.acknowledged',
+  {
+    defaultMessage: 'Acknowledge',
+  }
+);
+
+export const EPISODES_KPI_SNOOZED = i18n.translate('xpack.alertingV2.episodes.kpi.snoozed', {
+  defaultMessage: 'Snoozed',
+});
+
+export const EPISODES_KPI_RULES_TITLE = i18n.translate('xpack.alertingV2.episodes.kpi.rulesTitle', {
+  defaultMessage: 'Rules',
+});
+
+export const EPISODES_KPI_TOTAL_RULES = i18n.translate('xpack.alertingV2.episodes.kpi.totalRules', {
+  defaultMessage: 'Total rules',
+});
+
+export const EPISODES_KPI_FIRING_RULES = i18n.translate('xpack.alertingV2.episodes.kpi.firingRules', {
+  defaultMessage: 'Firing',
+});
+
+export const EPISODES_KPI_ENABLED_RULES = i18n.translate(
+  'xpack.alertingV2.episodes.kpi.enabledRules',
+  {
+    defaultMessage: 'Enabled',
+  }
+);
+
 export const EPISODES_FILTER_BAR_RESET_FILTERS = i18n.translate(
   'xpack.alertingV2.episodes.filterBar.resetFilters',
   {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_filter_utils.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_filter_utils.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_EPISODES_LIST_FILTER } from './episodes_list_url_state';
+import {
+  getEpisodesToolbarStatusKind,
+  isDefaultActiveAlertsView,
+  isViewAllAlertsScope,
+  shouldShowToolbarReset,
+} from './episodes_filter_utils';
+
+describe('episodes_filter_utils', () => {
+  describe('isDefaultActiveAlertsView', () => {
+    it('returns true for the default active alerts scope', () => {
+      expect(isDefaultActiveAlertsView(DEFAULT_EPISODES_LIST_FILTER)).toBe(true);
+    });
+
+    it('returns false when Total (view all) is selected', () => {
+      expect(
+        isDefaultActiveAlertsView({
+          ...DEFAULT_EPISODES_LIST_FILTER,
+          alertsKpi: 'total',
+          status: undefined,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('isViewAllAlertsScope', () => {
+    it('returns true for the Total KPI', () => {
+      expect(
+        isViewAllAlertsScope({
+          alertsKpi: 'total',
+          status: undefined,
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe('getEpisodesToolbarStatusKind', () => {
+    it('uses active_alerts on first visit', () => {
+      expect(getEpisodesToolbarStatusKind(DEFAULT_EPISODES_LIST_FILTER)).toBe('active_alerts');
+    });
+
+    it('uses view_all for the Total KPI without narrowing filters', () => {
+      expect(
+        getEpisodesToolbarStatusKind({
+          alertsKpi: 'total',
+          status: undefined,
+        })
+      ).toBe('view_all');
+    });
+
+    it('uses active_alerts when search narrows the default active scope', () => {
+      expect(
+        getEpisodesToolbarStatusKind({
+          ...DEFAULT_EPISODES_LIST_FILTER,
+          queryString: 'error',
+        })
+      ).toBe('active_alerts');
+    });
+  });
+
+  describe('shouldShowToolbarReset', () => {
+    it('shows reset on the default active view', () => {
+      expect(shouldShowToolbarReset(DEFAULT_EPISODES_LIST_FILTER)).toBe(true);
+    });
+
+    it('hides reset when view all (Total) is selected', () => {
+      expect(
+        shouldShowToolbarReset({
+          alertsKpi: 'total',
+          status: undefined,
+        })
+      ).toBe(false);
+    });
+
+    it('hides reset on view all even when search is applied', () => {
+      expect(
+        shouldShowToolbarReset({
+          alertsKpi: 'total',
+          status: undefined,
+          queryString: 'error',
+        })
+      ).toBe(false);
+    });
+
+    it('shows reset when Active alerts is selected with narrowing filters', () => {
+      expect(
+        shouldShowToolbarReset({
+          ...DEFAULT_EPISODES_LIST_FILTER,
+          ruleId: 'rule-1',
+        })
+      ).toBe(true);
+    });
+
+    it('hides reset when high severity is selected', () => {
+      expect(
+        shouldShowToolbarReset({
+          ...DEFAULT_EPISODES_LIST_FILTER,
+          alertsKpi: 'high_severity',
+          highSeverityOnly: true,
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_filter_utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_filter_utils.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EpisodesFilterState } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import deepEqual from 'fast-deep-equal';
+import { DEFAULT_EPISODES_LIST_FILTER } from './episodes_list_url_state';
+import { isAlertsKpiSelected } from './episodes_kpi_filter_utils';
+
+/** Default list scope on first visit: Active alerts KPI with no extra filters. */
+export const isDefaultActiveAlertsView = (filterState: EpisodesFilterState): boolean =>
+  filterState.alertsKpi === DEFAULT_EPISODES_LIST_FILTER.alertsKpi &&
+  filterState.status === DEFAULT_EPISODES_LIST_FILTER.status &&
+  !filterState.highSeverityOnly &&
+  !filterState.actionKpi &&
+  !filterState.ruleId &&
+  !filterState.tags?.length &&
+  !filterState.assigneeUid &&
+  !filterState.queryString;
+
+/** Active alerts KPI is selected (default scope on first visit). */
+export const isActiveAlertsScope = (filterState: EpisodesFilterState): boolean =>
+  isAlertsKpiSelected(filterState, 'active');
+
+/** Total KPI / all statuses — the "view all" pool used as the comparison total. */
+export const isViewAllAlertsScope = (filterState: EpisodesFilterState): boolean =>
+  filterState.alertsKpi === 'total' ||
+  (filterState.status == null &&
+    filterState.alertsKpi !== 'active' &&
+    filterState.alertsKpi !== 'high_severity' &&
+    !filterState.highSeverityOnly);
+
+export const isHighSeverityAlertsScope = (filterState: EpisodesFilterState): boolean =>
+  filterState.alertsKpi === 'high_severity' || Boolean(filterState.highSeverityOnly);
+
+/** Search, rule, tags, assignee, or alert-action KPIs layered on top of the alerts scope. */
+export const hasNarrowingEpisodesFilters = (filterState: EpisodesFilterState): boolean =>
+  Boolean(
+    filterState.ruleId ||
+      filterState.tags?.length ||
+      filterState.assigneeUid ||
+      filterState.queryString ||
+      filterState.actionKpi
+  );
+
+export const hasActiveEpisodesFilters = (filterState: EpisodesFilterState): boolean =>
+  !deepEqual(filterState, DEFAULT_EPISODES_LIST_FILTER);
+
+/** Reset is shown only for Active alerts; Total (view all) never shows reset. */
+export const shouldShowToolbarReset = (filterState: EpisodesFilterState): boolean =>
+  isActiveAlertsScope(filterState);
+
+export type EpisodesToolbarStatusKind =
+  | 'active_alerts'
+  | 'view_all'
+  | 'high_severity'
+  | 'filtered';
+
+export const getEpisodesToolbarStatusKind = (
+  filterState: EpisodesFilterState
+): EpisodesToolbarStatusKind => {
+  if (isActiveAlertsScope(filterState)) {
+    return 'active_alerts';
+  }
+
+  if (isViewAllAlertsScope(filterState)) {
+    return 'view_all';
+  }
+
+  if (hasNarrowingEpisodesFilters(filterState)) {
+    return 'filtered';
+  }
+
+  if (isHighSeverityAlertsScope(filterState)) {
+    return 'high_severity';
+  }
+
+  return 'filtered';
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_kpi_filter_utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_kpi_filter_utils.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  EpisodesActionKpiFilter,
+  EpisodesAlertsKpiFilter,
+  EpisodesFilterState,
+} from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import { DEFAULT_EPISODES_LIST_FILTER } from './episodes_list_url_state';
+
+export const toggleAlertsKpiFilter = (
+  filterState: EpisodesFilterState,
+  kpi: EpisodesAlertsKpiFilter
+): EpisodesFilterState => {
+  const isSelected = filterState.alertsKpi === kpi;
+
+  if (isSelected) {
+    const next = { ...filterState, alertsKpi: undefined, highSeverityOnly: undefined };
+    if (kpi === 'total') {
+      next.status = DEFAULT_EPISODES_LIST_FILTER.status;
+    }
+    if (kpi === 'active') {
+      next.status = DEFAULT_EPISODES_LIST_FILTER.status;
+    }
+    return next;
+  }
+
+  const next: EpisodesFilterState = {
+    ...filterState,
+    alertsKpi: kpi,
+    highSeverityOnly: undefined,
+  };
+
+  if (kpi === 'active') {
+    next.status = 'active';
+  } else if (kpi === 'high_severity') {
+    next.highSeverityOnly = true;
+    next.status = filterState.status ?? DEFAULT_EPISODES_LIST_FILTER.status;
+  } else if (kpi === 'total') {
+    next.status = undefined;
+  }
+
+  return next;
+};
+
+export const toggleActionKpiFilter = (
+  filterState: EpisodesFilterState,
+  kpi: EpisodesActionKpiFilter
+): EpisodesFilterState => {
+  const isSelected = filterState.actionKpi === kpi;
+
+  if (isSelected) {
+    return { ...filterState, actionKpi: undefined, assigneeUid: undefined };
+  }
+
+  return {
+    ...filterState,
+    actionKpi: kpi,
+    assigneeUid: undefined,
+  };
+};
+
+export const applyStatusFilterChange = (
+  prev: EpisodesFilterState,
+  status: string | undefined
+): EpisodesFilterState => {
+  const next: EpisodesFilterState = { ...prev, status };
+
+  if (status === 'active' && !prev.highSeverityOnly) {
+    return { ...next, alertsKpi: 'active', highSeverityOnly: undefined };
+  }
+
+  if (status === undefined) {
+    return { ...next, alertsKpi: 'total', highSeverityOnly: undefined };
+  }
+
+  return { ...next, alertsKpi: undefined, highSeverityOnly: undefined };
+};
+
+export const applyAssigneeFilterChange = (
+  prev: EpisodesFilterState,
+  assigneeUid: string | undefined
+): EpisodesFilterState => ({
+  ...prev,
+  assigneeUid,
+  actionKpi: undefined,
+});
+
+export const isAlertsKpiSelected = (
+  filterState: EpisodesFilterState,
+  kpi: EpisodesAlertsKpiFilter
+): boolean => {
+  if (filterState.alertsKpi != null) {
+    return filterState.alertsKpi === kpi;
+  }
+
+  if (kpi === 'active') {
+    return (
+      filterState.status === DEFAULT_EPISODES_LIST_FILTER.status && !filterState.highSeverityOnly
+    );
+  }
+
+  return false;
+};
+
+export const isActionKpiSelected = (
+  filterState: EpisodesFilterState,
+  kpi: EpisodesActionKpiFilter
+): boolean => filterState.actionKpi === kpi;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.test.ts
@@ -50,6 +50,7 @@ describe('episodes_list_url_state', () => {
       expect(readEpisodesListAppStateFromUrlStorage(storage)).toEqual({
         filterState: {
           status: 'active',
+          alertsKpi: 'active',
           ruleId: 'r1',
           queryString: 'host',
           tags: ['a', 'b'],
@@ -69,6 +70,7 @@ describe('episodes_list_url_state', () => {
       });
       expect(readEpisodesListAppStateFromUrlStorage(storage).filterState).toEqual({
         status: 'active',
+        alertsKpi: 'active',
       });
     });
 
@@ -82,7 +84,18 @@ describe('episodes_list_url_state', () => {
     it('defaults status to active when _a is missing', async () => {
       const storage = await createKbnTestUrlStorage();
       expect(readEpisodesListAppStateFromUrlStorage(storage)).toEqual({
-        filterState: { status: 'active' },
+        filterState: { status: 'active', alertsKpi: 'active' },
+      });
+    });
+
+    it('preserves explicit status when alertsKpi is total', async () => {
+      const storage = await createKbnTestUrlStorage({
+        alertsKpi: 'total',
+        status: 'pending',
+      });
+      expect(readEpisodesListAppStateFromUrlStorage(storage).filterState).toEqual({
+        alertsKpi: 'total',
+        status: 'pending',
       });
     });
   });
@@ -95,7 +108,7 @@ describe('episodes_list_url_state', () => {
 
       await writeEpisodesListAppStateToUrlStorage(
         storage,
-        { status: 'active' },
+        { status: 'active', alertsKpi: 'active' },
         DEFAULT_EPISODES_LIST_TIME_RANGE
       );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/utils/episodes_list_url_state.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import type { EpisodesFilterState } from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
+import type {
+  EpisodesActionKpiFilter,
+  EpisodesAlertsKpiFilter,
+  EpisodesFilterState,
+} from '@kbn/alerting-v2-episodes-ui/queries/episodes_query';
 import type { TimeRange } from '@kbn/es-query';
 import type { IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 import { isArray, isNil, isPlainObject, isString } from 'lodash';
@@ -16,8 +20,11 @@ export const EPISODES_LIST_APP_STATE_KEY = 'episodesList' as const;
 /** Serialized in `_a` so “all statuses” survives reload (distinct from default Active) */
 export const EPISODES_LIST_STATUS_URL_ALL = 'all' as const;
 
-/** Default list filters (Active episodes, no rule/tags/search/assignee). */
-export const DEFAULT_EPISODES_LIST_FILTER: EpisodesFilterState = { status: 'active' };
+/** Default list filters (Active episodes KPI, no rule/tags/search/assignee). */
+export const DEFAULT_EPISODES_LIST_FILTER: EpisodesFilterState = {
+  status: 'active',
+  alertsKpi: 'active',
+};
 
 /** Matches {@link useEpisodesTimeRange} fallback when timefilter has no prior state */
 export const DEFAULT_EPISODES_LIST_TIME_RANGE: TimeRange = {
@@ -53,23 +60,34 @@ function decodeFilterFields(o: Record<string, unknown>): EpisodesFilterState {
   if (isNonEmptyString(o.assigneeUid)) {
     result.assigneeUid = o.assigneeUid;
   }
+  if (isNonEmptyString(o.alertsKpi)) {
+    result.alertsKpi = o.alertsKpi as EpisodesAlertsKpiFilter;
+  }
+  if (isNonEmptyString(o.actionKpi)) {
+    result.actionKpi = o.actionKpi as EpisodesActionKpiFilter;
+  }
+  if (o.highSeverityOnly === true) {
+    result.highSeverityOnly = true;
+  }
   return result;
 }
 
 function splitEpisodesListRaw(raw: unknown): {
   filter: EpisodesFilterState;
   timeRange?: TimeRange;
+  hasExplicitStatus: boolean;
 } {
   if (!isPlainObject(raw)) {
-    return { filter: {} };
+    return { filter: {}, hasExplicitStatus: false };
   }
   const o = raw as Record<string, unknown>;
   const { timeFrom, timeTo, ...rest } = o;
   const filter = decodeFilterFields(rest);
+  const hasExplicitStatus = 'status' in rest;
   if (isNonEmptyString(timeFrom) && isNonEmptyString(timeTo)) {
-    return { filter, timeRange: { from: timeFrom, to: timeTo } };
+    return { filter, hasExplicitStatus, timeRange: { from: timeFrom, to: timeTo } };
   }
-  return { filter };
+  return { filter, hasExplicitStatus };
 }
 
 function encodeFilterFields(state: EpisodesFilterState): Record<string, unknown> {
@@ -91,6 +109,15 @@ function encodeFilterFields(state: EpisodesFilterState): Record<string, unknown>
   }
   if (isNonEmptyString(state.assigneeUid)) {
     result.assigneeUid = state.assigneeUid;
+  }
+  if (state.alertsKpi && state.alertsKpi !== DEFAULT_EPISODES_LIST_FILTER.alertsKpi) {
+    result.alertsKpi = state.alertsKpi;
+  }
+  if (state.actionKpi) {
+    result.actionKpi = state.actionKpi;
+  }
+  if (state.highSeverityOnly) {
+    result.highSeverityOnly = true;
   }
   return result;
 }
@@ -115,9 +142,21 @@ export function readEpisodesListAppStateFromUrlStorage(storage: IKbnUrlStateStor
   timeRange?: TimeRange;
 } {
   const raw = storage.get<AppStateRecord>('_a')?.[EPISODES_LIST_APP_STATE_KEY];
-  const { filter, timeRange } = splitEpisodesListRaw(raw);
+  const { filter, timeRange, hasExplicitStatus } = splitEpisodesListRaw(raw);
+  const filterState: EpisodesFilterState = { ...DEFAULT_EPISODES_LIST_FILTER, ...filter };
+
+  if (!hasExplicitStatus && filter.alertsKpi != null) {
+    if (filter.alertsKpi === 'total') {
+      filterState.status = undefined;
+    } else if (filter.alertsKpi === 'active') {
+      filterState.status = 'active';
+    } else if (filter.alertsKpi === 'high_severity') {
+      filterState.highSeverityOnly = true;
+    }
+  }
+
   return {
-    filterState: { ...DEFAULT_EPISODES_LIST_FILTER, ...filter },
+    filterState,
     ...(timeRange ? { timeRange } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- Adds KPI blocks (Alerts, Alert actions, Rules) with clickable filters wired to the episodes list query
- Adds a Discover-style table toolbar with status text ("Showing N of M alerts" on Active scope) and reset filters
- Syncs the top filter bar (Status, Assignee) with KPI state so filters and KPIs stay consistent
- Uses reversed EuiStat layout for KPI metrics (value above label)
- Persists filter/KPI state in URL app state

## Prototype scope
Design/engineering prototype for the alert episodes list page — not intended for merge as-is. Feedback welcome on KPI interaction, toolbar copy, and filter coupling.

## Test plan
- [ ] Open `/app/management/alertingV2/episodes/` — default shows Active alerts KPI selected
- [ ] Toolbar shows "Showing N of M alerts" with reset on Active scope; Total shows "Viewing all N" without reset
- [ ] Click Total / Active / High severity KPIs — table and toolbar update
- [ ] Change Status filter — KPI selection stays in sync (Active, All, other statuses)
- [ ] Rule, Tags, Assignee filters narrow results; Assignee clears action KPI conflicts
- [ ] Reset filters returns to default Active view
- [ ] Reload page — filter state persists in URL


Made with [Cursor](https://cursor.com)