### PR TITLE
[FLAKY VALIDATION — DO NOT MERGE] Pre-fix: un-skip install_notifications for #268548 CI demo

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_notifications.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/installation/install_notifications.cy.ts
@@ -25,8 +25,7 @@ import { resetRulesTableState } from '../../../../../tasks/common';
 import { login } from '../../../../../tasks/login';
 import { visitRulesManagementTable } from '../../../../../tasks/rules_management';
 
-// Failing: See https://github.com/elastic/kibana/issues/268548
-describe.skip(
+describe(
   'Detection rules, Prebuilt Rules Install Notifications',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {


### PR DESCRIPTION
**This PR exists solely to drive ~5 full CI runs against the pre-fix state of the [#268548](https://github.com/elastic/kibana/issues/268548) cluster. DO NOT MERGE.**

## What this branch contains

- Un-skipped `install_notifications.cy.ts` (the most recently skipped failing spec from the #268548 cluster).
- **No helper fix** — the intercept in `tasks/api_calls/prebuilt_rules.ts` is at its original `req.continue(callback)` form, which is the documented Cypress bug surface (see [cypress-io/cypress#26248](https://github.com/cypress-io/cypress/issues/26248)).

## Why

The flaky-test-suite-runner failed to reproduce the bug at 200 isolated runs (see [#12472](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/12472)). Hypothesis: the bug requires full-suite environmental conditions (spec ordering, ES contention, sequential Cypress runs) that the flaky runner doesn't capture. This PR drives the **real PR-CI pipeline**, which more closely mimics the kibana-on-merge environment where the 20 #268548 issues occurred.

## How to use

Push 4 more empty commits to this branch (or rerun the PR-CI build manually 4 times) to get 5 distinct CI runs. Watch the Cypress security-solution-rule-management steps for `Socket closed before finished writing response` failures.

## Paired post-fix PR
See **[draft PR for `flaky/268548-postfix-ci`]** (to be opened next) — same branch contents plus the helper fix. Comparing pass rates between the two PRs is the validation.