### PR TITLE
Update z-index and height properties in useMenuHeaderStyle hook

### DIFF
--- a/src/platform/kbn-ui/side-navigation/src/hooks/use_menu_header_style.test.ts
+++ b/src/platform/kbn-ui/side-navigation/src/hooks/use_menu_header_style.test.ts
@@ -22,6 +22,7 @@ const baseTheme = {
     width: { thin: '1px' },
   },
   size: { base: '16px', xs: '8px' },
+  levels: { content: 0 },
   colors: {},
 };
 

--- a/src/platform/kbn-ui/side-navigation/src/hooks/use_menu_header_style.ts
+++ b/src/platform/kbn-ui/side-navigation/src/hooks/use_menu_header_style.ts
@@ -24,10 +24,10 @@ export function useMenuHeaderStyle() {
 
     position: sticky;
     top: 0;
-    z-index: 1;
+    z-index: calc(${euiTheme.levels.content} + 1);
     padding: ${euiTheme.size.base} var(--horizontal-padding) ${euiTheme.size.xs}
       var(--horizontal-padding);
     margin: 0 1px;
-    height: var(--secondary-menu-header-height);
+    min-height: var(--secondary-menu-header-height);
   `;
 }


### PR DESCRIPTION
## Summary

This PR is a part of [Sidenav localization UI issues ](https://github.com/elastic/kibana/issues/269763).

Check in QA [this page](https://issue-serverless-gvchr-pr271325-ab89c4.kb.eu-west-1.aws.qa.elastic.cloud/app/management/security/api_keys) in French.
Before
<img width="573" height="463" alt="Screenshot 2026-05-26 at 19 27 35" src="https://github.com/user-attachments/assets/2ef6aa9e-d015-4696-9cdf-d59e13da6e52" />

After

<img width="351" height="419" alt="Screenshot 2026-05-26 at 19 28 05" src="https://github.com/user-attachments/assets/8354a197-060d-4278-abf1-795f0c3f26c7" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->