### PR TITLE
[One Workflow] Fix FAILED-status writes on legacy `error: text` indices

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts
@@ -12,8 +12,16 @@ import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
 import { ExecutionStatus } from '@kbn/workflows';
 import { getInputsFromDefinition } from '@kbn/workflows/spec/lib/field_conversion';
 import type { JsonModelSchemaType } from '@kbn/workflows/spec/schema/common/json_model_schema';
-import { validateWorkflowInputs } from './validate_workflow_inputs';
+import { featureFlags, validateWorkflowInputs } from './validate_workflow_inputs';
 import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+
+const makeDocumentParsingException = () => {
+  const err = new Error('document_parsing_exception');
+  (err as { meta?: unknown }).meta = {
+    body: { error: { type: 'document_parsing_exception' } },
+  };
+  return err;
+};
 
 jest.mock('@kbn/workflows/spec/lib/field_conversion', () => ({
   ...jest.requireActual('@kbn/workflows/spec/lib/field_conversion'),
@@ -243,5 +251,70 @@ describe('validateWorkflowInputs', () => {
     const result = await callValidate(stubWorkflow, {});
 
     expect(result).toBe(true);
+  });
+
+  describe('with legacy `error: text` index mapping (document_parsing_exception)', () => {
+    afterEach(() => {
+      featureFlags.legacyErrorMappingFallback = false;
+    });
+
+    const missingRequiredSchema = (): JsonModelSchemaType => ({
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    });
+
+    it('does not retry and logs the failure when the flag is off', async () => {
+      featureFlags.legacyErrorMappingFallback = false;
+      mockRepository.updateWorkflowExecution.mockRejectedValueOnce(makeDocumentParsingException());
+      setInputsSchema(missingRequiredSchema());
+
+      const result = await callValidate(stubWorkflow, { inputs: {} });
+
+      expect(result).toBe(false);
+      expect(mockRepository.updateWorkflowExecution).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to mark execution ${executionId} as FAILED`)
+      );
+    });
+
+    it('retries the update with a stringified error and succeeds when the flag is on', async () => {
+      featureFlags.legacyErrorMappingFallback = true;
+      mockRepository.updateWorkflowExecution
+        .mockRejectedValueOnce(makeDocumentParsingException())
+        .mockResolvedValueOnce(undefined);
+      setInputsSchema(missingRequiredSchema());
+
+      const result = await callValidate(stubWorkflow, { inputs: {} });
+
+      expect(result).toBe(false);
+      expect(mockRepository.updateWorkflowExecution).toHaveBeenCalledTimes(2);
+
+      const firstCall = mockRepository.updateWorkflowExecution.mock.calls[0][0];
+      expect(firstCall.error).toEqual({
+        type: 'InputValidationError',
+        message: expect.stringContaining('Workflow input validation failed'),
+      });
+
+      const retryCall = mockRepository.updateWorkflowExecution.mock.calls[1][0];
+      expect(retryCall.status).toBe(ExecutionStatus.FAILED);
+      expect(typeof retryCall.error).toBe('string');
+      expect(retryCall.error).toEqual(expect.stringContaining('InputValidationError'));
+      expect(retryCall.error).toEqual(expect.stringContaining('Workflow input validation failed'));
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('does not retry on unrelated update errors even when the flag is on', async () => {
+      featureFlags.legacyErrorMappingFallback = true;
+      mockRepository.updateWorkflowExecution.mockRejectedValueOnce(new Error('ES unavailable'));
+      setInputsSchema(missingRequiredSchema());
+
+      const result = await callValidate(stubWorkflow, { inputs: {} });
+
+      expect(result).toBe(false);
+      expect(mockRepository.updateWorkflowExecution).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to mark execution ${executionId} as FAILED`)
+      );
+    });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Logger } from '@kbn/core/server';
-import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
+import type { SerializedError, WorkflowExecutionEngineModel } from '@kbn/workflows';
 import { ExecutionStatus } from '@kbn/workflows';
 import { buildFieldsZodValidator } from '@kbn/workflows/spec/lib/build_fields_zod_validator';
 import {
@@ -16,6 +16,28 @@ import {
   getInputsFromDefinition,
 } from '@kbn/workflows/spec/lib/field_conversion';
 import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+
+/**
+ * Toggleable feature flags for this module. Exposed as a mutable container so
+ * downstream code (and tests) can flip behavior without re-plumbing config.
+ */
+export const featureFlags = {
+  /**
+   * When true, retry the FAILED-status update with a stringified `error` field
+   * if the structured-object update fails with `document_parsing_exception`.
+   *
+   * Targets legacy `.workflows-executions` indices (created before PR #243395,
+   * 2025-12-02) that have `error` mapped as `text`. Without this fallback, the
+   * execution doc is never flipped to FAILED on those projects and the run
+   * appears stuck in its initial status.
+   */
+  legacyErrorMappingFallback: false,
+};
+
+const isDocumentParsingException = (err: unknown): boolean => {
+  const meta = (err as { meta?: { body?: { error?: { type?: string } } } } | undefined)?.meta;
+  return meta?.body?.error?.type === 'document_parsing_exception';
+};
 
 /**
  * Validates workflow inputs against the workflow's input schema.
@@ -49,19 +71,39 @@ export const validateWorkflowInputs = async (
       .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
       .join('; ');
 
+    const errorPayload: SerializedError = {
+      type: 'InputValidationError',
+      message: `Workflow input validation failed: ${issues}`,
+    };
+
     try {
       await workflowExecutionRepository.updateWorkflowExecution({
         id: executionId,
         status: ExecutionStatus.FAILED,
-        error: {
-          type: 'InputValidationError',
-          message: `Workflow input validation failed: ${issues}`,
-        },
+        error: errorPayload,
       });
     } catch (updateError) {
-      logger.error(
-        `Failed to mark execution ${executionId} as FAILED after input validation error: ${updateError}`
-      );
+      if (featureFlags.legacyErrorMappingFallback && isDocumentParsingException(updateError)) {
+        try {
+          // Legacy `.workflows-executions` indices (pre-PR #243395) have
+          // `error` mapped as `text`, so retry with a stringified payload to
+          // coerce into the legacy mapping. Cast is required because
+          // EsWorkflowExecution.error is typed as SerializedError | null.
+          await workflowExecutionRepository.updateWorkflowExecution({
+            id: executionId,
+            status: ExecutionStatus.FAILED,
+            error: JSON.stringify(errorPayload) as unknown as SerializedError,
+          });
+        } catch (retryError) {
+          logger.error(
+            `Failed to mark execution ${executionId} as FAILED after input validation error (legacy fallback retry also failed): ${retryError}`
+          );
+        }
+      } else {
+        logger.error(
+          `Failed to mark execution ${executionId} as FAILED after input validation error: ${updateError}`
+        );
+      }
     }
 
     return false;


### PR DESCRIPTION
Refs https://github.com/elastic/security-team/issues/17574

## Summary
Legacy `.workflows-executions` indices — created before #243395, when `EsWorkflowExecution.error` was a string — have `error` dynamically mapped as `text`. The current explicit mapping in `workflows_execution_engine/common/mappings.ts` is `dynamic: false` and omits `error`, so the on-startup `putMapping` never overwrites the legacy mapping. Every write of the new `{type, message}` structured payload fails with `document_parsing_exception`, the catch in `validate_workflow_inputs.ts` swallows it, and the execution is never flipped to `FAILED`. The run appears stuck in its previous status.

Surfaced by [this prod alert](https://elastic.slack.com/archives/C091N2K1ML4/p1779785272095729) (2026-05-26, serverless observability project `cd05dfe9306d4a9b8044e6e362201b79`). Blast radius is small — 1 project, 2 events in May.

## What changes
- New off-by-default flag `featureFlags.legacyErrorMappingFallback` in `validate_workflow_inputs.ts`.
- On `document_parsing_exception` from `updateWorkflowExecution` (and only that error type), retry once with a `JSON.stringify`d error payload to coerce into the legacy `text` mapping. Unrelated errors keep falling through to the existing log line — no swallowing.
- Unit-test coverage for both flag states plus the no-retry branch on unrelated errors.

This PR only patches the input-validation call site. The same fallback should be applied to the other terminal `error:`-writing paths (`runWorkflow`, `cancelWorkflow`, engine `markAsFailed`) before flipping the default to `true`. Long-term mapping fix (rename / reindex / dual-write) is tracked in the issue.

## Test plan
- [x] `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/lib/validate_workflow_inputs.test.ts` — 15/15 pass
- [x] `node scripts/type_check --project src/platform/plugins/shared/workflows_execution_engine/tsconfig.json`
- [x] Verified the new "flag on → retry" test fails if the fix code is neutralized (proves gating).