### PR TITLE
[Security Solution] Fix flaky alerts_cell_actions Cypress test

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_cell_actions.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_cell_actions.cy.ts
@@ -37,8 +37,7 @@ import { openActiveTimeline } from '../../../tasks/timeline';
 
 import { ALERTS_URL } from '../../../urls/navigation';
 
-// Failing: See https://github.com/elastic/kibana/issues/246452
-describe.skip('Alerts cell actions', { tags: ['@ess', '@serverless'] }, () => {
+describe('Alerts cell actions', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     deleteAlertsAndRules();
     createRule(getNewRule());

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -454,10 +454,10 @@ export const showTopNAlertProperty = (propertySelector: string, rowIndex: number
 export const waitForAlerts = () => {
   waitForPageFilters();
   cy.get(REFRESH_BUTTON).should('not.have.attr', 'aria-label', 'Needs updating');
+  cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
   cy.get(DATAGRID_CHANGES_IN_PROGRESS).should('not.be.true');
   cy.get(EVENT_CONTAINER_TABLE_LOADING).should('not.exist');
   cy.get(LOADING_INDICATOR).should('not.exist');
-  cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
 };
 
 export const scrollAlertTableColumnIntoView = (columnSelector: string) => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -901,6 +901,7 @@ export const waitForAlertsToPopulate = (alertCountThreshold = 1) => {
     () => {
       cy.log('Waiting for alerts to appear');
       refreshPage();
+      cy.waitForNetworkIdle('/internal/search/privateRuleRegistryAlertsSearchStrategy', 500);
       cy.get([EMPTY_ALERT_TABLE, ALERTS_TABLE_COUNT].join(', '));
       return cy.root().then(($el) => {
         const emptyTableState = $el.find(EMPTY_ALERT_TABLE);

--- a/x-pack/solutions/security/test/security_solution_cypress/package.json
+++ b/x-pack/solutions/security/test/security_solution_cypress/package.json
@@ -8,8 +8,6 @@
     "cypress": "../../../../../node_modules/.bin/cypress",
     "junit:merge": "../../../../../node_modules/.bin/mochawesome-merge ../../../../../target/kibana-security-solution/cypress/results/mochawesome*.json > ../../../../../target/kibana-security-solution/cypress/results/output.json && ../../../../../node_modules/.bin/marge ../../../../../target/kibana-security-solution/cypress/results/output.json --reportDir ../../../../../target/kibana-security-solution/cypress/results && yarn junit:transform && mkdir -p ../../../../../target/junit && cp ../../../../../target/kibana-security-solution/cypress/results/*.xml ../../../../../target/junit/",
     "junit:transform": "node ../../plugins/security_solution/scripts/junit_transformer --pathPattern '../../../../../target/kibana-security-solution/cypress/results/*.xml' --rootDirectory ../../../../../ --reportName 'Security Solution Cypress' --writeInPlace",
-
-
     "cypress:open:ess": "TZ=UTC node ../../plugins/security_solution/scripts/start_cypress_parallel open --spec './cypress/e2e/**/*.cy.ts' --config-file ./test/security_solution_cypress/cypress/cypress.config.ts --ftr-config-file ./cli_config",
     "cypress:asset_inventory:run:ess": "yarn cypress:ess --spec '.cypress/screens/asset_inventory/**/*.cy.ts'",
     "cypress:entity_analytics:run:ess": "yarn cypress:ess --spec './cypress/e2e/entity_analytics/**/*.cy.ts'",
@@ -24,7 +22,7 @@
     "cypress:detection_engine:exceptions:run:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/detection_engine/exceptions/**/*.cy.ts'",
     "cypress:ai_assistant:run:ess": "yarn cypress:ess --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",
     "cypress:run:respops:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/**/*.cy.ts'",
-    "cypress:investigations:run:ess": "yarn cypress:ess --spec './cypress/e2e/investigations/**/*.cy.ts'",
+    "cypress:investigations:run:ess": "yarn cypress:ess --spec './cypress/e2e/investigations/alerts/alerts_cell_actions.cy.ts'",
     "cypress:explore:run:ess": "yarn cypress:ess --spec './cypress/e2e/explore/**/*.cy.ts'",
     "cypress:changed-specs-only:ess": "yarn cypress:ess --changed-specs-only --env burn=5",
     "cypress:cloud_security_posture:run:ess": "yarn cypress:ess --spec './cypress/e2e/cloud_security_posture/**/*.cy.ts'",
@@ -51,8 +49,6 @@
     "cypress:changed-specs-only:serverless": "yarn cypress:serverless --changed-specs-only --env burn=5",
     "cypress:cloud_security_posture:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/cloud_security_posture/**/*.cy.ts'",
     "cypress:burn:serverless": "yarn cypress:serverless --env burn=2",
-
-
     "cypress:qa:serverless": "TZ=UTC node ../../plugins/security_solution/scripts/start_cypress_parallel_serverless --config-file ./test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts",
     "cypress:open:qa:serverless": "yarn cypress:qa:serverless open",
     "cypress:run:qa:serverless:ai_assistant": "yarn cypress:qa:serverless --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",

--- a/x-pack/solutions/security/test/security_solution_cypress/package.json
+++ b/x-pack/solutions/security/test/security_solution_cypress/package.json
@@ -8,6 +8,8 @@
     "cypress": "../../../../../node_modules/.bin/cypress",
     "junit:merge": "../../../../../node_modules/.bin/mochawesome-merge ../../../../../target/kibana-security-solution/cypress/results/mochawesome*.json > ../../../../../target/kibana-security-solution/cypress/results/output.json && ../../../../../node_modules/.bin/marge ../../../../../target/kibana-security-solution/cypress/results/output.json --reportDir ../../../../../target/kibana-security-solution/cypress/results && yarn junit:transform && mkdir -p ../../../../../target/junit && cp ../../../../../target/kibana-security-solution/cypress/results/*.xml ../../../../../target/junit/",
     "junit:transform": "node ../../plugins/security_solution/scripts/junit_transformer --pathPattern '../../../../../target/kibana-security-solution/cypress/results/*.xml' --rootDirectory ../../../../../ --reportName 'Security Solution Cypress' --writeInPlace",
+
+
     "cypress:open:ess": "TZ=UTC node ../../plugins/security_solution/scripts/start_cypress_parallel open --spec './cypress/e2e/**/*.cy.ts' --config-file ./test/security_solution_cypress/cypress/cypress.config.ts --ftr-config-file ./cli_config",
     "cypress:asset_inventory:run:ess": "yarn cypress:ess --spec '.cypress/screens/asset_inventory/**/*.cy.ts'",
     "cypress:entity_analytics:run:ess": "yarn cypress:ess --spec './cypress/e2e/entity_analytics/**/*.cy.ts'",
@@ -22,7 +24,7 @@
     "cypress:detection_engine:exceptions:run:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/detection_engine/exceptions/**/*.cy.ts'",
     "cypress:ai_assistant:run:ess": "yarn cypress:ess --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",
     "cypress:run:respops:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/**/*.cy.ts'",
-    "cypress:investigations:run:ess": "yarn cypress:ess --spec './cypress/e2e/investigations/alerts/alerts_cell_actions.cy.ts'",
+    "cypress:investigations:run:ess": "yarn cypress:ess --spec './cypress/e2e/investigations/**/*.cy.ts'",
     "cypress:explore:run:ess": "yarn cypress:ess --spec './cypress/e2e/explore/**/*.cy.ts'",
     "cypress:changed-specs-only:ess": "yarn cypress:ess --changed-specs-only --env burn=5",
     "cypress:cloud_security_posture:run:ess": "yarn cypress:ess --spec './cypress/e2e/cloud_security_posture/**/*.cy.ts'",
@@ -49,6 +51,8 @@
     "cypress:changed-specs-only:serverless": "yarn cypress:serverless --changed-specs-only --env burn=5",
     "cypress:cloud_security_posture:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/cloud_security_posture/**/*.cy.ts'",
     "cypress:burn:serverless": "yarn cypress:serverless --env burn=2",
+
+
     "cypress:qa:serverless": "TZ=UTC node ../../plugins/security_solution/scripts/start_cypress_parallel_serverless --config-file ./test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts",
     "cypress:open:qa:serverless": "yarn cypress:qa:serverless open",
     "cypress:run:qa:serverless:ai_assistant": "yarn cypress:qa:serverless --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",


### PR DESCRIPTION
## Summary

### What
Fixes the flaky `cypress/e2e/investigations/alerts/alerts_cell_actions.cy.ts` Cypress test and unskips the suite.

### Why
The test was reporting 85.7% reliability (~1 failure per 7 runs), with a 1m 8s average duration per attempt — each failure burned an extra 68 seconds of CI time due to the retry.

Root cause: `waitForAlertsToPopulate` calls `refreshPage()` inside a polling loop every 500ms for up to 30s, firing up to 60 concurrent alert search requests. These concurrent requests kept Kibana's `globalLoadingIndicator` spinner alive indefinitely. After the loop exited, `waitForAlerts()` checked `LOADING_INDICATOR.should('not.exist')` **before** waiting for the network to be idle — so the check hit the CI `defaultCommandTimeout` of 150s while the backlogged searches drained.

Fixes #271252
Fixes https://github.com/elastic/kibana/issues/246452

## Changes

- **`tasks/alerts.ts`**: In `waitForAlerts`, move `cy.waitForNetworkIdle` for the alert search strategy **before** the `LOADING_INDICATOR` check. Once the network is idle the spinner is guaranteed to be gone; the old order inverted causality.
- **`tasks/create_new_rule.ts`**: In `waitForAlertsToPopulate`, add `cy.waitForNetworkIdle` inside the polling loop immediately after `refreshPage()`. This ensures each search request drains before the next fires — eliminating the 60-concurrent-request pileup — and ensures the alert count is read from settled data.
- **`alerts_cell_actions.cy.ts`**: Remove `describe.skip` and the stale failure comment. The suite is active again on both ESS and Serverless (the `@skipInServerlessMKI` tag on one specific test remains).

> **Note:** `waitForAlertsToPopulate` and `waitForAlerts` are shared utilities used by ~134 Cypress tests. Both fixes make the waits more correct, not just faster — tests that were previously getting lucky will now be more reliably settled before assertions run.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Shared utility slowdown (LOW):** `waitForAlertsToPopulate` iterations now include a `waitForNetworkIdle` call, making each iteration slightly slower. Mitigation: the total number of iterations drops significantly (one search at a time instead of 60 piled up), so overall `beforeEach` time should decrease on average.
- **No other risks:** no production code changed, no data migrations, no API surface affected.

### Release note

> No user-facing changes — internal Cypress test infrastructure fix.

**Suggested label:** `release_note:skip`