### PR TITLE
feat(security-detection-rule-management): replace title props and wrap EuiButtonIcon with EuiToolTip

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_results/flyout/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_results/flyout/header.tsx
@@ -7,15 +7,16 @@
 
 import React from 'react';
 import {
-  EuiFlyoutHeader,
+  EuiButtonIcon,
+  EuiCopy,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiTitle,
-  EuiText,
-  EuiSpacer,
+  EuiFlyoutHeader,
   EuiPanel,
-  EuiCopy,
-  EuiButtonIcon,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -51,12 +52,14 @@ export const FlyoutHeader: React.FC<FlyoutHeaderProps> = ({ item, titleId }) => 
           <EuiFlexItem grow={false}>
             <EuiCopy textToCopy={item.execution_uuid} beforeMessage={i18n.FLYOUT_COPY_EXECUTION_ID}>
               {(copy) => (
-                <EuiButtonIcon
-                  onClick={copy}
-                  iconType="copy"
-                  color="text"
-                  aria-label={i18n.FLYOUT_COPY_EXECUTION_ID}
-                />
+                <EuiToolTip content={i18n.FLYOUT_COPY_EXECUTION_ID} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    onClick={copy}
+                    iconType="copy"
+                    color="text"
+                    aria-label={i18n.FLYOUT_COPY_EXECUTION_ID}
+                  />
+                </EuiToolTip>
               )}
             </EuiCopy>
           </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -463,14 +463,16 @@ export const RuleDetailsPage = connector(
             </EuiFlexItem>
           ) : (
             <RuleStatus status={lastExecutionStatus} date={lastExecutionDate}>
-              <EuiButtonIcon
-                data-test-subj="ruleLastExecutionStatusRefreshButton"
-                color="primary"
-                onClick={refreshRule}
-                iconType="refresh"
-                aria-label={ruleI18n.REFRESH}
-                isDisabled={!isExistingRule}
-              />
+              <EuiToolTip content={ruleI18n.REFRESH} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  data-test-subj="ruleLastExecutionStatusRefreshButton"
+                  color="primary"
+                  onClick={refreshRule}
+                  iconType="refresh"
+                  aria-label={ruleI18n.REFRESH}
+                  isDisabled={!isExistingRule}
+                />
+              </EuiToolTip>
             </RuleStatus>
           )}
           <EuiFlexItem grow={false}>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
@@ -17,6 +17,7 @@ import {
   EuiLoadingSpinner,
   EuiPopover,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { Filter } from '@kbn/es-query';
@@ -283,11 +284,13 @@ const UnavailableMlJobLink: React.FC<UnavailableMlJobLinkProps> = ({ jobId }) =>
   const [isPopoverOpen, togglePopover] = useToggle(false);
 
   const button = (
-    <EuiButtonIcon
-      iconType="question"
-      onClick={togglePopover}
-      aria-label={i18n.MACHINE_LEARNING_JOB_NOT_AVAILABLE}
-    />
+    <EuiToolTip content={i18n.MACHINE_LEARNING_JOB_NOT_AVAILABLE} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="question"
+        onClick={togglePopover}
+        aria-label={i18n.MACHINE_LEARNING_JOB_NOT_AVAILABLE}
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
@@ -9,22 +9,19 @@ import React from 'react';
 import { isEmpty } from 'lodash/fp';
 import type { EuiDescriptionListProps } from '@elastic/eui';
 import {
-  EuiButtonIcon,
   EuiDescriptionList,
   EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIconTip,
   EuiLoadingSpinner,
-  EuiPopover,
   EuiText,
-  EuiToolTip,
 } from '@elastic/eui';
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { Filter } from '@kbn/es-query';
 import type { SavedQuery } from '@kbn/data-plugin/public';
 import { mapAndFlattenFilters } from '@kbn/data-plugin/public';
 import { FilterItems } from '@kbn/unified-search-plugin/public';
-import useToggle from 'react-use/lib/useToggle';
 import type {
   AlertSuppressionMissingFieldsStrategy,
   EqlOptionalFields,
@@ -281,24 +278,10 @@ interface UnavailableMlJobLinkProps {
 }
 
 const UnavailableMlJobLink: React.FC<UnavailableMlJobLinkProps> = ({ jobId }) => {
-  const [isPopoverOpen, togglePopover] = useToggle(false);
-
-  const button = (
-    <EuiToolTip content={i18n.MACHINE_LEARNING_JOB_NOT_AVAILABLE} disableScreenReaderOutput>
-      <EuiButtonIcon
-        iconType="question"
-        onClick={togglePopover}
-        aria-label={i18n.MACHINE_LEARNING_JOB_NOT_AVAILABLE}
-      />
-    </EuiToolTip>
-  );
-
   return (
     <EuiText component="span" color="subdued" size="s">
       {jobId}
-      <EuiPopover button={button} isOpen={isPopoverOpen} closePopover={togglePopover}>
-        {i18n.MACHINE_LEARNING_JOB_NOT_AVAILABLE}
-      </EuiPopover>
+      <EuiIconTip type="question" content={i18n.MACHINE_LEARNING_JOB_NOT_AVAILABLE} />
     </EuiText>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/comparison_side/comparison_side_help_info.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/comparison_side/comparison_side_help_info.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import useToggle from 'react-use/lib/useToggle';
-import { EuiPopover, EuiText, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiText, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import * as i18n from './translations';
 import type { VersionsPickerOptionEnum } from './versions_picker/versions_picker';
@@ -32,11 +32,13 @@ export function ComparisonSideHelpInfo({ options }: ComparisonSideHelpInfoProps)
   const optionsWithDescriptions = options.map((option) => getOptionDetails(option));
 
   const button = (
-    <EuiButtonIcon
-      iconType="question"
-      onClick={togglePopover}
-      aria-label={i18n.VERSION_COMPARISON_HELP_ARIA_LABEL}
-    />
+    <EuiToolTip content={i18n.VERSION_COMPARISON_HELP_ARIA_LABEL} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="question"
+        onClick={togglePopover}
+        aria-label={i18n.VERSION_COMPARISON_HELP_ARIA_LABEL}
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/field_final_side/components/field_final_side_help_info.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/field_final_side/components/field_final_side_help_info.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import useToggle from 'react-use/lib/useToggle';
-import { EuiPopover, EuiText, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiText, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import * as i18n from './translations';
 
@@ -24,11 +24,13 @@ export function FieldFinalSideHelpInfo(): JSX.Element {
   const [isPopoverOpen, togglePopover] = useToggle(false);
 
   const button = (
-    <EuiButtonIcon
-      iconType="question"
-      onClick={togglePopover}
-      aria-label={i18n.FINAL_UPDATE_HELP_ARIA_LABEL}
-    />
+    <EuiToolTip content={i18n.FINAL_UPDATE_HELP_ARIA_LABEL} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="question"
+        onClick={togglePopover}
+        aria-label={i18n.FINAL_UPDATE_HELP_ARIA_LABEL}
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/ml_rule_warning_popover/ml_rule_warning_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/ml_rule_warning_popover/ml_rule_warning_popover.tsx
@@ -13,6 +13,7 @@ import {
   EuiPopoverTitle,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine/rule_monitoring';
@@ -58,12 +59,15 @@ const MlRuleWarningPopoverComponent: React.FC<MlRuleWarningPopoverComponentProps
   }
 
   const button = (
-    <EuiButtonIcon
-      display={'empty'}
-      color={'warning'}
-      iconType={'warning'}
-      onClick={togglePopover}
-    />
+    <EuiToolTip content={i18n.ML_RULE_JOBS_WARNING_ICON_LABEL} disableScreenReaderOutput>
+      <EuiButtonIcon
+        display={'empty'}
+        color={'warning'}
+        iconType={'warning'}
+        onClick={togglePopover}
+        aria-label={i18n.ML_RULE_JOBS_WARNING_ICON_LABEL}
+      />
+    </EuiToolTip>
   );
   const popoverTitle = getCapitalizedStatusText(RuleExecutionStatusEnum['partial failure']);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_header_buttons.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexItem,
   EuiLoadingSpinner,
   EuiPopover,
+  EuiToolTip,
 } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 import useBoolean from 'react-use/lib/useBoolean';
@@ -85,14 +86,19 @@ export const AddPrebuiltRulesHeaderButtons = () => {
           <EuiFlexItem grow={false}>
             <EuiPopover
               button={
-                <EuiButtonIcon
-                  display="base"
-                  size="m"
-                  iconType="boxesVertical"
-                  aria-label={i18n.INSTALL_RULES_OVERFLOW_BUTTON_ARIA_LABEL}
-                  onClick={onOverflowButtonClick}
-                  disabled={!canEditRules || isRequestInProgress}
-                />
+                <EuiToolTip
+                  content={i18n.INSTALL_RULES_OVERFLOW_BUTTON_ARIA_LABEL}
+                  disableScreenReaderOutput
+                >
+                  <EuiButtonIcon
+                    display="base"
+                    size="m"
+                    iconType="boxesVertical"
+                    aria-label={i18n.INSTALL_RULES_OVERFLOW_BUTTON_ARIA_LABEL}
+                    onClick={onOverflowButtonClick}
+                    disabled={!canEditRules || isRequestInProgress}
+                  />
+                </EuiToolTip>
               }
               isOpen={isOverflowPopoverOpen}
               closePopover={closeOverflowPopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_install_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_install_button.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexItem,
   EuiLoadingSpinner,
   EuiPopover,
+  EuiToolTip,
 } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 import useBoolean from 'react-use/lib/useBoolean';
@@ -75,14 +76,16 @@ export const PrebuiltRulesInstallButton = ({
 
   const popoverButton = useMemo(
     () => (
-      <EuiButtonIcon
-        display="empty"
-        size="s"
-        iconType="boxesVertical"
-        aria-label={i18n.INSTALL_RULES_OVERFLOW_BUTTON_ARIA_LABEL}
-        onClick={onOverflowButtonClick}
-        disabled={isInstallButtonDisabled}
-      />
+      <EuiToolTip content={i18n.INSTALL_RULES_OVERFLOW_BUTTON_ARIA_LABEL} disableScreenReaderOutput>
+        <EuiButtonIcon
+          display="empty"
+          size="s"
+          iconType="boxesVertical"
+          aria-label={i18n.INSTALL_RULES_OVERFLOW_BUTTON_ARIA_LABEL}
+          onClick={onOverflowButtonClick}
+          disabled={isInstallButtonDisabled}
+        />
+      </EuiToolTip>
     ),
     [isInstallButtonDisabled, onOverflowButtonClick]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/feature_tour/rules_feature_tour.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/feature_tour/rules_feature_tour.tsx
@@ -17,6 +17,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
   EuiTourStep,
   useEuiTour,
 } from '@elastic/eui';
@@ -95,22 +96,26 @@ export const RuleFeatureTour: FC = () => {
                 <EuiSpacer size="s" />
                 <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      iconType="chevronSingleLeft"
-                      aria-label={i18n.PREVIOUS_STEP_LABEL}
-                      display="empty"
-                      disabled={index === 0}
-                      onClick={tourActions.decrementStep}
-                    />
+                    <EuiToolTip content={i18n.PREVIOUS_STEP_LABEL} disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        iconType="chevronSingleLeft"
+                        aria-label={i18n.PREVIOUS_STEP_LABEL}
+                        display="empty"
+                        disabled={index === 0}
+                        onClick={tourActions.decrementStep}
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      iconType="chevronSingleRight"
-                      aria-label={i18n.NEXT_STEP_LABEL}
-                      display="base"
-                      disabled={index === tourSteps.length - 1}
-                      onClick={tourActions.incrementStep}
-                    />
+                    <EuiToolTip content={i18n.NEXT_STEP_LABEL} disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        iconType="chevronSingleRight"
+                        aria-label={i18n.NEXT_STEP_LABEL}
+                        display="base"
+                        disabled={index === tourSteps.length - 1}
+                        onClick={tourActions.incrementStep}
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/ml_rule_warning_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/ml_rule_warning_popover.tsx
@@ -13,6 +13,7 @@ import {
   EuiPopoverTitle,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine/rule_monitoring';
@@ -58,12 +59,15 @@ const MlRuleWarningPopoverComponent: React.FC<MlRuleWarningPopoverComponentProps
   }
 
   const button = (
-    <EuiButtonIcon
-      display={'empty'}
-      color={'warning'}
-      iconType={'warning'}
-      onClick={togglePopover}
-    />
+    <EuiToolTip content={i18n.ML_RULE_JOBS_WARNING_ICON_LABEL} disableScreenReaderOutput>
+      <EuiButtonIcon
+        display={'empty'}
+        color={'warning'}
+        iconType={'warning'}
+        onClick={togglePopover}
+        aria-label={i18n.ML_RULE_JOBS_WARNING_ICON_LABEL}
+      />
+    </EuiToolTip>
   );
   const popoverTitle = getCapitalizedStatusText(RuleExecutionStatusEnum['partial failure']);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/translations.ts
@@ -15,6 +15,13 @@ export const ML_RULE_JOBS_WARNING_DESCRIPTION = i18n.translate(
   }
 );
 
+export const ML_RULE_JOBS_WARNING_ICON_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleManagementUi.rulesTable.mlJobsWarning.iconLabel',
+  {
+    defaultMessage: 'ML jobs warning',
+  }
+);
+
 export const ML_RULE_JOBS_WARNING_BUTTON_LABEL = i18n.translate(
   'xpack.securitySolution.detectionEngine.ruleManagementUi.rulesTable.mlJobsWarning.popover.buttonLabel',
   {


### PR DESCRIPTION
Relates to https://github.com/elastic/eui/issues/9566

> [!IMPORTANT]
> These changes **should be carefully tested visually by each code owner.** Wrapping with `EuiToolTip` instead of passing `title` leads to another DOM node and can potentially break the layout. In such cases, I would appreciate committing appropriate fixes to this PR directly, I cannot possibly setup and run all Kibana functionalities to fix every regression.

This PR:

- wraps ALL `EuiButtonIcon` with `EuiToolTip`, the content is the same as `aria-label`, any `title` passed to `EuiButtonIcon` is removed,
- changes several `title` cases (not truncation related) to use `EuiToolTip` instead (if applicable).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->