### PR TITLE
[SigEvents] Add lifecycle view and filters for significant events

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -212,6 +212,8 @@ export type {
   GeneratedSignificantEventQuery,
   SignificantEventsQueriesGenerationResult,
   SignificantEventsQueriesGenerationTaskResult,
+  LifecycleDetection,
+  EventLifecycleResponse,
 } from './src/api/significant_events';
 export { generatedSignificantEventQuerySchema } from './src/api/significant_events';
 

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/api/significant_events/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/api/significant_events/index.ts
@@ -16,6 +16,9 @@ import {
   type StreamQuery,
 } from '../../queries';
 import type { TaskStatus } from '../../tasks/types';
+import type { Discovery } from '../../sig_events/discoveries';
+import type { Verdict } from '../../sig_events/verdicts';
+import type { SigEvent } from '../../sig_events/events';
 
 /**
  * SignificantEvents Get Response
@@ -123,6 +126,21 @@ type SignificantEventsQueriesGenerationTaskResult =
       status: TaskStatus.Completed | TaskStatus.Acknowledged;
     } & SignificantEventsQueriesGenerationResult);
 
+interface LifecycleDetection {
+  detection_id: string;
+  rule_name?: string;
+  stream_name?: string;
+  change_point_type?: string;
+  detected_at: string;
+}
+
+interface EventLifecycleResponse {
+  detections: LifecycleDetection[];
+  discoveries: Discovery[];
+  verdicts: Verdict[];
+  events: SigEvent[];
+}
+
 export type {
   SignificantEventsResponse,
   SignificantEventsGetResponse,
@@ -131,4 +149,6 @@ export type {
   SignificantEventsGenerateResponse,
   SignificantEventsQueriesGenerationResult,
   SignificantEventsQueriesGenerationTaskResult,
+  LifecycleDetection,
+  EventLifecycleResponse,
 };

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/detections/detection_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/detections/detection_client.ts
@@ -7,6 +7,7 @@
 
 import type { IDataStreamClient } from '@kbn/data-streams';
 import { esql } from '@elastic/esql';
+import type { ESQLAstExpression } from '@elastic/esql/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import {
   type CommonSearchOptions,
@@ -14,7 +15,6 @@ import {
   type PaginatedResponse,
 } from '../query_utils';
 import {
-  type LatestSourceWhereCondition,
   andWhere,
   inFilter,
   runLatestSourceEsqlQuery,
@@ -60,8 +60,8 @@ export class DetectionClient {
     });
   }
 
-  private buildWhere(options: DetectionsSearchOptions): LatestSourceWhereCondition | undefined {
-    let where: LatestSourceWhereCondition | undefined;
+  private buildWhere(options: DetectionsSearchOptions): ESQLAstExpression | undefined {
+    let where: ESQLAstExpression | undefined;
     where = inFilter({ where, field: 'rule_uuid', values: options.rule_uuid });
 
     if (options.rule_name) {

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/detections/detection_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/detections/detection_client.ts
@@ -15,6 +15,8 @@ import {
 } from '../query_utils';
 import {
   type LatestSourceWhereCondition,
+  andWhere,
+  inFilter,
   runLatestSourceEsqlQuery,
   runPaginatedLatestSourceEsqlQuery,
   runFindByIdEsqlQuery,
@@ -41,13 +43,6 @@ export interface DetectionsPaginatedSearchOptions extends PaginatedSearchOptions
   rule_name?: string;
 }
 
-const andWhere = (
-  current: LatestSourceWhereCondition | undefined,
-  next: LatestSourceWhereCondition
-): LatestSourceWhereCondition => {
-  return current ? esql.exp`${current} AND ${next}` : next;
-};
-
 const GROUP_BY_FIELD = 'detection_id';
 
 export class DetectionClient {
@@ -68,11 +63,7 @@ export class DetectionClient {
 
   private buildWhere(options: DetectionsSearchOptions): LatestSourceWhereCondition | undefined {
     let where: LatestSourceWhereCondition | undefined;
-
-    const ruleUuidLiterals = options.rule_uuid?.map((ruleUuid) => esql.str(ruleUuid));
-    if (ruleUuidLiterals?.length) {
-      where = andWhere(where, esql.exp`${esql.col('rule_uuid')} IN (${ruleUuidLiterals})`);
-    }
+    where = inFilter({ where, field: 'rule_uuid', values: options.rule_uuid });
 
     if (options.rule_name) {
       where = andWhere(where, esql.exp`${esql.col('rule_name')} == ${esql.str(options.rule_name)}`);

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/detections/detection_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/detections/detection_client.ts
@@ -27,6 +27,7 @@ import {
   type StoredDetection,
   type detectionsMappings,
 } from './data_stream';
+import { FIELD_DETECTION_ID } from '../field_names';
 
 export type DetectionDataStreamClient = IDataStreamClient<
   typeof detectionsMappings,
@@ -42,8 +43,6 @@ export interface DetectionsPaginatedSearchOptions extends PaginatedSearchOptions
   rule_uuid?: string[];
   rule_name?: string;
 }
-
-const GROUP_BY_FIELD = 'detection_id';
 
 export class DetectionClient {
   constructor(
@@ -79,7 +78,7 @@ export class DetectionClient {
       options,
       index: DETECTIONS_DATA_STREAM,
       where: this.buildWhere(options),
-      groupBy: GROUP_BY_FIELD,
+      groupBy: FIELD_DETECTION_ID,
     });
   }
 
@@ -92,7 +91,7 @@ export class DetectionClient {
       options,
       index: DETECTIONS_DATA_STREAM,
       where: this.buildWhere(options),
-      groupBy: GROUP_BY_FIELD,
+      groupBy: FIELD_DETECTION_ID,
     });
   }
 
@@ -101,7 +100,7 @@ export class DetectionClient {
       esClient: this.clients.esClient,
       space: this.clients.space,
       index: DETECTIONS_DATA_STREAM,
-      idField: GROUP_BY_FIELD,
+      idField: FIELD_DETECTION_ID,
       idValue: detectionId,
     });
   }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/discoveries/discovery_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/discoveries/discovery_client.ts
@@ -24,13 +24,12 @@ import {
   type StoredDiscovery,
   type discoveriesMappings,
 } from './data_stream';
+import { FIELD_DISCOVERY_ID, FIELD_DISCOVERY_SLUG } from '../field_names';
 
 export type DiscoveryDataStreamClient = IDataStreamClient<
   typeof discoveriesMappings,
   StoredDiscovery
 >;
-
-const GROUP_BY_FIELD = 'discovery_id';
 
 export class DiscoveryClient {
   constructor(
@@ -54,7 +53,7 @@ export class DiscoveryClient {
       space: this.clients.space,
       options,
       index: DISCOVERIES_DATA_STREAM,
-      groupBy: GROUP_BY_FIELD,
+      groupBy: FIELD_DISCOVERY_ID,
     });
   }
 
@@ -66,7 +65,7 @@ export class DiscoveryClient {
       space: this.clients.space,
       options,
       index: DISCOVERIES_DATA_STREAM,
-      groupBy: GROUP_BY_FIELD,
+      groupBy: FIELD_DISCOVERY_ID,
     });
   }
 
@@ -75,7 +74,7 @@ export class DiscoveryClient {
       esClient: this.clients.esClient,
       space: this.clients.space,
       index: DISCOVERIES_DATA_STREAM,
-      idField: GROUP_BY_FIELD,
+      idField: FIELD_DISCOVERY_ID,
       idValue: discoveryId,
     });
   }
@@ -85,8 +84,18 @@ export class DiscoveryClient {
       esClient: this.clients.esClient,
       space: this.clients.space,
       index: DISCOVERIES_DATA_STREAM,
-      idField: GROUP_BY_FIELD,
+      idField: FIELD_DISCOVERY_ID,
       idValues: discoveryIds,
+    });
+  }
+
+  async findBySlug(slug: string): Promise<{ hits: Discovery[] }> {
+    return runFindByIdEsqlQuery<Discovery>({
+      esClient: this.clients.esClient,
+      space: this.clients.space,
+      index: DISCOVERIES_DATA_STREAM,
+      idField: FIELD_DISCOVERY_SLUG,
+      idValue: slug,
     });
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/discoveries/discovery_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/discoveries/discovery_client.ts
@@ -16,6 +16,7 @@ import {
   runLatestSourceEsqlQuery,
   runPaginatedLatestSourceEsqlQuery,
   runFindByIdEsqlQuery,
+  runFindByIdsEsqlQuery,
 } from '../latest_source_query';
 import {
   DISCOVERIES_DATA_STREAM,
@@ -76,6 +77,16 @@ export class DiscoveryClient {
       index: DISCOVERIES_DATA_STREAM,
       idField: GROUP_BY_FIELD,
       idValue: discoveryId,
+    });
+  }
+
+  async findByIds(discoveryIds: string[]): Promise<{ hits: Discovery[] }> {
+    return runFindByIdsEsqlQuery<Discovery>({
+      esClient: this.clients.esClient,
+      space: this.clients.space,
+      index: DISCOVERIES_DATA_STREAM,
+      idField: GROUP_BY_FIELD,
+      idValues: discoveryIds,
     });
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
@@ -24,7 +24,8 @@ export const eventsMappings = {
     stream_names: mappings.keyword(),
     verdict: mappings.keyword(),
     impact: mappings.keyword(),
-    title: mappings.keyword(),
+    title: mappings.text(),
+    summary: mappings.text(),
   },
 } satisfies MappingsDefinition;
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/data_stream.ts
@@ -19,7 +19,12 @@ export const eventsMappings = {
     event_id: mappings.keyword(),
     discovery_id: mappings.keyword(),
     discovery_slug: mappings.keyword(),
+    previous_event_id: mappings.keyword(),
     rule_names: mappings.keyword(),
+    stream_names: mappings.keyword(),
+    verdict: mappings.keyword(),
+    impact: mappings.keyword(),
+    title: mappings.keyword(),
   },
 } satisfies MappingsDefinition;
 
@@ -28,7 +33,7 @@ export type { SigEvent };
 
 export const eventsDataStream: DataStreamDefinition<typeof eventsMappings, StoredEvent> = {
   name: EVENTS_DATA_STREAM,
-  version: 2,
+  version: 3,
   hidden: true,
   template: {
     priority: 500,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IDataStreamClient } from '@kbn/data-streams';
+import { esql } from '@elastic/esql';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import {
   type CommonSearchOptions,
@@ -13,9 +14,13 @@ import {
   type PaginatedResponse,
 } from '../query_utils';
 import {
+  type LatestSourceWhereCondition,
+  andWhere,
+  inFilter,
   runLatestSourceEsqlQuery,
   runPaginatedLatestSourceEsqlQuery,
   runFindByIdEsqlQuery,
+  queryEsql,
 } from '../latest_source_query';
 import {
   EVENTS_DATA_STREAM,
@@ -25,6 +30,15 @@ import {
 } from './data_stream';
 
 export type EventDataStreamClient = IDataStreamClient<typeof eventsMappings, StoredEvent>;
+
+export interface EventsFilterOptions {
+  verdict?: string[];
+  stream?: string[];
+  impact?: string[];
+  search?: string;
+}
+
+export interface EventsPaginatedSearchOptions extends PaginatedSearchOptions, EventsFilterOptions {}
 
 const GROUP_BY_FIELD = 'event_id';
 
@@ -36,6 +50,23 @@ export class EventClient {
       space: string;
     }
   ) {}
+
+  private buildWhere(options: EventsFilterOptions): LatestSourceWhereCondition | undefined {
+    let where: LatestSourceWhereCondition | undefined;
+    where = inFilter({ where, field: 'verdict', values: options.verdict });
+    where = inFilter({ where, field: 'stream_names', values: options.stream });
+    where = inFilter({ where, field: 'impact', values: options.impact });
+
+    if (options.search) {
+      const escaped = options.search.toLowerCase().replace(/[*?]/g, '\\$&');
+      where = andWhere(
+        where,
+        esql.exp`TO_LOWER(${esql.col('title')}) LIKE ${esql.str(`*${escaped}*`)}`
+      );
+    }
+
+    return where;
+  }
 
   async bulkCreate(events: SigEvent[]) {
     return this.clients.dataStreamClient.create({
@@ -55,13 +86,22 @@ export class EventClient {
   }
 
   async findLatestPaginated(
-    options: PaginatedSearchOptions = {}
+    options: EventsPaginatedSearchOptions = {}
   ): Promise<PaginatedResponse<SigEvent>> {
+    const supersededIds = await this.findSupersededEventIds();
+
+    let where = this.buildWhere(options);
+    if (supersededIds.size > 0) {
+      const literals = [...supersededIds].map((id) => esql.str(id));
+      where = andWhere(where, esql.exp`NOT ${esql.col('event_id')} IN (${literals})`);
+    }
+
     return runPaginatedLatestSourceEsqlQuery<SigEvent>({
       esClient: this.clients.esClient,
       space: this.clients.space,
       options,
       index: EVENTS_DATA_STREAM,
+      where,
       groupBy: GROUP_BY_FIELD,
     });
   }
@@ -74,5 +114,34 @@ export class EventClient {
       idField: GROUP_BY_FIELD,
       idValue: eventId,
     });
+  }
+
+  async findSupersededEventIds(): Promise<Set<string>> {
+    const { space } = this.clients;
+    const prevId = esql.col('previous_event_id');
+
+    const query = esql.from([EVENTS_DATA_STREAM]).where`${esql.col(
+      'kibana.space_ids'
+    )} == ${space} OR ${esql.col('kibana.space_ids')} IS NULL`
+      .where`${prevId} IS NOT NULL AND ${prevId} != ${esql.str('')}`
+      .pipe`STATS ids = VALUES(${prevId})`.keep('ids');
+
+    try {
+      const response = await queryEsql({
+        esClient: this.clients.esClient,
+        query,
+      });
+
+      const idsIdx = response.columns.findIndex((c) => c.name === 'ids');
+      if (idsIdx === -1 || response.values.length === 0) {
+        return new Set();
+      }
+
+      const rawValue = response.values[0][idsIdx];
+      const ids = Array.isArray(rawValue) ? rawValue : [rawValue];
+      return new Set(ids.filter((v): v is string => typeof v === 'string'));
+    } catch {
+      return new Set();
+    }
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
@@ -16,14 +16,10 @@ import {
 import {
   type LatestSourceWhereCondition,
   andWhere,
-  applyTimeRange,
-  fromIndexForSpace,
   inFilter,
-  isIndexNotFoundError,
   runLatestSourceEsqlQuery,
   runPaginatedLatestSourceEsqlQuery,
   runFindByIdEsqlQuery,
-  queryEsql,
 } from '../latest_source_query';
 import {
   EVENTS_DATA_STREAM,
@@ -31,19 +27,17 @@ import {
   type StoredEvent,
   type eventsMappings,
 } from './data_stream';
+import { FIELD_EVENT_ID, FIELD_DISCOVERY_SLUG } from '../field_names';
 
 export type EventDataStreamClient = IDataStreamClient<typeof eventsMappings, StoredEvent>;
 
 export interface EventsFilterOptions {
   verdict?: string[];
   stream?: string[];
-  impact?: string[];
   search?: string;
 }
 
 export interface EventsPaginatedSearchOptions extends PaginatedSearchOptions, EventsFilterOptions {}
-
-const GROUP_BY_FIELD = 'event_id';
 
 export class EventClient {
   constructor(
@@ -58,7 +52,6 @@ export class EventClient {
     let where: LatestSourceWhereCondition | undefined;
     where = inFilter({ where, field: 'verdict', values: options.verdict });
     where = inFilter({ where, field: 'stream_names', values: options.stream });
-    where = inFilter({ where, field: 'impact', values: options.impact });
 
     if (options.search) {
       const escaped = options.search.toLowerCase().replace(/\\/g, '\\\\').replace(/[*?]/g, '\\$&');
@@ -84,31 +77,20 @@ export class EventClient {
       space: this.clients.space,
       options,
       index: EVENTS_DATA_STREAM,
-      groupBy: GROUP_BY_FIELD,
+      groupBy: FIELD_DISCOVERY_SLUG,
     });
   }
 
   async findLatestPaginated(
     options: EventsPaginatedSearchOptions = {}
   ): Promise<PaginatedResponse<SigEvent>> {
-    const supersededIds = await this.findSupersededEventIds({
-      from: options.from,
-      to: options.to,
-    });
-
-    let where = this.buildWhere(options);
-    if (supersededIds.size > 0) {
-      const literals = [...supersededIds].map((id) => esql.str(id));
-      where = andWhere(where, esql.exp`NOT ${esql.col('event_id')} IN (${literals})`);
-    }
-
     return runPaginatedLatestSourceEsqlQuery<SigEvent>({
       esClient: this.clients.esClient,
       space: this.clients.space,
       options,
       index: EVENTS_DATA_STREAM,
-      where,
-      groupBy: GROUP_BY_FIELD,
+      where: this.buildWhere(options),
+      groupBy: FIELD_DISCOVERY_SLUG,
     });
   }
 
@@ -117,42 +99,18 @@ export class EventClient {
       esClient: this.clients.esClient,
       space: this.clients.space,
       index: EVENTS_DATA_STREAM,
-      idField: GROUP_BY_FIELD,
+      idField: FIELD_EVENT_ID,
       idValue: eventId,
     });
   }
 
-  async findSupersededEventIds(
-    timeRange: { from?: string; to?: string } = {}
-  ): Promise<Set<string>> {
-    const { space } = this.clients;
-    const prevId = esql.col('previous_event_id');
-
-    const baseQuery = fromIndexForSpace({ index: EVENTS_DATA_STREAM, space })
-      .where`${prevId} IS NOT NULL AND ${prevId} != ${esql.str('')}`;
-
-    const query = applyTimeRange({ query: baseQuery, ...timeRange })
-      .pipe`STATS ids = VALUES(${prevId})`.keep('ids');
-
-    try {
-      const response = await queryEsql({
-        esClient: this.clients.esClient,
-        query,
-      });
-
-      const idsIdx = response.columns.findIndex((c) => c.name === 'ids');
-      if (idsIdx === -1 || response.values.length === 0) {
-        return new Set();
-      }
-
-      const rawValue = response.values[0][idsIdx];
-      const ids = Array.isArray(rawValue) ? rawValue : [rawValue];
-      return new Set(ids.filter((v): v is string => typeof v === 'string'));
-    } catch (error) {
-      if (isIndexNotFoundError(error)) {
-        return new Set();
-      }
-      throw error;
-    }
+  async findByDiscoverySlug(slug: string): Promise<{ hits: SigEvent[] }> {
+    return runFindByIdEsqlQuery<SigEvent>({
+      esClient: this.clients.esClient,
+      space: this.clients.space,
+      index: EVENTS_DATA_STREAM,
+      idField: FIELD_DISCOVERY_SLUG,
+      idValue: slug,
+    });
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
@@ -7,6 +7,7 @@
 
 import type { IDataStreamClient } from '@kbn/data-streams';
 import { esql } from '@elastic/esql';
+import type { ESQLAstExpression } from '@elastic/esql/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import {
   type CommonSearchOptions,
@@ -14,7 +15,6 @@ import {
   type PaginatedResponse,
 } from '../query_utils';
 import {
-  type LatestSourceWhereCondition,
   andWhere,
   inFilter,
   runLatestSourceEsqlQuery,
@@ -48,16 +48,19 @@ export class EventClient {
     }
   ) {}
 
-  private buildWhere(options: EventsFilterOptions): LatestSourceWhereCondition | undefined {
-    let where: LatestSourceWhereCondition | undefined;
+  private buildWhere(options: EventsFilterOptions): ESQLAstExpression | undefined {
+    let where: ESQLAstExpression | undefined;
     where = inFilter({ where, field: 'verdict', values: options.verdict });
     where = inFilter({ where, field: 'stream_names', values: options.stream });
 
     if (options.search) {
       const escaped = options.search.toLowerCase().replace(/\\/g, '\\\\').replace(/[*?]/g, '\\$&');
+      const pattern = esql.str(`*${escaped}*`);
       where = andWhere(
         where,
-        esql.exp`TO_LOWER(${esql.col('title')}) LIKE ${esql.str(`*${escaped}*`)}`
+        esql.exp`(TO_LOWER(${esql.col('title')}) LIKE ${pattern} OR TO_LOWER(${esql.col(
+          'summary'
+        )}) LIKE ${pattern})`
       );
     }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/events/event_client.ts
@@ -16,7 +16,10 @@ import {
 import {
   type LatestSourceWhereCondition,
   andWhere,
+  applyTimeRange,
+  fromIndexForSpace,
   inFilter,
+  isIndexNotFoundError,
   runLatestSourceEsqlQuery,
   runPaginatedLatestSourceEsqlQuery,
   runFindByIdEsqlQuery,
@@ -58,7 +61,7 @@ export class EventClient {
     where = inFilter({ where, field: 'impact', values: options.impact });
 
     if (options.search) {
-      const escaped = options.search.toLowerCase().replace(/[*?]/g, '\\$&');
+      const escaped = options.search.toLowerCase().replace(/\\/g, '\\\\').replace(/[*?]/g, '\\$&');
       where = andWhere(
         where,
         esql.exp`TO_LOWER(${esql.col('title')}) LIKE ${esql.str(`*${escaped}*`)}`
@@ -88,7 +91,10 @@ export class EventClient {
   async findLatestPaginated(
     options: EventsPaginatedSearchOptions = {}
   ): Promise<PaginatedResponse<SigEvent>> {
-    const supersededIds = await this.findSupersededEventIds();
+    const supersededIds = await this.findSupersededEventIds({
+      from: options.from,
+      to: options.to,
+    });
 
     let where = this.buildWhere(options);
     if (supersededIds.size > 0) {
@@ -116,14 +122,16 @@ export class EventClient {
     });
   }
 
-  async findSupersededEventIds(): Promise<Set<string>> {
+  async findSupersededEventIds(
+    timeRange: { from?: string; to?: string } = {}
+  ): Promise<Set<string>> {
     const { space } = this.clients;
     const prevId = esql.col('previous_event_id');
 
-    const query = esql.from([EVENTS_DATA_STREAM]).where`${esql.col(
-      'kibana.space_ids'
-    )} == ${space} OR ${esql.col('kibana.space_ids')} IS NULL`
-      .where`${prevId} IS NOT NULL AND ${prevId} != ${esql.str('')}`
+    const baseQuery = fromIndexForSpace({ index: EVENTS_DATA_STREAM, space })
+      .where`${prevId} IS NOT NULL AND ${prevId} != ${esql.str('')}`;
+
+    const query = applyTimeRange({ query: baseQuery, ...timeRange })
       .pipe`STATS ids = VALUES(${prevId})`.keep('ids');
 
     try {
@@ -140,8 +148,11 @@ export class EventClient {
       const rawValue = response.values[0][idsIdx];
       const ids = Array.isArray(rawValue) ? rawValue : [rawValue];
       return new Set(ids.filter((v): v is string => typeof v === 'string'));
-    } catch {
-      return new Set();
+    } catch (error) {
+      if (isIndexNotFoundError(error)) {
+        return new Set();
+      }
+      throw error;
     }
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/field_names.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/field_names.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const FIELD_EVENT_ID = 'event_id';
+export const FIELD_DETECTION_ID = 'detection_id';
+export const FIELD_DISCOVERY_ID = 'discovery_id';
+export const FIELD_DISCOVERY_SLUG = 'discovery_slug';

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/latest_source_query.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/latest_source_query.ts
@@ -37,7 +37,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 // Known typing gap in the ES client — centralized here to avoid scattered assertions.
 // Uses `toEsqlRequest` so named-parameter holes (`${{ name: value }}`) are bound
 // at the protocol level rather than inlined into the query string.
-const queryEsql = async ({
+export const queryEsql = async ({
   esClient,
   query,
 }: {
@@ -104,6 +104,26 @@ const executeCountQuery = async ({
 };
 
 export type LatestSourceWhereCondition = ESQLAstExpression & ComposerQueryTagHole;
+
+export const andWhere = (
+  current: LatestSourceWhereCondition | undefined,
+  next: LatestSourceWhereCondition
+): LatestSourceWhereCondition => {
+  return current ? esql.exp`${current} AND ${next}` : next;
+};
+
+export const inFilter = ({
+  where,
+  field,
+  values,
+}: {
+  where: LatestSourceWhereCondition | undefined;
+  field: string;
+  values: string[] | undefined;
+}): LatestSourceWhereCondition | undefined => {
+  if (!values?.length) return where;
+  return andWhere(where, esql.exp`${esql.col(field)} IN (${values.map((v) => esql.str(v))})`);
+};
 
 interface BuildLatestSourceBaseQueryArgs {
   space: string;

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/latest_source_query.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/latest_source_query.ts
@@ -21,7 +21,7 @@ import {
   type PaginatedSearchOptions,
 } from './query_utils';
 
-const isIndexNotFoundError = (error: unknown): boolean => {
+export const isIndexNotFoundError = (error: unknown): boolean => {
   if (error instanceof Error) {
     return (
       error.message.includes('verification_exception') && error.message.includes('Unknown index')
@@ -125,6 +125,43 @@ export const inFilter = ({
   return andWhere(where, esql.exp`${esql.col(field)} IN (${values.map((v) => esql.str(v))})`);
 };
 
+// TODO: Remove `IS NULL` fallback once workflows write `kibana.space_ids` on every document.
+export const fromIndexForSpace = ({
+  index,
+  space,
+  columns,
+}: {
+  index: string;
+  space: string;
+  columns?: string[];
+}): ComposerQuery => {
+  const base = columns ? esql.from([index], columns) : esql.from([index]);
+  return base.where`${esql.col('kibana.space_ids')} == ${space} OR ${esql.col(
+    'kibana.space_ids'
+  )} IS NULL`;
+};
+
+export const applyTimeRange = ({
+  query,
+  from,
+  to,
+}: {
+  query: ComposerQuery;
+  from?: string;
+  to?: string;
+}): ComposerQuery => {
+  let q = query;
+  if (from !== undefined) {
+    const fromIso = from;
+    q = q.where`@timestamp >= TO_DATETIME(${{ fromIso }})`;
+  }
+  if (to !== undefined) {
+    const toIso = to;
+    q = q.where`@timestamp <= TO_DATETIME(${{ toIso }})`;
+  }
+  return q;
+};
+
 interface BuildLatestSourceBaseQueryArgs {
   space: string;
   index: string;
@@ -140,20 +177,11 @@ const buildLatestSourceBaseQuery = ({
   where,
   groupBy,
 }: BuildLatestSourceBaseQueryArgs) => {
-  // TODO: Remove `IS NULL` fallback once workflows write `kibana.space_ids` on every document.
-  let query = esql.from([index], ['_id', '_source']).where`${esql.col(
-    'kibana.space_ids'
-  )} == ${space} OR ${esql.col('kibana.space_ids')} IS NULL`;
-
-  if (options.from !== undefined) {
-    const fromIso = options.from;
-    query = query.where`@timestamp >= TO_DATETIME(${{ fromIso }})`;
-  }
-
-  if (options.to !== undefined) {
-    const toIso = options.to;
-    query = query.where`@timestamp <= TO_DATETIME(${{ toIso }})`;
-  }
+  let query = applyTimeRange({
+    query: fromIndexForSpace({ index, space, columns: ['_id', '_source'] }),
+    from: options.from,
+    to: options.to,
+  });
 
   if (where) {
     query = query.where`${where}`;
@@ -263,12 +291,39 @@ export const runFindByIdEsqlQuery = async <T>({
   idField,
   idValue,
 }: RunFindByIdEsqlQueryArgs): Promise<{ hits: T[] }> => {
-  // TODO: Remove `IS NULL` fallback once workflows write `kibana.space_ids` on every document.
-  let query = esql.from([index], ['_source']).where`${esql.col(
-    'kibana.space_ids'
-  )} == ${space} OR ${esql.col('kibana.space_ids')} IS NULL`;
+  let query = fromIndexForSpace({ index, space, columns: ['_source'] });
 
   query = query.where`${esql.col(idField)} == ${esql.str(idValue)}`;
+  query = query.sort(['@timestamp', 'ASC']);
+  query = query.keep('_source');
+
+  const hits = await executeEsqlQuery<T>({ esClient, query });
+  return { hits };
+};
+
+interface RunFindByIdsEsqlQueryArgs {
+  esClient: ElasticsearchClient;
+  space: string;
+  index: string;
+  idField: string;
+  idValues: string[];
+}
+
+export const runFindByIdsEsqlQuery = async <T>({
+  esClient,
+  space,
+  index,
+  idField,
+  idValues,
+}: RunFindByIdsEsqlQueryArgs): Promise<{ hits: T[] }> => {
+  if (idValues.length === 0) return { hits: [] };
+
+  const where = inFilter({ where: undefined, field: idField, values: idValues });
+  let query = fromIndexForSpace({ index, space, columns: ['_source'] });
+
+  if (where) {
+    query = query.where`${where}`;
+  }
   query = query.sort(['@timestamp', 'ASC']);
   query = query.keep('_source');
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/latest_source_query.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/latest_source_query.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-import {
-  esql,
-  type ComposerQuery,
-  type ComposerQueryTagHole,
-  type ComposerSortShorthand,
-} from '@elastic/esql';
+import { esql, type ComposerQuery, type ComposerSortShorthand } from '@elastic/esql';
 import type { ESQLAstExpression } from '@elastic/esql/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { ESQLSearchResponse } from '@kbn/es-types';
@@ -103,12 +98,10 @@ const executeCountQuery = async ({
   }
 };
 
-export type LatestSourceWhereCondition = ESQLAstExpression & ComposerQueryTagHole;
-
 export const andWhere = (
-  current: LatestSourceWhereCondition | undefined,
-  next: LatestSourceWhereCondition
-): LatestSourceWhereCondition => {
+  current: ESQLAstExpression | undefined,
+  next: ESQLAstExpression
+): ESQLAstExpression => {
   return current ? esql.exp`${current} AND ${next}` : next;
 };
 
@@ -117,10 +110,10 @@ export const inFilter = ({
   field,
   values,
 }: {
-  where: LatestSourceWhereCondition | undefined;
+  where: ESQLAstExpression | undefined;
   field: string;
   values: string[] | undefined;
-}): LatestSourceWhereCondition | undefined => {
+}): ESQLAstExpression | undefined => {
   if (!values?.length) return where;
   return andWhere(where, esql.exp`${esql.col(field)} IN (${values.map((v) => esql.str(v))})`);
 };
@@ -166,7 +159,7 @@ interface BuildLatestSourceBaseQueryArgs {
   space: string;
   index: string;
   options: CommonSearchOptions;
-  where?: LatestSourceWhereCondition;
+  where?: ESQLAstExpression;
   groupBy: string;
 }
 
@@ -203,7 +196,7 @@ interface RunLatestSourceEsqlQueryArgs {
   space: string;
   options: CommonSearchOptions;
   index: string;
-  where?: LatestSourceWhereCondition;
+  where?: ESQLAstExpression;
   sort?: ComposerSortShorthand[];
   groupBy: string;
 }
@@ -237,7 +230,7 @@ interface RunPaginatedLatestSourceEsqlQueryArgs {
   space: string;
   options: PaginatedSearchOptions;
   index: string;
-  where?: LatestSourceWhereCondition;
+  where?: ESQLAstExpression;
   sort?: ComposerSortShorthand[];
   groupBy: string;
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/verdicts/verdict_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/verdicts/verdict_client.ts
@@ -24,10 +24,9 @@ import {
   type Verdict,
   type verdictsMappings,
 } from './data_stream';
+import { FIELD_DISCOVERY_ID, FIELD_DISCOVERY_SLUG } from '../field_names';
 
 export type VerdictDataStreamClient = IDataStreamClient<typeof verdictsMappings, StoredVerdict>;
-
-const GROUP_BY_FIELD = 'discovery_id';
 
 export class VerdictClient {
   constructor(
@@ -51,7 +50,7 @@ export class VerdictClient {
       space: this.clients.space,
       options,
       index: VERDICTS_DATA_STREAM,
-      groupBy: GROUP_BY_FIELD,
+      groupBy: FIELD_DISCOVERY_ID,
     });
   }
 
@@ -63,7 +62,7 @@ export class VerdictClient {
       space: this.clients.space,
       options,
       index: VERDICTS_DATA_STREAM,
-      groupBy: GROUP_BY_FIELD,
+      groupBy: FIELD_DISCOVERY_ID,
     });
   }
 
@@ -72,7 +71,7 @@ export class VerdictClient {
       esClient: this.clients.esClient,
       space: this.clients.space,
       index: VERDICTS_DATA_STREAM,
-      idField: GROUP_BY_FIELD,
+      idField: FIELD_DISCOVERY_ID,
       idValue: discoveryId,
     });
   }
@@ -82,8 +81,18 @@ export class VerdictClient {
       esClient: this.clients.esClient,
       space: this.clients.space,
       index: VERDICTS_DATA_STREAM,
-      idField: GROUP_BY_FIELD,
+      idField: FIELD_DISCOVERY_ID,
       idValues: discoveryIds,
+    });
+  }
+
+  async findByDiscoverySlug(slug: string): Promise<{ hits: Verdict[] }> {
+    return runFindByIdEsqlQuery<Verdict>({
+      esClient: this.clients.esClient,
+      space: this.clients.space,
+      index: VERDICTS_DATA_STREAM,
+      idField: FIELD_DISCOVERY_SLUG,
+      idValue: slug,
     });
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/verdicts/verdict_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/verdicts/verdict_client.ts
@@ -16,6 +16,7 @@ import {
   runLatestSourceEsqlQuery,
   runPaginatedLatestSourceEsqlQuery,
   runFindByIdEsqlQuery,
+  runFindByIdsEsqlQuery,
 } from '../latest_source_query';
 import {
   VERDICTS_DATA_STREAM,
@@ -73,6 +74,16 @@ export class VerdictClient {
       index: VERDICTS_DATA_STREAM,
       idField: GROUP_BY_FIELD,
       idValue: discoveryId,
+    });
+  }
+
+  async findByDiscoveryIds(discoveryIds: string[]): Promise<{ hits: Verdict[] }> {
+    return runFindByIdsEsqlQuery<Verdict>({
+      esClient: this.clients.esClient,
+      space: this.clients.space,
+      index: VERDICTS_DATA_STREAM,
+      idField: GROUP_BY_FIELD,
+      idValues: discoveryIds,
     });
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/events/route.ts
@@ -5,12 +5,81 @@
  * 2.0.
  */
 
-import { sigEventSchema, type SigEvent } from '@kbn/streams-schema';
+import {
+  sigEventSchema,
+  type SigEvent,
+  type Discovery,
+  type LifecycleDetection,
+  type EventLifecycleResponse,
+} from '@kbn/streams-schema';
 import { z } from '@kbn/zod/v4';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import type { PaginatedResponse } from '../../../../lib/sig_events/query_utils';
 import { createServerRoute } from '../../../create_server_route';
 import { assertSignificantEventsAccess } from '../../../utils/assert_significant_events_access';
+
+const toArray = (val: string | string[] | undefined): string[] | undefined =>
+  val === undefined ? undefined : Array.isArray(val) ? val : [val];
+
+const MAX_CHAIN_DEPTH = 10;
+
+interface EventChain {
+  events: SigEvent[];
+  discoveryIds: string[];
+}
+
+const walkEventChain = async ({
+  eventId,
+  findById,
+}: {
+  eventId: string;
+  findById: (id: string) => Promise<{ hits: SigEvent[] }>;
+}): Promise<EventChain> => {
+  const visited = new Set<string>();
+  const events: SigEvent[] = [];
+  const discoveryIds = new Set<string>();
+
+  let currentId: string | undefined = eventId;
+
+  while (currentId && !visited.has(currentId) && visited.size < MAX_CHAIN_DEPTH) {
+    visited.add(currentId);
+
+    const { hits } = await findById(currentId);
+    if (hits.length === 0) break;
+
+    events.push(...hits);
+
+    const latest = hits[hits.length - 1];
+    if (latest.discovery_id) {
+      discoveryIds.add(latest.discovery_id);
+    }
+    currentId = latest.previous_event_id;
+  }
+
+  return { events, discoveryIds: [...discoveryIds] };
+};
+
+const collectDetections = (discoveries: Discovery[]): LifecycleDetection[] => {
+  const seen = new Set<string>();
+  const detections: LifecycleDetection[] = [];
+
+  for (const discovery of discoveries) {
+    for (const det of discovery.detections ?? []) {
+      const { detection_id, rule_name, stream_name, change_point_type, detected_at } = det;
+      if (!detection_id || !detected_at || seen.has(detection_id)) continue;
+      seen.add(detection_id);
+      detections.push({
+        detection_id,
+        rule_name,
+        stream_name,
+        change_point_type,
+        detected_at,
+      });
+    }
+  }
+
+  return detections;
+};
 
 const eventsSearchRoute = createServerRoute({
   endpoint: 'GET /internal/sig_events/events',
@@ -30,6 +99,10 @@ const eventsSearchRoute = createServerRoute({
       to: z.iso.datetime().optional(),
       page: z.coerce.number().int().min(1).optional(),
       perPage: z.coerce.number().int().min(1).max(1000).optional(),
+      verdict: z.union([z.string(), z.array(z.string())]).optional(),
+      stream: z.union([z.string(), z.array(z.string())]).optional(),
+      impact: z.union([z.string(), z.array(z.string())]).optional(),
+      search: z.string().optional(),
     }),
   }),
   handler: async ({
@@ -42,7 +115,15 @@ const eventsSearchRoute = createServerRoute({
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
-    return getEventClient().findLatestPaginated(params.query);
+    const { verdict, stream, impact, search, ...rest } = params.query;
+
+    return getEventClient().findLatestPaginated({
+      ...rest,
+      verdict: toArray(verdict),
+      stream: toArray(stream),
+      impact: toArray(impact),
+      search: search || undefined,
+    });
   },
 });
 
@@ -96,8 +177,65 @@ const eventsBulkCreateRoute = createServerRoute({
   },
 });
 
+const eventsLifecycleRoute = createServerRoute({
+  endpoint: 'GET /internal/sig_events/events/{id}/lifecycle',
+  options: {
+    access: 'internal',
+    summary: 'Get event lifecycle',
+    description:
+      'Get the full lifecycle chain for a significant event: detections, discoveries, verdicts, and event versions.',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  params: z.object({
+    path: z.object({
+      id: z.string(),
+    }),
+  }),
+  handler: async ({
+    params,
+    request,
+    getScopedClients,
+    server,
+  }): Promise<EventLifecycleResponse> => {
+    const { getEventClient, getDiscoveryClient, getVerdictClient, licensing, uiSettingsClient } =
+      await getScopedClients({ request });
+
+    await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
+
+    const eventClient = getEventClient();
+    const { events, discoveryIds } = await walkEventChain({
+      eventId: params.path.id,
+      findById: (id) => eventClient.findById(id),
+    });
+
+    if (events.length === 0) {
+      return { detections: [], discoveries: [], verdicts: [], events: [] };
+    }
+
+    const [discoveryResults, verdictResults] = await Promise.all([
+      Promise.all(discoveryIds.map((id) => getDiscoveryClient().findById(id))),
+      Promise.all(discoveryIds.map((id) => getVerdictClient().findByDiscoveryId(id))),
+    ]);
+
+    const discoveries = discoveryResults.flatMap((r) => r.hits);
+    const verdicts = verdictResults.flatMap((r) => r.hits);
+
+    return {
+      detections: collectDetections(discoveries),
+      discoveries,
+      verdicts,
+      events,
+    };
+  },
+});
+
 export const internalSigEventsEventsRoutes = {
   ...eventsSearchRoute,
   ...eventsHistoryRoute,
+  ...eventsLifecycleRoute,
   ...eventsBulkCreateRoute,
 };

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/events/route.ts
@@ -99,10 +99,10 @@ const eventsSearchRoute = createServerRoute({
       to: z.iso.datetime().optional(),
       page: z.coerce.number().int().min(1).optional(),
       perPage: z.coerce.number().int().min(1).max(1000).optional(),
-      verdict: z.union([z.string(), z.array(z.string())]).optional(),
-      stream: z.union([z.string(), z.array(z.string())]).optional(),
-      impact: z.union([z.string(), z.array(z.string())]).optional(),
-      search: z.string().optional(),
+      verdict: z.union([z.string().max(50), z.array(z.string().max(50)).max(50)]).optional(),
+      stream: z.union([z.string().max(255), z.array(z.string().max(255)).max(50)]).optional(),
+      impact: z.union([z.string().max(50), z.array(z.string().max(50)).max(50)]).optional(),
+      search: z.string().max(500).optional(),
     }),
   }),
   handler: async ({
@@ -141,7 +141,7 @@ const eventsHistoryRoute = createServerRoute({
   },
   params: z.object({
     path: z.object({
-      id: z.string(),
+      id: z.string().max(255),
     }),
   }),
   handler: async ({ params, request, getScopedClients, server }): Promise<{ hits: SigEvent[] }> => {
@@ -192,7 +192,7 @@ const eventsLifecycleRoute = createServerRoute({
   },
   params: z.object({
     path: z.object({
-      id: z.string(),
+      id: z.string().max(255),
     }),
   }),
   handler: async ({
@@ -216,13 +216,10 @@ const eventsLifecycleRoute = createServerRoute({
       return { detections: [], discoveries: [], verdicts: [], events: [] };
     }
 
-    const [discoveryResults, verdictResults] = await Promise.all([
-      Promise.all(discoveryIds.map((id) => getDiscoveryClient().findById(id))),
-      Promise.all(discoveryIds.map((id) => getVerdictClient().findByDiscoveryId(id))),
+    const [{ hits: discoveries }, { hits: verdicts }] = await Promise.all([
+      getDiscoveryClient().findByIds(discoveryIds),
+      getVerdictClient().findByDiscoveryIds(discoveryIds),
     ]);
-
-    const discoveries = discoveryResults.flatMap((r) => r.hits);
-    const verdicts = verdictResults.flatMap((r) => r.hits);
 
     return {
       detections: collectDetections(discoveries),

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/events/route.ts
@@ -21,44 +21,6 @@ import { assertSignificantEventsAccess } from '../../../utils/assert_significant
 const toArray = (val: string | string[] | undefined): string[] | undefined =>
   val === undefined ? undefined : Array.isArray(val) ? val : [val];
 
-const MAX_CHAIN_DEPTH = 10;
-
-interface EventChain {
-  events: SigEvent[];
-  discoveryIds: string[];
-}
-
-const walkEventChain = async ({
-  eventId,
-  findById,
-}: {
-  eventId: string;
-  findById: (id: string) => Promise<{ hits: SigEvent[] }>;
-}): Promise<EventChain> => {
-  const visited = new Set<string>();
-  const events: SigEvent[] = [];
-  const discoveryIds = new Set<string>();
-
-  let currentId: string | undefined = eventId;
-
-  while (currentId && !visited.has(currentId) && visited.size < MAX_CHAIN_DEPTH) {
-    visited.add(currentId);
-
-    const { hits } = await findById(currentId);
-    if (hits.length === 0) break;
-
-    events.push(...hits);
-
-    const latest = hits[hits.length - 1];
-    if (latest.discovery_id) {
-      discoveryIds.add(latest.discovery_id);
-    }
-    currentId = latest.previous_event_id;
-  }
-
-  return { events, discoveryIds: [...discoveryIds] };
-};
-
 const collectDetections = (discoveries: Discovery[]): LifecycleDetection[] => {
   const seen = new Set<string>();
   const detections: LifecycleDetection[] = [];
@@ -101,7 +63,6 @@ const eventsSearchRoute = createServerRoute({
       perPage: z.coerce.number().int().min(1).max(1000).optional(),
       verdict: z.union([z.string().max(50), z.array(z.string().max(50)).max(50)]).optional(),
       stream: z.union([z.string().max(255), z.array(z.string().max(255)).max(50)]).optional(),
-      impact: z.union([z.string().max(50), z.array(z.string().max(50)).max(50)]).optional(),
       search: z.string().max(500).optional(),
     }),
   }),
@@ -115,13 +76,12 @@ const eventsSearchRoute = createServerRoute({
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
-    const { verdict, stream, impact, search, ...rest } = params.query;
+    const { verdict, stream, search, ...rest } = params.query;
 
     return getEventClient().findLatestPaginated({
       ...rest,
       verdict: toArray(verdict),
       stream: toArray(stream),
-      impact: toArray(impact),
       search: search || undefined,
     });
   },
@@ -206,19 +166,17 @@ const eventsLifecycleRoute = createServerRoute({
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
-    const eventClient = getEventClient();
-    const { events, discoveryIds } = await walkEventChain({
-      eventId: params.path.id,
-      findById: (id) => eventClient.findById(id),
-    });
-
-    if (events.length === 0) {
+    const { hits: initialHits } = await getEventClient().findById(params.path.id);
+    if (initialHits.length === 0) {
       return { detections: [], discoveries: [], verdicts: [], events: [] };
     }
 
-    const [{ hits: discoveries }, { hits: verdicts }] = await Promise.all([
-      getDiscoveryClient().findByIds(discoveryIds),
-      getVerdictClient().findByDiscoveryIds(discoveryIds),
+    const { discovery_slug: slug } = initialHits[0];
+
+    const [{ hits: events }, { hits: discoveries }, { hits: verdicts }] = await Promise.all([
+      getEventClient().findByDiscoverySlug(slug),
+      getDiscoveryClient().findBySlug(slug),
+      getVerdictClient().findByDiscoverySlug(slug),
     ]);
 
     return {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/detections_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/detections_tab/index.tsx
@@ -33,7 +33,6 @@ const columns: Array<EuiBasicTableColumn<Detection>> = [
     name: i18n.translate('xpack.streams.detectionsTab.timestampColumn', {
       defaultMessage: 'Timestamp',
     }),
-    sortable: true,
     render: (timestamp: string) => formatTimestamp(timestamp),
   },
   {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/discoveries_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/discoveries_tab/index.tsx
@@ -35,7 +35,6 @@ const columns: Array<EuiBasicTableColumn<Discovery>> = [
     name: i18n.translate('xpack.streams.discoveriesTab.timestampColumn', {
       defaultMessage: 'Timestamp',
     }),
-    sortable: true,
     render: (timestamp: string) => formatTimestamp(timestamp),
   },
   {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_constants.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_constants.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const VERDICT_OPTIONS = ['promoted', 'acknowledged', 'demoted'] as const;
+export type Verdict = (typeof VERDICT_OPTIONS)[number];
+
+export const IMPACT_OPTIONS = ['critical', 'high', 'medium', 'low'] as const;
+export type Impact = (typeof IMPACT_OPTIONS)[number];
+
+export const VERDICT_COLORS: Record<Verdict, string> = {
+  promoted: 'success',
+  acknowledged: 'warning',
+  demoted: 'default',
+};
+
+export const IMPACT_COLORS: Record<Impact, string> = {
+  critical: 'danger',
+  high: 'warning',
+  medium: 'primary',
+  low: 'hollow',
+};
+
+const isVerdict = (v: string): v is Verdict => v in VERDICT_COLORS;
+const isImpact = (v: string): v is Impact => v in IMPACT_COLORS;
+
+export const getVerdictColor = (verdict: string): string =>
+  isVerdict(verdict) ? VERDICT_COLORS[verdict] : 'default';
+
+export const getImpactColor = (impact: string): string =>
+  isImpact(impact) ? IMPACT_COLORS[impact] : 'hollow';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_constants.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_constants.ts
@@ -6,30 +6,16 @@
  */
 
 export const VERDICT_OPTIONS = ['promoted', 'acknowledged', 'demoted'] as const;
-export type Verdict = (typeof VERDICT_OPTIONS)[number];
+export type VerdictOption = (typeof VERDICT_OPTIONS)[number];
 
-export const IMPACT_OPTIONS = ['critical', 'high', 'medium', 'low'] as const;
-export type Impact = (typeof IMPACT_OPTIONS)[number];
-
-export const VERDICT_COLORS: Record<Verdict, string> = {
+export const VERDICT_COLORS: Record<VerdictOption, string> = {
   promoted: 'success',
   acknowledged: 'warning',
   demoted: 'default',
 };
 
-export const IMPACT_COLORS: Record<Impact, string> = {
-  critical: 'danger',
-  high: 'warning',
-  medium: 'primary',
-  low: 'hollow',
-};
-
-const isVerdict = (v: string): v is Verdict =>
+const isVerdict = (v: string): v is VerdictOption =>
   (VERDICT_OPTIONS as ReadonlyArray<string>).includes(v);
-const isImpact = (v: string): v is Impact => (IMPACT_OPTIONS as ReadonlyArray<string>).includes(v);
 
 export const getVerdictColor = (verdict: string): string =>
   isVerdict(verdict) ? VERDICT_COLORS[verdict] : 'default';
-
-export const getImpactColor = (impact: string): string =>
-  isImpact(impact) ? IMPACT_COLORS[impact] : 'hollow';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_constants.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_constants.ts
@@ -24,8 +24,9 @@ export const IMPACT_COLORS: Record<Impact, string> = {
   low: 'hollow',
 };
 
-const isVerdict = (v: string): v is Verdict => v in VERDICT_COLORS;
-const isImpact = (v: string): v is Impact => v in IMPACT_COLORS;
+const isVerdict = (v: string): v is Verdict =>
+  (VERDICT_OPTIONS as ReadonlyArray<string>).includes(v);
+const isImpact = (v: string): v is Impact => (IMPACT_OPTIONS as ReadonlyArray<string>).includes(v);
 
 export const getVerdictColor = (verdict: string): string =>
   isVerdict(verdict) ? VERDICT_COLORS[verdict] : 'default';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_popover.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_popover.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import type { EuiSelectableOption } from '@elastic/eui';
+import { EuiFilterButton, EuiPopover, EuiSelectable } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+interface FilterPopoverProps {
+  label: string;
+  ariaLabel: string;
+  options: EuiSelectableOption[];
+  numFilters: number;
+  numActiveFilters: number;
+  onChange: (options: EuiSelectableOption[]) => void;
+}
+
+const popoverContentCss = css`
+  width: 200px;
+`;
+
+export const FilterPopover = ({
+  label,
+  ariaLabel,
+  options,
+  numFilters,
+  numActiveFilters,
+  onChange,
+}: FilterPopoverProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <EuiPopover
+      aria-label={ariaLabel}
+      button={
+        <EuiFilterButton
+          iconType="arrowDown"
+          onClick={() => setIsOpen(!isOpen)}
+          isSelected={isOpen}
+          numFilters={numFilters}
+          hasActiveFilters={numActiveFilters > 0}
+          numActiveFilters={numActiveFilters}
+        >
+          {label}
+        </EuiFilterButton>
+      }
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      panelPaddingSize="none"
+    >
+      <EuiSelectable options={options} onChange={onChange}>
+        {(list) => <div css={popoverContentCss}>{list}</div>}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_popover.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/filter_popover.tsx
@@ -5,10 +5,15 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import type { EuiSelectableOption } from '@elastic/eui';
-import { EuiFilterButton, EuiPopover, EuiSelectable } from '@elastic/eui';
+import { EuiFilterButton, EuiPanel, EuiPopover, EuiSelectable } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { useBoolean } from '@kbn/react-hooks';
+
+const selectableListCss = css`
+  width: 200px;
+`;
 
 interface FilterPopoverProps {
   label: string;
@@ -19,10 +24,6 @@ interface FilterPopoverProps {
   onChange: (options: EuiSelectableOption[]) => void;
 }
 
-const popoverContentCss = css`
-  width: 200px;
-`;
-
 export const FilterPopover = ({
   label,
   ariaLabel,
@@ -31,7 +32,7 @@ export const FilterPopover = ({
   numActiveFilters,
   onChange,
 }: FilterPopoverProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, { off: close, toggle }] = useBoolean(false);
 
   return (
     <EuiPopover
@@ -39,7 +40,7 @@ export const FilterPopover = ({
       button={
         <EuiFilterButton
           iconType="arrowDown"
-          onClick={() => setIsOpen(!isOpen)}
+          onClick={toggle}
           isSelected={isOpen}
           numFilters={numFilters}
           hasActiveFilters={numActiveFilters > 0}
@@ -49,11 +50,15 @@ export const FilterPopover = ({
         </EuiFilterButton>
       }
       isOpen={isOpen}
-      closePopover={() => setIsOpen(false)}
+      closePopover={close}
       panelPaddingSize="none"
     >
       <EuiSelectable options={options} onChange={onChange}>
-        {(list) => <div css={popoverContentCss}>{list}</div>}
+        {(list) => (
+          <EuiPanel paddingSize="none" css={selectableListCss}>
+            {list}
+          </EuiPanel>
+        )}
       </EuiSelectable>
     </EuiPopover>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/index.tsx
@@ -31,12 +31,7 @@ import { useKiGeneration } from '../knowledge_indicators_table/ki_generation_con
 import { SigEventFlyout } from './sig_event_flyout';
 import { formatTimestamp } from '../../../../../util/formatters';
 import { FilterPopover } from './filter_popover';
-import {
-  VERDICT_OPTIONS,
-  IMPACT_OPTIONS,
-  getVerdictColor,
-  getImpactColor,
-} from './filter_constants';
+import { VERDICT_OPTIONS, getVerdictColor } from './filter_constants';
 
 const MAX_VISIBLE_STREAMS = 3;
 
@@ -117,14 +112,6 @@ const columns: Array<EuiBasicTableColumn<SigEvent>> = [
     },
   },
   {
-    field: 'impact',
-    name: i18n.translate('xpack.streams.sigEventsTab.impactColumn', {
-      defaultMessage: 'Impact',
-    }),
-    width: '90px',
-    render: (impact: string) => <EuiBadge color={getImpactColor(impact)}>{impact}</EuiBadge>,
-  },
-  {
     field: 'criticality',
     name: i18n.translate('xpack.streams.sigEventsTab.criticalityColumn', {
       defaultMessage: 'Criticality',
@@ -170,7 +157,6 @@ export const SigEventsTab = () => {
 
   const [verdictFilter, setVerdictFilter] = useState<string[]>([]);
   const [streamFilter, setStreamFilter] = useState<string[]>([]);
-  const [impactFilter, setImpactFilter] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearch = useDebouncedValue(searchQuery, 300);
 
@@ -184,17 +170,12 @@ export const SigEventsTab = () => {
     to: timeState.end,
     verdict: verdictFilter.length > 0 ? verdictFilter : undefined,
     stream: streamFilter.length > 0 ? streamFilter : undefined,
-    impact: impactFilter.length > 0 ? impactFilter : undefined,
     search: debouncedSearch || undefined,
   });
   const [selectedEvent, setSelectedEvent] = useState<SigEvent | undefined>();
 
   const onVerdictChange = useCallback(
     (opts: EuiSelectableOption[]) => setVerdictFilter(extractCheckedKeys(opts)),
-    []
-  );
-  const onImpactChange = useCallback(
-    (opts: EuiSelectableOption[]) => setImpactFilter(extractCheckedKeys(opts)),
     []
   );
   const onStreamChange = useCallback(
@@ -217,18 +198,6 @@ export const SigEventsTab = () => {
         onChange: onVerdictChange,
       },
       {
-        label: i18n.translate('xpack.streams.sigEventsTab.filter.impact', {
-          defaultMessage: 'Impact',
-        }),
-        ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.impactAriaLabel', {
-          defaultMessage: 'Filter by impact',
-        }),
-        options: buildSelectableOptions({ values: IMPACT_OPTIONS, selected: impactFilter }),
-        numFilters: IMPACT_OPTIONS.length,
-        numActiveFilters: impactFilter.length,
-        onChange: onImpactChange,
-      },
-      {
         label: i18n.translate('xpack.streams.sigEventsTab.filter.stream', {
           defaultMessage: 'Stream',
         }),
@@ -245,15 +214,7 @@ export const SigEventsTab = () => {
         onChange: onStreamChange,
       },
     ],
-    [
-      verdictFilter,
-      impactFilter,
-      streamFilter,
-      streamOptions,
-      onVerdictChange,
-      onImpactChange,
-      onStreamChange,
-    ]
+    [verdictFilter, streamFilter, streamOptions, onVerdictChange, onStreamChange]
   );
 
   const onTableChange = ({ page }: { page?: { index: number; size: number } }) => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/index.tsx
@@ -6,29 +6,63 @@
  */
 
 import React, { useMemo, useState } from 'react';
+import { useDebouncedValue } from '@kbn/react-hooks';
 import {
   EuiBasicTable,
   EuiBadge,
+  EuiCallOut,
+  EuiFieldSearch,
+  EuiFilterGroup,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSuperDatePicker,
+  EuiText,
 } from '@elastic/eui';
-import type { EuiBasicTableColumn } from '@elastic/eui';
+import type { EuiBasicTableColumn, EuiSelectableOption } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { capitalize } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import type { SigEvent } from '@kbn/streams-schema';
-import {
-  useFetchSigEvents,
-  useFetchSigEventHistory,
-} from '../../../../../hooks/sig_events/use_fetch_sig_events';
+import { useFetchSigEvents } from '../../../../../hooks/sig_events/use_fetch_sig_events';
 import { useTimefilter } from '../../../../../hooks/use_timefilter';
 import { useTimeRange } from '../../../../../hooks/use_time_range';
 import { useTimeRangeUpdate } from '../../../../../hooks/use_time_range_update';
-import { EntityDetailFlyout } from '../entity_detail_flyout';
+import { useKiGeneration } from '../knowledge_indicators_table/ki_generation_context';
+import { SigEventFlyout } from './sig_event_flyout';
 import { formatTimestamp } from '../../../../../util/formatters';
+import { FilterPopover } from './filter_popover';
+import {
+  VERDICT_OPTIONS,
+  IMPACT_OPTIONS,
+  getVerdictColor,
+  getImpactColor,
+} from './filter_constants';
+import type { Verdict, Impact } from './filter_constants';
 
 const MAX_VISIBLE_STREAMS = 3;
-const MAX_VISIBLE_RULES = 2;
+
+const clickableRowCss = css`
+  cursor: pointer;
+`;
+
+const SEARCH_PLACEHOLDER = i18n.translate('xpack.streams.sigEventsTab.searchPlaceholder', {
+  defaultMessage: 'Search events...',
+});
+const FETCH_ERROR_TITLE = i18n.translate('xpack.streams.sigEventsTab.fetchError', {
+  defaultMessage: 'Failed to load significant events',
+});
+const TABLE_CAPTION = i18n.translate('xpack.streams.sigEventsTab.tableCaption', {
+  defaultMessage: 'Significant Events',
+});
+const LOADING_MESSAGE = i18n.translate('xpack.streams.sigEventsTab.loadingMessage', {
+  defaultMessage: 'Loading events...',
+});
+const EMPTY_MESSAGE = i18n.translate('xpack.streams.sigEventsTab.emptyBody', {
+  defaultMessage: 'No significant events found.',
+});
+const MORE_LABEL = i18n.translate('xpack.streams.sigEventsTab.moreLabel', {
+  defaultMessage: 'more',
+});
 
 const columns: Array<EuiBasicTableColumn<SigEvent>> = [
   {
@@ -36,8 +70,16 @@ const columns: Array<EuiBasicTableColumn<SigEvent>> = [
     name: i18n.translate('xpack.streams.sigEventsTab.timestampColumn', {
       defaultMessage: 'Timestamp',
     }),
-    sortable: true,
+    width: '200px',
     render: (timestamp: string) => formatTimestamp(timestamp),
+  },
+  {
+    field: 'verdict',
+    name: i18n.translate('xpack.streams.sigEventsTab.verdictColumn', {
+      defaultMessage: 'Verdict',
+    }),
+    width: '110px',
+    render: (verdict: string) => <EuiBadge color={getVerdictColor(verdict)}>{verdict}</EuiBadge>,
   },
   {
     field: 'title',
@@ -45,76 +87,152 @@ const columns: Array<EuiBasicTableColumn<SigEvent>> = [
       defaultMessage: 'Title',
     }),
     truncateText: true,
-  },
-  {
-    field: 'verdict',
-    name: i18n.translate('xpack.streams.sigEventsTab.verdictColumn', {
-      defaultMessage: 'Verdict',
-    }),
-  },
-  {
-    field: 'criticality',
-    name: i18n.translate('xpack.streams.sigEventsTab.criticalityColumn', {
-      defaultMessage: 'Criticality',
-    }),
-    render: (value: number | undefined) => (value ? String(value) : '-'),
+    width: '40%',
   },
   {
     field: 'stream_names',
     name: i18n.translate('xpack.streams.sigEventsTab.streamsColumn', {
       defaultMessage: 'Streams',
     }),
-    render: (streamNames: string[]) => (
-      <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
-        {(streamNames ?? []).slice(0, MAX_VISIBLE_STREAMS).map((name) => (
-          <EuiFlexItem key={name} grow={false} style={{ maxWidth: '200px' }}>
-            <EuiBadge color="hollow">{name}</EuiBadge>
-          </EuiFlexItem>
-        ))}
-        {(streamNames ?? []).length > MAX_VISIBLE_STREAMS && (
-          <EuiFlexItem grow={false}>
-            <EuiBadge color="hollow">+{streamNames.length - MAX_VISIBLE_STREAMS}</EuiBadge>
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
-    ),
+    width: '150px',
+    render: (streamNames: string[]) => {
+      const names = streamNames ?? [];
+      const visible = names.slice(0, MAX_VISIBLE_STREAMS);
+      const remaining = names.length - visible.length;
+      return (
+        <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+          {visible.map((name, idx) => (
+            <EuiFlexItem grow={false} key={`${name}-${idx}`}>
+              <EuiBadge color="hollow">{name}</EuiBadge>
+            </EuiFlexItem>
+          ))}
+          {remaining > 0 && (
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                +{remaining} {MORE_LABEL}
+              </EuiText>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      );
+    },
   },
   {
-    field: 'rule_names',
-    name: i18n.translate('xpack.streams.sigEventsTab.rulesColumn', {
-      defaultMessage: 'Rules',
+    field: 'impact',
+    name: i18n.translate('xpack.streams.sigEventsTab.impactColumn', {
+      defaultMessage: 'Impact',
     }),
-    render: (ruleNames: string[]) => (
-      <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
-        {(ruleNames ?? []).slice(0, MAX_VISIBLE_RULES).map((name) => (
-          <EuiFlexItem key={name} grow={false} style={{ maxWidth: '200px' }}>
-            <EuiBadge color="hollow">{name}</EuiBadge>
-          </EuiFlexItem>
-        ))}
-        {(ruleNames ?? []).length > MAX_VISIBLE_RULES && (
-          <EuiFlexItem grow={false}>
-            <EuiBadge color="hollow">+{ruleNames.length - MAX_VISIBLE_RULES}</EuiBadge>
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
+    width: '90px',
+    render: (impact: string) => <EuiBadge color={getImpactColor(impact)}>{impact}</EuiBadge>,
+  },
+  {
+    field: 'criticality',
+    name: i18n.translate('xpack.streams.sigEventsTab.criticalityColumn', {
+      defaultMessage: 'Criticality',
+    }),
+    width: '90px',
+    render: (criticality: number | undefined) => <EuiText size="xs">{criticality ?? '-'}</EuiText>,
+  },
+  {
+    field: 'recommended_action',
+    name: i18n.translate('xpack.streams.sigEventsTab.actionColumn', {
+      defaultMessage: 'Action',
+    }),
+    width: '100px',
+    render: (action: string) => (
+      <EuiBadge color={action === 'escalate' ? 'danger' : 'hollow'}>{action}</EuiBadge>
     ),
   },
 ];
+
+const extractCheckedKeys = <T extends string>(options: EuiSelectableOption[]): T[] =>
+  options.filter((opt) => opt.checked === 'on').map((opt) => (opt.key ?? opt.label) as T);
+
+const buildSelectableOptions = <T extends string>({
+  values,
+  selected,
+  getLabel = capitalize,
+}: {
+  values: readonly T[];
+  selected: T[];
+  getLabel?: (value: T) => string;
+}): EuiSelectableOption[] =>
+  values.map((v) => ({
+    label: getLabel(v),
+    key: v,
+    checked: selected.includes(v) ? ('on' as const) : undefined,
+  }));
 
 export const SigEventsTab = () => {
   const { timeState } = useTimefilter();
   const { rangeFrom, rangeTo } = useTimeRange();
   const { updateTimeRange } = useTimeRangeUpdate();
+  const { filteredStreams } = useKiGeneration();
 
-  const { data, isLoading, refetch, pagination, setPagination } = useFetchSigEvents({
+  const [verdictFilter, setVerdictFilter] = useState<Verdict[]>([]);
+  const [streamFilter, setStreamFilter] = useState<string[]>([]);
+  const [impactFilter, setImpactFilter] = useState<Impact[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearch = useDebouncedValue(searchQuery, 300);
+
+  const streamOptions = useMemo(
+    () => (filteredStreams ?? []).map((s) => s.stream.name).sort(),
+    [filteredStreams]
+  );
+
+  const { data, isLoading, isError, refetch, pagination, setPagination } = useFetchSigEvents({
     from: timeState.start,
     to: timeState.end,
+    verdict: verdictFilter.length > 0 ? verdictFilter : undefined,
+    stream: streamFilter.length > 0 ? streamFilter : undefined,
+    impact: impactFilter.length > 0 ? impactFilter : undefined,
+    search: debouncedSearch || undefined,
   });
   const [selectedEvent, setSelectedEvent] = useState<SigEvent | undefined>();
 
-  const { data: historyData, isLoading: isHistoryLoading } = useFetchSigEventHistory(
-    selectedEvent?.event_id
-  );
+  const filters = [
+    {
+      label: i18n.translate('xpack.streams.sigEventsTab.filter.verdict', {
+        defaultMessage: 'Verdict',
+      }),
+      ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.verdictAriaLabel', {
+        defaultMessage: 'Filter by verdict',
+      }),
+      options: buildSelectableOptions({ values: VERDICT_OPTIONS, selected: verdictFilter }),
+      numFilters: VERDICT_OPTIONS.length,
+      numActiveFilters: verdictFilter.length,
+      onChange: (opts: EuiSelectableOption[]) =>
+        setVerdictFilter(extractCheckedKeys<Verdict>(opts)),
+    },
+    {
+      label: i18n.translate('xpack.streams.sigEventsTab.filter.impact', {
+        defaultMessage: 'Impact',
+      }),
+      ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.impactAriaLabel', {
+        defaultMessage: 'Filter by impact',
+      }),
+      options: buildSelectableOptions({ values: IMPACT_OPTIONS, selected: impactFilter }),
+      numFilters: IMPACT_OPTIONS.length,
+      numActiveFilters: impactFilter.length,
+      onChange: (opts: EuiSelectableOption[]) => setImpactFilter(extractCheckedKeys<Impact>(opts)),
+    },
+    {
+      label: i18n.translate('xpack.streams.sigEventsTab.filter.stream', {
+        defaultMessage: 'Stream',
+      }),
+      ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.streamAriaLabel', {
+        defaultMessage: 'Filter by stream',
+      }),
+      options: buildSelectableOptions({
+        values: streamOptions,
+        selected: streamFilter,
+        getLabel: (s) => s,
+      }),
+      numFilters: streamOptions.length,
+      numActiveFilters: streamFilter.length,
+      onChange: (opts: EuiSelectableOption[]) => setStreamFilter(extractCheckedKeys(opts)),
+    },
+  ];
 
   const onTableChange = ({ page }: { page?: { index: number; size: number } }) => {
     if (page) {
@@ -122,152 +240,78 @@ export const SigEventsTab = () => {
     }
   };
 
-  const euiPagination = {
-    pageIndex: pagination.page - 1,
-    pageSize: pagination.perPage,
-    totalItemCount: data?.total ?? 0,
-    pageSizeOptions: [10, 25, 50],
-  };
-
-  const flyoutDetails = selectedEvent
-    ? [
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.eventId', {
-            defaultMessage: 'Event ID',
-          }),
-          description: selectedEvent.event_id,
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.title', {
-            defaultMessage: 'Title',
-          }),
-          description: selectedEvent.title,
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.verdict', {
-            defaultMessage: 'Verdict',
-          }),
-          description: selectedEvent.verdict,
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.criticality', {
-            defaultMessage: 'Criticality',
-          }),
-          description: selectedEvent.criticality ? String(selectedEvent.criticality) : '-',
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.confidence', {
-            defaultMessage: 'Confidence',
-          }),
-          description: selectedEvent.confidence ? String(selectedEvent.confidence) : '-',
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.summary', {
-            defaultMessage: 'Summary',
-          }),
-          description: selectedEvent.summary,
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.rootCause', {
-            defaultMessage: 'Root Cause',
-          }),
-          description: selectedEvent.root_cause,
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.impact', {
-            defaultMessage: 'Impact',
-          }),
-          description: selectedEvent.impact ?? '-',
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.recommendedAction', {
-            defaultMessage: 'Recommended Action',
-          }),
-          description: selectedEvent.recommended_action ?? '-',
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.streams', {
-            defaultMessage: 'Streams',
-          }),
-          description: (selectedEvent.stream_names ?? []).join(', ') || '-',
-        },
-        {
-          title: i18n.translate('xpack.streams.sigEventsTab.flyout.rules', {
-            defaultMessage: 'Rules',
-          }),
-          description: (selectedEvent.rule_names ?? []).join(', ') || '-',
-        },
-      ]
-    : [];
-
-  const historyEntries = useMemo(
-    () =>
-      (historyData?.hits ?? []).map((entry) => ({
-        timestamp: formatTimestamp(entry['@timestamp']),
-        summary: entry.criticality
-          ? i18n.translate('xpack.streams.sigEventsTab.historySummaryWithCriticality', {
-              defaultMessage: '{verdict}: {title} (criticality: {criticality})',
-              values: {
-                verdict: entry.verdict,
-                title: entry.title,
-                criticality: String(entry.criticality),
-              },
-            })
-          : i18n.translate('xpack.streams.sigEventsTab.historySummary', {
-              defaultMessage: '{verdict}: {title}',
-              values: { verdict: entry.verdict, title: entry.title },
-            }),
-      })),
-    [historyData]
-  );
-
   return (
-    <EuiFlexGroup direction="column" gutterSize="s">
+    <EuiFlexGroup direction="column" gutterSize="m">
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup justifyContent="flexEnd">
+        <EuiFlexGroup gutterSize="m" alignItems="center">
+          <EuiFlexItem grow>
+            <EuiFieldSearch
+              placeholder={SEARCH_PLACEHOLDER}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              isClearable
+              fullWidth
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFilterGroup>
+              {filters.map((f) => (
+                <FilterPopover
+                  key={f.label}
+                  label={f.label}
+                  ariaLabel={f.ariaLabel}
+                  options={f.options}
+                  numFilters={f.numFilters}
+                  numActiveFilters={f.numActiveFilters}
+                  onChange={f.onChange}
+                />
+              ))}
+            </EuiFilterGroup>
+          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSuperDatePicker
               start={rangeFrom}
               end={rangeTo}
               onTimeChange={({ start: s, end: e }) => updateTimeRange({ from: s, to: e })}
               onRefresh={() => refetch()}
-              compressed
               showUpdateButton="iconOnly"
-              updateButtonProps={{ size: 's', fill: false }}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
+      {isError && (
+        <EuiFlexItem grow={false}>
+          <EuiCallOut
+            announceOnMount
+            title={FETCH_ERROR_TITLE}
+            color="danger"
+            iconType="error"
+            size="s"
+          />
+        </EuiFlexItem>
+      )}
       <EuiFlexItem grow={false}>
-        <EuiBasicTable
-          tableCaption={i18n.translate('xpack.streams.sigEventsTab.tableCaption', {
-            defaultMessage: 'Significant Events',
-          })}
+        <EuiBasicTable<SigEvent>
+          tableCaption={TABLE_CAPTION}
           items={data?.hits ?? []}
           columns={columns}
-          pagination={euiPagination}
+          pagination={{
+            pageIndex: pagination.page - 1,
+            pageSize: pagination.perPage,
+            totalItemCount: data?.total ?? 0,
+            pageSizeOptions: [10, 25, 50],
+          }}
           onChange={onTableChange}
           loading={isLoading}
-          noItemsMessage={i18n.translate('xpack.streams.sigEventsTab.emptyBody', {
-            defaultMessage: 'No significant events found.',
-          })}
           rowProps={(item) => ({
             onClick: () => setSelectedEvent(item),
-            css: css`
-              cursor: pointer;
-            `,
+            css: clickableRowCss,
           })}
+          noItemsMessage={isLoading ? LOADING_MESSAGE : EMPTY_MESSAGE}
         />
       </EuiFlexItem>
       {selectedEvent && (
-        <EntityDetailFlyout
-          title={selectedEvent.title}
-          entityId={selectedEvent.event_id}
-          details={flyoutDetails}
-          history={historyEntries}
-          isHistoryLoading={isHistoryLoading}
-          onClose={() => setSelectedEvent(undefined)}
-        />
+        <SigEventFlyout event={selectedEvent} onClose={() => setSelectedEvent(undefined)} />
       )}
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useDebouncedValue } from '@kbn/react-hooks';
 import {
   EuiBasicTable,
@@ -37,7 +37,6 @@ import {
   getVerdictColor,
   getImpactColor,
 } from './filter_constants';
-import type { Verdict, Impact } from './filter_constants';
 
 const MAX_VISIBLE_STREAMS = 3;
 
@@ -145,8 +144,8 @@ const columns: Array<EuiBasicTableColumn<SigEvent>> = [
   },
 ];
 
-const extractCheckedKeys = <T extends string>(options: EuiSelectableOption[]): T[] =>
-  options.filter((opt) => opt.checked === 'on').map((opt) => (opt.key ?? opt.label) as T);
+const extractCheckedKeys = (options: EuiSelectableOption[]): string[] =>
+  options.filter((opt) => opt.checked === 'on').map((opt) => opt.key ?? opt.label);
 
 const buildSelectableOptions = <T extends string>({
   values,
@@ -169,9 +168,9 @@ export const SigEventsTab = () => {
   const { updateTimeRange } = useTimeRangeUpdate();
   const { filteredStreams } = useKiGeneration();
 
-  const [verdictFilter, setVerdictFilter] = useState<Verdict[]>([]);
+  const [verdictFilter, setVerdictFilter] = useState<string[]>([]);
   const [streamFilter, setStreamFilter] = useState<string[]>([]);
-  const [impactFilter, setImpactFilter] = useState<Impact[]>([]);
+  const [impactFilter, setImpactFilter] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearch = useDebouncedValue(searchQuery, 300);
 
@@ -190,49 +189,72 @@ export const SigEventsTab = () => {
   });
   const [selectedEvent, setSelectedEvent] = useState<SigEvent | undefined>();
 
-  const filters = [
-    {
-      label: i18n.translate('xpack.streams.sigEventsTab.filter.verdict', {
-        defaultMessage: 'Verdict',
-      }),
-      ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.verdictAriaLabel', {
-        defaultMessage: 'Filter by verdict',
-      }),
-      options: buildSelectableOptions({ values: VERDICT_OPTIONS, selected: verdictFilter }),
-      numFilters: VERDICT_OPTIONS.length,
-      numActiveFilters: verdictFilter.length,
-      onChange: (opts: EuiSelectableOption[]) =>
-        setVerdictFilter(extractCheckedKeys<Verdict>(opts)),
-    },
-    {
-      label: i18n.translate('xpack.streams.sigEventsTab.filter.impact', {
-        defaultMessage: 'Impact',
-      }),
-      ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.impactAriaLabel', {
-        defaultMessage: 'Filter by impact',
-      }),
-      options: buildSelectableOptions({ values: IMPACT_OPTIONS, selected: impactFilter }),
-      numFilters: IMPACT_OPTIONS.length,
-      numActiveFilters: impactFilter.length,
-      onChange: (opts: EuiSelectableOption[]) => setImpactFilter(extractCheckedKeys<Impact>(opts)),
-    },
-    {
-      label: i18n.translate('xpack.streams.sigEventsTab.filter.stream', {
-        defaultMessage: 'Stream',
-      }),
-      ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.streamAriaLabel', {
-        defaultMessage: 'Filter by stream',
-      }),
-      options: buildSelectableOptions({
-        values: streamOptions,
-        selected: streamFilter,
-        getLabel: (s) => s,
-      }),
-      numFilters: streamOptions.length,
-      numActiveFilters: streamFilter.length,
-      onChange: (opts: EuiSelectableOption[]) => setStreamFilter(extractCheckedKeys(opts)),
-    },
-  ];
+  const onVerdictChange = useCallback(
+    (opts: EuiSelectableOption[]) => setVerdictFilter(extractCheckedKeys(opts)),
+    []
+  );
+  const onImpactChange = useCallback(
+    (opts: EuiSelectableOption[]) => setImpactFilter(extractCheckedKeys(opts)),
+    []
+  );
+  const onStreamChange = useCallback(
+    (opts: EuiSelectableOption[]) => setStreamFilter(extractCheckedKeys(opts)),
+    []
+  );
+
+  const filters = useMemo(
+    () => [
+      {
+        label: i18n.translate('xpack.streams.sigEventsTab.filter.verdict', {
+          defaultMessage: 'Verdict',
+        }),
+        ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.verdictAriaLabel', {
+          defaultMessage: 'Filter by verdict',
+        }),
+        options: buildSelectableOptions({ values: VERDICT_OPTIONS, selected: verdictFilter }),
+        numFilters: VERDICT_OPTIONS.length,
+        numActiveFilters: verdictFilter.length,
+        onChange: onVerdictChange,
+      },
+      {
+        label: i18n.translate('xpack.streams.sigEventsTab.filter.impact', {
+          defaultMessage: 'Impact',
+        }),
+        ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.impactAriaLabel', {
+          defaultMessage: 'Filter by impact',
+        }),
+        options: buildSelectableOptions({ values: IMPACT_OPTIONS, selected: impactFilter }),
+        numFilters: IMPACT_OPTIONS.length,
+        numActiveFilters: impactFilter.length,
+        onChange: onImpactChange,
+      },
+      {
+        label: i18n.translate('xpack.streams.sigEventsTab.filter.stream', {
+          defaultMessage: 'Stream',
+        }),
+        ariaLabel: i18n.translate('xpack.streams.sigEventsTab.filter.streamAriaLabel', {
+          defaultMessage: 'Filter by stream',
+        }),
+        options: buildSelectableOptions({
+          values: streamOptions,
+          selected: streamFilter,
+          getLabel: (s) => s,
+        }),
+        numFilters: streamOptions.length,
+        numActiveFilters: streamFilter.length,
+        onChange: onStreamChange,
+      },
+    ],
+    [
+      verdictFilter,
+      impactFilter,
+      streamFilter,
+      streamOptions,
+      onVerdictChange,
+      onImpactChange,
+      onStreamChange,
+    ]
+  );
 
   const onTableChange = ({ page }: { page?: { index: number; size: number } }) => {
     if (page) {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/lifecycle_timeline.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/lifecycle_timeline.tsx
@@ -118,7 +118,7 @@ function buildTimelineEntries(data: EventLifecycleResponse): TimelineEntry[] {
   }));
 
   const sortedEvents = [...data.events].sort(
-    (a, b) => Date.parse(a['@timestamp']) - Date.parse(b['@timestamp'])
+    (a, b) => (Date.parse(a['@timestamp']) || 0) - (Date.parse(b['@timestamp']) || 0)
   );
   const events: TimelineEntry[] = sortedEvents.map((event, idx) => ({
     type: 'event' as const,
@@ -128,7 +128,7 @@ function buildTimelineEntries(data: EventLifecycleResponse): TimelineEntry[] {
   }));
 
   return [...detections, ...discoveries, ...verdicts, ...events].sort(
-    (a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp)
+    (a, b) => (Date.parse(a.timestamp) || 0) - (Date.parse(b.timestamp) || 0)
   );
 }
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/lifecycle_timeline.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/lifecycle_timeline.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiTimelineItem,
+  EuiText,
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiEmptyPrompt,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { EventLifecycleResponse } from '@kbn/streams-schema';
+import { formatTimestamp } from '../../../../../util/formatters';
+
+type EntityType = 'detection' | 'discovery' | 'verdict' | 'event';
+
+interface TimelineEntry {
+  type: EntityType;
+  timestamp: string;
+  title: string;
+  description: string;
+}
+
+interface LifecycleTimelineProps {
+  data: EventLifecycleResponse | undefined;
+}
+
+const ENTITY_ICONS: Record<EntityType, string> = {
+  detection: 'bell',
+  discovery: 'inspect',
+  verdict: 'check',
+  event: 'documentEdit',
+};
+
+const ENTITY_COLORS: Record<EntityType, string> = {
+  detection: 'warning',
+  discovery: 'primary',
+  verdict: 'success',
+  event: 'accent',
+};
+
+const ENTITY_LABELS: Record<EntityType, string> = {
+  detection: i18n.translate('xpack.streams.lifecycle.detection', {
+    defaultMessage: 'Detection',
+  }),
+  discovery: i18n.translate('xpack.streams.lifecycle.discovery', {
+    defaultMessage: 'Discovery',
+  }),
+  verdict: i18n.translate('xpack.streams.lifecycle.verdict', {
+    defaultMessage: 'Verdict',
+  }),
+  event: i18n.translate('xpack.streams.lifecycle.event', {
+    defaultMessage: 'Event',
+  }),
+};
+
+const EVENT_CREATED_LABEL = i18n.translate('xpack.streams.lifecycle.eventCreated', {
+  defaultMessage: 'Event created',
+});
+
+const EVENT_UPDATED_LABEL = i18n.translate('xpack.streams.lifecycle.eventUpdated', {
+  defaultMessage: 'Event updated',
+});
+
+const buildDiscoveryDescription = (
+  discovery: EventLifecycleResponse['discoveries'][number]
+): string =>
+  i18n.translate('xpack.streams.lifecycle.discoveryDesc', {
+    defaultMessage: '{kind} · criticality {criticality}',
+    values: { kind: discovery.kind, criticality: discovery.criticality || '-' },
+  });
+
+const buildEventDescription = ({
+  event,
+  isFirst,
+}: {
+  event: EventLifecycleResponse['events'][number];
+  isFirst: boolean;
+}) =>
+  isFirst
+    ? event.title
+    : i18n.translate('xpack.streams.lifecycle.eventUpdatedDesc', {
+        defaultMessage: 'Verdict: {verdict}, Criticality: {criticality}',
+        values: {
+          verdict: event.verdict,
+          criticality: event.criticality ? String(event.criticality) : '-',
+        },
+      });
+
+function buildTimelineEntries(data: EventLifecycleResponse): TimelineEntry[] {
+  const detections: TimelineEntry[] = data.detections.map((detection) => ({
+    type: 'detection' as const,
+    timestamp: detection.detected_at,
+    title: detection.rule_name ?? '-',
+    description: [detection.stream_name, detection.change_point_type].filter(Boolean).join(' · '),
+  }));
+
+  const discoveries: TimelineEntry[] = data.discoveries.map((discovery) => ({
+    type: 'discovery' as const,
+    timestamp: discovery['@timestamp'],
+    title: discovery.title,
+    description: buildDiscoveryDescription(discovery),
+  }));
+
+  const verdicts: TimelineEntry[] = data.verdicts.map((verdict) => ({
+    type: 'verdict' as const,
+    timestamp: verdict['@timestamp'],
+    title: verdict.verdict,
+    description: verdict.verdict_summary,
+  }));
+
+  const sortedEvents = [...data.events].sort(
+    (a, b) => Date.parse(a['@timestamp']) - Date.parse(b['@timestamp'])
+  );
+  const events: TimelineEntry[] = sortedEvents.map((event, idx) => ({
+    type: 'event' as const,
+    timestamp: event['@timestamp'],
+    title: idx === 0 ? EVENT_CREATED_LABEL : EVENT_UPDATED_LABEL,
+    description: buildEventDescription({ event, isFirst: idx === 0 }),
+  }));
+
+  return [...detections, ...discoveries, ...verdicts, ...events].sort(
+    (a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp)
+  );
+}
+
+export const LifecycleTimeline = ({ data }: LifecycleTimelineProps) => {
+  const entries = data ? buildTimelineEntries(data) : [];
+
+  if (entries.length === 0) {
+    return (
+      <EuiEmptyPrompt
+        iconType="timeline"
+        titleSize="xs"
+        title={
+          <h3>
+            {i18n.translate('xpack.streams.lifecycle.emptyTitle', {
+              defaultMessage: 'No lifecycle data',
+            })}
+          </h3>
+        }
+        body={i18n.translate('xpack.streams.lifecycle.emptyBody', {
+          defaultMessage: 'No lifecycle chain could be reconstructed for this event.',
+        })}
+      />
+    );
+  }
+
+  return (
+    <>
+      {entries.map((entry, idx) => (
+        <EuiTimelineItem
+          key={`${entry.type}-${entry.timestamp}-${idx}`}
+          icon={ENTITY_ICONS[entry.type]}
+          iconAriaLabel={ENTITY_LABELS[entry.type]}
+          verticalAlign="top"
+        >
+          <EuiPanel paddingSize="s" color="plain" hasBorder>
+            <EuiText size="xs" color="subdued">
+              {formatTimestamp(entry.timestamp)}
+            </EuiText>
+            <EuiSpacer size="xs" />
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+              <EuiFlexItem grow={false}>
+                <EuiBadge color={ENTITY_COLORS[entry.type]}>{ENTITY_LABELS[entry.type]}</EuiBadge>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s">
+                  <strong>{entry.title}</strong>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            {entry.description && (
+              <>
+                <EuiSpacer size="xs" />
+                <EuiText size="xs" color="subdued">
+                  {entry.description}
+                </EuiText>
+              </>
+            )}
+          </EuiPanel>
+        </EuiTimelineItem>
+      ))}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/sig_event_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/sig_event_flyout.tsx
@@ -1,0 +1,260 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiHorizontalRule,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiText,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { SigEvent } from '@kbn/streams-schema';
+import { useFetchEventLifecycle } from '../../../../../hooks/sig_events/use_fetch_sig_events';
+import { LifecycleTimeline } from './lifecycle_timeline';
+import { getVerdictColor, getImpactColor } from './filter_constants';
+import { formatTimestamp } from '../../../../../util/formatters';
+
+const evidencePanelCss = css`
+  margin-bottom: 4px;
+`;
+
+const ROOT_CAUSE_TITLE = i18n.translate('xpack.streams.sigEventsTab.flyout.rootCause', {
+  defaultMessage: 'Root Cause',
+});
+const RECOMMENDATIONS_TITLE = i18n.translate('xpack.streams.sigEventsTab.flyout.recommendations', {
+  defaultMessage: 'Recommendations',
+});
+const CAUSE_KIS_TITLE = i18n.translate('xpack.streams.sigEventsTab.flyout.causeKis', {
+  defaultMessage: 'Cause KIs',
+});
+const STREAMS_TITLE = i18n.translate('xpack.streams.sigEventsTab.flyout.streams', {
+  defaultMessage: 'Streams',
+});
+const RULES_TITLE = i18n.translate('xpack.streams.sigEventsTab.flyout.rules', {
+  defaultMessage: 'Rules',
+});
+const LIFECYCLE_TITLE = i18n.translate('xpack.streams.sigEventsTab.flyout.lifecycleTitle', {
+  defaultMessage: 'Lifecycle',
+});
+const LIFECYCLE_ERROR = i18n.translate('xpack.streams.sigEventsTab.flyout.lifecycleError', {
+  defaultMessage: 'Failed to load lifecycle data',
+});
+const CLOSE_LABEL = i18n.translate('xpack.streams.sigEventsTab.flyout.close', {
+  defaultMessage: 'Close',
+});
+
+const BadgeRow = ({ items, color }: { items: string[]; color?: string }) => (
+  <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+    {items.map((item) => (
+      <EuiFlexItem grow={false} key={item}>
+        <EuiBadge color={color ?? 'default'}>{item}</EuiBadge>
+      </EuiFlexItem>
+    ))}
+  </EuiFlexGroup>
+);
+
+interface SigEventFlyoutProps {
+  event: SigEvent;
+  onClose: () => void;
+}
+
+export const SigEventFlyout = ({ event, onClose }: SigEventFlyoutProps) => {
+  const {
+    data: lifecycleData,
+    isLoading: isLifecycleLoading,
+    isError: isLifecycleError,
+  } = useFetchEventLifecycle(event.event_id);
+
+  const flyoutTitleId = useGeneratedHtmlId({ prefix: 'sigEventFlyout' });
+  const ruleNames = event.rule_names ?? [];
+
+  return (
+    <EuiFlyout onClose={onClose} size="m" aria-labelledby={flyoutTitleId}>
+      <EuiFlyoutHeader hasBorder>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color={getVerdictColor(event.verdict)}>{event.verdict}</EuiBadge>
+            </EuiFlexItem>
+            {event.impact && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color={getImpactColor(event.impact)}>{event.impact}</EuiBadge>
+              </EuiFlexItem>
+            )}
+            {event.recommended_action && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color={event.recommended_action === 'escalate' ? 'danger' : 'hollow'}>
+                  {event.recommended_action}
+                </EuiBadge>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+          <EuiTitle size="m">
+            <h2 id={flyoutTitleId}>{event.title}</h2>
+          </EuiTitle>
+          <EuiText size="xs" color="subdued">
+            {formatTimestamp(event['@timestamp'])}
+            {event.criticality != null && ` · Criticality: ${event.criticality}`}
+            {event.confidence != null && ` · Confidence: ${event.confidence}%`}
+          </EuiText>
+        </EuiFlexGroup>
+      </EuiFlyoutHeader>
+
+      <EuiFlyoutBody>
+        <EuiFlexGroup direction="column" gutterSize="m">
+          {event.summary && (
+            <EuiText size="s">
+              <p>{event.summary}</p>
+            </EuiText>
+          )}
+
+          {event.root_cause && (
+            <EuiFlexGroup direction="column" gutterSize="s">
+              <EuiTitle size="xs">
+                <h3>{ROOT_CAUSE_TITLE}</h3>
+              </EuiTitle>
+              <EuiPanel color="plain" hasBorder paddingSize="s">
+                <EuiText size="s">
+                  <p>{event.root_cause}</p>
+                </EuiText>
+              </EuiPanel>
+            </EuiFlexGroup>
+          )}
+
+          {event.recommendations && event.recommendations.length > 0 && (
+            <EuiFlexGroup direction="column" gutterSize="s">
+              <EuiTitle size="xs">
+                <h3>{RECOMMENDATIONS_TITLE}</h3>
+              </EuiTitle>
+              <EuiPanel color="subdued" paddingSize="s" hasBorder={false}>
+                <EuiText size="s">
+                  <ol>
+                    {event.recommendations.map((rec, idx) => (
+                      <li key={idx}>{rec}</li>
+                    ))}
+                  </ol>
+                </EuiText>
+              </EuiPanel>
+            </EuiFlexGroup>
+          )}
+
+          {event.evidences && event.evidences.length > 0 && (
+            <EuiFlexGroup direction="column" gutterSize="s">
+              <EuiTitle size="xs">
+                <h3>
+                  {i18n.translate('xpack.streams.sigEventsTab.flyout.evidence', {
+                    defaultMessage: 'Evidence ({count})',
+                    values: { count: event.evidences.length },
+                  })}
+                </h3>
+              </EuiTitle>
+              {event.evidences.map((ev, idx) => (
+                <EuiPanel key={idx} color="plain" hasBorder paddingSize="s" css={evidencePanelCss}>
+                  <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+                    {ev.rule_name && (
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="s">
+                          <strong>{ev.rule_name}</strong>
+                        </EuiText>
+                      </EuiFlexItem>
+                    )}
+                    {ev.stream_name && (
+                      <EuiFlexItem grow={false}>
+                        <EuiBadge color="hollow">{ev.stream_name}</EuiBadge>
+                      </EuiFlexItem>
+                    )}
+                    {ev.result && (
+                      <EuiFlexItem grow={false}>
+                        <EuiBadge color={ev.result === 'anomaly' ? 'warning' : 'hollow'}>
+                          {ev.result}
+                        </EuiBadge>
+                      </EuiFlexItem>
+                    )}
+                  </EuiFlexGroup>
+                  {ev.description && (
+                    <EuiText size="xs" color="subdued">
+                      {ev.description}
+                    </EuiText>
+                  )}
+                </EuiPanel>
+              ))}
+            </EuiFlexGroup>
+          )}
+
+          {event.cause_kis && event.cause_kis.length > 0 && (
+            <EuiFlexGroup direction="column" gutterSize="xs">
+              <EuiTitle size="xxs">
+                <h4>{CAUSE_KIS_TITLE}</h4>
+              </EuiTitle>
+              <BadgeRow
+                items={event.cause_kis.map(
+                  (ki) => `${ki.name || '-'}${ki.stream_name ? ` (${ki.stream_name})` : ''}`
+                )}
+              />
+            </EuiFlexGroup>
+          )}
+
+          <EuiHorizontalRule margin="none" />
+
+          <EuiFlexGroup direction="column" gutterSize="xs">
+            <EuiTitle size="xxs">
+              <h4>{STREAMS_TITLE}</h4>
+            </EuiTitle>
+            <BadgeRow items={event.stream_names ?? []} color="hollow" />
+          </EuiFlexGroup>
+
+          {ruleNames.length > 0 && (
+            <EuiFlexGroup direction="column" gutterSize="xs">
+              <EuiTitle size="xxs">
+                <h4>{RULES_TITLE}</h4>
+              </EuiTitle>
+              <BadgeRow items={ruleNames} />
+            </EuiFlexGroup>
+          )}
+
+          <EuiHorizontalRule margin="none" />
+
+          <EuiFlexGroup direction="column" gutterSize="s">
+            <EuiTitle size="xs">
+              <h3>{LIFECYCLE_TITLE}</h3>
+            </EuiTitle>
+            {isLifecycleLoading ? (
+              <EuiLoadingSpinner size="m" />
+            ) : isLifecycleError ? (
+              <EuiCallOut
+                announceOnMount
+                title={LIFECYCLE_ERROR}
+                color="danger"
+                iconType="error"
+                size="s"
+              />
+            ) : (
+              <LifecycleTimeline data={lifecycleData} />
+            )}
+          </EuiFlexGroup>
+        </EuiFlexGroup>
+      </EuiFlyoutBody>
+
+      <EuiFlyoutFooter>
+        <EuiButtonEmpty onClick={onClose}>{CLOSE_LABEL}</EuiButtonEmpty>
+      </EuiFlyoutFooter>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/sig_event_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/sig_event_flyout.tsx
@@ -29,7 +29,7 @@ import { i18n } from '@kbn/i18n';
 import type { SigEvent } from '@kbn/streams-schema';
 import { useFetchEventLifecycle } from '../../../../../hooks/sig_events/use_fetch_sig_events';
 import { LifecycleTimeline } from './lifecycle_timeline';
-import { getVerdictColor, getImpactColor } from './filter_constants';
+import { getVerdictColor } from './filter_constants';
 import { formatTimestamp } from '../../../../../util/formatters';
 
 const evidencePanelCss = css`
@@ -100,11 +100,6 @@ export const SigEventFlyout = ({ event, onClose }: SigEventFlyoutProps) => {
             <EuiFlexItem grow={false}>
               <EuiBadge color={getVerdictColor(event.verdict)}>{event.verdict}</EuiBadge>
             </EuiFlexItem>
-            {event.impact && (
-              <EuiFlexItem grow={false}>
-                <EuiBadge color={getImpactColor(event.impact)}>{event.impact}</EuiBadge>
-              </EuiFlexItem>
-            )}
             {event.recommended_action && (
               <EuiFlexItem grow={false}>
                 <EuiBadge color={event.recommended_action === 'escalate' ? 'danger' : 'hollow'}>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/sig_event_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/sig_events_tab/sig_event_flyout.tsx
@@ -17,6 +17,7 @@ import {
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiHorizontalRule,
+  EuiListGroup,
   EuiLoadingSpinner,
   EuiPanel,
   EuiText,
@@ -59,11 +60,17 @@ const LIFECYCLE_ERROR = i18n.translate('xpack.streams.sigEventsTab.flyout.lifecy
 const CLOSE_LABEL = i18n.translate('xpack.streams.sigEventsTab.flyout.close', {
   defaultMessage: 'Close',
 });
+const CRITICALITY_LABEL = i18n.translate('xpack.streams.sigEventsTab.flyout.criticalityLabel', {
+  defaultMessage: 'Criticality',
+});
+const CONFIDENCE_LABEL = i18n.translate('xpack.streams.sigEventsTab.flyout.confidenceLabel', {
+  defaultMessage: 'Confidence',
+});
 
 const BadgeRow = ({ items, color }: { items: string[]; color?: string }) => (
   <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
-    {items.map((item) => (
-      <EuiFlexItem grow={false} key={item}>
+    {items.map((item, idx) => (
+      <EuiFlexItem grow={false} key={`${item}-${idx}`}>
         <EuiBadge color={color ?? 'default'}>{item}</EuiBadge>
       </EuiFlexItem>
     ))}
@@ -111,8 +118,8 @@ export const SigEventFlyout = ({ event, onClose }: SigEventFlyoutProps) => {
           </EuiTitle>
           <EuiText size="xs" color="subdued">
             {formatTimestamp(event['@timestamp'])}
-            {event.criticality != null && ` · Criticality: ${event.criticality}`}
-            {event.confidence != null && ` · Confidence: ${event.confidence}%`}
+            {event.criticality != null && ` · ${CRITICALITY_LABEL}: ${event.criticality}`}
+            {event.confidence != null && ` · ${CONFIDENCE_LABEL}: ${event.confidence}%`}
           </EuiText>
         </EuiFlexGroup>
       </EuiFlyoutHeader>
@@ -144,13 +151,14 @@ export const SigEventFlyout = ({ event, onClose }: SigEventFlyoutProps) => {
                 <h3>{RECOMMENDATIONS_TITLE}</h3>
               </EuiTitle>
               <EuiPanel color="subdued" paddingSize="s" hasBorder={false}>
-                <EuiText size="s">
-                  <ol>
-                    {event.recommendations.map((rec, idx) => (
-                      <li key={idx}>{rec}</li>
-                    ))}
-                  </ol>
-                </EuiText>
+                <EuiListGroup
+                  listItems={event.recommendations.map((rec, idx) => ({
+                    label: `${idx + 1}. ${rec}`,
+                    size: 's' as const,
+                    wrapText: true,
+                  }))}
+                  bordered={false}
+                />
               </EuiPanel>
             </EuiFlexGroup>
           )}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/verdicts_tab/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/verdicts_tab/index.tsx
@@ -35,7 +35,6 @@ const columns: Array<EuiBasicTableColumn<Verdict>> = [
     name: i18n.translate('xpack.streams.verdictsTab.timestampColumn', {
       defaultMessage: 'Timestamp',
     }),
-    sortable: true,
     render: (timestamp: string) => formatTimestamp(timestamp),
   },
   {

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_fetch_sig_events.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_fetch_sig_events.ts
@@ -40,14 +40,9 @@ export const useFetchSigEvents = ({
 
   const [pagination, setPagination] = useState({ page: 1, perPage: 25 });
 
-  const verdictKey = verdict?.join(',') ?? '';
-  const streamKey = stream?.join(',') ?? '';
-  const impactKey = impact?.join(',') ?? '';
-  const searchKey = search ?? '';
-
   useEffect(() => {
     setPagination((prev) => (prev.page === 1 ? prev : { ...prev, page: 1 }));
-  }, [from, to, verdictKey, streamKey, impactKey, searchKey]);
+  }, [from, to, verdict, stream, impact, search]);
 
   const query = useQuery<PaginatedResponse<SigEvent>, Error>({
     queryKey: [
@@ -56,10 +51,10 @@ export const useFetchSigEvents = ({
       pagination.perPage,
       from,
       to,
-      verdictKey,
-      streamKey,
-      impactKey,
-      searchKey,
+      verdict,
+      stream,
+      impact,
+      search,
     ],
     queryFn: async ({ signal }: QueryFunctionContext): Promise<PaginatedResponse<SigEvent>> => {
       return streamsRepositoryClient.fetch('GET /internal/sig_events/events', {
@@ -72,7 +67,7 @@ export const useFetchSigEvents = ({
             ...(verdict?.length ? { verdict } : {}),
             ...(stream?.length ? { stream } : {}),
             ...(impact?.length ? { impact } : {}),
-            ...(searchKey ? { search: searchKey } : {}),
+            ...(search ? { search } : {}),
           },
         },
         signal: signal ?? null,

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_fetch_sig_events.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_fetch_sig_events.ts
@@ -17,7 +17,6 @@ interface UseFetchSigEventsParams {
   to: string | number;
   verdict?: string[];
   stream?: string[];
-  impact?: string[];
   search?: string;
 }
 
@@ -26,7 +25,6 @@ export const useFetchSigEvents = ({
   to,
   verdict,
   stream,
-  impact,
   search,
 }: UseFetchSigEventsParams) => {
   const {
@@ -42,20 +40,10 @@ export const useFetchSigEvents = ({
 
   useEffect(() => {
     setPagination((prev) => (prev.page === 1 ? prev : { ...prev, page: 1 }));
-  }, [from, to, verdict, stream, impact, search]);
+  }, [from, to, verdict, stream, search]);
 
   const query = useQuery<PaginatedResponse<SigEvent>, Error>({
-    queryKey: [
-      'sigEvents',
-      pagination.page,
-      pagination.perPage,
-      from,
-      to,
-      verdict,
-      stream,
-      impact,
-      search,
-    ],
+    queryKey: ['sigEvents', pagination.page, pagination.perPage, from, to, verdict, stream, search],
     queryFn: async ({ signal }: QueryFunctionContext): Promise<PaginatedResponse<SigEvent>> => {
       return streamsRepositoryClient.fetch('GET /internal/sig_events/events', {
         params: {
@@ -66,7 +54,6 @@ export const useFetchSigEvents = ({
             to: new Date(to).toISOString(),
             ...(verdict?.length ? { verdict } : {}),
             ...(stream?.length ? { stream } : {}),
-            ...(impact?.length ? { impact } : {}),
             ...(search ? { search } : {}),
           },
         },

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_fetch_sig_events.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_fetch_sig_events.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { type QueryFunctionContext, useQuery } from '@kbn/react-query';
-import type { SigEvent } from '@kbn/streams-schema';
+import type { SigEvent, EventLifecycleResponse } from '@kbn/streams-schema';
 import type { PaginatedResponse } from '@kbn/streams-plugin/common';
 import { useKibana } from '../use_kibana';
 import { useFetchErrorToast } from '../use_fetch_error_toast';
@@ -15,9 +15,20 @@ import { useFetchErrorToast } from '../use_fetch_error_toast';
 interface UseFetchSigEventsParams {
   from: string | number;
   to: string | number;
+  verdict?: string[];
+  stream?: string[];
+  impact?: string[];
+  search?: string;
 }
 
-export const useFetchSigEvents = ({ from, to }: UseFetchSigEventsParams) => {
+export const useFetchSigEvents = ({
+  from,
+  to,
+  verdict,
+  stream,
+  impact,
+  search,
+}: UseFetchSigEventsParams) => {
   const {
     dependencies: {
       start: {
@@ -29,12 +40,28 @@ export const useFetchSigEvents = ({ from, to }: UseFetchSigEventsParams) => {
 
   const [pagination, setPagination] = useState({ page: 1, perPage: 25 });
 
+  const verdictKey = verdict?.join(',') ?? '';
+  const streamKey = stream?.join(',') ?? '';
+  const impactKey = impact?.join(',') ?? '';
+  const searchKey = search ?? '';
+
   useEffect(() => {
     setPagination((prev) => (prev.page === 1 ? prev : { ...prev, page: 1 }));
-  }, [from, to]);
+  }, [from, to, verdictKey, streamKey, impactKey, searchKey]);
 
-  const fetchSigEvents = useCallback(
-    async ({ signal }: QueryFunctionContext): Promise<PaginatedResponse<SigEvent>> => {
+  const query = useQuery<PaginatedResponse<SigEvent>, Error>({
+    queryKey: [
+      'sigEvents',
+      pagination.page,
+      pagination.perPage,
+      from,
+      to,
+      verdictKey,
+      streamKey,
+      impactKey,
+      searchKey,
+    ],
+    queryFn: async ({ signal }: QueryFunctionContext): Promise<PaginatedResponse<SigEvent>> => {
       return streamsRepositoryClient.fetch('GET /internal/sig_events/events', {
         params: {
           query: {
@@ -42,24 +69,22 @@ export const useFetchSigEvents = ({ from, to }: UseFetchSigEventsParams) => {
             perPage: pagination.perPage,
             from: new Date(from).toISOString(),
             to: new Date(to).toISOString(),
+            ...(verdict?.length ? { verdict } : {}),
+            ...(stream?.length ? { stream } : {}),
+            ...(impact?.length ? { impact } : {}),
+            ...(searchKey ? { search: searchKey } : {}),
           },
         },
         signal: signal ?? null,
       });
     },
-    [streamsRepositoryClient, pagination, from, to]
-  );
-
-  const query = useQuery<PaginatedResponse<SigEvent>, Error>({
-    queryKey: ['sigEvents', pagination.page, pagination.perPage, from, to],
-    queryFn: fetchSigEvents,
     onError: showFetchErrorToast,
   });
 
   return { ...query, pagination, setPagination };
 };
 
-export const useFetchSigEventHistory = (eventId: string | undefined) => {
+export const useFetchEventLifecycle = (eventId: string | undefined) => {
   const {
     dependencies: {
       start: {
@@ -69,10 +94,10 @@ export const useFetchSigEventHistory = (eventId: string | undefined) => {
   } = useKibana();
   const showFetchErrorToast = useFetchErrorToast();
 
-  return useQuery<{ hits: SigEvent[] }, Error>({
-    queryKey: ['sigEventHistory', eventId],
+  return useQuery<EventLifecycleResponse, Error>({
+    queryKey: ['sigEventLifecycle', eventId],
     queryFn: async ({ signal }) => {
-      return streamsRepositoryClient.fetch('GET /internal/sig_events/events/{id}/history', {
+      return streamsRepositoryClient.fetch('GET /internal/sig_events/events/{id}/lifecycle', {
         params: { path: { id: eventId! } },
         signal: signal ?? null,
       });

--- a/x-pack/platform/plugins/shared/streams_app/public/util/formatters.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/util/formatters.ts
@@ -16,12 +16,13 @@ export function getPercentageFormatter(opts?: { precision: number }): Intl.Numbe
 
 export function formatTimestamp(value: string | number): string {
   const date = new Date(value);
-  const formattedDate = date.toLocaleDateString('en-US', {
+  const locale = i18n.getLocale();
+  const formattedDate = date.toLocaleDateString(locale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
   });
-  const formattedTime = date.toLocaleTimeString('en-US', {
+  const formattedTime = date.toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',


### PR DESCRIPTION
## Summary

Adds an event lifecycle endpoint and timeline UI so users can trace the full chain of detections → discoveries → verdicts → event versions when clicking a significant event. Also introduces search and filter controls on the events tab.

### Lifecycle
- New `GET /internal/sig_events/events/{id}/lifecycle` endpoint that walks the event chain via `previous_event_id`, collects related discoveries and verdicts in parallel, and deduplicates detections
- Flyout with event details, root cause, recommendations, evidences, and a chronological lifecycle timeline

### Filters & search
- Added verdict, impact, and stream filter popovers to the events tab
- Added debounced text search
- Route accepts array-based query params for multi-select filters

https://github.com/user-attachments/assets/2a11830b-f726-45b2-b110-10810ccf63cf
