### PR TITLE
[Fleet] Fix namespace index templates labels

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
@@ -468,7 +468,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                                 'xpack.fleet.createPackagePolicy.namespaceCustomization.disabledMissingNamespace',
                                 {
                                   defaultMessage:
-                                    'Enter a namespace to enable the namespace index template.',
+                                    'Enter a namespace to enable namespace index templates.',
                                 }
                               )
                             : !isNamespacePrefixAllowed
@@ -476,7 +476,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                                 'xpack.fleet.createPackagePolicy.namespaceCustomization.disabledPrefix',
                                 {
                                   defaultMessage:
-                                    'This namespace does not match an allowed prefix for this space, so the namespace index template cannot be enabled.',
+                                    'This namespace does not match an allowed prefix for this space, so namespace index templates cannot be enabled.',
                                 }
                               )
                             : isManaged
@@ -537,14 +537,14 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                               'xpack.fleet.createPackagePolicy.namespaceCustomization.optInImpactTitle',
                               {
                                 defaultMessage:
-                                  'Enabling the namespace index template will affect {count, plural, one {# other policy} other {# other policies}}',
+                                  'Enabling namespace index templates will affect {count, plural, one {# other policy} other {# other policies}}',
                                 values: { count: otherPoliciesCount },
                               }
                             )}
                           >
                             <FormattedMessage
                               id="xpack.fleet.createPackagePolicy.namespaceCustomization.optInImpactDescription"
-                              defaultMessage="The namespace index template is shared across all {packageTitle} integration policies targeting namespace {namespace}. Enabling it here will apply it to all of them."
+                              defaultMessage="Namespace index templates are shared across all {packageTitle} integration policies targeting namespace {namespace}. Enabling them here will apply them to all of them."
                               values={{
                                 packageTitle: packageInfo.title,
                                 namespace: <strong>{currentNamespace}</strong>,
@@ -566,14 +566,14 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                               'xpack.fleet.createPackagePolicy.namespaceCustomization.optOutImpactTitle',
                               {
                                 defaultMessage:
-                                  'Disabling the namespace index template will affect {count, plural, one {# other policy} other {# other policies}}',
+                                  'Disabling namespace index templates will affect {count, plural, one {# other policy} other {# other policies}}',
                                 values: { count: otherPoliciesCount },
                               }
                             )}
                           >
                             <FormattedMessage
                               id="xpack.fleet.createPackagePolicy.namespaceCustomization.optOutImpactDescription"
-                              defaultMessage="The namespace index template is shared across all {packageTitle} integration policies targeting namespace {namespace}. Disabling it here will remove it from all of them."
+                              defaultMessage="Namespace index templates are shared across all {packageTitle} integration policies targeting namespace {namespace}. Disabling them here will remove them from all of them."
                               values={{
                                 packageTitle: packageInfo.title,
                                 namespace: <strong>{currentNamespace}</strong>,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/apply_namespace_customization.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/apply_namespace_customization.ts
@@ -43,7 +43,7 @@ export async function applyNamespaceCustomizationChange(
   if (error) {
     notifications.toasts.addError(error, {
       title: i18n.translate('xpack.fleet.packagePolicy.namespaceCustomizationApplyErrorTitle', {
-        defaultMessage: 'Could not update namespace index template for {title}',
+        defaultMessage: 'Could not update namespace index templates for {title}',
         values: { title: packageTitle },
       }),
     });
@@ -52,10 +52,10 @@ export async function applyNamespaceCustomizationChange(
 
   notifications.toasts.addSuccess({
     title: i18n.translate('xpack.fleet.packagePolicy.namespaceCustomizationApplySuccessTitle', {
-      defaultMessage: 'Namespace index template updated',
+      defaultMessage: 'Namespace index templates updated',
     }),
     text: i18n.translate('xpack.fleet.packagePolicy.namespaceCustomizationApplySuccessText', {
-      defaultMessage: 'Applying namespace index template changes for {title}.',
+      defaultMessage: 'Applying changes to namespace index templates for {title}.',
       values: { title: packageTitle },
     }),
   });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/namespace_customization_section.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/namespace_customization_section.tsx
@@ -202,7 +202,7 @@ export const NamespaceCustomizationSection: React.FC<Props> = ({
                 <EuiFlexItem grow={false}>
                   <FormattedMessage
                     id="xpack.fleet.integrations.settings.namespaceCustomization.applying"
-                    defaultMessage="Applying namespace index template changes…"
+                    defaultMessage="Applying changes to namespace index templates…"
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -194,7 +194,7 @@ export const SettingsPage: React.FC<Props> = memo(
                 text: i18n.translate(
                   'xpack.fleet.integrations.namespaceCustomizationSavedSuccess',
                   {
-                    defaultMessage: 'Applying namespace index template changes for {title}.',
+                    defaultMessage: 'Applying changes to namespace index templates for {title}.',
                     values: { title },
                   }
                 ),


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/kibana/issues/264065

Some UI labels for integration namespace index templates were incorrectly using the singular. This PR fixes that.

Quick summary of how they work:
Fleet-managed namespace index templates are created for each data stream defined by the package. They are named according to `{type}-{dataset}@namespace.{namespace`}, e.g. `logs-system.application@namespace.production`, and their `composed_of` contains a reference to a `{namespace}@custom` component template, which is left to the user to create.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

UI labels change only.