### PR TITLE
[Entity Store] Don't check privileges on negated indices

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
@@ -166,6 +166,71 @@ describe('AssetManagerClient', () => {
     expect(mockEngineDescriptorClient.update).not.toHaveBeenCalled();
   });
 
+  describe('getPrivileges', () => {
+    let checkPrivilegesWithRequestMock: jest.Mock;
+    let getLocalIndexPatternsMock: jest.Mock;
+    let getPrivilegesClient: AssetManagerClient;
+
+    beforeEach(() => {
+      checkPrivilegesWithRequestMock = jest.fn().mockResolvedValue({});
+      getLocalIndexPatternsMock = jest.fn();
+
+      getPrivilegesClient = new AssetManagerClient({
+        logger: loggerMock.create(),
+        esClient: {} as jest.Mocked<ElasticsearchClient>,
+        taskManager: {} as jest.Mocked<TaskManagerStartContract>,
+        engineDescriptorClient:
+          mockEngineDescriptorClient as unknown as import('../saved_objects').EngineDescriptorClient,
+        globalStateClient:
+          mockGlobalStateClient as unknown as import('../saved_objects').EntityStoreGlobalStateClient,
+        ccsLogExtractionStateClient: {
+          delete: jest.fn().mockResolvedValue(undefined),
+        } as unknown as import('../saved_objects/ccs_log_extraction_state').CcsLogExtractionStateClient,
+        namespace,
+        isServerless: false,
+        logsExtractionClient: {
+          getLocalIndexPatterns: getLocalIndexPatternsMock,
+        } as unknown as import('../logs_extraction').LogsExtractionClient,
+        security: {
+          authz: {
+            checkPrivilegesDynamicallyWithRequest: jest
+              .fn()
+              .mockReturnValue(checkPrivilegesWithRequestMock),
+            actions: {
+              savedObject: {
+                get: jest.fn().mockReturnValue('some-kibana-privilege'),
+              },
+            },
+          },
+        } as unknown as SecurityPluginStart,
+        analytics: {
+          reportEvent: jest.fn(),
+        } as unknown as import('../../telemetry/events').TelemetryReporter,
+        savedObjectsClient: {} as SavedObjectsClientContract,
+      });
+    });
+
+    it('strips negative index patterns before forwarding to _has_privileges', async () => {
+      getLocalIndexPatternsMock.mockResolvedValue([
+        'logs-*',
+        '-logs-cloud_security_posture.*',
+        '.entities.entities-default',
+        '-logs-excluded-*',
+      ]);
+
+      await getPrivilegesClient.getPrivileges({} as KibanaRequest);
+
+      const [calledWith] = checkPrivilegesWithRequestMock.mock.calls[0];
+      const indexKeys = Object.keys(calledWith.elasticsearch.index);
+
+      expect(indexKeys.every((key) => !key.startsWith('-'))).toBe(true);
+      expect(indexKeys).toContain('logs-*');
+      expect(indexKeys).toContain('.entities.entities-default');
+      expect(indexKeys).not.toContain('-logs-cloud_security_posture.*');
+      expect(indexKeys).not.toContain('-logs-excluded-*');
+    });
+  });
+
   describe('logsExtraction resolution on install', () => {
     const existingLogsExtraction = {
       additionalIndexPatterns: ['existing-*'],

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -346,8 +346,12 @@ export class AssetManagerClient {
       'create'
     );
 
+    // _has_privileges treats a leading `-` as a literal index name, not an exclusion.
+    // Negative patterns are a query-time directive and have no meaning here.
     const sourceIndexPrivileges = Object.fromEntries(
-      sourceIndexPatterns.map((idx) => [idx, ENTITY_STORE_SOURCE_INDICES_PRIVILEGES])
+      sourceIndexPatterns
+        .filter((idx) => !idx.startsWith('-'))
+        .map((idx) => [idx, ENTITY_STORE_SOURCE_INDICES_PRIVILEGES])
     );
 
     const targetIndexPrivileges = {


### PR DESCRIPTION
## Summary

Negated indices (with leading `-`) are not part of the query, therefore we don't need to check them. Beyond that, it breaks `_has_privileges` es check.




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->