### PR TITLE
[Scout] Sanitize Buildkite step keys for nested plugin names

### DIFF
--- a/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
@@ -144,10 +144,16 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
   const scoutCiRunGroups = scheduledModules.map((module) => {
     const usesParallelWorkers = module.configs.some((config) => config.usesParallelWorkers);
     const affectedPrefix = module.isAffected ? 'affected ' : '';
+    // Buildkite step keys only allow alphanumeric, underscores, dashes, and colons.
+    // Plugin names like "cloud_integrations/cloud_links" contain slashes, so we replace
+    // any invalid characters with dashes. The original name is preserved separately and
+    // passed as SCOUT_CONFIG_GROUP_KEY so child steps can still look up the manifest entry.
+    const stepKey = module.name.replace(/[^a-zA-Z0-9_\-:]/g, '-');
 
     return {
       label: `${affectedPrefix}Scout: [ ${module.group} / ${module.name} ] ${module.type}`,
-      key: module.name,
+      key: stepKey,
+      configGroupKey: module.name,
       agents: expandAgentQueue(usesParallelWorkers ? 'n2-8-spot' : 'n2-4-spot'),
       group: module.group,
     };
@@ -159,14 +165,14 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
       key: 'scout-configs',
       depends_on: SCOUT_CONFIGS_DEPS,
       steps: scoutCiRunGroups.map(
-        ({ label, key, group, agents }): BuildkiteStep => ({
+        ({ label, key, configGroupKey, group, agents }): BuildkiteStep => ({
           label,
           command: getRequiredEnv('SCOUT_CONFIGS_SCRIPT'),
           timeout_in_minutes: 60,
           key,
           agents,
           env: {
-            SCOUT_CONFIG_GROUP_KEY: key,
+            SCOUT_CONFIG_GROUP_KEY: configGroupKey,
             SCOUT_CONFIG_GROUP_TYPE: group,
             ...envFromlabels,
             ...scoutExtraEnv,


### PR DESCRIPTION
## Summary

Plugin names like `cloud_integrations/cloud_links` (introduced by PR #270031) contain slashes that Buildkite rejects as invalid step keys. The `configs` distribution strategy — used by the `kibana-elasticsearch-snapshot-verify` pipeline — passed `module.name` directly as the Buildkite step key, causing the Scout Test Run Builder to fail. The fix sanitizes the step key while preserving the original module name as `SCOUT_CONFIG_GROUP_KEY` so child steps can still resolve their entry in the manifest.

## Changes

- Compute a sanitized `stepKey` from `module.name` by replacing any character outside `[a-zA-Z0-9_-:]` with a dash
- Pass the original `module.name` as `configGroupKey` and use it for `SCOUT_CONFIG_GROUP_KEY` in the child step env

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->