### PR TITLE
[ES|QL] Disable logging of views errors in serverless

### DIFF
--- a/src/platform/plugins/shared/esql/server/plugin.ts
+++ b/src/platform/plugins/shared/esql/server/plugin.ts
@@ -47,7 +47,8 @@ export class EsqlServerPlugin
       }),
     });
 
-    registerRoutes(core, this.extensionsRegistry, initContext);
+    const isServerless = initContext.env.packageInfo.buildFlavor === 'serverless';
+    registerRoutes(core, this.extensionsRegistry, initContext, isServerless);
 
     return {
       getExtensionsRegistry: () => this.extensionsRegistry,

--- a/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
@@ -70,7 +70,8 @@ const checkViewLikeSourceForTimestamp = async ({
 const resolveTimeField = async (
   client: ElasticsearchClient,
   query: string,
-  logger: Logger
+  logger: Logger,
+  isServerless: boolean
 ): Promise<{ timeField: string | undefined }> => {
   // Query is of the form "from index | where timefield >= ?_tstart".
   // At this point we just want to extract the timefield if present in the query
@@ -89,16 +90,19 @@ const resolveTimeField = async (
   const subqueryArgs = sourceCommand.args.filter(isSubQuery);
   const hasSubqueries = subqueryArgs.length > 0;
   const service = new EsqlService({ client });
-  const { views } = await service.getViews().catch((viewsError) => {
-    const message = viewsError instanceof Error ? viewsError.message : String(viewsError);
-    logger.error(`Failed to fetch ES|QL views while resolving timefield: ${message}`, {
-      tags: ['esql', 'timefield', 'views'],
-      error: {
-        stack_trace: viewsError instanceof Error ? viewsError.stack : undefined,
-      },
-    });
-    return { views: [] };
-  });
+  // TODO: Remove this once views are available in serverless
+  const { views } = isServerless
+    ? { views: [] }
+    : await service.getViews().catch((viewsError) => {
+        const message = viewsError instanceof Error ? viewsError.message : String(viewsError);
+        logger.error(`Failed to fetch ES|QL views while resolving timefield: ${message}`, {
+          tags: ['esql', 'timefield', 'views'],
+          error: {
+            stack_trace: viewsError instanceof Error ? viewsError.stack : undefined,
+          },
+        });
+        return { views: [] };
+      });
   const viewNames = new Set(views.map(({ name }) => name));
   const splitSources = sources
     .split(',')
@@ -174,7 +178,8 @@ const resolveTimeField = async (
 
 export const registerGetTimeFieldRoute = (
   router: IRouter,
-  { logger }: PluginInitializerContext
+  { logger }: PluginInitializerContext,
+  isServerless: boolean
 ) => {
   router.post(
     {
@@ -197,7 +202,7 @@ export const registerGetTimeFieldRoute = (
       const client = core.elasticsearch.client.asCurrentUser;
 
       try {
-        const body = await resolveTimeField(client, query, logger.get());
+        const body = await resolveTimeField(client, query, logger.get(), isServerless);
         esqlRouteRequestCounter.add(1, {
           route: 'timefield',
           outcome: 'success',

--- a/src/platform/plugins/shared/esql/server/routes/get_views.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_views.ts
@@ -12,7 +12,11 @@ import { VIEWS_ROUTE } from '@kbn/esql-types';
 import { EsqlService } from '@kbn/esql-server-utils';
 import { esqlRouteRequestCounter, getErrorStatusCode } from '../metrics';
 
-export const registerGetViewsRoute = (router: IRouter, { logger }: PluginInitializerContext) => {
+export const registerGetViewsRoute = (
+  router: IRouter,
+  { logger }: PluginInitializerContext,
+  isServerless: boolean
+) => {
   router.get(
     {
       path: VIEWS_ROUTE,
@@ -25,6 +29,11 @@ export const registerGetViewsRoute = (router: IRouter, { logger }: PluginInitial
       },
     },
     async (requestHandlerContext, request, response) => {
+      // TODO: Remove this once views are available in serverless
+      if (isServerless) {
+        return response.ok({ body: { views: [] } });
+      }
+
       try {
         const core = await requestHandlerContext.core;
         const service = new EsqlService({ client: core.elasticsearch.client.asCurrentUser });

--- a/src/platform/plugins/shared/esql/server/routes/index.ts
+++ b/src/platform/plugins/shared/esql/server/routes/index.ts
@@ -26,19 +26,20 @@ import { registerSuggestFixRoute } from './suggest_fix_route';
 export const registerRoutes = (
   setup: CoreSetup<EsqlServerPluginStart>,
   extensionsRegistry: ESQLExtensionsRegistry,
-  initContext: PluginInitializerContext
+  initContext: PluginInitializerContext,
+  isServerless: boolean
 ) => {
   const router = setup.http.createRouter();
 
   registerGetJoinIndicesRoute(router, initContext);
   registerGetTimeseriesIndicesRoute(router, initContext);
-  registerGetViewsRoute(router, initContext);
+  registerGetViewsRoute(router, initContext, isServerless);
   registerGetDatasetsRoute(router, initContext);
   registerESQLExtensionsRoute(router, extensionsRegistry, initContext);
   registerGetInferenceEndpointsRoute(router, initContext);
   registerLookupIndexRoutes(router, initContext);
   registerGetSourcesRoute(router, initContext);
-  registerGetTimeFieldRoute(router, initContext);
+  registerGetTimeFieldRoute(router, initContext, isServerless);
   registerNLtoESQLRoute(router, setup.getStartServices, initContext);
   registerSuggestFixRoute(router, setup.getStartServices, initContext);
 };


### PR DESCRIPTION
## Summary

Thanks to the monitoring I added recently I discovered that views are available only on prem instances. As a result the api logs errors while in serverless. This is not user facing as we are defaulting to [] when the api fails but it was creating wrong logs to the monitoring cluster which I dont like.

This PR is silencing them for isServerless and I will remove it when it is allowed. 