### PR TITLE
feat(contextual-security-apps, security-entity-analytics): replace title props and wrap EuiButtonIcon with EuiToolTip

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/action_column.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/action_column.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useState } from 'react';
 import type { InputAlert } from '../../../hooks/use_risk_contributing_alerts';
@@ -26,17 +26,27 @@ export const ActionColumn: React.FC<ActionColumnProps> = ({ input }) => {
     <EuiPopover
       data-test-subj="risk-inputs-actions"
       button={
-        <EuiButtonIcon
-          onClick={togglePopover}
-          iconType="boxesVertical"
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'xpack.securitySolution.flyout.entityDetails.riskInputs.actions.ariaLabel',
             {
               defaultMessage: 'Actions',
             }
           )}
-          color="text"
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            onClick={togglePopover}
+            iconType="boxesVertical"
+            aria-label={i18n.translate(
+              'xpack.securitySolution.flyout.entityDetails.riskInputs.actions.ariaLabel',
+              {
+                defaultMessage: 'Actions',
+              }
+            )}
+            color="text"
+          />
+        </EuiToolTip>
       }
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/entity_highlights_result.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/entity_highlights_result.tsx
@@ -17,6 +17,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import {
@@ -119,29 +120,45 @@ export const EntityHighlightsResult: React.FC<EntityHighlightsResultProps> = ({
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  iconType="refresh"
-                  aria-label={i18n.translate(
+                <EuiToolTip
+                  content={i18n.translate(
                     'xpack.securitySolution.flyout.entityDetails.highlights.refreshAriaLabel',
                     { defaultMessage: 'Regenerate summary' }
                   )}
-                  onClick={onRefresh}
-                  size="xs"
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    iconType="refresh"
+                    aria-label={i18n.translate(
+                      'xpack.securitySolution.flyout.entityDetails.highlights.refreshAriaLabel',
+                      { defaultMessage: 'Regenerate summary' }
+                    )}
+                    onClick={onRefresh}
+                    size="xs"
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
               {textToCopy && (
                 <EuiFlexItem grow={false}>
                   <EuiCopy textToCopy={textToCopy}>
                     {(copy) => (
-                      <EuiButtonIcon
-                        iconType="copy"
-                        aria-label={i18n.translate(
+                      <EuiToolTip
+                        content={i18n.translate(
                           'xpack.securitySolution.flyout.entityDetails.highlights.copyAriaLabel',
                           { defaultMessage: 'Copy summary' }
                         )}
-                        onClick={copy}
-                        size="xs"
-                      />
+                        disableScreenReaderOutput
+                      >
+                        <EuiButtonIcon
+                          iconType="copy"
+                          aria-label={i18n.translate(
+                            'xpack.securitySolution.flyout.entityDetails.highlights.copyAriaLabel',
+                            { defaultMessage: 'Copy summary' }
+                          )}
+                          onClick={copy}
+                          size="xs"
+                        />
+                      </EuiToolTip>
                     )}
                   </EuiCopy>
                 </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/entity_highlights_settings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/entity_highlights_settings.tsx
@@ -7,16 +7,17 @@
 
 import type { EuiSwitchEvent } from '@elastic/eui';
 import {
+  EuiButtonIcon,
+  EuiContextMenu,
   EuiContextMenuItem,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSwitch,
-  EuiContextMenu,
   EuiPopover,
-  EuiButtonIcon,
-  EuiText,
   EuiPopoverTitle,
+  EuiSwitch,
+  EuiText,
   EuiTextTruncate,
+  EuiToolTip,
 } from '@elastic/eui';
 import React, { useMemo, useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -152,19 +153,29 @@ export const EntityHighlightsSettings: React.FC<EntityHighlightsSettingsProps> =
                       </EuiFlexItem>
 
                       <EuiFlexItem grow={false}>
-                        <EuiButtonIcon
-                          aria-label={i18n.translate(
+                        <EuiToolTip
+                          content={i18n.translate(
                             'xpack.securitySolution.flyout.entityDetails.highlights.anonymizationArialLabel',
                             {
                               defaultMessage: 'Anonymization',
                             }
                           )}
-                          data-test-subj="anonymizationSettings"
-                          iconType="gear"
-                          onClick={showAnonymizationModal}
-                          size="s"
-                          color="text"
-                        />
+                          disableScreenReaderOutput
+                        >
+                          <EuiButtonIcon
+                            aria-label={i18n.translate(
+                              'xpack.securitySolution.flyout.entityDetails.highlights.anonymizationArialLabel',
+                              {
+                                defaultMessage: 'Anonymization',
+                              }
+                            )}
+                            data-test-subj="anonymizationSettings"
+                            iconType="gear"
+                            onClick={showAnonymizationModal}
+                            size="s"
+                            color="text"
+                          />
+                        </EuiToolTip>
                       </EuiFlexItem>
                     </EuiFlexGroup>
                   </EuiFlexItem>
@@ -221,17 +232,27 @@ export const EntityHighlightsSettings: React.FC<EntityHighlightsSettingsProps> =
   return (
     <EuiPopover
       button={
-        <EuiButtonIcon
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'xpack.securitySolution.flyout.entityDetails.highlights.openMenuAriaLabel',
             {
               defaultMessage: 'Entity highlights settings menu',
             }
           )}
-          iconType="boxesVertical"
-          onClick={openPopover}
-          disabled={isLoading}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            aria-label={i18n.translate(
+              'xpack.securitySolution.flyout.entityDetails.highlights.openMenuAriaLabel',
+              {
+                defaultMessage: 'Entity highlights settings menu',
+              }
+            )}
+            iconType="boxesVertical"
+            onClick={openPopover}
+            disabled={isLoading}
+          />
+        </EuiToolTip>
       }
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
@@ -17,6 +17,7 @@ import {
   EuiInMemoryTable,
   EuiSpacer,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
@@ -366,18 +367,26 @@ const RiskInputsTabContent = <T extends EntityType>({
     const columns: Array<EuiBasicTableColumn<InputAlert>> = [
       {
         render: (data: InputAlert) => (
-          <EuiButtonIcon
-            iconType="expand"
-            data-test-subj={EXPAND_ALERT_TEST_ID}
-            onClick={() => openAlertPreview(data._id, data.input.index)}
-            aria-label={i18n.translate(
-              'xpack.securitySolution.flyout.right.alertPreview.ariaLabel',
-              {
-                defaultMessage: 'Preview alert with id {id}',
-                values: { id: data._id },
-              }
-            )}
-          />
+          <EuiToolTip
+            content={i18n.translate('xpack.securitySolution.flyout.right.alertPreview.ariaLabel', {
+              defaultMessage: 'Preview alert with id {id}',
+              values: { id: data._id },
+            })}
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              iconType="expand"
+              data-test-subj={EXPAND_ALERT_TEST_ID}
+              onClick={() => openAlertPreview(data._id, data.input.index)}
+              aria-label={i18n.translate(
+                'xpack.securitySolution.flyout.right.alertPreview.ariaLabel',
+                {
+                  defaultMessage: 'Preview alert with id {id}',
+                  values: { id: data._id },
+                }
+              )}
+            />
+          </EuiToolTip>
         ),
         width: '5%',
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/add_entities_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/add_entities_section.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn, CriteriaWithPagination } from '@elastic/eui';
 import type { EntityType } from '@kbn/entity-store/public';
@@ -119,22 +120,26 @@ export const AddEntitiesSection: React.FC<AddEntitiesSectionProps> = ({
           return (
             <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  iconType="expand"
-                  color="primary"
-                  aria-label={EXPAND_ENTITY_BUTTON}
-                  onClick={() => onEntityNameClick?.(entity)}
-                />
+                <EuiToolTip content={EXPAND_ENTITY_BUTTON} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="expand"
+                    color="primary"
+                    aria-label={EXPAND_ENTITY_BUTTON}
+                    onClick={() => onEntityNameClick?.(entity)}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  iconType="plus"
-                  color="primary"
-                  aria-label={ADD_ENTITY_BUTTON}
-                  onClick={() => onAddEntity(entity)}
-                  disabled={disabled || !!addingEntityId}
-                  isLoading={isThisEntityAdding}
-                />
+                <EuiToolTip content={ADD_ENTITY_BUTTON} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="plus"
+                    color="primary"
+                    aria-label={ADD_ENTITY_BUTTON}
+                    onClick={() => onAddEntity(entity)}
+                    disabled={disabled || !!addingEntityId}
+                    isLoading={isThisEntityAdding}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             </EuiFlexGroup>
           );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
@@ -92,24 +92,28 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
           const isThisEntityRemoving = removingEntityId === entityId;
 
           const expandButton = (
-            <EuiButtonIcon
-              iconType="expand"
-              color={isCurrentEntity ? 'text' : 'primary'}
-              aria-label={EXPAND_ENTITY_BUTTON}
-              disabled={isCurrentEntity}
-              onClick={() => onEntityNameClick?.(entity)}
-            />
+            <EuiToolTip content={EXPAND_ENTITY_BUTTON} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="expand"
+                color={isCurrentEntity ? 'text' : 'primary'}
+                aria-label={EXPAND_ENTITY_BUTTON}
+                disabled={isCurrentEntity}
+                onClick={() => onEntityNameClick?.(entity)}
+              />
+            </EuiToolTip>
           );
 
           const removeButton = (
-            <EuiButtonIcon
-              iconType="cross"
-              color="primary"
-              aria-label={REMOVE_ENTITY_BUTTON}
-              disabled={isTarget || !!removingEntityId}
-              onClick={() => onRemoveEntity?.(entityId)}
-              isLoading={isThisEntityRemoving}
-            />
+            <EuiToolTip content={REMOVE_ENTITY_BUTTON} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="cross"
+                color="primary"
+                aria-label={REMOVE_ENTITY_BUTTON}
+                disabled={isTarget || !!removingEntityId}
+                onClick={() => onRemoveEntity?.(entityId)}
+                isLoading={isThisEntityRemoving}
+              />
+            </EuiToolTip>
           );
 
           return (
@@ -140,9 +144,9 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
           const nameContent =
             onEntityNameClick && !isCurrentEntity && !showActions ? (
               <EuiText size="xs" css={truncatedCellCss}>
-                <EuiLink onClick={() => onEntityNameClick(entity)} title={name}>
-                  {name}
-                </EuiLink>
+                <EuiToolTip content={name}>
+                  <EuiLink onClick={() => onEntityNameClick(entity)}>{name}</EuiLink>
+                </EuiToolTip>
               </EuiText>
             ) : (
               <EuiText size="xs" css={truncatedCellCss}>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
@@ -143,11 +143,11 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
 
           const nameContent =
             onEntityNameClick && !isCurrentEntity && !showActions ? (
-              <EuiText size="xs" css={truncatedCellCss}>
-                <EuiToolTip content={name}>
+              <EuiToolTip content={name}>
+                <EuiText size="xs" css={truncatedCellCss}>
                   <EuiLink onClick={() => onEntityNameClick(entity)}>{name}</EuiLink>
-                </EuiToolTip>
-              </EuiText>
+                </EuiText>
+              </EuiToolTip>
             ) : (
               <EuiText size="xs" css={truncatedCellCss}>
                 {name}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/engines_status/hooks/use_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/engines_status/hooks/use_columns.tsx
@@ -6,13 +6,14 @@
  */
 
 import {
+  EuiButtonIcon,
+  EuiHealth,
+  EuiIcon,
   EuiLink,
+  EuiScreenReaderOnly,
+  EuiToolTip,
   type EuiBasicTableColumn,
   type IconColor,
-  EuiHealth,
-  EuiScreenReaderOnly,
-  EuiButtonIcon,
-  EuiIcon,
 } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -105,9 +106,21 @@ export const useColumns = (
         align: 'center',
         render: (value: boolean) =>
           value ? (
-            <EuiIcon data-test-subj="installation-status" type="check" color="success" size="l" />
+            <EuiIcon
+              data-test-subj="installation-status"
+              type="check"
+              color="success"
+              size="l"
+              aria-hidden={true}
+            />
           ) : (
-            <EuiIcon data-test-subj="installation-status" type="cross" color="danger" size="l" />
+            <EuiIcon
+              data-test-subj="installation-status"
+              type="cross"
+              color="danger"
+              size="l"
+              aria-hidden={true}
+            />
           ),
       },
       {
@@ -146,11 +159,13 @@ export const useColumns = (
           const isItemExpanded = expandedItems.includes(component);
 
           return component.errors && component.errors.length > 0 ? (
-            <EuiButtonIcon
-              onClick={() => onToggleExpandedItem(component)}
-              aria-label={isItemExpanded ? 'Collapse' : 'Expand'}
-              iconType={isItemExpanded ? 'chevronSingleDown' : 'chevronSingleRight'}
-            />
+            <EuiToolTip content={isItemExpanded ? 'Collapse' : 'Expand'} disableScreenReaderOutput>
+              <EuiButtonIcon
+                onClick={() => onToggleExpandedItem(component)}
+                aria-label={isItemExpanded ? 'Collapse' : 'Expand'}
+                iconType={isItemExpanded ? 'chevronSingleDown' : 'chevronSingleRight'}
+              />
+            </EuiToolTip>
           ) : null;
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/engines_status/hooks/use_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/engines_status/hooks/use_columns.tsx
@@ -17,6 +17,7 @@ import {
 } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import {
   EngineComponentResourceEnum,
   type EngineComponentResource,
@@ -158,11 +159,21 @@ export const useColumns = (
         render: (component: EngineComponentStatus) => {
           const isItemExpanded = expandedItems.includes(component);
 
+          const collapseLabel = i18n.translate(
+            'xpack.securitySolution.entityAnalytics.entityStore.enginesStatus.collapse',
+            { defaultMessage: 'Collapse' }
+          );
+          const expandLabel = i18n.translate(
+            'xpack.securitySolution.entityAnalytics.entityStore.enginesStatus.expand',
+            { defaultMessage: 'Expand' }
+          );
+          const label = isItemExpanded ? collapseLabel : expandLabel;
+
           return component.errors && component.errors.length > 0 ? (
-            <EuiToolTip content={isItemExpanded ? 'Collapse' : 'Expand'} disableScreenReaderOutput>
+            <EuiToolTip content={label} disableScreenReaderOutput>
               <EuiButtonIcon
                 onClick={() => onToggleExpandedItem(component)}
-                aria-label={isItemExpanded ? 'Collapse' : 'Expand'}
+                aria-label={label}
                 iconType={isItemExpanded ? 'chevronSingleDown' : 'chevronSingleRight'}
               />
             </EuiToolTip>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_columns.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { EuiButtonIcon, EuiIcon, useEuiTheme } from '@elastic/eui';
+import { EuiButtonIcon, EuiIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -86,17 +86,28 @@ export const useEntitiesListColumns = (): EntitiesListColumns => {
         }
 
         return (
-          <EuiButtonIcon
-            iconType="maximize"
-            onClick={onClick}
-            aria-label={i18n.translate(
+          <EuiToolTip
+            content={i18n.translate(
               'xpack.securitySolution.entityAnalytics.entityStore.entitiesList.entityPreview.ariaLabel',
               {
                 defaultMessage: 'Preview entity with name {name}',
                 values: { name: value },
               }
             )}
-          />
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              iconType="maximize"
+              onClick={onClick}
+              aria-label={i18n.translate(
+                'xpack.securitySolution.entityAnalytics.entityStore.entitiesList.entityPreview.ariaLabel',
+                {
+                  defaultMessage: 'Preview entity with name {name}',
+                  values: { name: value },
+                }
+              )}
+            />
+          </EuiToolTip>
         );
       },
       width: '5%',

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_summary_grid.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_summary_grid.tsx
@@ -90,19 +90,27 @@ export const EntitySummaryGrid = memo(
                   >
                     <EuiCopy textToCopy={entityId}>
                       {(copy) => (
-                        <EuiButtonIcon
-                          iconType="copy"
-                          aria-label={i18n.translate(
+                        <EuiToolTip
+                          content={i18n.translate(
                             'xpack.securitySolution.flyout.entityDetails.grid.copyToClipboard',
                             { defaultMessage: 'Copy to clipboard' }
                           )}
-                          onClick={copy}
-                          iconSize="s"
-                          color="text"
-                          css={css`
-                            transform: translateY(-50%);
-                          `}
-                        />
+                          disableScreenReaderOutput
+                        >
+                          <EuiButtonIcon
+                            iconType="copy"
+                            aria-label={i18n.translate(
+                              'xpack.securitySolution.flyout.entityDetails.grid.copyToClipboard',
+                              { defaultMessage: 'Copy to clipboard' }
+                            )}
+                            onClick={copy}
+                            iconSize="s"
+                            color="text"
+                            css={css`
+                              transform: translateY(-50%);
+                            `}
+                          />
+                        </EuiToolTip>
                       )}
                     </EuiCopy>
                   </EuiToolTip>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_summary_grid.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_summary_grid.tsx
@@ -87,6 +87,7 @@ export const EntitySummaryGrid = memo(
                       'xpack.securitySolution.flyout.entityDetails.grid.copyToClipboard',
                       { defaultMessage: 'Copy to clipboard' }
                     )}
+                    disableScreenReaderOutput
                   >
                     <EuiCopy textToCopy={entityId}>
                       {(copy) => (


### PR DESCRIPTION
Relates to https://github.com/elastic/eui/issues/9566

> [!IMPORTANT]
> These changes **should be carefully tested visually by each code owner.** Wrapping with `EuiToolTip` instead of passing `title` leads to another DOM node and can potentially break the layout. In such cases, I would appreciate committing appropriate fixes to this PR directly, I cannot possibly setup and run all Kibana functionalities to fix every regression.

This PR:

- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same as `aria-label`, any `title` passed to `EuiButtonIcon` is removed,
- changes several `title` cases (not truncation related) to use `EuiToolTip` instead (if applicable).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->