### PR TITLE
[9.4] [One workflow] Lazy rollover for workflows data streams on mapping version mismatch (#269514)

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/constants.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD = 'managed_index_mappings_version';

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/ensure_data_streams_rolled_over.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/ensure_data_streams_rolled_over.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+jest.mock('./roll_data_stream_if_required', () => ({
+  rollDataStreamIfRequired: jest.fn(),
+}));
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { ensureWorkflowsDataStreamsRolledOver } from './ensure_data_streams_rolled_over';
+import { rollDataStreamIfRequired } from './roll_data_stream_if_required';
+import { WORKFLOWS_EXECUTION_LOGS_DATA_STREAM } from '../../repositories/logs_repository/constants';
+import { WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../repositories/logs_repository/data_stream';
+import { WORKFLOWS_EVENTS_DATA_STREAM } from '../../trigger_events/event_logs/constants';
+import { WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../trigger_events/event_logs/trigger_events_data_stream';
+
+const mockRollDataStreamIfRequired = rollDataStreamIfRequired as jest.MockedFunction<
+  typeof rollDataStreamIfRequired
+>;
+
+describe('ensureWorkflowsDataStreamsRolledOver', () => {
+  const mockLogger = loggingSystemMock.createLogger();
+  let mockEsClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+  });
+
+  it('attempts rollover for both streams when the first stream rollover throws', async () => {
+    const boom = new Error('roll failed');
+    mockRollDataStreamIfRequired.mockImplementation(async ({ dataStreamName }) => {
+      if (dataStreamName === WORKFLOWS_EXECUTION_LOGS_DATA_STREAM) {
+        throw boom;
+      }
+      return true;
+    });
+
+    await ensureWorkflowsDataStreamsRolledOver(mockLogger, mockEsClient);
+
+    expect(mockRollDataStreamIfRequired).toHaveBeenCalledTimes(2);
+    expect(mockRollDataStreamIfRequired.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        logger: mockLogger,
+        esClient: mockEsClient,
+        dataStreamName: WORKFLOWS_EXECUTION_LOGS_DATA_STREAM,
+        targetManagedIndexMappingsVersion: WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION,
+      })
+    );
+    expect(mockRollDataStreamIfRequired.mock.calls[1][0]).toEqual(
+      expect.objectContaining({
+        logger: mockLogger,
+        esClient: mockEsClient,
+        dataStreamName: WORKFLOWS_EVENTS_DATA_STREAM,
+        targetManagedIndexMappingsVersion: WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION,
+      })
+    );
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      `Error rolling over workflows data stream ${WORKFLOWS_EXECUTION_LOGS_DATA_STREAM}: roll failed`,
+      { error: { stack_trace: boom.stack } }
+    );
+  });
+
+  it('runs both stream checks when both succeed', async () => {
+    mockRollDataStreamIfRequired.mockResolvedValue(false);
+
+    await ensureWorkflowsDataStreamsRolledOver(mockLogger, mockEsClient);
+
+    expect(mockRollDataStreamIfRequired).toHaveBeenCalledTimes(2);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/ensure_data_streams_rolled_over.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/ensure_data_streams_rolled_over.test.ts
@@ -14,10 +14,12 @@ jest.mock('./roll_data_stream_if_required', () => ({
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { ensureWorkflowsDataStreamsRolledOver } from './ensure_data_streams_rolled_over';
 import { rollDataStreamIfRequired } from './roll_data_stream_if_required';
+import {
+  WORKFLOWS_EVENTS_DATA_STREAM,
+  WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION,
+} from './workflows_events_constants';
 import { WORKFLOWS_EXECUTION_LOGS_DATA_STREAM } from '../../repositories/logs_repository/constants';
 import { WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../repositories/logs_repository/data_stream';
-import { WORKFLOWS_EVENTS_DATA_STREAM } from '../../trigger_events/event_logs/constants';
-import { WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../trigger_events/event_logs/trigger_events_data_stream';
 
 const mockRollDataStreamIfRequired = rollDataStreamIfRequired as jest.MockedFunction<
   typeof rollDataStreamIfRequired

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/ensure_data_streams_rolled_over.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/ensure_data_streams_rolled_over.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { rollDataStreamIfRequired } from './roll_data_stream_if_required';
+import { WORKFLOWS_EXECUTION_LOGS_DATA_STREAM } from '../../repositories/logs_repository/constants';
+import { WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../repositories/logs_repository/data_stream';
+import { WORKFLOWS_EVENTS_DATA_STREAM } from '../../trigger_events/event_logs/constants';
+import { WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../trigger_events/event_logs/trigger_events_data_stream';
+
+export async function ensureWorkflowsDataStreamsRolledOver(
+  logger: Logger,
+  esClient: ElasticsearchClient
+): Promise<void> {
+  const streams = [
+    {
+      dataStreamName: WORKFLOWS_EXECUTION_LOGS_DATA_STREAM,
+      targetManagedIndexMappingsVersion: WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION,
+    },
+    {
+      dataStreamName: WORKFLOWS_EVENTS_DATA_STREAM,
+      targetManagedIndexMappingsVersion: WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION,
+    },
+  ] as const;
+
+  await Promise.all(
+    streams.map(async ({ dataStreamName, targetManagedIndexMappingsVersion }) => {
+      try {
+        await rollDataStreamIfRequired({
+          logger,
+          esClient,
+          dataStreamName,
+          targetManagedIndexMappingsVersion,
+        });
+      } catch (error) {
+        logger.error(
+          `Error rolling over workflows data stream ${dataStreamName}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          error instanceof Error ? { error: { stack_trace: error.stack } } : undefined
+        );
+      }
+    })
+  );
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/ensure_data_streams_rolled_over.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/ensure_data_streams_rolled_over.ts
@@ -9,10 +9,12 @@
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { rollDataStreamIfRequired } from './roll_data_stream_if_required';
+import {
+  WORKFLOWS_EVENTS_DATA_STREAM,
+  WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION,
+} from './workflows_events_constants';
 import { WORKFLOWS_EXECUTION_LOGS_DATA_STREAM } from '../../repositories/logs_repository/constants';
 import { WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../repositories/logs_repository/data_stream';
-import { WORKFLOWS_EVENTS_DATA_STREAM } from '../../trigger_events/event_logs/constants';
-import { WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../trigger_events/event_logs/trigger_events_data_stream';
 
 export async function ensureWorkflowsDataStreamsRolledOver(
   logger: Logger,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/roll_data_stream_if_required.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/roll_data_stream_if_required.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { IndicesGetMappingResponse } from '@elastic/elasticsearch/lib/api/types';
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD } from './constants';
+import { rollDataStreamIfRequired } from './roll_data_stream_if_required';
+import { WORKFLOWS_EXECUTION_LOGS_DATA_STREAM } from '../../repositories/logs_repository/constants';
+import { WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION } from '../../repositories/logs_repository/data_stream';
+
+const DATA_STREAM_NAME = WORKFLOWS_EXECUTION_LOGS_DATA_STREAM;
+const TARGET_VERSION = WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION;
+
+describe('rollDataStreamIfRequired', () => {
+  const mockLogger = loggingSystemMock.createLogger();
+  let mockEsClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+
+  const msgPrefix = `Data stream ${DATA_STREAM_NAME}`;
+  const skipMessage = 'does not need to be rolled over';
+  const scheduleMessage = 'scheduling lazy rollover';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+  });
+
+  const rollParams = () => ({
+    logger: mockLogger,
+    esClient: mockEsClient,
+    dataStreamName: DATA_STREAM_NAME,
+    targetManagedIndexMappingsVersion: TARGET_VERSION,
+  });
+
+  it('does nothing when getMapping returns no backing indices (missing data stream)', async () => {
+    mockEsClient.indices.getMapping.mockResponse({});
+
+    await rollDataStreamIfRequired(rollParams());
+
+    expect(mockEsClient.indices.getMapping).toHaveBeenCalledWith({
+      index: DATA_STREAM_NAME,
+      allow_no_indices: true,
+    });
+    expect(mockLogger.debug).toHaveBeenCalledWith(`${msgPrefix} does not exist so ${skipMessage}`);
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+
+  it('rolls over if backing indices have no managed_index_mappings_version', async () => {
+    const mappings: IndicesGetMappingResponse = {
+      indexName: {
+        mappings: { _meta: {} },
+      },
+    };
+    mockEsClient.indices.getMapping.mockResponse(mappings);
+
+    await rollDataStreamIfRequired(rollParams());
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      `${msgPrefix} has no ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD} on backing indices; ${scheduleMessage}`
+    );
+    expect(mockEsClient.indices.rollover).toHaveBeenCalledWith({
+      alias: DATA_STREAM_NAME,
+      lazy: true,
+    });
+  });
+
+  it('rolls over if deployed version is older than the Kibana target', async () => {
+    const olderVersion = TARGET_VERSION - 1;
+    const mappings: IndicesGetMappingResponse = {
+      indexName: {
+        mappings: {
+          _meta: { [MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD]: olderVersion },
+        },
+      },
+    };
+    mockEsClient.indices.getMapping.mockResponse(mappings);
+
+    await rollDataStreamIfRequired(rollParams());
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      `${msgPrefix} has ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD} ${olderVersion}, target is ${TARGET_VERSION}; ${scheduleMessage}`
+    );
+    expect(mockEsClient.indices.rollover).toHaveBeenCalled();
+  });
+
+  it('warns and skips rollover if deployed version is newer than the Kibana target', async () => {
+    const newerVersion = TARGET_VERSION + 1;
+    const mappings: IndicesGetMappingResponse = {
+      indexName: {
+        mappings: {
+          _meta: { [MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD]: newerVersion },
+        },
+      },
+    };
+    mockEsClient.indices.getMapping.mockResponse(mappings);
+
+    await rollDataStreamIfRequired(rollParams());
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      `${msgPrefix} has ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD} ${newerVersion} which is newer than this node's Kibana target ${TARGET_VERSION}. Skipping rollover; this can happen during rolling Kibana upgrades when other nodes have already advanced the data stream.`
+    );
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+
+  it('does nothing if deployed version matches the Kibana target', async () => {
+    const mappings: IndicesGetMappingResponse = {
+      indexName: {
+        mappings: {
+          _meta: { [MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD]: TARGET_VERSION },
+        },
+      },
+    };
+    mockEsClient.indices.getMapping.mockResponse(mappings);
+
+    await rollDataStreamIfRequired(rollParams());
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      `${msgPrefix} has latest mappings applied so ${skipMessage}`
+    );
+    expect(mockEsClient.indices.rollover).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/roll_data_stream_if_required.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/roll_data_stream_if_required.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD } from './constants';
+
+export interface RollDataStreamIfRequiredParams {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  dataStreamName: string;
+  targetManagedIndexMappingsVersion: number;
+}
+
+/**
+ * Schedules a lazy rollover when backing indices lack the target
+ * `mappings._meta.managed_index_mappings_version`.
+ *
+ * The `managed_index_mappings_version` value is read from Elasticsearch backing-index
+ * mappings (`_meta`); Kibana does not stamp it here—it compares the deployed value to
+ * a local target constant to decide whether to call rollover.
+ */
+export async function rollDataStreamIfRequired({
+  logger,
+  esClient,
+  dataStreamName,
+  targetManagedIndexMappingsVersion,
+}: RollDataStreamIfRequiredParams): Promise<boolean> {
+  const msgPrefix = `Data stream ${dataStreamName}`;
+  const skipMessage = 'does not need to be rolled over';
+  const scheduleMessage = 'scheduling lazy rollover';
+
+  const indexMappings = await esClient.indices.getMapping({
+    index: dataStreamName,
+    allow_no_indices: true,
+  });
+
+  const mappingsArray = Object.values(indexMappings);
+  if (mappingsArray.length === 0) {
+    logger.debug(`${msgPrefix} does not exist so ${skipMessage}`);
+    return false;
+  }
+
+  logger.debug(
+    `${msgPrefix} target ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD}: ${targetManagedIndexMappingsVersion}`
+  );
+
+  const deployedVersions = mappingsArray
+    .map((m) => m.mappings._meta?.[MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD])
+    .filter((value): value is number => typeof value === 'number');
+
+  const deployedVersion = deployedVersions.length === 0 ? undefined : Math.max(...deployedVersions);
+
+  logger.debug(
+    `${msgPrefix} deployed ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD}: ${
+      deployedVersion ?? '<none>'
+    }`
+  );
+
+  if (deployedVersion === targetManagedIndexMappingsVersion) {
+    logger.debug(`${msgPrefix} has latest mappings applied so ${skipMessage}`);
+    return false;
+  }
+
+  if (deployedVersion !== undefined && deployedVersion > targetManagedIndexMappingsVersion) {
+    logger.warn(
+      `${msgPrefix} has ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD} ${deployedVersion} which is newer than this node's Kibana target ${targetManagedIndexMappingsVersion}. Skipping rollover; this can happen during rolling Kibana upgrades when other nodes have already advanced the data stream.`
+    );
+    return false;
+  }
+
+  if (deployedVersion === undefined) {
+    logger.info(
+      `${msgPrefix} has no ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD} on backing indices; ${scheduleMessage}`
+    );
+  } else {
+    logger.info(
+      `${msgPrefix} has ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD} ${deployedVersion}, target is ${targetManagedIndexMappingsVersion}; ${scheduleMessage}`
+    );
+  }
+
+  await esClient.indices.rollover({
+    alias: dataStreamName,
+    lazy: true,
+  });
+
+  logger.info(
+    `${msgPrefix} scheduled lazy rollover for ${MANAGED_INDEX_MAPPINGS_VERSION_META_FIELD} ${targetManagedIndexMappingsVersion}`
+  );
+  return true;
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/workflows_events_constants.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/data_streams/workflows_events_constants.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Keep in sync with workflows_management/server/trigger_events_log/*.
+ * This local copy avoids a server-side dependency from execution_engine to
+ * workflows_management while still allowing rollover checks during startup.
+ */
+export const WORKFLOWS_EVENTS_DATA_STREAM = '.workflows-events';
+
+export const WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION = 3;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -36,6 +36,7 @@ import {
 } from './execution_functions';
 import { cancelWaitingWorkflow } from './lib/cancel_waiting_workflow';
 import { checkLicense } from './lib/check_license';
+import { ensureWorkflowsDataStreamsRolledOver } from './lib/data_streams/ensure_data_streams_rolled_over';
 import { getAuthenticatedUser } from './lib/get_user';
 import {
   resolveExhaustedWorkflowRunTask,
@@ -594,9 +595,11 @@ export class WorkflowsExecutionEnginePlugin
       throw new Error('Setup not called before start');
     }
 
+    const esClient = coreStart.elasticsearch.client.asInternalUser;
+    void ensureWorkflowsDataStreamsRolledOver(this.logger.get('data-stream-rollover'), esClient);
+
     // Initialize ConcurrencyManager with dependencies
     const workflowTaskManager = new WorkflowTaskManager(plugins.taskManager);
-    const esClient = coreStart.elasticsearch.client.asInternalUser;
     const workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
     const workflowRepository = new WorkflowRepository({ esClient, logger: this.logger });
     this.concurrencyManager = new ConcurrencyManager(

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/data_stream.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/logs_repository/data_stream.ts
@@ -93,6 +93,16 @@ export type LogsRepositoryDataStreamClient = IDataStreamClient<
   WorkflowLogEvent
 >;
 
+/**
+ * Bump when Elasticsearch index mappings for the workflows execution logs data stream change.
+ * Compared on startup against `mappings._meta.managed_index_mappings_version` on backing indices
+ * to decide whether to schedule a lazy rollover.
+ *
+ * This is independent of `registerDataStream({ version })` above (template lifecycle) and from
+ * `WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION` — logs and events streams can bump separately.
+ */
+export const WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION = 2;
+
 export const initializeDataStreamClient = (
   coreDataStreams: DataStreamsStart
 ): Promise<LogsRepositoryDataStreamClient> => {

--- a/src/platform/plugins/shared/workflows_management/server/trigger_events_log/trigger_events_data_stream.ts
+++ b/src/platform/plugins/shared/workflows_management/server/trigger_events_log/trigger_events_data_stream.ts
@@ -55,6 +55,16 @@ export type TriggerEventsDataStreamClient = IDataStreamClient<
   TriggerEventDocument
 >;
 
+/**
+ * Bump when Elasticsearch index mappings for the workflows trigger-events data stream change.
+ * Compared on startup against `mappings._meta.managed_index_mappings_version` on backing indices
+ * to decide whether to schedule a lazy rollover.
+ *
+ * This is independent of `registerDataStream({ version })` above (template lifecycle) and from
+ * `WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION` — logs and events streams can bump separately.
+ */
+export const WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION = 3;
+
 export const initializeTriggerEventsClient = (
   coreDataStreams: DataStreamsStart
 ): Promise<TriggerEventsDataStreamClient> => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[One workflow] Lazy rollover for workflows data streams on mapping version mismatch (#269514)](https://github.com/elastic/kibana/pull/269514)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yngrid Coello","email":"yngrid.coello@elastic.co"},"sourceCommit":{"committedDate":"2026-05-16T10:51:40Z","message":"[One workflow] Lazy rollover for workflows data streams on mapping version mismatch (#269514)\n\nCloses https://github.com/elastic/elasticsearch/issues/148871.\n\n## Summary\n\nAdds startup logic to the workflows execution engine that compares\n`mappings._meta.managed_index_mappings_version` on elasticsearch backing\nindices against version constants in kibana. When the deployed version\nis missing or older, it schedules a **lazy** rollover so a new write\nindex is created on the next ingest (not on every restart when versions\nalready match).\n\nApplies to:\n\n- `.workflows-execution-data-stream-logs`\n(`WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION = 2`)\n- `.workflows-events` (`WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION\n= 3`)\n\n## Motivation\n\n`@kbn/data-streams` updates index templates and applies compatible\nmapping changes via `putMapping` on the write index. Incompatible\nmapping changes (or stamping `_meta` on new write indices) still require\na rollover. Without a version check, we would either skip rollover\nentirely or risk rolling over on every kibana restart.\n\nThis change makes rollover **conditional** and **idempotent**: restart\nwith no version bump should not schedule rollover when backing indices\nalready match the kibana target.\n\n## Notes for reviewers\n\n- **Lazy rollover** does not create a new backing index until the next\ndocument is indexed. `GET _data_stream/...` may look unchanged\nimmediately after startup.\n- Rollover compares **`mappings._meta.managed_index_mappings_version`**\non backing indices, not `index_template._meta.version` used by\n`@kbn/data-streams`.\n- Keep `WORKFLOWS_*_MANAGED_INDEX_MAPPINGS_VERSION` in sync with\n`registerDataStream({ version })` when bumping mappings; consider\nstamping `managed_index_mappings_version` in index template mappings in\na follow-up so post-rollover indices inherit the target version from the\ntemplate.","sha":"c2f552e8f1fe4476771f32a952c252ebb9b1dc96","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport missing","backport:version","Team:One Workflow","v9.5.0","v9.4.1","v9.4.2"],"title":"[One workflow] Lazy rollover for workflows data streams on mapping version mismatch","number":269514,"url":"https://github.com/elastic/kibana/pull/269514","mergeCommit":{"message":"[One workflow] Lazy rollover for workflows data streams on mapping version mismatch (#269514)\n\nCloses https://github.com/elastic/elasticsearch/issues/148871.\n\n## Summary\n\nAdds startup logic to the workflows execution engine that compares\n`mappings._meta.managed_index_mappings_version` on elasticsearch backing\nindices against version constants in kibana. When the deployed version\nis missing or older, it schedules a **lazy** rollover so a new write\nindex is created on the next ingest (not on every restart when versions\nalready match).\n\nApplies to:\n\n- `.workflows-execution-data-stream-logs`\n(`WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION = 2`)\n- `.workflows-events` (`WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION\n= 3`)\n\n## Motivation\n\n`@kbn/data-streams` updates index templates and applies compatible\nmapping changes via `putMapping` on the write index. Incompatible\nmapping changes (or stamping `_meta` on new write indices) still require\na rollover. Without a version check, we would either skip rollover\nentirely or risk rolling over on every kibana restart.\n\nThis change makes rollover **conditional** and **idempotent**: restart\nwith no version bump should not schedule rollover when backing indices\nalready match the kibana target.\n\n## Notes for reviewers\n\n- **Lazy rollover** does not create a new backing index until the next\ndocument is indexed. `GET _data_stream/...` may look unchanged\nimmediately after startup.\n- Rollover compares **`mappings._meta.managed_index_mappings_version`**\non backing indices, not `index_template._meta.version` used by\n`@kbn/data-streams`.\n- Keep `WORKFLOWS_*_MANAGED_INDEX_MAPPINGS_VERSION` in sync with\n`registerDataStream({ version })` when bumping mappings; consider\nstamping `managed_index_mappings_version` in index template mappings in\na follow-up so post-rollover indices inherit the target version from the\ntemplate.","sha":"c2f552e8f1fe4476771f32a952c252ebb9b1dc96"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/269514","number":269514,"mergeCommit":{"message":"[One workflow] Lazy rollover for workflows data streams on mapping version mismatch (#269514)\n\nCloses https://github.com/elastic/elasticsearch/issues/148871.\n\n## Summary\n\nAdds startup logic to the workflows execution engine that compares\n`mappings._meta.managed_index_mappings_version` on elasticsearch backing\nindices against version constants in kibana. When the deployed version\nis missing or older, it schedules a **lazy** rollover so a new write\nindex is created on the next ingest (not on every restart when versions\nalready match).\n\nApplies to:\n\n- `.workflows-execution-data-stream-logs`\n(`WORKFLOWS_LOGS_MANAGED_INDEX_MAPPINGS_VERSION = 2`)\n- `.workflows-events` (`WORKFLOWS_EVENTS_MANAGED_INDEX_MAPPINGS_VERSION\n= 3`)\n\n## Motivation\n\n`@kbn/data-streams` updates index templates and applies compatible\nmapping changes via `putMapping` on the write index. Incompatible\nmapping changes (or stamping `_meta` on new write indices) still require\na rollover. Without a version check, we would either skip rollover\nentirely or risk rolling over on every kibana restart.\n\nThis change makes rollover **conditional** and **idempotent**: restart\nwith no version bump should not schedule rollover when backing indices\nalready match the kibana target.\n\n## Notes for reviewers\n\n- **Lazy rollover** does not create a new backing index until the next\ndocument is indexed. `GET _data_stream/...` may look unchanged\nimmediately after startup.\n- Rollover compares **`mappings._meta.managed_index_mappings_version`**\non backing indices, not `index_template._meta.version` used by\n`@kbn/data-streams`.\n- Keep `WORKFLOWS_*_MANAGED_INDEX_MAPPINGS_VERSION` in sync with\n`registerDataStream({ version })` when bumping mappings; consider\nstamping `managed_index_mappings_version` in index template mappings in\na follow-up so post-rollover indices inherit the target version from the\ntemplate.","sha":"c2f552e8f1fe4476771f32a952c252ebb9b1dc96"}},{"branch":"9.4","label":"v9.4.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->