### PR TITLE
[Chrome Next] Avoid empty fallback AppHeader due to empty menu

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/app_menu.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/app_menu.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { lazy, Suspense } from 'react';
-import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
+import { hasNonGlobalStaticItems, type AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import { useHasLegacyActionMenu } from './hooks/chrome';
 import { LegacyHeaderActionMenu } from './legacy_action_menu';
 import { useAppHeaderMenu } from './hooks';
@@ -27,8 +27,9 @@ export interface AppMenuProps {
 export const AppMenu = React.memo<AppMenuProps>(({ menu, docLink, showAddIntegrations }) => {
   const { config, staticItems } = useAppHeaderMenu(menu, docLink, showAddIntegrations);
   const hasLegacyActionMenu = useHasLegacyActionMenu();
+  const hasStaticItems = hasNonGlobalStaticItems(staticItems);
 
-  if (config || staticItems?.length) {
+  if (config || hasStaticItems) {
     return (
       <Suspense>
         <AppMenuComponent config={config} staticItems={staticItems} />

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
@@ -37,4 +37,5 @@ export {
   getPopoverPanels,
   getPopoverActionItems,
   getIsSelectedColor,
+  hasNonGlobalStaticItems,
 } from './src';

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState } from 'react';
 import { EuiHeaderLinks, useIsWithinBreakpoints } from '@elastic/eui';
-import { getAppMenuItems, processStaticItems } from '../utils';
+import { getAppMenuItems, hasNonGlobalStaticItems, processStaticItems } from '../utils';
 import { AppMenuActionButton } from './app_menu_action_button';
 import { AppMenuItem } from './app_menu_item';
 import { AppMenuOverflowButton } from './app_menu_overflow_button';
@@ -51,9 +51,9 @@ export const AppMenuComponent = ({
    * If only global static items are present, we don't want to render
    * the app menu.
    */
-  const hasNonGlobalStaticItems = !!staticItems?.length && staticItems.some((item) => !item.global);
+  const hasVisibleStaticItems = hasNonGlobalStaticItems(staticItems);
 
-  if ((!config || hasNoItems(config)) && !hasNonGlobalStaticItems) {
+  if ((!config || hasNoItems(config)) && !hasVisibleStaticItems) {
     return null;
   }
 
@@ -78,7 +78,7 @@ export const AppMenuComponent = ({
     shouldOverflow: shouldOverflowBase,
   } = getAppMenuItems({
     config,
-    hasStaticItems: hasNonGlobalStaticItems,
+    hasStaticItems: hasVisibleStaticItems,
   });
 
   const processedStaticItems = processStaticItems(staticItems);

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
@@ -40,4 +40,5 @@ export {
   getPopoverActionItems,
   getPopoverSwitchItems,
   getIsSelectedColor,
+  hasNonGlobalStaticItems,
 } from './utils';

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -126,6 +126,9 @@ export const processStaticItems = (staticItems?: AppMenuItemType[]): AppMenuItem
     overflow: true,
   }));
 
+export const hasNonGlobalStaticItems = (staticItems?: Array<{ global?: boolean }>): boolean =>
+  !!staticItems?.some((item) => !item.global);
+
 export const isDisabled = (disableButton: AppMenuItemCommon['disableButton']) =>
   Boolean(isFunction(disableButton) ? disableButton() : disableButton);
 


### PR DESCRIPTION
Part of https://github.com/elastic/kibana-team/issues/3115

## Summary

Prevents Chrome Next app headers from rendering an empty menu row when the only static app-menu item is global. The app-header wrapper now reuses the app-menu component visibility rule, allowing legacy header action menu content to render instead of being hidden behind a global-only static item.