### PR TITLE
[One Workflow] feat(workflows): add system workflow settings section to Advanced Settings

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/constants.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/constants.ts
@@ -26,6 +26,12 @@ export const WORKFLOWS_UI_SHOW_EXECUTOR_SETTING_ID = 'workflows:ui:showExecutor:
 export const WORKFLOW_EXECUTION_STATS_BAR_SETTING_ID = 'workflows:executionStatsBar:enabled';
 
 /**
+ * UI Setting IDs for system workflow visibility controls
+ */
+export const WORKFLOW_SHOW_SYSTEM_WORKFLOWS_SETTING_ID = 'workflows:ui:showSystemWorkflows';
+export const WORKFLOW_SHOW_SYSTEM_EXECUTIONS_SETTING_ID = 'workflows:ui:showSystemExecutions';
+
+/**
  * Map of regular (saved object) connector types -> their system connector equivalents.
  * Use this map to make the `connector-id` step config property optional for a given connector step type, allowing it to be executed via its linked system connector.
  * Pre-requisite for this to work:

--- a/src/platform/plugins/shared/workflows_management/kibana.jsonc
+++ b/src/platform/plugins/shared/workflows_management/kibana.jsonc
@@ -32,7 +32,7 @@
       "embeddable",
       "licensing"
     ],
-    "optionalPlugins": ["alerting", "serverless", "cloud", "inbox"],
+    "optionalPlugins": ["alerting", "serverless", "cloud", "inbox", "advancedSettings"],
     "runtimePluginDependencies": ["agentBuilder", "agentContextLayer"],
     "extraPublicDirs": ["common"]
   }

--- a/src/platform/plugins/shared/workflows_management/public/features/system_workflow_settings/system_workflow_settings_section.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/system_workflow_settings/system_workflow_settings_section.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  EuiCallOut,
+  EuiDescribedFormGroup,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSpacer,
+  EuiSplitPanel,
+  EuiSwitch,
+  EuiTitle,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { IUiSettingsClient, ToastsStart } from '@kbn/core/public';
+import type { UiSettingsScope } from '@kbn/core-ui-settings-common';
+import {
+  WORKFLOW_SHOW_SYSTEM_EXECUTIONS_SETTING_ID,
+  WORKFLOW_SHOW_SYSTEM_WORKFLOWS_SETTING_ID,
+} from '@kbn/workflows/common/constants';
+
+interface SystemWorkflowSettingsSectionProps {
+  uiSettings: IUiSettingsClient;
+  toasts: ToastsStart;
+  enableSaving: Record<UiSettingsScope, boolean>;
+}
+
+export function SystemWorkflowSettingsSection({
+  uiSettings,
+  toasts,
+  enableSaving,
+}: SystemWorkflowSettingsSectionProps) {
+  const canSave = enableSaving.namespace ?? enableSaving.global ?? false;
+  const {
+    euiTheme: { size },
+  } = useEuiTheme();
+
+  const panelCSS = css`
+    & + & {
+      margin-top: ${size.l};
+    }
+  `;
+
+  const rowCSS = css`
+    + * {
+      margin-top: ${size.base};
+    }
+  `;
+
+  const [showSystemWorkflows, setShowSystemWorkflows] = useState<boolean>(
+    uiSettings.get(WORKFLOW_SHOW_SYSTEM_WORKFLOWS_SETTING_ID, false)
+  );
+  const [showSystemExecutions, setShowSystemExecutions] = useState<boolean>(
+    uiSettings.get(WORKFLOW_SHOW_SYSTEM_EXECUTIONS_SETTING_ID, false)
+  );
+
+  useEffect(() => {
+    const sub = uiSettings.getUpdate$().subscribe(({ key, newValue }) => {
+      if (key === WORKFLOW_SHOW_SYSTEM_WORKFLOWS_SETTING_ID) {
+        setShowSystemWorkflows(newValue as boolean);
+      }
+      if (key === WORKFLOW_SHOW_SYSTEM_EXECUTIONS_SETTING_ID) {
+        setShowSystemExecutions(newValue as boolean);
+      }
+    });
+    return () => sub.unsubscribe();
+  }, [uiSettings]);
+
+  const handleToggle = useCallback(
+    async (settingId: string, value: boolean, setter: (v: boolean) => void) => {
+      setter(value);
+      try {
+        await uiSettings.set(settingId, value);
+      } catch (err) {
+        setter(!value);
+        toasts.addError(err, {
+          title: i18n.translate('workflowsManagement.systemSettings.saveError', {
+            defaultMessage: 'Failed to save setting',
+          }),
+        });
+      }
+    },
+    [uiSettings, toasts]
+  );
+
+  return (
+    <EuiSplitPanel.Outer hasBorder css={panelCSS}>
+      <EuiSplitPanel.Inner color="subdued">
+        <EuiFlexGroup alignItems="baseline">
+          <EuiFlexItem grow={false}>
+            <EuiTitle>
+              <h2>
+                <FormattedMessage
+                  id="workflowsManagement.systemSettings.sectionTitle"
+                  defaultMessage="Workflows"
+                />
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner>
+        <EuiCallOut
+          title={i18n.translate('workflowsManagement.systemSettings.callout.title', {
+            defaultMessage: 'System workflow settings',
+          })}
+          color="warning"
+          iconType="warning"
+        >
+          <p>
+            <FormattedMessage
+              id="workflowsManagement.systemSettings.callout.body"
+              defaultMessage="System workflows are managed by Elastic and power core platform features. Editing, disabling, or deleting them may cause unexpected behaviour or break product functionality. Enable these settings only if you know what you are doing."
+            />
+          </p>
+        </EuiCallOut>
+        <EuiSpacer size="l" />
+        <EuiDescribedFormGroup
+          css={rowCSS}
+          fullWidth
+          title={
+            <h3>
+              <FormattedMessage
+                id="workflowsManagement.systemSettings.showSystemWorkflows.label"
+                defaultMessage="Show system workflows"
+              />
+            </h3>
+          }
+          description={
+            <FormattedMessage
+              id="workflowsManagement.systemSettings.showSystemWorkflows.help"
+              defaultMessage="Display internal system workflows in the Workflows list."
+            />
+          }
+        >
+          <EuiFormRow fullWidth label={WORKFLOW_SHOW_SYSTEM_WORKFLOWS_SETTING_ID}>
+            <EuiSwitch
+              label={i18n.translate(
+                'workflowsManagement.systemSettings.showSystemWorkflows.switchLabel',
+                { defaultMessage: 'Show system workflows' }
+              )}
+              checked={showSystemWorkflows}
+              disabled={!canSave}
+              onChange={(e) =>
+                handleToggle(
+                  WORKFLOW_SHOW_SYSTEM_WORKFLOWS_SETTING_ID,
+                  e.target.checked,
+                  setShowSystemWorkflows
+                )
+              }
+              data-test-subj="workflowsShowSystemWorkflowsToggle"
+            />
+          </EuiFormRow>
+        </EuiDescribedFormGroup>
+        <EuiDescribedFormGroup
+          css={rowCSS}
+          fullWidth
+          title={
+            <h3>
+              <FormattedMessage
+                id="workflowsManagement.systemSettings.showSystemExecutions.label"
+                defaultMessage="Show system workflow executions"
+              />
+            </h3>
+          }
+          description={
+            <FormattedMessage
+              id="workflowsManagement.systemSettings.showSystemExecutions.help"
+              defaultMessage="Display execution history for internal system workflows."
+            />
+          }
+        >
+          <EuiFormRow fullWidth label={WORKFLOW_SHOW_SYSTEM_EXECUTIONS_SETTING_ID}>
+            <EuiSwitch
+              label={i18n.translate(
+                'workflowsManagement.systemSettings.showSystemExecutions.switchLabel',
+                { defaultMessage: 'Show system workflow executions' }
+              )}
+              checked={showSystemExecutions}
+              disabled={!canSave}
+              onChange={(e) =>
+                handleToggle(
+                  WORKFLOW_SHOW_SYSTEM_EXECUTIONS_SETTING_ID,
+                  e.target.checked,
+                  setShowSystemExecutions
+                )
+              }
+              data-test-subj="workflowsShowSystemExecutionsToggle"
+            />
+          </EuiFormRow>
+        </EuiDescribedFormGroup>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+  );
+}

--- a/src/platform/plugins/shared/workflows_management/public/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/public/plugin.ts
@@ -7,7 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import React from 'react';
 import { filter, Subject, type Subscription } from 'rxjs';
+import { SystemWorkflowSettingsSection } from './features/system_workflow_settings/system_workflow_settings_section';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type {
   AppDeepLinkLocations,
@@ -82,6 +84,25 @@ export class WorkflowsPlugin
     // Return early if workflows UI is not enabled, do not register the connector type and UI
     if (!isWorkflowsUiEnabled) {
       return {};
+    }
+
+    // Register system workflow settings section in Advanced Settings
+    if (plugins.advancedSettings) {
+      const uiSettingsClient = core.uiSettings;
+      const SEARCH_TERMS = ['workflows', 'system', 'system workflow'];
+
+      plugins.advancedSettings.addSpaceSection(
+        ({ toasts, enableSaving }) =>
+          React.createElement(SystemWorkflowSettingsSection, {
+            uiSettings: uiSettingsClient,
+            toasts,
+            enableSaving,
+          }),
+        (query) => {
+          const term = query.toLowerCase();
+          return SEARCH_TERMS.some((t) => t.includes(term) || term.includes(t));
+        }
+      );
     }
 
     // Register workflows connector UI component lazily to reduce main bundle size

--- a/src/platform/plugins/shared/workflows_management/public/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
+import type { AdvancedSettingsSetup } from '@kbn/advanced-settings-plugin/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 import type { CoreStart } from '@kbn/core/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
@@ -38,6 +39,7 @@ export interface WorkflowsPublicPluginSetup {}
 
 export interface WorkflowsPublicPluginSetupDependencies {
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
+  advancedSettings?: AdvancedSettingsSetup;
 }
 
 export interface WorkflowsPublicPluginStart {

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -10,7 +10,11 @@
 import { schema } from '@kbn/config-schema';
 import type { CoreSetup } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
-import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows/common/constants';
+import {
+  WORKFLOWS_UI_SETTING_ID,
+  WORKFLOW_SHOW_SYSTEM_WORKFLOWS_SETTING_ID,
+  WORKFLOW_SHOW_SYSTEM_EXECUTIONS_SETTING_ID,
+} from '@kbn/workflows/common/constants';
 import type { WorkflowsServerPluginSetupDeps } from './types';
 import { WORKFLOWS_DOCUMENTATION_URL } from '../common';
 
@@ -48,6 +52,30 @@ export const registerUISettings = (
       readonly: false,
       requiresPageReload: true,
       category: ['general'],
+    },
+    [WORKFLOW_SHOW_SYSTEM_WORKFLOWS_SETTING_ID]: {
+      name: i18n.translate('workflowsManagement.uiSettings.showSystemWorkflows.name', {
+        defaultMessage: 'Show system workflows',
+      }),
+      description: i18n.translate(
+        'workflowsManagement.uiSettings.showSystemWorkflows.description',
+        { defaultMessage: 'Display internal system workflows in the Workflows list.' }
+      ),
+      schema: schema.boolean(),
+      value: false,
+      category: ['workflows'],
+    },
+    [WORKFLOW_SHOW_SYSTEM_EXECUTIONS_SETTING_ID]: {
+      name: i18n.translate('workflowsManagement.uiSettings.showSystemExecutions.name', {
+        defaultMessage: 'Show system workflow executions',
+      }),
+      description: i18n.translate(
+        'workflowsManagement.uiSettings.showSystemExecutions.description',
+        { defaultMessage: 'Display execution history for internal system workflows.' }
+      ),
+      schema: schema.boolean(),
+      value: false,
+      category: ['workflows'],
     },
   });
 };

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -15,6 +15,7 @@
     "server/**/*.json"
   ],
   "kbn_references": [
+    "@kbn/advanced-settings-plugin",
     "@kbn/core",
     "@kbn/esql-language",
     "@kbn/esql-types",


### PR DESCRIPTION

<img width="1350" height="365" alt="image" src="https://github.com/user-attachments/assets/f960f306-15ec-471f-ad22-397a58573049" />


## Summary

Adds a dedicated **Workflows** section to the Advanced Settings page (Stack Management → Advanced Settings) with system workflow visibility controls.

- Registers two new `uiSettings` boolean values (`workflows:ui:showSystemWorkflows`, `workflows:ui:showSystemExecutions`), both defaulting to `false`
- Adds a custom `EuiSplitPanel`-based section component matching the visual style of other Advanced Settings categories (Cases, Elasticsearch, ML, etc.)
- Includes a warning callout explaining the risks of enabling system workflow visibility
- Section is registered via `advancedSettings.addSpaceSection()` (optional plugin dependency), so it gracefully degrades when the advanced settings plugin is absent
- Toggle state stays in sync with external uiSettings changes via `getUpdate$()` subscription

## Test plan

- [ ] Navigate to Stack Management → Advanced Settings → search "workflows" — the section appears
- [ ] Toggle "Show system workflows" on/off — setting persists on page reload
- [ ] Toggle "Show system executions" on/off — setting persists on page reload
- [ ] Verify toggles are disabled when the user lacks save permissions
- [ ] Verify the section is absent when `workflows:ui` feature flag is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)