### PR TITLE
[kbn-code-owners] Add `elastic/observability-bi` team under Observability area

### DIFF
--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -64,6 +64,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-onboarding-team',
     'elastic/obs-presentation-team',
     'elastic/obs-ux-management-team',
+    'elastic/observability-bi',
     'elastic/observability-design',
     'elastic/observability-ui',
     'elastic/obs-sig-events-team',


### PR DESCRIPTION
This PR adds the `elastic/observability-bi` to the `observability` code owner <> area mapping. Adding the team here ensures their tests are correctly attributed to the observability area by our Scout Reporter.