### PR TITLE
feat(fleet): replace title props and wrap EuiButtonIcon with EuiToolTip

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
@@ -436,7 +436,7 @@ queue:
         cy.get(`a[href="/app/fleet/settings/outputs/${kafkaOutputId}"]`)
           .parents('tr')
           .within(() => {
-            cy.get('[title="Delete"]').click();
+            cy.getBySel('deleteOutputBtn').click();
           });
         cy.getBySel(SETTINGS_CONFIRM_MODAL_BTN).click();
         cy.get(`a[href="app/fleet/settings/outputs/${kafkaOutputId}"]`).should('not.exist');

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/custom_fields/global_data_tags_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/custom_fields/global_data_tags_table.tsx
@@ -11,19 +11,20 @@ import { i18n } from '@kbn/i18n';
 
 import {
   EuiBasicTable,
-  EuiPanel,
-  EuiText,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiButton,
-  EuiFormRow,
-  EuiFieldText,
   EuiButtonIcon,
   EuiCode,
-  EuiSpacer,
   EuiConfirmModal,
-  useGeneratedHtmlId,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
   type EuiBasicTableColumn,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import type { NewAgentPolicy, AgentPolicy, GlobalDataTag } from '../../../../../common/types';
@@ -328,24 +329,28 @@ export const GlobalDataTagsTable: React.FunctionComponent<Props> = ({
               return isEditing || isAddingRow ? (
                 <EuiFlexGroup alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      size="xs"
-                      color="primary"
-                      iconType="checkCircleFill"
-                      onClick={isAdding ? confirmNewTagChanges : () => confirmEditChanges(index)}
-                      aria-label="Confirm"
-                    />
+                    <EuiToolTip content="Confirm" disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        size="xs"
+                        color="primary"
+                        iconType="checkCircleFill"
+                        onClick={isAdding ? confirmNewTagChanges : () => confirmEditChanges(index)}
+                        aria-label="Confirm"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               ) : (
-                <EuiButtonIcon
-                  aria-label="Edit"
-                  iconType="pencil"
-                  color="text"
-                  data-test-subj={`globalDataTagEditField${index}Btn`}
-                  isDisabled={isDisabled}
-                  onClick={() => handleStartEdit(index)}
-                />
+                <EuiToolTip content="Edit" disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    aria-label="Edit"
+                    iconType="pencil"
+                    color="text"
+                    data-test-subj={`globalDataTagEditField${index}Btn`}
+                    isDisabled={isDisabled}
+                    onClick={() => handleStartEdit(index)}
+                  />
+                </EuiToolTip>
               );
             },
           },
@@ -359,24 +364,28 @@ export const GlobalDataTagsTable: React.FunctionComponent<Props> = ({
               return isEditing || isAddingRow ? (
                 <EuiFlexGroup alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      size="xs"
-                      color="danger"
-                      iconType="errorFill"
-                      onClick={isAddingRow ? cancelNewTagChanges : () => cancelEditChanges(index)}
-                      aria-label="Cancel"
-                    />
+                    <EuiToolTip content="Cancel" disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        size="xs"
+                        color="danger"
+                        iconType="errorFill"
+                        onClick={isAddingRow ? cancelNewTagChanges : () => cancelEditChanges(index)}
+                        aria-label="Cancel"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               ) : (
-                <EuiButtonIcon
-                  aria-label="Delete"
-                  iconType="trash"
-                  color="text"
-                  data-test-subj={`globalDataTagDeleteField${index}Btn`}
-                  isDisabled={isDisabled}
-                  onClick={() => deleteTag(index)}
-                />
+                <EuiToolTip content="Delete" disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    aria-label="Delete"
+                    iconType="trash"
+                    color="text"
+                    data-test-subj={`globalDataTagDeleteField${index}Btn`}
+                    isDisabled={isDisabled}
+                    onClick={() => deleteTag(index)}
+                  />
+                </EuiToolTip>
               );
             },
           },

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/multi_text_input.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/multi_text_input.tsx
@@ -8,13 +8,14 @@ import React, { useCallback, useState, useEffect } from 'react';
 import type { FunctionComponent, ChangeEvent } from 'react';
 
 import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFieldPassword,
+  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonEmpty,
-  EuiFieldText,
-  EuiFieldPassword,
-  EuiButtonIcon,
   EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -96,19 +97,30 @@ const Row: FunctionComponent<RowProps> = ({
       </EuiFlexItem>
       {isMultiRow && (
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            color="text"
-            onClick={onDeleteHandler}
-            iconType="cross"
-            disabled={isDisabled}
-            aria-label={i18n.translate('xpack.fleet.multiTextInput.deleteRowButton', {
+          <EuiToolTip
+            content={i18n.translate('xpack.fleet.multiTextInput.deleteRowButton', {
               defaultMessage: 'Delete "{fieldLabel}" input {index}',
               values: {
                 fieldLabel,
                 index: index + 1,
               },
             })}
-          />
+            disableScreenReaderOutput
+          >
+            <EuiButtonIcon
+              color="text"
+              onClick={onDeleteHandler}
+              iconType="cross"
+              disabled={isDisabled}
+              aria-label={i18n.translate('xpack.fleet.multiTextInput.deleteRowButton', {
+                defaultMessage: 'Delete "{fieldLabel}" input {index}',
+                values: {
+                  fieldLabel,
+                  index: index + 1,
+                },
+              })}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       )}
     </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tag_options.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/tag_options.tsx
@@ -16,6 +16,7 @@ import {
   EuiLink,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
   EuiWrappingPopover,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -96,17 +97,24 @@ export const TagOptions: React.FC<Props> = ({ tagName, isTagHovered, onTagsUpdat
   return (
     <>
       {tagMenuButtonVisible && (
-        <EuiButtonIcon
-          iconType="boxesVertical"
-          aria-label={i18n.translate('xpack.fleet.tagOptions.tagOptionsToggleButtonLabel', {
+        <EuiToolTip
+          content={i18n.translate('xpack.fleet.tagOptions.tagOptionsToggleButtonLabel', {
             defaultMessage: 'Tag Options',
           })}
-          color="text"
-          onClick={(event: MouseEvent<HTMLButtonElement>) => {
-            setTagOptionsButton(event.currentTarget);
-            setTagOptionsVisible(!tagOptionsVisible);
-          }}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            iconType="boxesVertical"
+            aria-label={i18n.translate('xpack.fleet.tagOptions.tagOptionsToggleButtonLabel', {
+              defaultMessage: 'Tag Options',
+            })}
+            color="text"
+            onClick={(event: MouseEvent<HTMLButtonElement>) => {
+              setTagOptionsButton(event.currentTarget);
+              setTagOptionsVisible(!tagOptionsVisible);
+            }}
+          />
+        </EuiToolTip>
       )}
       {tagOptionsVisible && (
         <EuiWrappingPopover

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/hierarchical_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/hierarchical_actions_menu.tsx
@@ -6,7 +6,14 @@
  */
 
 import React, { useMemo, useCallback, useState } from 'react';
-import { EuiPopover, EuiContextMenu, EuiButtonIcon, EuiButton, EuiIcon } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiContextMenu,
+  EuiIcon,
+  EuiPopover,
+  EuiToolTip,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { EuiContextMenuPanelDescriptor, IconType, EuiIconProps } from '@elastic/eui';
 
@@ -186,14 +193,21 @@ export const HierarchicalActionsMenu: React.FC<HierarchicalActionsMenuProps> = (
       {button.children}
     </EuiButton>
   ) : (
-    <EuiButtonIcon
-      iconType="boxesVertical"
-      onClick={toggleMenu}
-      aria-label={i18n.translate('xpack.fleet.hierarchicalMenu.openMenuAriaLabel', {
+    <EuiToolTip
+      content={i18n.translate('xpack.fleet.hierarchicalMenu.openMenuAriaLabel', {
         defaultMessage: 'Open menu',
       })}
-      data-test-subj={dataTestSubj || 'hierarchicalMenuButton'}
-    />
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        iconType="boxesVertical"
+        onClick={toggleMenu}
+        aria-label={i18n.translate('xpack.fleet.hierarchicalMenu.openMenuAriaLabel', {
+          defaultMessage: 'Open menu',
+        })}
+        data-test-subj={dataTestSubj || 'hierarchicalMenuButton'}
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/download_source_headers.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/download_source_headers.tsx
@@ -15,6 +15,7 @@ import {
   EuiFormRow,
   EuiSpacer,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useMemo, useState } from 'react';
@@ -182,19 +183,29 @@ export const DownloadSourceHeaders: React.FunctionComponent<{
               </EuiFlexItem>
 
               <EuiFlexItem grow={false} style={{ marginTop: index === 0 ? 28 : 0 }}>
-                <EuiButtonIcon
-                  data-test-subj={`downloadSourceHeadersDeleteButton${index}`}
-                  color="text"
-                  onClick={() => deleteKeyValuePair(index)}
-                  iconType="cross"
-                  disabled={deleteButtonDisabled}
-                  aria-label={i18n.translate(
+                <EuiToolTip
+                  content={i18n.translate(
                     'xpack.fleet.settings.editDownloadSourcesFlyout.deleteHeaderButton',
                     {
                       defaultMessage: 'Delete header',
                     }
                   )}
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    data-test-subj={`downloadSourceHeadersDeleteButton${index}`}
+                    color="text"
+                    onClick={() => deleteKeyValuePair(index)}
+                    iconType="cross"
+                    disabled={deleteButtonDisabled}
+                    aria-label={i18n.translate(
+                      'xpack.fleet.settings.editDownloadSourcesFlyout.deleteHeaderButton',
+                      {
+                        defaultMessage: 'Delete header',
+                      }
+                    )}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             </EuiFlexGroup>
           </div>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_table/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/download_source_table/index.tsx
@@ -7,7 +7,14 @@
 
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { EuiBasicTable, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiToolTip,
+} from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -116,27 +123,29 @@ export const DownloadSourceTable: React.FunctionComponent<DownloadSourceTablePro
             <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
                 {isDeleteVisible && (
-                  <EuiButtonIcon
-                    aria-label={deleteDownloadSourceLabel}
-                    color="text"
-                    iconType="trash"
-                    onClick={() => deleteDownloadSource(downloadSource)}
-                    title={deleteDownloadSourceLabel}
-                    data-test-subj="editDownloadSourceTable.delete.btn"
-                  />
+                  <EuiToolTip content={deleteDownloadSourceLabel} disableScreenReaderOutput>
+                    <EuiButtonIcon
+                      aria-label={deleteDownloadSourceLabel}
+                      color="text"
+                      iconType="trash"
+                      onClick={() => deleteDownloadSource(downloadSource)}
+                      data-test-subj="editDownloadSourceTable.delete.btn"
+                    />
+                  </EuiToolTip>
                 )}
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  aria-label={editDownloadSourceLabel}
-                  color="text"
-                  iconType="pencil"
-                  href={getHref('settings_edit_download_sources', {
-                    downloadSourceId: downloadSource.id,
-                  })}
-                  title={editDownloadSourceLabel}
-                  data-test-subj="editDownloadSourceTable.edit.btn"
-                />
+                <EuiToolTip content={editDownloadSourceLabel} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    aria-label={editDownloadSourceLabel}
+                    color="text"
+                    iconType="pencil"
+                    href={getHref('settings_edit_download_sources', {
+                      downloadSourceId: downloadSource.id,
+                    })}
+                    data-test-subj="editDownloadSourceTable.edit.btn"
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             </EuiFlexGroup>
           );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_headers.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_headers.tsx
@@ -16,6 +16,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useMemo, useState } from 'react';
@@ -172,16 +173,23 @@ export const OutputFormKafkaHeaders: React.FunctionComponent<{ inputs: OutputFor
               </EuiFlexItem>
 
               <EuiFlexItem grow={false} style={{ marginTop: 28 }}>
-                <EuiButtonIcon
-                  data-test-subj={`settingsOutputsFlyout.kafkaHeadersDeleteButton${index}`}
-                  color="text"
-                  onClick={() => deleteKeyValuePair(index)}
-                  iconType="cross"
-                  disabled={deleteButtonDisabled}
-                  aria-label={i18n.translate('xpack.fleet.kafkaHeadersInput.deleteButton', {
+                <EuiToolTip
+                  content={i18n.translate('xpack.fleet.kafkaHeadersInput.deleteButton', {
                     defaultMessage: 'Delete row',
                   })}
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    data-test-subj={`settingsOutputsFlyout.kafkaHeadersDeleteButton${index}`}
+                    color="text"
+                    onClick={() => deleteKeyValuePair(index)}
+                    iconType="cross"
+                    disabled={deleteButtonDisabled}
+                    aria-label={i18n.translate('xpack.fleet.kafkaHeadersInput.deleteButton', {
+                      defaultMessage: 'Delete row',
+                    })}
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             </EuiFlexGroup>
           </div>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_proxies_table/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_proxies_table/index.tsx
@@ -7,7 +7,14 @@
 
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { EuiBasicTable, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIconTip,
+  EuiToolTip,
+} from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -92,27 +99,29 @@ export const FleetProxiesTable: React.FunctionComponent<FleetProxiesTableProps> 
             <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
                 {isDeleteVisible && (
-                  <EuiButtonIcon
-                    aria-label={deleteButtonLabel}
-                    color="text"
-                    iconType="trash"
-                    onClick={() => deleteFleetProxy(fleetProxy)}
-                    title={deleteButtonLabel}
-                    data-test-subj="fleetProxiesTable.delete.btn"
-                  />
+                  <EuiToolTip content={deleteButtonLabel} disableScreenReaderOutput>
+                    <EuiButtonIcon
+                      aria-label={deleteButtonLabel}
+                      color="text"
+                      iconType="trash"
+                      onClick={() => deleteFleetProxy(fleetProxy)}
+                      data-test-subj="fleetProxiesTable.delete.btn"
+                    />
+                  </EuiToolTip>
                 )}
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  aria-label={editButtonLabel}
-                  color="text"
-                  iconType="pencil"
-                  href={getHref('settings_edit_fleet_proxy', {
-                    itemId: fleetProxy.id,
-                  })}
-                  title={editButtonLabel}
-                  data-test-subj="fleetProxiesTable.edit.btn"
-                />
+                <EuiToolTip content={editButtonLabel} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    aria-label={editButtonLabel}
+                    color="text"
+                    iconType="pencil"
+                    href={getHref('settings_edit_fleet_proxy', {
+                      itemId: fleetProxy.id,
+                    })}
+                    data-test-subj="fleetProxiesTable.edit.btn"
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             </EuiFlexGroup>
           );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_table/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/fleet_server_hosts_table/index.tsx
@@ -15,6 +15,7 @@ import {
   EuiIconTip,
   EuiIcon,
   EuiButtonIcon,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -125,47 +126,55 @@ export const FleetServerHostsTable: React.FunctionComponent<FleetServerHostsTabl
             <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
                 {isDeleteVisible && (
-                  <EuiButtonIcon
-                    color="text"
-                    iconType="trash"
-                    onClick={() => deleteFleetServerHost(fleetServerHost)}
-                    title={i18n.translate(
+                  <EuiToolTip
+                    content={i18n.translate(
                       'xpack.fleet.settings.fleetServerHostsTable.deleteButtonTitle',
                       {
                         defaultMessage: 'Delete',
                       }
                     )}
-                    aria-label={i18n.translate(
-                      'xpack.fleet.settings.fleetServerHostsTable.deleteButtonAriaLabel',
-                      {
-                        defaultMessage: 'Delete host',
-                      }
-                    )}
-                    data-test-subj="fleetServerHostsTable.delete.btn"
-                  />
+                    disableScreenReaderOutput
+                  >
+                    <EuiButtonIcon
+                      color="text"
+                      iconType="trash"
+                      onClick={() => deleteFleetServerHost(fleetServerHost)}
+                      aria-label={i18n.translate(
+                        'xpack.fleet.settings.fleetServerHostsTable.deleteButtonAriaLabel',
+                        {
+                          defaultMessage: 'Delete host',
+                        }
+                      )}
+                      data-test-subj="fleetServerHostsTable.delete.btn"
+                    />
+                  </EuiToolTip>
                 )}
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  color="text"
-                  iconType="pencil"
-                  href={getHref('settings_edit_fleet_server_hosts', {
-                    itemId: fleetServerHost.id,
-                  })}
-                  title={i18n.translate(
+                <EuiToolTip
+                  content={i18n.translate(
                     'xpack.fleet.settings.fleetServerHostsTable.editButtonTitle',
                     {
                       defaultMessage: 'Edit',
                     }
                   )}
-                  aria-label={i18n.translate(
-                    'xpack.fleet.settings.fleetServerHostsTable.editButtonAriaLabel',
-                    {
-                      defaultMessage: 'Edit host',
-                    }
-                  )}
-                  data-test-subj="fleetServerHostsTable.edit.btn"
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    color="text"
+                    iconType="pencil"
+                    href={getHref('settings_edit_fleet_server_hosts', {
+                      itemId: fleetServerHost.id,
+                    })}
+                    aria-label={i18n.translate(
+                      'xpack.fleet.settings.fleetServerHostsTable.editButtonAriaLabel',
+                      {
+                        defaultMessage: 'Edit host',
+                      }
+                    )}
+                    data-test-subj="fleetServerHostsTable.edit.btn"
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             </EuiFlexGroup>
           );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/logstash_instructions/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/logstash_instructions/index.tsx
@@ -8,14 +8,15 @@
 import React, { useState, useMemo } from 'react';
 
 import {
-  EuiCallOut,
   EuiButton,
-  EuiSpacer,
-  EuiLink,
+  EuiButtonIcon,
+  EuiCallOut,
   EuiCode,
   EuiCodeBlock,
   EuiCopy,
-  EuiButtonIcon,
+  EuiLink,
+  EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { EuiCallOutProps } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -136,18 +137,28 @@ const LogstashInstructionSteps = ({ isSSLEnabled }: LogstashInstructionStepsProp
                   <div className="euiCodeBlock__copyButton">
                     <EuiCopy textToCopy={logstashApiKey.apiKey}>
                       {(copy) => (
-                        <EuiButtonIcon
-                          onClick={copy}
-                          iconType="copy"
-                          color="text"
-                          disabled={!hasAllSettings}
-                          aria-label={i18n.translate(
+                        <EuiToolTip
+                          content={i18n.translate(
                             'xpack.fleet.settings.logstashInstructions.copyApiKeyButtonLabel',
                             {
                               defaultMessage: 'Copy message',
                             }
                           )}
-                        />
+                          disableScreenReaderOutput
+                        >
+                          <EuiButtonIcon
+                            onClick={copy}
+                            iconType="copy"
+                            color="text"
+                            disabled={!hasAllSettings}
+                            aria-label={i18n.translate(
+                              'xpack.fleet.settings.logstashInstructions.copyApiKeyButtonLabel',
+                              {
+                                defaultMessage: 'Copy message',
+                              }
+                            )}
+                          />
+                        </EuiToolTip>
                       )}
                     </EuiCopy>
                   </div>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/multi_row_input/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/multi_row_input/index.tsx
@@ -9,21 +9,22 @@ import type { ReactNode, FunctionComponent, ChangeEvent } from 'react';
 import sytled, { useTheme } from 'styled-components';
 
 import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiDragDropContext,
+  EuiDraggable,
+  EuiDroppable,
+  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonEmpty,
-  EuiFormRow,
-  EuiFieldText,
-  EuiDragDropContext,
-  EuiDroppable,
-  EuiDraggable,
-  EuiIcon,
-  EuiButtonIcon,
-  EuiSpacer,
-  EuiFormHelpText,
-  euiDragDropReorder,
   EuiFormErrorText,
+  EuiFormHelpText,
+  EuiFormRow,
+  EuiIcon,
+  EuiSpacer,
   EuiTextArea,
+  EuiToolTip,
+  euiDragDropReorder,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -161,15 +162,22 @@ const SortableTextField: FunctionComponent<SortableTextFieldProps> = React.memo(
               {displayErrors(errors)}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                color="text"
-                onClick={onDeleteHandler}
-                iconType="cross"
-                disabled={disabled}
-                aria-label={i18n.translate('xpack.fleet.multiRowInput.deleteButton', {
+              <EuiToolTip
+                content={i18n.translate('xpack.fleet.multiRowInput.deleteButton', {
                   defaultMessage: 'Delete row',
                 })}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  color="text"
+                  onClick={onDeleteHandler}
+                  iconType="cross"
+                  disabled={disabled}
+                  aria-label={i18n.translate('xpack.fleet.multiRowInput.deleteButton', {
+                    defaultMessage: 'Delete row',
+                  })}
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         )}
@@ -228,15 +236,22 @@ const NonSortableTextField: FunctionComponent<NonSortableTextFieldProps> = React
           </EuiFlexItem>
           {deletable && (
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                color="text"
-                onClick={onDeleteHandler}
-                iconType="cross"
-                disabled={disabled}
-                aria-label={i18n.translate('xpack.fleet.multiRowInput.deleteButton', {
+              <EuiToolTip
+                content={i18n.translate('xpack.fleet.multiRowInput.deleteButton', {
                   defaultMessage: 'Delete row',
                 })}
-              />
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  color="text"
+                  onClick={onDeleteHandler}
+                  iconType="cross"
+                  disabled={disabled}
+                  aria-label={i18n.translate('xpack.fleet.multiRowInput.deleteButton', {
+                    defaultMessage: 'Delete row',
+                  })}
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/outputs_table/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/outputs_table/index.tsx
@@ -7,7 +7,14 @@
 
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { EuiBasicTable, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIconTip,
+  EuiToolTip,
+} from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -154,35 +161,50 @@ export const OutputsTable: React.FunctionComponent<OutputsTableProps> = ({
             <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
                 {isDeleteVisible && (
-                  <EuiButtonIcon
-                    color="text"
-                    iconType="trash"
-                    onClick={() => deleteOutput(output)}
-                    title={i18n.translate('xpack.fleet.settings.outputSection.deleteButtonTitle', {
-                      defaultMessage: 'Delete',
-                    })}
-                    aria-label={i18n.translate(
+                  <EuiToolTip
+                    content={i18n.translate(
                       'xpack.fleet.settings.outputSection.deleteButtonTitle',
                       {
                         defaultMessage: 'Delete',
                       }
                     )}
-                  />
+                    disableScreenReaderOutput
+                  >
+                    <EuiButtonIcon
+                      color="text"
+                      iconType="trash"
+                      onClick={() => deleteOutput(output)}
+                      aria-label={i18n.translate(
+                        'xpack.fleet.settings.outputSection.deleteButtonTitle',
+                        {
+                          defaultMessage: 'Delete',
+                        }
+                      )}
+                      data-test-subj="deleteOutputBtn"
+                    />
+                  </EuiToolTip>
                 )}
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
-                  color="text"
-                  iconType="pencil"
-                  href={getHref('settings_edit_outputs', { outputId: output.id })}
-                  title={i18n.translate('xpack.fleet.settings.outputSection.editButtonTitle', {
+                <EuiToolTip
+                  content={i18n.translate('xpack.fleet.settings.outputSection.editButtonTitle', {
                     defaultMessage: 'Edit',
                   })}
-                  aria-label={i18n.translate('xpack.fleet.settings.outputSection.editButtonTitle', {
-                    defaultMessage: 'Edit',
-                  })}
-                  data-test-subj="editOutputBtn"
-                />
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    color="text"
+                    iconType="pencil"
+                    href={getHref('settings_edit_outputs', { outputId: output.id })}
+                    aria-label={i18n.translate(
+                      'xpack.fleet.settings.outputSection.editButtonTitle',
+                      {
+                        defaultMessage: 'Edit',
+                      }
+                    )}
+                    data-test-subj="editOutputBtn"
+                  />
+                </EuiToolTip>
               </EuiFlexItem>
             </EuiFlexGroup>
           );

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
@@ -11,14 +11,15 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiSpacer,
   EuiButton,
   EuiButtonIcon,
-  EuiPopover,
-  EuiContextMenuPanel,
   EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiSpacer,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 
@@ -282,13 +283,15 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
                   data-test-subj="epmList.showMoreSubCategoriesButton"
                   id="moreSubCategories"
                   button={
-                    <EuiButtonIcon
-                      display="base"
-                      onClick={onButtonClick}
-                      iconType="boxesVertical"
-                      aria-label="Show more subcategories"
-                      size="s"
-                    />
+                    <EuiToolTip content="Show more subcategories" disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        display="base"
+                        onClick={onButtonClick}
+                        iconType="boxesVertical"
+                        aria-label="Show more subcategories"
+                        size="s"
+                      />
+                    </EuiToolTip>
                   }
                   isOpen={isPopoverOpen}
                   closePopover={closePopover}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/create_new_integration.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/create_new_integration.tsx
@@ -11,9 +11,10 @@ import {
   EuiButtonIcon,
   EuiContextMenuItem,
   EuiContextMenuPanel,
-  EuiFlexItem,
   EuiFlexGroup,
+  EuiFlexItem,
   EuiPopover,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useHistory } from 'react-router-dom';
@@ -60,24 +61,31 @@ export const CreateNewIntegrationButton: React.FC = () => {
           anchorPosition="downRight"
           style={{ display: 'flex', height: '100%' }}
           button={
-            <EuiButtonIcon
-              display="fill"
-              color="primary"
-              iconType="chevronSingleDown"
-              aria-label={i18n.translate(
-                'xpack.fleet.epmList.createNewIntegrationDropdownAriaLabel',
-                { defaultMessage: 'More integration creation options' }
-              )}
-              onClick={() => setIsPopoverOpen((prev) => !prev)}
-              style={{
-                borderTopLeftRadius: 0,
-                borderBottomLeftRadius: 0,
-                borderLeft: '1px solid rgba(255,255,255,0.3)',
-                height: 40,
-                minHeight: 0,
-              }}
-              data-test-subj="createNewIntegrationDropdownBtn"
-            />
+            <EuiToolTip
+              content={i18n.translate('xpack.fleet.epmList.createNewIntegrationDropdownAriaLabel', {
+                defaultMessage: 'More integration creation options',
+              })}
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                display="fill"
+                color="primary"
+                iconType="chevronSingleDown"
+                aria-label={i18n.translate(
+                  'xpack.fleet.epmList.createNewIntegrationDropdownAriaLabel',
+                  { defaultMessage: 'More integration creation options' }
+                )}
+                onClick={() => setIsPopoverOpen((prev) => !prev)}
+                style={{
+                  borderTopLeftRadius: 0,
+                  borderBottomLeftRadius: 0,
+                  borderLeft: '1px solid rgba(255,255,255,0.3)',
+                  height: 40,
+                  minHeight: 0,
+                }}
+                data-test-subj="createNewIntegrationDropdownBtn"
+              />
+            </EuiToolTip>
           }
         >
           <EuiContextMenuPanel

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
@@ -7,14 +7,15 @@
 
 import React, { useCallback, useState } from 'react';
 import {
-  EuiButtonIcon,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiConfirmModal,
-  EuiIcon,
   EuiContextMenuItem,
   EuiContextMenuPanel,
+  EuiIcon,
   EuiPopover,
   EuiTextColor,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -207,17 +208,25 @@ export const ManageIntegrationActions: React.FC<{
           anchorPosition="downRight"
           panelPaddingSize="none"
           button={
-            <EuiButtonIcon
-              iconType="boxesVertical"
-              color="text"
-              style={{ color: euiTheme.colors.textSubdued }}
-              aria-label={i18n.translate(
+            <EuiToolTip
+              content={i18n.translate(
                 'xpack.fleet.epmList.manageIntegrations.actions.openMenuLabel',
                 { defaultMessage: 'Open actions menu' }
               )}
-              onClick={togglePopover}
-              data-test-subj="manageIntegrationActionsBtn"
-            />
+              disableScreenReaderOutput
+            >
+              <EuiButtonIcon
+                iconType="boxesVertical"
+                color="text"
+                style={{ color: euiTheme.colors.textSubdued }}
+                aria-label={i18n.translate(
+                  'xpack.fleet.epmList.manageIntegrations.actions.openMenuLabel',
+                  { defaultMessage: 'Open actions menu' }
+                )}
+                onClick={togglePopover}
+                data-test-subj="manageIntegrationActionsBtn"
+              />
+            </EuiToolTip>
           }
           isOpen={isPopoverOpen}
           closePopover={closePopover}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
@@ -30,6 +30,7 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
   htmlIdGenerator,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn, EuiComboBoxOptionOption } from '@elastic/eui';
@@ -397,14 +398,22 @@ export const ReviewApproveModal: React.FC<{
       name: '',
       width: '32px',
       render: (item: ReviewTableRow) => (
-        <EuiButtonIcon
-          iconType="expand"
-          aria-label={i18n.translate(
+        <EuiToolTip
+          content={i18n.translate(
             'xpack.fleet.epmList.manageIntegrations.actions.reviewRowOpenFlyoutAriaLabel',
             { defaultMessage: 'Open data stream results flyout' }
           )}
-          onClick={() => setSelectedDataStreamForFlyout(item.dataStream)}
-        />
+          disableScreenReaderOutput
+        >
+          <EuiButtonIcon
+            iconType="expand"
+            aria-label={i18n.translate(
+              'xpack.fleet.epmList.manageIntegrations.actions.reviewRowOpenFlyoutAriaLabel',
+              { defaultMessage: 'Open data stream results flyout' }
+            )}
+            onClick={() => setSelectedDataStreamForFlyout(item.dataStream)}
+          />
+        </EuiToolTip>
       ),
     },
     {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/search_and_filters_bar.tsx
@@ -9,8 +9,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiButton,
   EuiButtonIcon,
-  EuiContextMenuPanel,
   EuiContextMenuItem,
+  EuiContextMenuPanel,
   EuiFieldSearch,
   EuiFilterButton,
   EuiFilterGroup,
@@ -22,6 +22,7 @@ import {
   EuiScreenReaderOnly,
   EuiSelectable,
   EuiSpacer,
+  EuiToolTip,
   mathWithUnits,
   useEuiTheme,
 } from '@elastic/eui';
@@ -587,16 +588,24 @@ export const SearchAndFiltersBar: React.FC<SearchAndFiltersBarProps> = ({
                   data-test-subj="browseIntegrations.showMoreSubCategoriesButton"
                   id="browseIntegrationsMoreSubCategories"
                   button={
-                    <EuiButtonIcon
-                      display="base"
-                      onClick={() => setIsSubCategoryPopoverOpen((prev) => !prev)}
-                      iconType="boxesHorizontal"
-                      aria-label={i18n.translate(
+                    <EuiToolTip
+                      content={i18n.translate(
                         'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.showMoreSubCategories',
                         { defaultMessage: 'Show more subcategories' }
                       )}
-                      size="s"
-                    />
+                      disableScreenReaderOutput
+                    >
+                      <EuiButtonIcon
+                        display="base"
+                        onClick={() => setIsSubCategoryPopoverOpen((prev) => !prev)}
+                        iconType="boxesHorizontal"
+                        aria-label={i18n.translate(
+                          'xpack.fleet.epm.browseIntegrations.searchAndFilterBar.showMoreSubCategories',
+                          { defaultMessage: 'Show more subcategories' }
+                        )}
+                        size="s"
+                      />
+                    </EuiToolTip>
                   }
                   isOpen={isSubCategoryPopoverOpen}
                   closePopover={() => setIsSubCategoryPopoverOpen(false)}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agent_based_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agent_based_table.tsx
@@ -201,7 +201,7 @@ export const AgentBasedPackagePoliciesTable = ({
             }),
             truncateText: true,
             render(updatedBy: PackagePolicy['updated_by']) {
-              return <Persona size="s" name={updatedBy} title={updatedBy} />;
+              return <Persona size="s" name={updatedBy} />;
             },
           },
           {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/agentless_table.tsx
@@ -201,7 +201,7 @@ export const AgentlessPackagePoliciesTable = ({
             }),
             truncateText: true,
             render(updatedBy: PackagePolicy['updated_by']) {
-              return <Persona size="s" name={updatedBy} title={updatedBy} />;
+              return <Persona size="s" name={updatedBy} />;
             },
           },
           {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/persona.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/policies/persona.tsx
@@ -15,7 +15,7 @@ const MIN_WIDTH: CSSProperties = { minWidth: 0 };
  * Shows a user's name along with an avatar. Name is truncated if its wider than the availble space
  */
 export const Persona = memo<EuiAvatarProps>(
-  ({ name, className, 'data-test-subj': dataTestSubj, title, ...otherAvatarProps }) => {
+  ({ name, className, 'data-test-subj': dataTestSubj, ...otherAvatarProps }) => {
     const getTestId = useCallback(
       (suffix: any) => {
         if (dataTestSubj) {
@@ -31,7 +31,6 @@ export const Persona = memo<EuiAvatarProps>(
         style={MIN_WIDTH}
         className={className}
         data-test-subj={dataTestSubj}
-        title={title}
         responsive={false}
       >
         <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/resizable_panel.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/resizable_panel.tsx
@@ -186,6 +186,7 @@ export const ResizablePanel: React.FunctionComponent<{
                 content={i18n.translate('xpack.fleet.integrationsResizablePanel.collapseButton', {
                   defaultMessage: 'Collapse panel',
                 })}
+                disableScreenReaderOutput
               >
                 <EuiButtonIcon
                   key="chevronSingleUp"
@@ -203,6 +204,7 @@ export const ResizablePanel: React.FunctionComponent<{
                 content={i18n.translate('xpack.fleet.integrationsResizablePanel.collapseButton', {
                   defaultMessage: 'Collapse panel',
                 })}
+                disableScreenReaderOutput
               >
                 <EuiButtonIcon
                   key="chevronSingleDown"

--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_policy_summary_line.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_policy_summary_line.test.tsx
@@ -149,7 +149,7 @@ describe('AgentPolicySummaryLine', () => {
 
     test('it should render a tooltip with the policy ID when showPolicyId is true', () => {
       const results = renderWithPolicyId(true);
-      expect(results.getByTitle('My Policy').closest('[data-popover-open]')).toBeDefined();
+      expect(results.getByText('My Policy').closest('[data-popover-open]')).toBeDefined();
       const tooltipAnchor = results.container.querySelector(
         '[data-test-subj="agentPolicyNameLink"]'
       );

--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_policy_summary_line.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_policy_summary_line.tsx
@@ -171,7 +171,6 @@ export const AgentPolicySummaryLine = memo<{
                 <EuiLink
                   className="eui-textBreakWord"
                   href={getHref('policy_details', { policyId: id })}
-                  title={policyDisplayName}
                   data-test-subj="agentPolicyNameLink"
                 >
                   {policyDisplayName}
@@ -240,9 +239,11 @@ export const AgentPolicySummaryLine = memo<{
 
         {withDescription && description && (
           <EuiFlexItem>
-            <EuiText color="subdued" title={description} size="xs">
-              {description}
-            </EuiText>
+            <EuiToolTip content={description}>
+              <EuiText color="subdued" size="xs">
+                {description}
+              </EuiText>
+            </EuiToolTip>
           </EuiFlexItem>
         )}
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/fleet/public/components/context_menu_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/context_menu_actions.tsx
@@ -60,18 +60,28 @@ export const ContextMenuActions = React.memo<Props>(
         {button.children}
       </EuiButton>
     ) : (
-      <EuiButtonIcon
-        isDisabled={props.isManaged}
-        iconType="boxesVertical"
-        onClick={handleToggleMenu}
-        aria-label={
+      <EuiToolTip
+        content={
           ariaLabel ??
           i18n.translate('xpack.fleet.genericActionsMenuText', {
             defaultMessage: 'Actions',
           })
         }
-        data-test-subj="agentActionsBtn"
-      />
+        disableScreenReaderOutput
+      >
+        <EuiButtonIcon
+          isDisabled={props.isManaged}
+          iconType="boxesVertical"
+          onClick={handleToggleMenu}
+          aria-label={
+            ariaLabel ??
+            i18n.translate('xpack.fleet.genericActionsMenuText', {
+              defaultMessage: 'Actions',
+            })
+          }
+          data-test-subj="agentActionsBtn"
+        />
+      </EuiToolTip>
     );
 
     return (

--- a/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/component_detail.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/otel_ui/collector_config_view/component_detail/component_detail.tsx
@@ -16,6 +16,7 @@ import {
   EuiTab,
   EuiTabs,
   EuiTitle,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -150,17 +151,24 @@ export const OTelComponentDetail: React.FunctionComponent<OTelComponentDetailPro
           <EuiFlexGroup alignItems="center" gutterSize="s">
             {componentHealth && healhtLabel}
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                iconType="cross"
-                aria-label={i18n.translate(
-                  'xpack.fleet.otelUi.componentDetail.closeButtonAriaLabel',
-                  {
-                    defaultMessage: 'Close component detail',
-                  }
-                )}
-                onClick={onClose}
-                data-test-subj="otelComponentDetailCloseButton"
-              />
+              <EuiToolTip
+                content={i18n.translate('xpack.fleet.otelUi.componentDetail.closeButtonAriaLabel', {
+                  defaultMessage: 'Close component detail',
+                })}
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  iconType="cross"
+                  aria-label={i18n.translate(
+                    'xpack.fleet.otelUi.componentDetail.closeButtonAriaLabel',
+                    {
+                      defaultMessage: 'Close component detail',
+                    }
+                  )}
+                  onClick={onClose}
+                  data-test-subj="otelComponentDetailCloseButton"
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>


### PR DESCRIPTION
Relates to https://github.com/elastic/eui/issues/9566

> [!IMPORTANT]
> These changes **should be carefully tested visually by each code owner.** Wrapping with `EuiToolTip` instead of passing `title` leads to another DOM node and can potentially break the layout. In such cases, I would appreciate committing appropriate fixes to this PR directly, I cannot possibly setup and run all Kibana functionalities to fix every regression.

This PR:

- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same as `aria-label`, any `title` passed to `EuiButtonIcon` is removed,
- changes several `title` cases (not truncation related) to use `EuiToolTip` instead (if applicable).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->