### PR TITLE
feat(kibana-data-discovery, security-threat-hunting): replace title props and wrap EuiButtonIcon with EuiToolTip

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/__mocks__/external_control_columns.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/__mocks__/external_control_columns.tsx
@@ -10,13 +10,14 @@
 import React, { useState } from 'react';
 import type { EuiDataGridControlColumn } from '@elastic/eui';
 import {
-  EuiCheckbox,
   EuiButtonIcon,
-  EuiPopover,
+  EuiCheckbox,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiPopover,
   EuiPopoverTitle,
   EuiSpacer,
+  EuiToolTip,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { RowControlColumn } from '@kbn/discover-utils';
@@ -72,12 +73,14 @@ const TestTrailingColumn = () => {
       panelPaddingSize="s"
       aria-labelledby={popoverTitleId}
       button={
-        <EuiButtonIcon
-          aria-label="show actions"
-          iconType="boxesVertical"
-          color="text"
-          onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-        />
+        <EuiToolTip content="show actions" disableScreenReaderOutput>
+          <EuiButtonIcon
+            aria-label="show actions"
+            iconType="boxesVertical"
+            color="text"
+            onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+          />
+        </EuiToolTip>
       }
       data-test-subj="test-trailing-column-popover-button"
       closePopover={() => setIsPopoverOpen(false)}
@@ -87,7 +90,9 @@ const TestTrailingColumn = () => {
         <button type="button" onClick={() => {}}>
           <EuiFlexGroup alignItems="center" component="span" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon aria-label="Pin selected items" iconType="pin" color="text" />
+              <EuiToolTip content="Pin selected items" disableScreenReaderOutput>
+                <EuiButtonIcon aria-label="Pin selected items" iconType="pin" color="text" />
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem>{'Pin'}</EuiFlexItem>
           </EuiFlexGroup>
@@ -96,7 +101,9 @@ const TestTrailingColumn = () => {
         <button type="button" onClick={() => {}}>
           <EuiFlexGroup alignItems="center" component="span" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon aria-label="Delete selected items" iconType="trash" color="text" />
+              <EuiToolTip content="Delete selected items" disableScreenReaderOutput>
+                <EuiButtonIcon aria-label="Delete selected items" iconType="trash" color="text" />
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem>{'Delete'}</EuiFlexItem>
           </EuiFlexGroup>

--- a/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
@@ -166,7 +166,7 @@ describe('Unified data table cell rendering', function () {
       />
     );
     expect(component.html()).toMatchInlineSnapshot(
-      `"<div data-test-subj=\\"dataTableExpandCellActionPopover\\" class=\\"euiFlexGroup css-1h68cm-euiFlexGroup-none-flexStart-stretch-row\\"><div class=\\"euiFlexItem css-9sbomz-euiFlexItem-grow-1\\"><span class=\\"unifiedDataTable__cellPopoverValue eui-textBreakWord css-i1xbf4-popover\\"><span>100</span></span></div><div class=\\"euiFlexItem css-kpsrin-euiFlexItem-growZero\\"><button class=\\"euiButtonIcon css-cxyb91-euiButtonIcon-xs-empty-primary\\" type=\\"button\\" aria-label=\\"Close popover\\" data-test-subj=\\"docTableClosePopover\\"><span data-euiicon-type=\\"cross\\" class=\\"euiButtonIcon__icon\\" aria-hidden=\\"true\\" color=\\"inherit\\"></span></button></div></div>"`
+      `"<div data-test-subj=\\"dataTableExpandCellActionPopover\\" class=\\"euiFlexGroup css-1h68cm-euiFlexGroup-none-flexStart-stretch-row\\"><div class=\\"euiFlexItem css-9sbomz-euiFlexItem-grow-1\\"><span class=\\"unifiedDataTable__cellPopoverValue eui-textBreakWord css-i1xbf4-popover\\"><span>100</span></span></div><div class=\\"euiFlexItem css-kpsrin-euiFlexItem-growZero\\"><span id=\\"generated-id_euiToolTipAnchor\\" class=\\"euiToolTipAnchor css-jcaat8-euiToolTipAnchor-inlineBlock\\"><button class=\\"euiButtonIcon css-cxyb91-euiButtonIcon-xs-empty-primary\\" type=\\"button\\" aria-label=\\"Close popover\\" data-test-subj=\\"docTableClosePopover\\"><span data-euiicon-type=\\"cross\\" class=\\"euiButtonIcon__icon\\" aria-hidden=\\"true\\" color=\\"inherit\\"></span></button></span></div></div>"`
     );
   });
 
@@ -193,7 +193,7 @@ describe('Unified data table cell rendering', function () {
       />
     );
     expect(component.html()).toMatchInlineSnapshot(
-      `"<div data-test-subj=\\"dataTableExpandCellActionPopover\\" class=\\"euiFlexGroup css-1h68cm-euiFlexGroup-none-flexStart-stretch-row\\"><div class=\\"euiFlexItem css-9sbomz-euiFlexItem-grow-1\\"><span class=\\"unifiedDataTable__cellPopoverValue eui-textBreakWord css-i1xbf4-popover\\"><span>100</span></span></div><div class=\\"euiFlexItem css-kpsrin-euiFlexItem-growZero\\"><button class=\\"euiButtonIcon css-cxyb91-euiButtonIcon-xs-empty-primary\\" type=\\"button\\" aria-label=\\"Close popover\\" data-test-subj=\\"docTableClosePopover\\"><span data-euiicon-type=\\"cross\\" class=\\"euiButtonIcon__icon\\" aria-hidden=\\"true\\" color=\\"inherit\\"></span></button></div></div>"`
+      `"<div data-test-subj=\\"dataTableExpandCellActionPopover\\" class=\\"euiFlexGroup css-1h68cm-euiFlexGroup-none-flexStart-stretch-row\\"><div class=\\"euiFlexItem css-9sbomz-euiFlexItem-grow-1\\"><span class=\\"unifiedDataTable__cellPopoverValue eui-textBreakWord css-i1xbf4-popover\\"><span>100</span></span></div><div class=\\"euiFlexItem css-kpsrin-euiFlexItem-growZero\\"><span id=\\"generated-id_euiToolTipAnchor\\" class=\\"euiToolTipAnchor css-jcaat8-euiToolTipAnchor-inlineBlock\\"><button class=\\"euiButtonIcon css-cxyb91-euiButtonIcon-xs-empty-primary\\" type=\\"button\\" aria-label=\\"Close popover\\" data-test-subj=\\"docTableClosePopover\\"><span data-euiicon-type=\\"cross\\" class=\\"euiButtonIcon__icon\\" aria-hidden=\\"true\\" color=\\"inherit\\"></span></button></span></div></div>"`
     );
     findTestSubject(component, 'docTableClosePopover').simulate('click');
     expect(closePopoverMockFn).toHaveBeenCalledTimes(1);
@@ -307,14 +307,19 @@ describe('Unified data table cell rendering', function () {
     expect(component).toMatchInlineSnapshot(`
       <SourcePopoverContent
         closeButton={
-          <EuiButtonIcon
-            aria-label="Close popover"
-            data-test-subj="docTableClosePopover"
-            iconSize="s"
-            iconType="cross"
-            onClick={[MockFunction]}
-            size="xs"
-          />
+          <EuiToolTip
+            content="Close popover"
+            disableScreenReaderOutput={true}
+          >
+            <EuiButtonIcon
+              aria-label="Close popover"
+              data-test-subj="docTableClosePopover"
+              iconSize="s"
+              iconType="cross"
+              onClick={[MockFunction]}
+              size="xs"
+            />
+          </EuiToolTip>
         }
         columnId="_source"
         row={
@@ -495,14 +500,19 @@ describe('Unified data table cell rendering', function () {
     expect(component).toMatchInlineSnapshot(`
       <SourcePopoverContent
         closeButton={
-          <EuiButtonIcon
-            aria-label="Close popover"
-            data-test-subj="docTableClosePopover"
-            iconSize="s"
-            iconType="cross"
-            onClick={[MockFunction]}
-            size="xs"
-          />
+          <EuiToolTip
+            content="Close popover"
+            disableScreenReaderOutput={true}
+          >
+            <EuiButtonIcon
+              aria-label="Close popover"
+              data-test-subj="docTableClosePopover"
+              iconSize="s"
+              iconType="cross"
+              onClick={[MockFunction]}
+              size="xs"
+            />
+          </EuiToolTip>
         }
         columnId="_source"
         row={
@@ -653,14 +663,19 @@ describe('Unified data table cell rendering', function () {
     expect(component).toMatchInlineSnapshot(`
       <SourcePopoverContent
         closeButton={
-          <EuiButtonIcon
-            aria-label="Close popover"
-            data-test-subj="docTableClosePopover"
-            iconSize="s"
-            iconType="cross"
-            onClick={[MockFunction]}
-            size="xs"
-          />
+          <EuiToolTip
+            content="Close popover"
+            disableScreenReaderOutput={true}
+          >
+            <EuiButtonIcon
+              aria-label="Close popover"
+              data-test-subj="docTableClosePopover"
+              iconSize="s"
+              iconType="cross"
+              onClick={[MockFunction]}
+              size="xs"
+            />
+          </EuiToolTip>
         }
         columnId="object"
         row={
@@ -885,14 +900,19 @@ describe('Unified data table cell rendering', function () {
         <EuiFlexItem
           grow={false}
         >
-          <EuiButtonIcon
-            aria-label="Close popover"
-            data-test-subj="docTableClosePopover"
-            iconSize="s"
-            iconType="cross"
-            onClick={[MockFunction]}
-            size="xs"
-          />
+          <EuiToolTip
+            content="Close popover"
+            disableScreenReaderOutput={true}
+          >
+            <EuiButtonIcon
+              aria-label="Close popover"
+              data-test-subj="docTableClosePopover"
+              iconSize="s"
+              iconType="cross"
+              onClick={[MockFunction]}
+              size="xs"
+            />
+          </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>
     `);

--- a/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { i18n } from '@kbn/i18n';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
 import type { EuiDataGridCellValueElementProps, EuiDataGridSetCellProps } from '@elastic/eui';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { getDataViewFieldOrCreateFromColumnMeta } from '@kbn/data-view-utils';
 import type {
@@ -237,16 +237,23 @@ function renderPopoverContent({
   isPlainRecord?: boolean;
 }) {
   const closeButton = (
-    <EuiButtonIcon
-      aria-label={i18n.translate('unifiedDataTable.grid.closePopover', {
+    <EuiToolTip
+      content={i18n.translate('unifiedDataTable.grid.closePopover', {
         defaultMessage: `Close popover`,
       })}
-      data-test-subj="docTableClosePopover"
-      iconSize="s"
-      iconType="cross"
-      size="xs"
-      onClick={closePopover}
-    />
+      disableScreenReaderOutput
+    >
+      <EuiButtonIcon
+        aria-label={i18n.translate('unifiedDataTable.grid.closePopover', {
+          defaultMessage: `Close popover`,
+        })}
+        data-test-subj="docTableClosePopover"
+        iconSize="s"
+        iconType="cross"
+        size="xs"
+        onClick={closePopover}
+      />
+    </EuiToolTip>
   );
   if (
     useTopLevelObjectColumns ||


### PR DESCRIPTION
Relates to https://github.com/elastic/eui/issues/9566

> [!IMPORTANT]
> These changes **should be carefully tested visually by each code owner.** Wrapping with `EuiToolTip` instead of passing `title` leads to another DOM node and can potentially break the layout. In such cases, I would appreciate committing appropriate fixes to this PR directly, I cannot possibly setup and run all Kibana functionalities to fix every regression.

This PR:

- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same as `aria-label`, any `title` passed to `EuiButtonIcon` is removed,
- changes several `title` cases (not truncation related) to use `EuiToolTip` instead (if applicable).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->