### PR TITLE
[Dashboards as Code] Change max sizes for arrays in internal read requests

### DIFF
--- a/src/platform/packages/shared/controls/controls-schemas/src/controls_group_schema.ts
+++ b/src/platform/packages/shared/controls/controls-schemas/src/controls_group_schema.ts
@@ -48,7 +48,7 @@ export const pinnedControlSchema = schema.object({
   }),
 });
 
-export const getControlsGroupSchema = () => {
+export const getControlsGroupSchema = (isInternalReadRequest: boolean = false) => {
   const pinnedControl = pinnedControlSchema.getPropSchemas();
   return schema.arrayOf(
     /**
@@ -119,7 +119,7 @@ export const getControlsGroupSchema = () => {
     ]),
     {
       defaultValue: [],
-      maxSize: 100,
+      maxSize: isInternalReadRequest ? Number.MAX_SAFE_INTEGER : 100,
       meta: { description: 'An array of control panels and their state in the control group.' },
     }
   );

--- a/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
@@ -230,16 +230,19 @@ export const accessControlSchema = schema.maybe(
   )
 );
 
-export function getDashboardStateSchema(isDashboardAppRequest: boolean) {
+export function getDashboardStateSchema(
+  isDashboardAppRequest: boolean,
+  isReadRequest: boolean = false
+) {
   return schema.object(
     {
-      pinned_panels: getPinnedPanelsSchema(),
+      pinned_panels: getPinnedPanelsSchema(isDashboardAppRequest && isReadRequest),
       description: schema.maybe(
         schema.string({ meta: { description: 'A short description of the dashboard.' } })
       ),
       filters: schema.maybe(
         schema.arrayOf(asCodeFilterSchema, {
-          maxSize: 500,
+          maxSize: isDashboardAppRequest && isReadRequest ? Number.MAX_SAFE_INTEGER : 500,
           meta: {
             description: 'Filters applied across all panels, including pinned panels.',
           },
@@ -253,7 +256,7 @@ export function getDashboardStateSchema(isDashboardAppRequest: boolean) {
         ]),
         {
           defaultValue: [],
-          maxSize: MAX_PANELS,
+          maxSize: isDashboardAppRequest && isReadRequest ? Number.MAX_SAFE_INTEGER : MAX_PANELS,
           meta: {
             description:
               'Panels and sections in the dashboard. Each entry is either a panel (with a `type` and `config`) or a collapsible section (with a `title`, `collapsed` state, and nested `panels`).',
@@ -272,7 +275,7 @@ export function getDashboardStateSchema(isDashboardAppRequest: boolean) {
       refresh_interval: schema.maybe(refreshIntervalSchema),
       tags: schema.maybe(
         schema.arrayOf(schema.string(), {
-          maxSize: 100,
+          maxSize: isDashboardAppRequest && isReadRequest ? Number.MAX_SAFE_INTEGER : 100,
           meta: { description: 'Tag IDs to associate with this dashboard.' },
         })
       ),

--- a/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
@@ -121,7 +121,7 @@ const sectionGridSchema = schema.object({
   y: schema.number({ meta: { description: 'The y coordinate of the section in grid units.' } }),
 });
 
-export function getSectionSchema(isDashboardAppRequest: boolean) {
+export function getSectionSchema(isDashboardAppRequest: boolean, isReadRequest: boolean = false) {
   return schema.object(
     {
       title: schema.string({
@@ -138,7 +138,7 @@ export function getSectionSchema(isDashboardAppRequest: boolean) {
       panels: schema.arrayOf(getPanelSchema(isDashboardAppRequest), {
         meta: { description: 'The panels that belong to the section.' },
         defaultValue: [],
-        maxSize: MAX_PANELS,
+        maxSize: isDashboardAppRequest && isReadRequest ? Number.MAX_SAFE_INTEGER : MAX_PANELS,
       }),
       id: schema.maybe(
         schema.string({
@@ -252,7 +252,7 @@ export function getDashboardStateSchema(
       panels: schema.arrayOf(
         schema.oneOf([
           getPanelSchema(isDashboardAppRequest),
-          getSectionSchema(isDashboardAppRequest),
+          getSectionSchema(isDashboardAppRequest, isReadRequest),
         ]),
         {
           defaultValue: [],

--- a/src/platform/plugins/shared/dashboard/server/api/read/register_read_route.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/read/register_read_route.ts
@@ -37,7 +37,7 @@ export function registerReadRoute(
   // Route is registered during setup and before all plugins have registered embeddable schemas.
   // Instead, use once to only call getDashboardStateSchema the first time a route handler is executed.
   const getCachedDashboardStateSchema = once(() => {
-    return getDashboardStateSchema(isDashboardAppRequest);
+    return getDashboardStateSchema(isDashboardAppRequest, true);
   });
 
   readRoute.addVersion(

--- a/src/platform/plugins/shared/dashboard/server/api/read/schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/read/schemas.ts
@@ -20,7 +20,7 @@ export function getReadResponseBodySchema(isDashboardAppRequest: boolean) {
           'The unique ID of the dashboard, as returned by the create or search endpoints.',
       },
     }),
-    data: getDashboardStateSchema(isDashboardAppRequest),
+    data: getDashboardStateSchema(isDashboardAppRequest, true),
     meta: asCodeMetaSchema,
     warnings: schema.maybe(warningsSchema),
   });


### PR DESCRIPTION
## Summary


This is **one small subset** of the work being done in https://github.com/elastic/kibana/issues/269095; it includes the most critical piece of work (changing all array sizes to the max safe integer when validating internal read requests) so that **most** invalid dashboards will be viewable again. 

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->