### PR TITLE
[Lens] XY annotation groups should have a non-empty label

### DIFF
--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/__snapshots__/xy_chart.test.tsx.snap
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/__snapshots__/xy_chart.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`XYChart component annotations should render grouped line annotations pr
     Array [
       Object {
         "dataValue": 1647591917125,
-        "details": "",
+        "details": "3 event annotations",
       },
     ]
   }
@@ -117,7 +117,7 @@ exports[`XYChart component annotations should render grouped line annotations pr
           "icon": "3",
           "id": "event1",
           "isGrouped": true,
-          "label": "",
+          "label": "3 event annotations",
           "lineStyle": "dashed",
           "lineWidth": 3,
           "position": "bottom",
@@ -156,7 +156,7 @@ exports[`XYChart component annotations should render grouped line annotations wi
     Array [
       Object {
         "dataValue": 1647591917125,
-        "details": "",
+        "details": "2 event annotations",
       },
     ]
   }
@@ -172,7 +172,7 @@ exports[`XYChart component annotations should render grouped line annotations wi
           "icon": "2",
           "id": "event1",
           "isGrouped": true,
-          "label": "",
+          "label": "2 event annotations",
           "lineStyle": "solid",
           "lineWidth": 1,
           "position": "bottom",

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/annotations.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/annotations.tsx
@@ -31,6 +31,7 @@ import type {
 import type { FieldFormat, FormatFactory } from '@kbn/field-formats-plugin/common';
 import { getResolvedAnnotationColor } from '@kbn/event-annotation-common';
 import type { Datatable, DatatableColumn, DatatableRow } from '@kbn/expressions-plugin/common';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import type { MergedAnnotation } from '../../common';
@@ -268,12 +269,16 @@ export const getAnnotationsGroupedByInterval = (
     };
     if (rowsPerBucket.length > 1) {
       const commonStyles = getCommonStyles(rowsPerBucket, isDarkMode);
+      const count = rowsPerBucket.length;
       return {
         ...mergedAnnotation,
         ...commonStyles,
-        label: '',
+        label: i18n.translate('expressionXY.annotations.groupedMarkerAriaLabel', {
+          defaultMessage: '{count, plural, one {# event annotation} other {# event annotations}}',
+          values: { count },
+        }),
         isGrouped: true,
-        icon: String(rowsPerBucket.length),
+        icon: String(count),
       };
     }
     return mergedAnnotation;


### PR DESCRIPTION
## Summary

I came across an A11Y test failure related to annotations in a dashboard in #270868.

Does not change annotation tooltip just the `aria-label`.

<img width="242" height="165" alt="image" src="https://github.com/user-attachments/assets/aeaf078a-3cac-42d9-9c1a-cb5bfdd681fb" />

Basically, the `aria-label` is set in charts from the `details` of the annotation. For grouped annotations this is set to an empty string which Axe does not like too much. See failure [here](https://buildkite.com/elastic/kibana-pull-request/builds/448878#019e69cc-3c82-4c34-b028-b9046b7092cf).

```
1)    X-Pack Accessibility Tests - Group 1
--
  | Dashboard controls a11y tests
  | Controls main menu panel:
  |  
  | Error: a11y report:
  |  
  | VIOLATION
  | [role-img-alt]: Ensure [role="img"] elements have alternative text
  | Impact: serious
  | Help: https://dequeuniversity.com/rules/axe/4.11/role-img-alt?application=axeAPI
  | Elements:
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | - <div class="echAnnotation__marke..." data-testid="echAnnotationMarker" aria-describedby="echAnnotationTooltip..." aria-label="" tabindex="0" role="img" style="opacity: 1; transiti...">
  | at AccessibilityService.assertValidAxeReport (a11y.ts:77:13)
  | at AccessibilityService.testAppSnapshot (a11y.ts:50:10)
  | at processTicksAndRejections (node:internal/process/task_queues:104:5)
  | at Context.<anonymous> (dashboard_controls.ts:43:7)
  | at Object.apply (wrap_function.js:74:16)


```

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



