### PR TITLE
Split entity_analytics test CODEOWNERS by feature

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3241,16 +3241,23 @@ x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/
 x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store @elastic/contextual-security-apps @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/entity_analytics @elastic/contextual-security-apps @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics @elastic/contextual-security-apps @elastic/security-entity-analytics
-x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics @elastic/contextual-security-apps @elastic/security-entity-analytics
-x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/entity_analytics @elastic/contextual-security-apps @elastic/security-entity-analytics
-x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics @elastic/contextual-security-apps @elastic/security-entity-analytics
 
 ## Security Solution sub teams - Entity Resolution (contextual-security-apps co-ownership)
 x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution @elastic/contextual-security-apps @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution_file_uploader @elastic/contextual-security-apps @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_resolution @elastic/contextual-security-apps @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/common/entity_analytics/entity_store/resolution_csv_upload.ts @elastic/contextual-security-apps @elastic/security-entity-analytics
-x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution @elastic/contextual-security-apps @elastic/security-entity-analytics
+x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution @elastic/contextual-security-apps
+
+## Security Solution sub teams - entity_analytics test tree per-feature overrides
+x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_store @elastic/core-analysis
+x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout.cy.ts @elastic/contextual-security-apps @elastic/security-entity-analytics
+x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_flyout @elastic/contextual-security-apps @elastic/security-entity-analytics
+x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entity_analytics_home_page.cy.ts @elastic/contextual-security-apps @elastic/security-entity-analytics
+x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entities_table.cy.ts @elastic/contextual-security-apps @elastic/security-entity-analytics
+x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entities_table_grouping.cy.ts @elastic/contextual-security-apps @elastic/security-entity-analytics
+x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/entity_analytics/entity_analytics_home.ts @elastic/contextual-security-apps @elastic/security-entity-analytics
+x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/entity_analytics/entity_flyout_resolution.ts @elastic/contextual-security-apps
 
 ## Security Solution sub teams - GenAI
 x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai @elastic/security-threat-hunting


### PR DESCRIPTION
## Summary

Today the entity_analytics test trees (`test_suites/entity_analytics`, `cypress/e2e/entity_analytics`, `cypress/tasks/entity_analytics`) are co-owned by `@elastic/contextual-security-apps` + `@elastic/security-entity-analytics`. The two teams actually own different feature areas inside those trees, so the broad co-ownership causes:

- review pings and skipped-test attribution to the wrong team;
- `team-auto-tests-stats` inventory reports double-counting skipped TCs ;
- a silently-overridden `entity_store/ → @elastic/core-analysis` line (the broad co-ownership was winning on last-match).

This PR replaces the broad co-ownership with per-feature lines so each test subtree maps to its actual owning team:

| Path | Owner |
|---|---|
| `test_suites/entity_analytics/entity_store/` | `@elastic/core-analysis` |
| `test_suites/entity_analytics/entity_resolution/` | `@elastic/contextual-security-apps` |
| `test_suites/entity_analytics/{entity_details,monitoring,watchlists,risk_engine,risk_score_maintainer,utils}/` | `@elastic/security-entity-analytics` (broad default) |
| `cypress/e2e/entity_analytics/entity_flyout*`, `entity_analytics_home/entity_analytics_home_page.cy.ts`, `entities_table.cy.ts`, `entities_table_grouping.cy.ts` | co-owned: contextual-security-apps + security-entity-analytics |
| `cypress/e2e/entity_analytics/{asset_criticality_upload_page,dashboards,host_details,hosts,priv_mon,watchlists}` | `@elastic/security-entity-analytics` (broad default) |
| `cypress/tasks/entity_analytics/entity_flyout_resolution.ts` | `@elastic/contextual-security-apps` |
| `cypress/tasks/entity_analytics/privmon.ts` | `@elastic/security-entity-analytics` (broad default) |
| `cypress/tasks/entity_analytics/entity_analytics_home.ts` | co-owned |

### Heads-up for owners

- `@elastic/core-analysis` — the Entity Store API integration tests under `test_suites/entity_analytics/entity_store/` (the largest skipped-test cluster, ~37 skipped TCs) now route to your team for reviews and CI failure attribution. The earlier `@elastic/core-analysis` assignment for this directory was being silently overridden, so operationally this is closer to formalizing what the file always claimed.
- `@elastic/security-entity-analytics` — no new attribution; your Monitoring, Watchlists, Risk Engine, Risk Score Maintainer, Entity Details, and Cypress (priv_mon, hosts, dashboards, watchlists, asset_criticality) tests no longer share ownership with contextual-security-apps, so review-request distribution gets a bit cleaner.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The \`release_note:breaking\` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct \`release_note:*\` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable \`backport:*\` labels.

### Identify risks

- **Low** — CODEOWNERS-only change. No code or test behavior is modified.
- **Operational impact for core-analysis**: PR review requests on the entity_store API integration tests now route to them rather than the previous co-owned set. The current line in CODEOWNERS already nominally assigned this path to them, but was silently overridden — so for some team members this may look new. Recommend a quick Slack heads-up.