### PR TITLE
[UII] Trim auth fields in agent binary download locations

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.test.tsx
@@ -256,9 +256,7 @@ describe('Download source form validation', () => {
     it('should treat whitespace-only key or value as missing', () => {
       expect(validateDownloadSourceHeaders([{ key: '   ', value: '\t ' }])).toBeUndefined();
 
-      expect(
-        validateDownloadSourceHeaders([{ key: 'X-Custom-Header', value: '   ' }])
-      ).toEqual([
+      expect(validateDownloadSourceHeaders([{ key: 'X-Custom-Header', value: '   ' }])).toEqual([
         {
           message: 'Missing value for key "X-Custom-Header"',
           index: 0,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.test.tsx
@@ -113,6 +113,30 @@ describe('useDowloadSourceFlyoutForm SSL certificate path validation', () => {
 
     await testRenderer.waitFor(() => expect(onSuccess).toBeCalled());
   });
+
+  it('should block submission when username contains only spaces', async () => {
+    const testRenderer = createFleetTestRendererMock();
+    const onSuccess = jest.fn();
+    const { result } = testRenderer.renderHook(() =>
+      useDowloadSourceFlyoutForm(onSuccess, undefined)
+    );
+
+    act(() => {
+      result.current.inputs.nameInput.setValue('My Source');
+      result.current.inputs.hostInput.setValue('https://artifacts.example.com');
+      result.current.inputs.authTypeInput.setValue('username_password');
+      result.current.inputs.usernameInput.setValue('   ');
+      result.current.inputs.passwordInput.setValue('password');
+    });
+
+    await act(() => result.current.submit());
+
+    await testRenderer.waitFor(() => {
+      expect(result.current.inputs.usernameInput.errors).toEqual(['Username is required']);
+      expect(onSuccess).not.toBeCalled();
+      expect(result.current.isDisabled).toBeTruthy();
+    });
+  });
 });
 
 describe('Download source form validation', () => {
@@ -227,6 +251,30 @@ describe('Download source form validation', () => {
       const res = validateDownloadSourceHeaders([{ key: '', value: '' }]);
 
       expect(res).toBeUndefined();
+    });
+
+    it('should treat whitespace-only key or value as missing', () => {
+      expect(validateDownloadSourceHeaders([{ key: '   ', value: '\t ' }])).toBeUndefined();
+
+      expect(
+        validateDownloadSourceHeaders([{ key: 'X-Custom-Header', value: '   ' }])
+      ).toEqual([
+        {
+          message: 'Missing value for key "X-Custom-Header"',
+          index: 0,
+          hasKeyError: false,
+          hasValueError: true,
+        },
+      ]);
+
+      expect(validateDownloadSourceHeaders([{ key: '   ', value: 'some-value' }])).toEqual([
+        {
+          message: 'Missing key for value "some-value"',
+          index: 0,
+          hasKeyError: true,
+          hasValueError: false,
+        },
+      ]);
     });
 
     it('should return error when key is provided without value', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_download_source_flyout_form.tsx
@@ -202,7 +202,7 @@ export function useDowloadSourceFlyoutForm(onSuccess: () => void, downloadSource
     let authValid = true;
     if (authType === 'username_password') {
       // Username & password tab: require both username and password
-      const hasUsername = !!usernameInput.value;
+      const hasUsername = !!usernameInput.value.trim();
       const hasPassword = !!passwordInput.value || !!passwordSecretInput.value;
       if (!hasUsername) {
         usernameInput.setErrors([
@@ -279,7 +279,7 @@ export function useDowloadSourceFlyoutForm(onSuccess: () => void, downloadSource
       let auth: PostDownloadSourceRequest['body']['auth'] | null;
 
       const filteredHeaders = headersInput.value.filter(
-        (header) => header.key !== '' || header.value !== ''
+        (header) => header.key.trim() !== '' || header.value.trim() !== ''
       );
       const hasHeaders = filteredHeaders.length > 0;
 
@@ -390,7 +390,7 @@ export function useDowloadSourceFlyoutForm(onSuccess: () => void, downloadSource
   const authType = authTypeInput.value as AuthType;
   const isAuthMissing =
     (authType === 'username_password' &&
-      (!usernameInput.value || (!passwordInput.value && !passwordSecretInput.value))) ||
+      (!usernameInput.value.trim() || (!passwordInput.value && !passwordSecretInput.value))) ||
     (authType === 'api_key' && !apiKeyInput.value && !apiKeySecretInput.value);
 
   return {
@@ -458,8 +458,8 @@ export function validateDownloadSourceHeaders(
   pairs.forEach((pair, index) => {
     const { key, value } = pair;
 
-    const hasKey = !!key;
-    const hasValue = !!value;
+    const hasKey = key.trim() !== '';
+    const hasValue = value.trim() !== '';
 
     if (hasKey && !hasValue) {
       errors.push({


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/257590. As the title says, this PR trims whitespace in various auth fields for agent binary download locations so that validation kicks in correctly.

Trimming is not applied to password fields (user's prerogative).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->