### PR TITLE
[9.3] [Console] Fix method suggestions on body-like lines (#270635)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
@@ -194,6 +194,93 @@ describe('Editor actions provider', () => {
       ]);
     });
 
+    it('does not suggest methods when the line begins with a quote', async () => {
+      // A blank-ish line containing only a starting double quote is not a
+      // request line; method suggestions should not be offered there. The
+      // parser still emits a partial request (`startOffset` only) when it
+      // fails to match a method, so the autocomplete provider must guard
+      // both branches: with and without a parsed request on the line.
+      mockGetParsedRequests.mockResolvedValue([{ startOffset: 0 }]);
+      const quoteLineModel = {
+        ...mockModel,
+        getLineContent: () => '"',
+        getValueInRange: () => '"',
+      } as unknown as jest.Mocked<monaco.editor.ITextModel>;
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        quoteLineModel,
+        mockPosition,
+        mockContext
+      );
+      expect(completionItems?.suggestions).toEqual([]);
+    });
+
+    it('does not suggest methods when the cursor is before a quote-starting line', async () => {
+      mockGetParsedRequests.mockResolvedValue([{ startOffset: 0 }]);
+      const quoteLineModel = {
+        ...mockModel,
+        getLineContent: () => '"key": "value"',
+        getValueInRange: () => '',
+      } as unknown as jest.Mocked<monaco.editor.ITextModel>;
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        quoteLineModel,
+        mockPosition,
+        mockContext
+      );
+      expect(completionItems?.suggestions).toEqual([]);
+    });
+
+    it('does not suggest methods when there is no parsed request and the line begins with a quote', async () => {
+      // When the parser produces no request at all (e.g. on a totally fresh
+      // line), the no-request branch must also be guarded.
+      mockGetParsedRequests.mockResolvedValue([]);
+      const quoteLineModel = {
+        ...mockModel,
+        getLineContent: () => '"',
+        getValueInRange: () => '"',
+      } as unknown as jest.Mocked<monaco.editor.ITextModel>;
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        quoteLineModel,
+        mockPosition,
+        mockContext
+      );
+      expect(completionItems?.suggestions).toEqual([]);
+    });
+
+    it.each(['}', ']'])(
+      'does not suggest methods when the line contains only %s',
+      async (lineContent) => {
+        mockGetParsedRequests.mockResolvedValue([{ startOffset: 0 }]);
+        const bodyLineModel = {
+          ...mockModel,
+          getLineContent: () => lineContent,
+          getValueInRange: () => lineContent,
+        } as unknown as jest.Mocked<monaco.editor.ITextModel>;
+        const completionItems = await editorActionsProvider.provideCompletionItems(
+          bodyLineModel,
+          mockPosition,
+          mockContext
+        );
+        expect(completionItems?.suggestions).toEqual([]);
+      }
+    );
+
+    it('still suggests methods when the line is empty (preserves empty-line behavior)', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      const emptyLineModel = {
+        ...mockModel,
+        getLineContent: () => '',
+        getValueInRange: () => '',
+      } as unknown as jest.Mocked<monaco.editor.ITextModel>;
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        emptyLineModel,
+        mockPosition,
+        mockContext
+      );
+      expect(completionItems?.suggestions.map((suggestion) => suggestion.label)).toEqual(
+        expect.arrayContaining(['GET', 'POST'])
+      );
+    });
+
     it('returns completion items for url path if method already typed in', async () => {
       // mock a parsed request that only has a method
       mockGetParsedRequests.mockResolvedValue([

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
@@ -35,6 +35,7 @@ import {
   getRequestStartLineNumber,
   getUrlParamsCompletionItems,
   getUrlPathCompletionItems,
+  isRequestLineStart,
   replaceRequestVariables,
   shouldTriggerSuggestions,
   trackSentRequests,
@@ -504,9 +505,16 @@ export class MonacoEditorActionsProvider {
     const currentRequests = await this.getRequestsBetweenLines(model, lineNumber, lineNumber);
     const currentRequest = currentRequests.at(0);
 
-    // if there is no request, suggest method
+    // if there is no request, only suggest method when the line could plausibly
+    // be the start of a new request (empty or starting with letters). A line
+    // that starts with `"`, `{`, `[`, etc. is body-like content and must not
+    // trigger method suggestions.
+    // https://github.com/elastic/kibana/issues/186767
     if (!currentRequest) {
-      return AutocompleteType.METHOD;
+      if (isRequestLineStart(model.getLineContent(lineNumber))) {
+        return AutocompleteType.METHOD;
+      }
+      return null;
     }
 
     // if on the 1st line of the request, suggest method, url or url_params depending on the content
@@ -519,9 +527,17 @@ export class MonacoEditorActionsProvider {
         endLineNumber: lineNumber,
         endColumn: column,
       });
+      const fullLineContent = model.getLineContent(lineNumber);
       const lineTokens = getLineTokens(lineContent);
-      // if there is 1 or fewer tokens, suggest method
+      // if there is 1 or fewer tokens, suggest method — but only when the
+      // full line could plausibly start a request. The parser produces a
+      // partial request (`startOffset` only) on lines that begin with `"`, `{`,
+      // `[`, etc., so this branch is reached even for body-like content.
+      // https://github.com/elastic/kibana/issues/186767
       if (lineTokens.length <= 1) {
+        if (!isRequestLineStart(fullLineContent)) {
+          return null;
+        }
         return AutocompleteType.METHOD;
       }
       // if there are 2 tokens, look at the 2nd one and suggest path or url_params

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/index.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/index.ts
@@ -25,7 +25,7 @@ export {
   getBodyCompletionItems,
   shouldTriggerSuggestions,
 } from './autocomplete_utils';
-export { getLineTokens, containsUrlParams } from './tokens_utils';
+export { getLineTokens, containsUrlParams, isRequestLineStart } from './tokens_utils';
 export { getStatusCodeDecorations } from './status_code_decoration_utils';
 export {
   isMapboxVectorTile,

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.test.ts
@@ -7,7 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { parseBody, removeTrailingWhitespaces, parseUrl, parseLine } from './tokens_utils';
+import {
+  parseBody,
+  removeTrailingWhitespaces,
+  parseUrl,
+  parseLine,
+  isRequestLineStart,
+} from './tokens_utils';
 
 describe('tokens_utils', () => {
   describe('removeTrailingWhitespaces', () => {
@@ -269,6 +275,33 @@ describe('tokens_utils', () => {
       const result = parseUrl(url);
       expect(result.urlPathTokens).toEqual(['myindex', '"?literal"', '_search']);
       expect(result.urlParamsTokens[0]).toEqual(['q', 'type:organisation AND elastic']);
+    });
+  });
+
+  describe('isRequestLineStart', () => {
+    it('returns true for an empty line', () => {
+      expect(isRequestLineStart('')).toBe(true);
+    });
+    it('returns true for whitespace-only content', () => {
+      expect(isRequestLineStart('   ')).toBe(true);
+    });
+    it('returns true for partial method letters', () => {
+      expect(isRequestLineStart('G')).toBe(true);
+      expect(isRequestLineStart('  ge')).toBe(true);
+      expect(isRequestLineStart('POS')).toBe(true);
+    });
+    it('returns false for lines starting with a double quote', () => {
+      expect(isRequestLineStart('"')).toBe(false);
+      expect(isRequestLineStart('  "')).toBe(false);
+      expect(isRequestLineStart('"key"')).toBe(false);
+    });
+    it('returns false for body-like tokens', () => {
+      expect(isRequestLineStart('{')).toBe(false);
+      expect(isRequestLineStart('  [')).toBe(false);
+      expect(isRequestLineStart('}')).toBe(false);
+      expect(isRequestLineStart('  ]')).toBe(false);
+      expect(isRequestLineStart(',')).toBe(false);
+      expect(isRequestLineStart(':')).toBe(false);
     });
   });
 });

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.ts
@@ -12,6 +12,7 @@ import {
   digitRegex,
   equalsSignRegex,
   newLineRegex,
+  lettersRegex,
   numberStartRegex,
   questionMarkRegex,
   slashesRegex,
@@ -459,6 +460,21 @@ export const getLineTokens = (lineContent: string): string[] => {
  */
 export const containsUrlParams = (lineContent: string): boolean => {
   return questionMarkRegex.test(lineContent);
+};
+
+/*
+ * Whether the given line content could plausibly be the start of a request line.
+ * A request line either is empty (so the user can begin typing a method) or
+ * begins with letters (a potentially valid method like `g`, `GE`, `POST`). Lines
+ * that start with non-letter, non-whitespace characters (e.g. `"`, `{`, `[`, `,`)
+ * are body-like content and must not trigger method autocompletion.
+ */
+export const isRequestLineStart = (lineContent: string): boolean => {
+  const trimmed = lineContent.trim();
+  if (trimmed === '') {
+    return true;
+  }
+  return lettersRegex.test(trimmed.charAt(0));
 };
 
 /*


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Console] Fix method suggestions on body-like lines (#270635)](https://github.com/elastic/kibana/pull/270635)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-05-26T16:31:59Z","message":"[Console] Fix method suggestions on body-like lines (#270635)\n\nCloses #186767\n\n## Summary\n\n- Stops Console Monaco from suggesting HTTP methods on body-like lines\nthat start with `\"`, `}`, `]`, or other non-letter tokens.\n- Keeps empty lines eligible for method suggestions and preserves\nURL/path suggestions after valid request methods.\n- Adds provider and token utility regressions for both parsed-request\nand no-request autocomplete paths.\n\n## Before\n<img width=\"766\" height=\"395\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86148ee1-91f3-4011-ad32-22c430d14f7b\"\n/>\n\n## After\n<img width=\"730\" height=\"307\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e05966d-f99d-4a45-ac0c-eb6fe91a78fa\"\n/>\n\n## Test Plan\n\n- [x] `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.test.ts`\n- [x] `node scripts/eslint --fix $(git diff --name-only)`\n- [x] `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json`\n- [x] `node scripts/check_changes.ts` (passed with existing\n`no_direct_monaco_import` warnings)\n\nAssisted with Cursor using GPT-5.5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"49a65957d5915089f2d70bf0395734735b7c7d14","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:all-open","reviewer:claude","v9.5.0","reviewer:codex"],"title":"[Console] Fix method suggestions on body-like lines","number":270635,"url":"https://github.com/elastic/kibana/pull/270635","mergeCommit":{"message":"[Console] Fix method suggestions on body-like lines (#270635)\n\nCloses #186767\n\n## Summary\n\n- Stops Console Monaco from suggesting HTTP methods on body-like lines\nthat start with `\"`, `}`, `]`, or other non-letter tokens.\n- Keeps empty lines eligible for method suggestions and preserves\nURL/path suggestions after valid request methods.\n- Adds provider and token utility regressions for both parsed-request\nand no-request autocomplete paths.\n\n## Before\n<img width=\"766\" height=\"395\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86148ee1-91f3-4011-ad32-22c430d14f7b\"\n/>\n\n## After\n<img width=\"730\" height=\"307\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e05966d-f99d-4a45-ac0c-eb6fe91a78fa\"\n/>\n\n## Test Plan\n\n- [x] `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.test.ts`\n- [x] `node scripts/eslint --fix $(git diff --name-only)`\n- [x] `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json`\n- [x] `node scripts/check_changes.ts` (passed with existing\n`no_direct_monaco_import` warnings)\n\nAssisted with Cursor using GPT-5.5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"49a65957d5915089f2d70bf0395734735b7c7d14"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270635","number":270635,"mergeCommit":{"message":"[Console] Fix method suggestions on body-like lines (#270635)\n\nCloses #186767\n\n## Summary\n\n- Stops Console Monaco from suggesting HTTP methods on body-like lines\nthat start with `\"`, `}`, `]`, or other non-letter tokens.\n- Keeps empty lines eligible for method suggestions and preserves\nURL/path suggestions after valid request methods.\n- Adds provider and token utility regressions for both parsed-request\nand no-request autocomplete paths.\n\n## Before\n<img width=\"766\" height=\"395\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86148ee1-91f3-4011-ad32-22c430d14f7b\"\n/>\n\n## After\n<img width=\"730\" height=\"307\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9e05966d-f99d-4a45-ac0c-eb6fe91a78fa\"\n/>\n\n## Test Plan\n\n- [x] `node scripts/jest\n--config=src/platform/plugins/shared/console/jest.config.js\nsrc/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts\nsrc/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.test.ts`\n- [x] `node scripts/eslint --fix $(git diff --name-only)`\n- [x] `node scripts/type_check --project\nsrc/platform/plugins/shared/console/tsconfig.json`\n- [x] `node scripts/check_changes.ts` (passed with existing\n`no_direct_monaco_import` warnings)\n\nAssisted with Cursor using GPT-5.5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"49a65957d5915089f2d70bf0395734735b7c7d14"}}]}] BACKPORT-->