### PR TITLE
Update EUI to v116.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@elastic/elasticsearch": "9.4.0",
     "@elastic/ems-client": "8.7.0",
     "@elastic/esql": "4.2.0",
-    "@elastic/eui": "116.1.0",
+    "@elastic/eui": "116.2.0",
     "@elastic/eui-theme-borealis": "8.0.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/kibana-d3-color": "npm:@elastic/kibana-d3-color@2.0.1",

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -18,7 +18,7 @@
 @elastic/esql@4.2.0
 @elastic/eui-theme-borealis@8.0.0
 @elastic/eui-theme-common@10.0.0
-@elastic/eui@116.1.0
+@elastic/eui@116.2.0
 @elastic/numeral@2.5.1
 @elastic/prismjs-esql@1.1.2
 @emotion/babel-plugin@11.13.5
@@ -508,7 +508,6 @@ util@0.12.5
 utility-types@3.11.0
 uuid@11.1.0
 uuid@14.0.0
-uuid@8.3.2
 value-equal@0.4.0
 vfile-location@3.0.1
 vfile-message@2.0.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,10 +2331,10 @@
     chroma-js "^2.4.2"
     lodash "^4.17.21"
 
-"@elastic/eui@116.1.0":
-  version "116.1.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-116.1.0.tgz#e6071970bc6d488962514d427cbce066e79fbe7d"
-  integrity sha512-zhEODZxdKU8xP6itESAkhrj/8t8dyWxUON4DOF5+zOav5QtM6HdFidjMsSi2Xk0ByytTfAEKmlUuzSTJm2OpSA==
+"@elastic/eui@116.2.0":
+  version "116.2.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-116.2.0.tgz#53971013b96ebd10798f73e1430cde9f019d1fe8"
+  integrity sha512-yGyAbRhAp/35Mvk2ael228h9BVEfKTEgvSdDerfKUMUCnw9cSebPS1c8wK9dLnRt6DV1OMbgGyCObRR1sXToYQ==
   dependencies:
     "@elastic/eui-theme-common" "10.0.0"
     "@elastic/prismjs-esql" "^1.1.2"
@@ -2370,7 +2370,7 @@
     unist-util-visit "^2.0.3"
     url-parse "^1.5.10"
     use-sync-external-store "^1.6.0"
-    uuid "^8.3.0"
+    uuid "^14.0.0"
     vfile "^4.2.1"
 
 "@elastic/filesaver@1.1.2":
@@ -35897,7 +35897,7 @@ uuid@^14.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
-uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
## Dependency updates

- `@elastic/eui` - v116.1.0 ⏩ v116.2.0

---

## Package updates

### @elastic/eui [`v116.2.0`](https://github.com/elastic/eui/blob/main/packages/eui/changelogs/CHANGELOG_2026.md)

- Added experimental support for always-visible sticky horizontal scrollbars in `EuiTable`, `EuiBasicTable` and `EuiInMemoryTable` useful for dense tables that exceed the height of the viewport. This feature is currently opt-in and can be enabled by setting `stickyScrollbar: true`. ([#9674](https://github.com/elastic/eui/pull/9674))
- Added `significantEvents` glyph to `EuiIcon` ([#9665](https://github.com/elastic/eui/pull/9665))

**Bug fixes**

- Fixed `EuiDataGrid` incorrectly styling disabled `cellActions` icon buttons and making them look like they were not disabled ([#9672](https://github.com/elastic/eui/pull/9672))
- Fixed a visual misalignment on `EuiSelectableTemplateSitewide` list items when search terms are highlighted ([#9669](https://github.com/elastic/eui/pull/9669))

**Dependency updates**

- Updated `uuid` to v14.0.0 ([#9663](https://github.com/elastic/eui/pull/9663))