### PR TITLE
[CI] Skip archive upload when tsc fails

### DIFF
--- a/packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_legacy_cli.ts
@@ -102,7 +102,7 @@ export const runLegacyTypeCheckCli = () => {
         const localChanges = shouldUploadArchive ? await detectLocalChanges() : [];
         const hasLocalChanges = localChanges.length > 0;
 
-        if (shouldUploadArchive) {
+        if (shouldUploadArchive && !tscFailed) {
           if (hasLocalChanges) {
             const changedFiles = localChanges.join('\n');
             const message = `uncommitted changes were detected after the TypeScript build. TypeScript cache artifacts must be generated from a clean working tree.\nChanged files:\n${changedFiles}`;


### PR DESCRIPTION
When tsc exits non-zero, TypeScript still emits .d.ts outputs and writes .tsbuildinfo marking each project as up-to-date (noEmitOnError defaults to false). Uploading this archive on failure causes subsequent runs to skip re-checking those packages, masking the errors. The contract-based path in executeTypeCheckValidation already guards upload behind !tscFailed; apply the same guard to runLegacyTypeCheckCli.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->