### PR TITLE
[APM] [PoC] Service map dashboard creation/edit workflow

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/apm/kibana.jsonc
@@ -32,6 +32,7 @@
       "unifiedSearch",
       "kql",
       "dataViews",
+      "presentationUtil",
       "lens",
       "maps",
       "uiActions",

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
@@ -24,6 +24,7 @@ import { APM_SERVICE_MAP_EMBEDDABLE } from '../../../embeddable/service_map/cons
 import type { ServiceMapEmbeddableState } from '../../../../server/lib/embeddables/service_map_embeddable_schema';
 import type { Environment } from '../../../../common/environment_rt';
 import type { ServiceMapOrientation } from './service_map_options_panel';
+import type { ServiceMapViewFilters } from './apply_service_map_visibility';
 import { readInitialAppStateFromRawUrl } from './use_filter_url_sync';
 
 interface AddToDashboardButtonProps {
@@ -34,6 +35,7 @@ interface AddToDashboardButtonProps {
   serviceName?: string;
   serviceGroupId?: string;
   mapOrientation: ServiceMapOrientation;
+  viewFilters: ServiceMapViewFilters;
 }
 
 /** Serialize a single string value as a quoted KQL phrase. */
@@ -146,6 +148,7 @@ export function AddToDashboardButton({
   serviceName,
   serviceGroupId,
   mapOrientation,
+  viewFilters,
 }: AddToDashboardButtonProps) {
   const { services } = useKibana<ApmPluginStartDeps>();
   const embeddable = services?.embeddable;
@@ -176,6 +179,20 @@ export function AddToDashboardButton({
         // Default ON for the APM-UI creation flow: the user explicitly chose to put this
         // view on a dashboard, so they likely want it to behave like a dashboard panel.
         sync_with_dashboard_filters: true,
+        // Snapshot the options-panel selections so the dashboard panel renders with the
+        // same filter chips selected. Empty arrays are dropped to keep saved state minimal.
+        alert_status_filter: viewFilters.alertStatusFilter.length
+          ? viewFilters.alertStatusFilter
+          : undefined,
+        slo_status_filter: viewFilters.sloStatusFilter.length
+          ? viewFilters.sloStatusFilter
+          : undefined,
+        connection_filter: viewFilters.connectionFilter.length
+          ? viewFilters.connectionFilter
+          : undefined,
+        anomaly_severity_filter: viewFilters.anomalySeverityFilter.length
+          ? viewFilters.anomalySeverityFilter
+          : undefined,
       };
 
       const packageState: EmbeddablePackageState<ServiceMapEmbeddableState> = {
@@ -200,6 +217,7 @@ export function AddToDashboardButton({
       environment,
       serviceGroupId,
       mapOrientation,
+      viewFilters,
     ]
   );
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
@@ -36,6 +36,8 @@ interface AddToDashboardButtonProps {
   serviceGroupId?: string;
   mapOrientation: ServiceMapOrientation;
   viewFilters: ServiceMapViewFilters;
+  /** Current find-in-page query — captured into the dashboard panel state. */
+  searchQuery: string;
 }
 
 /** Serialize a single string value as a quoted KQL phrase. */
@@ -149,6 +151,7 @@ export function AddToDashboardButton({
   serviceGroupId,
   mapOrientation,
   viewFilters,
+  searchQuery,
 }: AddToDashboardButtonProps) {
   const { services } = useKibana<ApmPluginStartDeps>();
   const embeddable = services?.embeddable;
@@ -193,6 +196,7 @@ export function AddToDashboardButton({
         anomaly_severity_filter: viewFilters.anomalySeverityFilter.length
           ? viewFilters.anomalySeverityFilter
           : undefined,
+        find_query: searchQuery.trim() ? searchQuery : undefined,
       };
 
       const packageState: EmbeddablePackageState<ServiceMapEmbeddableState> = {
@@ -218,6 +222,7 @@ export function AddToDashboardButton({
       serviceGroupId,
       mapOrientation,
       viewFilters,
+      searchQuery,
     ]
   );
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { EmbeddablePackageState } from '@kbn/embeddable-plugin/public';
+import type { Filter } from '@kbn/es-query';
+import { getPhraseFilterValue, isPhraseFilter, isPhrasesFilter } from '@kbn/es-query';
+import type { SaveModalDashboardProps } from '@kbn/presentation-util-plugin/public';
+import { SavedObjectSaveModalDashboard } from '@kbn/presentation-util-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { ApmPluginStartDeps } from '../../../plugin';
+import { APM_SERVICE_MAP_EMBEDDABLE } from '../../../embeddable/service_map/constants';
+import type { ServiceMapEmbeddableState } from '../../../../server/lib/embeddables/service_map_embeddable_schema';
+import type { Environment } from '../../../../common/environment_rt';
+import type { ServiceMapOrientation } from './service_map_options_panel';
+import { readInitialAppStateFromRawUrl } from './use_filter_url_sync';
+
+interface AddToDashboardButtonProps {
+  environment: Environment;
+  kuery: string;
+  start: string;
+  end: string;
+  serviceName?: string;
+  serviceGroupId?: string;
+  mapOrientation: ServiceMapOrientation;
+}
+
+/** Serialize a single string value as a quoted KQL phrase. */
+function quoteKqlValue(value: string): string {
+  return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+/** Convert a phrase / phrases filter to a KQL fragment; returns `undefined` for unsupported filter shapes. */
+function filterToKql(filter: Filter): string | undefined {
+  const field = filter.meta?.key;
+  if (!field || filter.meta?.disabled) return undefined;
+  const negate = filter.meta?.negate ? 'not ' : '';
+  if (isPhraseFilter(filter)) {
+    const value = getPhraseFilterValue(filter);
+    if (value == null) return undefined;
+    return `${negate}${field}: ${quoteKqlValue(String(value))}`;
+  }
+  if (isPhrasesFilter(filter)) {
+    const params = filter.meta.params;
+    if (!params || params.length === 0) return undefined;
+    const values = params.map((v) => quoteKqlValue(String(v))).join(' or ');
+    return `${negate}${field}: (${values})`;
+  }
+  return undefined;
+}
+
+/** Convert a Record<field, values[]> control-selections map to KQL fragments. */
+function controlSelectionsToKql(selections: Record<string, string[]>): string[] {
+  return Object.entries(selections)
+    .filter(([, values]) => values.length > 0)
+    .map(([field, values]) =>
+      values.length === 1
+        ? `${field}: ${quoteKqlValue(values[0])}`
+        : `${field}: (${values.map(quoteKqlValue).join(' or ')})`
+    );
+}
+
+/**
+ * Read the current page's filters from URL + filterManager and project them onto the
+ * embeddable's schema fields:
+ * - URL service name (from `/services/{name}/service-map`) → `service_name`
+ * - Controls API single `service.name` selection → `service_name` (when no URL one)
+ * - service.environment selection → ignored here (URL `?environment=` already captured)
+ * - everything else (URL kuery, remaining Controls selections, pill filters) → KQL clauses appended to `kuery`
+ *
+ * Service-name pills with the same value as the promoted `service_name` are skipped to
+ * avoid double-filtering; pills with a different value are kept as KQL clauses.
+ */
+function capturePageFilters({
+  urlKuery,
+  urlServiceName,
+  filterManagerFilters,
+}: {
+  urlKuery: string;
+  urlServiceName: string | undefined;
+  filterManagerFilters: Filter[];
+}): { kuery: string | undefined; service_name: string | undefined } {
+  const appState = readInitialAppStateFromRawUrl();
+  const controlSelections = appState?.controlSelections ?? {};
+
+  // Promote a single Controls API service.name selection to the dedicated field
+  // when no URL service name is set. Multiple selections stay as a KQL clause.
+  let serviceName = urlServiceName;
+  let promotedServiceNameFromControls = false;
+  const serviceNameSelection = controlSelections['service.name'];
+  if (!serviceName && serviceNameSelection && serviceNameSelection.length === 1) {
+    serviceName = serviceNameSelection[0];
+    promotedServiceNameFromControls = true;
+  }
+
+  // Build KQL fragments from remaining Controls selections.
+  const remainingSelections: Record<string, string[]> = { ...controlSelections };
+  delete remainingSelections['service.environment'];
+  if (promotedServiceNameFromControls) {
+    delete remainingSelections['service.name'];
+  }
+  const controlsKql = controlSelectionsToKql(remainingSelections);
+
+  // Build KQL fragments from filter-bar pills:
+  // - skip env (dedicated URL param)
+  // - skip a service.name pill whose value matches the promoted service_name (avoid duplicate)
+  const pillsKql = filterManagerFilters
+    .filter((f) => {
+      if (f.meta?.key === 'service.environment') return false;
+      if (f.meta?.key === 'service.name' && serviceName && isPhraseFilter(f)) {
+        return String(getPhraseFilterValue(f)) !== serviceName;
+      }
+      return true;
+    })
+    .map(filterToKql)
+    .filter((s): s is string => Boolean(s));
+
+  const fragments = [
+    urlKuery.trim() ? `(${urlKuery.trim()})` : undefined,
+    ...controlsKql,
+    ...pillsKql,
+  ].filter((s): s is string => Boolean(s));
+
+  return {
+    kuery: fragments.length > 0 ? fragments.join(' and ') : undefined,
+    service_name: serviceName || undefined,
+  };
+}
+
+export function AddToDashboardButton({
+  environment,
+  kuery,
+  start,
+  end,
+  serviceName,
+  serviceGroupId,
+  mapOrientation,
+}: AddToDashboardButtonProps) {
+  const { services } = useKibana<ApmPluginStartDeps>();
+  const embeddable = services?.embeddable;
+  const filterManager = services?.data?.query?.filterManager;
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleSave: SaveModalDashboardProps['onSave'] = useCallback(
+    async ({ dashboardId, newTitle, newDescription }) => {
+      if (!embeddable) return;
+      const stateTransfer = embeddable.getStateTransfer();
+
+      const { kuery: capturedKuery, service_name: capturedServiceName } = capturePageFilters({
+        urlKuery: kuery,
+        urlServiceName: serviceName,
+        filterManagerFilters: filterManager?.getFilters() ?? [],
+      });
+
+      const serializedState: ServiceMapEmbeddableState = {
+        title: newTitle,
+        description: newDescription,
+        time_range: { from: start, to: end },
+        environment,
+        kuery: capturedKuery,
+        service_name: capturedServiceName,
+        service_group_id: serviceGroupId || undefined,
+        map_orientation: mapOrientation,
+        // Default ON for the APM-UI creation flow: the user explicitly chose to put this
+        // view on a dashboard, so they likely want it to behave like a dashboard panel.
+        sync_with_dashboard_filters: true,
+      };
+
+      const packageState: EmbeddablePackageState<ServiceMapEmbeddableState> = {
+        type: APM_SERVICE_MAP_EMBEDDABLE,
+        serializedState,
+      };
+
+      const path = dashboardId === 'new' ? '#/create' : `#/view/${dashboardId}`;
+
+      stateTransfer.navigateToWithEmbeddablePackages<ServiceMapEmbeddableState>('dashboards', {
+        state: [packageState],
+        path,
+      });
+    },
+    [
+      embeddable,
+      filterManager,
+      kuery,
+      serviceName,
+      start,
+      end,
+      environment,
+      serviceGroupId,
+      mapOrientation,
+    ]
+  );
+
+  // Hide entirely when the host doesn't expose the embeddable plugin (e.g. unit tests
+  // that don't wire a kibana context).
+  if (!embeddable) {
+    return null;
+  }
+
+  const objectType = i18n.translate('xpack.apm.serviceMap.addToDashboard.objectTypeLabel', {
+    defaultMessage: 'Service map',
+  });
+
+  const attachmentTitle = i18n.translate('xpack.apm.serviceMap.addToDashboard.attachmentTitle', {
+    defaultMessage: 'Service map',
+  });
+
+  return (
+    <>
+      <EuiButton
+        iconType="dashboardApp"
+        size="s"
+        color="primary"
+        onClick={() => setIsModalOpen(true)}
+        data-test-subj="apmServiceMapAddToDashboardButton"
+      >
+        {i18n.translate('xpack.apm.serviceMap.addToDashboardButton', {
+          defaultMessage: 'Add to dashboard',
+        })}
+      </EuiButton>
+      {isModalOpen && (
+        <SavedObjectSaveModalDashboard
+          objectType={objectType}
+          documentInfo={{ title: attachmentTitle }}
+          canSaveByReference={false}
+          onClose={() => setIsModalOpen(false)}
+          onSave={handleSave}
+        />
+      )}
+    </>
+  );
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
@@ -5,8 +5,13 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
-import { EuiButton } from '@elastic/eui';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  EuiButtonIcon,
+  EuiContextMenuPanel,
+  EuiContextMenuItem,
+  EuiPopover,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { EmbeddablePackageState } from '@kbn/embeddable-plugin/public';
 import type { Filter } from '@kbn/es-query';
@@ -146,6 +151,7 @@ export function AddToDashboardButton({
   const embeddable = services?.embeddable;
   const filterManager = services?.data?.query?.filterManager;
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const handleSave: SaveModalDashboardProps['onSave'] = useCallback(
     async ({ dashboardId, newTitle, newDescription }) => {
@@ -211,19 +217,51 @@ export function AddToDashboardButton({
     defaultMessage: 'Service map',
   });
 
+  const menuLabel = i18n.translate('xpack.apm.serviceMap.panelActions.menuLabel', {
+    defaultMessage: 'More actions',
+  });
+
+  const menuItems = useMemo(
+    () => [
+      <EuiContextMenuItem
+        key="copyToDashboard"
+        icon="addToDashboard"
+        onClick={() => {
+          setIsMenuOpen(false);
+          setIsModalOpen(true);
+        }}
+        data-test-subj="apmServiceMapCopyToDashboardMenuItem"
+      >
+        {i18n.translate('xpack.apm.serviceMap.copyToDashboardMenuItem', {
+          defaultMessage: 'Copy to dashboard',
+        })}
+      </EuiContextMenuItem>,
+    ],
+    []
+  );
+
   return (
     <>
-      <EuiButton
-        iconType="dashboardApp"
-        size="s"
-        color="primary"
-        onClick={() => setIsModalOpen(true)}
-        data-test-subj="apmServiceMapAddToDashboardButton"
+      <EuiPopover
+        anchorPosition="downRight"
+        panelPaddingSize="none"
+        isOpen={isMenuOpen}
+        closePopover={() => setIsMenuOpen(false)}
+        button={
+          <EuiButtonIcon
+            iconType="boxesHorizontal"
+            color="text"
+            display="base"
+            size="s"
+            aria-label={menuLabel}
+            title={menuLabel}
+            onClick={() => setIsMenuOpen((open) => !open)}
+            data-test-subj="apmServiceMapPanelActionsButton"
+          />
+        }
       >
-        {i18n.translate('xpack.apm.serviceMap.addToDashboardButton', {
-          defaultMessage: 'Add to dashboard',
-        })}
-      </EuiButton>
+        <EuiContextMenuPanel size="s" items={menuItems} />
+      </EuiPopover>
       {isModalOpen && (
         <SavedObjectSaveModalDashboard
           objectType={objectType}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -62,6 +62,7 @@ import {
   type ServiceMapOrientation,
 } from './service_map_options_panel';
 import { ServiceMapLegend } from './service_map_legend';
+import { AddToDashboardButton } from './add_to_dashboard_button';
 import type { Environment } from '../../../../common/environment_rt';
 import {
   isServiceNode,
@@ -106,6 +107,12 @@ interface GraphProps {
    * (frame, fill, primary node ring). Blue edges/markers remain tied to explicit selection only.
    */
   highlightedServiceName?: string;
+  /** Controlled initial / current orientation when supplied. Falls back to internal `useState` otherwise. */
+  mapOrientation?: ServiceMapOrientation;
+  /** Called when orientation changes (Options panel or any other host control). */
+  onMapOrientationChange?: (next: ServiceMapOrientation) => void;
+  /** Optional service group filter — forwarded to the "Add to dashboard" panel state. */
+  serviceGroupId?: string;
 }
 
 function GraphInner({
@@ -125,6 +132,9 @@ function GraphInner({
   alwaysNavigateOnPopoverFocus,
   clearKueryOnPopoverNavigation,
   highlightedServiceName,
+  mapOrientation: controlledOrientation,
+  onMapOrientationChange,
+  serviceGroupId,
 }: GraphProps) {
   const { services } = useKibana<ApmPluginStartDeps & ApmServices>();
   const { telemetry } = services;
@@ -143,7 +153,17 @@ function GraphInner({
     DEFAULT_SERVICE_MAP_VIEW_FILTERS
   );
   const [panelExpanded, setPanelExpanded] = useState(true);
-  const [mapOrientation, setMapOrientation] = useState<ServiceMapOrientation>('horizontal');
+  const [internalOrientation, setInternalOrientation] = useState<ServiceMapOrientation>(
+    controlledOrientation ?? 'horizontal'
+  );
+  const mapOrientation = controlledOrientation ?? internalOrientation;
+  const setMapOrientation = useCallback(
+    (next: ServiceMapOrientation) => {
+      setInternalOrientation(next);
+      onMapOrientationChange?.(next);
+    },
+    [onMapOrientationChange]
+  );
 
   // Track the current selected node for use in layout effect without triggering re-layout
   const selectedNodeIdRef = useRef<string | null>(null);
@@ -686,6 +706,19 @@ function GraphInner({
                 />
               )}
             </Panel>
+            {!isEmbedded && (
+              <Panel position="top-right">
+                <AddToDashboardButton
+                  environment={environment}
+                  kuery={kuery}
+                  start={start}
+                  end={end}
+                  serviceName={serviceName}
+                  serviceGroupId={serviceGroupId}
+                  mapOrientation={mapOrientation}
+                />
+              </Panel>
+            )}
             {!isEmbedded && <ServiceMapMinimap />}
           </ReactFlow>
           <MapPopover

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -115,6 +115,10 @@ interface GraphProps {
   viewFilters?: ServiceMapViewFilters;
   /** Called when view filters change in the options panel. */
   onViewFiltersChange?: (next: ServiceMapViewFilters) => void;
+  /** Controlled find-in-page query when supplied (e.g. embeddable hydrating from persisted state). */
+  searchQuery?: string;
+  /** Called when the user edits the find-in-page search field. */
+  onSearchQueryChange?: (next: string) => void;
   /** Optional service group filter — forwarded to the "Add to dashboard" panel state. */
   serviceGroupId?: string;
 }
@@ -140,6 +144,8 @@ function GraphInner({
   onMapOrientationChange,
   viewFilters: controlledViewFilters,
   onViewFiltersChange,
+  searchQuery: controlledSearchQuery,
+  onSearchQueryChange,
   serviceGroupId,
 }: GraphProps) {
   const { services } = useKibana<ApmPluginStartDeps & ApmServices>();
@@ -169,12 +175,24 @@ function GraphInner({
     },
     [onViewFiltersChange]
   );
+  const [internalSearchQuery, setInternalSearchQuery] = useState(controlledSearchQuery ?? '');
+  const searchQuery = controlledSearchQuery ?? internalSearchQuery;
+  const setSearchQuery = useCallback(
+    (next: string) => {
+      setInternalSearchQuery(next);
+      onSearchQueryChange?.(next);
+    },
+    [onSearchQueryChange]
+  );
   const hasAnyViewFilter =
     viewFilters.alertStatusFilter.length > 0 ||
     viewFilters.sloStatusFilter.length > 0 ||
     viewFilters.connectionFilter.length > 0 ||
     viewFilters.anomalySeverityFilter.length > 0;
-  const [panelExpanded, setPanelExpanded] = useState(!isEmbedded || hasAnyViewFilter);
+  const hasSearchQuery = searchQuery.trim().length > 0;
+  const [panelExpanded, setPanelExpanded] = useState(
+    !isEmbedded || hasAnyViewFilter || hasSearchQuery
+  );
   const [internalOrientation, setInternalOrientation] = useState<ServiceMapOrientation>(
     controlledOrientation ?? 'horizontal'
   );
@@ -721,6 +739,8 @@ function GraphInner({
                   }
                   mapOrientation={mapOrientation}
                   onMapOrientationChange={setMapOrientation}
+                  searchQuery={searchQuery}
+                  onSearchQueryChange={setSearchQuery}
                 />
               )}
             </Panel>
@@ -735,6 +755,7 @@ function GraphInner({
                   serviceGroupId={serviceGroupId}
                   mapOrientation={mapOrientation}
                   viewFilters={viewFilters}
+                  searchQuery={searchQuery}
                 />
               </Panel>
             )}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -184,15 +184,16 @@ function GraphInner({
     },
     [onSearchQueryChange]
   );
-  const hasAnyViewFilter =
+  // Used to badge the controls toggle when the panel is collapsed but state is non-default.
+  // Persisted view filters / search query keep the map "the same view" — but the options panel
+  // itself stays closed on the dashboard (product feedback: it's an authoring affordance).
+  const hasActiveControls =
     viewFilters.alertStatusFilter.length > 0 ||
     viewFilters.sloStatusFilter.length > 0 ||
     viewFilters.connectionFilter.length > 0 ||
-    viewFilters.anomalySeverityFilter.length > 0;
-  const hasSearchQuery = searchQuery.trim().length > 0;
-  const [panelExpanded, setPanelExpanded] = useState(
-    !isEmbedded || hasAnyViewFilter || hasSearchQuery
-  );
+    viewFilters.anomalySeverityFilter.length > 0 ||
+    searchQuery.trim().length > 0;
+  const [panelExpanded, setPanelExpanded] = useState(!isEmbedded);
   const [internalOrientation, setInternalOrientation] = useState<ServiceMapOrientation>(
     controlledOrientation ?? 'horizontal'
   );
@@ -628,6 +629,7 @@ function GraphInner({
                 <ServiceMapOptionsPanelToggle
                   isExpanded={panelExpanded}
                   onExpandedChange={setPanelExpanded}
+                  hasActiveControls={hasActiveControls}
                 />
                 <EuiPanel
                   hasBorder

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -111,6 +111,10 @@ interface GraphProps {
   mapOrientation?: ServiceMapOrientation;
   /** Called when orientation changes (Options panel or any other host control). */
   onMapOrientationChange?: (next: ServiceMapOrientation) => void;
+  /** Controlled view filters when supplied (e.g. embeddable hydrating from persisted state). */
+  viewFilters?: ServiceMapViewFilters;
+  /** Called when view filters change in the options panel. */
+  onViewFiltersChange?: (next: ServiceMapViewFilters) => void;
   /** Optional service group filter — forwarded to the "Add to dashboard" panel state. */
   serviceGroupId?: string;
 }
@@ -134,6 +138,8 @@ function GraphInner({
   highlightedServiceName,
   mapOrientation: controlledOrientation,
   onMapOrientationChange,
+  viewFilters: controlledViewFilters,
+  onViewFiltersChange,
   serviceGroupId,
 }: GraphProps) {
   const { services } = useKibana<ApmPluginStartDeps & ApmServices>();
@@ -149,10 +155,26 @@ function GraphInner({
   const serviceMapId = useGeneratedHtmlId({ prefix: 'serviceMap' });
   const mapRegionRef = useRef<HTMLDivElement | null>(null);
 
-  const [viewFilters, setViewFilters] = useState<ServiceMapViewFilters>(
-    DEFAULT_SERVICE_MAP_VIEW_FILTERS
+  const [internalViewFilters, setInternalViewFilters] = useState<ServiceMapViewFilters>(
+    controlledViewFilters ?? DEFAULT_SERVICE_MAP_VIEW_FILTERS
   );
-  const [panelExpanded, setPanelExpanded] = useState(!isEmbedded);
+  const viewFilters = controlledViewFilters ?? internalViewFilters;
+  const setViewFilters = useCallback(
+    (updater: ServiceMapViewFilters | ((prev: ServiceMapViewFilters) => ServiceMapViewFilters)) => {
+      setInternalViewFilters((prev) => {
+        const next = typeof updater === 'function' ? updater(prev) : updater;
+        onViewFiltersChange?.(next);
+        return next;
+      });
+    },
+    [onViewFiltersChange]
+  );
+  const hasAnyViewFilter =
+    viewFilters.alertStatusFilter.length > 0 ||
+    viewFilters.sloStatusFilter.length > 0 ||
+    viewFilters.connectionFilter.length > 0 ||
+    viewFilters.anomalySeverityFilter.length > 0;
+  const [panelExpanded, setPanelExpanded] = useState(!isEmbedded || hasAnyViewFilter);
   const [internalOrientation, setInternalOrientation] = useState<ServiceMapOrientation>(
     controlledOrientation ?? 'horizontal'
   );
@@ -712,6 +734,7 @@ function GraphInner({
                   serviceName={serviceName}
                   serviceGroupId={serviceGroupId}
                   mapOrientation={mapOrientation}
+                  viewFilters={viewFilters}
                 />
               </Panel>
             )}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -152,7 +152,7 @@ function GraphInner({
   const [viewFilters, setViewFilters] = useState<ServiceMapViewFilters>(
     DEFAULT_SERVICE_MAP_VIEW_FILTERS
   );
-  const [panelExpanded, setPanelExpanded] = useState(true);
+  const [panelExpanded, setPanelExpanded] = useState(!isEmbedded);
   const [internalOrientation, setInternalOrientation] = useState<ServiceMapOrientation>(
     controlledOrientation ?? 'horizontal'
   );
@@ -585,12 +585,10 @@ function GraphInner({
             <Background gap={24} size={1} color={euiTheme.colors.lightShade} />
             <Panel position="top-left" css={topLeftToolbarStyles}>
               <div css={topLeftToolbarColumnStyles}>
-                {!isEmbedded && (
-                  <ServiceMapOptionsPanelToggle
-                    isExpanded={panelExpanded}
-                    onExpandedChange={setPanelExpanded}
-                  />
-                )}
+                <ServiceMapOptionsPanelToggle
+                  isExpanded={panelExpanded}
+                  onExpandedChange={setPanelExpanded}
+                />
                 <EuiPanel
                   hasBorder
                   hasShadow={false}
@@ -679,7 +677,7 @@ function GraphInner({
                   <ServiceMapLegend controlIconCss={mapToolbarControlIconCss} />
                 </EuiPanel>
               </div>
-              {!isEmbedded && panelExpanded && (
+              {panelExpanded && (
                 <ServiceMapOptionsPanel
                   nodes={nodesAfterFilters}
                   filterOptionCounts={filterOptionCounts}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -630,19 +630,17 @@ function GraphInner({
                       data-test-subj="serviceMapZoomOutButton"
                       css={mapToolbarControlIconCss}
                     />
-                    {!isEmbedded && (
-                      <EuiButtonIcon
-                        display="empty"
-                        color="text"
-                        size="s"
-                        iconType="crosshair"
-                        onClick={() => fitView(getFitViewOptions())}
-                        title={fitViewLabel}
-                        aria-label={fitViewLabel}
-                        data-test-subj="serviceMapFitViewButton"
-                        css={mapToolbarControlIconCss}
-                      />
-                    )}
+                    <EuiButtonIcon
+                      display="empty"
+                      color="text"
+                      size="s"
+                      iconType="crosshair"
+                      onClick={() => fitView(getFitViewOptions())}
+                      title={fitViewLabel}
+                      aria-label={fitViewLabel}
+                      data-test-subj="serviceMapFitViewButton"
+                      css={mapToolbarControlIconCss}
+                    />
                     {fullMapHref && (
                       <EuiButtonIcon
                         display="empty"

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/index.tsx
@@ -294,6 +294,7 @@ export function ServiceMap({
               kuery={kuery}
               start={start}
               end={end}
+              serviceGroupId={serviceGroupId}
               isFullscreen={isFullscreen}
               onToggleFullscreen={onToggleFullscreen}
               fullMapHref={fullMapHref}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_find_in_page.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_find_in_page.tsx
@@ -53,15 +53,31 @@ function getAbsolutePosition(
 
 export interface ServiceMapFindInPageProps {
   nodes: ServiceMapNode[];
+  /** Controlled search query when supplied (e.g. embeddable hydrating from persisted state). */
+  searchQuery?: string;
+  /** Fires when the user types in the search field (use to mirror state up for snapshot persistence). */
+  onSearchQueryChange?: (next: string) => void;
 }
 
 /**
  * Find-in-page for the service map: filters visible service/dependency nodes, centers the canvas on
  * matches, and keeps `selectedIndex` aligned with the last centered match (so prev/next stay in sync).
  */
-export function ServiceMapFindInPage({ nodes }: ServiceMapFindInPageProps) {
+export function ServiceMapFindInPage({
+  nodes,
+  searchQuery: controlledSearchQuery,
+  onSearchQueryChange,
+}: ServiceMapFindInPageProps) {
   const { euiTheme } = useEuiTheme();
-  const [searchQuery, setSearchQuery] = useState('');
+  const [internalSearchQuery, setInternalSearchQuery] = useState(controlledSearchQuery ?? '');
+  const searchQuery = controlledSearchQuery ?? internalSearchQuery;
+  const setSearchQuery = useCallback(
+    (next: string) => {
+      setInternalSearchQuery(next);
+      onSearchQueryChange?.(next);
+    },
+    [onSearchQueryChange]
+  );
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isFocused, setIsFocused] = useState(false);
   const { setSearchHighlight } = useServiceMapSearchContext();

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_options_panel.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_options_panel.tsx
@@ -164,6 +164,10 @@ export interface ServiceMapOptionsPanelProps {
   onAnomalySeverityFilterChange: (next: ML_ANOMALY_SEVERITY[]) => void;
   mapOrientation: ServiceMapOrientation;
   onMapOrientationChange: (next: ServiceMapOrientation) => void;
+  /** Pass-through to ServiceMapFindInPage for controlled search query. */
+  searchQuery?: string;
+  /** Pass-through to ServiceMapFindInPage; called whenever the user edits the search field. */
+  onSearchQueryChange?: (next: string) => void;
 }
 
 /** Same hit target as map zoom / fit controls in graph.tsx (2 × base size). */
@@ -245,6 +249,8 @@ export function ServiceMapOptionsPanel({
   onAnomalySeverityFilterChange,
   mapOrientation,
   onMapOrientationChange,
+  searchQuery,
+  onSearchQueryChange,
 }: ServiceMapOptionsPanelProps) {
   const connectionCounts = filterOptionCounts.connection;
   const alertCounts = filterOptionCounts.alerts;
@@ -378,7 +384,11 @@ export function ServiceMapOptionsPanel({
       grow={false}
       css={panelSizingCss}
     >
-      <ServiceMapFindInPage nodes={nodes} />
+      <ServiceMapFindInPage
+        nodes={nodes}
+        searchQuery={searchQuery}
+        onSearchQueryChange={onSearchQueryChange}
+      />
 
       <EuiHorizontalRule margin="m" />
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_options_panel.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_options_panel.tsx
@@ -149,6 +149,8 @@ const ANOMALY_SEVERITY_OPTIONS: { value: ML_ANOMALY_SEVERITY; label: string }[] 
 export interface ServiceMapOptionsPanelToggleProps {
   isExpanded: boolean;
   onExpandedChange: (next: boolean) => void;
+  /** When true, show a small dot on the toggle indicating filters or a search query are active. */
+  hasActiveControls?: boolean;
 }
 
 export interface ServiceMapOptionsPanelProps {
@@ -191,16 +193,50 @@ const useToolbarToggleIconCss = () => {
 export function ServiceMapOptionsPanelToggle({
   isExpanded,
   onExpandedChange,
+  hasActiveControls = false,
 }: ServiceMapOptionsPanelToggleProps) {
   const mapToolbarToggleIconCss = useToolbarToggleIconCss();
+  const { euiTheme } = useEuiTheme();
 
-  const toggleLabel = isExpanded
+  // Only badge while collapsed — once open the chips themselves communicate the same thing.
+  const showBadge = hasActiveControls && !isExpanded;
+
+  const baseLabel = isExpanded
     ? i18n.translate('xpack.apm.serviceMap.controls.hideControls', {
         defaultMessage: 'Hide controls',
       })
     : i18n.translate('xpack.apm.serviceMap.controls.showControls', {
         defaultMessage: 'Show controls',
       });
+
+  const toggleLabel = showBadge
+    ? i18n.translate('xpack.apm.serviceMap.controls.showControlsWithActiveFilters', {
+        defaultMessage: '{baseLabel} (filters active)',
+        values: { baseLabel },
+      })
+    : baseLabel;
+
+  const panelWrapperCss = useMemo(
+    () => css`
+      position: relative;
+    `,
+    []
+  );
+
+  const badgeCss = useMemo(
+    () => css`
+      position: absolute;
+      top: -${euiTheme.size.xs};
+      right: -${euiTheme.size.xs};
+      width: ${euiTheme.size.s};
+      height: ${euiTheme.size.s};
+      border-radius: 50%;
+      background-color: ${euiTheme.colors.accent};
+      border: ${euiTheme.border.width.thin} solid ${euiTheme.colors.emptyShade};
+      pointer-events: none;
+    `,
+    [euiTheme]
+  );
 
   return (
     <EuiPanel
@@ -210,6 +246,7 @@ export function ServiceMapOptionsPanelToggle({
       paddingSize="none"
       borderRadius="m"
       grow={false}
+      css={panelWrapperCss}
     >
       <EuiFlexGroup
         justifyContent="center"
@@ -232,6 +269,13 @@ export function ServiceMapOptionsPanelToggle({
           }
         />
       </EuiFlexGroup>
+      {showBadge && (
+        <span
+          css={badgeCss}
+          data-test-subj="serviceMapOptionsPanelToggleActiveIndicator"
+          aria-hidden="true"
+        />
+      )}
     </EuiPanel>
   );
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/use_filter_url_sync.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/use_filter_url_sync.ts
@@ -37,7 +37,7 @@ interface AppFilterState {
  * (via deepExactRt) before React components mount — so kbnUrlStateStorage
  * won't find `_a` in history.location.search.
  */
-function readInitialAppStateFromRawUrl(): AppFilterState | null {
+export function readInitialAppStateFromRawUrl(): AppFilterState | null {
   try {
     const raw = window.location.href;
     const match = raw.match(/[?&]_a=([^&#]+)/);

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_editor_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_editor_flyout.tsx
@@ -8,6 +8,7 @@
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiButtonGroup,
   EuiComboBox,
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,8 +19,10 @@ import {
   EuiFormRow,
   EuiLink,
   EuiSkeletonText,
+  EuiSwitch,
   EuiTitle,
 } from '@elastic/eui';
+import type { ServiceMapOrientation } from '../../components/app/service_map/service_map_options_panel';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -177,6 +180,12 @@ export function ServiceMapEditorFlyout({
   );
   const [kuery, setKuery] = useState(initialState?.kuery ?? '');
   const [serviceName, setServiceName] = useState(initialState?.service_name ?? '');
+  const [mapOrientation, setMapOrientation] = useState<ServiceMapOrientation>(
+    initialState?.map_orientation ?? 'horizontal'
+  );
+  const [syncWithDashboardFilters, setSyncWithDashboardFilters] = useState<boolean>(
+    initialState?.sync_with_dashboard_filters ?? false
+  );
 
   const [selectedServiceOption, setSelectedServiceOption] = useState<
     Array<EuiComboBoxOptionOption<string>>
@@ -251,9 +260,11 @@ export function ServiceMapEditorFlyout({
       environment,
       kuery: kuery.trim() ? kuery : undefined,
       service_name: serviceName || undefined,
+      map_orientation: mapOrientation,
+      sync_with_dashboard_filters: syncWithDashboardFilters,
     };
     onSave(state);
-  }, [environment, kuery, serviceName, onSave]);
+  }, [environment, kuery, serviceName, mapOrientation, syncWithDashboardFilters, onSave]);
 
   return (
     <div style={serviceMapFlyoutShellStyle}>
@@ -341,6 +352,57 @@ export function ServiceMapEditorFlyout({
           </EuiFormRow>
 
           <KueryInput kuery={kuery} onChange={setKuery} deps={deps} />
+
+          <EuiFormRow
+            label={i18n.translate('xpack.apm.serviceMapEditor.orientationLabel', {
+              defaultMessage: 'Layout orientation',
+            })}
+            fullWidth
+          >
+            <EuiButtonGroup
+              legend={i18n.translate('xpack.apm.serviceMapEditor.orientationLegend', {
+                defaultMessage: 'Service map layout orientation',
+              })}
+              idSelected={mapOrientation}
+              onChange={(id) => setMapOrientation(id as ServiceMapOrientation)}
+              options={[
+                {
+                  id: 'horizontal',
+                  label: i18n.translate('xpack.apm.serviceMapEditor.orientationHorizontal', {
+                    defaultMessage: 'Horizontal',
+                  }),
+                  iconType: 'arrowRight',
+                },
+                {
+                  id: 'vertical',
+                  label: i18n.translate('xpack.apm.serviceMapEditor.orientationVertical', {
+                    defaultMessage: 'Vertical',
+                  }),
+                  iconType: 'arrowDown',
+                },
+              ]}
+              buttonSize="compressed"
+              isFullWidth
+              data-test-subj="apmServiceMapEditorOrientation"
+            />
+          </EuiFormRow>
+
+          <EuiFormRow
+            helpText={i18n.translate('xpack.apm.serviceMapEditor.syncFiltersHelpText', {
+              defaultMessage:
+                "When on, the panel responds to the dashboard's global filters and search. Time range is not synced — it stays panel-owned.",
+            })}
+            fullWidth
+          >
+            <EuiSwitch
+              label={i18n.translate('xpack.apm.serviceMapEditor.syncFiltersLabel', {
+                defaultMessage: 'Sync with dashboard filters',
+              })}
+              checked={syncWithDashboardFilters}
+              onChange={(e) => setSyncWithDashboardFilters(e.target.checked)}
+              data-test-subj="apmServiceMapEditorSyncFiltersToggle"
+            />
+          </EuiFormRow>
         </EuiForm>
       </EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_editor_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_editor_flyout.tsx
@@ -8,7 +8,6 @@
 import {
   EuiButton,
   EuiButtonEmpty,
-  EuiButtonGroup,
   EuiComboBox,
   EuiFlexGroup,
   EuiFlexItem,
@@ -22,7 +21,6 @@ import {
   EuiSwitch,
   EuiTitle,
 } from '@elastic/eui';
-import type { ServiceMapOrientation } from '../../components/app/service_map/service_map_options_panel';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -180,9 +178,6 @@ export function ServiceMapEditorFlyout({
   );
   const [kuery, setKuery] = useState(initialState?.kuery ?? '');
   const [serviceName, setServiceName] = useState(initialState?.service_name ?? '');
-  const [mapOrientation, setMapOrientation] = useState<ServiceMapOrientation>(
-    initialState?.map_orientation ?? 'horizontal'
-  );
   const [syncWithDashboardFilters, setSyncWithDashboardFilters] = useState<boolean>(
     initialState?.sync_with_dashboard_filters ?? false
   );
@@ -260,11 +255,10 @@ export function ServiceMapEditorFlyout({
       environment,
       kuery: kuery.trim() ? kuery : undefined,
       service_name: serviceName || undefined,
-      map_orientation: mapOrientation,
       sync_with_dashboard_filters: syncWithDashboardFilters,
     };
     onSave(state);
-  }, [environment, kuery, serviceName, mapOrientation, syncWithDashboardFilters, onSave]);
+  }, [environment, kuery, serviceName, syncWithDashboardFilters, onSave]);
 
   return (
     <div style={serviceMapFlyoutShellStyle}>
@@ -352,40 +346,6 @@ export function ServiceMapEditorFlyout({
           </EuiFormRow>
 
           <KueryInput kuery={kuery} onChange={setKuery} deps={deps} />
-
-          <EuiFormRow
-            label={i18n.translate('xpack.apm.serviceMapEditor.orientationLabel', {
-              defaultMessage: 'Layout orientation',
-            })}
-            fullWidth
-          >
-            <EuiButtonGroup
-              legend={i18n.translate('xpack.apm.serviceMapEditor.orientationLegend', {
-                defaultMessage: 'Service map layout orientation',
-              })}
-              idSelected={mapOrientation}
-              onChange={(id) => setMapOrientation(id as ServiceMapOrientation)}
-              options={[
-                {
-                  id: 'horizontal',
-                  label: i18n.translate('xpack.apm.serviceMapEditor.orientationHorizontal', {
-                    defaultMessage: 'Horizontal',
-                  }),
-                  iconType: 'arrowRight',
-                },
-                {
-                  id: 'vertical',
-                  label: i18n.translate('xpack.apm.serviceMapEditor.orientationVertical', {
-                    defaultMessage: 'Vertical',
-                  }),
-                  iconType: 'arrowDown',
-                },
-              ]}
-              buttonSize="compressed"
-              isFullWidth
-              data-test-subj="apmServiceMapEditorOrientation"
-            />
-          </EuiFormRow>
 
           <EuiFormRow
             helpText={i18n.translate('xpack.apm.serviceMapEditor.syncFiltersHelpText', {

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
@@ -74,8 +74,12 @@ export interface ServiceMapEmbeddableProps {
   parentQuery?: Query | AggregateQuery;
   /** Persisted view filters (alerts / SLOs / connection / anomaly severity) captured at "Copy to dashboard" time. */
   viewFilters?: ServiceMapViewFilters;
+  /** Push in-panel filter edits back to the state manager so the embeddable's controlled value updates. */
+  onViewFiltersChange?: (next: ServiceMapViewFilters) => void;
   /** Persisted find-in-page query captured at "Copy to dashboard" time. */
   searchQuery?: string;
+  /** Push in-panel search edits back to the state manager. */
+  onSearchQueryChange?: (next: string) => void;
 }
 
 function LoadingSpinner() {
@@ -110,7 +114,9 @@ export function ServiceMapEmbeddable({
   parentFilters,
   parentQuery,
   viewFilters,
+  onViewFiltersChange,
   searchQuery,
+  onSearchQueryChange,
 }: ServiceMapEmbeddableProps) {
   const license = useLicenseContext();
   const { config } = useApmPluginContext();
@@ -322,7 +328,9 @@ export function ServiceMapEmbeddable({
           mapOrientation={mapOrientation}
           onMapOrientationChange={onMapOrientationChange}
           viewFilters={viewFilters}
+          onViewFiltersChange={onViewFiltersChange}
           searchQuery={searchQuery}
+          onSearchQueryChange={onSearchQueryChange}
         />
       </div>
       {sloOverviewFlyout && (

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
@@ -13,6 +13,7 @@ import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import { useKibanaQuerySettings } from '@kbn/observability-shared-plugin/public';
 import type { ServiceMapOrientation } from '../../components/app/service_map/service_map_options_panel';
+import type { ServiceMapViewFilters } from '../../components/app/service_map/apply_service_map_visibility';
 import { useAdHocApmDataView } from '../../hooks/use_adhoc_apm_data_view';
 import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
 import { getDateRange } from '../../context/url_params_context/helpers';
@@ -71,6 +72,8 @@ export interface ServiceMapEmbeddableProps {
   parentFilters?: Filter[];
   /** Parent dashboard query when the panel opts in to sync. */
   parentQuery?: Query | AggregateQuery;
+  /** Persisted view filters (alerts / SLOs / connection / anomaly severity) captured at "Copy to dashboard" time. */
+  viewFilters?: ServiceMapViewFilters;
 }
 
 function LoadingSpinner() {
@@ -104,6 +107,7 @@ export function ServiceMapEmbeddable({
   onMapOrientationChange,
   parentFilters,
   parentQuery,
+  viewFilters,
 }: ServiceMapEmbeddableProps) {
   const license = useLicenseContext();
   const { config } = useApmPluginContext();
@@ -314,6 +318,7 @@ export function ServiceMapEmbeddable({
           clearKueryOnPopoverNavigation={clearKueryOnPopoverNavigation}
           mapOrientation={mapOrientation}
           onMapOrientationChange={onMapOrientationChange}
+          viewFilters={viewFilters}
         />
       </div>
       {sloOverviewFlyout && (

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
@@ -210,6 +210,23 @@ export function ServiceMapEmbeddable({
     nodesStatus: status,
   });
 
+  // The alert / SLO / anomaly-severity filters depend on badge data. Until badges arrive,
+  // node fields like `alertsCount` / `sloStatus` are undefined and the visibility helper
+  // would hide every service — producing a flash of empty map on dashboard load whenever
+  // a persisted filter is set. Strip those filters until badges resolve; the connection
+  // filter stays since it only needs topology. On a badges failure we deliberately stay
+  // stripped (fail open: show all services rather than nothing).
+  const viewFiltersForGraph = useMemo<ServiceMapViewFilters | undefined>(() => {
+    if (!viewFilters) return viewFilters;
+    if (badgesStatus === FETCH_STATUS.SUCCESS) return viewFilters;
+    return {
+      ...viewFilters,
+      alertStatusFilter: [],
+      sloStatusFilter: [],
+      anomalySeverityFilter: [],
+    };
+  }, [viewFilters, badgesStatus]);
+
   if (!license || !isActivePlatinumLicense(license) || !config.serviceMapEnabled) {
     return (
       <div
@@ -327,7 +344,7 @@ export function ServiceMapEmbeddable({
           clearKueryOnPopoverNavigation={clearKueryOnPopoverNavigation}
           mapOrientation={mapOrientation}
           onMapOrientationChange={onMapOrientationChange}
-          viewFilters={viewFilters}
+          viewFilters={viewFiltersForGraph}
           onViewFiltersChange={onViewFiltersChange}
           searchQuery={searchQuery}
           onSearchQueryChange={onSearchQueryChange}

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
@@ -74,6 +74,8 @@ export interface ServiceMapEmbeddableProps {
   parentQuery?: Query | AggregateQuery;
   /** Persisted view filters (alerts / SLOs / connection / anomaly severity) captured at "Copy to dashboard" time. */
   viewFilters?: ServiceMapViewFilters;
+  /** Persisted find-in-page query captured at "Copy to dashboard" time. */
+  searchQuery?: string;
 }
 
 function LoadingSpinner() {
@@ -108,6 +110,7 @@ export function ServiceMapEmbeddable({
   parentFilters,
   parentQuery,
   viewFilters,
+  searchQuery,
 }: ServiceMapEmbeddableProps) {
   const license = useLicenseContext();
   const { config } = useApmPluginContext();
@@ -319,6 +322,7 @@ export function ServiceMapEmbeddable({
           mapOrientation={mapOrientation}
           onMapOrientationChange={onMapOrientationChange}
           viewFilters={viewFilters}
+          searchQuery={searchQuery}
         />
       </div>
       {sloOverviewFlyout && (

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable.tsx
@@ -9,6 +9,11 @@ import { EuiCallOut, EuiLoadingSpinner, EuiPanel } from '@elastic/eui';
 import React, { useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { CoreStart } from '@kbn/core/public';
+import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
+import { buildEsQuery } from '@kbn/es-query';
+import { useKibanaQuerySettings } from '@kbn/observability-shared-plugin/public';
+import type { ServiceMapOrientation } from '../../components/app/service_map/service_map_options_panel';
+import { useAdHocApmDataView } from '../../hooks/use_adhoc_apm_data_view';
 import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
 import { getDateRange } from '../../context/url_params_context/helpers';
 import { isActivePlatinumLicense } from '../../../common/license_check';
@@ -58,6 +63,14 @@ export interface ServiceMapEmbeddableProps {
   onEmptyStateChange?: (isEmpty: boolean) => void;
   /** Field-value pairs to pass as filter bar pills in the "View full map" link instead of kuery. */
   filterPills?: Array<{ field: string; value: string }>;
+  /** Initial layout orientation; if `onMapOrientationChange` is also provided, becomes controlled. */
+  mapOrientation?: ServiceMapOrientation;
+  /** Called when the user (or the host) changes orientation. */
+  onMapOrientationChange?: (next: ServiceMapOrientation) => void;
+  /** Parent dashboard filters when the panel opts in to sync. Excludes `service.environment` (handled server-side). */
+  parentFilters?: Filter[];
+  /** Parent dashboard query when the panel opts in to sync. */
+  parentQuery?: Query | AggregateQuery;
 }
 
 function LoadingSpinner() {
@@ -87,6 +100,10 @@ export function ServiceMapEmbeddable({
   strictEnvironmentScope,
   onEmptyStateChange,
   filterPills,
+  mapOrientation,
+  onMapOrientationChange,
+  parentFilters,
+  parentQuery,
 }: ServiceMapEmbeddableProps) {
   const license = useLicenseContext();
   const { config } = useApmPluginContext();
@@ -129,6 +146,30 @@ export function ServiceMapEmbeddable({
   const { sloOverviewFlyout, openSloOverviewFlyout, closeSloOverviewFlyout } =
     useSloOverviewFlyout();
 
+  // Build an ES query from dashboard-level filters/query when the panel opts in to
+  // sync_with_dashboard_filters. Environment is excluded — it's still passed via the
+  // dedicated server param, mirroring service_map_search_bar.tsx.
+  const { dataView } = useAdHocApmDataView();
+  const kibanaQuerySettings = useKibanaQuerySettings();
+  const esQuery = useMemo(() => {
+    const hasParentSearchState =
+      (parentFilters && parentFilters.length > 0) ||
+      (parentQuery && 'query' in parentQuery && typeof parentQuery.query === 'string'
+        ? parentQuery.query.trim().length > 0
+        : Boolean(parentQuery));
+    if (!dataView || !hasParentSearchState) {
+      return undefined;
+    }
+    const filtersWithoutEnv = (parentFilters ?? []).filter(
+      (f) => f.meta?.key !== 'service.environment'
+    );
+    const queries: Query[] =
+      parentQuery && 'query' in parentQuery
+        ? [{ query: String(parentQuery.query ?? ''), language: parentQuery.language ?? 'kuery' }]
+        : [{ query: '', language: 'kuery' }];
+    return buildEsQuery(dataView, queries, filtersWithoutEnv, kibanaQuerySettings);
+  }, [dataView, parentFilters, parentQuery, kibanaQuerySettings]);
+
   const { data, status, error } = useServiceMap({
     environment,
     kuery,
@@ -137,6 +178,7 @@ export function ServiceMapEmbeddable({
     serviceGroupId,
     serviceName,
     strictEnvironmentScope,
+    esQuery,
   });
 
   // Only fire on SUCCESS — loading/error states carry no emptiness signal.
@@ -270,6 +312,8 @@ export function ServiceMapEmbeddable({
           showFocusMap={showFocusMapInPopover}
           alwaysNavigateOnPopoverFocus={alwaysNavigateOnPopoverFocus}
           clearKueryOnPopoverNavigation={clearKueryOnPopoverNavigation}
+          mapOrientation={mapOrientation}
+          onMapOrientationChange={onMapOrientationChange}
         />
       </div>
       {sloOverviewFlyout && (

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
@@ -51,6 +51,8 @@ const defaultCustomState: WithAllKeys<ServiceMapCustomState> = {
   kuery: undefined,
   service_name: undefined,
   service_group_id: undefined,
+  map_orientation: 'horizontal',
+  sync_with_dashboard_filters: false,
 };
 
 const customStateComparators: StateComparators<ServiceMapCustomState> = {
@@ -58,6 +60,8 @@ const customStateComparators: StateComparators<ServiceMapCustomState> = {
   kuery: 'referenceEquality',
   service_name: 'referenceEquality',
   service_group_id: 'referenceEquality',
+  map_orientation: 'referenceEquality',
+  sync_with_dashboard_filters: 'referenceEquality',
 };
 
 export type ServiceMapEmbeddableApi = DefaultEmbeddableApi<ServiceMapEmbeddableState> &
@@ -124,6 +128,8 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
           kuery: state.kuery,
           service_name: state.service_name,
           service_group_id: state.service_group_id,
+          map_orientation: state.map_orientation,
+          sync_with_dashboard_filters: state.sync_with_dashboard_filters,
         },
         defaultCustomState
       );
@@ -204,6 +210,10 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
                       }
                       customStateManager.api.setKuery(newState.kuery);
                       customStateManager.api.setServiceName(newState.service_name);
+                      customStateManager.api.setMapOrientation(newState.map_orientation);
+                      customStateManager.api.setSyncWithDashboardFilters(
+                        newState.sync_with_dashboard_filters
+                      );
                       closeFlyout();
                     }}
                   />
@@ -233,15 +243,30 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
             };
           }, []);
 
-          const [environment, kuery, serviceName, serviceGroupId] = useBatchedPublishingSubjects(
+          const [
+            environment,
+            kuery,
+            serviceName,
+            serviceGroupId,
+            mapOrientation,
+            syncWithDashboardFilters,
+          ] = useBatchedPublishingSubjects(
             customStateManager.api.environment$,
             customStateManager.api.kuery$,
             customStateManager.api.serviceName$,
-            customStateManager.api.serviceGroupId$
+            customStateManager.api.serviceGroupId$,
+            customStateManager.api.mapOrientation$,
+            customStateManager.api.syncWithDashboardFilters$
           );
 
-          const { timeRange } = useFetchContext(api);
-          const effectiveTimeRange = timeRange ?? DEFAULT_TIME_RANGE;
+          const fetchContext = useFetchContext(api);
+          const effectiveTimeRange = fetchContext.timeRange ?? DEFAULT_TIME_RANGE;
+
+          // Parent dashboard filters/query are merged into fetchContext by `useFetchContext`.
+          // Only forward them when the panel opts in via `sync_with_dashboard_filters`; otherwise
+          // the panel stays isolated (preserves back-compat for panels added from the dashboard menu).
+          const parentFilters = syncWithDashboardFilters ? fetchContext.filters : undefined;
+          const parentQuery = syncWithDashboardFilters ? fetchContext.query : undefined;
 
           return (
             <div style={{ width: '100%', height: '100%', position: 'relative' }}>
@@ -260,6 +285,10 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
                   serviceGroupId={serviceGroupId ?? undefined}
                   core={deps.coreStart}
                   onBlockingError={(error) => blockingError$.next(error)}
+                  mapOrientation={mapOrientation ?? 'horizontal'}
+                  onMapOrientationChange={customStateManager.api.setMapOrientation}
+                  parentFilters={parentFilters}
+                  parentQuery={parentQuery}
                 />
               </ApmEmbeddableContext>
             </div>

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import type { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
 import type { EmbeddablePublicDefinition } from '@kbn/embeddable-plugin/public';
 import type {
@@ -40,6 +40,7 @@ import type {
 
 import type { EmbeddableDeps } from '../types';
 import { ApmEmbeddableContext } from '../embeddable_context';
+import type { ServiceMapViewFilters } from '../../components/app/service_map/apply_service_map_visibility';
 import { ServiceMapEmbeddable } from './service_map_embeddable';
 import { ServiceMapEditorFlyout } from './service_map_editor_flyout';
 import { APM_SERVICE_MAP_EMBEDDABLE } from './constants';
@@ -53,6 +54,10 @@ const defaultCustomState: WithAllKeys<ServiceMapCustomState> = {
   service_group_id: undefined,
   map_orientation: 'horizontal',
   sync_with_dashboard_filters: false,
+  alert_status_filter: undefined,
+  slo_status_filter: undefined,
+  connection_filter: undefined,
+  anomaly_severity_filter: undefined,
 };
 
 const customStateComparators: StateComparators<ServiceMapCustomState> = {
@@ -62,6 +67,10 @@ const customStateComparators: StateComparators<ServiceMapCustomState> = {
   service_group_id: 'referenceEquality',
   map_orientation: 'referenceEquality',
   sync_with_dashboard_filters: 'referenceEquality',
+  alert_status_filter: 'referenceEquality',
+  slo_status_filter: 'referenceEquality',
+  connection_filter: 'referenceEquality',
+  anomaly_severity_filter: 'referenceEquality',
 };
 
 export type ServiceMapEmbeddableApi = DefaultEmbeddableApi<ServiceMapEmbeddableState> &
@@ -130,6 +139,10 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
           service_group_id: state.service_group_id,
           map_orientation: state.map_orientation,
           sync_with_dashboard_filters: state.sync_with_dashboard_filters,
+          alert_status_filter: state.alert_status_filter,
+          slo_status_filter: state.slo_status_filter,
+          connection_filter: state.connection_filter,
+          anomaly_severity_filter: state.anomaly_severity_filter,
         },
         defaultCustomState
       );
@@ -250,13 +263,34 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
             serviceGroupId,
             mapOrientation,
             syncWithDashboardFilters,
+            alertStatusFilter,
+            sloStatusFilter,
+            connectionFilter,
+            anomalySeverityFilter,
           ] = useBatchedPublishingSubjects(
             customStateManager.api.environment$,
             customStateManager.api.kuery$,
             customStateManager.api.serviceName$,
             customStateManager.api.serviceGroupId$,
             customStateManager.api.mapOrientation$,
-            customStateManager.api.syncWithDashboardFilters$
+            customStateManager.api.syncWithDashboardFilters$,
+            customStateManager.api.alertStatusFilter$,
+            customStateManager.api.sloStatusFilter$,
+            customStateManager.api.connectionFilter$,
+            customStateManager.api.anomalySeverityFilter$
+          );
+
+          // Schema literals (`'critical' | 'major' | ...`) and the runtime enums consumed by
+          // ServiceMapViewFilters share string values, so a single cast preserves the shape.
+          const viewFilters = useMemo(
+            () =>
+              ({
+                alertStatusFilter: alertStatusFilter ?? [],
+                sloStatusFilter: sloStatusFilter ?? [],
+                connectionFilter: connectionFilter ?? [],
+                anomalySeverityFilter: anomalySeverityFilter ?? [],
+              } as ServiceMapViewFilters),
+            [alertStatusFilter, sloStatusFilter, connectionFilter, anomalySeverityFilter]
           );
 
           const fetchContext = useFetchContext(api);
@@ -289,6 +323,7 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
                   onMapOrientationChange={customStateManager.api.setMapOrientation}
                   parentFilters={parentFilters}
                   parentQuery={parentQuery}
+                  viewFilters={viewFilters}
                 />
               </ApmEmbeddableContext>
             </div>

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import type { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
 import type { EmbeddablePublicDefinition } from '@kbn/embeddable-plugin/public';
 import type {
@@ -299,6 +299,28 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
             [alertStatusFilter, sloStatusFilter, connectionFilter, anomalySeverityFilter]
           );
 
+          // Push in-panel edits back to the state manager so the controlled `viewFilters` /
+          // `searchQuery` reflect changes; without these the chips/search would feel locked.
+          // Empty arrays / empty strings are normalized to `undefined` so saved state stays tidy.
+          const onViewFiltersChange = useCallback((next: ServiceMapViewFilters) => {
+            customStateManager.api.setAlertStatusFilter(
+              next.alertStatusFilter.length ? next.alertStatusFilter : undefined
+            );
+            customStateManager.api.setSloStatusFilter(
+              next.sloStatusFilter.length ? next.sloStatusFilter : undefined
+            );
+            customStateManager.api.setConnectionFilter(
+              next.connectionFilter.length ? next.connectionFilter : undefined
+            );
+            customStateManager.api.setAnomalySeverityFilter(
+              next.anomalySeverityFilter.length ? next.anomalySeverityFilter : undefined
+            );
+          }, []);
+
+          const onSearchQueryChange = useCallback((next: string) => {
+            customStateManager.api.setFindQuery(next.trim() ? next : undefined);
+          }, []);
+
           const fetchContext = useFetchContext(api);
           const effectiveTimeRange = fetchContext.timeRange ?? DEFAULT_TIME_RANGE;
 
@@ -330,7 +352,9 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
                   parentFilters={parentFilters}
                   parentQuery={parentQuery}
                   viewFilters={viewFilters}
+                  onViewFiltersChange={onViewFiltersChange}
                   searchQuery={findQuery ?? undefined}
+                  onSearchQueryChange={onSearchQueryChange}
                 />
               </ApmEmbeddableContext>
             </div>

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
@@ -58,6 +58,7 @@ const defaultCustomState: WithAllKeys<ServiceMapCustomState> = {
   slo_status_filter: undefined,
   connection_filter: undefined,
   anomaly_severity_filter: undefined,
+  find_query: undefined,
 };
 
 const customStateComparators: StateComparators<ServiceMapCustomState> = {
@@ -71,6 +72,7 @@ const customStateComparators: StateComparators<ServiceMapCustomState> = {
   slo_status_filter: 'referenceEquality',
   connection_filter: 'referenceEquality',
   anomaly_severity_filter: 'referenceEquality',
+  find_query: 'referenceEquality',
 };
 
 export type ServiceMapEmbeddableApi = DefaultEmbeddableApi<ServiceMapEmbeddableState> &
@@ -143,6 +145,7 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
           slo_status_filter: state.slo_status_filter,
           connection_filter: state.connection_filter,
           anomaly_severity_filter: state.anomaly_severity_filter,
+          find_query: state.find_query,
         },
         defaultCustomState
       );
@@ -268,6 +271,7 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
             sloStatusFilter,
             connectionFilter,
             anomalySeverityFilter,
+            findQuery,
           ] = useBatchedPublishingSubjects(
             customStateManager.api.environment$,
             customStateManager.api.kuery$,
@@ -278,7 +282,8 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
             customStateManager.api.alertStatusFilter$,
             customStateManager.api.sloStatusFilter$,
             customStateManager.api.connectionFilter$,
-            customStateManager.api.anomalySeverityFilter$
+            customStateManager.api.anomalySeverityFilter$,
+            customStateManager.api.findQuery$
           );
 
           // Schema literals (`'critical' | 'major' | ...`) and the runtime enums consumed by
@@ -325,6 +330,7 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
                   parentFilters={parentFilters}
                   parentQuery={parentQuery}
                   viewFilters={viewFilters}
+                  searchQuery={findQuery ?? undefined}
                 />
               </ApmEmbeddableContext>
             </div>

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
@@ -223,7 +223,8 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
                       }
                       customStateManager.api.setKuery(newState.kuery);
                       customStateManager.api.setServiceName(newState.service_name);
-                      customStateManager.api.setMapOrientation(newState.map_orientation);
+                      // map_orientation is managed via the in-panel options toggle, not the
+                      // editor flyout; leave the persisted value untouched.
                       customStateManager.api.setSyncWithDashboardFilters(
                         newState.sync_with_dashboard_filters
                       );

--- a/x-pack/solutions/observability/plugins/apm/server/lib/embeddables/service_map_embeddable_schema.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/embeddables/service_map_embeddable_schema.ts
@@ -58,6 +58,7 @@ export const serviceMapCustomStateSchema = schema.object({
       ])
     )
   ),
+  find_query: schema.maybe(schema.string()),
 });
 
 export type ServiceMapCustomState = TypeOf<typeof serviceMapCustomStateSchema>;

--- a/x-pack/solutions/observability/plugins/apm/server/lib/embeddables/service_map_embeddable_schema.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/embeddables/service_map_embeddable_schema.ts
@@ -23,6 +23,41 @@ export const serviceMapCustomStateSchema = schema.object({
     schema.oneOf([schema.literal('horizontal'), schema.literal('vertical')])
   ),
   sync_with_dashboard_filters: schema.maybe(schema.boolean()),
+  alert_status_filter: schema.maybe(
+    schema.arrayOf(
+      schema.oneOf([
+        schema.literal('active'),
+        schema.literal('recovered'),
+        schema.literal('untracked'),
+        schema.literal('delayed'),
+      ])
+    )
+  ),
+  slo_status_filter: schema.maybe(
+    schema.arrayOf(
+      schema.oneOf([
+        schema.literal('healthy'),
+        schema.literal('degrading'),
+        schema.literal('violated'),
+        schema.literal('noData'),
+      ])
+    )
+  ),
+  connection_filter: schema.maybe(
+    schema.arrayOf(schema.oneOf([schema.literal('orphaned'), schema.literal('connected')]))
+  ),
+  anomaly_severity_filter: schema.maybe(
+    schema.arrayOf(
+      schema.oneOf([
+        schema.literal('critical'),
+        schema.literal('major'),
+        schema.literal('minor'),
+        schema.literal('warning'),
+        schema.literal('low'),
+        schema.literal('unknown'),
+      ])
+    )
+  ),
 });
 
 export type ServiceMapCustomState = TypeOf<typeof serviceMapCustomStateSchema>;

--- a/x-pack/solutions/observability/plugins/apm/server/lib/embeddables/service_map_embeddable_schema.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/embeddables/service_map_embeddable_schema.ts
@@ -19,6 +19,10 @@ export const serviceMapCustomStateSchema = schema.object({
   kuery: schema.maybe(schema.string()),
   service_name: schema.maybe(schema.string()),
   service_group_id: schema.maybe(schema.string()),
+  map_orientation: schema.maybe(
+    schema.oneOf([schema.literal('horizontal'), schema.literal('vertical')])
+  ),
+  sync_with_dashboard_filters: schema.maybe(schema.boolean()),
 });
 
 export type ServiceMapCustomState = TypeOf<typeof serviceMapCustomStateSchema>;

--- a/x-pack/solutions/observability/plugins/apm/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/apm/tsconfig.json
@@ -162,6 +162,7 @@
     "@kbn/agent-builder-common",
     "@kbn/agent-builder-server",
     "@kbn/presentation-util",
+    "@kbn/presentation-util-plugin",
     "@kbn/unified-doc-viewer-plugin",
     "@kbn/ebt-click",
     "@kbn/apm-types-shared",


### PR DESCRIPTION
## Summary

PoC for the APM → dashboard service map workflow. Adds a new entry point on the APM service map page that lets users persist their current view as a dashboard panel, while extending the existing embeddable to honor layout orientation and (opt-in) sync with the dashboard's global filters.

- **New "Add to dashboard" button** in the service map top-right toolbar (hidden when `isEmbedded`). Mirrors SLO's pattern — `SavedObjectSaveModalDashboard` + `stateTransfer.navigateToWithEmbeddablePackages('dashboards', …)`. Captures the user's current filters from URL kuery, Controls API selections (`_a.controlSelections`), and filter-bar pills, projecting them onto the embeddable schema as `service_name` + `kuery`.
- **Embeddable schema** gains optional `map_orientation` and `sync_with_dashboard_filters` (both `schema.maybe(...)` — existing saved panels deserialize unchanged).
- **Editor flyout** exposes an orientation `EuiButtonGroup` and a "Sync with dashboard filters" `EuiSwitch` — closes the round-trip from the dashboard back to APM.
- **Dashboard filter sync** (opt-in): when `sync_with_dashboard_filters` is true, the embeddable consumes parent `filters$`/`query$` via the existing `useFetchContext(api)` (no manual subscriptions) and merges them via `buildEsQuery` (excluding `service.environment`, mirroring `service_map_search_bar.tsx`). **Time range stays panel-owned** to avoid expensive re-queries on dashboard time changes — explicit per the issue's performance note.
- **Defaults**: panels created via the new APM-UI flow default `sync_with_dashboard_filters: true`; panels added via the existing dashboard "Add panel" flyout default to `false` (preserves back-compat).

## Test plan

- [ ] APM → Service map: apply env/KQL/Controls selections, change orientation, click "Add to dashboard"; New dashboard opens with the panel reflecting all the same filters and orientation.
- [ ] Repeat with "Existing dashboard" → panel appears on the chosen dashboard.
- [ ] On the dashboard, edit the panel via the gear icon: orientation toggle + sync switch both round-trip through save.
- [ ] Toggle "Sync with dashboard filters" ON → dashboard filter bar / Controls affect the map; OFF → map is isolated.
- [ ] Changing the dashboard's global time range does NOT trigger a service map re-query (panel-owned time range).
- [ ] Existing dashboard "Add panel → Service map preview" flow still works; new panels default to sync OFF (back-compat).
- [ ] Already-saved dashboards with service map panels load without error (no new required fields).

## References

Closes elastic/kibana#271275
Parent: elastic/observability-dev#5458