### PR TITLE
[Agent Builder] Persist `read` and `status` for conversations

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -350,6 +350,8 @@ export interface Conversation {
    * Any new or updated conversation has `read` set to `false` by default
    */
   read?: boolean;
+  /** current status of the conversation */
+  status?: ConversationRoundStatus;
 }
 
 export type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -345,6 +345,11 @@ export interface Conversation {
    * Keeps track of which prompts have been answered and the response.
    */
   state?: ConversationInternalState;
+  /**
+   * Whether the conversation has been marked as read.
+   * Any new or updated conversation has `read` set to `false` by default
+   */
+  read?: boolean;
 }
 
 export type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/conversations.ts
@@ -19,3 +19,8 @@ export interface RenameConversationResponse {
   id: string;
   title: string;
 }
+
+export interface MarkReadConversationResponse {
+  id: string;
+  read: boolean;
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRouter } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { registerInternalConversationRoutes } from './conversations';
+import type { RouteDependencies } from '../types';
+import { internalApiPath } from '../../../common/constants';
+
+const MARK_READ_PATH = `${internalApiPath}/conversations/{conversation_id}/_mark_read`;
+
+describe('registerInternalConversationRoutes - _mark_read', () => {
+  let routeHandler: (ctx: any, req: any, res: any) => Promise<any>;
+  let update: jest.Mock;
+
+  const createMockContext = () => ({
+    core: Promise.resolve({}),
+    licensing: Promise.resolve({
+      license: { status: 'active', hasAtLeast: jest.fn().mockReturnValue(true) },
+    }),
+  });
+
+  const createRequest = (overrides: { params?: object; body?: object } = {}) =>
+    httpServerMock.createKibanaRequest({
+      method: 'post',
+      path: MARK_READ_PATH,
+      params: { conversation_id: 'conv-1' },
+      body: { read: true },
+      ...overrides,
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    update = jest.fn().mockResolvedValue({ id: 'conv-1', read: true });
+
+    const getInternalServices = jest.fn().mockReturnValue({
+      conversations: {
+        getScopedClient: jest.fn().mockResolvedValue({ update }),
+      },
+    });
+
+    const routeHandlers: Record<string, (ctx: any, req: any, res: any) => Promise<any>> = {};
+
+    const router = {
+      post: jest
+        .fn()
+        .mockImplementation(
+          (config: { path: string }, handler: (ctx: any, req: any, res: any) => Promise<any>) => {
+            routeHandlers[config.path] = handler;
+          }
+        ),
+    } as unknown as IRouter;
+
+    registerInternalConversationRoutes({
+      router,
+      getInternalServices,
+      logger: loggingSystemMock.createLogger(),
+    } as unknown as RouteDependencies);
+
+    routeHandler = routeHandlers[MARK_READ_PATH];
+  });
+
+  it('calls client.update and returns id and read on success', async () => {
+    const response = await routeHandler(
+      createMockContext() as any,
+      createRequest(),
+      kibanaResponseFactory
+    );
+
+    expect(update).toHaveBeenCalledWith({ id: 'conv-1', read: true });
+    expect(response.status).toBe(200);
+    expect(response.payload).toMatchObject({ id: 'conv-1', read: true });
+  });
+
+  it('returns 500 when the persisted read value does not match the requested value', async () => {
+    // Simulates ES returning a stale/legacy doc where `read` is undefined
+    update.mockResolvedValue({ id: 'conv-1', read: undefined });
+
+    const response = await routeHandler(
+      createMockContext() as any,
+      createRequest(),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.test.ts
@@ -77,17 +77,4 @@ describe('registerInternalConversationRoutes - _mark_read', () => {
     expect(response.status).toBe(200);
     expect(response.payload).toMatchObject({ id: 'conv-1', read: true });
   });
-
-  it('returns 500 when the persisted read value does not match the requested value', async () => {
-    // Simulates ES returning a stale/legacy doc where `read` is undefined
-    update.mockResolvedValue({ id: 'conv-1', read: undefined });
-
-    const response = await routeHandler(
-      createMockContext() as any,
-      createRequest(),
-      kibanaResponseFactory
-    );
-
-    expect(response.status).toBe(500);
-  });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.ts
@@ -65,7 +65,7 @@ export function registerInternalConversationRoutes({
       path: `${internalApiPath}/conversations/{conversation_id}/_mark_read`,
       validate: {
         params: schema.object({
-          conversation_id: schema.string(),
+          conversation_id: schema.string({ maxLength: 256 }),
         }),
         body: schema.object({
           read: schema.boolean(),

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { createInternalError } from '@kbn/agent-builder-common';
 import type { RouteDependencies } from '../types';
 import { getHandlerWrapper } from '../wrap_handler';
 import type {
@@ -86,11 +87,11 @@ export function registerInternalConversationRoutes({
         read,
       });
 
-      // Do this validation in order to be able to return `read` that is always defined instead of an optional `read` which is in the Conversation type.
+      // Enables `read` to be mandatory in the response and not `read?`.
       if (read !== updatedConversation.read) {
-        // TODO: check what error to throw, there are also x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/errors.ts
-        throw new Error(
-          `Failed to persist read state for conversation ${conversationId}: expected ${read}, got ${updatedConversation.read}`
+        throw createInternalError(
+          `Failed to persist read state for conversation ${conversationId}: expected ${read}, got ${updatedConversation.read}`,
+          { conversationId, expected: read, actual: updatedConversation.read }
         );
       }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.ts
@@ -8,7 +8,10 @@
 import { schema } from '@kbn/config-schema';
 import type { RouteDependencies } from '../types';
 import { getHandlerWrapper } from '../wrap_handler';
-import type { RenameConversationResponse } from '../../../common/http_api/conversations';
+import type {
+  MarkReadConversationResponse,
+  RenameConversationResponse,
+} from '../../../common/http_api/conversations';
 import { apiPrivileges } from '../../../common/features';
 import { internalApiPath } from '../../../common/constants';
 
@@ -51,6 +54,50 @@ export function registerInternalConversationRoutes({
         body: {
           id: updatedConversation.id,
           title: updatedConversation.title,
+        },
+      });
+    })
+  );
+
+  router.post(
+    {
+      path: `${internalApiPath}/conversations/{conversation_id}/_mark_read`,
+      validate: {
+        params: schema.object({
+          conversation_id: schema.string(),
+        }),
+        body: schema.object({
+          read: schema.boolean(),
+        }),
+      },
+      options: { access: 'internal' },
+      security: {
+        authz: { requiredPrivileges: [apiPrivileges.readAgentBuilder] },
+      },
+    },
+    wrapHandler(async (ctx, request, response) => {
+      const { conversations: conversationsService } = getInternalServices();
+      const { conversation_id: conversationId } = request.params;
+      const { read } = request.body;
+
+      const client = await conversationsService.getScopedClient({ request });
+      const updatedConversation = await client.update({
+        id: conversationId,
+        read,
+      });
+
+      // Do this validation in order to be able to return `read` that is always defined instead of an optional `read` which is in the Conversation type.
+      if (read !== updatedConversation.read) {
+        // TODO: check what error to throw, there are also x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/errors.ts
+        throw new Error(
+          `Failed to persist read state for conversation ${conversationId}: expected ${read}, got ${updatedConversation.read}`
+        );
+      }
+
+      return response.ok<MarkReadConversationResponse>({
+        body: {
+          id: updatedConversation.id,
+          read: updatedConversation.read,
         },
       });
     })

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/conversations.ts
@@ -6,7 +6,6 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { createInternalError } from '@kbn/agent-builder-common';
 import type { RouteDependencies } from '../types';
 import { getHandlerWrapper } from '../wrap_handler';
 import type {
@@ -87,18 +86,10 @@ export function registerInternalConversationRoutes({
         read,
       });
 
-      // Enables `read` to be mandatory in the response and not `read?`.
-      if (read !== updatedConversation.read) {
-        throw createInternalError(
-          `Failed to persist read state for conversation ${conversationId}: expected ${read}, got ${updatedConversation.read}`,
-          { conversationId, expected: read, actual: updatedConversation.read }
-        );
-      }
-
       return response.ok<MarkReadConversationResponse>({
         body: {
           id: updatedConversation.id,
-          read: updatedConversation.read,
+          read: updatedConversation.read!,
         },
       });
     })

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -79,7 +79,16 @@ class ConversationClientImpl implements ConversationClient {
     const response = await this.storage.getClient().search({
       track_total_hits: false,
       size: 1000,
-      _source: ['agent_id', 'user_id', 'user_name', 'title', 'created_at', 'updated_at', 'read'],
+      _source: [
+        'agent_id',
+        'user_id',
+        'user_name',
+        'title',
+        'created_at',
+        'updated_at',
+        'read',
+        'status',
+      ],
       query: {
         bool: {
           filter: [createSpaceDslFilter(this.space)],

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -79,7 +79,7 @@ class ConversationClientImpl implements ConversationClient {
     const response = await this.storage.getClient().search({
       track_total_hits: false,
       size: 1000,
-      _source: ['agent_id', 'user_id', 'user_name', 'title', 'created_at', 'updated_at'],
+      _source: ['agent_id', 'user_id', 'user_name', 'title', 'created_at', 'updated_at', 'read'],
       query: {
         bool: {
           filter: [createSpaceDslFilter(this.space)],

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/client.ts
@@ -86,8 +86,8 @@ class ConversationClientImpl implements ConversationClient {
         'title',
         'created_at',
         'updated_at',
-        'read',
         'status',
+        'read',
       ],
       query: {
         bool: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -59,8 +59,8 @@ const convertBaseFromEs = (document: Document) => {
     title: document._source.title,
     created_at: document._source.created_at,
     updated_at: document._source.updated_at,
-    ...(document._source.status !== undefined && { status: document._source.status }),
-    ...(document._source.read !== undefined && { read: document._source.read }),
+    status: document._source.status,
+    read: document._source.read,
   };
 };
 
@@ -233,10 +233,8 @@ export const toEs = (conversation: Conversation, space: string): ConversationPro
     conversation_rounds: serializeStepResults(conversation.rounds),
     attachments: conversation.attachments ?? [],
     state: conversation.state,
-    ...(conversation.rounds.length > 0 && {
-      status: conversation.rounds[conversation.rounds.length - 1].status,
-    }),
-    ...(conversation.read !== undefined && { read: conversation.read }),
+    status: conversation.status,
+    read: conversation.read,
   };
 };
 
@@ -283,9 +281,7 @@ export const createRequestToEs = ({
     conversation_rounds: serializeStepResults(conversation.rounds),
     attachments: conversation.attachments ?? [],
     state: conversation.state,
-    ...(conversation.rounds.length > 0 && {
-      status: conversation.rounds[conversation.rounds.length - 1].status,
-    }),
+    status: conversation.status,
     read: false,
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -59,6 +59,7 @@ const convertBaseFromEs = (document: Document) => {
     title: document._source.title,
     created_at: document._source.created_at,
     updated_at: document._source.updated_at,
+    ...(document._source.read !== undefined && { read: document._source.read }),
   };
 };
 
@@ -193,6 +194,7 @@ export const fromEs = (document: Document): Conversation => {
       ...base,
       rounds: roundsWithRefs,
       attachments: existingAttachments,
+      ...(document._source!.read !== undefined && { read: document._source!.read }),
       ...(document._source!.state && { state: document._source!.state }),
     };
   }
@@ -202,6 +204,7 @@ export const fromEs = (document: Document): Conversation => {
       ...base,
       rounds: roundsWithRefs,
       ...(attachmentsForRefs.length > 0 && { attachments: attachmentsForRefs }),
+      ...(document._source!.read !== undefined && { read: document._source!.read }),
       ...(document._source!.state && { state: document._source!.state }),
     };
   }
@@ -209,6 +212,7 @@ export const fromEs = (document: Document): Conversation => {
   return {
     ...base,
     rounds: roundsWithRefs,
+    ...(document._source!.read !== undefined && { read: document._source!.read }),
     ...(document._source!.state && { state: document._source!.state }),
   };
 };
@@ -231,6 +235,7 @@ export const toEs = (conversation: Conversation, space: string): ConversationPro
     conversation_rounds: serializeStepResults(conversation.rounds),
     attachments: conversation.attachments ?? [],
     state: conversation.state,
+    ...(conversation.read !== undefined && { read: conversation.read }),
   };
 };
 
@@ -277,5 +282,6 @@ export const createRequestToEs = ({
     conversation_rounds: serializeStepResults(conversation.rounds),
     attachments: conversation.attachments ?? [],
     state: conversation.state,
+    ...(conversation.read !== undefined && { read: conversation.read }),
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -60,6 +60,7 @@ const convertBaseFromEs = (document: Document) => {
     created_at: document._source.created_at,
     updated_at: document._source.updated_at,
     ...(document._source.read !== undefined && { read: document._source.read }),
+    ...(document._source.status !== undefined && { status: document._source.status }),
   };
 };
 
@@ -194,8 +195,6 @@ export const fromEs = (document: Document): Conversation => {
       ...base,
       rounds: roundsWithRefs,
       attachments: existingAttachments,
-      ...(document._source!.read !== undefined && { read: document._source!.read }),
-      ...(document._source!.state && { state: document._source!.state }),
     };
   }
 
@@ -204,16 +203,12 @@ export const fromEs = (document: Document): Conversation => {
       ...base,
       rounds: roundsWithRefs,
       ...(attachmentsForRefs.length > 0 && { attachments: attachmentsForRefs }),
-      ...(document._source!.read !== undefined && { read: document._source!.read }),
-      ...(document._source!.state && { state: document._source!.state }),
     };
   }
 
   return {
     ...base,
     rounds: roundsWithRefs,
-    ...(document._source!.read !== undefined && { read: document._source!.read }),
-    ...(document._source!.state && { state: document._source!.state }),
   };
 };
 
@@ -235,6 +230,9 @@ export const toEs = (conversation: Conversation, space: string): ConversationPro
     conversation_rounds: serializeStepResults(conversation.rounds),
     attachments: conversation.attachments ?? [],
     state: conversation.state,
+    ...(conversation.rounds.length > 0 && {
+      status: conversation.rounds[conversation.rounds.length - 1].status,
+    }),
     ...(conversation.read !== undefined && { read: conversation.read }),
   };
 };
@@ -282,6 +280,9 @@ export const createRequestToEs = ({
     conversation_rounds: serializeStepResults(conversation.rounds),
     attachments: conversation.attachments ?? [],
     state: conversation.state,
+    ...(conversation.rounds.length > 0 && {
+      status: conversation.rounds[conversation.rounds.length - 1].status,
+    }),
     ...(conversation.read !== undefined && { read: conversation.read }),
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -195,6 +195,7 @@ export const fromEs = (document: Document): Conversation => {
       ...base,
       rounds: roundsWithRefs,
       attachments: existingAttachments,
+      ...(document._source!.state && { state: document._source!.state }),
     };
   }
 
@@ -203,12 +204,14 @@ export const fromEs = (document: Document): Conversation => {
       ...base,
       rounds: roundsWithRefs,
       ...(attachmentsForRefs.length > 0 && { attachments: attachmentsForRefs }),
+      ...(document._source!.state && { state: document._source!.state }),
     };
   }
 
   return {
     ...base,
     rounds: roundsWithRefs,
+    ...(document._source!.state && { state: document._source!.state }),
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -59,8 +59,8 @@ const convertBaseFromEs = (document: Document) => {
     title: document._source.title,
     created_at: document._source.created_at,
     updated_at: document._source.updated_at,
-    ...(document._source.read !== undefined && { read: document._source.read }),
     ...(document._source.status !== undefined && { status: document._source.status }),
+    ...(document._source.read !== undefined && { read: document._source.read }),
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/converters.ts
@@ -286,6 +286,6 @@ export const createRequestToEs = ({
     ...(conversation.rounds.length > 0 && {
       status: conversation.rounds[conversation.rounds.length - 1].status,
     }),
-    ...(conversation.read !== undefined && { read: conversation.read }),
+    read: false,
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
@@ -10,7 +10,10 @@ import type { IndexStorageSettings } from '@kbn/storage-adapter';
 import { StorageIndexAdapter, types } from '@kbn/storage-adapter';
 import { chatSystemIndex } from '@kbn/agent-builder-server';
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
-import type { ConversationInternalState } from '@kbn/agent-builder-common/chat';
+import type {
+  ConversationInternalState,
+  ConversationRoundStatus,
+} from '@kbn/agent-builder-common/chat';
 import type { PersistentConversationRound } from './types';
 
 export const conversationIndexName = chatSystemIndex('conversations');
@@ -29,6 +32,7 @@ const storageSettings = {
       conversation_rounds: types.object({ dynamic: false, properties: {} }),
       attachments: types.object({ dynamic: false, properties: {} }),
       state: types.object({ dynamic: false, properties: {} }),
+      status: types.keyword({}),
       read: types.boolean({}),
     },
   },
@@ -45,6 +49,7 @@ export interface ConversationProperties {
   conversation_rounds: PersistentConversationRound[];
   attachments?: VersionedAttachment[];
   state?: ConversationInternalState;
+  status?: ConversationRoundStatus;
   read?: boolean;
   // legacy field
   rounds?: PersistentConversationRound[];

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/storage.ts
@@ -29,6 +29,7 @@ const storageSettings = {
       conversation_rounds: types.object({ dynamic: false, properties: {} }),
       attachments: types.object({ dynamic: false, properties: {} }),
       state: types.object({ dynamic: false, properties: {} }),
+      read: types.boolean({}),
     },
   },
 } satisfies IndexStorageSettings;
@@ -44,6 +45,7 @@ export interface ConversationProperties {
   conversation_rounds: PersistentConversationRound[];
   attachments?: VersionedAttachment[];
   state?: ConversationInternalState;
+  read?: boolean;
   // legacy field
   rounds?: PersistentConversationRound[];
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/types.ts
@@ -27,7 +27,7 @@ export type ConversationCreateRequest = Omit<
 };
 
 export type ConversationUpdateRequest = Pick<Conversation, 'id'> &
-  Partial<Pick<Conversation, 'title' | 'rounds' | 'attachments' | 'state'>>;
+  Partial<Pick<Conversation, 'title' | 'rounds' | 'attachments' | 'state' | 'read'>>;
 
 export interface ConversationListOptions {
   agentId?: string;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/types.ts
@@ -27,7 +27,7 @@ export type ConversationCreateRequest = Omit<
 };
 
 export type ConversationUpdateRequest = Pick<Conversation, 'id'> &
-  Partial<Pick<Conversation, 'title' | 'rounds' | 'attachments' | 'state' | 'read' | 'status'>>;
+  Partial<Pick<Conversation, 'title' | 'rounds' | 'attachments' | 'state' | 'status' | 'read'>>;
 
 export interface ConversationListOptions {
   agentId?: string;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/client/types.ts
@@ -27,7 +27,7 @@ export type ConversationCreateRequest = Omit<
 };
 
 export type ConversationUpdateRequest = Pick<Conversation, 'id'> &
-  Partial<Pick<Conversation, 'title' | 'rounds' | 'attachments' | 'state' | 'read'>>;
+  Partial<Pick<Conversation, 'title' | 'rounds' | 'attachments' | 'state' | 'read' | 'status'>>;
 
 export interface ConversationListOptions {
   agentId?: string;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.test.ts
@@ -111,6 +111,8 @@ describe('conversations utils', () => {
         expect(conversationClient.update).toHaveBeenCalledWith(
           expect.objectContaining({
             rounds: [newRound],
+            read: false,
+            status: newRound.status,
           })
         );
       });
@@ -147,6 +149,8 @@ describe('conversations utils', () => {
         expect(conversationClient.update).toHaveBeenCalledWith(
           expect.objectContaining({
             rounds: [existingRound, newRound],
+            read: false,
+            status: newRound.status,
           })
         );
       });
@@ -184,6 +188,8 @@ describe('conversations utils', () => {
         expect(conversationClient.update).toHaveBeenCalledWith(
           expect.objectContaining({
             rounds: [newRound],
+            read: false,
+            status: newRound.status,
           })
         );
       });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
@@ -42,6 +42,7 @@ export const createConversation$ = ({
         title,
         agent_id: agentId,
         state: roundCompletedEvent.data.conversation_state,
+        read: false,
         rounds: [roundCompletedEvent.data.round],
         ...(roundCompletedEvent.data.attachments
           ? { attachments: roundCompletedEvent.data.attachments }
@@ -87,6 +88,7 @@ export const updateConversation$ = ({
         title,
         rounds: updatedRound,
         state: conversation_state,
+        read: false,
         ...(roundCompletedEvent.data.attachments !== undefined
           ? { attachments: roundCompletedEvent.data.attachments }
           : {}),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
@@ -8,10 +8,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Observable } from 'rxjs';
 import { of, forkJoin, switchMap } from 'rxjs';
-import type {
-  Conversation,
-  RoundCompleteEvent,
-  ConversationAction,
+import {
+  type Conversation,
+  type RoundCompleteEvent,
+  type ConversationAction,
 } from '@kbn/agent-builder-common';
 import type { ConversationClient } from '../../conversation';
 import { createConversationUpdatedEvent, createConversationCreatedEvent } from './events';
@@ -42,6 +42,7 @@ export const createConversation$ = ({
         title,
         agent_id: agentId,
         state: roundCompletedEvent.data.conversation_state,
+        status: roundCompletedEvent.data.round.status,
         read: false,
         rounds: [roundCompletedEvent.data.round],
         ...(roundCompletedEvent.data.attachments
@@ -89,6 +90,7 @@ export const updateConversation$ = ({
         rounds: updatedRound,
         state: conversation_state,
         read: false,
+        status: round.status,
         ...(roundCompletedEvent.data.attachments !== undefined
           ? { attachments: roundCompletedEvent.data.attachments }
           : {}),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/conversations.ts
@@ -8,10 +8,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Observable } from 'rxjs';
 import { of, forkJoin, switchMap } from 'rxjs';
-import {
-  type Conversation,
-  type RoundCompleteEvent,
-  type ConversationAction,
+import type {
+  Conversation,
+  RoundCompleteEvent,
+  ConversationAction,
 } from '@kbn/agent-builder-common';
 import type { ConversationClient } from '../../conversation';
 import { createConversationUpdatedEvent, createConversationCreatedEvent } from './events';
@@ -89,8 +89,8 @@ export const updateConversation$ = ({
         title,
         rounds: updatedRound,
         state: conversation_state,
-        read: false,
         status: round.status,
+        read: false,
         ...(roundCompletedEvent.data.attachments !== undefined
           ? { attachments: roundCompletedEvent.data.attachments }
           : {}),


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/14515

<img width="1602" height="948" alt="image" src="https://github.com/user-attachments/assets/ff041064-badd-43a2-bd2a-6d305f014032" />


## Summary

Backend foundation for the [Chat status epic (#14513)](https://github.com/elastic/search-team/issues/14513). Adds two new conversation-level fields the frontend needs to render sidebar status chat icons:

- **`read: boolean`** 
  - tracks whether the user has seen the latest content
  - set to `false` on each round write to a conversation (e.g. renaming doesn't affect `read`)
  - not returned from API for legacy conversations that pre-date this change
- **`status: ConversationRoundStatus`**
  - denormalized from the last round's status so the list endpoint doesn't need to load rounds
  - stored on each round write
  - not returned from API for legacy conversations that pre-date this change

### Decisions

- the naming `status` (new) vs `state` (existing). I considered different name like `last_round_status` but that reveals an implementation details that might change in the future, so I decided to keep the same existing name (even though a bit confusing because of the existence of `state`)
- I also considered placing `status` into `state` but as `state` is not indexed, it's a no go

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [ ] **`dynamic: strict` mapping update.** `.chat-conversations` is `dynamic: strict`; new fields must be added to the mapping before any write succeeds. Severity: Low. Mitigation: Check with peers how this work.



