### PR TITLE
[Streams][SignificantEvents] Use SCS codebase workflows for KI extraction and query generation

### DIFF
--- a/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
+++ b/src/platform/packages/shared/kbn-management/settings/setting_ids/index.ts
@@ -162,6 +162,8 @@ export const OBSERVABILITY_STREAMS_SIG_EVENTS_INDEX_PATTERNS =
 export const OBSERVABILITY_STREAMS_SIG_EVENTS_TUNING_CONFIG =
   'observability:streamsSigEventsTuningConfig';
 export const OBSERVABILITY_STREAMS_ENABLE_MEMORY = 'observability:streamsEnableMemory';
+export const OBSERVABILITY_STREAMS_SCS_CODEBASE_INDEX =
+  'observability:streamsScsCodebaseIndex';
 export const OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS_ALERTING_V2 =
   'observability:streamsEnableSignificantEventsAlertingV2';
 export const OBSERVABILITY_ENABLE_DIAGNOSTIC_MODE = 'observability:enableDiagnosticMode';

--- a/x-pack/platform/plugins/shared/streams/server/feature_flags.ts
+++ b/x-pack/platform/plugins/shared/streams/server/feature_flags.ts
@@ -22,6 +22,7 @@ import {
   OBSERVABILITY_STREAMS_SIG_EVENTS_TUNING_CONFIG,
   OBSERVABILITY_STREAMS_ENABLE_MEMORY,
   OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS_ALERTING_V2,
+  OBSERVABILITY_STREAMS_SCS_CODEBASE_INDEX,
 } from '@kbn/management-settings-ids';
 import { DEFAULT_INDEX_PATTERNS } from '@kbn/streams-schema';
 import type { StreamsPluginStartDependencies } from './types';
@@ -138,6 +139,25 @@ export function registerFeatureFlags(
             }),
             type: 'boolean',
             schema: schema.boolean(),
+            requiresPageReload: false,
+            solutionViews: ['classic', 'oblt'],
+            technicalPreview: true,
+          },
+        });
+
+        core.uiSettings.register({
+          [OBSERVABILITY_STREAMS_SCS_CODEBASE_INDEX]: {
+            category: ['observability'],
+            name: i18n.translate('xpack.streams.scsCodebaseIndexSettingsName', {
+              defaultMessage: 'Streams SCS codebase index',
+            }) as string,
+            value: '',
+            description: i18n.translate('xpack.streams.scsCodebaseIndexSettingsDescription', {
+              defaultMessage:
+                'Elasticsearch index name created by Semantic Code Search (SCS). When set, the Knowledge Indicator query generation agent can search the indexed codebase for relevant patterns when writing ES|QL queries. Run `scs index` and `scs install-agentic-interfaces` to set up SCS before enabling this.',
+            }),
+            type: 'string',
+            schema: schema.string(),
             requiresPageReload: false,
             solutionViews: ['classic', 'oblt'],
             technicalPreview: true,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_inferred_features.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_inferred_features.ts
@@ -356,6 +356,12 @@ export interface IdentifyInferredFeaturesOptions {
   tuning?: IterationTuningParams;
   diverseOffset?: number;
   trackFeaturesIdentified?: (data: FeaturesIdentifiedTelemetry) => void;
+  /**
+   * Optional SCS codebase context pre-fetched by the caller (once per task run).
+   * When present, appended to the system prompt so the LLM has source-code
+   * context when identifying features from log samples.
+   */
+  scsContextSnippet?: string;
 }
 
 export interface IdentifyInferredFeaturesResult {
@@ -383,16 +389,21 @@ export async function identifyInferredFeatures({
   tuning = {},
   diverseOffset = 0,
   trackFeaturesIdentified,
+  scsContextSnippet,
 }: IdentifyInferredFeaturesOptions): Promise<IdentifyInferredFeaturesResult> {
   const [
     { hits: allFeatures },
     { hits: excludedFeatures },
-    { featurePromptOverride: systemPrompt },
+    { featurePromptOverride: baseSystemPrompt },
   ] = await Promise.all([
     featureClient.getFeatures(streamName),
     featureClient.getExcludedFeatures(streamName),
     new PromptsConfigService({ soClient, logger }).getPrompt(),
   ]);
+
+  const systemPrompt = scsContextSnippet
+    ? `${baseSystemPrompt}\n\n${scsContextSnippet}`
+    : baseSystemPrompt;
 
   const discoveredFeatures = allFeatures.filter((f) => !isComputedFeature(f) && f.run_id === runId);
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/generate_significant_events.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/generate_significant_events.ts
@@ -14,6 +14,7 @@ import type { SignificantEventsToolUsage } from '@kbn/streams-ai';
 import type { FeatureClient } from '../streams/feature/feature_client';
 import type { QueryClient } from '../streams/assets/query/query_client';
 import type { MemoryDiscoveryTools } from './memory_discovery_tools';
+import type { ScsCodebaseTools } from './scs_codebase_tools';
 
 interface Params {
   definition: Streams.all.Definition;
@@ -30,6 +31,7 @@ interface Dependencies {
   signal: AbortSignal;
   esClient: ElasticsearchClient;
   memoryTools?: MemoryDiscoveryTools;
+  scsTools?: ScsCodebaseTools;
 }
 
 export async function generateSignificantEventDefinitions(
@@ -41,8 +43,16 @@ export async function generateSignificantEventDefinitions(
   toolUsage: SignificantEventsToolUsage;
 }> {
   const { definition, connectorId, systemPrompt, maxExistingQueriesForContext } = params;
-  const { inferenceClient, featureClient, queryClient, logger, signal, esClient, memoryTools } =
-    dependencies;
+  const {
+    inferenceClient,
+    featureClient,
+    queryClient,
+    logger,
+    signal,
+    esClient,
+    memoryTools,
+    scsTools,
+  } = dependencies;
 
   const { [definition.name]: existingLinks } = await queryClient.getStreamToQueryLinksMap([
     definition.name,
@@ -61,19 +71,37 @@ export async function generateSignificantEventDefinitions(
     connectorId,
   });
 
+  const additionalTools = {
+    ...(memoryTools?.tools ?? {}),
+    ...(scsTools?.tools ?? {}),
+  };
+  const additionalToolCallbacks = {
+    ...(memoryTools?.callbacks ?? {}),
+    ...(scsTools?.callbacks ?? {}),
+  };
+  const hasAdditionalTools = Object.keys(additionalTools).length > 0;
+
+  const systemPromptWithSnippets = [
+    systemPrompt,
+    memoryTools?.promptSnippet,
+    scsTools?.promptSnippet,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
   const { queries, tokensUsed, toolUsage } = await generateSignificantEvents({
     stream: definition,
     esClient,
     inferenceClient: boundInferenceClient,
     logger,
     signal,
-    systemPrompt: memoryTools ? `${systemPrompt}\n${memoryTools.promptSnippet}` : systemPrompt,
+    systemPrompt: systemPromptWithSnippets,
     getFeatures: async (filters) => {
       const response = await featureClient.getFeatures(definition.name, filters);
       return response.hits;
     },
-    additionalTools: memoryTools?.tools,
-    additionalToolCallbacks: memoryTools?.callbacks,
+    additionalTools: hasAdditionalTools ? additionalTools : undefined,
+    additionalToolCallbacks: hasAdditionalTools ? additionalToolCallbacks : undefined,
     existingQueries,
     maxExistingQueriesForContext,
   });

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/ki_queries_generation_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/ki_queries_generation_service.ts
@@ -18,10 +18,14 @@ import {
   STREAMS_SIG_EVENTS_KI_QUERY_GENERATION_INFERENCE_FEATURE_ID,
   type SignificantEventsQueriesGenerationResult,
 } from '@kbn/streams-schema';
-import { OBSERVABILITY_STREAMS_ENABLE_MEMORY } from '@kbn/management-settings-ids';
+import {
+  OBSERVABILITY_STREAMS_ENABLE_MEMORY,
+  OBSERVABILITY_STREAMS_SCS_CODEBASE_INDEX,
+} from '@kbn/management-settings-ids';
 import { isInferenceProviderError } from '@kbn/inference-common';
 import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import type { SignificantEventsToolUsage } from '@kbn/streams-ai';
+import type { WorkflowsManagementApi } from '@kbn/workflows-management-plugin/server';
 import type { StreamsClient } from '../streams/client';
 import type { FeatureClient } from '../streams/feature/feature_client';
 import type { QueryClient } from '../streams/assets/query/query_client';
@@ -32,6 +36,7 @@ import { PromptsConfigService } from './saved_objects/prompts_config_service';
 import { generateSignificantEventDefinitions } from './generate_significant_events';
 import { MemoryServiceImpl } from '../memory';
 import { createMemoryDiscoveryTools } from './memory_discovery_tools';
+import { createScsCodebaseTools } from './scs_codebase_tools';
 
 export interface GenerateKIQueriesParams {
   streamName: string;
@@ -48,10 +53,12 @@ export interface GenerateKIQueriesDependencies {
   esClient: ElasticsearchClient;
   uiSettingsClient: IUiSettingsClient;
   searchInferenceEndpoints: SearchInferenceEndpointsPluginStart | undefined;
+  workflowsManagement: WorkflowsManagementApi | undefined;
   request: KibanaRequest;
   logger: Logger;
   signal: AbortSignal;
   telemetry: EbtTelemetryClient;
+  spaceId?: string;
 }
 
 export async function generateKIQueries(
@@ -73,10 +80,12 @@ export async function generateKIQueries(
     esClient,
     uiSettingsClient,
     searchInferenceEndpoints,
+    workflowsManagement,
     request,
     logger,
     signal,
     telemetry,
+    spaceId,
   } = deps;
 
   const connectorId =
@@ -90,11 +99,13 @@ export async function generateKIQueries(
 
   logger.debug(`Using connector ${connectorId} for query generation`);
 
-  const [definition, { significantEventsPromptOverride }, useMemory] = await Promise.all([
-    streamsClient.getStream(streamName),
-    new PromptsConfigService({ soClient, logger }).getPrompt(),
-    uiSettingsClient.get<boolean>(OBSERVABILITY_STREAMS_ENABLE_MEMORY),
-  ]);
+  const [definition, { significantEventsPromptOverride }, useMemory, scsIndexName] =
+    await Promise.all([
+      streamsClient.getStream(streamName),
+      new PromptsConfigService({ soClient, logger }).getPrompt(),
+      uiSettingsClient.get<boolean>(OBSERVABILITY_STREAMS_ENABLE_MEMORY),
+      uiSettingsClient.get<string>(OBSERVABILITY_STREAMS_SCS_CODEBASE_INDEX),
+    ]);
 
   const memoryTools = useMemory
     ? createMemoryDiscoveryTools({
@@ -104,6 +115,16 @@ export async function generateKIQueries(
         }),
       })
     : undefined;
+
+  const scsTools =
+    workflowsManagement && scsIndexName
+      ? createScsCodebaseTools({
+          workflowsManagement,
+          scsIndexName,
+          spaceId: spaceId ?? 'default',
+          request,
+        })
+      : undefined;
 
   const result = await generateSignificantEventDefinitions(
     {
@@ -120,6 +141,7 @@ export async function generateKIQueries(
       logger: logger.get('significant_events_generation'),
       signal,
       memoryTools,
+      scsTools,
     }
   ).catch(async (error) => {
     if (isInferenceProviderError(error)) {

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/scs_codebase_tools.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/scs_codebase_tools.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import type { ToolCallback, ToolDefinition } from '@kbn/inference-common';
+import type { WorkflowsManagementApi } from '@kbn/workflows-management-plugin/server';
+
+/**
+ * Kibana Workflow IDs for the SCS agentic interfaces installed by
+ * `scs install-agentic-interfaces`. These are deterministic UUIDs derived
+ * from the SDK namespace + workflow sdkId using UUIDv5.
+ *
+ * SDK namespace: uuidV5(DNS_UUID, 'kibana-agent-builder-sdk')
+ *   = cdd25ba0-c280-5396-8018-b71458577d90
+ *
+ * workflow-<uuidV5(sdkNamespace, sdkId)>:
+ *   scs.semantic_search  -> workflow-38aec933-751e-5da9-b915-c6353529cc96
+ *   scs.symbol_analysis  -> workflow-0ccbb4a8-608d-5185-af15-e9b134029bfe
+ */
+export const SCS_SEMANTIC_SEARCH_WORKFLOW_ID = 'workflow-38aec933-751e-5da9-b915-c6353529cc96';
+export const SCS_SYMBOL_ANALYSIS_WORKFLOW_ID = 'workflow-0ccbb4a8-608d-5185-af15-e9b134029bfe';
+
+export interface ScsCodebaseTools {
+  tools: Record<string, ToolDefinition>;
+  callbacks: Record<string, ToolCallback>;
+  promptSnippet: string;
+}
+
+interface ScsSearchResult {
+  id: string;
+  score: number;
+  type: string;
+  language: string;
+  kind: string;
+  content: string;
+  locations: Array<{ filePath: string; startLine: number }>;
+}
+
+interface WorkflowExecutionOutput {
+  steps?: Record<string, { output?: unknown }>;
+  output?: unknown;
+}
+
+function extractSearchResults(execution: WorkflowExecutionOutput): ScsSearchResult[] {
+  try {
+    const stepsOutput = execution?.steps;
+    if (!stepsOutput) return [];
+    for (const step of Object.values(stepsOutput)) {
+      const output = step?.output;
+      if (Array.isArray(output)) {
+        return output as ScsSearchResult[];
+      }
+      if (typeof output === 'string') {
+        return JSON.parse(output) as ScsSearchResult[];
+      }
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Creates tool definitions and callbacks that give the query generation
+ * reasoning agent the ability to search a SCS-indexed codebase via the
+ * Kibana Workflows installed by `scs install-agentic-interfaces`.
+ *
+ * Mirrors the shape of {@link MemoryDiscoveryTools} so it can be merged
+ * alongside memory tools in `generateSignificantEventDefinitions`.
+ */
+export const createScsCodebaseTools = ({
+  workflowsManagement,
+  scsIndexName,
+  spaceId,
+  request,
+}: {
+  workflowsManagement: WorkflowsManagementApi;
+  scsIndexName: string;
+  spaceId: string;
+  request: KibanaRequest;
+}): ScsCodebaseTools => {
+  const tools: Record<string, ToolDefinition> = {
+    search_codebase: {
+      description:
+        'Semantically search the indexed source codebase for relevant code patterns, field names, event structures, or ES|QL examples. Use this when you need to understand what fields the application emits, how events are structured, or to find existing ES|QL patterns in the codebase.',
+      schema: {
+        type: 'object' as const,
+        properties: {
+          query: {
+            type: 'string' as const,
+            description:
+              'Natural-language search query. Descriptive phrases work better than single keywords (e.g. "error handling with status codes" rather than "error").',
+          },
+          size: {
+            type: 'number' as const,
+            description: 'Maximum number of code chunks to return (default 5, max 20).',
+          },
+        },
+        required: ['query'] as const,
+      },
+    },
+    analyze_codebase_symbol: {
+      description:
+        'Deeply analyze a specific symbol (function, class, variable, constant) across the indexed codebase. Returns definitions, call sites, import references, and documentation. Use when you need to understand a specific field name, event type, or error code in depth.',
+      schema: {
+        type: 'object' as const,
+        properties: {
+          symbol_name: {
+            type: 'string' as const,
+            description:
+              'Exact symbol name to analyze (e.g. "handleRequest", "ERROR_CODE_TIMEOUT", "UserService").',
+          },
+        },
+        required: ['symbol_name'] as const,
+      },
+    },
+  };
+
+  const callbacks: Record<string, ToolCallback> = {
+    search_codebase: async (toolCall) => {
+      const { query, size } = toolCall.function.arguments as {
+        query: string;
+        size?: number;
+      };
+      try {
+        const { execution } = await workflowsManagement.executeWorkflow({
+          workflowId: SCS_SEMANTIC_SEARCH_WORKFLOW_ID,
+          inputs: {
+            query,
+            index: scsIndexName,
+            size: Math.min(size ?? 5, 20),
+          },
+          spaceId,
+          request,
+          waitForCompletion: true,
+        });
+
+        const results = extractSearchResults(execution as WorkflowExecutionOutput);
+        return {
+          response: {
+            results: results.map(({ id, score, language, kind, content, locations }) => ({
+              id,
+              score,
+              language,
+              kind,
+              content,
+              locations: locations?.slice(0, 3),
+            })),
+            count: results.length,
+          },
+        };
+      } catch (error) {
+        return {
+          response: {
+            results: [],
+            count: 0,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        };
+      }
+    },
+    analyze_codebase_symbol: async (toolCall) => {
+      const { symbol_name: symbolName } = toolCall.function.arguments as {
+        symbol_name: string;
+      };
+      try {
+        const { execution } = await workflowsManagement.executeWorkflow({
+          workflowId: SCS_SYMBOL_ANALYSIS_WORKFLOW_ID,
+          inputs: {
+            symbol_name: symbolName,
+            index: scsIndexName,
+          },
+          spaceId,
+          request,
+          waitForCompletion: true,
+        });
+
+        const stepsOutput = (execution as WorkflowExecutionOutput)?.steps ?? {};
+        const formatStep = Object.values(stepsOutput).at(-1);
+        const report =
+          typeof formatStep?.output === 'string'
+            ? formatStep.output
+            : JSON.stringify(formatStep?.output ?? {});
+
+        return {
+          response: {
+            symbol: symbolName,
+            report,
+          },
+        };
+      } catch (error) {
+        return {
+          response: {
+            symbol: symbolName,
+            report: null,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        };
+      }
+    },
+  };
+
+  const promptSnippet = `
+You have access to a semantically indexed source codebase via SCS (Semantic Code Search). Use these tools to find patterns and context that will help you write more accurate ES|QL queries:
+- **search_codebase** — Search the codebase by natural language to find how events are emitted, what fields are logged, or how errors are structured. Use this before writing queries to discover real field names and event patterns.
+- **analyze_codebase_symbol** — Deep-dive on a specific symbol (function name, constant, class) to understand its definition, call sites, and imports.
+
+Prioritize searching the codebase when you need to verify field names, understand event structures, or find existing query patterns. Code evidence makes queries more accurate.`;
+
+  return { tools, callbacks, promptSnippet };
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/significant_events_queries_generation.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/significant_events_queries_generation.ts
@@ -84,6 +84,7 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                     esClient: scopedClusterClient.asCurrentUser,
                     uiSettingsClient,
                     searchInferenceEndpoints: taskContext.server.searchInferenceEndpoints,
+                    workflowsManagement: taskContext.server.workflowsManagement,
                     request: fakeRequest,
                     logger: taskLogger,
                     signal: runContext.abortController.signal,

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
@@ -175,6 +175,59 @@ async function runFeaturesIdentification(
 
     let diverseOffset = 0;
 
+    // Pre-fetch SCS codebase context once per task run. If SCS is configured
+    // the resulting snippet is injected into each iteration's system prompt so
+    // the LLM has source-code context while identifying features from log samples.
+    let scsContextSnippet: string | undefined;
+    const workflowsManagement = taskContext.server.workflowsManagement;
+    if (workflowsManagement) {
+      const { uiSettingsClient } = await taskContext.getScopedClients({ request: fakeRequest });
+      const scsIndexName = await uiSettingsClient
+        .get<string>('observability:streamsScsCodebaseIndex')
+        .catch(() => '');
+
+      if (scsIndexName) {
+        try {
+          const { execution } = await workflowsManagement.executeWorkflow({
+            workflowId: 'workflow-38aec933-751e-5da9-b915-c6353529cc96',
+            inputs: { query: streamName, index: scsIndexName, size: 5 },
+            spaceId: 'default',
+            request: fakeRequest,
+            waitForCompletion: true,
+          });
+          const stepsOutput = (execution as { steps?: Record<string, { output?: unknown }> })
+            ?.steps;
+          const chunks: Array<{ content?: string; language?: string; locations?: unknown[] }> = [];
+          for (const step of Object.values(stepsOutput ?? {})) {
+            const out = step?.output;
+            if (Array.isArray(out)) {
+              chunks.push(...out);
+              break;
+            }
+          }
+          if (chunks.length > 0) {
+            const summary = chunks
+              .slice(0, 5)
+              .map(
+                (c, idx) =>
+                  `[${idx + 1}] (${c.language ?? 'unknown'}) ${(c.content ?? '').slice(0, 400)}`
+              )
+              .join('\n\n');
+            scsContextSnippet =
+              `The following code snippets from the application source code may help you understand ` +
+              `what events and fields are emitted by the "${streamName}" stream:\n\n${summary}`;
+            taskLogger.debug(`SCS pre-fetch for feature extraction: ${chunks.length} chunks`);
+          }
+        } catch (scsError) {
+          taskLogger.debug(
+            `SCS pre-fetch for feature extraction failed (non-fatal): ${
+              scsError instanceof Error ? scsError.message : String(scsError)
+            }`
+          );
+        }
+      }
+    }
+
     for (let i = 0; i < maxIterations; i++) {
       if (runContext.abortController.signal.aborted) {
         taskLogger.debug('Feature identification aborted');
@@ -203,6 +256,7 @@ async function runFeaturesIdentification(
         tuning,
         diverseOffset,
         trackFeaturesIdentified,
+        scsContextSnippet,
       });
 
       if (!result.hasDocuments) {

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -20,6 +20,7 @@ import {
   OBSERVABILITY_STREAMS_ENABLE_WIRED_STREAM_VIEWS,
 } from '@kbn/management-settings-ids';
 import { STREAMS_RULE_TYPE_IDS } from '@kbn/rule-data-utils';
+import type { WorkflowsManagementApi } from '@kbn/workflows-management-plugin/server';
 import { registerRoutes } from '@kbn/server-route-repository';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import type { RulesClient, RulesClientCreateOptions } from '@kbn/alerting-plugin/server';
@@ -107,7 +108,7 @@ export class StreamsPlugin
   private statsTelemetryService = new StatsTelemetryService();
   private processorSuggestionsService: ProcessorSuggestionsService;
   private patternExtractionService?: PatternExtractionService;
-  private workflowsManagementApi?: import('@kbn/workflows-management-plugin/server').WorkflowsManagementApi;
+  private workflowsManagementApi?: WorkflowsManagementApi;
 
   constructor(context: PluginInitializerContext<StreamsConfig>) {
     this.isDev = context.env.mode.dev;

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -107,6 +107,7 @@ export class StreamsPlugin
   private statsTelemetryService = new StatsTelemetryService();
   private processorSuggestionsService: ProcessorSuggestionsService;
   private patternExtractionService?: PatternExtractionService;
+  private workflowsManagementApi?: import('@kbn/workflows-management-plugin/server').WorkflowsManagementApi;
 
   constructor(context: PluginInitializerContext<StreamsConfig>) {
     this.isDev = context.env.mode.dev;
@@ -342,6 +343,7 @@ export class StreamsPlugin
     let continuousKiExtractionWorkflowService: ContinuousKiExtractionWorkflowService | undefined;
 
     if (plugins.workflowsManagement) {
+      this.workflowsManagementApi = plugins.workflowsManagement.management;
       continuousKiExtractionWorkflowService = createContinuousKiExtractionWorkflowService(
         this.logger,
         plugins.workflowsManagement.management
@@ -584,6 +586,7 @@ export class StreamsPlugin
       this.server.licensing = plugins.licensing;
       this.server.taskManager = plugins.taskManager;
       this.server.searchInferenceEndpoints = plugins.searchInferenceEndpoints;
+      this.server.workflowsManagement = this.workflowsManagementApi;
 
       // Set up memory trigger registry with all built-in triggers
       const memoryTriggerRegistry = new MemoryTriggerRegistry({ logger: this.logger });

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/queries/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/queries/route.ts
@@ -494,6 +494,7 @@ const generateQueriesRoute = createServerRoute({
         esClient: scopedClusterClient.asCurrentUser,
         uiSettingsClient,
         searchInferenceEndpoints: server.searchInferenceEndpoints,
+        workflowsManagement: server.workflowsManagement,
         request,
         logger: logger.get('significant_events_queries_generation'),
         signal: getRequestAbortSignal(request),

--- a/x-pack/platform/plugins/shared/streams/server/routes/sig_events/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/sig_events/streams/significant_events/route.ts
@@ -12,7 +12,10 @@ import {
 } from '@kbn/streams-schema';
 import { z } from '@kbn/zod/v4';
 import { catchError, from as fromRxjs, map } from 'rxjs';
-import { OBSERVABILITY_STREAMS_ENABLE_MEMORY } from '@kbn/management-settings-ids';
+import {
+  OBSERVABILITY_STREAMS_ENABLE_MEMORY,
+  OBSERVABILITY_STREAMS_SCS_CODEBASE_INDEX,
+} from '@kbn/management-settings-ids';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import { PromptsConfigService } from '../../../../lib/sig_events/saved_objects/prompts_config_service';
 import { generateSignificantEventDefinitions } from '../../../../lib/sig_events/generate_significant_events';
@@ -30,6 +33,7 @@ import { getRequestAbortSignal } from '../../../utils/get_request_abort_signal';
 import { resolveConnectorId } from '../../../utils/resolve_connector_id';
 import { MemoryServiceImpl } from '../../../../lib/memory';
 import { createMemoryDiscoveryTools } from '../../../../lib/sig_events/memory_discovery_tools';
+import { createScsCodebaseTools } from '../../../../lib/sig_events/scs_codebase_tools';
 import { searchModeSchema } from '../../../utils/search_mode';
 
 // Make sure strings are expected for input, but still converted to a
@@ -297,7 +301,11 @@ const generateSignificantEventsRoute = createServerRoute({
       logger,
     });
 
-    const useMemory = await uiSettingsClient.get<boolean>(OBSERVABILITY_STREAMS_ENABLE_MEMORY);
+    const [useMemory, scsIndexName] = await Promise.all([
+      uiSettingsClient.get<boolean>(OBSERVABILITY_STREAMS_ENABLE_MEMORY),
+      uiSettingsClient.get<string>(OBSERVABILITY_STREAMS_SCS_CODEBASE_INDEX),
+    ]);
+
     const memoryTools = useMemory
       ? createMemoryDiscoveryTools({
           memoryService: new MemoryServiceImpl({
@@ -306,6 +314,16 @@ const generateSignificantEventsRoute = createServerRoute({
           }),
         })
       : undefined;
+
+    const scsTools =
+      server.workflowsManagement && scsIndexName
+        ? createScsCodebaseTools({
+            workflowsManagement: server.workflowsManagement,
+            scsIndexName,
+            spaceId: 'default',
+            request,
+          })
+        : undefined;
 
     const [connector, definition, { significantEventsPromptOverride }, featureClient, queryClient] =
       await Promise.all([
@@ -331,6 +349,7 @@ const generateSignificantEventsRoute = createServerRoute({
           signal: getRequestAbortSignal(request),
           esClient: scopedClusterClient.asCurrentUser,
           memoryTools,
+          scsTools,
         }
       )
     ).pipe(

--- a/x-pack/platform/plugins/shared/streams/server/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/types.ts
@@ -35,7 +35,10 @@ import type {
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type { ConsoleStart as ConsoleServerStart } from '@kbn/console-plugin/server';
-import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import type {
+  WorkflowsManagementApi,
+  WorkflowsServerPluginSetup,
+} from '@kbn/workflows-management-plugin/server';
 import type {
   SearchInferenceEndpointsPluginSetup,
   SearchInferenceEndpointsPluginStart,
@@ -58,6 +61,7 @@ export interface StreamsServer {
   ensureMemorySkillRegistered?: () => void;
   ensureMemoryTasksScheduled?: () => Promise<void>;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginStart;
+  workflowsManagement?: WorkflowsManagementApi;
 }
 
 export interface ElasticsearchAccessorOptions {


### PR DESCRIPTION
## Summary

Connects Kibana's Knowledge Indicator pipeline to the [Semantic Code Search](https://github.com/elastic/semantic-code-search) agentic interfaces installed via Semantic Code Search's `npx scs install-agentic-interfaces`.

**Query generation**: adds `search_codebase` and `analyze_codebase_symbol` as additional tools to the KI query generation reasoning agent. 

When the `observability:streamsScsCodebaseIndex` advanced setting is configured, the agent can search the indexed codebase during ES|QL generation to discover real field names, event structures, and existing patterns — producing more accurate queries.

**Feature extraction**: pre-fetches relevant source code snippets once per task run and injects them into the system prompt, giving the LLM codebase context when identifying features from log samples.

Both integrations are gated behind the new `observability:streamsScsCodebaseIndex` setting (empty by default, no-op when unset) and require `workflowsManagement` to be available.

## How to test

- Clone / fork the [Semantic Code Search](https://github.com/elastic/semantic-code-search) repo
- Run `yarn && yarn build`
- Run `npx scs setup`, complete the SCS setup wizard to ingest code into a running ES cluster and install SCS Workflows into a running Kibana instance
- Test whether KI extraction and query generation works
- Run evals