### PR TITLE
[One Workflow] Fix workflow editor UX issues (#270895)

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.test.tsx
@@ -7,12 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { useWorkflowsCapabilities, type WorkflowsManagementCapabilities } from '@kbn/workflows-ui';
 import { createMockWorkflowsCapabilities } from '@kbn/workflows-ui/mocks';
-import type { WorkflowDetailHeaderProps } from './workflow_detail_header';
-import { WorkflowDetailHeader } from './workflow_detail_header';
+import {
+  SkipUnsavedRunConfirmationStorageKey,
+  WorkflowDetailHeader,
+  type WorkflowDetailHeaderProps,
+} from './workflow_detail_header';
 import { createMockStore } from '../../../entities/workflows/store/__mocks__/store.mock';
 import {
   _clearComputedData,
@@ -20,6 +23,7 @@ import {
   setWorkflow,
   setYamlString,
 } from '../../../entities/workflows/store/workflow_detail/slice';
+import { saveYamlThunk } from '../../../entities/workflows/store/workflow_detail/thunks/save_yaml_thunk';
 import { TestWrapper } from '../../../shared/test_utils/test_wrapper';
 
 const mockUseKibana = jest.fn();
@@ -86,11 +90,13 @@ describe('WorkflowDetailHeader', () => {
       hasChanges = false,
       hasYamlSchemaValidationErrors = false,
       serverValid = true,
+      isSaving = false,
     }: {
       isValid?: boolean;
       hasChanges?: boolean;
       hasYamlSchemaValidationErrors?: boolean;
       serverValid?: boolean;
+      isSaving?: boolean;
     } = {}
   ) => {
     const store = createMockStore();
@@ -109,16 +115,20 @@ describe('WorkflowDetailHeader', () => {
     if (hasYamlSchemaValidationErrors) {
       store.dispatch(setHasYamlSchemaValidationErrors(true));
     }
+    if (isSaving) {
+      store.dispatch(saveYamlThunk.pending('', undefined));
+    }
 
     const wrapper = ({ children }: { children: React.ReactNode }) => {
       return <TestWrapper store={store}>{children}</TestWrapper>;
     };
 
-    return render(component, { wrapper });
+    return { ...render(component, { wrapper }), store };
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
     mockUseKibana.mockReturnValue({
       services: {
         application: {
@@ -155,18 +165,16 @@ describe('WorkflowDetailHeader', () => {
   });
 
   it('shows saved status when no changes', () => {
-    const { container } = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />);
-    // The WorkflowUnsavedChangesBadge component displays "Saved" when there are no changes
-    // We need to check if the component renders without the unsaved changes badge
-    expect(container).toBeTruthy();
+    const { getByTestId } = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />);
+    expect(getByTestId('saveWorkflowHeaderButton')).toBeDisabled();
   });
 
   it('shows unsaved changes when there are changes', () => {
-    const { container } = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />, {
+    const { getByTestId } = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />, {
       isValid: true,
       hasChanges: true,
     });
-    expect(container).toBeTruthy();
+    expect(getByTestId('saveWorkflowHeaderButton')).not.toBeDisabled();
   });
 
   it('disables run workflow button when yaml has syntax errors', () => {
@@ -206,6 +214,60 @@ describe('WorkflowDetailHeader', () => {
     const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />);
     const button = result.getByTestId('runWorkflowHeaderButton');
     expect(button).toBeEnabled();
+  });
+
+  it('shows the unsaved changes confirmation when running with unsaved changes', () => {
+    const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />, {
+      hasChanges: true,
+    });
+
+    fireEvent.click(result.getByTestId('runWorkflowHeaderButton'));
+
+    expect(
+      result.getByTestId('runWorkflowWithUnsavedChangesConfirmationModal')
+    ).toBeInTheDocument();
+    expect(result.getByTestId('runWorkflowWithUnsavedChangesDontAskAgain')).toBeInTheDocument();
+  });
+
+  it('stores the run confirmation preference when confirming with the checkbox selected', () => {
+    const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />, {
+      hasChanges: true,
+    });
+
+    fireEvent.click(result.getByTestId('runWorkflowHeaderButton'));
+    fireEvent.click(result.getByTestId('runWorkflowWithUnsavedChangesDontAskAgain'));
+    fireEvent.click(result.getByTestId('confirmModalConfirmButton'));
+
+    expect(localStorage.getItem(SkipUnsavedRunConfirmationStorageKey)).toBe('true');
+    expect(result.queryByTestId('runWorkflowWithUnsavedChangesConfirmationModal')).toBeNull();
+    expect(result.store.getState().detail.isTestModalOpen).toBe(true);
+  });
+
+  it('skips the unsaved changes confirmation when the preference is stored', () => {
+    localStorage.setItem(SkipUnsavedRunConfirmationStorageKey, 'true');
+    const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />, {
+      hasChanges: true,
+    });
+
+    fireEvent.click(result.getByTestId('runWorkflowHeaderButton'));
+
+    expect(result.queryByTestId('runWorkflowWithUnsavedChangesConfirmationModal')).toBeNull();
+    expect(result.store.getState().detail.isTestModalOpen).toBe(true);
+  });
+
+  it('disables run workflow button while save is in flight', () => {
+    const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />, {
+      hasChanges: true,
+      isSaving: true,
+    });
+
+    const runButton = result.getByTestId('runWorkflowHeaderButton');
+
+    expect(runButton).toBeDisabled();
+    fireEvent.click(runButton);
+
+    expect(result.queryByTestId('runWorkflowWithUnsavedChangesConfirmationModal')).toBeNull();
+    expect(result.store.getState().detail.isTestModalOpen).toBe(false);
   });
 
   it('disables executions tab when user cannot read workflow executions', () => {
@@ -273,7 +335,7 @@ describe('WorkflowDetailHeader', () => {
           canCancelWorkflowExecution: false,
         },
         expectRunDisabled: false,
-        expectSaveDisabled: false,
+        expectSaveDisabled: true,
         expectEnabledSwitchDisabled: false,
         expectExecutionsTabDisabled: false,
       },
@@ -289,7 +351,7 @@ describe('WorkflowDetailHeader', () => {
           canCancelWorkflowExecution: false,
         },
         expectRunDisabled: false,
-        expectSaveDisabled: false,
+        expectSaveDisabled: true,
         expectEnabledSwitchDisabled: false,
         expectExecutionsTabDisabled: true,
       },
@@ -353,7 +415,9 @@ describe('WorkflowDetailHeader', () => {
         canCancelWorkflowExecution: false,
       });
 
-      const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />);
+      const result = renderWithProviders(<WorkflowDetailHeader {...defaultProps} />, {
+        hasChanges: true,
+      });
       expect(result.getByTestId('saveWorkflowHeaderButton')).not.toBeDisabled();
     });
   });

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_header.tsx
@@ -13,15 +13,21 @@ import {
   EuiButtonEmpty,
   EuiButtonGroup,
   EuiButtonIcon,
-  EuiConfirmModal,
+  EuiCheckbox,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
   EuiPageHeaderSection,
   EuiPageTemplate,
   EuiSkeletonLoading,
   EuiSkeletonRectangle,
   EuiSkeletonTitle,
   EuiSwitch,
+  EuiText,
   EuiTitle,
   EuiToolTip,
 } from '@elastic/eui';
@@ -62,6 +68,8 @@ const executionsTabReadExecutionDisabledTooltip = i18n.translate(
   }
 );
 
+export const SkipUnsavedRunConfirmationStorageKey = 'workflows:skipUnsavedRunConfirmation';
+
 const Translations = {
   runWorkflow: i18n.translate('workflows.workflowDetailHeader.runWorkflow', {
     defaultMessage: 'Run workflow',
@@ -72,6 +80,9 @@ const Translations = {
   ),
   runWorkflowCancel: i18n.translate('workflows.workflowDetailHeader.runWorkflowCancel', {
     defaultMessage: 'Cancel',
+  }),
+  dontAskAgain: i18n.translate('workflows.workflowDetailHeader.dontAskAgain', {
+    defaultMessage: "Don't ask again",
   }),
   backLink: i18n.translate('workflows.workflowDetailHeader.backLink', {
     defaultMessage: 'Back to Workflows',
@@ -160,6 +171,7 @@ export const WorkflowDetailHeader = React.memo(
     }, [dispatch]);
 
     const [showRunConfirmation, setShowRunConfirmation] = useState(false);
+    const [dontAskAgain, setDontAskAgain] = useState(false);
 
     // Combined validity: syntax must parse AND no strict validation errors AND server considers it valid.
     // workflow?.valid !== false covers the initial page load before Monaco validates.
@@ -171,8 +183,9 @@ export const WorkflowDetailHeader = React.memo(
         isExecutionsTab,
         isValid: isSyntaxValid,
         canRunWorkflow: canExecuteWorkflow,
+        isSaving,
       });
-    }, [isSyntaxValid, canExecuteWorkflow, isExecutionsTab]);
+    }, [isSyntaxValid, canExecuteWorkflow, isExecutionsTab, isSaving]);
 
     const saveWorkflowTooltipContent = useMemo(() => {
       const isCreate = !workflowId;
@@ -180,15 +193,19 @@ export const WorkflowDetailHeader = React.memo(
         isExecutionsTab,
         canSaveWorkflow: isCreate ? canCreateWorkflow : canUpdateWorkflow,
         isCreate,
+        hasUnsavedChanges,
       });
-    }, [isExecutionsTab, workflowId, canCreateWorkflow, canUpdateWorkflow]);
+    }, [isExecutionsTab, workflowId, canCreateWorkflow, canUpdateWorkflow, hasUnsavedChanges]);
 
     const canSaveWorkflow = useMemo(() => {
       return workflowId ? canUpdateWorkflow : canCreateWorkflow;
     }, [canUpdateWorkflow, canCreateWorkflow, workflowId]);
 
     const handleRunClickWithUnsavedCheck = useCallback(() => {
-      if (hasUnsavedChanges) {
+      const shouldSkipUnsavedRunConfirmation =
+        localStorage.getItem(SkipUnsavedRunConfirmationStorageKey) === 'true';
+      if (hasUnsavedChanges && !shouldSkipUnsavedRunConfirmation) {
+        setDontAskAgain(false);
         setShowRunConfirmation(true);
       } else {
         openTestModal();
@@ -196,11 +213,15 @@ export const WorkflowDetailHeader = React.memo(
     }, [hasUnsavedChanges, openTestModal]);
 
     const handleConfirmRun = useCallback(() => {
+      if (dontAskAgain) {
+        localStorage.setItem(SkipUnsavedRunConfirmationStorageKey, 'true');
+      }
       setShowRunConfirmation(false);
       openTestModal();
-    }, [openTestModal]);
+    }, [dontAskAgain, openTestModal]);
 
     const handleCancelRun = useCallback(() => {
+      setDontAskAgain(false);
       setShowRunConfirmation(false);
     }, []);
 
@@ -324,7 +345,13 @@ export const WorkflowDetailHeader = React.memo(
                     iconType="play"
                     size="s"
                     onClick={handleRunClickWithUnsavedCheck}
-                    disabled={isExecutionsTab || !canExecuteWorkflow || isLoading || !isSyntaxValid}
+                    disabled={
+                      isExecutionsTab ||
+                      !canExecuteWorkflow ||
+                      isLoading ||
+                      isSaving ||
+                      !isSyntaxValid
+                    }
                     aria-label={Translations.runWorkflow}
                     data-test-subj="runWorkflowHeaderButton"
                   />
@@ -336,7 +363,12 @@ export const WorkflowDetailHeader = React.memo(
                     size="s"
                     onClick={handleSaveWorkflow}
                     disabled={
-                      isExecutionsTab || !canSaveWorkflow || isLoading || isSaving || !isYamlSynced
+                      isExecutionsTab ||
+                      !canSaveWorkflow ||
+                      isLoading ||
+                      isSaving ||
+                      !isYamlSynced ||
+                      !hasUnsavedChanges
                     }
                     isLoading={isSaving}
                     data-test-subj="saveWorkflowHeaderButton"
@@ -353,24 +385,59 @@ export const WorkflowDetailHeader = React.memo(
           </EuiPageTemplate.Header>
         </EuiPageTemplate>
         {showRunConfirmation && (
-          <EuiConfirmModal
+          <EuiModal
+            className="euiModal--confirmation"
             data-test-subj="runWorkflowWithUnsavedChangesConfirmationModal"
-            title={Translations.runWithUnsavedChangesQuestion}
-            onCancel={handleCancelRun}
-            onConfirm={handleConfirmRun}
-            cancelButtonText={Translations.runWorkflowCancel}
-            confirmButtonText={Translations.runWorkflow}
-            buttonColor="success"
-            defaultFocusedButton="confirm"
+            onClose={handleCancelRun}
+            role="alertdialog"
+            initialFocus="[data-test-subj='confirmModalConfirmButton']"
             aria-label={Translations.runWithUnsavedChangesQuestion}
           >
-            <p>
-              <FormattedMessage
-                id="workflows.workflowDetailHeader.runWithUnsavedChanges.message"
-                defaultMessage="You have unsaved changes. Running the workflow will not save your changes. Are you sure you want to continue?"
+            <EuiModalHeader>
+              <EuiModalHeaderTitle data-test-subj="confirmModalTitleText">
+                {Translations.runWithUnsavedChangesQuestion}
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+            <EuiModalBody>
+              <EuiText data-test-subj="confirmModalBodyText">
+                <p>
+                  <FormattedMessage
+                    id="workflows.workflowDetailHeader.runWithUnsavedChanges.message"
+                    defaultMessage="You have unsaved changes. Running the workflow will not save your changes. Are you sure you want to continue?"
+                  />
+                </p>
+              </EuiText>
+            </EuiModalBody>
+            <EuiModalFooter css={styles.runConfirmationFooter}>
+              <EuiCheckbox
+                id="workflowsRunWithUnsavedChangesDontAskAgain"
+                data-test-subj="runWorkflowWithUnsavedChangesDontAskAgain"
+                label={Translations.dontAskAgain}
+                checked={dontAskAgain}
+                onChange={(event) => setDontAskAgain(event.target.checked)}
               />
-            </p>
-          </EuiConfirmModal>
+              <EuiFlexGroup gutterSize="m" justifyContent="flexEnd" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    data-test-subj="confirmModalCancelButton"
+                    onClick={handleCancelRun}
+                  >
+                    {Translations.runWorkflowCancel}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    data-test-subj="confirmModalConfirmButton"
+                    onClick={handleConfirmRun}
+                    fill
+                    color="success"
+                  >
+                    {Translations.runWorkflow}
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiModalFooter>
+          </EuiModal>
         )}
       </>
     );
@@ -407,6 +474,10 @@ const componentStyles = {
       backgroundColor: euiTheme.colors.borderBasePlain,
       alignSelf: 'stretch',
     }),
+  runConfirmationFooter: css({
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  }),
   skeletonTitle: css({
     minWidth: '250px',
     width: '100%',

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/workflow_action_buttons/get_workflow_tooltip_content.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/workflow_action_buttons/get_workflow_tooltip_content.test.ts
@@ -97,6 +97,16 @@ describe('getTestRunTooltipContent', () => {
     expect(result).toBe('You need the Workflows "Execute" privilege to run workflows.');
   });
 
+  it('returns saving message when workflow is saving', () => {
+    const result = getTestRunTooltipContent({
+      isValid: true,
+      canRunWorkflow: true,
+      isExecutionsTab: false,
+      isSaving: true,
+    });
+    expect(result).toBe('Workflow is saving');
+  });
+
   it('returns null when all conditions are met', () => {
     const result = getTestRunTooltipContent({
       isValid: true,
@@ -131,6 +141,7 @@ describe('getSaveWorkflowTooltipContent', () => {
       isExecutionsTab: true,
       canSaveWorkflow: true,
       isCreate: false,
+      hasUnsavedChanges: true,
     });
     expect(result).toBe('Can not save workflow from executions tab');
   });
@@ -140,6 +151,7 @@ describe('getSaveWorkflowTooltipContent', () => {
       isExecutionsTab: false,
       canSaveWorkflow: false,
       isCreate: true,
+      hasUnsavedChanges: true,
     });
     expect(result).toBe('You are not allowed to create workflows');
   });
@@ -149,6 +161,7 @@ describe('getSaveWorkflowTooltipContent', () => {
       isExecutionsTab: false,
       canSaveWorkflow: false,
       isCreate: false,
+      hasUnsavedChanges: true,
     });
     expect(result).toBe('You are not allowed to update workflows');
   });
@@ -158,6 +171,7 @@ describe('getSaveWorkflowTooltipContent', () => {
       isExecutionsTab: false,
       canSaveWorkflow: true,
       isCreate: false,
+      hasUnsavedChanges: true,
     });
     expect(result).toBeNull();
   });
@@ -167,6 +181,7 @@ describe('getSaveWorkflowTooltipContent', () => {
       isExecutionsTab: false,
       canSaveWorkflow: true,
       isCreate: true,
+      hasUnsavedChanges: true,
     });
     expect(result).toBeNull();
   });
@@ -176,7 +191,18 @@ describe('getSaveWorkflowTooltipContent', () => {
       isExecutionsTab: true,
       canSaveWorkflow: false,
       isCreate: true,
+      hasUnsavedChanges: false,
     });
     expect(result).toBe('Can not save workflow from executions tab');
+  });
+
+  it('returns no changes message when workflow has no unsaved changes', () => {
+    const result = getSaveWorkflowTooltipContent({
+      isExecutionsTab: false,
+      canSaveWorkflow: true,
+      isCreate: false,
+      hasUnsavedChanges: false,
+    });
+    expect(result).toBe('No changes to save');
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/workflow_action_buttons/get_workflow_tooltip_content.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/workflow_action_buttons/get_workflow_tooltip_content.tsx
@@ -48,15 +48,22 @@ interface GetTestRunTooltipContentProps {
   isValid: boolean;
   canRunWorkflow: boolean;
   isExecutionsTab: boolean;
+  isSaving?: boolean;
 }
 export function getTestRunTooltipContent({
   isValid,
   canRunWorkflow,
   isExecutionsTab,
+  isSaving = false,
 }: GetTestRunTooltipContentProps) {
   if (isExecutionsTab) {
     return i18n.translate('workflows.actionButtons.runWorkflow.executionsTab', {
       defaultMessage: 'Can not run workflow from executions tab',
+    });
+  }
+  if (isSaving) {
+    return i18n.translate('workflows.actionButtons.runWorkflow.saving', {
+      defaultMessage: 'Workflow is saving',
     });
   }
   if (!isValid) {
@@ -97,11 +104,13 @@ interface GetSaveWorkflowTooltipContentProps {
   isExecutionsTab: boolean;
   canSaveWorkflow: boolean;
   isCreate: boolean;
+  hasUnsavedChanges: boolean;
 }
 export function getSaveWorkflowTooltipContent({
   isExecutionsTab,
   canSaveWorkflow,
   isCreate,
+  hasUnsavedChanges,
 }: GetSaveWorkflowTooltipContentProps) {
   if (isExecutionsTab) {
     return i18n.translate('workflows.actionButtons.saveWorkflow.executionsTab', {
@@ -118,6 +127,11 @@ export function getSaveWorkflowTooltipContent({
         defaultMessage: 'You are not allowed to update workflows',
       });
     }
+  }
+  if (!hasUnsavedChanges) {
+    return i18n.translate('workflows.actionButtons.saveWorkflow.noChanges', {
+      defaultMessage: 'No changes to save',
+    });
   }
   return null;
 }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -229,6 +229,9 @@ export const WorkflowYAMLEditor = ({
 
   const highlightedStepId = useSelector(selectHighlightedStepId);
   const workflowLookup = useSelector(selectEditorWorkflowLookup);
+  const workflowLookupRef = useRef(workflowLookup);
+  workflowLookupRef.current = workflowLookup;
+  const lastRevealedHighlightedStepIdRef = useRef<string | undefined>(undefined);
 
   // Data
   const connectorsData = useAvailableConnectors();
@@ -538,21 +541,33 @@ export const WorkflowYAMLEditor = ({
   }, [isEditorMounted, dispatch]);
 
   // Scroll editor to highlighted step when selected from execution flyout.
-  // workflowLookup is a dependency because the line numbers may shift, but in
-  // practice this only fires in execution mode where the editor is read-only,
-  // so re-scrolling on lookup changes is harmless.
+  // Do not re-scroll on workflow lookup updates; editing can change line numbers
+  // while a step remains highlighted for reference.
   useEffect(() => {
-    if (!isEditorMounted || !highlightedStepId || !workflowLookup) {
+    if (!highlightedStepId) {
+      lastRevealedHighlightedStepIdRef.current = undefined;
       return;
     }
+    if (!isEditorMounted) {
+      return;
+    }
+    if (lastRevealedHighlightedStepIdRef.current === highlightedStepId) {
+      return;
+    }
+    const currentWorkflowLookup = workflowLookupRef.current;
+    if (!currentWorkflowLookup) {
+      return;
+    }
+
     const lineStart =
       highlightedStepId === HIGHLIGHTED_STEP_TRIGGER
-        ? workflowLookup.triggersLineStart
-        : workflowLookup.steps[highlightedStepId]?.lineStart;
+        ? currentWorkflowLookup.triggersLineStart
+        : currentWorkflowLookup.steps[highlightedStepId]?.lineStart;
     if (lineStart != null) {
       editorRef.current?.revealLineInCenter(lineStart);
+      lastRevealedHighlightedStepIdRef.current = highlightedStepId;
     }
-  }, [isEditorMounted, highlightedStepId, workflowLookup]);
+  }, [isEditorMounted, highlightedStepId]);
 
   // Actions
   const [actionsPopoverOpen, setActionsPopoverOpen] = useState(false);

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/execution_step_scroll.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_execution/execution_step_scroll.spec.ts
@@ -68,6 +68,21 @@ test.describe('Workflow execution - Step scroll', { tag: [...tags.stateful.class
       await expectEditorScrolledTo('name: step_alpha');
     });
 
+    await test.step('editing while a step is highlighted does not jump back to that step', async () => {
+      await pageObjects.workflowEditor.setCursorToText('message: "Hotel executing last"');
+      await expectEditorScrolledTo('name: step_hotel');
+
+      const currentYaml = await pageObjects.workflowEditor.getYamlEditorValue();
+      await pageObjects.workflowEditor.setYamlEditorValue(`${currentYaml}
+
+  - name: step_india
+    type: console
+    with:
+      message: "India executing after hotel"`);
+
+      await expectEditorScrolledTo('name: step_hotel');
+    });
+
     await test.step('click trigger and verify editor scrolled to triggers section', async () => {
       await pageObjects.workflowExecution.executionPanel
         .getByRole('button', { name: 'manual' })


### PR DESCRIPTION
## Summary

Backport of #270895 to 9.4.

- Fixes scroll-jump in YAML editor when a highlighted execution step changes
- Adds persisted "Don't ask again" to the unsaved-run confirmation
- Disables Run while saving; disables Save when there are no unsaved changes
- Adds tooltip explaining why Save is disabled on a clean workflow

## Conflicts resolved

- `workflow_yaml_editor.tsx`: added three `useRef` declarations that didn't exist on 9.4

<!--BACKPORT [{"author":{"name":"Tal","email":"tal.borenstein@elastic.co"},"sourceCommit":{"committedDate":"2026-05-25T17:37:52+03:00","message":"[One Workflow] Fix workflow editor UX issues (#270895)","sha":"d57479d870e78336e71fd2e99b29f2cb91de678f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:One Workflow","release_note:skip","backport:version","v9.4.0","v9.4.2","v9.5.0"],"number":270895,"url":"https://github.com/elastic/kibana/pull/270895","mergeCommit":{"message":"[One Workflow] Fix workflow editor UX issues (#270895)","sha":"d57479d870e78336e71fd2e99b29f2cb91de678f"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->