### PR TITLE
[Fleet] Consolidate data stream operations concurrency

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/index.ts
@@ -73,6 +73,9 @@ export interface FleetConfigType {
     maxConcurrentPackageOperations?: number;
     packageUpgradeBatchSize?: number;
   };
+  packageInstallation?: {
+    maxConcurrentDatastreamOperations?: number;
+  };
   developer?: {
     maxAgentPoliciesWithInactivityTimeout?: number;
     disableRegistryVersionCheck?: boolean;

--- a/x-pack/platform/plugins/shared/fleet/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.test.ts
@@ -142,6 +142,43 @@ describe('Config schema', () => {
     }).not.toThrow();
   });
 
+  it('should allow to specify packageInstallation configuration', () => {
+    expect(() => {
+      config.schema.validate({
+        packageInstallation: {
+          maxConcurrentDatastreamOperations: 25,
+        },
+      });
+    }).not.toThrow();
+  });
+
+  it('should use 50 as default for maxConcurrentDatastreamOperations', () => {
+    const result = config.schema.validate({
+      packageInstallation: {},
+    });
+    expect(result.packageInstallation?.maxConcurrentDatastreamOperations).toBe(50);
+  });
+
+  it('should reject maxConcurrentDatastreamOperations below 1', () => {
+    expect(() => {
+      config.schema.validate({
+        packageInstallation: {
+          maxConcurrentDatastreamOperations: 0,
+        },
+      });
+    }).toThrow();
+  });
+
+  it('should reject maxConcurrentDatastreamOperations above 50', () => {
+    expect(() => {
+      config.schema.validate({
+        packageInstallation: {
+          maxConcurrentDatastreamOperations: 51,
+        },
+      });
+    }).toThrow();
+  });
+
   it('should allow to specify fleetPolicyRevisionsCleanup configuration', () => {
     expect(() => {
       config.schema.validate({

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -258,6 +258,15 @@ export const config: PluginConfigDescriptor = {
           packageUpgradeBatchSize: schema.number({ defaultValue: 50, min: 10, max: 200 }),
         })
       ),
+      /**
+       * Package installation settings to tune ES operation concurrency and error handling.
+       */
+      packageInstallation: schema.maybe(
+        schema.object({
+          /** Maximum data stream operations to run concurrently per Kibana node during package installation */
+          maxConcurrentDatastreamOperations: schema.number({ defaultValue: 50, min: 1, max: 50 }),
+        })
+      ),
       developer: schema.object({
         maxAgentPoliciesWithInactivityTimeout: schema.maybe(schema.number()),
         disableRegistryVersionCheck: schema.boolean({ defaultValue: false }),

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/retry_data_stream_update.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/retry_data_stream_update.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import pRetry from 'p-retry';
+
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import { loggerMock } from '@kbn/logging-mocks';
+
+import { retryDataStreamUpdateOnClusterEventTimeout } from './retry_data_stream_update';
+
+// Use 0ms delays so tests run synchronously without fake timers.
+jest.mock('p-retry', () => {
+  const actual = jest.requireActual<typeof import('p-retry')>('p-retry');
+  const mockFn = jest
+    .fn()
+    .mockImplementation((fn: Parameters<typeof actual.default>[0], options: any) =>
+      actual.default(fn, { ...options, minTimeout: 0, maxTimeout: 0, randomize: false })
+    );
+  (mockFn as any).AbortError = actual.AbortError;
+  return { __esModule: true, default: mockFn, AbortError: actual.AbortError };
+});
+
+const buildResponseError = (statusCode: number, errorType: string): EsErrors.ResponseError =>
+  new EsErrors.ResponseError({
+    statusCode,
+    body: { error: { type: errorType, reason: errorType } },
+    headers: {},
+    meta: {} as any,
+    warnings: [],
+  });
+
+describe('retryDataStreamUpdateOnClusterEventTimeout', () => {
+  beforeEach(() => {
+    jest.mocked(pRetry).mockClear();
+  });
+
+  it('resolves immediately when the operation succeeds on the first attempt', async () => {
+    const operation = jest.fn().mockResolvedValue('ok');
+    const logger = loggerMock.create();
+
+    const result = await retryDataStreamUpdateOnClusterEventTimeout(operation, {
+      logger,
+      dataStreamName: 'test-stream',
+    });
+
+    expect(result).toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('retries on process_cluster_event_timeout_exception (body.error.type) and succeeds', async () => {
+    const clusterTimeoutError = buildResponseError(503, 'process_cluster_event_timeout_exception');
+    const operation = jest
+      .fn()
+      .mockRejectedValueOnce(clusterTimeoutError)
+      .mockResolvedValueOnce('ok');
+    const logger = loggerMock.create();
+
+    const result = await retryDataStreamUpdateOnClusterEventTimeout(operation, {
+      logger,
+      dataStreamName: 'test-stream',
+    });
+
+    expect(result).toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('process_cluster_event_timeout_exception')
+    );
+  });
+
+  it('retries on process_cluster_event_timeout_exception via root_cause', async () => {
+    const clusterTimeoutError = new EsErrors.ResponseError({
+      statusCode: 503,
+      body: {
+        error: {
+          type: 'some_outer_type',
+          root_cause: [{ type: 'process_cluster_event_timeout_exception' }],
+        },
+      },
+      headers: {},
+      meta: {} as any,
+      warnings: [],
+    });
+    const operation = jest
+      .fn()
+      .mockRejectedValueOnce(clusterTimeoutError)
+      .mockResolvedValueOnce('ok');
+    const logger = loggerMock.create();
+
+    const result = await retryDataStreamUpdateOnClusterEventTimeout(operation, {
+      logger,
+      dataStreamName: 'test-stream',
+    });
+
+    expect(result).toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on 429 TooManyRequests errors', async () => {
+    const tooManyRequestsError = buildResponseError(429, 'circuit_breaking_exception');
+    const operation = jest
+      .fn()
+      .mockRejectedValueOnce(tooManyRequestsError)
+      .mockResolvedValueOnce('ok');
+    const logger = loggerMock.create();
+
+    const result = await retryDataStreamUpdateOnClusterEventTimeout(operation, {
+      logger,
+      dataStreamName: 'test-stream',
+    });
+
+    expect(result).toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('test-stream'));
+  });
+
+  it('aborts immediately (no retry) on non-ES errors', async () => {
+    const arbitraryError = new Error('some unexpected error');
+    const operation = jest.fn().mockRejectedValue(arbitraryError);
+    const logger = loggerMock.create();
+
+    await expect(
+      retryDataStreamUpdateOnClusterEventTimeout(operation, {
+        logger,
+        dataStreamName: 'test-stream',
+      })
+    ).rejects.toThrow('some unexpected error');
+
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('aborts immediately on ES errors that are not cluster-event-timeout or 429', async () => {
+    const illegalArgError = buildResponseError(400, 'illegal_argument_exception');
+    const operation = jest.fn().mockRejectedValue(illegalArgError);
+    const logger = loggerMock.create();
+
+    await expect(
+      retryDataStreamUpdateOnClusterEventTimeout(operation, {
+        logger,
+        dataStreamName: 'test-stream',
+      })
+    ).rejects.toThrow();
+
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops retrying after exhausting the retry limit (4 retries = 5 total attempts)', async () => {
+    const clusterTimeoutError = buildResponseError(503, 'process_cluster_event_timeout_exception');
+    const operation = jest.fn().mockRejectedValue(clusterTimeoutError);
+    const logger = loggerMock.create();
+
+    await expect(
+      retryDataStreamUpdateOnClusterEventTimeout(operation, {
+        logger,
+        dataStreamName: 'test-stream',
+      })
+    ).rejects.toThrow();
+
+    // 1 initial attempt + 4 retries
+    expect(operation).toHaveBeenCalledTimes(5);
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/retry_data_stream_update.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/retry_data_stream_update.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import pRetry from 'p-retry';
+
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import type { Logger } from '@kbn/logging';
+
+const RETRIES = 4;
+const MIN_TIMEOUT_MS = 2_000;
+const MAX_TIMEOUT_MS = 30_000;
+const FACTOR = 2;
+
+const CLUSTER_EVENT_TIMEOUT_EXCEPTION = 'process_cluster_event_timeout_exception';
+
+const isClusterEventTimeoutError = (err: unknown): boolean => {
+  if (!(err instanceof EsErrors.ResponseError)) {
+    return false;
+  }
+  if (err.body?.error?.type === CLUSTER_EVENT_TIMEOUT_EXCEPTION) {
+    return true;
+  }
+  if (Array.isArray(err.body?.error?.root_cause)) {
+    return err.body.error.root_cause.some(
+      (cause: { type?: string }) => cause.type === CLUSTER_EVENT_TIMEOUT_EXCEPTION
+    );
+  }
+  return false;
+};
+
+const isTooManyRequestsError = (err: unknown): boolean =>
+  err instanceof EsErrors.ResponseError && err.statusCode === 429;
+
+/**
+ * Wraps an async operation that updates a data stream with jittered exponential-backoff retry
+ * logic that triggers specifically on `process_cluster_event_timeout_exception` and 429 errors.
+ * All other errors abort immediately and propagate unchanged.
+ *
+ * Confined to the package-install code path (does not touch retryTransientEsErrors).
+ */
+export const retryDataStreamUpdateOnClusterEventTimeout = async <T>(
+  operation: () => Promise<T>,
+  { logger, dataStreamName }: { logger: Logger; dataStreamName: string }
+): Promise<T> => {
+  return pRetry(operation, {
+    retries: RETRIES,
+    factor: FACTOR,
+    minTimeout: MIN_TIMEOUT_MS,
+    maxTimeout: MAX_TIMEOUT_MS,
+    randomize: true,
+    onFailedAttempt: (err) => {
+      if (!isClusterEventTimeoutError(err) && !isTooManyRequestsError(err)) {
+        throw new pRetry.AbortError(err);
+      }
+      logger.warn(
+        `Retrying data stream update for [${dataStreamName}] after cluster event timeout (attempt ${
+          err.attemptNumber
+        }/${RETRIES + 1}): ${err.message}`
+      );
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -2747,6 +2747,75 @@ describe('EPM template', () => {
         })
       );
     });
+
+    it('should complete successfully when packageInstallation.maxConcurrentDatastreamOperations is set in config', async () => {
+      appContextService.start(
+        createAppContextStartContractMock({
+          packageInstallation: { maxConcurrentDatastreamOperations: 5 },
+        })
+      );
+
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.indices.getDataStream.mockResponse({
+        data_streams: [{ name: 'logs.prefix1-default' }],
+      } as any);
+      esClient.indices.simulateTemplate.mockResponse({
+        template: {
+          settings: { index: {} },
+          mappings: { properties: {} },
+        },
+      } as any);
+
+      const logger = loggerMock.create();
+      await updateCurrentWriteIndices(esClient, logger, [
+        {
+          templateName: 'logs.prefix1',
+          indexTemplate: {
+            index_patterns: ['logs.prefix1-*'],
+            template: {
+              settings: { index: {} },
+              mappings: { properties: {} },
+            },
+          } as any,
+        },
+      ]);
+
+      const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
+      expect(putMappingsCall).toHaveLength(1);
+      expect(putMappingsCall[0]).toBe('logs.prefix1-default');
+    });
+
+    it('should complete successfully when packageInstallation config is absent (falls back to constant)', async () => {
+      appContextService.start(createAppContextStartContractMock());
+
+      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+      esClient.indices.getDataStream.mockResponse({
+        data_streams: [{ name: 'logs.prefix1-default' }],
+      } as any);
+      esClient.indices.simulateTemplate.mockResponse({
+        template: {
+          settings: { index: {} },
+          mappings: { properties: {} },
+        },
+      } as any);
+
+      const logger = loggerMock.create();
+      await updateCurrentWriteIndices(esClient, logger, [
+        {
+          templateName: 'logs.prefix1',
+          indexTemplate: {
+            index_patterns: ['logs.prefix1-*'],
+            template: {
+              settings: { index: {} },
+              mappings: { properties: {} },
+            },
+          } as any,
+        },
+      ]);
+
+      const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
+      expect(putMappingsCall).toHaveLength(1);
+    });
   });
 
   describe('getTemplate — event-ingested suppression when agentIdVerification is enabled', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -48,6 +48,7 @@ import { PackageESError, PackageInvalidArchiveError } from '../../../../errors';
 
 import { isUserSettingsTemplate, fillConstantKeywordValues } from './utils';
 import { MappingsBuilder } from './mappings_builder';
+import { retryDataStreamUpdateOnClusterEventTimeout } from './retry_data_stream_update';
 
 export interface IndexTemplateMapping {
   [key: string]: any;
@@ -397,13 +398,16 @@ const queryDataStreamsFromTemplates = async (
   esClient: ElasticsearchClient,
   templates: IndexTemplateEntry[]
 ): Promise<CurrentDataStream[]> => {
+  const concurrency =
+    appContextService.getConfig()?.packageInstallation?.maxConcurrentDatastreamOperations ??
+    MAX_CONCURRENT_DATASTREAM_OPERATIONS;
   const dataStreamObjects = await pMap(
     templates,
     (template) => {
       return getDataStreams(esClient, template);
     },
     {
-      concurrency: MAX_CONCURRENT_DATASTREAM_OPERATIONS,
+      concurrency,
     }
   );
   return dataStreamObjects.filter(isCurrentDataStream).flat();
@@ -481,19 +485,26 @@ const updateAllDataStreams = async (
     skipDataStreamRollover?: boolean;
   }
 ): Promise<void> => {
+  const concurrency =
+    appContextService.getConfig()?.packageInstallation?.maxConcurrentDatastreamOperations ??
+    MAX_CONCURRENT_DATASTREAM_OPERATIONS;
   await pMap(
     indexNameWithTemplates,
     (templateEntry) => {
-      return updateExistingDataStream({
-        esClient,
-        logger,
-        currentWriteIndex: templateEntry.currentWriteIndex,
-        dataStreamName: templateEntry.dataStreamName,
-        options,
-      });
+      return retryDataStreamUpdateOnClusterEventTimeout(
+        () =>
+          updateExistingDataStream({
+            esClient,
+            logger,
+            currentWriteIndex: templateEntry.currentWriteIndex,
+            dataStreamName: templateEntry.dataStreamName,
+            options,
+          }),
+        { logger, dataStreamName: templateEntry.dataStreamName }
+      );
     },
     {
-      concurrency: MAX_CONCURRENT_DATASTREAM_OPERATIONS,
+      concurrency,
     }
   );
 };

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -459,21 +459,22 @@ function errorNeedRollover(err: any): boolean {
   return false;
 }
 
-const rolloverDataStream = (dataStreamName: string, esClient: ElasticsearchClient) => {
-  try {
-    // Do no wrap rollovers in retryTransientEsErrors since it is not idempotent
-    return esClient.transport.request({
-      method: 'POST',
-      path: `/${dataStreamName}/_rollover`,
-      querystring: {
-        lazy: true,
-      },
-    });
-  } catch (error) {
-    throw new PackageESError(
-      `Cannot rollover data stream [${dataStreamName}] due to error: ${error}`
-    );
-  }
+const rolloverDataStream = (
+  dataStreamName: string,
+  esClient: ElasticsearchClient,
+  logger: Logger
+) => {
+  return retryDataStreamUpdateOnClusterEventTimeout(
+    () =>
+      esClient.transport.request({
+        method: 'POST',
+        path: `/${dataStreamName}/_rollover`,
+        querystring: {
+          lazy: true,
+        },
+      }),
+    { logger, dataStreamName }
+  );
 };
 
 const updateAllDataStreams = async (
@@ -491,17 +492,13 @@ const updateAllDataStreams = async (
   await pMap(
     indexNameWithTemplates,
     (templateEntry) => {
-      return retryDataStreamUpdateOnClusterEventTimeout(
-        () =>
-          updateExistingDataStream({
-            esClient,
-            logger,
-            currentWriteIndex: templateEntry.currentWriteIndex,
-            dataStreamName: templateEntry.dataStreamName,
-            options,
-          }),
-        { logger, dataStreamName: templateEntry.dataStreamName }
-      );
+      return updateExistingDataStream({
+        esClient,
+        logger,
+        currentWriteIndex: templateEntry.currentWriteIndex,
+        dataStreamName: templateEntry.dataStreamName,
+        options,
+      });
     },
     {
       concurrency,
@@ -594,7 +591,7 @@ const updateExistingDataStream = async ({
         return;
       } else {
         logger.info(`Triggering a rollover for ${dataStreamName}`);
-        await rolloverDataStream(dataStreamName, esClient);
+        await rolloverDataStream(dataStreamName, esClient, logger);
         return;
       }
     }
@@ -651,7 +648,7 @@ const updateExistingDataStream = async ({
           ? `Dynamic dimension mappings changed for ${dataStreamName}, triggering a rollover`
           : `Index mode or source type has changed for ${dataStreamName}, triggering a rollover`
       );
-      await rolloverDataStream(dataStreamName, esClient);
+      await rolloverDataStream(dataStreamName, esClient, logger);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/263980

This PR introduces two mitigations measures to reduce `process_cluster_event_timeout_exception` exceptions during package installation in large deployments:
* Configurable concurrency with `xpack.fleet.packageInstallation.maxConcurrentDatastreamOperations`: defaults to 50 (current hardcoded value), configurable between 1 and 50.
* Jittered retry wrapper: each per-stream update is wrapped in a new `retryDataStreamUpdateOnClusterEventTimeout` helper using `p-retry` (4 retries, exponential backoff with `randomize: true`, 2s–30s window). This retries only `process_cluster_event_timeout_exception` and 429; all other errors abort immediately.

Code correctness was validated using production logs.

Note that this mitigation does not address the root cause: without cross-node coordination (https://github.com/elastic/kibana/issues/263979), all nodes still start at roughly the same time. The jitter in the new wrapper spreads out retries, but not the initial burst.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

The new retry wrapper retries the entire `updateExistingDataStream` call, so on a rollover failure every retry re-issues both `simulateTemplate` and `putMapping` before reaching the rollover again. Those are additional cluster state operations during an already-overloaded period. This should, however, be mitigated by the jitter.