### PR TITLE
feat(appex-sharedux, eui-team): replace title props and wrap EuiButtonIcon with EuiToolTip

### DIFF
--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.tsx
@@ -77,14 +77,16 @@ const OptionsList = ({ options, showShorthand, showExtraActions }: OptionsListPr
           suffix={showShorthand ? getOptionShorthand(option) ?? undefined : undefined}
           extraActions={
             showExtraActions && onPresetDelete ? (
-              <EuiButtonIcon
-                aria-label={mainPanelTexts.deletePresetAriaLabel}
-                iconType="trash"
-                color="danger"
-                size="xs"
-                data-test-subj="dateRangePickerDeletePresetButton"
-                onClick={() => onPresetDelete(option)}
-              />
+              <EuiToolTip content={mainPanelTexts.deletePresetAriaLabel} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  aria-label={mainPanelTexts.deletePresetAriaLabel}
+                  iconType="trash"
+                  color="danger"
+                  size="xs"
+                  data-test-subj="dateRangePickerDeletePresetButton"
+                  onClick={() => onPresetDelete(option)}
+                />
+              </EuiToolTip>
             ) : undefined
           }
         >
@@ -228,15 +230,17 @@ export function MainPanel() {
           ) : undefined
         }
       >
-        <EuiButtonIcon
-          aria-label={mainPanelTexts.settingsAriaLabel}
-          iconType="gear"
-          display="base"
-          color="text"
-          size="s"
-          data-test-subj="dateRangePickerSettingsButton"
-          onClick={() => navigateTo(SettingsPanel.PANEL_ID)}
-        />
+        <EuiToolTip content={mainPanelTexts.settingsAriaLabel} disableScreenReaderOutput>
+          <EuiButtonIcon
+            aria-label={mainPanelTexts.settingsAriaLabel}
+            iconType="gear"
+            display="base"
+            color="text"
+            size="s"
+            data-test-subj="dateRangePickerSettingsButton"
+            onClick={() => navigateTo(SettingsPanel.PANEL_ID)}
+          />
+        </EuiToolTip>
         {timeZoneDisplay && (
           <EuiText color="subdued" size="xs" component="span">
             {timeZoneDisplay}


### PR DESCRIPTION
Relates to https://github.com/elastic/eui/issues/9566

> [!IMPORTANT]
> These changes **should be carefully tested visually by each code owner.** Wrapping with `EuiToolTip` instead of passing `title` leads to another DOM node and can potentially break the layout. In such cases, I would appreciate committing appropriate fixes to this PR directly, I cannot possibly setup and run all Kibana functionalities to fix every regression.

This PR:

- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same as `aria-label`, any `title` passed to `EuiButtonIcon` is removed,
- changes several `title` cases (not truncation related) to use `EuiToolTip` instead (if applicable).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->