### PR TITLE
chore(eslint): enforce `@elastic/eui/consistent-is-invalid-props` rule at the `error` level

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -402,6 +402,7 @@ module.exports = {
     '@elastic/eui/prefer-eui-icon-tip': 'error',
     '@elastic/eui/sr-output-disabled-tooltip': 'error',
     '@elastic/eui/badge-accessibility-rules': 'error',
+    '@elastic/eui/consistent-is-invalid-props': 'error',
   },
 
   overrides: [


### PR DESCRIPTION
## Summary

This PR enforces `@elastic/eui/consistent-is-invalid-props` rule at the `error` level in the shared `@kbn/eslint-config` configuration:

- **`@elastic/eui/consistent-is-invalid-props`** — Ensure that form control components within `EuiFormRow` components have matching `isInvalid` prop values. This maintains consistent validation state between parent form rows and their child form controls, leading to a more predictable and accessible user experience.

  
All pre-existing violations of these rules have been fixed prior to this change. Setting them to `error` (instead of `warn` or off) prevents future regressions.

### Changes

- `packages/kbn-eslint-config/.eslintrc.js`