### PR TITLE
[CI] Remove shallow checkout for rspack verify step

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -31,21 +31,6 @@ steps:
       diskSizeGb: 200
     key: verify_rspack_build
     timeout_in_minutes: 60
-    plugins:
-      - custom-checkout#v1.8.0:
-          skip_checkout: true
-          repos:
-            - url: git@github.com:elastic/kibana.git
-              mirror_url: /opt/git-mirrors/git-github-com-elastic-kibana-git
-              ref: "${BUILDKITE_COMMIT}"
-              fetch: true
-              clone_flags:
-                - '--depth=1'
-                - '--no-tags'
-                - '--single-branch'
-              fetch_flags:
-                - '--depth=1'
-                - '--no-tags'
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
This is failing for stacked PR's because the base is another feature branch who's commits would not be included.

Removing this until we pass through the stacked ENV.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->