### PR TITLE
use more granular permissions

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/connectors/agent_connectors.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/connectors/agent_connectors.test.tsx
@@ -124,7 +124,13 @@ describe('AgentConnectors', () => {
       unassign: jest.fn(),
     });
 
-    useHasConnectorsAllPrivileges.mockReturnValue(true);
+    useHasConnectorsAllPrivileges.mockReturnValue({
+      hasAllPrivileges: true,
+      canShow: true,
+      canExecute: true,
+      canSave: true,
+      canDelete: true,
+    });
 
     useConnectorsActions.mockReturnValue({ openCreateFlyout });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/connectors/agent_connectors.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/connectors/agent_connectors.tsx
@@ -48,8 +48,10 @@ export const AgentConnectors = ({ agentId }: AgentConnectorsProps) => {
   const { actionTypeRegistry } = useKibana().services.plugins.triggersActionsUi;
   const agentQuery = useAgentBuilderAgentById(agentId);
   const { openCreateFlyout } = useConnectorsActions();
-  const hasAllPrivileges = useHasConnectorsAllPrivileges();
+  const { canShow, canExecute, canSave } = useHasConnectorsAllPrivileges();
   const canEditAgent = useCanEditAgent({ agent: agentQuery.agent ?? null });
+  const canAddFromLibrary = canEditAgent && canShow && canExecute;
+  const canCreateNew = canEditAgent && canSave;
 
   const [isAddMenuOpen, setIsAddMenuOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -164,7 +166,7 @@ export const AgentConnectors = ({ agentId }: AgentConnectorsProps) => {
                       </a>
                     </EuiText>
                   </EuiFlexItem>
-                  {hasAllPrivileges && canEditAgent && (
+                  {(canAddFromLibrary || canCreateNew) && (
                     <EuiFlexItem grow={false}>
                       <EuiPopover
                         aria-label={labels.connectors.addConnectorPopoverLabel}
@@ -189,7 +191,7 @@ export const AgentConnectors = ({ agentId }: AgentConnectorsProps) => {
                             <EuiContextMenuItem
                               key="from-library"
                               icon="importAction"
-                              disabled={isAddDisabled}
+                              disabled={isAddDisabled || !canAddFromLibrary}
                               onClick={() => {
                                 setIsAddMenuOpen(false);
                                 openLibrary();
@@ -200,6 +202,7 @@ export const AgentConnectors = ({ agentId }: AgentConnectorsProps) => {
                             <EuiContextMenuItem
                               key="create-new"
                               icon="plusInCircle"
+                              disabled={!canCreateNew}
                               onClick={() => {
                                 setIsAddMenuOpen(false);
                                 openCreateFlyout();

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/connectors.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/connectors.tsx
@@ -17,7 +17,7 @@ import { useHasConnectorsAllPrivileges } from '../../hooks/use_has_connectors_al
 
 export const AgentBuilderConnectors = () => {
   const { openCreateFlyout } = useConnectorsActions();
-  const hasAllPrivileges = useHasConnectorsAllPrivileges();
+  const { hasAllPrivileges } = useHasConnectorsAllPrivileges();
 
   return (
     <KibanaPageTemplate data-test-subj="agentBuilderConnectorsPage">

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/more_actions_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/more_actions_button.tsx
@@ -91,7 +91,7 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onCloseSid
   const {
     services: { application, plugins },
   } = useKibana();
-  const hasAccessToGenAiSettings = useHasConnectorsAllPrivileges();
+  const { hasAllPrivileges: hasAccessToGenAiSettings } = useHasConnectorsAllPrivileges();
 
   const getAddToDatasetAction = plugins.evals?.getAddToDatasetAction;
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_has_connectors_all_privileges.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_has_connectors_all_privileges.ts
@@ -17,11 +17,16 @@ export const useHasConnectorsAllPrivileges = () => {
   const { services } = useKibana();
   const { application } = services;
 
-  const hasConnectorsAllPrivilege =
-    application.capabilities.actions?.show === true &&
-    application.capabilities.actions?.execute === true &&
-    application.capabilities.actions?.delete === true &&
-    application.capabilities.actions?.save === true;
+  const canShow = application.capabilities.actions?.show === true;
+  const canExecute = application.capabilities.actions?.execute === true;
+  const canSave = application.capabilities.actions?.save === true;
+  const canDelete = application.capabilities.actions?.delete === true;
 
-  return hasConnectorsAllPrivilege;
+  return {
+    hasAllPrivileges: canShow && canExecute && canDelete && canSave,
+    canShow,
+    canExecute,
+    canSave,
+    canDelete,
+  };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/embeddable/embeddable_welcome_message.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/embeddable/embeddable_welcome_message.tsx
@@ -22,7 +22,7 @@ export const EmbeddableWelcomeMessage = () => {
   } = useKibana();
   const { euiTheme } = useEuiTheme();
   const { docLinksService } = useAgentBuilderServices();
-  const hasAccessToGenAiSettings = useHasConnectorsAllPrivileges();
+  const { hasAllPrivileges: hasAccessToGenAiSettings } = useHasConnectorsAllPrivileges();
 
   const [showCallOut, setShowCallOut] = useState(
     !localStorage.getItem(storageKeys.welcomeMessageDismissed)


### PR DESCRIPTION
## Summary

- The "Add connector" button required all connector privileges (show + execute + save + delete).
- The Assign from Library button ... <todo: add entire description with image>

Fix: Gate each action on what it actually needs — show + execute for "From library", save for "Create new".