### PR TITLE
[Home] Hide inaccessible Stack Management link

### DIFF
--- a/src/platform/plugins/shared/home/public/application/components/manage_data/__snapshots__/manage_data.test.tsx.snap
+++ b/src/platform/plugins/shared/home/public/application/components/manage_data/__snapshots__/manage_data.test.tsx.snap
@@ -134,21 +134,6 @@ exports[`ManageData render 1`] = `
             />
           </EuiButtonEmpty>
         </EuiFlexItem>
-        <EuiFlexItem
-          grow={false}
-        >
-          <EuiButtonEmpty
-            data-test-subj="homeManage"
-            flush="both"
-            href=""
-            iconType="gear"
-          >
-            <MemoizedFormattedMessage
-              defaultMessage="Stack Management"
-              id="home.manageData.stackManagementButtonLabel"
-            />
-          </EuiButtonEmpty>
-        </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx
@@ -8,12 +8,13 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { EuiProvider } from '@elastic/eui';
 import { ManageData } from './manage_data';
 import { shallowWithIntl } from '@kbn/test-jest-helpers';
-import type { ApplicationStart } from '@kbn/core/public';
+import { AppStatus, type ApplicationStart, type PublicAppInfo } from '@kbn/core/public';
+import { BehaviorSubject } from 'rxjs';
 import type { FeatureCatalogueEntry } from '../../../services';
 
 jest.mock('../app_navigation_handler', () => {
@@ -33,13 +34,39 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const applicationStartMock = {
-  capabilities: { navLinks: { management: true, dev_tools: true } },
-} as unknown as ApplicationStart;
+const createApplicationStartMock = ({
+  isManagementEnabled,
+  isDevToolsEnabled,
+  managementAppStatus = AppStatus.accessible,
+}: {
+  isManagementEnabled: boolean;
+  isDevToolsEnabled: boolean;
+  managementAppStatus?: AppStatus;
+}) =>
+  ({
+    capabilities: { navLinks: { management: isManagementEnabled, dev_tools: isDevToolsEnabled } },
+    applications$: new BehaviorSubject(
+      new Map<string, PublicAppInfo>([
+        ['management', { status: managementAppStatus } as PublicAppInfo],
+      ])
+    ),
+  } as unknown as ApplicationStart);
 
-const applicationStartMockRestricted = {
-  capabilities: { navLinks: { management: false, dev_tools: false } },
-} as unknown as ApplicationStart;
+const applicationStartMock = createApplicationStartMock({
+  isManagementEnabled: true,
+  isDevToolsEnabled: true,
+});
+
+const applicationStartMockRestricted = createApplicationStartMock({
+  isManagementEnabled: false,
+  isDevToolsEnabled: false,
+});
+
+const applicationStartMockWithInaccessibleManagement = createApplicationStartMock({
+  isManagementEnabled: true,
+  isDevToolsEnabled: true,
+  managementAppStatus: AppStatus.inaccessible,
+});
 
 const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
 
@@ -132,6 +159,22 @@ describe('ManageData', () => {
     expect(screen.getByTestId('homeDevTools')).toBeInTheDocument();
   });
 
+  test('renders stack management link when management app is accessible', async () => {
+    render(
+      <EuiProvider>
+        <I18nProvider>
+          <ManageData
+            addBasePath={addBasePathMock}
+            application={applicationStartMock}
+            features={mockFeatures}
+          />
+        </I18nProvider>
+      </EuiProvider>
+    );
+
+    expect(await screen.findByTestId('homeManage')).toBeInTheDocument();
+  });
+
   test('does not render dev tools link when capability is disabled', () => {
     render(
       <EuiProvider>
@@ -145,5 +188,22 @@ describe('ManageData', () => {
       </EuiProvider>
     );
     expect(screen.queryByTestId('homeDevTools')).not.toBeInTheDocument();
+  });
+
+  test('does not render stack management link when management app is inaccessible', async () => {
+    render(
+      <EuiProvider>
+        <I18nProvider>
+          <ManageData
+            addBasePath={addBasePathMock}
+            application={applicationStartMockWithInaccessibleManagement}
+            features={mockFeatures}
+          />
+        </I18nProvider>
+      </EuiProvider>
+    );
+
+    expect(screen.getByTestId('homeDevTools')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByTestId('homeManage')).not.toBeInTheDocument());
   });
 });

--- a/src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.tsx
@@ -15,11 +15,14 @@ import { EuiButtonEmpty, EuiFlexGroup, EuiSpacer, EuiTitle, EuiFlexItem } from '
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { METRIC_TYPE } from '@kbn/analytics';
-import type { ApplicationStart } from '@kbn/core/public';
+import { AppStatus, type ApplicationStart } from '@kbn/core/public';
+import useObservable from 'react-use/lib/useObservable';
 import type { FeatureCatalogueEntry } from '../../../services';
 import { createAppNavigationHandler } from '../app_navigation_handler';
 import { Synopsis } from '../synopsis';
 import { getServices } from '../../kibana_services';
+
+const MANAGEMENT_APP_ID = 'management';
 
 interface Props {
   addBasePath: (path: string) => string;
@@ -34,11 +37,15 @@ export const ManageData: FC<Props> = ({ addBasePath, application, features }) =>
   const managementHref = share.url.locators
     .get('MANAGEMENT_APP_LOCATOR')
     ?.useUrl({ sectionId: '' });
+  const { management: isManagementEnabled, dev_tools: isDevToolsEnabled } =
+    application.capabilities.navLinks;
+  const applications = useObservable(application.applications$);
+  const managementApp = applications?.get(MANAGEMENT_APP_ID);
+  const isManagementAppAccessible = Boolean(
+    isManagementEnabled && managementApp?.status === AppStatus.accessible
+  );
 
   if (features.length) {
-    const { management: isManagementEnabled, dev_tools: isDevToolsEnabled } =
-      application.capabilities.navLinks;
-
     return (
       <KibanaPageTemplate.Section
         bottomBorder
@@ -55,7 +62,7 @@ export const ManageData: FC<Props> = ({ addBasePath, application, features }) =>
             </EuiTitle>
           </EuiFlexItem>
 
-          {isDevToolsEnabled || isManagementEnabled ? (
+          {isDevToolsEnabled || isManagementAppAccessible ? (
             <EuiFlexItem grow={false}>
               <EuiFlexGroup alignItems="center" responsive={false} wrap>
                 {/* Check if both the Dev Tools UI and the Console UI are enabled. */}
@@ -75,7 +82,7 @@ export const ManageData: FC<Props> = ({ addBasePath, application, features }) =>
                   </EuiFlexItem>
                 ) : null}
 
-                {isManagementEnabled ? (
+                {isManagementAppAccessible ? (
                   <EuiFlexItem grow={false}>
                     <EuiButtonEmpty
                       data-test-subj="homeManage"


### PR DESCRIPTION
Closes #239725

## Summary
- Hides the Stack Management shortcut on the Home Management section when the registered Management app is marked inaccessible.
- Preserves the Dev Tools shortcut for users who only have Dev Tools privileges.
- Note: this touches `src/platform/plugins/shared/home`, owned by `@elastic/appex-sharedux`, so that team should review the Home UI change.

## Root Cause
- The Management app marks itself `AppStatus.inaccessible` when the current user has no enabled Management apps, but Home only checked `capabilities.navLinks.management` before rendering the Stack Management shortcut.

## Fix
- Home now derives Stack Management shortcut visibility from both the Management nav-link capability and the registered app status from `application.applications$`.
- Adds regression coverage for accessible Management and Dev Tools-only/inaccessible Management states.

## Screenshots

### Before
<img width="2532" height="666" alt="image" src="https://github.com/user-attachments/assets/ab6405e2-95eb-4a0c-ad68-6b78abc16cfa" />

### After
<img width="1481" height="435" alt="image" src="https://github.com/user-attachments/assets/fa81716d-f08e-464c-85f1-e50582e60241" />

## Test Plan
- Local UI repro/check:
  1. Start Kibana locally with security enabled and sign in as a user that can create roles.
  2. Create a role with only Kibana feature privilege `Dev Tools: All` and no Management privileges. For example, create a role with `kibana: [{ spaces: ["*"], base: [], feature: { dev_tools: ["all"] } }]`.
  3. Assign only that role to a test user and sign in as that user.
  4. Open Home. Verify `Dev Tools` is visible in the Management section and `Stack Management` is not visible.
  5. Optionally navigate directly to `/app/management` to confirm the Management app is inaccessible for that role.
- `node scripts/jest src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx`
- `node scripts/eslint src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.tsx src/platform/plugins/shared/home/public/application/components/manage_data/manage_data.test.tsx`
- `node scripts/type_check --project src/platform/plugins/shared/home/tsconfig.json`
- `node scripts/check_changes.ts`

Assisted with Cursor using GPT-5.5

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->