### PR TITLE
[9.4] [One workflow] 🐞 Include registered triggers in agent builder experience (#270221)

### DIFF
--- a/examples/workflows_extensions_example/common/triggers/custom_trigger.ts
+++ b/examples/workflows_extensions_example/common/triggers/custom_trigger.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { i18n } from '@kbn/i18n';
 import { z } from '@kbn/zod/v4';
 import type { CommonTriggerDefinition } from '@kbn/workflows-extensions/common';
 
@@ -34,8 +35,69 @@ export const customTriggerEventSchema = z.object({
 
 export type CustomTriggerEvent = z.infer<typeof customTriggerEventSchema>;
 
-/** Shared trigger definition (id + eventSchema) for use by public and server. */
+/** Shared trigger definition for use by public and server. */
 export const commonCustomTriggerDefinition: CommonTriggerDefinition = {
   id: CUSTOM_TRIGGER_ID,
   eventSchema: customTriggerEventSchema,
+  title: i18n.translate('workflowsExtensionsExample.customTrigger.title', {
+    defaultMessage: 'Custom trigger',
+  }),
+  description: i18n.translate('workflowsExtensionsExample.customTrigger.description', {
+    defaultMessage:
+      'Emitted when a custom event occurs. Used by the workflows extensions example plugin.',
+  }),
+  documentation: {
+    details: i18n.translate('workflowsExtensionsExample.customTrigger.documentation.details', {
+      defaultMessage:
+        'Emitted when a custom event occurs. Events can include an optional category (e.g. alerts, notifications, audit, demo). In the `on` block, add a condition (KQL) to filter when this workflow runs using event properties: `event.category`, `event.message`, `event.source`.',
+    }),
+    examples: [
+      i18n.translate(
+        'workflowsExtensionsExample.customTrigger.documentation.exampleMatchCategory',
+        {
+          defaultMessage: `## Match by category (conditional subscription)
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+    on:
+      condition: 'event.category: "alerts"'
+\`\`\``,
+          values: { triggerId: CUSTOM_TRIGGER_ID },
+        }
+      ),
+      i18n.translate('workflowsExtensionsExample.customTrigger.documentation.exampleMatchMessage', {
+        defaultMessage: `## Match any message
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+    on:
+      condition: 'event.message: *'
+\`\`\``,
+        values: { triggerId: CUSTOM_TRIGGER_ID },
+      }),
+      i18n.translate('workflowsExtensionsExample.customTrigger.documentation.exampleMatchSource', {
+        defaultMessage: `## Match events from a specific source
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+    on:
+      condition: 'event.source: "api"'
+\`\`\``,
+        values: { triggerId: CUSTOM_TRIGGER_ID },
+      }),
+      i18n.translate('workflowsExtensionsExample.customTrigger.documentation.exampleMatchError', {
+        defaultMessage: `## Match message containing "error"
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+    on:
+      condition: 'event.message: *error*'
+\`\`\``,
+        values: { triggerId: CUSTOM_TRIGGER_ID },
+      }),
+    ],
+  },
+  snippets: {
+    condition: 'event.category: "alerts"',
+  },
 };

--- a/examples/workflows_extensions_example/common/triggers/loop_trigger.ts
+++ b/examples/workflows_extensions_example/common/triggers/loop_trigger.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { i18n } from '@kbn/i18n';
 import { z } from '@kbn/zod/v4';
 import type { CommonTriggerDefinition } from '@kbn/workflows-extensions/common';
 
@@ -20,8 +21,35 @@ export const loopTriggerEventSchema = z.object({
 
 export type LoopTriggerEvent = z.infer<typeof loopTriggerEventSchema>;
 
-/** Shared trigger definition (id + eventSchema) for use by public and server. */
+/** Shared trigger definition for use by public and server. */
 export const commonLoopTriggerDefinition: CommonTriggerDefinition = {
   id: LOOP_TRIGGER_ID,
   eventSchema: loopTriggerEventSchema,
+  title: i18n.translate('workflowsExtensionsExample.loopTrigger.title', {
+    defaultMessage: 'Loop trigger',
+  }),
+  description: i18n.translate('workflowsExtensionsExample.loopTrigger.description', {
+    defaultMessage:
+      'Emitted for the event-chain depth demo. Start or re-emit via POST to /api/workflows_extensions_example/emit_loop.',
+  }),
+  documentation: {
+    details: i18n.translate('workflowsExtensionsExample.loopTrigger.documentation.details', {
+      defaultMessage:
+        'Used to demonstrate the event-chain depth guardrail (workflowsExecutionEngine.eventDriven.maxChainDepth, default 10). Emit via the emit_loop endpoint; a workflow should use a kibana.request step to POST back to that endpoint with the next iteration so chain depth headers propagate until the guardrail stops scheduling.',
+    }),
+    examples: [
+      i18n.translate('workflowsExtensionsExample.loopTrigger.documentation.exampleStart', {
+        defaultMessage: `## Start the loop
+\`\`\`bash
+curl -X POST -u elastic:changeme -H 'Content-Type: application/json' \\
+  'http://localhost:5601/api/workflows_extensions_example/emit_loop' \\
+  -d '{}'
+\`\`\`
+(iteration defaults to 0.)`,
+      }),
+    ],
+  },
+  snippets: {
+    condition: '',
+  },
 };

--- a/examples/workflows_extensions_example/public/triggers/custom_trigger.ts
+++ b/examples/workflows_extensions_example/public/triggers/custom_trigger.ts
@@ -7,78 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { i18n } from '@kbn/i18n';
-import type { PublicTriggerDefinition } from '@kbn/workflows-extensions/public';
 import React from 'react';
-import {
-  CUSTOM_TRIGGER_ID,
-  commonCustomTriggerDefinition,
-} from '../../common/triggers/custom_trigger';
+import type { PublicTriggerDefinition } from '@kbn/workflows-extensions/public';
+import { commonCustomTriggerDefinition } from '../../common/triggers/custom_trigger';
 
 export const customTriggerPublicDefinition: PublicTriggerDefinition = {
   ...commonCustomTriggerDefinition,
-  title: i18n.translate('workflowsExtensionsExample.customTrigger.title', {
-    defaultMessage: 'Custom trigger',
-  }),
-  description: i18n.translate('workflowsExtensionsExample.customTrigger.description', {
-    defaultMessage:
-      'Emitted when a custom event occurs. Used by the workflows extensions example plugin.',
-  }),
   icon: React.lazy(() =>
     import('@elastic/eui/es/components/icon/assets/star').then(({ icon }) => ({ default: icon }))
   ),
-  documentation: {
-    details: i18n.translate('workflowsExtensionsExample.customTrigger.documentation.details', {
-      defaultMessage:
-        'Emitted when a custom event occurs. Events can include an optional category (e.g. alerts, notifications, audit, demo). In the `on` block, add a condition (KQL) to filter when this workflow runs using event properties: `event.category`, `event.message`, `event.source`.',
-    }),
-    examples: [
-      i18n.translate(
-        'workflowsExtensionsExample.customTrigger.documentation.exampleMatchCategory',
-        {
-          defaultMessage: `## Match by category (conditional subscription)
-\`\`\`yaml
-triggers:
-  - type: {triggerId}
-    on:
-      condition: 'event.category: "alerts"'
-\`\`\``,
-          values: { triggerId: CUSTOM_TRIGGER_ID },
-        }
-      ),
-      i18n.translate('workflowsExtensionsExample.customTrigger.documentation.exampleMatchMessage', {
-        defaultMessage: `## Match any message
-\`\`\`yaml
-triggers:
-  - type: {triggerId}
-    on:
-      condition: 'event.message: *'
-\`\`\``,
-        values: { triggerId: CUSTOM_TRIGGER_ID },
-      }),
-      i18n.translate('workflowsExtensionsExample.customTrigger.documentation.exampleMatchSource', {
-        defaultMessage: `## Match events from a specific source
-\`\`\`yaml
-triggers:
-  - type: {triggerId}
-    on:
-      condition: 'event.source: "api"'
-\`\`\``,
-        values: { triggerId: CUSTOM_TRIGGER_ID },
-      }),
-      i18n.translate('workflowsExtensionsExample.customTrigger.documentation.exampleMatchError', {
-        defaultMessage: `## Match message containing "error"
-\`\`\`yaml
-triggers:
-  - type: {triggerId}
-    on:
-      condition: 'event.message: *error*'
-\`\`\``,
-        values: { triggerId: CUSTOM_TRIGGER_ID },
-      }),
-    ],
-  },
-  snippets: {
-    condition: 'event.category: "alerts"',
-  },
 };

--- a/examples/workflows_extensions_example/public/triggers/loop_trigger.ts
+++ b/examples/workflows_extensions_example/public/triggers/loop_trigger.ts
@@ -7,41 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { i18n } from '@kbn/i18n';
-import type { PublicTriggerDefinition } from '@kbn/workflows-extensions/public';
 import React from 'react';
+import type { PublicTriggerDefinition } from '@kbn/workflows-extensions/public';
 import { commonLoopTriggerDefinition } from '../../common/triggers/loop_trigger';
 
 export const loopTriggerPublicDefinition: PublicTriggerDefinition = {
   ...commonLoopTriggerDefinition,
-  title: i18n.translate('workflowsExtensionsExample.loopTrigger.title', {
-    defaultMessage: 'Loop trigger',
-  }),
-  description: i18n.translate('workflowsExtensionsExample.loopTrigger.description', {
-    defaultMessage:
-      'Emitted for the event-chain depth demo. Start or re-emit via POST to /api/workflows_extensions_example/emit_loop.',
-  }),
   icon: React.lazy(() =>
     import('@elastic/eui/es/components/icon/assets/refresh').then(({ icon }) => ({ default: icon }))
   ),
-  documentation: {
-    details: i18n.translate('workflowsExtensionsExample.loopTrigger.documentation.details', {
-      defaultMessage:
-        'Used to demonstrate the event-chain depth guardrail (workflowsExecutionEngine.eventDriven.maxChainDepth, default 10). Emit via the emit_loop endpoint; a workflow should use a kibana.request step to POST back to that endpoint with the next iteration so chain depth headers propagate until the guardrail stops scheduling.',
-    }),
-    examples: [
-      i18n.translate('workflowsExtensionsExample.loopTrigger.documentation.exampleStart', {
-        defaultMessage: `## Start the loop
-\`\`\`bash
-curl -X POST -u elastic:changeme -H 'Content-Type: application/json' \\
-  'http://localhost:5601/api/workflows_extensions_example/emit_loop' \\
-  -d '{}'
-\`\`\`
-(iteration defaults to 0.)`,
-      }),
-    ],
-  },
-  snippets: {
-    condition: '',
-  },
 };

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -209,6 +209,6 @@ pageLoadAssetSize:
   visualizationListing: 5148
   visualizations: 52210
   watcher: 10485
-  workflowsExtensions: 38894
+  workflowsExtensions: 44875
   workflowsManagement: 35010
   workplaceAIApp: 14056

--- a/src/platform/plugins/shared/workflows_extensions/README.md
+++ b/src/platform/plugins/shared/workflows_extensions/README.md
@@ -30,7 +30,7 @@ This separation ensures that:
 
 The trigger registry follows the same pattern as steps:
 
-- **Server-side registry**: Stores trigger definitions (`id`, `eventSchema`, title, description, documentation, snippets). Other plugins register the shared **common** definition during `setup()`.
+- **Server-side registry**: Stores trigger definitions (`id`, `eventSchema`, title, description, and optional documentation/snippets). Other plugins register the shared **common** definition during `setup()`.
 - **Public-side registry**: Spreads the same common definition and adds **icon** (and optional async loader) for the workflows UI.
 
 **Async registration (public only):** The public trigger registry accepts either a definition or a **loader function** `() => Promise<PublicTriggerDefinition>`. Using a loader (e.g. `() => import('./my_trigger').then(m => m.myTriggerDefinition)`) keeps trigger modules and heavy deps out of your plugin's main bundle. Loaders are resolved in the background; `workflowsExtensions.isReady()` waits for both step and trigger loaders before the workflows UI renders.

--- a/src/platform/plugins/shared/workflows_extensions/README.md
+++ b/src/platform/plugins/shared/workflows_extensions/README.md
@@ -30,8 +30,8 @@ This separation ensures that:
 
 The trigger registry follows the same pattern as steps:
 
-- **Server-side registry**: Stores trigger definitions (id + `eventSchema` for payload validation). Other plugins register during `setup()`.
-- **Public-side registry**: Stores UI definition (title, description, icon, documentation, snippets) so the workflows UI can display triggers and help users subscribe.
+- **Server-side registry**: Stores trigger definitions (`id`, `eventSchema`, title, description, documentation, snippets). Other plugins register the shared **common** definition during `setup()`.
+- **Public-side registry**: Spreads the same common definition and adds **icon** (and optional async loader) for the workflows UI.
 
 **Async registration (public only):** The public trigger registry accepts either a definition or a **loader function** `() => Promise<PublicTriggerDefinition>`. Using a loader (e.g. `() => import('./my_trigger').then(m => m.myTriggerDefinition)`) keeps trigger modules and heavy deps out of your plugin's main bundle. Loaders are resolved in the background; `workflowsExtensions.isReady()` waits for both step and trigger loaders before the workflows UI renders.
 

--- a/src/platform/plugins/shared/workflows_extensions/common/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/index.ts
@@ -8,7 +8,11 @@
  */
 
 export type { CommonStepDefinition } from './step_registry/types';
-export type { CommonTriggerDefinition } from './trigger_registry/types';
+export type {
+  CommonTriggerDefinition,
+  TriggerDocumentation,
+  TriggerSnippets,
+} from './trigger_registry/types';
 export { EVENT_FIELD_PREFIX } from './trigger_registry/constants';
 export { DataMapStepTypeId } from './steps/data';
 export {

--- a/src/platform/plugins/shared/workflows_extensions/common/trigger_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/trigger_registry/types.ts
@@ -42,7 +42,7 @@ export interface TriggerSnippets {
  * - id: globally unique, namespaced format <solution>.<event>
  * - eventSchema: must be a Zod object schema that rejects unknown fields
  *
- * Server and agent tooling read title, description, documentation, and snippets from here.
+ * Server and agent tooling read title and description from here; documentation and snippets are optional.
  * Public definitions spread this object and add UI-only fields (e.g. icon).
  */
 export interface CommonTriggerDefinition<EventSchema extends z.ZodType = z.ZodType> {
@@ -57,11 +57,11 @@ export interface CommonTriggerDefinition<EventSchema extends z.ZodType = z.ZodTy
   /**
    * Short human-readable name for this trigger (UI and agent catalog label).
    */
-  title?: string;
+  title: string;
   /**
    * User-facing description of when this trigger is emitted.
    */
-  description?: string;
+  description: string;
   /**
    * Documentation (details + YAML examples), aligned with step definitions.
    */

--- a/src/platform/plugins/shared/workflows_extensions/common/trigger_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/trigger_registry/types.ts
@@ -10,14 +10,43 @@
 import type { z } from '@kbn/zod/v4';
 
 /**
+ * Documentation for a trigger (aligned with steps: details + examples).
+ */
+export interface TriggerDocumentation {
+  /**
+   * Detailed description with usage examples (markdown supported)
+   */
+  details?: string;
+  /**
+   * Usage examples as markdown strings (e.g. "## Title\n```yaml\n...").
+   */
+  examples?: string[];
+}
+
+/**
+ * Pre-filled snippet values when the user adds this trigger from the UI.
+ */
+export interface TriggerSnippets {
+  /**
+   * KQL condition pre-filled in the trigger's `on.condition` when the user adds this
+   * trigger from the UI (actions menu or YAML autocomplete).
+   * Must be valid KQL and only reference properties from the event schema (validated at registration).
+   */
+  condition?: string;
+}
+
+/**
  * Shared trigger contract (common to server and public).
  *
  * Constraints (enforced at registration):
  * - id: globally unique, namespaced format <solution>.<event>
  * - eventSchema: must be a Zod object schema that rejects unknown fields
+ *
+ * Server and agent tooling read title, description, documentation, and snippets from here.
+ * Public definitions spread this object and add UI-only fields (e.g. icon).
  */
 export interface CommonTriggerDefinition<EventSchema extends z.ZodType = z.ZodType> {
-  /** Globally unique, namespaced identifier (e.g. cases.updated, alerts.severity_high) */
+  /** Globally unique, namespaced identifier (e.g. cases.updated, alerts.recovered) */
   id: string;
   /**
    * Payload contract (Zod object schema; must reject unknown fields by default).
@@ -25,4 +54,20 @@ export interface CommonTriggerDefinition<EventSchema extends z.ZodType = z.ZodTy
    * help users to understand the data they will receive with the event.
    */
   eventSchema: EventSchema;
+  /**
+   * Short human-readable name for this trigger (UI and agent catalog label).
+   */
+  title?: string;
+  /**
+   * User-facing description of when this trigger is emitted.
+   */
+  description?: string;
+  /**
+   * Documentation (details + YAML examples), aligned with step definitions.
+   */
+  documentation?: TriggerDocumentation;
+  /**
+   * Pre-filled values for snippet insertion (e.g. on.condition).
+   */
+  snippets?: TriggerSnippets;
 }

--- a/src/platform/plugins/shared/workflows_extensions/common/triggers/workflow_execution_failed.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/triggers/workflow_execution_failed.ts
@@ -136,4 +136,75 @@ export type WorkflowExecutionFailedEvent = z.infer<typeof workflowExecutionFaile
 export const commonWorkflowExecutionFailedTriggerDefinition: CommonTriggerDefinition = {
   id: WORKFLOW_EXECUTION_FAILED_TRIGGER_ID,
   eventSchema: workflowExecutionFailedEventSchema,
+  title: i18n.translate('workflowsExtensions.triggers.workflowExecutionFailed.title', {
+    defaultMessage: 'Workflow failed',
+  }),
+  description: i18n.translate('workflowsExtensions.triggers.workflowExecutionFailed.description', {
+    defaultMessage:
+      'Emitted when any workflow in the same space fails. Use to handle errors, send notifications, perform cleanup, or retry failed operations.',
+  }),
+  documentation: {
+    details: i18n.translate(
+      'workflowsExtensions.triggers.workflowExecutionFailed.documentation.details',
+      {
+        defaultMessage: `Emitted when a workflow run fails. The event includes \`workflow\` (id, name, spaceId, isErrorHandler), \`execution\` (id, startedAt, failedAt), and \`error\` (message, stepId, stepName, stepExecutionId). Use KQL in \`on.condition\` to filter by workflow name, failed step, or exclude error-handler workflows to avoid infinite loops.`,
+      }
+    ),
+    examples: [
+      i18n.translate(
+        'workflowsExtensions.triggers.workflowExecutionFailed.documentation.exampleBasic',
+        {
+          defaultMessage: `## Log all workflow failures
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+steps:
+  - name: log_to_index
+    type: elasticsearch.index
+    with:
+      index: workflow-errors
+      body:
+        workflow_id: "{eventWorkflowId}"
+        error: "{eventErrorMessage}"
+        timestamp: "{eventFailedAt}"
+\`\`\``,
+          values: {
+            triggerId: WORKFLOW_EXECUTION_FAILED_TRIGGER_ID,
+            eventWorkflowId: '{{event.workflow.id}}',
+            eventErrorMessage: '{{event.error.message}}',
+            eventFailedAt: '{{event.execution.failedAt}}',
+          },
+        }
+      ),
+      i18n.translate(
+        'workflowsExtensions.triggers.workflowExecutionFailed.documentation.exampleFilterName',
+        {
+          defaultMessage: `## Filter by workflow name
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+    on:
+      condition: event.workflow.name: critical*
+\`\`\``,
+          values: { triggerId: WORKFLOW_EXECUTION_FAILED_TRIGGER_ID },
+        }
+      ),
+      i18n.translate(
+        'workflowsExtensions.triggers.workflowExecutionFailed.documentation.exampleExcludeErrorHandlers',
+        {
+          defaultMessage: `## Exclude error-handler workflows (prevent loops)
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+    on:
+      condition: not event.workflow.isErrorHandler:true
+\`\`\``,
+          values: { triggerId: WORKFLOW_EXECUTION_FAILED_TRIGGER_ID },
+        }
+      ),
+    ],
+  },
+  snippets: {
+    condition: 'not event.workflow.isErrorHandler:true',
+  },
 };

--- a/src/platform/plugins/shared/workflows_extensions/dev_docs/TRIGGERS.md
+++ b/src/platform/plugins/shared/workflows_extensions/dev_docs/TRIGGERS.md
@@ -6,7 +6,7 @@ This section provides a complete guide for contributors who want to add event-dr
 
 **Quick checklist:**
 
-1. Define common trigger (id + eventSchema) in your plugin
+1. Define common trigger (id, eventSchema, title, description; optional documentation and snippets) in your plugin
 2. Register on server and public in plugin `setup()`
 3. Emit events via request context or direct `emitEvent`
 4. Add to approved list and get workflows-eng approval
@@ -20,11 +20,12 @@ Trigger IDs use the following convention:
 - ⚠️ Allowed: Inherited forms from OpenAPI/connectors/platform-owned contracts
 - ❌ Bad: `"my_trigger"` (no namespace), `"custom_trigger"` (event not camelCase)
 
-### Step 1: Define common trigger (id + eventSchema)
+### Step 1: Define common trigger (id, eventSchema, title, description; optional documentation and snippets)
 
-Create a shared definition (e.g. `common/triggers/my_trigger.ts`) in your plugin:
+Create a shared definition (e.g. `common/triggers/my_trigger.ts`) in your plugin. **title** and **description** are required. **documentation** (details + YAML examples) and **snippets** (e.g. a default `on.condition`) are optional but strongly recommended so the YAML editor, hover docs, and agent tools can guide users (aligned with custom steps):
 
 ```typescript
+import { i18n } from '@kbn/i18n';
 import { z } from '@kbn/zod/v4';
 import type { CommonTriggerDefinition } from '@kbn/workflows-extensions/common';
 
@@ -42,15 +43,28 @@ export type MyTriggerEvent = z.infer<typeof myTriggerEventSchema>;
 export const commonMyTriggerDefinition: CommonTriggerDefinition = {
   id: MY_TRIGGER_ID,
   eventSchema: myTriggerEventSchema,
+  title: i18n.translate('myPlugin.myTrigger.title', { defaultMessage: 'My trigger' }),
+  description: i18n.translate('myPlugin.myTrigger.description', {
+    defaultMessage: 'Emitted when something happens.',
+  }),
+  documentation: {
+    details: 'Filter when this workflow runs using KQL on event properties (e.g. event.category, event.message).',
+    examples: [
+      `## Match by category\n\`\`\`yaml\ntriggers:\n  - type: ${MY_TRIGGER_ID}\n    on:\n      condition: 'event.category: "alerts"'\n\`\`\``,
+    ],
+  },
+  snippets: { condition: 'event.category: "alerts"' },
 };
 ```
 
 - Use `.describe()` on schema fields so the UI and docs show helpful text.
 - `eventSchema` must be a Zod object schema; payloads are validated at emit time.
+- When you provide `documentation.examples`, each example must only reference fields present on `eventSchema` (agents pattern-match YAML examples).
+- When you provide `snippets.condition`, it must be valid KQL using only `event.*` fields from `eventSchema` (validated at registration).
 
 ### Step 2: Register on server
 
-In your plugin's server `setup()`, register the common definition (id + eventSchema only):
+In your plugin's server `setup()`, register the **same** common definition:
 
 ```typescript
 import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
@@ -68,30 +82,18 @@ Reference: `examples/workflows_extensions_example/server/triggers/index.ts`.
 
 ### Step 3: Register on public
 
-Create a public definition with UI metadata and register it in your plugin's public `setup()`:
+Spread the common definition and add **icon** only (browser-only UI):
 
 ```typescript
 import type { PublicTriggerDefinition } from '@kbn/workflows-extensions/public';
-import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { MY_TRIGGER_ID, commonMyTriggerDefinition } from '../common/triggers/my_trigger';
+import { commonMyTriggerDefinition } from '../common/triggers/my_trigger';
 
 export const myTriggerPublicDefinition: PublicTriggerDefinition = {
   ...commonMyTriggerDefinition,
-  title: i18n.translate('myPlugin.myTrigger.title', { defaultMessage: 'My trigger' }),
-  description: i18n.translate('myPlugin.myTrigger.description', {
-    defaultMessage: 'Emitted when something happens. Use in workflow triggers to run on this event.',
-  }),
   icon: React.lazy(() =>
     import('@elastic/eui/es/components/icon/assets/star').then(({ icon }) => ({ default: icon }))
   ),
-  documentation: {
-    details: 'Filter when this workflow runs using KQL on event properties (e.g. event.category, event.message).',
-    examples: [
-      `## Match by category\n\`\`\`yaml\ntriggers:\n  - type: ${MY_TRIGGER_ID}\n    on:\n      condition: 'event.category: "alerts"'\n\`\`\``,
-    ],
-  },
-  snippets: { condition: 'event.category: "alerts"' },
 };
 
 // In public plugin setup():

--- a/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/trigger_registry/types.ts
@@ -10,77 +10,22 @@
 import type { z } from '@kbn/zod/v4';
 import type { CommonTriggerDefinition } from '../../common';
 
-/**
- * Documentation for a trigger (aligned with steps: details + generic examples).
- */
-export interface TriggerDocumentation {
-  /**
-   * Detailed description with usage examples (markdown supported)
-   */
-  details?: string;
-  /**
-   * Usage examples as markdown strings (e.g. "## Title\n```yaml\n...").
-   * Shown in the YAML editor hover.
-   */
-  examples?: string[];
-}
-
-/**
- * Pre-filled snippet values when the user adds this trigger from the UI.
- */
-export interface TriggerSnippets {
-  /**
-   * KQL condition pre-filled in the trigger's `on.condition` when the user adds this
-   * trigger from the UI (actions menu or YAML autocomplete).
-   * Must be valid KQL and only reference properties from the event schema (validated at registration).
-   */
-  condition?: string;
-}
+export type { TriggerDocumentation, TriggerSnippets } from '../../common/trigger_registry/types';
 
 /**
  * User-facing definition for a workflow trigger.
- * Used by the UI to display trigger information (title, description, icon, event schema, documentation).
- * Extends the server contract (id + eventSchema) with UI-only fields.
+ * Spreads the shared common contract and adds UI-only presentation (icon).
  *
- * @example Definition with documentation and snippets (aligned with steps pattern)
+ * @example
  * {
- *   id: 'example.my_trigger',
- *   title: 'My Trigger',
- *   description: 'Fired when something happens.',
- *   eventSchema: z.object({ severity: z.string(), message: z.string() }),
- *   documentation: {
- *     details: 'Filter when this workflow runs using KQL on event properties.',
- *     examples: ['## Match high severity\n```yaml\ntriggers:\n  - type: example.my_trigger\n    on:\n      condition: \'event.severity: "high"\'\n```'],
- *   },
- *   snippets: { condition: 'event.severity: "high"' },
+ *   ...commonMyTriggerDefinition,
+ *   icon: React.lazy(() => import('...')),
  * }
  */
 export interface PublicTriggerDefinition<EventSchema extends z.ZodType = z.ZodType>
   extends CommonTriggerDefinition<EventSchema> {
   /**
-   * Short human-readable name for this trigger.
-   * Displayed in the UI when selecting or viewing triggers.
-   */
-  title: string;
-
-  /**
-   * User-facing description of when this trigger is emitted.
-   * Displayed as help text or in tooltips.
-   */
-  description: string;
-
-  /**
    * Used to visually represent this trigger in the UI.
    */
   icon?: React.ComponentType;
-
-  /**
-   * Documentation (details + examples), aligned with step definitions.
-   */
-  documentation?: TriggerDocumentation;
-
-  /**
-   * Pre-filled values for snippet insertion (e.g. on.condition).
-   */
-  snippets?: TriggerSnippets;
 }

--- a/src/platform/plugins/shared/workflows_extensions/public/triggers/workflow_execution_failed.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/triggers/workflow_execution_failed.ts
@@ -8,87 +8,12 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
-import {
-  commonWorkflowExecutionFailedTriggerDefinition,
-  WORKFLOW_EXECUTION_FAILED_TRIGGER_ID,
-} from '../../common/triggers/workflow_execution_failed';
+import { commonWorkflowExecutionFailedTriggerDefinition } from '../../common/triggers/workflow_execution_failed';
 import type { PublicTriggerDefinition } from '../trigger_registry/types';
 
 export const workflowExecutionFailedPublicTriggerDefinition: PublicTriggerDefinition = {
   ...commonWorkflowExecutionFailedTriggerDefinition,
-  title: i18n.translate('workflowsExtensions.triggers.workflowExecutionFailed.title', {
-    defaultMessage: 'Workflow failed',
-  }),
-  description: i18n.translate('workflowsExtensions.triggers.workflowExecutionFailed.description', {
-    defaultMessage:
-      'Emitted when any workflow in the same space fails. Use to handle errors, send notifications, perform cleanup, or retry failed operations.',
-  }),
   icon: React.lazy(() =>
     import('@elastic/eui/es/components/icon/assets/error').then(({ icon }) => ({ default: icon }))
   ),
-  documentation: {
-    details: i18n.translate(
-      'workflowsExtensions.triggers.workflowExecutionFailed.documentation.details',
-      {
-        defaultMessage: `Emitted when a workflow run fails. The event includes \`workflow\` (id, name, spaceId, isErrorHandler), \`execution\` (id, startedAt, failedAt), and \`error\` (message, stepId, stepName, stepExecutionId). Use KQL in \`on.condition\` to filter by workflow name, failed step, or exclude error-handler workflows to avoid infinite loops.`,
-      }
-    ),
-    examples: [
-      i18n.translate(
-        'workflowsExtensions.triggers.workflowExecutionFailed.documentation.exampleBasic',
-        {
-          defaultMessage: `## Log all workflow failures
-\`\`\`yaml
-triggers:
-  - type: {triggerId}
-steps:
-  - name: log_to_index
-    type: elasticsearch.index
-    with:
-      index: workflow-errors
-      body:
-        workflow_id: "{eventWorkflowId}"
-        error: "{eventErrorMessage}"
-        timestamp: "{eventFailedAt}"
-\`\`\``,
-          values: {
-            triggerId: WORKFLOW_EXECUTION_FAILED_TRIGGER_ID,
-            eventWorkflowId: '{{event.workflow.id}}',
-            eventErrorMessage: '{{event.error.message}}',
-            eventFailedAt: '{{event.execution.failedAt}}',
-          },
-        }
-      ),
-      i18n.translate(
-        'workflowsExtensions.triggers.workflowExecutionFailed.documentation.exampleFilterName',
-        {
-          defaultMessage: `## Filter by workflow name
-\`\`\`yaml
-triggers:
-  - type: {triggerId}
-    on:
-      condition: event.workflow.name: critical*
-\`\`\``,
-          values: { triggerId: WORKFLOW_EXECUTION_FAILED_TRIGGER_ID },
-        }
-      ),
-      i18n.translate(
-        'workflowsExtensions.triggers.workflowExecutionFailed.documentation.exampleExcludeErrorHandlers',
-        {
-          defaultMessage: `## Exclude error-handler workflows (prevent loops)
-\`\`\`yaml
-triggers:
-  - type: {triggerId}
-    on:
-      condition: not event.workflow.isErrorHandler:true
-\`\`\``,
-          values: { triggerId: WORKFLOW_EXECUTION_FAILED_TRIGGER_ID },
-        }
-      ),
-    ],
-  },
-  snippets: {
-    condition: 'not event.workflow.isErrorHandler:true',
-  },
 };

--- a/src/platform/plugins/shared/workflows_extensions/server/emit_event.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/emit_event.test.ts
@@ -19,6 +19,13 @@ const eventSchema = z.object({
   status: z.string(),
 });
 
+const createTriggerDefinition = (): ServerTriggerDefinition => ({
+  id: 'cases.updated',
+  title: 'Case updated',
+  description: 'Emitted when a case is updated',
+  eventSchema,
+});
+
 const createDeps = (overrides: Partial<EmitEventDeps> = {}): EmitEventDeps => ({
   triggerRegistry: new TriggerRegistry(),
   triggerEventHandler: null,
@@ -47,10 +54,7 @@ describe('emitEvent', () => {
 
   it('throws when payload does not match the trigger eventSchema', async () => {
     const registry = new TriggerRegistry();
-    registry.register({
-      id: 'cases.updated',
-      eventSchema,
-    } as ServerTriggerDefinition);
+    registry.register(createTriggerDefinition());
     const handler = jest.fn();
     const deps = createDeps({
       triggerRegistry: registry,
@@ -74,10 +78,7 @@ describe('emitEvent', () => {
 
   it('calls handler when payload matches eventSchema', async () => {
     const registry = new TriggerRegistry();
-    registry.register({
-      id: 'cases.updated',
-      eventSchema,
-    } as ServerTriggerDefinition);
+    registry.register(createTriggerDefinition());
     const handler = jest.fn().mockResolvedValue(undefined);
     const deps = createDeps({
       triggerRegistry: registry,
@@ -108,10 +109,7 @@ describe('emitEvent', () => {
 
   it('passes eventChainContext undefined when request has no chain context (e.g. direct emit_loop)', async () => {
     const registry = new TriggerRegistry();
-    registry.register({
-      id: 'cases.updated',
-      eventSchema,
-    } as ServerTriggerDefinition);
+    registry.register(createTriggerDefinition());
     const handler = jest.fn().mockResolvedValue(undefined);
     const deps = createDeps({
       triggerRegistry: registry,
@@ -135,10 +133,7 @@ describe('emitEvent', () => {
 
   it('passes eventChainContext from request when not provided in params', async () => {
     const registry = new TriggerRegistry();
-    registry.register({
-      id: 'cases.updated',
-      eventSchema,
-    } as ServerTriggerDefinition);
+    registry.register(createTriggerDefinition());
     const handler = jest.fn().mockResolvedValue(undefined);
     const deps = createDeps({
       triggerRegistry: registry,
@@ -166,10 +161,7 @@ describe('emitEvent', () => {
 
   it('skips schema validation when eventSchema has no safeParse method', async () => {
     const registry = new TriggerRegistry();
-    registry.register({
-      id: 'cases.updated',
-      eventSchema,
-    } as ServerTriggerDefinition);
+    registry.register(createTriggerDefinition());
     // Overwrite the definition's eventSchema with an object that lacks safeParse
     const definition = registry.get('cases.updated')!;
     (definition as any).eventSchema = { shape: {} };
@@ -194,10 +186,7 @@ describe('emitEvent', () => {
 
   it('includes stringified error when schema validation error is not an Error instance', async () => {
     const registry = new TriggerRegistry();
-    registry.register({
-      id: 'cases.updated',
-      eventSchema,
-    } as ServerTriggerDefinition);
+    registry.register(createTriggerDefinition());
     // Replace eventSchema with a fake that returns a non-Error failure
     const definition = registry.get('cases.updated')!;
     (definition as any).eventSchema = {
@@ -226,10 +215,7 @@ describe('emitEvent', () => {
 
   it('throws when no handler is registered', async () => {
     const registry = new TriggerRegistry();
-    registry.register({
-      id: 'cases.updated',
-      eventSchema,
-    } as ServerTriggerDefinition);
+    registry.register(createTriggerDefinition());
     const deps = createDeps({
       triggerRegistry: registry,
       triggerEventHandler: null,

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
@@ -21,6 +21,8 @@ const createValidDefinition = (
   overrides: Partial<ServerTriggerDefinition> = {}
 ): ServerTriggerDefinition => ({
   id: 'cases.updated',
+  title: 'Case updated',
+  description: 'Fired when a case is updated.',
   eventSchema: validEventSchema,
   ...overrides,
 });

--- a/src/platform/plugins/shared/workflows_management/common/build_trigger_definitions_for_agent.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/build_trigger_definitions_for_agent.test.ts
@@ -146,6 +146,8 @@ describe('lookupTriggerDefinitionsForAgent', () => {
         {
           id: 'example.minimal',
           eventSchema: z.object({ value: z.string() }),
+          title: 'Minimal trigger',
+          description: 'Minimal trigger for testing.',
         },
       ],
       triggerType: 'example.minimal',

--- a/src/platform/plugins/shared/workflows_management/common/build_trigger_definitions_for_agent.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/build_trigger_definitions_for_agent.test.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { builtInTriggerDefinitions } from '@kbn/workflows';
+import { commonWorkflowExecutionFailedTriggerDefinition } from '@kbn/workflows-extensions/common';
+import { z } from '@kbn/zod/v4';
+import {
+  isTriggerDefinitionsLookupError,
+  lookupTriggerDefinitionsForAgent,
+} from './build_trigger_definitions_for_agent';
+
+const mockCasesTrigger = {
+  id: 'cases.caseUpdated',
+  eventSchema: z.object({
+    caseId: z.string(),
+    owner: z.string(),
+    updatedFields: z.array(z.string()).optional(),
+  }),
+  title: 'Cases - Case updated',
+  description: 'Emitted when a case is updated.',
+  documentation: {
+    examples: [
+      `triggers:
+  - type: cases.caseUpdated
+    on:
+      condition: 'event.owner: "securitySolution"'`,
+    ],
+  },
+};
+
+describe('lookupTriggerDefinitionsForAgent', () => {
+  it('returns built-in and registered trigger types without filter', () => {
+    const result = lookupTriggerDefinitionsForAgent({
+      registeredTriggers: [mockCasesTrigger],
+    });
+
+    expect(isTriggerDefinitionsLookupError(result)).toBe(false);
+    if (isTriggerDefinitionsLookupError(result)) {
+      return;
+    }
+
+    expect(result.count).toBe(builtInTriggerDefinitions.length + 1);
+    expect(result.triggerTypes.map((t) => t.id)).toContain('cases.caseUpdated');
+    expect(result.triggerTypes.map((t) => t.id)).toContain('manual');
+  });
+
+  it('returns jsonSchema and examples for built-in triggers', () => {
+    const result = lookupTriggerDefinitionsForAgent({
+      registeredTriggers: [mockCasesTrigger],
+    });
+
+    expect(isTriggerDefinitionsLookupError(result)).toBe(false);
+    if (isTriggerDefinitionsLookupError(result)) {
+      return;
+    }
+
+    const builtInTriggers = result.triggerTypes.filter((trigger) =>
+      builtInTriggerDefinitions.some((def) => def.id === trigger.id)
+    );
+    for (const trigger of builtInTriggers) {
+      expect(trigger.jsonSchema).toBeDefined();
+      expect(trigger.examples?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns custom trigger with trigger-specific eventContextSchema when filtered', () => {
+    const result = lookupTriggerDefinitionsForAgent({
+      registeredTriggers: [mockCasesTrigger],
+      triggerType: 'cases.caseUpdated',
+    });
+
+    expect(isTriggerDefinitionsLookupError(result)).toBe(false);
+    if (isTriggerDefinitionsLookupError(result)) {
+      return;
+    }
+
+    expect(result.count).toBe(1);
+    expect(result.triggerTypes[0].id).toBe('cases.caseUpdated');
+    const schemaStr = JSON.stringify(result.triggerTypes[0].eventContextSchema);
+    expect(schemaStr).toContain('caseId');
+    expect(schemaStr).toContain('owner');
+    expect(schemaStr).toContain('spaceId');
+    expect(schemaStr).toContain('timestamp');
+  });
+
+  it('filters by built-in triggerType', () => {
+    const result = lookupTriggerDefinitionsForAgent({
+      registeredTriggers: [mockCasesTrigger],
+      triggerType: 'scheduled',
+    });
+
+    expect(isTriggerDefinitionsLookupError(result)).toBe(false);
+    if (isTriggerDefinitionsLookupError(result)) {
+      return;
+    }
+
+    expect(result.count).toBe(1);
+    expect(result.triggerTypes[0].id).toBe('scheduled');
+  });
+
+  it('returns error for unknown trigger type with built-in and registered availableTypes', () => {
+    const result = lookupTriggerDefinitionsForAgent({
+      registeredTriggers: [mockCasesTrigger],
+      triggerType: 'nonexistent',
+    });
+
+    expect(isTriggerDefinitionsLookupError(result)).toBe(true);
+    if (!isTriggerDefinitionsLookupError(result)) {
+      return;
+    }
+
+    expect(result.error).toContain('not found');
+    expect(result.availableTypes).toContain('manual');
+    expect(result.availableTypes).toContain('cases.caseUpdated');
+  });
+
+  it('uses documentation.examples from registered trigger definitions', () => {
+    const result = lookupTriggerDefinitionsForAgent({
+      registeredTriggers: [commonWorkflowExecutionFailedTriggerDefinition],
+      triggerType: 'workflows.failed',
+    });
+
+    expect(isTriggerDefinitionsLookupError(result)).toBe(false);
+    if (isTriggerDefinitionsLookupError(result)) {
+      return;
+    }
+
+    const trigger = result.triggerTypes[0];
+    expect(trigger.examples?.length).toBeGreaterThan(0);
+    const examplesText = trigger.examples?.join('\n') ?? '';
+    expect(examplesText).toContain('event.workflow');
+    expect(examplesText).not.toContain('event.owner');
+    expect(trigger.label).toBe('Workflow failed');
+    expect(trigger.description).toContain('Emitted when any workflow');
+  });
+
+  it('omits examples when registered trigger has no documentation', () => {
+    const result = lookupTriggerDefinitionsForAgent({
+      registeredTriggers: [
+        {
+          id: 'example.minimal',
+          eventSchema: z.object({ value: z.string() }),
+        },
+      ],
+      triggerType: 'example.minimal',
+    });
+
+    expect(isTriggerDefinitionsLookupError(result)).toBe(false);
+    if (isTriggerDefinitionsLookupError(result)) {
+      return;
+    }
+
+    expect(result.triggerTypes[0].examples).toBeUndefined();
+  });
+
+  it('compacts large enums in scheduled trigger jsonSchema', () => {
+    const result = lookupTriggerDefinitionsForAgent({
+      registeredTriggers: [mockCasesTrigger],
+      triggerType: 'scheduled',
+    });
+
+    expect(isTriggerDefinitionsLookupError(result)).toBe(false);
+    if (isTriggerDefinitionsLookupError(result)) {
+      return;
+    }
+
+    const schemaStr = JSON.stringify(result.triggerTypes[0].jsonSchema);
+    expect(schemaStr).not.toContain('Pacific/Honolulu');
+    expect(schemaStr).toContain('allowed values');
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/common/build_trigger_definitions_for_agent.ts
+++ b/src/platform/plugins/shared/workflows_management/common/build_trigger_definitions_for_agent.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { BaseTriggerDefinition } from '@kbn/workflows';
+import {
+  builtInTriggerDefinitions,
+  EventTimestampSchema,
+  WorkflowEventsSchema,
+} from '@kbn/workflows';
+import { BaseEventSchema } from '@kbn/workflows/spec/schema/common/base_event';
+import { AlertEventSchema } from '@kbn/workflows/spec/schema/triggers/alert_trigger_schema';
+import type { ServerTriggerDefinition } from '@kbn/workflows-extensions/server';
+import { z } from '@kbn/zod/v4';
+
+const LARGE_ENUM_THRESHOLD = 20;
+
+export interface TriggerDefinitionForAgent {
+  id: string;
+  label: string;
+  description: string;
+  jsonSchema: unknown;
+  eventContextSchema: unknown;
+  eventContextNote: string;
+  examples?: string[];
+}
+
+export const EVENT_CONTEXT_NOTE =
+  'The event context is available via {{ event.* }} in Liquid templates. ' +
+  'NEVER use {{ triggers.event }} or {{ trigger.event }} — the correct variable is {{ event }}.';
+
+function zodToJsonSchemaSafe(schema: z.ZodType): unknown {
+  try {
+    const jsonSchema = z.toJSONSchema(schema, { target: 'draft-7', unrepresentable: 'any' });
+    return compactLargeEnums(jsonSchema as Record<string, unknown>);
+  } catch {
+    return undefined;
+  }
+}
+
+function compactLargeEnums(node: unknown): unknown {
+  if (node === null || typeof node !== 'object') return node;
+  if (Array.isArray(node)) return node.map(compactLargeEnums);
+
+  const obj = node as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'enum' && Array.isArray(value) && value.length > LARGE_ENUM_THRESHOLD) {
+      const examples = value.slice(0, 5) as string[];
+      result.type = 'string';
+      result.description = [
+        obj.description ?? '',
+        `One of ${value.length} allowed values, e.g.: ${examples.join(', ')}`,
+      ]
+        .filter(Boolean)
+        .join('. ');
+    } else {
+      result[key] = compactLargeEnums(value);
+    }
+  }
+
+  return result;
+}
+
+function isZodObject(schema: z.ZodType): schema is z.ZodObject<z.ZodRawShape> {
+  return schema instanceof z.ZodObject;
+}
+
+function getCustomTriggerYamlSchema(triggerId: string): z.ZodType {
+  return z.object({
+    type: z.literal(triggerId),
+    on: z
+      .object({
+        condition: z.string().optional(),
+        workflowEvents: WorkflowEventsSchema.optional(),
+      })
+      .optional(),
+  });
+}
+
+function humanizeTriggerId(triggerId: string): string {
+  const [namespace, event] = triggerId.split('.');
+  const formatSegment = (segment: string) =>
+    segment
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/[_-]+/g, ' ')
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+  if (!event) {
+    return formatSegment(triggerId);
+  }
+  return `${formatSegment(namespace)} - ${formatSegment(event)}`;
+}
+
+function getEventContextSchema(
+  triggerId: string,
+  customDefsById: Map<string, ServerTriggerDefinition>
+): unknown {
+  if (triggerId === 'alert') {
+    return zodToJsonSchemaSafe(AlertEventSchema);
+  }
+
+  const custom = customDefsById.get(triggerId);
+  if (custom && isZodObject(custom.eventSchema)) {
+    return zodToJsonSchemaSafe(
+      z.object({
+        ...BaseEventSchema.shape,
+        ...EventTimestampSchema.shape,
+        ...custom.eventSchema.shape,
+      })
+    );
+  }
+
+  return zodToJsonSchemaSafe(BaseEventSchema);
+}
+
+function createRegisteredTriggersMap(
+  registeredTriggers: ServerTriggerDefinition[]
+): Map<string, ServerTriggerDefinition> {
+  return new Map(registeredTriggers.map((def) => [def.id, def]));
+}
+
+function formatBuiltInTrigger(
+  def: BaseTriggerDefinition,
+  registeredTriggersById: Map<string, ServerTriggerDefinition>
+): TriggerDefinitionForAgent {
+  return {
+    id: def.id,
+    label: def.label,
+    description: def.description,
+    jsonSchema: zodToJsonSchemaSafe(def.schema),
+    eventContextSchema: getEventContextSchema(def.id, registeredTriggersById),
+    eventContextNote: EVENT_CONTEXT_NOTE,
+    examples: def.documentation.examples,
+  };
+}
+
+function formatRegisteredTrigger(
+  def: ServerTriggerDefinition,
+  registeredTriggersById: Map<string, ServerTriggerDefinition>
+): TriggerDefinitionForAgent {
+  const formatted: TriggerDefinitionForAgent = {
+    id: def.id,
+    label: def.title ?? humanizeTriggerId(def.id),
+    description:
+      def.description ??
+      `Event-driven trigger (${def.id}). Use on.condition with KQL on event.* fields to filter when the workflow runs.`,
+    jsonSchema: zodToJsonSchemaSafe(getCustomTriggerYamlSchema(def.id)),
+    eventContextSchema: getEventContextSchema(def.id, registeredTriggersById),
+    eventContextNote: EVENT_CONTEXT_NOTE,
+  };
+
+  const examples = def.documentation?.examples;
+  if (examples && examples.length > 0) {
+    formatted.examples = examples;
+  }
+
+  return formatted;
+}
+
+/**
+ * Full trigger catalog for workflow authoring agents.
+ *
+ * - Built-ins (`manual`, `scheduled`, `alert`) come from `@kbn/workflows`.
+ * - Everything else comes from `api.getRegisteredTriggers()` (workflows_extensions registry).
+ */
+export function getAllTriggerDefinitionsForAgent(
+  registeredTriggers: ServerTriggerDefinition[]
+): TriggerDefinitionForAgent[] {
+  const registeredById = createRegisteredTriggersMap(registeredTriggers);
+  const builtInIds = new Set(builtInTriggerDefinitions.map((def) => def.id));
+
+  const builtIn = builtInTriggerDefinitions.map((def) => formatBuiltInTrigger(def, registeredById));
+  const pluginRegistered = registeredTriggers
+    .filter((def) => !builtInIds.has(def.id))
+    .map((def) => formatRegisteredTrigger(def, registeredById));
+
+  return [...builtIn, ...pluginRegistered];
+}
+
+export interface TriggerDefinitionsLookupSuccess {
+  count: number;
+  triggerTypes: TriggerDefinitionForAgent[];
+}
+
+export interface TriggerDefinitionsLookupError {
+  error: string;
+  availableTypes: string[];
+}
+
+export type TriggerDefinitionsLookupResult =
+  | TriggerDefinitionsLookupSuccess
+  | TriggerDefinitionsLookupError;
+
+export const isTriggerDefinitionsLookupError = (
+  result: TriggerDefinitionsLookupResult
+): result is TriggerDefinitionsLookupError => 'error' in result;
+
+/**
+ * Resolves the agent trigger catalog, optionally filtered to a single trigger id.
+ */
+export function lookupTriggerDefinitionsForAgent({
+  registeredTriggers,
+  triggerType,
+}: {
+  registeredTriggers: ServerTriggerDefinition[];
+  triggerType?: string;
+}): TriggerDefinitionsLookupResult {
+  const allTriggerDefinitions = getAllTriggerDefinitionsForAgent(registeredTriggers);
+
+  if (!triggerType) {
+    return { count: allTriggerDefinitions.length, triggerTypes: allTriggerDefinitions };
+  }
+
+  const matching = allTriggerDefinitions.filter((def) => def.id === triggerType);
+  if (matching.length === 0) {
+    return {
+      error: `Trigger type "${triggerType}" not found`,
+      availableTypes: allTriggerDefinitions.map((def) => def.id),
+    };
+  }
+
+  return { count: matching.length, triggerTypes: matching };
+}

--- a/src/platform/plugins/shared/workflows_management/common/build_trigger_definitions_for_agent.ts
+++ b/src/platform/plugins/shared/workflows_management/common/build_trigger_definitions_for_agent.ts
@@ -9,12 +9,11 @@
 
 import type { BaseTriggerDefinition } from '@kbn/workflows';
 import {
+  AlertEventSchema,
+  BaseEventSchema,
   builtInTriggerDefinitions,
   EventTimestampSchema,
-  WorkflowEventsSchema,
 } from '@kbn/workflows';
-import { BaseEventSchema } from '@kbn/workflows/spec/schema/common/base_event';
-import { AlertEventSchema } from '@kbn/workflows/spec/schema/triggers/alert_trigger_schema';
 import type { ServerTriggerDefinition } from '@kbn/workflows-extensions/server';
 import { z } from '@kbn/zod/v4';
 
@@ -78,7 +77,6 @@ function getCustomTriggerYamlSchema(triggerId: string): z.ZodType {
     on: z
       .object({
         condition: z.string().optional(),
-        workflowEvents: WorkflowEventsSchema.optional(),
       })
       .optional(),
   });

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/register_workflow_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/register_workflow_agent_builder_integration.ts
@@ -39,7 +39,7 @@ export function registerWorkflowAgentBuilderIntegration({
 
   registerValidateWorkflowTool(agentBuilder, api);
   registerGetStepDefinitionsTool(agentBuilder, api);
-  registerGetTriggerDefinitionsTool(agentBuilder);
+  registerGetTriggerDefinitionsTool(agentBuilder, api);
   registerGetConnectorsTool(agentBuilder, api);
   registerGetExamplesTool(agentBuilder);
 

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.test.ts
@@ -9,16 +9,32 @@
 
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
-import { builtInTriggerDefinitions } from '@kbn/workflows';
+import { z } from '@kbn/zod/v4';
+import type { WorkflowsManagementApi } from '../../api/workflows_management_api';
 import { registerGetTriggerDefinitionsTool } from './get_trigger_definitions_tool';
+
+type GetRegisteredTriggersApi = Pick<WorkflowsManagementApi, 'getRegisteredTriggers'>;
 
 const invokeHandler = async (tool: BuiltinToolDefinition, input: unknown, context: unknown) =>
   (await tool.handler(input as never, context as never)) as ToolHandlerStandardReturn;
 
+const mockCasesTrigger = {
+  id: 'cases.caseUpdated',
+  eventSchema: z.object({
+    caseId: z.string(),
+    owner: z.string(),
+  }),
+};
+
 describe('registerGetTriggerDefinitionsTool', () => {
   let registeredTool: BuiltinToolDefinition;
+  let mockApi: jest.Mocked<GetRegisteredTriggersApi>;
 
   beforeEach(() => {
+    mockApi = {
+      getRegisteredTriggers: jest.fn().mockResolvedValue([mockCasesTrigger]),
+    };
+
     const agentBuilder = {
       tools: {
         register: jest.fn((tool: BuiltinToolDefinition) => {
@@ -26,60 +42,22 @@ describe('registerGetTriggerDefinitionsTool', () => {
         }),
       },
     } as any;
-    registerGetTriggerDefinitionsTool(agentBuilder);
+    registerGetTriggerDefinitionsTool(agentBuilder, mockApi);
   });
 
   it('registers with correct id', () => {
     expect(registeredTool.id).toBe('platform.workflows.get_trigger_definitions');
   });
 
-  it('returns all trigger types without filter', async () => {
-    const result = await invokeHandler(registeredTool, {}, {});
-    const data = result.results[0].data as any;
-    expect(data.count).toBe(builtInTriggerDefinitions.length);
-    expect(data.triggerTypes.length).toBe(builtInTriggerDefinitions.length);
-  });
+  it('wraps lookup result in agent builder tool response shape', async () => {
+    const result = await invokeHandler(registeredTool, { triggerType: 'manual' }, {});
 
-  it('returns jsonSchema and examples for each trigger', async () => {
-    const result = await invokeHandler(registeredTool, {}, {});
-    const data = result.results[0].data as any;
-    for (const trigger of data.triggerTypes) {
-      expect(trigger).toHaveProperty('id');
-      expect(trigger).toHaveProperty('label');
-      expect(trigger).toHaveProperty('description');
-      expect(trigger).toHaveProperty('jsonSchema');
-      expect(trigger).toHaveProperty('examples');
-      expect(trigger.examples.length).toBeGreaterThan(0);
-    }
-  });
-
-  it('filters by triggerType', async () => {
-    const result = await invokeHandler(registeredTool, { triggerType: 'scheduled' }, {});
-    const data = result.results[0].data as any;
-    expect(data.count).toBe(1);
-    expect(data.triggerTypes[0].id).toBe('scheduled');
-  });
-
-  it('returns error for unknown trigger type', async () => {
-    const result = await invokeHandler(registeredTool, { triggerType: 'nonexistent' }, {});
-    const data = result.results[0].data as any;
-    expect(data.error).toContain('not found');
-    expect(data.availableTypes).toContain('manual');
-  });
-
-  it('compacts large enums like timezone names in the schema', async () => {
-    const result = await invokeHandler(registeredTool, { triggerType: 'scheduled' }, {});
-    const data = result.results[0].data as any;
-    const schemaStr = JSON.stringify(data.triggerTypes[0].jsonSchema);
-    expect(schemaStr).not.toContain('Pacific/Honolulu');
-    expect(schemaStr).toContain('allowed values');
-  });
-
-  it('returns results in expected shape', async () => {
-    const result = await invokeHandler(registeredTool, {}, {});
-    expect(result).toHaveProperty('results');
+    expect(mockApi.getRegisteredTriggers).toHaveBeenCalled();
     expect(result.results).toHaveLength(1);
     expect(result.results[0].type).toBe('other');
-    expect(result.results[0]).toHaveProperty('data');
+    expect(result.results[0].data).toEqual({
+      count: 1,
+      triggerTypes: [expect.objectContaining({ id: 'manual' })],
+    });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.test.ts
@@ -10,8 +10,8 @@
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
 import { z } from '@kbn/zod/v4';
-import type { WorkflowsManagementApi } from '../../api/workflows_management_api';
 import { registerGetTriggerDefinitionsTool } from './get_trigger_definitions_tool';
+import type { WorkflowsManagementApi } from '../../api/workflows_management_api';
 
 type GetRegisteredTriggersApi = Pick<WorkflowsManagementApi, 'getRegisteredTriggers'>;
 

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.ts
@@ -9,9 +9,9 @@
 
 import { ToolType } from '@kbn/agent-builder-common';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
-import { lookupTriggerDefinitionsForAgent } from '@kbn/workflows-management-plugin/common/build_trigger_definitions_for_agent';
 import { z } from '@kbn/zod/v4';
 import { workflowTools } from '../../../common/agent_builder/constants';
+import { lookupTriggerDefinitionsForAgent } from '../../../common/build_trigger_definitions_for_agent';
 import type { WorkflowsManagementApi } from '../../api/workflows_management_api';
 import type { AgentBuilderPluginSetupContract } from '../../types';
 

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.ts
@@ -9,67 +9,17 @@
 
 import { ToolType } from '@kbn/agent-builder-common';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
-import { AlertEventSchema, BaseEventSchema, builtInTriggerDefinitions } from '@kbn/workflows';
+import { lookupTriggerDefinitionsForAgent } from '@kbn/workflows-management-plugin/common/build_trigger_definitions_for_agent';
 import { z } from '@kbn/zod/v4';
 import { workflowTools } from '../../../common/agent_builder/constants';
+import type { WorkflowsManagementApi } from '../../api/workflows_management_api';
 import type { AgentBuilderPluginSetupContract } from '../../types';
 
-const LARGE_ENUM_THRESHOLD = 20;
-
-function zodToJsonSchemaSafe(schema: z.ZodType): unknown {
-  try {
-    const jsonSchema = z.toJSONSchema(schema, { target: 'draft-7', unrepresentable: 'any' });
-    return compactLargeEnums(jsonSchema as Record<string, unknown>);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Recursively walk a JSON Schema and replace enum arrays larger than
- * {@link LARGE_ENUM_THRESHOLD} with a compact description + a few examples.
- * This avoids sending 600+ timezone names (or similar) to the LLM.
- */
-function compactLargeEnums(node: unknown): unknown {
-  if (node === null || typeof node !== 'object') return node;
-  if (Array.isArray(node)) return node.map(compactLargeEnums);
-
-  const obj = node as Record<string, unknown>;
-  const result: Record<string, unknown> = {};
-
-  for (const [key, value] of Object.entries(obj)) {
-    if (key === 'enum' && Array.isArray(value) && value.length > LARGE_ENUM_THRESHOLD) {
-      const examples = value.slice(0, 5) as string[];
-      result.type = 'string';
-      result.description = [
-        obj.description ?? '',
-        `One of ${value.length} allowed values, e.g.: ${examples.join(', ')}`,
-      ]
-        .filter(Boolean)
-        .join('. ');
-    } else {
-      result[key] = compactLargeEnums(value);
-    }
-  }
-
-  return result;
-}
-
-/**
- * Returns the JSON Schema for `{{ event.* }}` variables available at runtime for a given trigger type.
- * Alert triggers get the full alert event context (alerts array, rule, params);
- * other built-in triggers only get `BaseEventSchema` (spaceId).
- */
-function getEventContextSchema(triggerTypeId: string): unknown {
-  // TODO: support custom trigger event schemas
-  if (triggerTypeId === 'alert') {
-    return zodToJsonSchemaSafe(AlertEventSchema);
-  }
-  return zodToJsonSchemaSafe(BaseEventSchema);
-}
+type GetRegisteredTriggersApi = Pick<WorkflowsManagementApi, 'getRegisteredTriggers'>;
 
 export function registerGetTriggerDefinitionsTool(
-  agentBuilder: AgentBuilderPluginSetupContract
+  agentBuilder: AgentBuilderPluginSetupContract,
+  api: GetRegisteredTriggersApi
 ): void {
   agentBuilder.tools.register({
     id: workflowTools.getTriggerDefinitions,
@@ -79,12 +29,14 @@ export function registerGetTriggerDefinitionsTool(
 **When to use:** To learn how to configure the \`triggers\` section of a workflow, or to understand what \`{{ event.* }}\` variables are available at runtime for a given trigger type.
 **When NOT to use:** For step definitions (use get_step_definitions) or connector instances (use get_connectors).
 
-Returns built-in trigger types (manual, scheduled, alert) including the event context schema that describes what \`{{ event.* }}\` contains at runtime.`,
+Returns built-in trigger types (manual, scheduled, alert) plus event-driven triggers (e.g. cases.caseUpdated) including the event context schema that describes what \`{{ event.* }}\` contains at runtime.`,
     schema: z.object({
       triggerType: z
         .string()
         .optional()
-        .describe('Filter by exact trigger type (e.g., "manual", "scheduled", "alert")'),
+        .describe(
+          'Filter by exact trigger type (e.g., "manual", "scheduled", "alert", "workflows.failed", "cases.caseUpdated")'
+        ),
     }),
     tags: ['workflows', 'yaml', 'triggers'],
     availability: {
@@ -98,48 +50,16 @@ Returns built-in trigger types (manual, scheduled, alert) including the event co
       },
       cacheMode: 'space',
     },
-    handler: async ({ triggerType }) => {
-      let definitions = builtInTriggerDefinitions.map((def) => ({
-        id: def.id,
-        label: def.label,
-        description: def.description,
-        jsonSchema: zodToJsonSchemaSafe(def.schema),
-        eventContextSchema: getEventContextSchema(def.id),
-        eventContextNote:
-          'The event context is available via {{ event.* }} in Liquid templates. ' +
-          'NEVER use {{ triggers.event }} or {{ trigger.event }} — the correct variable is {{ event }}.',
-        examples: def.documentation.examples,
-      }));
-
-      if (triggerType) {
-        definitions = definitions.filter((def) => def.id === triggerType);
-      }
-
-      if (definitions.length === 0 && triggerType) {
-        return {
-          results: [
-            {
-              type: 'other' as const,
-              data: {
-                error: `Trigger type "${triggerType}" not found`,
-                availableTypes: builtInTriggerDefinitions.map((d) => d.id),
-              },
-            },
-          ],
-        };
-      }
-
-      return {
-        results: [
-          {
-            type: 'other' as const,
-            data: {
-              count: definitions.length,
-              triggerTypes: definitions,
-            },
-          },
-        ],
-      };
-    },
+    handler: async ({ triggerType }) => ({
+      results: [
+        {
+          type: 'other' as const,
+          data: lookupTriggerDefinitionsForAgent({
+            registeredTriggers: await api.getRegisteredTriggers(),
+            triggerType,
+          }),
+        },
+      ],
+    }),
   });
 }

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -35,6 +35,7 @@ import type {
   ExecutionLogsParams,
   StepLogsParams,
 } from '@kbn/workflows-execution-engine/server/workflow_event_logger/types';
+import type { ServerTriggerDefinition } from '@kbn/workflows-extensions/server';
 import type { z } from '@kbn/zod/v4';
 import type { StepExecutionListResult } from './lib/search_step_executions';
 import type {
@@ -583,6 +584,10 @@ export class WorkflowsManagementApi {
     request: KibanaRequest
   ): Promise<GetAvailableConnectorsResponse> {
     return this.workflowsService.getAvailableConnectors(spaceId, request);
+  }
+
+  public async getRegisteredTriggers(): Promise<ServerTriggerDefinition[]> {
+    return this.workflowsService.getRegisteredCustomTriggerDefinitions();
   }
 
   public async getWorkflowJsonSchema(

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -59,7 +59,10 @@ import type {
   ExecutionLogsParams,
   StepLogsParams,
 } from '@kbn/workflows-execution-engine/server/workflow_event_logger/types';
-import type { WorkflowsExtensionsServerPluginStart } from '@kbn/workflows-extensions/server';
+import type {
+  ServerTriggerDefinition,
+  WorkflowsExtensionsServerPluginStart,
+} from '@kbn/workflows-extensions/server';
 import type { z } from '@kbn/zod/v4';
 
 import { getChildWorkflowExecutions } from './lib/get_child_workflow_executions';
@@ -2181,6 +2184,11 @@ export class WorkflowsService {
       return { config: { taskType: connector.config?.taskType } };
     }
     return undefined;
+  }
+
+  public async getRegisteredCustomTriggerDefinitions(): Promise<ServerTriggerDefinition[]> {
+    await this.ensureInitialized();
+    return this.workflowsExtensions?.getAllTriggerDefinitions() ?? [];
   }
 
   public async validateWorkflow(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[One workflow] 🐞 Include registered triggers in agent builder experience (#270221)](https://github.com/elastic/kibana/pull/270221)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yngrid Coello","email":"yngrid.coello@elastic.co"},"sourceCommit":{"committedDate":"2026-05-22T14:18:12Z","message":"[One workflow] 🐞 Include registered triggers in agent builder experience (#270221)\n\nCloses https://github.com/elastic/security-team/issues/17218.\n\n## Summary\n\nExtends the workflow agent `platform.workflows.get_trigger_definitions`\ntool (and workflow-gen `get_trigger_definitions`) so agents see\n**built-in triggers** (`manual`, `scheduled`, `alert`) **plus**\nevent-driven triggers from `workflows_extensions` (e.g.\n`cases.caseUpdated`), each with `jsonSchema`, `eventContextSchema`, and\nexamples where applicable.\n\n## UI verification prompt\n\n```\nList all workflow triggers\n```\nor\n```\nI need a workflow that will alert me every time a cases status changes\n```\nor\n```\nCreate a workflow that would alert me in slack eveytime a workflow fails\n```\n\nAny of those prompts should include the use of event-driven triggers\n\n## 🎥 Demo\n\n\nhttps://github.com/user-attachments/assets/1a08f47a-929a-4928-9ffd-da4fa8fa00c8","sha":"828e21578872aa0098b308656084209bb837921a","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport missing","backport:version","Team:One Workflow","v9.4.0","v9.5.0","v9.4.1","v9.4.2"],"title":"[One workflow] 🐞 Include registered triggers in agent builder experience","number":270221,"url":"https://github.com/elastic/kibana/pull/270221","mergeCommit":{"message":"[One workflow] 🐞 Include registered triggers in agent builder experience (#270221)\n\nCloses https://github.com/elastic/security-team/issues/17218.\n\n## Summary\n\nExtends the workflow agent `platform.workflows.get_trigger_definitions`\ntool (and workflow-gen `get_trigger_definitions`) so agents see\n**built-in triggers** (`manual`, `scheduled`, `alert`) **plus**\nevent-driven triggers from `workflows_extensions` (e.g.\n`cases.caseUpdated`), each with `jsonSchema`, `eventContextSchema`, and\nexamples where applicable.\n\n## UI verification prompt\n\n```\nList all workflow triggers\n```\nor\n```\nI need a workflow that will alert me every time a cases status changes\n```\nor\n```\nCreate a workflow that would alert me in slack eveytime a workflow fails\n```\n\nAny of those prompts should include the use of event-driven triggers\n\n## 🎥 Demo\n\n\nhttps://github.com/user-attachments/assets/1a08f47a-929a-4928-9ffd-da4fa8fa00c8","sha":"828e21578872aa0098b308656084209bb837921a"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/270221","number":270221,"mergeCommit":{"message":"[One workflow] 🐞 Include registered triggers in agent builder experience (#270221)\n\nCloses https://github.com/elastic/security-team/issues/17218.\n\n## Summary\n\nExtends the workflow agent `platform.workflows.get_trigger_definitions`\ntool (and workflow-gen `get_trigger_definitions`) so agents see\n**built-in triggers** (`manual`, `scheduled`, `alert`) **plus**\nevent-driven triggers from `workflows_extensions` (e.g.\n`cases.caseUpdated`), each with `jsonSchema`, `eventContextSchema`, and\nexamples where applicable.\n\n## UI verification prompt\n\n```\nList all workflow triggers\n```\nor\n```\nI need a workflow that will alert me every time a cases status changes\n```\nor\n```\nCreate a workflow that would alert me in slack eveytime a workflow fails\n```\n\nAny of those prompts should include the use of event-driven triggers\n\n## 🎥 Demo\n\n\nhttps://github.com/user-attachments/assets/1a08f47a-929a-4928-9ffd-da4fa8fa00c8","sha":"828e21578872aa0098b308656084209bb837921a"}}]}] BACKPORT-->