### PR TITLE
[Fleet] Don't try to invalidate remote API keys

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.test.ts
@@ -15,6 +15,8 @@ import { appContextService } from '../app_context';
 
 import { createAppContextStartContractMock } from '../../mocks';
 
+import { outputService } from '../output';
+
 import type { Agent } from '../../types';
 
 import { SO_SEARCH_LIMIT } from '../../constants';
@@ -336,9 +338,19 @@ describe('unenroll', () => {
   });
 
   describe('invalidateAPIKeysForAgents', () => {
+    let mockOutputServiceGet: jest.SpyInstance;
+
     beforeEach(() => {
       mockedInvalidateAPIKeys.mockReset();
+      mockOutputServiceGet = jest
+        .spyOn(outputService, 'get')
+        .mockResolvedValue({ type: 'elasticsearch' } as any);
     });
+
+    afterEach(() => {
+      mockOutputServiceGet.mockRestore();
+    });
+
     it('revoke all the agents API keys', async () => {
       await invalidateAPIKeysForAgents([
         {
@@ -384,6 +396,46 @@ describe('unenroll', () => {
         'outputApiKey2',
         'outputApiKey3',
       ]);
+    });
+
+    it('excludes remote output keys from invalidateAPIKeys', async () => {
+      mockOutputServiceGet.mockImplementation(async (id: string) => {
+        if (id === 'remoteOutput1') return { type: 'remote_elasticsearch' } as any;
+        return { type: 'elasticsearch' } as any;
+      });
+
+      await invalidateAPIKeysForAgents([
+        {
+          id: 'agent1',
+          access_api_key_id: 'accessApiKey1',
+          outputs: {
+            localOutput1: {
+              api_key_id: 'localOutputApiKey1',
+            },
+            remoteOutput1: {
+              api_key_id: 'remoteApiKey1',
+              to_retire_api_key_ids: [{ id: 'remoteRetireKey1' }],
+            },
+          },
+        } as any,
+      ]);
+
+      expect(mockedInvalidateAPIKeys).toBeCalledWith(['accessApiKey1', 'localOutputApiKey1']);
+    });
+
+    it('treats output as local when outputService.get throws', async () => {
+      mockOutputServiceGet.mockRejectedValue(new Error('output not found'));
+
+      await invalidateAPIKeysForAgents([
+        {
+          id: 'agent1',
+          outputs: {
+            output1: { api_key_id: 'outputApiKey1' },
+          },
+        } as any,
+      ]);
+
+      expect(mockedInvalidateAPIKeys).toBeCalledWith(['outputApiKey1']);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll_action_runner.ts
@@ -15,9 +15,12 @@ import type { Agent } from '../../types';
 
 import { FleetError, HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 
+import { outputType } from '../../../common/constants';
+
 import { invalidateAPIKeys } from '../api_keys';
 
 import { appContextService } from '../app_context';
+import { outputService } from '../output';
 
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
@@ -215,34 +218,67 @@ async function getAgentsWithoutActionResults(
 }
 
 export async function invalidateAPIKeysForAgents(agents: Agent[]) {
-  const apiKeys = agents.reduce<string[]>((keys, agent) => {
+  // Identify which output IDs are remote ES so their keys are not sent to the
+  // local cluster's invalidation API.
+  // Remote output keys are handled by Fleet Server using its own service-account
+  // credentials. Kibana cannot do this directly because the service token is
+  // stored in Fleet secrets, readable only by Fleet Server.
+  const allOutputIds = new Set<string>();
+  for (const agent of agents) {
+    if (agent.outputs) {
+      for (const outputId of Object.keys(agent.outputs)) {
+        allOutputIds.add(outputId);
+      }
+    }
+  }
+
+  const remoteOutputIds = new Set<string>();
+  await Promise.all(
+    [...allOutputIds].map(async (outputId) => {
+      try {
+        const output = await outputService.get(outputId);
+        if (output.type === outputType.RemoteElasticsearch) {
+          remoteOutputIds.add(outputId);
+        }
+      } catch {
+        // Output was deleted or not found, do nothing.
+      }
+    })
+  );
+
+  const localKeys: string[] = [];
+
+  for (const agent of agents) {
     if (agent.access_api_key_id) {
-      keys.push(agent.access_api_key_id);
+      localKeys.push(agent.access_api_key_id);
     }
     if (agent.default_api_key_id) {
-      keys.push(agent.default_api_key_id);
+      localKeys.push(agent.default_api_key_id);
     }
     if (agent.default_api_key_history) {
-      agent.default_api_key_history.forEach((apiKey) => keys.push(apiKey.id));
+      agent.default_api_key_history.forEach((apiKey) => localKeys.push(apiKey.id));
     }
     if (agent.outputs) {
-      Object.values(agent.outputs).forEach((output) => {
-        if (output.api_key_id) {
-          keys.push(output.api_key_id);
+      for (const [outputId, outputEntry] of Object.entries(agent.outputs)) {
+        if (remoteOutputIds.has(outputId)) {
+          appContextService
+            .getLogger()
+            .debug(`Skipping local API key invalidation for remote output ${outputId}`);
+          continue;
         }
-        if (output.to_retire_api_key_ids) {
-          Object.values(output.to_retire_api_key_ids).forEach((apiKey) => {
-            if (apiKey?.id) {
-              keys.push(apiKey.id);
-            }
+        if (outputEntry.api_key_id) {
+          localKeys.push(outputEntry.api_key_id);
+        }
+        if (outputEntry.to_retire_api_key_ids) {
+          outputEntry.to_retire_api_key_ids.forEach((apiKey) => {
+            if (apiKey?.id) localKeys.push(apiKey.id);
           });
         }
-      });
+      }
     }
-    return keys;
-  }, []);
+  }
 
-  if (apiKeys.length) {
-    await invalidateAPIKeys(apiKeys);
+  if (localKeys.length) {
+    await invalidateAPIKeys(localKeys);
   }
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/258498

After more investigation, API keys used by Elastic Agents running a policy with a remote ES output (these API keys live on the remote cluster and cannot be invalidated by Kibana) should normally correctly be invalidated by Fleet Server. This PR only adds a small improvement to exclude these API keys from the batch to invalidate.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Negligible, output not found exception is silenced.