### PR TITLE
[9.3] [Fleet] Normalize endpoint package policy input ids (#271269)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -1738,6 +1738,88 @@ describe('Agent policy', () => {
         ]
       );
     });
+
+    it('should remove copied endpoint package policy input ids before bulk create', async () => {
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
+      soClient = createSavedObjectClientMock();
+      const mockPolicy = {
+        type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+        references: [],
+        attributes: { revision: 1, package_policies: ['package-1'] } as any,
+      };
+      soClient.bulkGet.mockImplementation(async (objects) => {
+        return {
+          saved_objects: objects.map(({ id }) => {
+            return {
+              id,
+              ...mockPolicy,
+            };
+          }),
+        };
+      });
+      soClient.create.mockImplementation(async (type, attributes) => {
+        return {
+          attributes: attributes as unknown as NewAgentPolicy,
+          id: 'mocked',
+          type: 'mocked',
+          references: [],
+        };
+      });
+      const packagePolicies = [
+        {
+          id: 'package-1',
+          name: 'endpoint-1',
+          policy_id: 'policy_1',
+          policy_ids: ['policy_1'],
+          package: {
+            name: 'endpoint',
+            title: 'Elastic Endpoint',
+            version: '1.0.0',
+          },
+          inputs: [
+            {
+              id: 'stale-input-id',
+              type: 'endpoint',
+              enabled: true,
+              streams: [
+                {
+                  id: 'stale-stream-id',
+                  enabled: true,
+                  data_stream: { type: 'logs', dataset: 'endpoint.events' },
+                },
+              ],
+            },
+          ],
+        },
+      ] as any;
+      mockedPackagePolicyService.findAllForAgentPolicy.mockReturnValue(packagePolicies);
+      mockedPackagePolicyService.list.mockResolvedValue({ items: packagePolicies } as any);
+
+      await agentPolicyService.copy(soClient, esClient, 'mocked', {
+        name: 'copy mocked',
+      });
+
+      const copiedPackagePolicies = mockedPackagePolicyService.bulkCreate.mock.calls[0][2];
+
+      expect(copiedPackagePolicies[0].inputs).toEqual([
+        {
+          type: 'endpoint',
+          enabled: true,
+          streams: [
+            {
+              enabled: true,
+              data_stream: { type: 'logs', dataset: 'endpoint.events' },
+            },
+          ],
+        },
+      ]);
+      expect(copiedPackagePolicies[0]).toEqual(
+        expect.objectContaining({
+          name: 'endpoint-1 (copy)',
+          policy_ids: ['mocked'],
+        })
+      );
+    });
   });
 
   describe('deployPolicy', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/get_input_with_ids.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/get_input_with_ids.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { FLEET_ENDPOINT_PACKAGE } from '../../../common/constants/epm';
+
 import { getInputsWithIds } from './get_input_with_ids';
 
 describe('getInputsWithIds', () => {
@@ -89,5 +91,141 @@ describe('getInputsWithIds', () => {
     expect(inputs[0].id).toBe('existing-input-id');
     expect(inputs[0].streams[0].id).toBe('existing-input-id-1');
     expect(inputs[0].streams[1].id).toBe('existing-input-id-2');
+  });
+
+  it('should force endpoint input id to the package policy id when already present', () => {
+    const inputs = getInputsWithIds(
+      {
+        name: 'endpoint-policy',
+        namespace: 'default',
+        policy_ids: ['policy1'],
+        package: {
+          name: FLEET_ENDPOINT_PACKAGE,
+          title: 'Elastic Defend',
+          version: '1.0.0',
+        },
+        enabled: true,
+        inputs: [
+          {
+            id: 'stale-input-id',
+            type: 'endpoint',
+            enabled: true,
+            streams: [
+              {
+                id: 'existing-stream-id',
+                enabled: true,
+                data_stream: { type: 'logs', dataset: 'endpoint.events' },
+              },
+            ],
+          },
+        ],
+      },
+      'endpoint-package-policy-id',
+      false,
+      {
+        name: FLEET_ENDPOINT_PACKAGE,
+        title: 'Elastic Defend',
+        version: '1.0.0',
+        policy_templates: [],
+      } as any
+    );
+
+    expect(inputs[0].id).toBe('endpoint-package-policy-id');
+    expect(inputs[0].streams[0].id).toBe('existing-stream-id');
+  });
+
+  it('should force endpoint input id using package policy package name when package info is unavailable', () => {
+    const inputs = getInputsWithIds(
+      {
+        name: 'endpoint-policy',
+        namespace: 'default',
+        policy_ids: ['policy1'],
+        package: {
+          name: FLEET_ENDPOINT_PACKAGE,
+          title: 'Elastic Defend',
+          version: '1.0.0',
+        },
+        enabled: true,
+        inputs: [
+          {
+            id: 'stale-input-id',
+            type: 'endpoint',
+            enabled: true,
+            streams: [],
+          },
+        ],
+      },
+      'endpoint-package-policy-id'
+    );
+
+    expect(inputs[0].id).toBe('endpoint-package-policy-id');
+  });
+
+  it('should use default endpoint template input id when package policy id is unavailable', () => {
+    const inputs = getInputsWithIds(
+      {
+        name: 'endpoint-policy',
+        namespace: 'default',
+        policy_ids: ['policy1'],
+        package: {
+          name: FLEET_ENDPOINT_PACKAGE,
+          title: 'Elastic Defend',
+          version: '1.0.0',
+        },
+        enabled: true,
+        inputs: [
+          {
+            type: 'endpoint',
+            enabled: true,
+            streams: [],
+          },
+        ],
+      },
+      undefined,
+      false,
+      {
+        name: FLEET_ENDPOINT_PACKAGE,
+        title: 'Elastic Defend',
+        version: '1.0.0',
+        policy_templates: [],
+      } as any
+    );
+
+    expect(inputs[0].id).toBe('default');
+  });
+
+  it('should fall back to type when name is not present', () => {
+    const inputs = getInputsWithIds(
+      {
+        name: 'test-policy',
+        namespace: 'default',
+        policy_ids: ['policy1'],
+        package: { name: 'test-package', title: 'Test Package', version: '1.0.0' },
+        enabled: true,
+        inputs: [
+          {
+            type: 'logfile',
+            enabled: true,
+            streams: [
+              {
+                enabled: true,
+                data_stream: { type: 'logs', dataset: 'test-dataset' },
+              },
+            ],
+          },
+        ],
+      },
+      'policy123',
+      false,
+      {
+        name: 'test-package',
+        title: 'Test Package',
+        version: '1.0.0',
+        policy_templates: [],
+      } as any
+    );
+
+    expect(inputs[0].id).toBe('logfile-policy123');
+    expect(inputs[0].streams[0].id).toBe('logfile-test-dataset-policy123');
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/get_input_with_ids.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/get_input_with_ids.ts
@@ -7,6 +7,7 @@
 
 import type { NewPackagePolicy, PackageInfo, PackagePolicy } from '../../types';
 import { getInputId } from '../agent_policies/package_policies_to_agent_inputs';
+import { FLEET_ENDPOINT_PACKAGE } from '../../../common/constants/epm';
 
 /**
  * Populate the ids for inputs and streams of a package policy if they are not already set
@@ -20,8 +21,16 @@ export function getInputsWithIds(
   allEnabled?: boolean,
   packageInfo?: PackageInfo
 ): PackagePolicy['inputs'] {
+  const packageName = packageInfo?.name ?? packagePolicy.package?.name;
+  const isEndpointPackage = packageName === FLEET_ENDPOINT_PACKAGE;
+
   return packagePolicy.inputs.map((input) => {
-    const inputId = input.id ? input.id : getInputId(input, packagePolicyId, packageInfo);
+    const inputId =
+      isEndpointPackage && packagePolicyId
+        ? packagePolicyId
+        : input.id
+        ? input.id
+        : getInputId(input, packagePolicyId, packageInfo);
 
     return {
       ...input,

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -321,6 +321,24 @@ const mockAgentPolicyGet = (spaceIds: string[] = ['default'], additionalProps?: 
   );
 };
 
+const createEndpointPackagePolicyWithInputId = (
+  packagePolicyId: string,
+  inputId: string
+): PackagePolicy => {
+  const packagePolicy = createPackagePolicyMock();
+
+  return {
+    ...packagePolicy,
+    id: packagePolicyId,
+    inputs: [
+      {
+        ...packagePolicy.inputs[0],
+        id: inputId,
+      },
+    ],
+  };
+};
+
 describe('Package policy service', () => {
   beforeEach(() => {
     appContextService.start(createAppContextStartContractMock());
@@ -2906,6 +2924,72 @@ describe('Package policy service', () => {
       expect(result.name).toEqual('test');
     });
 
+    it('should normalize endpoint input id to the package policy id without endpoint callbacks', async () => {
+      const savedObjectsClient = createSavedObjectClientMock();
+      const packagePolicyId = 'endpoint-package-policy-id';
+      const mockPackagePolicy = createEndpointPackagePolicyWithInputId(
+        packagePolicyId,
+        'stale-input-id'
+      );
+
+      savedObjectsClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: packagePolicyId,
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            references: [],
+            version: 'test',
+            attributes: mockPackagePolicy,
+          },
+        ],
+      });
+
+      savedObjectsClient.update.mockImplementation(
+        async (
+          type: string,
+          id: string,
+          attrs: any
+        ): Promise<SavedObjectsUpdateResponse<PackagePolicySOAttributes>> => {
+          savedObjectsClient.bulkGet.mockResolvedValue({
+            saved_objects: [
+              {
+                id,
+                type,
+                references: [],
+                version: 'test',
+                attributes: attrs,
+              },
+            ],
+          });
+          return {
+            id,
+            type,
+            references: [],
+            attributes: attrs,
+          };
+        }
+      );
+
+      const elasticsearchClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      const result = await packagePolicyService.update(
+        savedObjectsClient,
+        elasticsearchClient,
+        packagePolicyId,
+        mockPackagePolicy
+      );
+
+      expect(result.inputs[0].id).toBe(packagePolicyId);
+      expect(savedObjectsClient.update).toHaveBeenCalledWith(
+        LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+        packagePolicyId,
+        expect.objectContaining({
+          inputs: [expect.objectContaining({ id: packagePolicyId })],
+        }),
+        expect.anything()
+      );
+    });
+
     it('should call audit logger', async () => {
       const soClient = createSavedObjectClientMock();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
@@ -3820,6 +3904,72 @@ describe('Package policy service', () => {
       );
 
       expect(updatedPolicies![0].name).toEqual('test');
+    });
+
+    it('should normalize endpoint input id to the package policy id during bulk update', async () => {
+      mockAgentPolicyGet();
+
+      const savedObjectsClient = createSavedObjectClientMock();
+      const packagePolicyId = 'endpoint-package-policy-id';
+      const mockPackagePolicy = createEndpointPackagePolicyWithInputId(
+        packagePolicyId,
+        'stale-input-id'
+      );
+
+      savedObjectsClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: packagePolicyId,
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            references: [],
+            version: 'test',
+            attributes: mockPackagePolicy,
+          },
+        ],
+      });
+
+      savedObjectsClient.bulkUpdate.mockImplementation(
+        async (
+          objs: Array<{
+            type: string;
+            id: string;
+            attributes: any;
+          }>
+        ) => {
+          const newObjs = objs.map((obj) => ({
+            id: obj.id,
+            type: obj.type,
+            references: [],
+            version: 'test',
+            attributes: obj.attributes,
+          }));
+          savedObjectsClient.bulkGet.mockResolvedValue({
+            saved_objects: newObjs,
+          });
+          return {
+            saved_objects: newObjs,
+          };
+        }
+      );
+
+      const elasticsearchClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      const { failedPolicies, updatedPolicies } = await packagePolicyService.bulkUpdate(
+        savedObjectsClient,
+        elasticsearchClient,
+        [mockPackagePolicy]
+      );
+
+      expect(failedPolicies).toHaveLength(0);
+      expect(updatedPolicies![0].inputs[0].id).toBe(packagePolicyId);
+      expect(savedObjectsClient.bulkUpdate).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: packagePolicyId,
+          attributes: expect.objectContaining({
+            inputs: [expect.objectContaining({ id: packagePolicyId })],
+          }),
+        }),
+      ]);
     });
 
     it('should send telemetry event when upgrading a package policy', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Fleet] Normalize endpoint package policy input ids (#271269)](https://github.com/elastic/kibana/pull/271269)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joey F. Poon","email":"joey.poon@elastic.co"},"sourceCommit":{"committedDate":"2026-05-27T09:12:10Z","message":"[Fleet] Normalize endpoint package policy input ids (#271269)\n\n## Summary\n\nEnsure Elastic Defend package policy inputs use the package policy id\neven when input ids are supplied as Defend code depends on input id\nmatching the package policy id. Maintains existing behavior for\nnon-Defend packages.\n\nI investigated using extension points to help enforce Defend package\ninput id behavior but decided against it since the scope of the changes\nseemed to greatly outweigh the scale of the issue. Instead, I opted to\nadd more unit tests to mitigate accidental bypass of the explicit Defend\npackage input id logic.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"4ac79e06331a3a54ddb4e096357cb16eaa3ae421","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","QA:Validated","backport:all-open","ci:cloud-deploy","v9.5.0","v9.4.2"],"title":"[Fleet] Normalize endpoint package policy input ids","number":271269,"url":"https://github.com/elastic/kibana/pull/271269","mergeCommit":{"message":"[Fleet] Normalize endpoint package policy input ids (#271269)\n\n## Summary\n\nEnsure Elastic Defend package policy inputs use the package policy id\neven when input ids are supplied as Defend code depends on input id\nmatching the package policy id. Maintains existing behavior for\nnon-Defend packages.\n\nI investigated using extension points to help enforce Defend package\ninput id behavior but decided against it since the scope of the changes\nseemed to greatly outweigh the scale of the issue. Instead, I opted to\nadd more unit tests to mitigate accidental bypass of the explicit Defend\npackage input id logic.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"4ac79e06331a3a54ddb4e096357cb16eaa3ae421"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/271269","number":271269,"mergeCommit":{"message":"[Fleet] Normalize endpoint package policy input ids (#271269)\n\n## Summary\n\nEnsure Elastic Defend package policy inputs use the package policy id\neven when input ids are supplied as Defend code depends on input id\nmatching the package policy id. Maintains existing behavior for\nnon-Defend packages.\n\nI investigated using extension points to help enforce Defend package\ninput id behavior but decided against it since the scope of the changes\nseemed to greatly outweigh the scale of the issue. Instead, I opted to\nadd more unit tests to mitigate accidental bypass of the explicit Defend\npackage input id logic.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"4ac79e06331a3a54ddb4e096357cb16eaa3ae421"}},{"branch":"9.4","label":"v9.4.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/271398","number":271398,"state":"MERGED","mergeCommit":{"sha":"a2c8bf6e7ff38dedad8e5f0fa015ed069939a953","message":"[9.4] [Fleet] Normalize endpoint package policy input ids (#271269) (#271398)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Fleet] Normalize endpoint package policy input ids\n(#271269)](https://github.com/elastic/kibana/pull/271269)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Joey F. Poon <joey.poon@elastic.co>"}}]}] BACKPORT-->