### PR TITLE
(fix) OBS BI - exclude rollup indices from otel telemetry collection plugin

### DIFF
--- a/x-pack/platform/plugins/private/otel_telemetry_collection/server/lib/services/receiver.test.ts
+++ b/x-pack/platform/plugins/private/otel_telemetry_collection/server/lib/services/receiver.test.ts
@@ -87,6 +87,11 @@ describe('OtelTelemetryReceiver', () => {
       expect(call.query.bool.filter).toEqual([
         { range: { '@timestamp': { gte: `now-${defaultConfig.query_window}` } } },
       ]);
+      expect(call.query.bool.must_not).toEqual([
+        { wildcard: { 'data_stream.dataset': '*.1m.otel' } },
+        { wildcard: { 'data_stream.dataset': '*.10m.otel' } },
+        { wildcard: { 'data_stream.dataset': '*.60m.otel' } },
+      ]);
 
       const composite = call.aggs.combos.composite;
       expect(composite.size).toBe(defaultConfig.composite_page_size);

--- a/x-pack/platform/plugins/private/otel_telemetry_collection/server/lib/services/receiver.ts
+++ b/x-pack/platform/plugins/private/otel_telemetry_collection/server/lib/services/receiver.ts
@@ -186,6 +186,11 @@ export class OtelTelemetryReceiver {
       query: {
         bool: {
           filter: [{ range: { '@timestamp': { gte: `now-${config.query_window}` } } }],
+          must_not: [
+            { wildcard: { 'data_stream.dataset': '*.1m.otel' } },
+            { wildcard: { 'data_stream.dataset': '*.10m.otel' } },
+            { wildcard: { 'data_stream.dataset': '*.60m.otel' } },
+          ],
         },
       },
       aggs: {


### PR DESCRIPTION
## Summary


Exclude APM rollup data streams (*.1m.otel, *.10m.otel, *.60m.otel) from the per-service OTel metrics composite agg. These streams are span-derived rollups, not raw OTLP metrics. Filtering them yields one bucket per real service and accurate metric counts. Traces/logs queries unaffected — rollups only live under `metrics-*` but the query is the same for all signals.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->