### PR TITLE
[ci] Disable composite uploads

### DIFF
--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -222,7 +222,7 @@ upload_tmp_artifact() {
   "${SCRIPTS_COMMON_DIR}/activate_service_account.sh" "kibana-ci-artifacts-${GCS_CI_ARTIFACT_REGIONS[0]}"
 
   printf '%s\n' "${GCS_CI_ARTIFACT_REGIONS[@]}" | xargs -P 0 -I{} \
-    gcloud storage cp "$local_path" "gs://kibana-ci-artifacts-{}/tmp/builds/${build_id}/${artifact_name}"
+    gcloud storage cp --no-parallel-composite-upload "$local_path" "gs://kibana-ci-artifacts-{}/tmp/builds/${build_id}/${artifact_name}"
 }
 
 print_if_dry_run() {

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -218,11 +218,27 @@ download_tmp_artifact() {
 }
 upload_tmp_artifact() {
   local local_path="$1" artifact_name="$2" build_id="$3"
+  local region pid exit_code=0
+  local upload_pids=()
 
   "${SCRIPTS_COMMON_DIR}/activate_service_account.sh" "kibana-ci-artifacts-${GCS_CI_ARTIFACT_REGIONS[0]}"
 
-  printf '%s\n' "${GCS_CI_ARTIFACT_REGIONS[@]}" | xargs -P 0 -I{} \
-    gcloud storage cp "$local_path" "gs://kibana-ci-artifacts-{}/tmp/builds/${build_id}/${artifact_name}"
+  for region in "${GCS_CI_ARTIFACT_REGIONS[@]}"; do
+    (
+      retry 3 1 gcloud storage cp \
+        "$local_path" \
+        "gs://kibana-ci-artifacts-${region}/tmp/builds/${build_id}/${artifact_name}"
+    ) &
+    upload_pids+=("$!")
+  done
+
+  for pid in "${upload_pids[@]}"; do
+    if ! wait "$pid"; then
+      exit_code=1
+    fi
+  done
+
+  return "$exit_code"
 }
 
 print_if_dry_run() {

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -218,27 +218,11 @@ download_tmp_artifact() {
 }
 upload_tmp_artifact() {
   local local_path="$1" artifact_name="$2" build_id="$3"
-  local region pid exit_code=0
-  local upload_pids=()
 
   "${SCRIPTS_COMMON_DIR}/activate_service_account.sh" "kibana-ci-artifacts-${GCS_CI_ARTIFACT_REGIONS[0]}"
 
-  for region in "${GCS_CI_ARTIFACT_REGIONS[@]}"; do
-    (
-      retry 3 1 gcloud storage cp \
-        "$local_path" \
-        "gs://kibana-ci-artifacts-${region}/tmp/builds/${build_id}/${artifact_name}"
-    ) &
-    upload_pids+=("$!")
-  done
-
-  for pid in "${upload_pids[@]}"; do
-    if ! wait "$pid"; then
-      exit_code=1
-    fi
-  done
-
-  return "$exit_code"
+  printf '%s\n' "${GCS_CI_ARTIFACT_REGIONS[@]}" | xargs -P 0 -I{} \
+    gcloud storage cp "$local_path" "gs://kibana-ci-artifacts-{}/tmp/builds/${build_id}/${artifact_name}"
 }
 
 print_if_dry_run() {

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -222,7 +222,7 @@ upload_tmp_artifact() {
   "${SCRIPTS_COMMON_DIR}/activate_service_account.sh" "kibana-ci-artifacts-${GCS_CI_ARTIFACT_REGIONS[0]}"
 
   printf '%s\n' "${GCS_CI_ARTIFACT_REGIONS[@]}" | xargs -P 0 -I{} \
-    gcloud --property=storage/parallel_composite_upload_enabled=False storage cp \
+    env CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED=False gcloud storage cp \
       "$local_path" \
       "gs://kibana-ci-artifacts-{}/tmp/builds/${build_id}/${artifact_name}"
 }

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -222,7 +222,9 @@ upload_tmp_artifact() {
   "${SCRIPTS_COMMON_DIR}/activate_service_account.sh" "kibana-ci-artifacts-${GCS_CI_ARTIFACT_REGIONS[0]}"
 
   printf '%s\n' "${GCS_CI_ARTIFACT_REGIONS[@]}" | xargs -P 0 -I{} \
-    gcloud storage cp --no-parallel-composite-upload "$local_path" "gs://kibana-ci-artifacts-{}/tmp/builds/${build_id}/${artifact_name}"
+    gcloud --property=storage/parallel_composite_upload_enabled=False storage cp \
+      "$local_path" \
+      "gs://kibana-ci-artifacts-{}/tmp/builds/${build_id}/${artifact_name}"
 }
 
 print_if_dry_run() {


### PR DESCRIPTION
Currently we're running multiple composite uploads in parallel.  This can occasionally cause issues: [example](https://buildkite.com/elastic/kibana-pull-request/builds/448905#019e69bd-ca57-434f-ae87-8a80bab26b53/L2173).

This disables composite uploads.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->